### PR TITLE
Fix ambiguity of AGENT instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@
 - **Run a Python script:** `breeze run python dev/my_script.py`
 - **Run Airflow CLI:** `breeze run airflow dags list`
 - **Type-check:** `breeze run mypy path/to/code`
-- **Lint/format (runs on host):** `prek run --ref-from <target_branch>`
 - **Lint with ruff only:** `prek run ruff --ref-from <target_branch>`
 - **Format with ruff only:** `prek run ruff-format --ref-from <target_branch>`
+- **Run regular(fast) static checks:** `prek run --ref-from <target_branch> --hook-stage pre-commit`
+- **Run manual(slower) checks:** `prek run --ref-from <target_branch> --hook-stage manual`
 
 `<target_branch>` is the branch the PR will be merged into — usually `main`, but could be
 `v3-1-test` when creating a PR for the 3.1 branch.
@@ -110,9 +111,11 @@ code review checklist in [`.github/instructions/code-review.instructions.md`](.g
    API correctness, and AI-generated code signals. Fix any violations before pushing.
 3. Confirm the code follows the project's coding standards and architecture boundaries
    described in this file.
-4. Run static checks (`prek run --ref-from <target_branch>`) and fix any failures.
-5. Run relevant tests (`breeze run pytest <path> -xvs`) and confirm they pass.
-6. Check for security issues — no secrets, no injection vulnerabilities, no unsafe patterns.
+4. Run regular (fast) static checks (`prek run --ref-from <target_branch> --hook-stage pre-commit`)
+   and fix any failures.
+5. Run manual (slower) checks (`prek run --ref-from <target_branch> --hook-stage manual`) and fix any failures.
+6. Run relevant tests (`breeze run pytest <path> -xvs`) and confirm they pass.
+7. Check for security issues — no secrets, no injection vulnerabilities, no unsafe patterns.
 
 Then push the branch to the user's fork remote and open the PR creation page in the browser
 with the body pre-filled (including the generative AI disclosure already checked):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@
 - **Type-check:** `breeze run mypy path/to/code`
 - **Lint with ruff only:** `prek run ruff --ref-from <target_branch>`
 - **Format with ruff only:** `prek run ruff-format --ref-from <target_branch>`
-- **Run regular(fast) static checks:** `prek run --ref-from <target_branch> --hook-stage pre-commit`
-- **Run manual(slower) checks:** `prek run --ref-from <target_branch> --hook-stage manual`
+- **Run regular (fast) static checks:** `prek run --ref-from <target_branch> --hook-stage pre-commit`
+- **Run manual (slower) checks:** `prek run --ref-from <target_branch> --hook-stage manual`
 
 `<target_branch>` is the branch the PR will be merged into — usually `main`, but could be
 `v3-1-test` when creating a PR for the 3.1 branch.


### PR DESCRIPTION
The prek commants were somewaht ambiguous, depending on how prek was installed. Adding explicit --hook-stage makes it unambiguous.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
