### PR TITLE
Add configurable timeout to requests API calls in OpenFaasHook

### DIFF
--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -24,6 +24,7 @@ import requests
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook
 
 OK_STATUS_CODE = 202
+REQUEST_TIMEOUT = 60
 
 
 class OpenFaasHook(BaseHook):
@@ -71,8 +72,7 @@ class OpenFaasHook(BaseHook):
         else:
             url = self.get_conn().host + self.DEPLOY_FUNCTION
             self.log.info("Deploying function %s", url)
-            timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
-            response = requests.post(url, body, timeout=timeout)
+            response = requests.post(url, body, timeout=REQUEST_TIMEOUT)
             if response.status_code != OK_STATUS_CODE:
                 self.log.error("Response status %d", response.status_code)
                 self.log.error("Failed to deploy")
@@ -83,8 +83,7 @@ class OpenFaasHook(BaseHook):
         """Invoke function asynchronously."""
         url = self.get_conn().host + self.INVOKE_ASYNC_FUNCTION + self.function_name
         self.log.info("Invoking function asynchronously %s", url)
-        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
-        response = requests.post(url, body, timeout=timeout)
+        response = requests.post(url, body, timeout=REQUEST_TIMEOUT)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
         else:
@@ -95,8 +94,7 @@ class OpenFaasHook(BaseHook):
         """Invoke function synchronously. This will block until function completes and returns."""
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
-        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
-        response = requests.post(url, body, timeout=timeout)
+        response = requests.post(url, body, timeout=REQUEST_TIMEOUT)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)
@@ -109,8 +107,7 @@ class OpenFaasHook(BaseHook):
         """Update OpenFaaS function."""
         url = self.get_conn().host + self.UPDATE_FUNCTION
         self.log.info("Updating function %s", url)
-        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
-        response = requests.put(url, body, timeout=timeout)
+        response = requests.put(url, body, timeout=REQUEST_TIMEOUT)
         if response.status_code != OK_STATUS_CODE:
             self.log.error("Response status %d", response.status_code)
             self.log.error("Failed to update response %s", response.content.decode("utf-8"))
@@ -120,9 +117,7 @@ class OpenFaasHook(BaseHook):
     def does_function_exist(self) -> bool:
         """Whether OpenFaaS function exists or not."""
         url = self.get_conn().host + self.GET_FUNCTION + self.function_name
-        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
-
-        response = requests.get(url, timeout=timeout)
+        response = requests.get(url, timeout=REQUEST_TIMEOUT)
         if response.ok:
             return True
         self.log.error("Failed to find function %s", self.function_name)

--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -71,7 +71,8 @@ class OpenFaasHook(BaseHook):
         else:
             url = self.get_conn().host + self.DEPLOY_FUNCTION
             self.log.info("Deploying function %s", url)
-            response = requests.post(url, body)
+            timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+            response = requests.post(url, body, timeout=timeout)
             if response.status_code != OK_STATUS_CODE:
                 self.log.error("Response status %d", response.status_code)
                 self.log.error("Failed to deploy")
@@ -82,7 +83,8 @@ class OpenFaasHook(BaseHook):
         """Invoke function asynchronously."""
         url = self.get_conn().host + self.INVOKE_ASYNC_FUNCTION + self.function_name
         self.log.info("Invoking function asynchronously %s", url)
-        response = requests.post(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.post(url, body, timeout=timeout)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
         else:
@@ -93,7 +95,8 @@ class OpenFaasHook(BaseHook):
         """Invoke function synchronously. This will block until function completes and returns."""
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
-        response = requests.post(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.post(url, body, timeout=timeout)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)
@@ -106,7 +109,8 @@ class OpenFaasHook(BaseHook):
         """Update OpenFaaS function."""
         url = self.get_conn().host + self.UPDATE_FUNCTION
         self.log.info("Updating function %s", url)
-        response = requests.put(url, body)
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
+        response = requests.put(url, body, timeout=timeout)
         if response.status_code != OK_STATUS_CODE:
             self.log.error("Response status %d", response.status_code)
             self.log.error("Failed to update response %s", response.content.decode("utf-8"))
@@ -116,8 +120,9 @@ class OpenFaasHook(BaseHook):
     def does_function_exist(self) -> bool:
         """Whether OpenFaaS function exists or not."""
         url = self.get_conn().host + self.GET_FUNCTION + self.function_name
+        timeout = int(self.get_conn().extra_dejson.get("timeout", 60))
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=timeout)
         if response.ok:
             return True
         self.log.error("Failed to find function %s", self.function_name)


### PR DESCRIPTION
All HTTP requests in `OpenFaasHook` (get, post, put) now include a configurable timeout parameter (default 60s) read from the connection `extra` dict. 

### Justification:
Without a timeout, an unresponsive remote OpenFaaS server could cause Airflow execution tasks to hang indefinitely, tying up worker slots. Using the connection's `extra_dejson` block allows users to configure this timeout based on their expected function execution time, defaulting to 60 seconds.

This was originally submitted alongside #62990 but split out per reviewer request.