### PR TITLE
[v3-1-test] Variable table handle long words break when values are expanded (#62416)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -82,12 +82,28 @@ const getColumns = ({
   },
   {
     accessorKey: "value",
-    cell: ({ row }) => <TrimText showTooltip text={row.original.value} />,
+    cell: ({ row }) => (
+        <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
+          <TrimText
+            charLimit={open ? row.original.value.length : undefined}
+            showTooltip
+            text={row.original.value}
+          />
+        </Box>
+      ),
     header: translate("columns.value"),
   },
   {
     accessorKey: "description",
-    cell: ({ row }) => <TrimText showTooltip text={row.original.description} />,
+    cell: ({ row }) =>  (
+        <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
+          <TrimText
+            charLimit={open ? row.original.description?.length : undefined}
+            showTooltip
+            text={row.original.description}
+          />
+        </Box>
+      ),
     header: translate("columns.description"),
   },
   {


### PR DESCRIPTION
Backport of https://github.com/apache/airflow/pull/62416

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
