### PR TITLE
Cleanup the DualStatsManager and fix any leftover Stats calls 

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -45,6 +45,7 @@ from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7
 
+from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
 from airflow._shared.observability.metrics.stats import Stats, normalize_name_for_stats
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
@@ -1288,11 +1289,11 @@ def process_parse_results(
         file_name = normalize_name_for_stats(Path(relative_fileloc).stem)
         # bundle_name is included to distinguish files with the same name across different bundles
         normalized_bundle = normalize_name_for_stats(bundle_name)
-        Stats.timing(f"dag_processing.last_duration.{normalized_bundle}.{file_name}", stat.last_duration)
-        Stats.timing(
+        DualStatsManager.timing(
             "dag_processing.last_duration",
             stat.last_duration,
-            tags={"file_name": file_name, "bundle_name": normalized_bundle},
+            tags={},
+            legacy_name_tags={"bundle_name": normalized_bundle, "file_name": file_name},
         )
 
     if parsing_result is None:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -886,7 +886,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "pool.starving_tasks",
                 num_starving_tasks,
                 tags={},
-                extra_tags={"pool_name": pool_name},
+                legacy_name_tags={"pool_name": pool_name},
             )
 
         Stats.gauge("scheduler.tasks.starving", num_starving_tasks_total)
@@ -2145,7 +2145,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "dagrun.schedule_delay",
                     schedule_delay,
                     tags={},
-                    extra_tags={"dag_id": dag.dag_id},
+                    legacy_name_tags={"dag_id": dag.dag_id},
                 )
 
         # cache saves time during scheduling of many dag_runs for same dag
@@ -2289,7 +2289,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     "dagrun.duration.failed",
                     duration,
                     tags={},
-                    extra_tags={"dag_id": dag_run.dag_id},
+                    legacy_name_tags={"dag_id": dag_run.dag_id},
                 )
             return callback_to_execute
 
@@ -2584,7 +2584,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     f"ti.{state}",
                     float(count),
                     tags={},
-                    extra_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
+                    legacy_name_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
                 )
 
             for prev_key in self.previous_ti_metrics[state]:
@@ -2595,7 +2595,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         f"ti.{state}",
                         0,
                         tags={},
-                        extra_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
+                        legacy_name_tags={"queue": queue, "dag_id": dag_id, "task_id": task_id},
                     )
 
             self.previous_ti_metrics[state] = ti_metrics
@@ -2617,31 +2617,31 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "pool.open_slots",
                 slot_stats["open"],
                 tags={},
-                extra_tags={"pool_name": normalized_pool_name},
+                legacy_name_tags={"pool_name": normalized_pool_name},
             )
             DualStatsManager.gauge(
                 "pool.queued_slots",
                 slot_stats["queued"],
                 tags={},
-                extra_tags={"pool_name": normalized_pool_name},
+                legacy_name_tags={"pool_name": normalized_pool_name},
             )
             DualStatsManager.gauge(
                 "pool.running_slots",
                 slot_stats["running"],
                 tags={},
-                extra_tags={"pool_name": normalized_pool_name},
+                legacy_name_tags={"pool_name": normalized_pool_name},
             )
             DualStatsManager.gauge(
                 "pool.deferred_slots",
                 slot_stats["deferred"],
                 tags={},
-                extra_tags={"pool_name": normalized_pool_name},
+                legacy_name_tags={"pool_name": normalized_pool_name},
             )
             DualStatsManager.gauge(
                 "pool.scheduled_slots",
                 slot_stats["scheduled"],
                 tags={},
-                extra_tags={"pool_name": normalized_pool_name},
+                legacy_name_tags={"pool_name": normalized_pool_name},
             )
 
     @provide_session

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -615,7 +615,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             "triggers.running",
             len(self.running_triggers),
             tags={},
-            extra_tags={"hostname": self.job.hostname},
+            legacy_name_tags={"hostname": self.job.hostname},
         )
 
         capacity_left = self.capacity - len(self.running_triggers)
@@ -623,7 +623,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             "triggerer.capacity_left",
             capacity_left,
             tags={},
-            extra_tags={"hostname": self.job.hostname},
+            legacy_name_tags={"hostname": self.job.hostname},
         )
 
     def update_triggers(self, requested_trigger_ids: set[int]):

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1562,10 +1562,12 @@ class DagRun(Base, LoggingMixin):
             else:
                 true_delay = first_start_date - self.run_after
                 if true_delay.total_seconds() > 0:
-                    Stats.timing(
-                        f"dagrun.{dag.dag_id}.first_task_scheduling_delay", true_delay, tags=self.stats_tags
+                    DualStatsManager.timing(
+                        "dagrun.first_task_scheduling_delay",
+                        true_delay,
+                        tags=self.stats_tags,
+                        legacy_name_tags={"dag_id": dag.dag_id},
                     )
-                    Stats.timing("dagrun.first_task_scheduling_delay", true_delay, tags=self.stats_tags)
         except Exception:
             self.log.warning("Failed to record first_task_scheduling_delay metric:", exc_info=True)
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1083,7 +1083,7 @@ class DagRun(Base, LoggingMixin):
         with DualStatsManager.timer(
             "dagrun.dependency-check",
             tags={},
-            extra_tags=self.stats_tags,
+            legacy_name_tags=self.stats_tags,
         ):
             dag = self.get_dag()
             info = self.task_instance_scheduling_decisions(session)
@@ -1584,7 +1584,7 @@ class DagRun(Base, LoggingMixin):
             f"dagrun.duration.{self.state}",
             dt=duration,
             tags=self.stats_tags,
-            extra_tags={"dag_id": self.dag_id},
+            legacy_name_tags={"dag_id": self.dag_id},
         )
 
     @provide_session
@@ -1664,7 +1664,7 @@ class DagRun(Base, LoggingMixin):
                     DualStatsManager.incr(
                         "task_restored_to_dag",
                         tags=self.stats_tags,
-                        extra_tags={"dag_id": dag.dag_id},
+                        legacy_name_tags={"dag_id": dag.dag_id},
                     )
                     ti.state = None
             except AirflowException:
