### PR TITLE
Fix flaky DAG calendar tab e2e tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-calendar-tab.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-calendar-tab.spec.ts
@@ -61,7 +61,26 @@ test.describe("DAG Calendar Tab", () => {
       const data = (await response.json()) as { dag_run_id: string };
       const dagRunId = data.dag_run_id;
 
-      await page.request.patch(`/api/v2/dags/${dagId}/dagRuns/${dagRunId}`, { data: { state } });
+      // Retry PATCH until the state is confirmed — the DagBag may not have the DAG loaded yet
+      const maxRetries = 5;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        const patchResp = await page.request.patch(`/api/v2/dags/${dagId}/dagRuns/${dagRunId}`, {
+          data: { state },
+        });
+
+        if (patchResp.ok()) {
+          const patchData = (await patchResp.json()) as { state: string };
+
+          if (patchData.state === state) {
+            return;
+          }
+        }
+        // Wait before retrying
+        await page.waitForTimeout(1000);
+      }
+
+      throw new Error(`Failed to set run ${dagRunId} to state "${state}" after ${maxRetries} retries`);
     }
 
     await createRun(`cal_success_${Date.now()}`, successIso, "success");


### PR DESCRIPTION
Add retry logic to the `createRun` helper in the DAG calendar tab e2e tests.

The PATCH request that sets a DAG run's state can fail silently when the
DagBag hasn't loaded the DAG yet. The helper now retries the PATCH up to
5 times with 1-second delays, confirming the state is set before proceeding.
This prevents downstream assertions from failing due to runs stuck in
"queued" state.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)