### PR TITLE
Add clickable terminal links in `breeze issues unassign`

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/issues_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/issues_commands.py
@@ -64,9 +64,22 @@ def _get_collaborator_logins(repo) -> set[str]:
     return collaborators
 
 
+def _issue_link(github_repository: str, number: int) -> str:
+    """Return a Rich-formatted clickable link for a GitHub issue."""
+    url = f"https://github.com/{github_repository}/issues/{number}"
+    return f"[link={url}]#{number}[/link]"
+
+
+def _user_link(login: str) -> str:
+    """Return a Rich-formatted clickable link for a GitHub user."""
+    url = f"https://github.com/{login}"
+    return f"[link={url}]@{login}[/link]"
+
+
 def _process_batch(
     batch: list[tuple],
     dry_run: bool,
+    github_repository: str,
 ) -> int:
     """Display a batch of proposed unassignments and handle confirmation.
 
@@ -81,9 +94,9 @@ def _process_batch(
     table.add_column("Non-collaborator assignees", style="red")
     for issue, non_collab_logins in batch:
         table.add_row(
-            str(issue.number),
+            _issue_link(github_repository, issue.number),
             issue.title[:80],
-            ", ".join(sorted(non_collab_logins)),
+            ", ".join(_user_link(login) for login in sorted(non_collab_logins)),
         )
     get_console().print(table)
 
@@ -101,8 +114,10 @@ def _process_batch(
 
     unassigned_count = 0
     for issue, non_collab_logins in batch:
+        issue_ref = _issue_link(github_repository, issue.number)
         for login in non_collab_logins:
-            get_console().print(f"  Removing [red]{login}[/] from issue #{issue.number}")
+            user_ref = _user_link(login)
+            get_console().print(f"  Removing [red]{user_ref}[/] from issue {issue_ref}")
             issue.remove_from_assignees(login)
             comment = (
                 f"@{login} We are unassigning you from this issue as part of our "
@@ -117,7 +132,7 @@ def _process_batch(
                 f"prevented others from contributing when the assignee was not actively "
                 f"working on the issue."
             )
-            get_console().print(f"  Commenting on issue #{issue.number} about @{login}")
+            get_console().print(f"  Commenting on issue {issue_ref} about {user_ref}")
             issue.create_comment(comment)
             unassigned_count += 1
     return unassigned_count
@@ -187,11 +202,11 @@ def unassign(
             break
 
         if len(batch) >= batch_size:
-            total_unassigned += _process_batch(batch, dry_run)
+            total_unassigned += _process_batch(batch, dry_run, github_repository)
             batch = []
 
     # Process remaining batch
-    total_unassigned += _process_batch(batch, dry_run)
+    total_unassigned += _process_batch(batch, dry_run, github_repository)
 
     get_console().print()
     get_console().print("[success]Done![/]")


### PR DESCRIPTION
Add Rich `[link=...]` markup so that issue numbers and GitHub usernames
displayed by `breeze issues unassign` become clickable hyperlinks in
terminals that support OSC 8.

Links are added in:
- The "Proposed unassignments" table (issue # and assignee columns)
- The "Removing" and "Commenting" log lines during unassignment

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)