@@ -1675,7 +1675,7 @@ class DagRun(Base, LoggingMixin):
                     DualStatsManager.incr(
                         "task_removed_from_dag",
                         tags=self.stats_tags,
-                        extra_tags={"dag_id": dag.dag_id},
+                        legacy_name_tags={"dag_id": dag.dag_id},
                     )
                     ti.state = TaskInstanceState.REMOVED
                 continue
@@ -1843,7 +1843,7 @@ class DagRun(Base, LoggingMixin):
                     "task_instance_created",
                     count,
                     tags=self.stats_tags,
-                    extra_tags={"task_type": task_type},
+                    legacy_name_tags={"task_type": task_type},
                 )
             session.flush()
         except IntegrityError:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1314,7 +1314,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             f"task.{metric_name}",
             timing,
             tags={},
-            extra_tags={"task_id": self.task_id, "dag_id": self.dag_id, "queue": self.queue},
+            legacy_name_tags={"task_id": self.task_id, "dag_id": self.dag_id, "queue": self.queue},
         )
 
     def clear_next_method_args(self) -> None:
@@ -1534,7 +1534,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         DualStatsManager.incr(
             "operator_failures",
             tags=ti.stats_tags,
-            extra_tags={"operator_name": ti.operator},
+            legacy_name_tags={"operator_name": ti.operator},
         )
         Stats.incr("ti_failures", tags=ti.stats_tags)
 

--- a/airflow-core/tests/unit/core/test_dual_stats_manager.py
+++ b/airflow-core/tests/unit/core/test_dual_stats_manager.py
@@ -119,79 +119,81 @@ class TestDualStatsManager:
         assert sorted(args_dict) == sorted(expected_args_dict)
 
     @pytest.mark.parametrize(
-        ("args_dict", "tags", "extra_tags", "expected_args_dict"),
+        ("args_dict", "tags", "legacy_name_tags", "expected_args_dict"),
         [
             pytest.param(
                 {"count": 1},
                 {"test": True},
                 {},
                 {"count": 1, "tags": {"test": True}},
-                id="no_extra_tags",
+                id="no_legacy_name_tags",
             ),
             pytest.param(
                 {},
                 {"test": True},
                 {},
                 {"tags": {"test": True}},
-                id="no_args_no_extra_but_tags",
+                id="no_args_no_legacy_but_tags",
             ),
             pytest.param(
                 {},
                 {"test": True},
-                {"test_extra": True},
-                {"tags": {"test": True, "test_extra": True}},
-                id="no_args_but_tags_and_extra",
+                {"test_legacy": True},
+                {"tags": {"test": True, "test_legacy": True}},
+                id="no_args_but_tags_and_legacy",
             ),
             pytest.param(
                 {"count": 1},
                 {"test": True},
                 {},
                 {"count": 1, "tags": {"test": True}},
-                id="no_args_no_tags_but_extra_tags",
+                id="no_args_no_tags_but_legacy_name_tags",
             ),
             pytest.param(
                 {"count": 1},
                 {"test": True},
-                {"test_extra": True},
-                {"count": 1, "tags": {"test": True, "test_extra": True}},
+                {"test_legacy": True},
+                {"count": 1, "tags": {"test": True, "test_legacy": True}},
                 id="all_params_provided",
             ),
             pytest.param(
                 {"count": 1, "rate": 3},
                 {"test1": True, "test2": False},
-                {"test_extra1": True, "test_extra2": False, "test_extra3": True},
+                {"test_legacy1": True, "test_legacy2": False, "test_legacy3": True},
                 {
                     "count": 1,
                     "rate": 3,
                     "tags": {
                         "test1": True,
                         "test2": False,
-                        "test_extra1": True,
-                        "test_extra2": False,
-                        "test_extra3": True,
+                        "test_legacy1": True,
+                        "test_legacy2": False,
+                        "test_legacy3": True,
                     },
                 },
                 id="multiple_params",
             ),
         ],
     )
