### PR TITLE
Chart: warn on deprecated per-component securityContext values

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -223,6 +223,30 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if .Values.scheduler.securityContext }}
+
+ DEPRECATION WARNING:
+    `scheduler.securityContext` has been renamed to `scheduler.securityContexts`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if .Values.webserver.securityContext }}
+
+ DEPRECATION WARNING:
+    `webserver.securityContext` has been renamed to `webserver.securityContexts`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if .Values.statsd.securityContext }}
+
+ DEPRECATION WARNING:
+    `statsd.securityContext` has been renamed to `statsd.securityContexts`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if ne (int .Values.workers.replicas) 1 }}
 
  DEPRECATION WARNING:


### PR DESCRIPTION
Add DEPRECATION WARNING notices in NOTES.txt for
scheduler.securityContext, webserver.securityContext, and statsd.securityContext. These fields were already marked deprecated in values.yaml (use securityContexts instead) but no warning was shown to users at install/upgrade time.

  | Scenario | Result |
  |---|---|
  | `scheduler.securityContext` set | ✅ warning fires |
  | `webserver.securityContext` set | ✅ warning fires |
  | `statsd.securityContext` set | ✅ warning fires |
  | Default values (all empty) | ✅ no warnings |
  | All three set simultaneously | ✅ all three warnings fire independently |
  | Deprecated value still applied to pod spec | ✅ backward compat intact (`runAsUser: 12345` renders correctly) |
  | New `securityContexts` path used | ✅ no spurious warning |

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below)

Generated-by: Cursor