### PR TITLE
feat(keycloak): add method to retrieve teams from Keycloak as resources

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -471,6 +471,24 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
             )
         raise AirflowException(f"Unexpected error: {resp.status_code} - {resp.text}")
 
+    def _get_teams(self) -> set[str]:
+        realm = conf.get(CONF_SECTION_NAME, CONF_REALM_KEY)
+        server_url = conf.get(CONF_SECTION_NAME, CONF_SERVER_URL_KEY)
+
+        pat = self.get_keycloak_client().token(grant_type="client_credentials")["access_token"]
+
+        prefix = f"{KeycloakResource.TEAM.value}:"
+        resource_url = f"{server_url.rstrip('/')}/realms/{realm}/authz/protection/resource_set"
+        resources_resp = self.http_session.get(
+            resource_url,
+            params={"name": prefix, "matchingUri": "false", "max": -1, "deep": "true"},
+            headers={"Authorization": f"Bearer {pat}"},
+            timeout=5,
+        )
+        resources_resp.raise_for_status()
+
+        return {r["name"][len(prefix) :] for r in resources_resp.json() if r["name"].startswith(prefix)}
+
     @staticmethod
     def _get_token_url(server_url, realm):
         # Normalize server_url to avoid double slashes (required for Keycloak 26.4+ strict path validation).

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -481,7 +481,7 @@ class KeycloakAuthManager(BaseAuthManager[KeycloakAuthManagerUser]):
         resource_url = f"{server_url.rstrip('/')}/realms/{realm}/authz/protection/resource_set"
         resources_resp = self.http_session.get(
             resource_url,
-            params={"name": prefix, "matchingUri": "false", "max": -1, "deep": "true"},
+            params={"name": prefix, "matchingUri": "false", "max": "-1", "deep": "true"},
             headers={"Authorization": f"Bearer {pat}"},
             timeout=5,
         )

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -956,7 +956,7 @@ class TestKeycloakAuthManager:
         assert result == {"team-a", "team-b"}
         auth_manager_multi_team.http_session.get.assert_called_once_with(
             "server_url/realms/realm/authz/protection/resource_set",
-            params={"name": "Team:", "matchingUri": "false", "max": -1, "deep": "true"},
+            params={"name": "Team:", "matchingUri": "false", "max": "-1", "deep": "true"},
             headers={"Authorization": "Bearer pat-token"},
             timeout=5,
         )

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py
@@ -933,3 +933,30 @@ class TestKeycloakAuthManager:
         """Test that _get_token_url normalizes server_url by stripping trailing slashes."""
         token_url = auth_manager._get_token_url(server_url, "myrealm")
         assert token_url == expected_url
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Team not available before Airflow 3.2.0")
+    @patch(
+        "airflow.providers.keycloak.auth_manager.keycloak_auth_manager.KeycloakAuthManager.get_keycloak_client"
+    )
+    def test_get_teams(self, mock_get_keycloak_client, auth_manager_multi_team):
+        """_get_teams fetches Team: resources from Keycloak and returns team names."""
+        mock_get_keycloak_client.return_value.token.return_value = {"access_token": "pat-token"}
+
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {"name": "Team:team-a", "type": "urn:airflow:resource"},
+            {"name": "Team:team-b", "type": "urn:airflow:resource"},
+            {"name": "Connection", "type": "urn:airflow:resource"},  # should be ignored
+        ]
+        mock_response.raise_for_status = Mock()
+        auth_manager_multi_team.http_session.get = Mock(return_value=mock_response)
+
+        result = auth_manager_multi_team._get_teams()
+
+        assert result == {"team-a", "team-b"}
+        auth_manager_multi_team.http_session.get.assert_called_once_with(
+            "server_url/realms/realm/authz/protection/resource_set",
+            params={"name": "Team:", "matchingUri": "false", "max": -1, "deep": "true"},
+            headers={"Authorization": "Bearer pat-token"},
+            timeout=5,
+        )


### PR DESCRIPTION
Implement `_get_teams()` in `KeycloakAuthManager` to allow Airflow to
discover teams defined in Keycloak when `multi_team=True`.

Follow-up on https://github.com/apache/airflow/pull/62527
Part of https://github.com/apache/airflow/issues/62252

## Background

`BaseAuthManager._get_teams()` is called at startup when
`AIRFLOW__CORE__MULTI_TEAM=True` to sync team definitions between the
auth manager backend and Airflow's internal team table. Without this
implementation, the API server crashes on startup when using the Keycloak
auth manager in multi-tenant mode.

## Implementation

Teams are stored in Keycloak as UMA (User-Managed Access) resources
named `Team:{team_name}` (e.g. `Team:team-a`). The implementation:

1. Obtains a Protection API Token (PAT) via the client credentials grant
   — user context is not available at startup, so we authenticate as the
   service itself.
2. Calls the UMA Protection API (`/realms/{realm}/authz/protection/resource_set`)
   with `name=Team:` (prefix filter) and `deep=true` (returns full
   resource objects, not just IDs).
3. Strips the `Team:` prefix from each matching resource name and
   returns the resulting set of team names.

## Testing

Unit test added for `_get_teams()`, covering:
- PAT acquisition via `get_keycloak_client().token(grant_type="client_credentials")`
- Correct URL and query params sent to Keycloak
- Filtering of non-`Team:` resources
- Correct stripping of the `Team:` prefix

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6
