### PR TITLE
Make temporal mapper timezone aware

### DIFF
--- a/airflow-core/src/airflow/partition_mappers/temporal.py
+++ b/airflow-core/src/airflow/partition_mappers/temporal.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from airflow._shared.timezones.timezone import parse_timezone
 from airflow.partition_mappers.base import PartitionMapper
+
+if TYPE_CHECKING:
+    from pendulum import FixedTimezone, Timezone
 
 
 class _BaseTemporalMapper(PartitionMapper, ABC):
@@ -30,11 +34,16 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
 
     def __init__(
         self,
-        input_format: str = "%Y-%m-%dT%H:%M:%S",
+        *,
+        timezone: str | Timezone | FixedTimezone,
+        input_format: str = "%Y-%m-%dT%H:%M:%S%z",
         output_format: str | None = None,
     ):
         self.input_format = input_format
         self.output_format = output_format or self.default_output_format
+        if isinstance(timezone, str):
+            timezone = parse_timezone(timezone)
+        self._timezone = timezone
 
     def to_downstream(self, key: str) -> str:
         dt = datetime.strptime(key, self.input_format)
@@ -50,7 +59,10 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
         return dt.strftime(self.output_format)
 
     def serialize(self) -> dict[str, Any]:
+        from airflow.serialization.encoders import encode_timezone
+
         return {
+            "timezone": encode_timezone(self._timezone),
             "input_format": self.input_format,
             "output_format": self.output_format,
         }
@@ -58,6 +70,7 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
         return cls(
+            timezone=parse_timezone(data["timezone"]),
             input_format=data["input_format"],
             output_format=data["output_format"],
         )
@@ -66,7 +79,7 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
 class StartOfHourMapper(_BaseTemporalMapper):
     """Map a time-based partition key to hour."""
 
-    default_output_format = "%Y-%m-%dT%H"
+    default_output_format = "%Y-%m-%dT%H%z"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(minute=0, second=0, microsecond=0)
@@ -75,7 +88,7 @@ class StartOfHourMapper(_BaseTemporalMapper):
 class StartOfDayMapper(_BaseTemporalMapper):
     """Map a time-based partition key to day."""
 
-    default_output_format = "%Y-%m-%d"
+    default_output_format = "%Y-%m-%d%z"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -84,7 +97,7 @@ class StartOfDayMapper(_BaseTemporalMapper):
 class StartOfWeekMapper(_BaseTemporalMapper):
     """Map a time-based partition key to week."""
 
-    default_output_format = "%Y-%m-%d (W%V)"
+    default_output_format = "%Y-%m-%d (W%V)%z"
 
     def normalize(self, dt: datetime) -> datetime:
         start = dt - timedelta(days=dt.weekday())
@@ -94,7 +107,7 @@ class StartOfWeekMapper(_BaseTemporalMapper):
 class StartOfMonthMapper(_BaseTemporalMapper):
     """Map a time-based partition key to month."""
 
