### PR TITLE
Add test coverage for untested VaultBackend path branches

### DIFF
--- a/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
+++ b/providers/hashicorp/tests/unit/hashicorp/secrets/test_vault.py
@@ -111,6 +111,14 @@ class TestVaultSecrets:
         connection = test_client.get_connection(conn_id="airflow/test_postgres")
         assert connection.get_uri() == "postgresql://airflow:airflow@host:5432/airflow?foo=bar&baz=taz"
 
+        # When mount_point=None and conn_id does not contain "/",
+        # backend should return None and not call Vault
+
+        mock_client.reset_mock()
+
+        assert test_client.get_connection("simple_id") is None
+        mock_client.secrets.kv.v2.read_secret_version.assert_not_called()
+
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_variable_value(self, mock_hvac):
         mock_client = mock.MagicMock()
@@ -487,6 +495,40 @@ class TestVaultSecrets:
         test_client = VaultBackend(**kwargs)
         assert test_client.get_connection(conn_id="test") is None
         mock_hvac.Client.assert_not_called()
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_get_connection_with_empty_connections_path(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {
+                "data": {"conn_uri": "postgresql://user:pass@host:5432/db"},
+                "metadata": {"version": 1},
+            }
+        }
+
+        kwargs = {
+            "connections_path": "",
+            "mount_point": "airflow",
+            "auth_type": "token",
+            "url": "http://127.0.0.1:8200",
+            "token": "token",
+        }
+
+        backend = VaultBackend(**kwargs)
+
+        connection = backend.get_connection("my_conn")
+
+        # Assert Vault was called without "connections/" prefix
+        mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            mount_point="airflow",
+            path="my_conn",
+            version=None,
+            raise_on_deleted_version=True,
+        )
+
+        assert connection.get_uri() == "postgres://user:pass@host:5432/db"
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_variables_path_none_value(self, mock_hvac):


### PR DESCRIPTION
**Description**

Add test coverage for previously untested edge cases in `VaultBackend` path resolution.
Specifically, this change adds coverage for the `connections_path=""` branch to ensure connection IDs are not automatically prefixed, and extends the `mount_point=None` scenario to verify that non-prefixed keys correctly return `None` without invoking Vault.

**Rationale**

These branches are reachable through documented configuration options but were not explicitly protected by existing tests. Adding coverage ensures correct path resolution semantics are preserved and prevents regressions in shared `_parse_path` logic affecting connection retrieval behavior.