### PR TITLE
Fix backward compatibility for ``workloads.TaskInstance`` import

### DIFF
--- a/airflow-core/tests/unit/executors/test_workloads.py
+++ b/airflow-core/tests/unit/executors/test_workloads.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,33 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Workload schemas for executor communication."""
-
 from __future__ import annotations
 
-from typing import Annotated
+from airflow.executors import workloads
+from airflow.executors.workloads import TaskInstance, TaskInstanceDTO
 
-from pydantic import Field
 
-from airflow.executors.workloads.base import BaseWorkload, BundleInfo
-from airflow.executors.workloads.callback import CallbackFetchMethod, ExecuteCallback
-from airflow.executors.workloads.task import ExecuteTask, TaskInstanceDTO
-from airflow.executors.workloads.trigger import RunTrigger
-
-All = Annotated[
-    ExecuteTask | ExecuteCallback | RunTrigger,
-    Field(discriminator="type"),
-]
-
-TaskInstance = TaskInstanceDTO
-
-__all__ = [
-    "All",
-    "BaseWorkload",
-    "BundleInfo",
-    "CallbackFetchMethod",
-    "ExecuteCallback",
-    "ExecuteTask",
-    "TaskInstance",
-    "TaskInstanceDTO",
-]
+def test_task_instance_alias_keeps_backwards_compat():
+    assert TaskInstance is TaskInstanceDTO
+    assert workloads.TaskInstance is TaskInstanceDTO
+    assert workloads.TaskInstanceDTO is TaskInstanceDTO


### PR DESCRIPTION
Re-export `TaskInstance` from `airflow.executors.workloads` as an alias to `TaskInstanceDTO` so integrations using the old import path continue to work. Add a regression test that verifies the alias remains available.

This broke in https://github.com/apache/airflow/pull/61153

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
