### PR TITLE
Fix chart NOTES.txt showing deprecation warnings only without secret key

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -213,8 +213,6 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if not (or .Values.webserverSecretKey .Values.webserverSecretKeySecretName .Values.apiSecretKey .Values.apiSecretKeySecretName) }}
-
 {{- if .Values.securityContext }}
 
  DEPRECATION WARNING:
@@ -407,6 +405,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not (or .Values.webserverSecretKey .Values.webserverSecretKeySecretName .Values.apiSecretKey .Values.apiSecretKeySecretName) }}
 {{ if (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 #####################################################
 #  WARNING: You should set a static API secret key  #


### PR DESCRIPTION
The webserver/API secret key conditional was incorrectly wrapping all deprecation warnings (securityContext, workers.*, webserver.defaultUser), causing them to only display when no secret key was configured. Moved the conditional to only wrap the secret key warning where it belongs.



##  Verification

Deprecated value in use + secret key configured:

```
  # Before: warning silently suppressed
  helm install --dry-run airflow ./chart \
    --set webserverSecretKey=mysecretkey \
    --set securityContext.runAsUser=999 \
    | grep "DEPRECATION"
  # (no output)
  # After: warning correctly shown
   DEPRECATION WARNING:
      `securityContext` has been renamed to `securityContexts`, to be enabled
      on container and pod level. Please change your values as support for the
      old name will be dropped in a future release.
```

Secret key warning still appears when no key is set (no regression):

```
  helm install --dry-run airflow ./chart | grep -A1 "WARNING: You should"
  #  WARNING: You should set a static API secret key  #
  #####################################################
```

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)


Generated-by: Cursor