-    default_output_format = "%Y-%m"
+    default_output_format = "%Y-%m%z"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(
@@ -109,7 +122,7 @@ class StartOfMonthMapper(_BaseTemporalMapper):
 class StartOfQuarterMapper(_BaseTemporalMapper):
     """Map a time-based partition key to quarter."""
 
-    default_output_format = "%Y-Q{quarter}"
+    default_output_format = "%Y-Q{quarter}%z"
 
     def normalize(self, dt: datetime) -> datetime:
         quarter = (dt.month - 1) // 3
@@ -131,7 +144,7 @@ class StartOfQuarterMapper(_BaseTemporalMapper):
 class StartOfYearMapper(_BaseTemporalMapper):
     """Map a time-based partition key to year."""
 
-    default_output_format = "%Y"
+    default_output_format = "%Y%z"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(

--- a/airflow-core/src/airflow/partition_mappers/temporal.py
+++ b/airflow-core/src/airflow/partition_mappers/temporal.py
@@ -49,6 +49,8 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
         dt = datetime.strptime(key, self.input_format)
         if dt.tzinfo is None:
             dt = make_aware(dt, self._timezone)
+        else:
+            dt = dt.astimezone(self._timezone)
         normalized = self.normalize(dt)
         return self.format(normalized)
 

--- a/airflow-core/src/airflow/partition_mappers/temporal.py
+++ b/airflow-core/src/airflow/partition_mappers/temporal.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from airflow._shared.timezones.timezone import parse_timezone
+from airflow._shared.timezones.timezone import make_aware, parse_timezone
 from airflow.partition_mappers.base import PartitionMapper
 
 if TYPE_CHECKING:
@@ -35,8 +35,8 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
     def __init__(
         self,
         *,
-        timezone: str | Timezone | FixedTimezone,
-        input_format: str = "%Y-%m-%dT%H:%M:%S%z",
+        timezone: str | Timezone | FixedTimezone = "UTC",
+        input_format: str = "%Y-%m-%dT%H:%M:%S",
         output_format: str | None = None,
     ):
         self.input_format = input_format
@@ -47,6 +47,8 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
 
     def to_downstream(self, key: str) -> str:
         dt = datetime.strptime(key, self.input_format)
+        if dt.tzinfo is None:
+            dt = make_aware(dt, self._timezone)
         normalized = self.normalize(dt)
         return self.format(normalized)
 
@@ -70,7 +72,7 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
     @classmethod
     def deserialize(cls, data: dict[str, Any]) -> PartitionMapper:
         return cls(
-            timezone=parse_timezone(data["timezone"]),
+            timezone=parse_timezone(data.get("timezone", "UTC")),
             input_format=data["input_format"],
             output_format=data["output_format"],
         )
@@ -79,7 +81,7 @@ class _BaseTemporalMapper(PartitionMapper, ABC):
 class StartOfHourMapper(_BaseTemporalMapper):
     """Map a time-based partition key to hour."""
 
-    default_output_format = "%Y-%m-%dT%H%z"
+    default_output_format = "%Y-%m-%dT%H"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(minute=0, second=0, microsecond=0)
@@ -88,7 +90,7 @@ class StartOfHourMapper(_BaseTemporalMapper):
 class StartOfDayMapper(_BaseTemporalMapper):
     """Map a time-based partition key to day."""
 
-    default_output_format = "%Y-%m-%d%z"
+    default_output_format = "%Y-%m-%d"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -97,7 +99,7 @@ class StartOfDayMapper(_BaseTemporalMapper):
 class StartOfWeekMapper(_BaseTemporalMapper):
     """Map a time-based partition key to week."""
 
-    default_output_format = "%Y-%m-%d (W%V)%z"
+    default_output_format = "%Y-%m-%d (W%V)"
 
     def normalize(self, dt: datetime) -> datetime:
         start = dt - timedelta(days=dt.weekday())
@@ -107,7 +109,7 @@ class StartOfWeekMapper(_BaseTemporalMapper):
 class StartOfMonthMapper(_BaseTemporalMapper):
     """Map a time-based partition key to month."""
 
-    default_output_format = "%Y-%m%z"
+    default_output_format = "%Y-%m"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(
@@ -122,7 +124,7 @@ class StartOfMonthMapper(_BaseTemporalMapper):
 class StartOfQuarterMapper(_BaseTemporalMapper):
     """Map a time-based partition key to quarter."""
 
-    default_output_format = "%Y-Q{quarter}%z"
+    default_output_format = "%Y-Q{quarter}"
 
     def normalize(self, dt: datetime) -> datetime:
         quarter = (dt.month - 1) // 3
@@ -144,7 +146,7 @@ class StartOfQuarterMapper(_BaseTemporalMapper):
 class StartOfYearMapper(_BaseTemporalMapper):
     """Map a time-based partition key to year."""
 
-    default_output_format = "%Y%z"
+    default_output_format = "%Y"
 
     def normalize(self, dt: datetime) -> datetime:
         return dt.replace(

--- a/airflow-core/tests/unit/partition_mappers/test_temporal.py
+++ b/airflow-core/tests/unit/partition_mappers/test_temporal.py
@@ -46,7 +46,7 @@ class TestTemporalMappers:
         mapper_cls: type[_BaseTemporalMapper],
         expected_downstream_key: str,
     ):
-        pm = mapper_cls(timezone="UTC")
+        pm = mapper_cls()
         assert pm.to_downstream("2026-02-10T14:30:45") == expected_downstream_key
 
     @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ class TestTemporalMappers:
         ],
     )
     def test_serialize(self, mapper_cls: type[_BaseTemporalMapper], expected_outut_format: str):
-        pm = mapper_cls(timezone="UTC")
+        pm = mapper_cls()
         assert pm.serialize() == {
             "timezone": "UTC",
             "input_format": "%Y-%m-%dT%H:%M:%S",
@@ -91,27 +91,6 @@ class TestTemporalMappers:
         assert pm.input_format == "%Y-%m-%dT%H:%M:%S"
         assert pm.output_format == "customized-format"
 
-    @pytest.mark.parametrize(
-        "mapper_cls",
-        [
-            StartOfHourMapper,
-            StartOfDayMapper,
-            StartOfWeekMapper,
-            StartOfMonthMapper,
-            StartOfQuarterMapper,
-            StartOfYearMapper,
-        ],
-    )
-    def test_deserialize_legacy_no_timezone(self, mapper_cls):
-        """Deserializing data without a timezone key defaults to UTC."""
-        pm = mapper_cls.deserialize(
-            {
-                "input_format": "%Y-%m-%dT%H:%M:%S",
-                "output_format": "customized-format",
-            }
-        )
-        assert isinstance(pm, mapper_cls)
-
     def test_to_downstream_timezone_aware(self):
         """Input is interpreted as local time in the given timezone."""
         pm = StartOfDayMapper(timezone="America/New_York")
@@ -119,3 +98,17 @@ class TestTemporalMappers:
         assert pm.to_downstream("2026-02-10T23:00:00") == "2026-02-10"
         # 2026-02-11T01:00:00 in New York local time → start-of-day is 2026-02-11
         assert pm.to_downstream("2026-02-11T01:00:00") == "2026-02-11"
+
+    def test_to_downstream_input_timezone_differs_from_mapper_timezone(self):
+        """When input_format includes %z and the parsed tz differs from the mapper tz,
+        the key is converted to the mapper timezone before normalization."""
+        pm = StartOfDayMapper(
+            timezone="America/New_York",
+            input_format="%Y-%m-%dT%H:%M:%S%z",
+        )
+        # 2026-02-11T04:00:00+00:00 UTC == 2026-02-10T23:00:00-05:00 New York
+        # → start-of-day in New York is 2026-02-10, not 2026-02-11
+        assert pm.to_downstream("2026-02-11T04:00:00+0000") == "2026-02-10"
+        # 2026-02-11T06:00:00+00:00 UTC == 2026-02-11T01:00:00-05:00 New York
+        # → start-of-day in New York is 2026-02-11
+        assert pm.to_downstream("2026-02-11T06:00:00+0000") == "2026-02-11"

--- a/airflow-core/tests/unit/partition_mappers/test_temporal.py
+++ b/airflow-core/tests/unit/partition_mappers/test_temporal.py
@@ -46,7 +46,7 @@ class TestTemporalMappers:
         mapper_cls: type[_BaseTemporalMapper],
         expected_downstream_key: str,
     ):
-        pm = mapper_cls()
+        pm = mapper_cls(timezone="UTC")
         assert pm.to_downstream("2026-02-10T14:30:45") == expected_downstream_key
 
     @pytest.mark.parametrize(
@@ -61,8 +61,9 @@ class TestTemporalMappers:
         ],
     )
     def test_serialize(self, mapper_cls: type[_BaseTemporalMapper], expected_outut_format: str):
