### PR TITLE
Fix `common.ai` provider's dependencies

### DIFF
--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -97,12 +97,14 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``3.0.0``.
 
-====================  ==================
-PIP package           Version required
-====================  ==================
-``apache-airflow``    ``>=3.0.0``
-``pydantic-ai-slim``  ``>=1.14.0``
-====================  ==================
+==========================================  ==================
+PIP package                                 Version required
+==========================================  ==================
+``apache-airflow``                          ``>=3.0.0``
+``apache-airflow-providers-common-compat``  ``>=1.13.1``
+``apache-airflow-providers-standard``       ``>=1.12.0``
+``pydantic-ai-slim``                        ``>=1.14.0``
+==========================================  ==================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -59,8 +59,8 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=3.0.0",
-    "apache-airflow-providers-common-compat>=1.13.1",
-    "apache-airflow-providers-standard>=1.12.0",
+    "apache-airflow-providers-common-compat>=1.13.1",  # use next version
+    "apache-airflow-providers-standard>=1.12.0",  # use next version
     "pydantic-ai-slim>=1.14.0",
 ]
 

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -59,6 +59,8 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=3.0.0",
+    "apache-airflow-providers-common-compat>=1.13.1",
+    "apache-airflow-providers-standard>=1.12.0",
     "pydantic-ai-slim>=1.14.0",
 ]
 
@@ -69,18 +71,12 @@ dependencies = [
 "bedrock" = ["pydantic-ai-slim[bedrock]"]
 "google" = ["pydantic-ai-slim[google]"]
 "openai" = ["pydantic-ai-slim[openai]"]
-"common.compat" = [
-    "apache-airflow-providers-common-compat"
-]
 "sql" = [
     "apache-airflow-providers-common-sql",
     "sqlglot>=26.0.0",
 ]
 "common.sql" = [
     "apache-airflow-providers-common-sql"
-]
-"standard" = [
-    "apache-airflow-providers-standard"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
The common.ai provider unconditionally imports from `common.compat` (`BaseHook`, `BaseOperator`, `DecoratedOperator`, `TaskDecorator`) and `standard` (`BranchMixIn`) in its core modules, but both were listed as optional extras. Anyone installing `apache-airflow-providers-common-ai` without the extras gets `ImportError` on any operator/hook usage.

This moves both to hard dependencies and removes the now-unnecessary optional extras.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes