### PR TITLE
Add Dutch (nl) translation agent skill guidelines

### DIFF
--- a/.github/skills/airflow-translations/locales/nl.md
+++ b/.github/skills/airflow-translations/locales/nl.md
@@ -35,9 +35,9 @@ that **must be used consistently**:
 
 | English Term          | Dutch Translation          | Notes                                      |
 | --------------------- | -------------------------- | ------------------------------------------ |
-| Task                  | Task / taak                | Use "Task" as object, "taak" in prose      |
-| Task Instance         | Task Instance              | Plural: "Task Instances"                   |
-| Task Group            | Task groep                 |                                            |
+| Task                  | Taak                       | Always translate Task to "taak" / "Taak"   |
+| Task Instance         | Taak Instance              | Plural: "Taak Instances"                   |
+| Task Group            | Taak Groep                 | Plural: "Taak Groepen"                     |
 | Dag Run               | Dag Run                    | Plural: "Dag Runs"                         |
 | Backfill              | Backfill                   |                                            |
 | Trigger (noun)        | Trigger                    | e.g. "Asset Triggered"                     |
@@ -87,7 +87,7 @@ that **must be used consistently**:
 ### Gender and Number
 
 - Dutch nouns have grammatical gender, but for technical terms, focus on common usage:
-  - "Task" is generally **de-word**: "de task"
+  - "Taak" is generally **de-word**: "de taak"
   - "Run" is **de-word**: "de run"
   - "Process" is **het-word**: "het proces"
 
@@ -97,13 +97,13 @@ that **must be used consistently**:
   Most technical terms add "s" or "en":
   - "Connectie" -> "Connecties"
   - "Variabele" -> "Variabelen"
-  - "Task" -> "Tasks"
+  - "Taak" -> "Taken"
 
 ### Capitalization
 
 - Use **Sentence case** (Zinvallende hoofdletters) for descriptions.
 - Use **Title Case** or **Initial Capital** for labels and buttons if the English source does so.
-- Always capitalize "Dag", "Task" (when referring to the object), "Asset", "XCom", etc.
+- Always capitalize "Dag", "Taak" (when referring to the object), "Asset", "XCom", etc.
 
 ## 5. Examples from Existing Translations
 

--- a/.github/skills/airflow-translations/locales/nl.md
+++ b/.github/skills/airflow-translations/locales/nl.md
@@ -1,0 +1,147 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Dutch (nl) Translation Agent Skill
+
+**Locale code:** `nl`
+**Preferred variant:** Standard Dutch (Netherlands), consistent with existing translations in `airflow-core/src/airflow/ui/public/i18n/locales/nl/`
+
+This file contains locale-specific guidelines so AI translation agents produce
+new Dutch strings that stay 100% consistent with the existing translations.
+
+## 1. Core Airflow Terminology
+
+The following terms **must remain in English unchanged** (case-sensitive):
+
+- `Dag` / `Dags` — Airflow concept; never write "DAG"
+- `XCom` / `XComs` — Airflow cross-communication mechanism
+- `Asset` / `Assets` — Data dependency tracked by Airflow
+- `Plugin` / `Plugins` — Airflow extensibility mechanism
+- `Pool` / `Pools` — Resource constraint mechanism
+- `Provider` / `Providers` — Airflow extension package name
+- `Run` / `Runs` — When used standalone (e.g., "Laatste Run")
+- `Map Index` — Task mapping index
+- `PID` — Unix process identifier
+- `ID` — Universal abbreviation
+- `UTC` — Time standard
+- `JSON` — Standard technical format name
+- `REST API` — Standard technical term
+- Log levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`
+
+## 2. Standard Translations
+
+The following Airflow-specific terms have established Dutch translations
+that **must be used consistently**:
+
+| English Term          | Dutch Translation          | Notes                                      |
+| --------------------- | -------------------------- | ------------------------------------------ |
+| Task                  | Task / taak                | Use "Task" as object, "taak" in prose      |
+| Task Instance         | Task Instance              | Plural: "Task Instances"                   |
+| Task Group            | Task groep                 |                                            |
+| Dag Run               | Dag Run                    | Plural: "Dag Runs"                         |
+| Backfill              | Backfill                   |                                            |
+| Trigger (noun)        | Trigger                    | e.g. "Asset Triggered"                     |
+| Trigger Rule          | Trigger regel              |                                            |
+| Triggerer             | Triggerer                  | Component name                             |
+| Scheduler             | Scheduler                  |                                            |
+| Schedule (noun)       | Planning                   |                                            |
+| Executor              | Executor                   |                                            |
+| Connection            | Connectie                  | Plural: "Connecties"                       |
+| Variable              | Variabele                  | Plural: "Variabelen"                       |
+| Audit Log             | Audit Log                  |                                            |
+| Log                   | Log                        | Plural: "Logs"                             |
+| State                 | Status                     | e.g. "Totaal {{state}}" -> "Totaal Status" |
+| Queue (noun)          | Wachtrij                   |                                            |
+| Config / Configuration| Configuratie               |                                            |
+| Operator              | Operator                   | Plural: "Operators"                        |
+| Asset Event           | Asset Event                | Keep as in English                         |
+| Catchup               | Catchup                    | Keep as in English                         |
+
+## 3. Task/Run States
+
+| English State       | Dutch Translation     |
+| ------------------- | --------------------- |
+| running             | Lopend                |
+| failed              | Mislukt               |
+| success             | Succesvol             |
+| queued              | Wachtend              |
+| scheduled           | Gepland               |
+| skipped             | Overgeslagen          |
+| deferred            | Uitgesteld            |
+| removed             | Verwijderd            |
+| restarting          | Herstartend           |
+| up_for_retry        | Wachtend op een nieuwe poging |
+| up_for_reschedule   | Wachtend op herplanning |
+| upstream_failed     | Upstream mislukt      |
+| no_status / none    | Geen status           |
+| planned             | Gepland               |
+
+## 4. Dutch-Specific Guidelines
+
+### Tone and Register
+
+- Use **informal Dutch** ("je/jouw" form). Avoid the formal "u" unless specifically requested.
+- Use a professional yet accessible tone.
+- Keep UI strings concise — they appear in buttons, labels, and tooltips.
+
+### Gender and Number
+
+- Dutch nouns have grammatical gender, but for technical terms, focus on common usage:
+  - "Task" is generally **de-word**: "de task"
+  - "Run" is **de-word**: "de run"
+  - "Process" is **het-word**: "het proces"
+
+### Plural Forms
+
+- Dutch uses i18next plural suffixes `_one` and `_other`.
+  Most technical terms add "s" or "en":
+  - "Connectie" -> "Connecties"
+  - "Variabele" -> "Variabelen"
+  - "Task" -> "Tasks"
+
+### Capitalization
+
+- Use **Sentence case** (Zinvallende hoofdletters) for descriptions.
+- Use **Title Case** or **Initial Capital** for labels and buttons if the English source does so.
+- Always capitalize "Dag", "Task" (when referring to the object), "Asset", "XCom", etc.
+
+## 5. Examples from Existing Translations
+
+**Common UI Patterns:**
+
+```
+Add    → "Toevoegen"
+Delete → "Verwijderen" (or "Verwijder" on buttons)
+Edit   → "Wijzigen" / "Bewerken"
+Save   → "Opslaan"
+Cancel → "Annuleer"
+Search → "Zoeken"
+Filter → "Filter"
+```
+
+**Interpolation:**
+
+```json
+"delete_confirmation": "Weet je zeker dat je {{resourceName}} wilt verwijderen?"
+```
+
+## 6. Agent Instructions (DO / DON'T)
+
+**DO:**
+
+- Maintain the "je" (informal) address style.
+- Preserve all i18next placeholders: `{{count}}`, `{{dagId}}`, etc.
+- Use "Wachtrij" for technical queues.
+- Use "Planning" for schedules.
+- Provide both `_one` and `_other` plural forms.
+
+**DON'T:**
+
+- Use "u" (formal).
+- Translate "Dag" as "DAG".
+- Translate terms listed in Section 1.
+- Use inconsistent terms for "State" (always use "Status").
+
+---
+
+**Version:** 1.0 — derived from existing `nl/*.json` locale files (March 2026)

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
@@ -27,9 +27,8 @@ The Dutch translation follows these core principles:
 
 1.  **Airflow Specific Terms**: Terms like `Dag`, `XCom`, and `Asset` are kept in English as they are widely recognized technical objects within the Airflow ecosystem. We use `Dag` (not `DAG`) to align with Airflow conventions.
 2.  **User Address**: We use the informal **"je/jouw"** register. This makes the UI feel more modern and accessible, which is a common trend in technical software localized for the Dutch market.
-3.  **Technical vs. Natural Language**:
-    - `Task` is used when referring to the technical object (e.g., `Task Instance`).
-    - `taak` is used in more descriptive prose or standard UI actions.
+3.  **Consistency in Translation**:
+    - Based on maintainer consensus, `Task` is consistently translated to `taak` (or `Taak`) everywhere, rather than keeping the English term for technical objects.
 4.  **Established UI Mappings**:
     - `Schedule` -> `Planning`
     - `Queue` -> `Wachtrij`

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
@@ -1,0 +1,22 @@
+# Dutch (nl) Translation Guidelines
+
+This directory contains the Dutch translation files for the Airflow UI.
+
+## Terminology Selection
+
+The Dutch translation follows these core principles:
+
+1.  **Airflow Specific Terms**: Terms like `Dag`, `XCom`, and `Asset` are kept in English as they are widely recognized technical objects within the Airflow ecosystem. We use `Dag` (not `DAG`) to align with Airflow conventions.
+2.  **User Address**: We use the informal **"je/jouw"** register. This makes the UI feel more modern and accessible, which is a common trend in technical software localized for the Dutch market.
+3.  **Technical vs. Natural Language**: 
+    - `Task` is used when referring to the technical object (e.g., `Task Instance`).
+    - `taak` is used in more descriptive prose or standard UI actions.
+4.  **Established UI Mappings**:
+    - `Schedule` -> `Planning`
+    - `Queue` -> `Wachtrij`
+    - `State` -> `Status`
+    - `Run` -> `Run` (kept in English as it's a standard term in data engineering)
+
+## Consistency
+
+All new translations should be verified against `common.json` to ensure they use the standard Dutch terms for buttons (e.g., `Opslaan`, `Annuleren`, `Verwijderen`) and states (e.g., `Lopend`, `Mislukt`, `Succesvol`).

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
@@ -1,3 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
 # Dutch (nl) Translation Guidelines
 
 This directory contains the Dutch translation files for the Airflow UI.
@@ -8,7 +27,7 @@ The Dutch translation follows these core principles:
 
 1.  **Airflow Specific Terms**: Terms like `Dag`, `XCom`, and `Asset` are kept in English as they are widely recognized technical objects within the Airflow ecosystem. We use `Dag` (not `DAG`) to align with Airflow conventions.
 2.  **User Address**: We use the informal **"je/jouw"** register. This makes the UI feel more modern and accessible, which is a common trend in technical software localized for the Dutch market.
-3.  **Technical vs. Natural Language**: 
+3.  **Technical vs. Natural Language**:
     - `Task` is used when referring to the technical object (e.g., `Task Instance`).
     - `taak` is used in more descriptive prose or standard UI actions.
 4.  **Established UI Mappings**:


### PR DESCRIPTION
This PR defines the translation agent skill guidelines for the Dutch (nl) locale and adds a corresponding locale-specific README, as part of the initiative to improve AI-assisted localization (#61984).

Changes:

Added 

.github/skills/airflow-translations/locales/nl.md
 with guidelines on Dutch terminology (e.g., keeping Dag in English, using the informal "je" register).
Added 

airflow-core/src/airflow/ui/public/i18n/locales/nl/README.md
 to document the rationale for specific term selections for future contributors.
Verified that both files pass core static checks (license headers, trailing whitespace, and end-of-file-fixer).
Reference Issues:

closes: #61999
related: #61984
Was generative AI tooling used to co-author this PR?
 Yes (Antigravity/Claude Code)