-    def test_get_args_dict_with_extra_tags_if_set(
+    def test_get_args_dict_with_legacy_name_tags_if_set(
         self,
         args_dict: dict[str, Any] | None,
         tags: dict[str, Any] | None,
-        extra_tags: dict[str, Any] | None,
+        legacy_name_tags: dict[str, Any] | None,
         expected_args_dict: dict[str, Any],
     ):
-        dict_full = dual_stats_manager._get_args_dict_with_extra_tags_if_set(args_dict, tags, extra_tags)
+        dict_full = dual_stats_manager._get_args_dict_with_legacy_name_tags_if_set(
+            args_dict, tags, legacy_name_tags
+        )
         assert sorted(dict_full) == sorted(expected_args_dict)
 
     @pytest.mark.parametrize(
-        ("tags", "extra_tags", "expected_tags_dict"),
+        ("tags", "legacy_name_tags", "expected_tags_dict"),
         [
             pytest.param(
                 {"test": True},
-                {"test_extra": True},
-                {"test": True, "test_extra": True},
+                {"test_legacy": True},
+                {"test": True, "test_legacy": True},
                 id="all_params_provided",
             ),
             pytest.param(
@@ -208,31 +210,31 @@ class TestDualStatsManager:
             ),
             pytest.param(
                 {},
-                {"test_extra": True},
-                {"test_extra": True},
-                id="only_extra",
+                {"test_legacy": True},
+                {"test_legacy": True},
+                id="only_legacy",
             ),
             pytest.param(
                 {"test1": True, "test2": False},
-                {"test_extra1": True, "test_extra2": False, "test_extra3": True},
+                {"test_legacy1": True, "test_legacy2": False, "test_legacy3": True},
                 {
                     "test1": True,
                     "test2": False,
-                    "test_extra1": True,
-                    "test_extra2": False,
-                    "test_extra3": True,
+                    "test_legacy1": True,
+                    "test_legacy2": False,
+                    "test_legacy3": True,
                 },
                 id="multiple_params",
             ),
         ],
     )
-    def test_get_tags_with_extra(
+    def test_get_tags_with_legacy(
         self,
         tags: dict[str, Any] | None,
-        extra_tags: dict[str, Any] | None,
+        legacy_name_tags: dict[str, Any] | None,
         expected_tags_dict: dict[str, Any],
     ):
-        tags_full = dual_stats_manager._get_tags_with_extra(tags, extra_tags)
+        tags_full = dual_stats_manager._get_tags_with_legacy(tags, legacy_name_tags)
         assert sorted(tags_full) == sorted(expected_tags_dict)
 
     @pytest.mark.parametrize(

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -29,6 +29,7 @@ from airflow.executors import workloads
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.common.compat.sdk import Stats, timezone
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_2_PLUS
 from airflow.providers.edge3.models.db import EdgeDBManager, check_db_manager_config
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
 from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
@@ -36,11 +37,6 @@ from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWork
 from airflow.utils.db import DBLocks, create_global_lock
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -197,7 +193,9 @@ class EdgeExecutor(BaseExecutor):
                     "queue": job.queue,
                     "state": str(TaskInstanceState.FAILED),
                 }
-                if DualStatsManager is not None:
+                if AIRFLOW_V_3_2_PLUS:
+                    from airflow.sdk.observability.stats import DualStatsManager
+
                     DualStatsManager.incr("edge_worker.ti.finish", tags={}, legacy_name_tags=tags)
                 else:
                     Stats.incr(

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -27,13 +27,9 @@ from sqlalchemy import Integer, String, delete, select
 from sqlalchemy.orm import Mapped
 
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
-from airflow.providers.edge3.models.edge_base import Base
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
 from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_2_PLUS
+from airflow.providers.edge3.models.edge_base import Base
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -179,7 +175,9 @@ def set_metrics(
         EdgeWorkerState.OFFLINE_MAINTENANCE,
     )
 
-    if DualStatsManager is not None:
+    if AIRFLOW_V_3_2_PLUS:
+        from airflow.sdk.observability.stats import DualStatsManager
+
         DualStatsManager.gauge(
             "edge_worker.connected",
             int(connected),

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -184,42 +184,42 @@ def set_metrics(
             "edge_worker.connected",
             int(connected),
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
 
         DualStatsManager.gauge(
             "edge_worker.maintenance",
             int(maintenance),
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
 
         DualStatsManager.gauge(
             "edge_worker.jobs_active",
             jobs_active,
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
 
         DualStatsManager.gauge(
             "edge_worker.concurrency",
             concurrency,
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
 
         DualStatsManager.gauge(
             "edge_worker.free_concurrency",
             free_concurrency,
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
 
         DualStatsManager.gauge(
             "edge_worker.num_queues",
             len(queues),
             tags={},
-            extra_tags={"worker_name": worker_name, "queues": ",".join(queues)},
+            legacy_name_tags={"worker_name": worker_name, "queues": ",".join(queues)},
         )
     else:
         Stats.gauge(f"edge_worker.connected.{worker_name}", int(connected))

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
@@ -92,7 +92,7 @@ def fetch(
     # Edge worker does not backport emitted Airflow metrics, so export some metrics
     tags = {"dag_id": job.dag_id, "task_id": job.task_id, "queue": job.queue}
     if DualStatsManager is not None:
-        DualStatsManager.incr("edge_worker.ti.start", tags=tags)
+        DualStatsManager.incr("edge_worker.ti.start", tags={}, legacy_name_tags=tags)
     else:
         Stats.incr(f"edge_worker.ti.start.{job.queue}.{job.dag_id}.{job.task_id}", tags=tags)
         Stats.incr("edge_worker.ti.start", tags=tags)
@@ -149,10 +149,7 @@ def state(
                 "state": str(state),
             }
             if DualStatsManager is not None:
-                DualStatsManager.incr(
-                    "edge_worker.ti.finish",
-                    tags=tags,
-                )
+                DualStatsManager.incr("edge_worker.ti.finish", tags={}, legacy_name_tags=tags)
             else:
                 Stats.incr(
                     f"edge_worker.ti.finish.{job.queue}.{state}.{job.dag_id}.{job.task_id}",

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
@@ -27,11 +27,7 @@ from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.executors.workloads import ExecuteTask
 from airflow.providers.common.compat.sdk import Stats, timezone
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_2_PLUS
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
 from airflow.providers.edge3.worker_api.auth import jwt_token_authorization_rest
 from airflow.providers.edge3.worker_api.datamodels import (
@@ -40,6 +36,9 @@ from airflow.providers.edge3.worker_api.datamodels import (
     WorkerQueuesBody,
 )
 from airflow.utils.state import TaskInstanceState
+
+if AIRFLOW_V_3_2_PLUS:
+    from airflow.sdk.observability.stats import DualStatsManager
 
 jobs_router = AirflowRouter(tags=["Jobs"], prefix="/jobs")
 
@@ -91,7 +90,7 @@ def fetch(
     session.commit()
     # Edge worker does not backport emitted Airflow metrics, so export some metrics
     tags = {"dag_id": job.dag_id, "task_id": job.task_id, "queue": job.queue}
-    if DualStatsManager is not None:
+    if AIRFLOW_V_3_2_PLUS:
         DualStatsManager.incr("edge_worker.ti.start", tags={}, legacy_name_tags=tags)
     else:
         Stats.incr(f"edge_worker.ti.start.{job.queue}.{job.dag_id}.{job.task_id}", tags=tags)
@@ -148,7 +147,7 @@ def state(
                 "queue": job.queue,
                 "state": state,
             }
-            if DualStatsManager is not None:
+            if AIRFLOW_V_3_2_PLUS:
                 DualStatsManager.incr("edge_worker.ti.finish", tags={}, legacy_name_tags=tags)
             else:
                 Stats.incr(

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/jobs.py
@@ -146,7 +146,7 @@ def state(
                 "dag_id": job.dag_id,
                 "task_id": job.task_id,
                 "queue": job.queue,
-                "state": str(state),
+                "state": state,
             }
             if DualStatsManager is not None:
                 DualStatsManager.incr("edge_worker.ti.finish", tags={}, legacy_name_tags=tags)

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -223,7 +223,7 @@ def set_state(
             1,
             1,
             tags={},
-            extra_tags={"worker_name": worker_name},
+            legacy_name_tags={"worker_name": worker_name},
         )
     else:
         Stats.incr(f"edge_worker.heartbeat_count.{worker_name}", 1, 1)

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -27,11 +27,7 @@ from airflow.api_fastapi.common.db.common import SessionDep  # noqa: TC001
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
 from airflow.providers.common.compat.sdk import Stats, timezone
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_2_PLUS
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState, set_metrics
 from airflow.providers.edge3.worker_api.auth import jwt_token_authorization_rest
 from airflow.providers.edge3.worker_api.datamodels import (
@@ -217,7 +213,9 @@ def set_state(
     worker.sysinfo = json.dumps(body.sysinfo)
     worker.last_update = timezone.utcnow()
     session.commit()
-    if DualStatsManager is not None:
+    if AIRFLOW_V_3_2_PLUS:
+        from airflow.sdk.observability.stats import DualStatsManager
+
         DualStatsManager.incr(
             "edge_worker.heartbeat_count",
             1,

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -33,8 +33,9 @@ from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
 
-try:
+if AIRFLOW_V_3_2_PLUS:
     from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager  # noqa: F401
 
     stats_reference = "airflow.sdk._shared.observability.metrics.dual_stats_manager.DualStatsManager"
@@ -48,7 +49,7 @@ try:
         },
     }
     expected_call_count = 1
-except ImportError:
+else:
     from airflow.providers.common.compat.sdk import Stats
 
     stats_reference = f"{Stats.__module__}.Stats"

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -25,7 +25,7 @@ from sqlalchemy import delete, select
 
 from airflow.configuration import conf
 from airflow.models.taskinstancekey import TaskInstanceKey
-from airflow.providers.common.compat.sdk import Stats, timezone
+from airflow.providers.common.compat.sdk import timezone
 from airflow.providers.edge3.executors.edge_executor import EdgeExecutor
 from airflow.providers.edge3.models.edge_job import EdgeJobModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState
@@ -33,6 +33,34 @@ from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
+
+try:
+    from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager  # noqa: F401
+
+    stats_reference = "airflow.sdk._shared.observability.metrics.dual_stats_manager.DualStatsManager"
+    expected_incr_kwargs = {
+        "tags": {},
+        "legacy_name_tags": {
+            "dag_id": "test_dag",
+            "queue": "default",
+            "state": "failed",
+            "task_id": "started_running_orphaned",
+        },
+    }
+    expected_call_count = 1
+except ImportError:
+    from airflow.providers.common.compat.sdk import Stats
+
+    stats_reference = f"{Stats.__module__}.Stats"
+    expected_incr_kwargs = {
+        "tags": {
+            "dag_id": "test_dag",
+            "queue": "default",
+            "state": "failed",
+            "task_id": "started_running_orphaned",
+        },
+    }
+    expected_call_count = 2
 
 pytestmark = pytest.mark.db_test
 
@@ -57,7 +85,7 @@ class TestEdgeExecutor:
 
         return (executor, key)
 
-    @patch(f"{Stats.__module__}.Stats.incr")
+    @patch(f"{stats_reference}.incr")
     def test_sync_orphaned_tasks(self, mock_stats_incr):
         executor = EdgeExecutor()
 
@@ -93,16 +121,8 @@ class TestEdgeExecutor:
 
         executor.sync()
 
-        mock_stats_incr.assert_called_with(
-            "edge_worker.ti.finish",
-            tags={
-                "dag_id": "test_dag",
-                "queue": "default",
-                "state": "failed",
-                "task_id": "started_running_orphaned",
-            },
-        )
-        mock_stats_incr.call_count == 2
+        mock_stats_incr.assert_called_with("edge_worker.ti.finish", **expected_incr_kwargs)
+        assert mock_stats_incr.call_count == expected_call_count
 
         with create_session() as session:
             jobs = session.scalars(select(EdgeJobModel)).all()

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
@@ -27,6 +27,8 @@ from airflow.providers.edge3.worker_api.routes.jobs import state
 from airflow.utils.session import create_session
 from airflow.utils.state import TaskInstanceState
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_2_PLUS
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -35,7 +37,7 @@ TASK_ID = "my_task"
 RUN_ID = "manual__2024-11-24T21:03:01+01:00"
 QUEUE = "test"
 
-try:
+if AIRFLOW_V_3_2_PLUS:
     from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager  # noqa: F401
 
     stats_reference = "airflow.sdk._shared.observability.metrics.dual_stats_manager.DualStatsManager"
@@ -49,7 +51,7 @@ try:
         },
     }
     expected_call_count = 1
-except ImportError:
+else:
     from airflow.providers.common.compat.sdk import Stats
 
     stats_reference = f"{Stats.__module__}.Stats"

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
@@ -96,7 +96,8 @@ class TestJobsApiRoutes:
 
             mock_stats_incr.assert_called_with(
                 "edge_worker.ti.finish",
-                tags={
+                tags={},
+                legacy_name_tags={
                     "dag_id": DAG_ID,
                     "queue": QUEUE,
                     "state": TaskInstanceState.SUCCESS,

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_jobs.py
@@ -30,24 +30,40 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+DAG_ID = "my_dag"
+TASK_ID = "my_task"
+RUN_ID = "manual__2024-11-24T21:03:01+01:00"
+QUEUE = "test"
+
 try:
     from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager  # noqa: F401
 
     stats_reference = "airflow.sdk._shared.observability.metrics.dual_stats_manager.DualStatsManager"
+    expected_incr_kwargs = {
+        "tags": {},
+        "legacy_name_tags": {
+            "dag_id": DAG_ID,
+            "queue": QUEUE,
+            "state": TaskInstanceState.SUCCESS,
+            "task_id": TASK_ID,
+        },
+    }
     expected_call_count = 1
 except ImportError:
     from airflow.providers.common.compat.sdk import Stats
 
     stats_reference = f"{Stats.__module__}.Stats"
+    expected_incr_kwargs = {
+        "tags": {
+            "dag_id": DAG_ID,
+            "queue": QUEUE,
+            "state": TaskInstanceState.SUCCESS,
+            "task_id": TASK_ID,
+        },
+    }
     expected_call_count = 2
 
 pytestmark = pytest.mark.db_test
-
-
-DAG_ID = "my_dag"
-TASK_ID = "my_task"
-RUN_ID = "manual__2024-11-24T21:03:01+01:00"
-QUEUE = "test"
 
 
 class TestJobsApiRoutes:
@@ -94,16 +110,7 @@ class TestJobsApiRoutes:
                 session=session,
             )
 
-            mock_stats_incr.assert_called_with(
-                "edge_worker.ti.finish",
-                tags={},
-                legacy_name_tags={
-                    "dag_id": DAG_ID,
-                    "queue": QUEUE,
-                    "state": TaskInstanceState.SUCCESS,
-                    "task_id": TASK_ID,
-                },
-            )
+            mock_stats_incr.assert_called_with("edge_worker.ti.finish", **expected_incr_kwargs)
             assert mock_stats_incr.call_count == expected_call_count
 
             db_job: EdgeJobModel | None = session.scalar(select(EdgeJobModel))

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -167,7 +167,7 @@ class OpenLineageAdapter(LoggingMixin):
                     stack.enter_context(
                         DualStatsManager.timer(
                             "ol.emit.attempts",
-                            extra_tags={"event_type": event_type, "transport_type": transport_type},
+                            legacy_name_tags={"event_type": event_type, "transport_type": transport_type},
                         )
                     )
                 else:

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -36,11 +36,7 @@ from openlineage.client.facet_v2 import (
 )
 
 from airflow.providers.common.compat.sdk import Stats, conf as airflow_conf
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_2_PLUS
 from airflow.providers.openlineage import __version__ as OPENLINEAGE_PROVIDER_VERSION, conf
 from airflow.providers.openlineage.utils.utils import (
     OpenLineageRedactor,
@@ -163,7 +159,9 @@ class OpenLineageAdapter(LoggingMixin):
 
         try:
             with ExitStack() as stack:
-                if DualStatsManager is not None:
+                if AIRFLOW_V_3_2_PLUS:
+                    from airflow.sdk.observability.stats import DualStatsManager
+
                     stack.enter_context(
                         DualStatsManager.timer(
                             "ol.emit.attempts",

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -207,7 +207,7 @@ def test_emit_start_event(mock_stats_incr, mock_stats_timer):
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -325,7 +325,7 @@ def test_emit_start_event_with_additional_information(mock_stats_incr, mock_stat
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -388,7 +388,7 @@ def test_emit_complete_event(mock_stats_incr, mock_stats_timer):
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -508,7 +508,7 @@ def test_emit_complete_event_with_additional_information(mock_stats_incr, mock_s
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -571,7 +571,7 @@ def test_emit_failed_event(mock_stats_incr, mock_stats_timer):
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -692,7 +692,7 @@ def test_emit_failed_event_with_additional_information(mock_stats_incr, mock_sta
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -870,7 +870,7 @@ def test_emit_dag_started_event(mock_stats_incr, mock_stats_timer, build_ol_id, 
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -1042,7 +1042,7 @@ def test_emit_dag_complete_event(
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -1218,7 +1218,7 @@ def test_emit_dag_failed_event(
     mock_stats_incr.assert_not_called()
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")
@@ -1238,7 +1238,7 @@ def test_openlineage_adapter_stats_emit_failed(
 
     if AIRFLOW_V_3_2_PLUS:
         mock_stats_timer.assert_called_with(
-            "ol.emit.attempts", extra_tags={"event_type": ANY, "transport_type": ANY}
+            "ol.emit.attempts", legacy_name_tags={"event_type": ANY, "transport_type": ANY}
         )
     else:
         mock_stats_timer.assert_called_with("ol.emit.attempts")

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -60,11 +60,11 @@ from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_ma
 from tests_common.test_utils.taskinstance import create_task_instance
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
 
-try:
+if AIRFLOW_V_3_2_PLUS:
     from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager  # noqa: F401
 
     stats_reference = "airflow.sdk._shared.observability.metrics.dual_stats_manager.DualStatsManager"
-except ImportError:
+else:
     stats_reference = "airflow.providers.openlineage.plugins.adapter.Stats"
 
 

--- a/shared/observability/src/airflow_shared/observability/metrics/dual_stats_manager.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/dual_stats_manager.py
@@ -60,22 +60,22 @@ def _get_dict_with_defined_args(
     return defined_args_dict
 
 
-def _get_args_dict_with_extra_tags_if_set(
+def _get_args_dict_with_legacy_name_tags_if_set(
     args_dict: dict[str, Any] | None = None,
     prov_tags: dict[str, Any] | None = None,
-    prov_tags_extra: dict[str, Any] | None = None,
+    prov_tags_legacy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
-    Create a new merged tags dict if there are extra tags.
+    Create a new merged tags dict if there are legacy name tags.
 
     The new merged tags dict will replace the existing one, in the args dict.
     """
     # The args_dict already has the base tags.
-    # If there are no `extra_tags`, this method is basically
+    # If there are no `legacy_name_tags`, this method is basically
     # returning the `args_dict` unchanged.
     args_dict_full = dict(args_dict) if args_dict is not None else {}
 
-    tags_full = _get_tags_with_extra(prov_tags, prov_tags_extra)
+    tags_full = _get_tags_with_legacy(prov_tags, prov_tags_legacy)
 
     # Set `tags` only if there's something in `tags_full`.
     # If it's empty, remove any inherited key.
@@ -87,19 +87,19 @@ def _get_args_dict_with_extra_tags_if_set(
     return args_dict_full
 
 
-def _get_tags_with_extra(
+def _get_tags_with_legacy(
     prov_tags: dict[str, Any] | None = None,
-    prov_tags_extra: dict[str, Any] | None = None,
+    prov_tags_legacy: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Return a new dict with all tags if extra have been provided."""
-    # If there are no extra tags then return the original tags.
+    """Return a new dict with all tags if legacy name tags have been provided."""
+    # If there are no legacy name tags then return the original tags.
     tags_full: dict[str, Any] = {}
     if prov_tags:
         tags_full.update(prov_tags)
 
-    # If there are `extra_tags`, then add them to the dict.
-    if prov_tags_extra is not None:
-        tags_full.update(prov_tags_extra)
+    # If there are `legacy_name_tags`, then add them to the dict.
+    if prov_tags_legacy is not None:
+        tags_full.update(prov_tags_legacy)
 
     return tags_full
 
@@ -158,12 +158,12 @@ class DualStatsManager:
         rate: int | float | None = None,
         *,
         tags: dict[str, Any] | None = None,
-        extra_tags: dict[str, Any] | None = None,
+        legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
         kw = _get_dict_with_defined_args(count, rate, None, tags)
 
-        if cls.export_legacy_names and extra_tags is not None:
-            legacy_stat = cls.get_legacy_stat(stat=stat, variables=extra_tags)
+        if cls.export_legacy_names and legacy_name_tags is not None:
+            legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
             if legacy_stat is not None:
                 # Emit legacy metric
@@ -171,8 +171,10 @@ class DualStatsManager:
             else:
                 raise ValueError(f"Stat '{stat}' doesn't have a legacy name registered in the YAML file.")
 
-        kw_with_extra_tags_if_set = _get_args_dict_with_extra_tags_if_set(kw, tags, extra_tags)
-        Stats.incr(stat, **kw_with_extra_tags_if_set)
+        kw_with_legacy_name_tags_if_set = _get_args_dict_with_legacy_name_tags_if_set(
+            kw, tags, legacy_name_tags
+        )
+        Stats.incr(stat, **kw_with_legacy_name_tags_if_set)
 
     @classmethod
     def decr(
@@ -182,12 +184,12 @@ class DualStatsManager:
         rate: int | float | None = None,
         *,
         tags: dict[str, Any] | None = None,
-        extra_tags: dict[str, Any] | None = None,
+        legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
         kw = _get_dict_with_defined_args(count, rate, None, tags)
 
-        if cls.export_legacy_names and extra_tags is not None:
-            legacy_stat = cls.get_legacy_stat(stat=stat, variables=extra_tags)
+        if cls.export_legacy_names and legacy_name_tags is not None:
+            legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
             if legacy_stat is not None:
                 # Emit legacy metric
@@ -195,8 +197,10 @@ class DualStatsManager:
             else:
                 raise ValueError(f"Stat '{stat}' doesn't have a legacy name registered in the YAML file.")
 
-        kw_with_extra_tags_if_set = _get_args_dict_with_extra_tags_if_set(kw, tags, extra_tags)
-        Stats.decr(stat, **kw_with_extra_tags_if_set)
+        kw_with_legacy_name_tags_if_set = _get_args_dict_with_legacy_name_tags_if_set(
+            kw, tags, legacy_name_tags
+        )
+        Stats.decr(stat, **kw_with_legacy_name_tags_if_set)
 
     @classmethod
     def gauge(
@@ -207,12 +211,12 @@ class DualStatsManager:
         delta: bool | None = None,
         *,
         tags: dict[str, Any] | None = None,
-        extra_tags: dict[str, Any] | None = None,
+        legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
         kw = _get_dict_with_defined_args(None, rate, delta, tags)
 
-        if cls.export_legacy_names and extra_tags is not None:
-            legacy_stat = cls.get_legacy_stat(stat=stat, variables=extra_tags)
+        if cls.export_legacy_names and legacy_name_tags is not None:
+            legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
             if legacy_stat is not None:
                 # Emit legacy metric
@@ -220,8 +224,10 @@ class DualStatsManager:
             else:
                 raise ValueError(f"Stat '{stat}' doesn't have a legacy name registered in the YAML file.")
 
-        kw_with_extra_tags_if_set = _get_args_dict_with_extra_tags_if_set(kw, tags, extra_tags)
-        Stats.gauge(stat, value, **kw_with_extra_tags_if_set)
+        kw_with_legacy_name_tags_if_set = _get_args_dict_with_legacy_name_tags_if_set(
+            kw, tags, legacy_name_tags
+        )
+        Stats.gauge(stat, value, **kw_with_legacy_name_tags_if_set)
 
     @classmethod
     def timing(
@@ -230,10 +236,10 @@ class DualStatsManager:
         dt: DeltaType,
         *,
         tags: dict[str, Any] | None = None,
-        extra_tags: dict[str, Any] | None = None,
+        legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
-        if cls.export_legacy_names and extra_tags is not None:
-            legacy_stat = cls.get_legacy_stat(stat=stat, variables=extra_tags)
+        if cls.export_legacy_names and legacy_name_tags is not None:
+            legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
             if legacy_stat is not None:
                 if tags:
@@ -243,10 +249,10 @@ class DualStatsManager:
             else:
                 raise ValueError(f"Stat '{stat}' doesn't have a legacy name registered in the YAML file.")
 
-        tags_with_extra = _get_tags_with_extra(tags, extra_tags)
+        tags_with_legacy = _get_tags_with_legacy(tags, legacy_name_tags)
 
-        if tags_with_extra:
-            Stats.timing(stat, dt, tags=tags_with_extra)
+        if tags_with_legacy:
+            Stats.timing(stat, dt, tags=tags_with_legacy)
         else:
             Stats.timing(stat, dt)
 
@@ -255,7 +261,7 @@ class DualStatsManager:
         cls,
         stat: str,
         tags: dict[str, Any] | None = None,
-        extra_tags: dict[str, Any] | None = None,
+        legacy_name_tags: dict[str, Any] | None = None,
         **kwargs,
     ):
         kw = dict(kwargs)
@@ -265,8 +271,8 @@ class DualStatsManager:
         # Used with a context manager.
         stack = ExitStack()
 
-        if cls.export_legacy_names and extra_tags is not None:
-            legacy_stat = cls.get_legacy_stat(stat=stat, variables=extra_tags)
+        if cls.export_legacy_names and legacy_name_tags is not None:
+            legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
             ctx_mg1: AbstractContextManager[Any] = cast(
                 "AbstractContextManager[Any]", Stats.timer(legacy_stat, **kw)
@@ -276,7 +282,9 @@ class DualStatsManager:
 
         stack.enter_context(ctx_mg1)
 
-        kw_with_extra_tags_if_set = _get_args_dict_with_extra_tags_if_set(kw, tags, extra_tags)
-        stack.enter_context(Stats.timer(stat, **kw_with_extra_tags_if_set))
+        kw_with_legacy_name_tags_if_set = _get_args_dict_with_legacy_name_tags_if_set(
+            kw, tags, legacy_name_tags
+        )
+        stack.enter_context(Stats.timer(stat, **kw_with_legacy_name_tags_if_set))
 
         return stack

--- a/shared/observability/src/airflow_shared/observability/metrics/dual_stats_manager.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/dual_stats_manager.py
@@ -160,6 +160,15 @@ class DualStatsManager:
         tags: dict[str, Any] | None = None,
         legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
+        """
+        Increases the stat counter.
+
+        Legacy name tags are cross-referenced with the registry yaml file.
+        The 'tags' and 'legacy_name_tags' dictionaries are merged.
+
+        :param tags: Extra tags that are set to both new and legacy metrics
+        :param legacy_name_tags: Tags that will be used for the legacy name metric
+        """
         kw = _get_dict_with_defined_args(count, rate, None, tags)
 
         if cls.export_legacy_names and legacy_name_tags is not None:
@@ -186,6 +195,15 @@ class DualStatsManager:
         tags: dict[str, Any] | None = None,
         legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
+        """
+        Decreases the stat counter.
+
+        Legacy name tags are cross-referenced with the registry yaml file.
+        The 'tags' and 'legacy_name_tags' dictionaries are merged.
+
+        :param tags: Extra tags that are set to both new and legacy metrics
+        :param legacy_name_tags: Tags that will be used for the legacy name metric
+        """
         kw = _get_dict_with_defined_args(count, rate, None, tags)
 
         if cls.export_legacy_names and legacy_name_tags is not None:
@@ -213,6 +231,15 @@ class DualStatsManager:
         tags: dict[str, Any] | None = None,
         legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
+        """
+        Gauges the stat.
+
+        Legacy name tags are cross-referenced with the registry yaml file.
+        The 'tags' and 'legacy_name_tags' dictionaries are merged.
+
+        :param tags: Extra tags that are set to both new and legacy metrics
+        :param legacy_name_tags: Tags that will be used for the legacy name metric
+        """
         kw = _get_dict_with_defined_args(None, rate, delta, tags)
 
         if cls.export_legacy_names and legacy_name_tags is not None:
@@ -238,6 +265,15 @@ class DualStatsManager:
         tags: dict[str, Any] | None = None,
         legacy_name_tags: dict[str, Any] | None = None,
     ) -> None:
+        """
+        Stat timing.
+
+        Legacy name tags are cross-referenced with the registry yaml file.
+        The 'tags' and 'legacy_name_tags' dictionaries are merged.
+
+        :param tags: Extra tags that are set to both new and legacy metrics
+        :param legacy_name_tags: Tags that will be used for the legacy name metric
+        """
         if cls.export_legacy_names and legacy_name_tags is not None:
             legacy_stat = cls.get_legacy_stat(stat=stat, variables=legacy_name_tags)
 
@@ -264,6 +300,15 @@ class DualStatsManager:
         legacy_name_tags: dict[str, Any] | None = None,
         **kwargs,
     ):
+        """
+        Stat timer with a context manager.
+
+        Legacy name tags are cross-referenced with the registry yaml file.
+        The 'tags' and 'legacy_name_tags' dictionaries are merged.
+
+        :param tags: Extra tags that are set to both new and legacy metrics
+        :param legacy_name_tags: Tags that will be used for the legacy name metric
+        """
         kw = dict(kwargs)
         if tags is not None:
             kw["tags"] = tags

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -262,6 +262,19 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "edge_worker.ti.start"
+    description: "Number of task instances started in an edge worker"
+    type: "counter"
+    legacy_name: "edge_worker.ti.start.{queue}.{dag_id}.{task_id}"
+    name_variables: ["queue", "dag_id", "task_id"]
+
+  - name: "edge_worker.ti.finish"
+    description: "Number of task instances finished in an edge worker"
+    type: "counter"
+    legacy_name: "edge_worker.ti.finish.{queue}.{state}.{dag_id}.{task_id}"
+    name_variables: ["queue", "state", "dag_id", "task_id"]
+
+
   # ==========
   # Gauges
   # ==========
@@ -486,8 +499,8 @@ metrics:
   - name: "dag_processing.last_duration"
     description: "Milliseconds taken to load the given Dag file"
     type: "timer"
-    legacy_name: "dag_processing.last_duration.{dag_file}"
-    name_variables: ["dag_file"]
+    legacy_name: "dag_processing.last_duration.{bundle_name}.{file_name}"
+    name_variables: ["bundle_name", "file_name"]
 
   - name: "dagrun.duration.success"
     description: "Milliseconds taken for a DagRun to reach success state"

--- a/shared/observability/tests/observability/metrics/test_dual_stats_manager.py
+++ b/shared/observability/tests/observability/metrics/test_dual_stats_manager.py
@@ -119,79 +119,81 @@ class TestDualStatsManager:
         assert sorted(args_dict) == sorted(expected_args_dict)
 
     @pytest.mark.parametrize(
-        ("args_dict", "tags", "extra_tags", "expected_args_dict"),
+        ("args_dict", "tags", "legacy_name_tags", "expected_args_dict"),
         [
             pytest.param(
                 {"count": 1},
                 {"test": True},
                 {},
                 {"count": 1, "tags": {"test": True}},
-                id="no_extra_tags",
+                id="no_legacy_name_tags",
             ),
             pytest.param(
                 {},
                 {"test": True},
                 {},
                 {"tags": {"test": True}},
-                id="no_args_no_extra_but_tags",
+                id="no_args_no_legacy_but_tags",
             ),
             pytest.param(
                 {},
                 {"test": True},
-                {"test_extra": True},
-                {"tags": {"test": True, "test_extra": True}},
-                id="no_args_but_tags_and_extra",
+                {"test_legacy": True},
+                {"tags": {"test": True, "test_legacy": True}},
+                id="no_args_but_tags_and_legacy",
             ),
             pytest.param(
                 {"count": 1},
                 {"test": True},
                 {},
                 {"count": 1, "tags": {"test": True}},
-                id="no_args_no_tags_but_extra_tags",
+                id="no_args_no_tags_but_legacy_name_tags",
             ),
             pytest.param(
                 {"count": 1},
                 {"test": True},
-                {"test_extra": True},
-                {"count": 1, "tags": {"test": True, "test_extra": True}},
+                {"test_legacy": True},
+                {"count": 1, "tags": {"test": True, "test_legacy": True}},
                 id="all_params_provided",
             ),
             pytest.param(
                 {"count": 1, "rate": 3},
                 {"test1": True, "test2": False},
-                {"test_extra1": True, "test_extra2": False, "test_extra3": True},
+                {"test_legacy1": True, "test_legacy2": False, "test_legacy3": True},
                 {
                     "count": 1,
                     "rate": 3,
                     "tags": {
                         "test1": True,
                         "test2": False,
-                        "test_extra1": True,
-                        "test_extra2": False,
-                        "test_extra3": True,
+                        "test_legacy1": True,
+                        "test_legacy2": False,
+                        "test_legacy3": True,
                     },
                 },
                 id="multiple_params",
             ),
         ],
     )
-    def test_get_args_dict_with_extra_tags_if_set(
+    def test_get_args_dict_with_legacy_name_tags_if_set(
         self,
         args_dict: dict[str, Any] | None,
         tags: dict[str, Any] | None,
-        extra_tags: dict[str, Any] | None,
+        legacy_name_tags: dict[str, Any] | None,
         expected_args_dict: dict[str, Any],
     ):
-        dict_full = dual_stats_manager._get_args_dict_with_extra_tags_if_set(args_dict, tags, extra_tags)
+        dict_full = dual_stats_manager._get_args_dict_with_legacy_name_tags_if_set(
+            args_dict, tags, legacy_name_tags
+        )
         assert sorted(dict_full) == sorted(expected_args_dict)
 
     @pytest.mark.parametrize(
-        ("tags", "extra_tags", "expected_tags_dict"),
+        ("tags", "legacy_name_tags", "expected_tags_dict"),
         [
             pytest.param(
                 {"test": True},
-                {"test_extra": True},
-                {"test": True, "test_extra": True},
+                {"test_legacy": True},
+                {"test": True, "test_legacy": True},
                 id="all_params_provided",
             ),
             pytest.param(
@@ -208,31 +210,31 @@ class TestDualStatsManager:
             ),
             pytest.param(
                 {},
-                {"test_extra": True},
-                {"test_extra": True},
-                id="only_extra",
+                {"test_legacy": True},
+                {"test_legacy": True},
+                id="only_legacy",
             ),
             pytest.param(
                 {"test1": True, "test2": False},
-                {"test_extra1": True, "test_extra2": False, "test_extra3": True},
+                {"test_legacy1": True, "test_legacy2": False, "test_legacy3": True},
                 {
                     "test1": True,
                     "test2": False,
-                    "test_extra1": True,
-                    "test_extra2": False,
-                    "test_extra3": True,
+                    "test_legacy1": True,
+                    "test_legacy2": False,
+                    "test_legacy3": True,
                 },
                 id="multiple_params",
             ),
         ],
     )
-    def test_get_tags_with_extra(
+    def test_get_tags_with_legacy(
         self,
         tags: dict[str, Any] | None,
-        extra_tags: dict[str, Any] | None,
+        legacy_name_tags: dict[str, Any] | None,
         expected_tags_dict: dict[str, Any],
     ):
-        tags_full = dual_stats_manager._get_tags_with_extra(tags, extra_tags)
+        tags_full = dual_stats_manager._get_tags_with_legacy(tags, legacy_name_tags)
         assert sorted(tags_full) == sorted(expected_tags_dict)
 
     @pytest.mark.parametrize(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -41,6 +41,7 @@ from pydantic import AwareDatetime, ConfigDict, Field, JsonValue, TypeAdapter
 
 from airflow.dag_processing.bundles.base import BaseDagBundle, BundleVersionLock
 from airflow.dag_processing.bundles.manager import DagBundlesManager
+from airflow.sdk._shared.observability.metrics.dual_stats_manager import DualStatsManager
 from airflow.sdk._shared.observability.metrics.stats import Stats
 from airflow.sdk.api.client import get_hostname, getuser
 from airflow.sdk.api.datamodels._generated import (
@@ -1746,8 +1747,12 @@ def finalize(
         duration_ms = (ti.end_date - ti.start_date).total_seconds() * 1000
         stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}
 
-        Stats.timing(f"dag.{ti.dag_id}.{ti.task_id}.duration", duration_ms)
-        Stats.timing("task.duration", duration_ms, tags=stats_tags)
+        DualStatsManager.timing(
+            "task.duration",
+            duration_ms,
+            tags=stats_tags,
+            legacy_name_tags={"dag_id": ti.dag_id, "task_id": ti.task_id},
+        )
 
     task = ti.task
     # Pushing xcom for each operator extra links defined on the operator only.


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related discussion: https://github.com/apache/airflow/pull/62019#discussion_r2812822658

## DualStatsManager code explanation

Usually the legacy metrics don't have any tags and all the variables are included in the name.

The `tags` dict refers to tags that are set on both the new name metric and the legacy name metric (separately from the name variables).

The `legacy_name_tags` dict refers to the legacy name variables.

The legacy metrics will only have the `tags` values as tags.

Both dictionaries are eventually merged and the resulting dict is used for the final tags of the new metric.

For example,
```
tags={},
legacy_name_tags=tags
```
the legacy metric won't have any tags and after that is exported, `{}` and `tags` are merged and then set as the new metric tags.

## Patch changes

The patch is consisted of the following changes
* renamed `extra_tags` to `legacy_name_tags` for clarity
* added explanation comments in the `DualStasManager`
* replaced the word `...extra...` with the word `...legacy...` in all references
* cleaned up mess-ups with the `tags` and `legacy_name_tags` params
* added missing stats in the `metrics_template.yaml`
* for providers, followed the `try-except` pattern for the DualStatsManager import and maintained the old Stats calls as fallbacks

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No


<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
