### PR TITLE
[v3-1-test] Remove mp_start_method remnants (#61150)

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -158,18 +158,6 @@ core:
       type: integer
       example: ~
       default: "0"
-    mp_start_method:
-      description: |
-        The name of the method used in order to start Python processes via the multiprocessing module.
-        This corresponds directly with the options available in the Python docs:
-        `multiprocessing.set_start_method
-        <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method>`__
-        must be one of the values returned by `multiprocessing.get_all_start_methods()
-        <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods>`__.
-      version_added: "2.0.0"
-      type: string
-      default: ~
-      example: "fork"
     load_examples:
       description: |
         Whether to load the Dag examples that ship with Airflow. It's good to

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -22,7 +22,6 @@ import functools
 import itertools
 import json
 import logging
-import multiprocessing
 import os
 import pathlib
 import re
@@ -417,7 +416,6 @@ class AirflowConfigParser(ConfigParser):
     enums_options = {
         ("core", "default_task_weight_rule"): sorted(WeightRule.all_weight_rules()),
         ("core", "dag_ignore_file_syntax"): ["regexp", "glob"],
-        ("core", "mp_start_method"): multiprocessing.get_all_start_methods(),
         ("dag_processor", "file_parsing_sort_mode"): [
             "modified_time",
             "random_seeded_by_host",

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -21,7 +21,6 @@ import importlib
 import json
 import logging
 import os
-import platform
 import re
 import subprocess
 import sys
@@ -209,11 +208,6 @@ os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.fspath(AIRFLOW_CORE_TESTS_PATH / "
 os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
 os.environ["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 os.environ["CREDENTIALS_DIR"] = os.environ.get("CREDENTIALS_DIR") or "/files/airflow-breeze-config/keys"
-
-if platform.system() == "Darwin":
-    # mocks from unittest.mock work correctly in subprocesses only if they are created by "fork" method
-    # but macOS uses "spawn" by default
-    os.environ["AIRFLOW__CORE__MP_START_METHOD"] = "fork"
 
 
 @pytest.fixture


### PR DESCRIPTION
backport of https://github.com/apache/airflow/pull/61150

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
