### PR TITLE
[v3-1-test] Fix timer.duration unit labels in logs (#61824)

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1419,12 +1419,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 next_event = timers.run(blocking=False)
                 self.log.debug("Next timed event is in %f", next_event)
 
-            self.log.debug("Ran scheduling loop in %.2f seconds", timer.duration)
+            self.log.debug("Ran scheduling loop in %.2f ms", timer.duration)
             if span.is_recording():
                 span.add_event(
                     name="Ran scheduling loop",
                     attributes={
-                        "duration in seconds": timer.duration,
+                        "duration in ms": timer.duration,
                     },
                 )
 

--- a/airflow-core/src/airflow/metrics/otel_logger.py
+++ b/airflow-core/src/airflow/metrics/otel_logger.py
@@ -272,7 +272,7 @@ class SafeOtelLogger:
         *,
         tags: Attributes = None,
     ) -> None:
-        """OTel does not have a native timer, stored as a Gauge whose value is number of seconds elapsed."""
+        """OTel does not have a native timer, stored as a Gauge whose value is elapsed ms."""
         if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
             if isinstance(dt, datetime.timedelta):
                 dt = dt.total_seconds() * 1000.0

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -360,7 +360,7 @@ def ensure_plugins_loaded():
             load_providers_plugins()
 
     if plugins:
-        log.debug("Loading %d plugin(s) took %.2f seconds", len(plugins), timer.duration)
+        log.debug("Loading %d plugin(s) took %.2f ms", len(plugins), timer.duration)
 
 
 def initialize_ui_plugins():

--- a/airflow-core/src/airflow/serialization/serde.py
+++ b/airflow-core/src/airflow/serialization/serde.py
@@ -390,7 +390,7 @@ def _register():
                 log.debug("registering %s for stringifying", c)
                 _stringifiers[c] = name
 
-    log.debug("loading serializers took %.3f seconds", timer.duration)
+    log.debug("loading serializers took %.3f ms", timer.duration)
 
 
 @functools.cache

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -324,7 +324,7 @@ or to time but not send a metric:
     with Stats.timer() as timer:
         ...
 
-    log.info("Code took %.3f seconds", timer.duration)
+    log.info("Code took %.3f ms", timer.duration)
 
 For full docs on ``timer()`` check out `airflow/stats.py`_.
 

--- a/task-sdk/src/airflow/sdk/io/fs.py
+++ b/task-sdk/src/airflow/sdk/io/fs.py
@@ -67,7 +67,7 @@ def _register_filesystems() -> Mapping[
                     raise ImportError(f"Filesystem {fs_module_name} does not have a get_fs method")
                 scheme_to_fs[scheme] = method
 
-    log.debug("loading filesystems from providers took %.3f seconds", timer.duration)
+    log.debug("loading filesystems from providers took %.3f ms", timer.duration)
     return scheme_to_fs
 
 


### PR DESCRIPTION
backport of https://github.com/apache/airflow/pull/61824

(cherry picked from commit 10dcb3a55200fa34e754769bd106a3f71280a8b0)
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