-        pm = mapper_cls()
+        pm = mapper_cls(timezone="UTC")
         assert pm.serialize() == {
+            "timezone": "UTC",
             "input_format": "%Y-%m-%dT%H:%M:%S",
             "output_format": expected_outut_format,
         }
@@ -81,6 +82,7 @@ class TestTemporalMappers:
     def test_deserialize(self, mapper_cls):
         pm = mapper_cls.deserialize(
             {
+                "timezone": "UTC",
                 "input_format": "%Y-%m-%dT%H:%M:%S",
                 "output_format": "customized-format",
             }
@@ -88,3 +90,32 @@ class TestTemporalMappers:
         assert isinstance(pm, mapper_cls)
         assert pm.input_format == "%Y-%m-%dT%H:%M:%S"
         assert pm.output_format == "customized-format"
+
+    @pytest.mark.parametrize(
+        "mapper_cls",
+        [
+            StartOfHourMapper,
+            StartOfDayMapper,
+            StartOfWeekMapper,
+            StartOfMonthMapper,
+            StartOfQuarterMapper,
+            StartOfYearMapper,
+        ],
+    )
+    def test_deserialize_legacy_no_timezone(self, mapper_cls):
+        """Deserializing data without a timezone key defaults to UTC."""
+        pm = mapper_cls.deserialize(
+            {
+                "input_format": "%Y-%m-%dT%H:%M:%S",
+                "output_format": "customized-format",
+            }
+        )
+        assert isinstance(pm, mapper_cls)
+
+    def test_to_downstream_timezone_aware(self):
+        """Input is interpreted as local time in the given timezone."""
+        pm = StartOfDayMapper(timezone="America/New_York")
+        # 2026-02-10T23:00:00 in New York local time → start-of-day is 2026-02-10
+        assert pm.to_downstream("2026-02-10T23:00:00") == "2026-02-10"
+        # 2026-02-11T01:00:00 in New York local time → start-of-day is 2026-02-11
+        assert pm.to_downstream("2026-02-11T01:00:00") == "2026-02-11"

--- a/airflow-core/tests/unit/partition_mappers/test_temporal.py
+++ b/airflow-core/tests/unit/partition_mappers/test_temporal.py
@@ -50,6 +50,13 @@ class TestTemporalMappers:
         assert pm.to_downstream("2026-02-10T14:30:45") == expected_downstream_key
 
     @pytest.mark.parametrize(
+        ("timezone", "expected_timezone"),
+        [
+            (None, "UTC"),
+            ("America/New_York", "America/New_York"),
+        ],
+    )
+    @pytest.mark.parametrize(
         ("mapper_cls", "expected_outut_format"),
         [
             (StartOfHourMapper, "%Y-%m-%dT%H"),
@@ -60,10 +67,16 @@ class TestTemporalMappers:
             (StartOfYearMapper, "%Y"),
         ],
     )
-    def test_serialize(self, mapper_cls: type[_BaseTemporalMapper], expected_outut_format: str):
-        pm = mapper_cls()
+    def test_serialize(
+        self,
+        mapper_cls: type[_BaseTemporalMapper],
+        expected_outut_format: str,
+        timezone: str | None,
+        expected_timezone: str,
+    ):
+        pm = mapper_cls() if timezone is None else mapper_cls(timezone=timezone)
         assert pm.serialize() == {
-            "timezone": "UTC",
+            "timezone": expected_timezone,
             "input_format": "%Y-%m-%dT%H:%M:%S",
             "output_format": expected_outut_format,
         }


### PR DESCRIPTION
## Why
Currently, `CronPartitionedTimetable` does not generate a timezone-aware partition key. Temporal partition mappers do not support timezone either. This might make the result misleading

## What
Make `CronParitionedTimetable` generate a timezone-aware partition key by default and make partition mappers parse the time info and then output a timezone aware partition key

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
