### PR TITLE
Bump minimum cryptography to 44.0.3 and paramiko to 3.4.0

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -86,8 +86,11 @@ dependencies = [
     "colorlog>=6.8.2",
     "cron-descriptor>=1.2.24",
     "croniter>=2.0.2",
-    # TODO(potiuk): We should bump cryptography to >=46.0.0 when sqlalchemy>=2.0 is required
-    "cryptography>=41.0.0,<46.0.0",
+    # Cryptography could be upgraded to 46.0.5, but it does not have overlap with earlier versions
+    # Of Airflow which were limited to <46.0.0 also earlier provider versions will not be compatible with newer
+    # airflow if we do not have overlapping version. We could set minimum version to 46.0.0 when we drop
+    # support for Airflow 3.1.
+    "cryptography>=44.0.3",
     "deprecated>=1.2.13",
     "dill>=0.2.2",
     "fastapi[standard-no-fastapi-cloud-cli]>=0.129.0",

--- a/providers/apache/flink/docs/index.rst
+++ b/providers/apache/flink/docs/index.rst
@@ -88,14 +88,14 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.11.0``.
 
-============================================  ====================
+============================================  ==================
 PIP package                                   Version required
-============================================  ====================
+============================================  ==================
 ``apache-airflow``                            ``>=2.11.0``
 ``apache-airflow-providers-common-compat``    ``>=1.10.1``
-``cryptography``                              ``>=41.0.0,<46.0.0``
+``cryptography``                              ``>=44.0.3``
 ``apache-airflow-providers-cncf-kubernetes``  ``>=5.1.0``
-============================================  ====================
+============================================  ==================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/apache/flink/pyproject.toml
+++ b/providers/apache/flink/pyproject.toml
@@ -60,8 +60,11 @@ requires-python = ">=3.10"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.10.1",
-    # TODO(potiuk): We should bump cryptography to >=46.0.0 when sqlalchemy>=2.0 is required
-    "cryptography>=41.0.0,<46.0.0",
+    # Cryptography could be upgraded to 46.0.5, but it does not have overlap with earlier versions
+    # Of Airflow which were limited to <46.0.0 also earlier provider versions will not be compatible with newer
+    # airflow if we do not have overlapping version. We could set minimum version to 46.0.0 when we drop
+    # support for Airflow 3.1.
+    "cryptography>=44.0.3",
     "apache-airflow-providers-cncf-kubernetes>=5.1.0",
 ]
 

--- a/providers/cncf/kubernetes/docs/index.rst
+++ b/providers/cncf/kubernetes/docs/index.rst
@@ -115,7 +115,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``asgiref``                                 ``>=3.5.2``
-``cryptography``                            ``>=41.0.0,<46.0.0``
+``cryptography``                            ``>=44.0.3``
 ``kubernetes``                              ``>=35.0.0,<36.0.0``
 ``urllib3``                                 ``>=2.1.0,!=2.6.0``
 ``kubernetes_asyncio``                      ``>=32.0.0,<35.0.0``

--- a/providers/cncf/kubernetes/pyproject.toml
+++ b/providers/cncf/kubernetes/pyproject.toml
@@ -62,8 +62,11 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.13.0",
     "asgiref>=3.5.2",
-    # TODO(potiuk): We should bump cryptography to >=46.0.0 when sqlalchemy>=2.0 is required
-    "cryptography>=41.0.0,<46.0.0",
+    # Cryptography could be upgraded to 46.0.5, but it does not have overlap with earlier versions
+    # Of Airflow which were limited to <46.0.0 also earlier provider versions will not be compatible with newer
+    # airflow if we do not have overlapping version. We could set minimum version to 46.0.0 when we drop
+    # support for Airflow 3.1.
+    "cryptography>=44.0.3",
     # The Kubernetes API is known to introduce problems when upgraded to a MAJOR version. Airflow Core
     # Uses Kubernetes for Kubernetes executor, and we also know that Kubernetes Python client follows SemVer
     # (https://github.com/kubernetes-client/python#compatibility). This is a crucial component of Airflow

--- a/providers/sftp/docs/index.rst
+++ b/providers/sftp/docs/index.rst
@@ -103,7 +103,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-ssh``            ``>=4.0.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
-``paramiko``                                ``>=2.9.0,<4.0.0``
+``paramiko``                                ``>=3.4.0,<4.0.0``
 ``asyncssh``                                ``>=2.12.0``
 ==========================================  ==================
 

--- a/providers/sftp/pyproject.toml
+++ b/providers/sftp/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow-providers-ssh>=4.0.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     # TODO: Bump to >= 4.0.0 once https://github.com/apache/airflow/issues/54079 is handled
-    "paramiko>=2.9.0,<4.0.0",
+    "paramiko>=3.4.0,<4.0.0",
     "asyncssh>=2.12.0",
 ]
 

--- a/providers/ssh/docs/index.rst
+++ b/providers/ssh/docs/index.rst
@@ -95,7 +95,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``asyncssh``                                ``>=2.12.0``
-``paramiko``                                ``>=2.9.0,<4.0.0``
+``paramiko``                                ``>=3.4.0,<4.0.0``
 ``sshtunnel``                               ``>=0.3.2``
 ==========================================  ==================
 

--- a/providers/ssh/pyproject.toml
+++ b/providers/ssh/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow-providers-common-compat>=1.12.0",
     "asyncssh>=2.12.0",
     # TODO: Bump to >= 4.0.0 once https://github.com/apache/airflow/issues/54079 is handled
-    "paramiko>=2.9.0,<4.0.0",
+    "paramiko>=3.4.0,<4.0.0",
     "sshtunnel>=0.3.2",
 ]
 


### PR DESCRIPTION
Remove the `<46.0.0` upper bound on cryptography and raise the minimum
to `44.0.3` — the lowest version that works with both SQLAlchemy 2 and
the cryptography 46+ API. We use `44.0.3` rather than `46.0.5` so that
provider packages remain installable alongside Airflow 3.1.x, which
previously capped cryptography at `<46.0.0`. We can raise the floor to
`46.0.0` once Airflow 3.1 is no longer supported.

Also bumps paramiko minimum to `3.4.0` in the ssh and sftp providers —
older paramiko versions are incompatible with cryptography >=44.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)