### PR TITLE
Filter on dag_id when querying task_instance in dag-processor

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -599,7 +599,15 @@ class SerializedDagModel(Base):
         has_task_instances: bool = False
         if dag_version:
             has_task_instances = bool(
-                session.scalar(select(exists().where(TaskInstance.dag_version_id == dag_version.id)))
+                session.scalar(
+                    select(
+                        exists().where(
+                            # Using dag_id filter to speed up query via the composite index.
+                            TaskInstance.dag_id == dag.dag_id,
+                            TaskInstance.dag_version_id == dag_version.id,
+                        )
+                    )
+                )
             )
 
         if dag_version and not has_task_instances:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Resolves a performance issue in dag-processor that prevents startup on a large migrated Airflow 2.11.0 system. The existing query attempts to filter on the `task_instance` table using only `dag_version_id`, when it should be using `dag_id` as an additional filter to use the available index.

* closes: #61894

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] No
- [ ] Yes (please specify the tool below)