### PR TITLE
Fix missing timeout in OpenFaasHook and replace bare print in KafkaConsumerHook

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/consume.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/consume.py
@@ -16,12 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 
 from confluent_kafka import Consumer, KafkaError
 
 from airflow.providers.apache.kafka.hooks.base import KafkaBaseHook
 from airflow.providers.common.compat.module_loading import import_string
+
+log = logging.getLogger(__name__)
 
 
 class KafkaAuthenticationError(Exception):
@@ -34,7 +37,7 @@ def error_callback(err):
     """Handle kafka errors."""
     if err.code() == KafkaError._AUTHENTICATION:
         raise KafkaAuthenticationError(f"Authentication failed: {err}")
-    print("Exception received: ", err)
+    log.error("Exception received from Kafka: %s", err)
 
 
 class KafkaConsumerHook(KafkaBaseHook):

--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -71,7 +71,8 @@ class OpenFaasHook(BaseHook):
         else:
             url = self.get_conn().host + self.DEPLOY_FUNCTION
             self.log.info("Deploying function %s", url)
-            response = requests.post(url, body)
+            timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+            response = requests.post(url, body, timeout=timeout)
             if response.status_code != OK_STATUS_CODE:
                 self.log.error("Response status %d", response.status_code)
                 self.log.error("Failed to deploy")
@@ -82,7 +83,8 @@ class OpenFaasHook(BaseHook):
         """Invoke function asynchronously."""
         url = self.get_conn().host + self.INVOKE_ASYNC_FUNCTION + self.function_name
         self.log.info("Invoking function asynchronously %s", url)
-        response = requests.post(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.post(url, body, timeout=timeout)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
         else:
@@ -93,7 +95,8 @@ class OpenFaasHook(BaseHook):
         """Invoke function synchronously. This will block until function completes and returns."""
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
-        response = requests.post(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.post(url, body, timeout=timeout)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)
@@ -106,7 +109,8 @@ class OpenFaasHook(BaseHook):
         """Update OpenFaaS function."""
         url = self.get_conn().host + self.UPDATE_FUNCTION
         self.log.info("Updating function %s", url)
-        response = requests.put(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.put(url, body, timeout=timeout)
         if response.status_code != OK_STATUS_CODE:
             self.log.error("Response status %d", response.status_code)
             self.log.error("Failed to update response %s", response.content.decode("utf-8"))
@@ -116,8 +120,9 @@ class OpenFaasHook(BaseHook):
     def does_function_exist(self) -> bool:
         """Whether OpenFaaS function exists or not."""
         url = self.get_conn().host + self.GET_FUNCTION + self.function_name
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=timeout)
         if response.ok:
             return True
         self.log.error("Failed to find function %s", self.function_name)


### PR DESCRIPTION
This pull request submits two minor bug fixes:
1) Adding timeout parameter to `requests` API calls in `OpenFaasHook`.
2) Replacing a bare `print` with a logger in `KafkaConsumerHook` `error_callback`.