### PR TITLE
Fix task log filters not working in fullscreen mode #62699

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -198,7 +198,7 @@ export const Logs = () => {
                 <Heading mb={2} size="xl">
                   {taskId}
                 </Heading>
-                <TaskLogHeader {...logHeaderProps} />
+                <TaskLogHeader {...logHeaderProps} isFullscreen />
               </Box>
             </Dialog.Header>
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -192,7 +192,7 @@ export const TaskLogHeader = ({
             <Select.Trigger clearable>
               <Select.ValueText placeholder={translate("dag:logs.allSources")} />
             </Select.Trigger>
-            <Select.Content>
+            <Select.Content zIndex={zIndex}>
               {sourceOptionList.items.map((option) => (
                 <Select.Item item={option} key={option.label}>
                   {option.label}


### PR DESCRIPTION
Fix log level, source, and settings dropdowns not rendering in fullscreen mode.                                                                      
                                                                                                                                                       
  - Pass `isFullscreen` prop to `TaskLogHeader` in the fullscreen dialog so the z-index fix activates
  - Add missing `zIndex` to source filter `Select.Content` for consistency with log level filter                                                       
                  
  closes: #62699