### PR TITLE
Add deferrable mode to AzureContainerInstancesOperator

### DIFF
--- a/providers/microsoft/azure/provider.yaml
+++ b/providers/microsoft/azure/provider.yaml
@@ -311,6 +311,9 @@ triggers:
   - integration-name: Microsoft Azure Compute
     python-modules:
       - airflow.providers.microsoft.azure.triggers.compute
+  - integration-name: Microsoft Azure Container Instances
+    python-modules:
+      - airflow.providers.microsoft.azure.triggers.container_instance
   - integration-name: Microsoft Azure Data Factory
     python-modules:
       - airflow.providers.microsoft.azure.triggers.data_factory

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
@@ -289,6 +289,10 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.microsoft.azure.triggers.compute"],
             },
             {
+                "integration-name": "Microsoft Azure Container Instances",
+                "python-modules": ["airflow.providers.microsoft.azure.triggers.container_instance"],
+            },
+            {
                 "integration-name": "Microsoft Azure Data Factory",
                 "python-modules": ["airflow.providers.microsoft.azure.triggers.data_factory"],
             },

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -29,6 +29,7 @@ from azure.mgmt.containerinstance.aio import (
     ContainerInstanceManagementClient as AsyncContainerInstanceManagementClient,
 )
 
+from airflow.providers.common.compat.connection import get_async_connection
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.base_azure import _AZURE_CLOUD_ENVIRONMENTS, AzureBaseHook
 from airflow.providers.microsoft.azure.utils import (
@@ -198,9 +199,9 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
     """
 
     def __init__(self, azure_conn_id: str = AzureContainerInstanceHook.default_conn_name) -> None:
+        super().__init__(azure_conn_id=azure_conn_id)
         self._async_conn: AsyncContainerInstanceManagementClient | None = None
         self._async_credential: Any = None
-        super().__init__(azure_conn_id=azure_conn_id)
 
     async def __aenter__(self) -> AzureContainerInstanceAsyncHook:
         return self
@@ -222,7 +223,7 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         if self._async_conn is not None:
             return self._async_conn
 
-        conn = self.get_connection(self.conn_id)
+        conn = await get_async_connection(self.conn_id)
         tenant = conn.extra_dejson.get("tenantId")
         subscription_id = cast("str", conn.extra_dejson.get("subscriptionId"))
 

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -199,6 +199,7 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
 
     def __init__(self, azure_conn_id: str = AzureContainerInstanceHook.default_conn_name) -> None:
         self._async_conn: AsyncContainerInstanceManagementClient | None = None
+        self._async_credential: Any = None
         super().__init__(azure_conn_id=azure_conn_id)
 
     async def __aenter__(self) -> AzureContainerInstanceAsyncHook:
@@ -208,10 +209,13 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         await self.close()
 
     async def close(self) -> None:
-        """Close the async connection."""
+        """Close the async connection and credential."""
         if self._async_conn is not None:
             await self._async_conn.close()
             self._async_conn = None
+        if self._async_credential is not None and hasattr(self._async_credential, "close"):
+            await self._async_credential.close()
+            self._async_credential = None
 
     async def get_async_conn(self) -> AsyncContainerInstanceManagementClient:
         """Return (or create) the async management client."""
@@ -223,7 +227,7 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         subscription_id = cast("str", conn.extra_dejson.get("subscriptionId"))
 
         if all([conn.login, conn.password, tenant]):
-            credential: Any = AsyncClientSecretCredential(
+            self._async_credential = AsyncClientSecretCredential(
                 client_id=cast("str", conn.login),
                 client_secret=cast("str", conn.password),
                 tenant_id=cast("str", tenant),
@@ -231,13 +235,13 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         else:
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credential = get_async_default_azure_credential(
+            self._async_credential = get_async_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )
 
         self._async_conn = AsyncContainerInstanceManagementClient(
-            credential=credential,
+            credential=self._async_credential,
             subscription_id=subscription_id,
         )
         return self._async_conn

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -23,11 +23,18 @@ from typing import TYPE_CHECKING, Any, cast
 from azure.common.client_factory import get_client_from_auth_file, get_client_from_json_dict
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.mgmt.containerinstance.aio import (
+    ContainerInstanceManagementClient as AsyncContainerInstanceManagementClient,
+)
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.hooks.base_azure import _AZURE_CLOUD_ENVIRONMENTS, AzureBaseHook
-from airflow.providers.microsoft.azure.utils import get_sync_default_azure_credential
+from airflow.providers.microsoft.azure.utils import (
+    get_async_default_azure_credential,
+    get_sync_default_azure_credential,
+)
 
 if TYPE_CHECKING:
     from azure.mgmt.containerinstance.models import (
@@ -180,3 +187,93 @@ class AzureContainerInstanceHook(AzureBaseHook):
             return False, str(e)
 
         return True, "Successfully connected to Azure Container Instance."
+
+
+class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
+    """
+    An async hook for communicating with Azure Container Instances.
+
+    :param azure_conn_id: :ref:`Azure connection id<howto/connection:azure>` of
+        a service principal which will be used to start the container instance.
+    """
+
+    def __init__(self, azure_conn_id: str = AzureContainerInstanceHook.default_conn_name) -> None:
+        self._async_conn: AsyncContainerInstanceManagementClient | None = None
+        super().__init__(azure_conn_id=azure_conn_id)
+
+    async def __aenter__(self) -> AzureContainerInstanceAsyncHook:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the async connection."""
+        if self._async_conn is not None:
+            await self._async_conn.close()
+            self._async_conn = None
+
+    async def get_async_conn(self) -> AsyncContainerInstanceManagementClient:
+        """Return (or create) the async management client."""
+        if self._async_conn is not None:
+            return self._async_conn
+
+        conn = self.get_connection(self.conn_id)
+        tenant = conn.extra_dejson.get("tenantId")
+        subscription_id = cast("str", conn.extra_dejson.get("subscriptionId"))
+
+        if all([conn.login, conn.password, tenant]):
+            credential: Any = AsyncClientSecretCredential(
+                client_id=cast("str", conn.login),
+                client_secret=cast("str", conn.password),
+                tenant_id=cast("str", tenant),
+            )
+        else:
+            managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
+            workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
+            credential = get_async_default_azure_credential(
+                managed_identity_client_id=managed_identity_client_id,
+                workload_identity_tenant_id=workload_identity_tenant_id,
+            )
+
+        self._async_conn = AsyncContainerInstanceManagementClient(
+            credential=credential,
+            subscription_id=subscription_id,
+        )
+        return self._async_conn
+
+    async def get_state(self, resource_group: str, name: str) -> ContainerGroup:  # type: ignore[override]
+        """
+        Get the state of a container group asynchronously.
+
+        :param resource_group: the name of the resource group
+        :param name: the name of the container group
+        :return: ContainerGroup
+        """
+        client = await self.get_async_conn()
+        return await client.container_groups.get(resource_group, name)
+
+    async def get_logs(self, resource_group: str, name: str, tail: int = 1000) -> list:  # type: ignore[override]
+        """
+        Get the tail from logs of a container group asynchronously.
+
+        :param resource_group: the name of the resource group
+        :param name: the name of the container group
+        :param tail: the size of the tail
+        :return: A list of log messages
+        """
+        client = await self.get_async_conn()
+        logs = await client.containers.list_logs(resource_group, name, name, tail=tail)
+        if logs.content is None:
+            return [None]
+        return logs.content.splitlines(True)
+
+    async def delete(self, resource_group: str, name: str) -> None:  # type: ignore[override]
+        """
+        Delete a container group asynchronously.
+
+        :param resource_group: the name of the resource group
+        :param name: the name of the container group
+        """
+        client = await self.get_async_conn()
+        await client.container_groups.begin_delete(resource_group, name)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -25,7 +25,10 @@ from typing import TYPE_CHECKING, Any, cast
 from azure.common.client_factory import get_client_from_auth_file, get_client_from_json_dict
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
-from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
+from azure.identity.aio import (
+    ClientSecretCredential as AsyncClientSecretCredential,
+    DefaultAzureCredential as AsyncDefaultAzureCredential,
+)
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.containerinstance.aio import (
     ContainerInstanceManagementClient as AsyncContainerInstanceManagementClient,
@@ -205,13 +208,12 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
 
     @asynccontextmanager
     async def get_async_conn(self) -> AsyncGenerator[AsyncContainerInstanceManagementClient, None]:
-        """
-        Create an async management client.
-        """
+        """Create an async management client bound to a single credential."""
         conn = await get_async_connection(self.conn_id)
         tenant = conn.extra_dejson.get("tenantId")
         subscription_id = cast("str", conn.extra_dejson.get("subscriptionId"))
 
+        credential: AsyncClientSecretCredential | AsyncDefaultAzureCredential
         if all([conn.login, conn.password, tenant]):
             credential = AsyncClientSecretCredential(
                 client_id=cast("str", conn.login),

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
@@ -200,35 +202,18 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
 
     def __init__(self, azure_conn_id: str = AzureContainerInstanceHook.default_conn_name) -> None:
         super().__init__(azure_conn_id=azure_conn_id)
-        self._async_conn: AsyncContainerInstanceManagementClient | None = None
-        self._async_credential: Any = None
 
-    async def __aenter__(self) -> AzureContainerInstanceAsyncHook:
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        await self.close()
-
-    async def close(self) -> None:
-        """Close the async connection and credential."""
-        if self._async_conn is not None:
-            await self._async_conn.close()
-            self._async_conn = None
-        if self._async_credential is not None and hasattr(self._async_credential, "close"):
-            await self._async_credential.close()
-            self._async_credential = None
-
-    async def get_async_conn(self) -> AsyncContainerInstanceManagementClient:
-        """Return (or create) the async management client."""
-        if self._async_conn is not None:
-            return self._async_conn
-
+    @asynccontextmanager
+    async def get_async_conn(self) -> AsyncGenerator[AsyncContainerInstanceManagementClient, None]:
+        """
+        Create an async management client.
+        """
         conn = await get_async_connection(self.conn_id)
         tenant = conn.extra_dejson.get("tenantId")
         subscription_id = cast("str", conn.extra_dejson.get("subscriptionId"))
 
         if all([conn.login, conn.password, tenant]):
-            self._async_credential = AsyncClientSecretCredential(
+            credential = AsyncClientSecretCredential(
                 client_id=cast("str", conn.login),
                 client_secret=cast("str", conn.password),
                 tenant_id=cast("str", tenant),
@@ -236,16 +221,21 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         else:
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            self._async_credential = get_async_default_azure_credential(
+            credential = get_async_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )
 
-        self._async_conn = AsyncContainerInstanceManagementClient(
-            credential=self._async_credential,
+        client = AsyncContainerInstanceManagementClient(
+            credential=credential,
             subscription_id=subscription_id,
         )
-        return self._async_conn
+        try:
+            yield client
+        finally:
+            await client.close()
+            if hasattr(credential, "close"):
+                await credential.close()
 
     async def get_state(self, resource_group: str, name: str) -> ContainerGroup:  # type: ignore[override]
         """
@@ -255,8 +245,8 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         :param name: the name of the container group
         :return: ContainerGroup
         """
-        client = await self.get_async_conn()
-        return await client.container_groups.get(resource_group, name)
+        async with self.get_async_conn() as client:
+            return await client.container_groups.get(resource_group, name)
 
     async def get_logs(self, resource_group: str, name: str, tail: int = 1000) -> list:  # type: ignore[override]
         """
@@ -267,11 +257,11 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         :param tail: the size of the tail
         :return: A list of log messages
         """
-        client = await self.get_async_conn()
-        logs = await client.containers.list_logs(resource_group, name, name, tail=tail)
-        if logs.content is None:
-            return [None]
-        return logs.content.splitlines(True)
+        async with self.get_async_conn() as client:
+            logs = await client.containers.list_logs(resource_group, name, name, tail=tail)
+            if logs.content is None:
+                return [None]
+            return logs.content.splitlines(True)
 
     async def delete(self, resource_group: str, name: str) -> None:  # type: ignore[override]
         """
@@ -280,5 +270,5 @@ class AzureContainerInstanceAsyncHook(AzureContainerInstanceHook):
         :param resource_group: the name of the resource group
         :param name: the name of the container group
         """
-        client = await self.get_async_conn()
-        await client.container_groups.begin_delete(resource_group, name)
+        async with self.get_async_conn() as client:
+            await client.container_groups.begin_delete(resource_group, name)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -111,7 +111,7 @@ class AzureContainerInstancesOperator(BaseOperator):
     :param deferrable: Run in deferrable mode, releasing the worker slot while the container
         runs. Defaults to ``[operators] default_deferrable`` in ``airflow.cfg``.
     :param remove_on_success: Delete the container group after a successful run. Default ``True``.
-    :param polling_interval: Seconds between status polls in deferrable mode. Default ``5.0``.
+    :param polling_interval: Seconds between status polls in deferrable mode. Default ``30.0``.
 
     **Example**::
 
@@ -202,7 +202,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         priority: str | None = "Regular",
         identity: ContainerGroupIdentity | dict | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
-        polling_interval: float = 5.0,
+        polling_interval: float = 30.0,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -446,10 +446,9 @@ class AzureContainerInstancesOperator(BaseOperator):
 
         finally:
             if _cleanup:
-                if exit_code == 0:
-                    if self.remove_on_success:
-                        self.on_kill()
-                elif self.remove_on_error:
+                if exit_code == 0 and self.remove_on_success:
+                    self.on_kill()
+                elif exit_code != 0 and self.remove_on_error:
                     self.on_kill()
 
     def on_kill(self) -> None:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -400,27 +400,17 @@ class AzureContainerInstancesOperator(BaseOperator):
             self.log.info("Container group started %s/%s", self.resource_group, self.name)
 
             if self.deferrable:
-                cg_state = self.hook.get_state(self.resource_group, self.name)
-                instance_view = cg_state.containers[0].instance_view
-                current_state = (
-                    instance_view.current_state.state
-                    if instance_view is not None
-                    else cg_state.provisioning_state
+                _cleanup = False
+                self.defer(
+                    trigger=AzureContainerInstanceTrigger(
+                        resource_group=self.resource_group,
+                        name=self.name,
+                        ci_conn_id=self.ci_conn_id,
+                        polling_interval=self.polling_interval,
+                    ),
+                    method_name=self.execute_complete.__name__,
+                    timeout=self.execution_timeout,
                 )
-                terminal_states = {"Terminated", "Succeeded", "Failed", "Unhealthy"}
-                if current_state not in terminal_states:
-                    _cleanup = False  # container is still running; do not delete on TaskDeferred
-                    self.defer(
-                        trigger=AzureContainerInstanceTrigger(
-                            resource_group=self.resource_group,
-                            name=self.name,
-                            ci_conn_id=self.ci_conn_id,
-                            polling_interval=self.polling_interval,
-                        ),
-                        method_name=self.execute_complete.__name__,
-                        timeout=self.execution_timeout,
-                    )
-                # Already terminal — fall through to synchronous completion below.
 
             exit_code = self._monitor_logging(self.resource_group, self.name)
             if self.xcom_all is not None:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -479,21 +479,21 @@ class AzureContainerInstancesOperator(BaseOperator):
                 )
             )
 
-        if self.xcom_all is not None:
-            logs = self.hook.get_logs(self.resource_group, self.name)
-            if logs is None:
-                context["ti"].xcom_push(key="logs", value=[])
-            elif self.xcom_all:
-                context["ti"].xcom_push(key="logs", value=logs)
-            else:
-                context["ti"].xcom_push(key="logs", value=logs[-1:])
+        try:
+            if self.xcom_all is not None:
+                logs = self.hook.get_logs(self.resource_group, self.name)
+                if logs is None:
+                    context["ti"].xcom_push(key="logs", value=[])
+                elif self.xcom_all:
+                    context["ti"].xcom_push(key="logs", value=logs)
+                else:
+                    context["ti"].xcom_push(key="logs", value=logs[-1:])
 
-        self.log.info("Container had exit code: %s", exit_code)
-
-        if self.remove_on_success:
-            self.on_kill()
-
-        return exit_code
+            self.log.info("Container had exit code: %s", exit_code)
+            return exit_code
+        finally:
+            if self.remove_on_success:
+                self.on_kill()
 
     def _monitor_logging(self, resource_group: str, name: str) -> int:
         last_state = None

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -464,17 +464,17 @@ class AzureContainerInstancesOperator(BaseOperator):
         Handle the trigger event after deferral.
 
         Called by the Triggerer when the container reaches a terminal state.
-        Raises an AirflowException on failure; returns the exit code on success.
+        Raises on failure; returns the exit code on success.
         """
         if event is None:
-            raise AirflowException("Trigger error: event is None")
+            raise ValueError("Trigger error: event is None")
 
         exit_code: int = event.get("exit_code", 1)
 
         if event["status"] == "error":
             if self.remove_on_error:
                 self.on_kill()
-            raise AirflowException(
+            raise RuntimeError(
                 event.get(
                     "message",
                     f"Container group {self.resource_group}/{self.name} failed with exit code {exit_code}",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -43,8 +43,7 @@ from azure.mgmt.containerinstance.models import (
 )
 from msrestazure.azure_exceptions import CloudError
 
-from airflow.configuration import conf
-from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout, BaseOperator
+from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout, BaseOperator, conf
 from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceHook
 from airflow.providers.microsoft.azure.hooks.container_registry import AzureContainerRegistryHook
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -316,7 +316,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         return identity
 
     @cached_property
-    def _ci_hook(self) -> AzureContainerInstanceHook:
+    def hook(self) -> AzureContainerInstanceHook:
         return AzureContainerInstanceHook(azure_conn_id=self.ci_conn_id)
 
     def execute(self, context: Context) -> int:
@@ -325,7 +325,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
         if self.fail_if_exists:
             self.log.info("Testing if container group already exists")
-            if self._ci_hook.exists(self.resource_group, self.name):
+            if self.hook.exists(self.resource_group, self.name):
                 raise AirflowException("Container group exists")
 
         if self.registry_conn_id:
@@ -396,12 +396,12 @@ class AzureContainerInstancesOperator(BaseOperator):
                 identity=self.identity,
             )
 
-            self._ci_hook.create_or_update(self.resource_group, self.name, container_group)
+            self.hook.create_or_update(self.resource_group, self.name, container_group)
 
             self.log.info("Container group started %s/%s", self.resource_group, self.name)
 
             if self.deferrable:
-                cg_state = self._ci_hook.get_state(self.resource_group, self.name)
+                cg_state = self.hook.get_state(self.resource_group, self.name)
                 instance_view = cg_state.containers[0].instance_view
                 current_state = (
                     instance_view.current_state.state
@@ -425,7 +425,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
             exit_code = self._monitor_logging(self.resource_group, self.name)
             if self.xcom_all is not None:
-                logs = self._ci_hook.get_logs(self.resource_group, self.name)
+                logs = self.hook.get_logs(self.resource_group, self.name)
                 if logs is None:
                     context["ti"].xcom_push(key="logs", value=[])
                 else:
@@ -454,7 +454,7 @@ class AzureContainerInstancesOperator(BaseOperator):
     def on_kill(self) -> None:
         self.log.info("Deleting container group")
         try:
-            self._ci_hook.delete(self.resource_group, self.name)
+            self.hook.delete(self.resource_group, self.name)
         except Exception:
             self.log.exception("Could not delete container group")
 
@@ -481,7 +481,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             )
 
         if self.xcom_all is not None:
-            logs = self._ci_hook.get_logs(self.resource_group, self.name)
+            logs = self.hook.get_logs(self.resource_group, self.name)
             if logs is None:
                 context["ti"].xcom_push(key="logs", value=[])
             elif self.xcom_all:
@@ -503,7 +503,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
         while True:
             try:
-                cg_state = self._ci_hook.get_state(resource_group, name)
+                cg_state = self.hook.get_state(resource_group, name)
                 instance_view = cg_state.containers[0].instance_view
                 # If there is no instance view, we show the provisioning state
                 if instance_view is not None:
@@ -528,7 +528,7 @@ class AzureContainerInstancesOperator(BaseOperator):
 
                 if state in ["Running", "Terminated", "Succeeded"]:
                     try:
-                        logs = self._ci_hook.get_logs(resource_group, name)
+                        logs = self.hook.get_logs(resource_group, name)
                         if logs and logs[0] is None:
                             self.log.error("Container log is broken, marking as failed.")
                             return 1

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py
@@ -21,6 +21,7 @@ import re
 import time
 from collections import namedtuple
 from collections.abc import Sequence
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 from azure.mgmt.containerinstance.models import (
@@ -42,10 +43,12 @@ from azure.mgmt.containerinstance.models import (
 )
 from msrestazure.azure_exceptions import CloudError
 
+from airflow.configuration import conf
 from airflow.providers.common.compat.sdk import AirflowException, AirflowTaskTimeout, BaseOperator
 from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceHook
 from airflow.providers.microsoft.azure.hooks.container_registry import AzureContainerRegistryHook
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook
+from airflow.providers.microsoft.azure.triggers.container_instance import AzureContainerInstanceTrigger
 
 if TYPE_CHECKING:
     from airflow.sdk import Context
@@ -105,6 +108,10 @@ class AzureContainerInstancesOperator(BaseOperator):
     :param diagnostics: Container group diagnostic information (Log Analytics).
     :param priority: Container group priority, Possible values include: 'Regular', 'Spot'
     :param identity: List of User/System assigned identities for the container group.
+    :param deferrable: Run in deferrable mode, releasing the worker slot while the container
+        runs. Defaults to ``[operators] default_deferrable`` in ``airflow.cfg``.
+    :param remove_on_success: Delete the container group after a successful run. Default ``True``.
+    :param polling_interval: Seconds between status polls in deferrable mode. Default ``5.0``.
 
     **Example**::
 
@@ -181,6 +188,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         gpu: Any | None = None,
         command: list[str] | None = None,
         remove_on_error: bool = True,
+        remove_on_success: bool = True,
         fail_if_exists: bool = True,
         tags: dict[str, str] | None = None,
         xcom_all: bool | None = None,
@@ -193,6 +201,8 @@ class AzureContainerInstancesOperator(BaseOperator):
         diagnostics: ContainerGroupDiagnostics | None = None,
         priority: str | None = "Regular",
         identity: ContainerGroupIdentity | dict | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        polling_interval: float = 5.0,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -211,8 +221,8 @@ class AzureContainerInstancesOperator(BaseOperator):
         self.gpu = gpu
         self.command = command
         self.remove_on_error = remove_on_error
+        self.remove_on_success = remove_on_success
         self.fail_if_exists = fail_if_exists
-        self._ci_hook: Any = None
         self.tags = tags
         self.xcom_all = xcom_all
         self.os_type = os_type
@@ -242,6 +252,8 @@ class AzureContainerInstancesOperator(BaseOperator):
                 "Please set 'Regular' or 'Spot' as the priority. "
                 f"Found `{self.priority}`."
             )
+        self.deferrable = deferrable
+        self.polling_interval = polling_interval
 
     # helper to accept dict (user-friendly) or ContainerGroupIdentity (SDK object)
     @staticmethod
@@ -303,11 +315,13 @@ class AzureContainerInstancesOperator(BaseOperator):
             )
         return identity
 
+    @cached_property
+    def _ci_hook(self) -> AzureContainerInstanceHook:
+        return AzureContainerInstanceHook(azure_conn_id=self.ci_conn_id)
+
     def execute(self, context: Context) -> int:
         # Check name again in case it was templated.
         self._check_name(self.name)
-
-        self._ci_hook = AzureContainerInstanceHook(azure_conn_id=self.ci_conn_id)
 
         if self.fail_if_exists:
             self.log.info("Testing if container group already exists")
@@ -340,6 +354,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             volume_mounts.append(VolumeMount(name=mount_name, mount_path=mount_path, read_only=read_only))
 
         exit_code = 1
+        _cleanup = True
         try:
             self.log.info("Starting container group with %.1f cpu %.1f mem", self.cpu, self.memory_in_gb)
             if self.gpu:
@@ -385,6 +400,29 @@ class AzureContainerInstancesOperator(BaseOperator):
 
             self.log.info("Container group started %s/%s", self.resource_group, self.name)
 
+            if self.deferrable:
+                cg_state = self._ci_hook.get_state(self.resource_group, self.name)
+                instance_view = cg_state.containers[0].instance_view
+                current_state = (
+                    instance_view.current_state.state
+                    if instance_view is not None
+                    else cg_state.provisioning_state
+                )
+                terminal_states = {"Terminated", "Succeeded", "Failed", "Unhealthy"}
+                if current_state not in terminal_states:
+                    _cleanup = False  # container is still running; do not delete on TaskDeferred
+                    self.defer(
+                        trigger=AzureContainerInstanceTrigger(
+                            resource_group=self.resource_group,
+                            name=self.name,
+                            ci_conn_id=self.ci_conn_id,
+                            polling_interval=self.polling_interval,
+                        ),
+                        method_name=self.execute_complete.__name__,
+                        timeout=self.execution_timeout,
+                    )
+                # Already terminal — fall through to synchronous completion below.
+
             exit_code = self._monitor_logging(self.resource_group, self.name)
             if self.xcom_all is not None:
                 logs = self._ci_hook.get_logs(self.resource_group, self.name)
@@ -407,8 +445,12 @@ class AzureContainerInstancesOperator(BaseOperator):
             raise AirflowException("Could not start container group")
 
         finally:
-            if exit_code == 0 or self.remove_on_error:
-                self.on_kill()
+            if _cleanup:
+                if exit_code == 0:
+                    if self.remove_on_success:
+                        self.on_kill()
+                elif self.remove_on_error:
+                    self.on_kill()
 
     def on_kill(self) -> None:
         self.log.info("Deleting container group")
@@ -416,6 +458,44 @@ class AzureContainerInstancesOperator(BaseOperator):
             self._ci_hook.delete(self.resource_group, self.name)
         except Exception:
             self.log.exception("Could not delete container group")
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None) -> int:
+        """
+        Handle the trigger event after deferral.
+
+        Called by the Triggerer when the container reaches a terminal state.
+        Raises an AirflowException on failure; returns the exit code on success.
+        """
+        if event is None:
+            raise AirflowException("Trigger error: event is None")
+
+        exit_code: int = event.get("exit_code", 1)
+
+        if event["status"] == "error":
+            if self.remove_on_error:
+                self.on_kill()
+            raise AirflowException(
+                event.get(
+                    "message",
+                    f"Container group {self.resource_group}/{self.name} failed with exit code {exit_code}",
+                )
+            )
+
+        if self.xcom_all is not None:
+            logs = self._ci_hook.get_logs(self.resource_group, self.name)
+            if logs is None:
+                context["ti"].xcom_push(key="logs", value=[])
+            elif self.xcom_all:
+                context["ti"].xcom_push(key="logs", value=logs)
+            else:
+                context["ti"].xcom_push(key="logs", value=logs[-1:])
+
+        self.log.info("Container had exit code: %s", exit_code)
+
+        if self.remove_on_success:
+            self.on_kill()
+
+        return exit_code
 
     def _monitor_logging(self, resource_group: str, name: str) -> int:
         last_state = None

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
@@ -77,9 +77,14 @@ class AzureContainerInstanceTrigger(BaseTrigger):
                         exit_code = c_state.exit_code
                         detail_status = c_state.detail_status
                     else:
-                        state = cg_state.provisioning_state
-                        exit_code = 0
-                        detail_status = "Provisioning"
+                        prov = cg_state.provisioning_state
+                        if prov in ("Failed", "Unhealthy"):
+                            state = prov
+                            exit_code = 1
+                            detail_status = prov
+                        else:
+                            await asyncio.sleep(self.polling_interval)
+                            continue
 
                     if state in TERMINAL_STATES:
                         if state in SUCCESS_STATES and exit_code == 0:
@@ -110,6 +115,8 @@ class AzureContainerInstanceTrigger(BaseTrigger):
                         return
 
                     await asyncio.sleep(self.polling_interval)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             yield TriggerEvent(
                 {

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
@@ -42,7 +42,7 @@ class AzureContainerInstanceTrigger(BaseTrigger):
         resource_group: str,
         name: str,
         ci_conn_id: str,
-        polling_interval: float = 5.0,
+        polling_interval: float = 30.0,
     ) -> None:
         super().__init__()
         self.resource_group = resource_group
@@ -79,8 +79,6 @@ class AzureContainerInstanceTrigger(BaseTrigger):
                         state = cg_state.provisioning_state
                         exit_code = 0
                         detail_status = "Provisioning"
-
-                    self.log.info("Container group %s/%s state: %s", self.resource_group, self.name, state)
 
                     if state in TERMINAL_STATES:
                         if state in SUCCESS_STATES and exit_code == 0:

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceAsyncHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+TERMINAL_STATES = frozenset({"Terminated", "Succeeded", "Failed", "Unhealthy"})
+SUCCESS_STATES = frozenset({"Terminated", "Succeeded"})
+
+
+class AzureContainerInstanceTrigger(BaseTrigger):
+    """
+    Poll an Azure Container Instance until it reaches a terminal state.
+
+    :param resource_group: the name of the resource group
+    :param name: the name of the container group
+    :param ci_conn_id: connection id of the Azure service principal
+    :param polling_interval: time in seconds between state polls
+    """
+
+    def __init__(
+        self,
+        resource_group: str,
+        name: str,
+        ci_conn_id: str,
+        polling_interval: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self.resource_group = resource_group
+        self.name = name
+        self.ci_conn_id = ci_conn_id
+        self.polling_interval = polling_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize trigger arguments and classpath."""
+        return (
+            "airflow.providers.microsoft.azure.triggers.container_instance.AzureContainerInstanceTrigger",
+            {
+                "resource_group": self.resource_group,
+                "name": self.name,
+                "ci_conn_id": self.ci_conn_id,
+                "polling_interval": self.polling_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Poll ACI until a terminal state is reached, then yield a TriggerEvent."""
+        try:
+            async with AzureContainerInstanceAsyncHook(azure_conn_id=self.ci_conn_id) as hook:
+                while True:
+                    cg_state = await hook.get_state(self.resource_group, self.name)
+                    instance_view = cg_state.containers[0].instance_view
+
+                    if instance_view is not None:
+                        c_state = instance_view.current_state
+                        state = c_state.state
+                        exit_code = c_state.exit_code
+                        detail_status = c_state.detail_status
+                    else:
+                        state = cg_state.provisioning_state
+                        exit_code = 0
+                        detail_status = "Provisioning"
+
+                    self.log.info("Container group %s/%s state: %s", self.resource_group, self.name, state)
+
+                    if state in TERMINAL_STATES:
+                        if state in SUCCESS_STATES and exit_code == 0:
+                            yield TriggerEvent(
+                                {
+                                    "status": "success",
+                                    "exit_code": exit_code,
+                                    "detail_status": detail_status,
+                                    "resource_group": self.resource_group,
+                                    "name": self.name,
+                                }
+                            )
+                        else:
+                            yield TriggerEvent(
+                                {
+                                    "status": "error",
+                                    "exit_code": exit_code,
+                                    "detail_status": detail_status,
+                                    "resource_group": self.resource_group,
+                                    "name": self.name,
+                                    "message": (
+                                        f"Container group {self.resource_group}/{self.name} "
+                                        f"reached state {state!r} with exit code {exit_code} "
+                                        f"({detail_status})"
+                                    ),
+                                }
+                            )
+                        return
+
+                    await asyncio.sleep(self.polling_interval)
+        except Exception as e:
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "message": str(e),
+                    "resource_group": self.resource_group,
+                    "name": self.name,
+                    "exit_code": 1,
+                    "detail_status": "",
+                }
+            )

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/container_instance.py
@@ -64,10 +64,11 @@ class AzureContainerInstanceTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Poll ACI until a terminal state is reached, then yield a TriggerEvent."""
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=self.ci_conn_id)
         try:
-            async with AzureContainerInstanceAsyncHook(azure_conn_id=self.ci_conn_id) as hook:
+            async with hook.get_async_conn() as client:
                 while True:
-                    cg_state = await hook.get_state(self.resource_group, self.name)
+                    cg_state = await client.container_groups.get(self.resource_group, self.name)
                     instance_view = cg_state.containers[0].instance_view
 
                     if instance_view is not None:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
@@ -302,23 +302,24 @@ class TestAzureContainerInstanceAsyncHook:
         async_conn_with_credentials,
     ):
         mock_credential = MagicMock(spec=AsyncClientSecretCredential)
+        mock_credential.close = AsyncMock()
         mock_credential_cls.return_value = mock_credential
         mock_client_instance = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_instance.close = AsyncMock()
         mock_client_cls.return_value = mock_client_instance
 
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        conn = await hook.get_async_conn()
-
-        mock_credential_cls.assert_called_once_with(
-            client_id="client-id",
-            client_secret="client-secret",
-            tenant_id="tenant-id",
-        )
-        mock_client_cls.assert_called_once_with(
-            credential=mock_credential,
-            subscription_id="subscription-id",
-        )
-        assert conn == mock_client_instance
+        async with hook.get_async_conn() as conn:
+            mock_credential_cls.assert_called_once_with(
+                client_id="client-id",
+                client_secret="client-secret",
+                tenant_id="tenant-id",
+            )
+            mock_client_cls.assert_called_once_with(
+                credential=mock_credential,
+                subscription_id="subscription-id",
+            )
+            assert conn is mock_client_instance
 
     @patch(
         "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
@@ -331,75 +332,136 @@ class TestAzureContainerInstanceAsyncHook:
         mock_client_cls,
         async_conn_without_credentials,
     ):
-        mock_credential = MagicMock(spec=AsyncClientSecretCredential)
+        mock_credential = MagicMock()
+        mock_credential.close = AsyncMock()
         mock_default_cred.return_value = mock_credential
         mock_client_instance = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_instance.close = AsyncMock()
         mock_client_cls.return_value = mock_client_instance
 
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_without_credentials.conn_id)
-        conn = await hook.get_async_conn()
-
-        mock_default_cred.assert_called_once_with(
-            managed_identity_client_id=None,
-            workload_identity_tenant_id=None,
-        )
-        assert conn == mock_client_instance
-
-    @pytest.mark.asyncio
-    async def test_get_async_conn_returns_cached_connection(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_conn = MagicMock(spec=AsyncContainerInstanceManagementClient)
-        hook._async_conn = mock_conn
-
-        conn = await hook.get_async_conn()
-        assert conn is mock_conn
+        async with hook.get_async_conn() as conn:
+            mock_default_cred.assert_called_once_with(
+                managed_identity_client_id=None,
+                workload_identity_tenant_id=None,
+            )
+            assert conn is mock_client_instance
 
     @patch(
-        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient",
-        autospec=True,
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
     )
-    @patch(
-        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential",
-        autospec=True,
-    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
     @pytest.mark.asyncio
-    async def test_get_async_conn_returns_same_instance_on_repeated_calls(
+    async def test_get_async_conn_closes_client_and_credential(
         self,
         mock_credential_cls,
         mock_client_cls,
         async_conn_with_credentials,
     ):
-        mock_client_cls.return_value = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
+        mock_credential_cls.return_value = mock_credential
+        mock_client_instance = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_cls.return_value = mock_client_instance
 
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        conn1 = await hook.get_async_conn()
-        conn2 = await hook.get_async_conn()
+        async with hook.get_async_conn() as conn:
+            assert conn is mock_client_instance
 
-        assert conn1 is conn2
-        mock_client_cls.assert_called_once()
+        mock_client_instance.close.assert_called_once()
+        mock_credential.close.assert_called_once()
 
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.get_async_default_azure_credential")
     @pytest.mark.asyncio
-    async def test_get_state(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_client = MagicMock()
-        mock_cg = MagicMock(spec=ContainerGroup)
-        mock_client.container_groups.get = AsyncMock(return_value=mock_cg)
-        hook._async_conn = mock_client
+    async def test_get_async_conn_skips_credential_close_when_not_closeable(
+        self,
+        mock_default_cred,
+        mock_client_cls,
+        async_conn_without_credentials,
+    ):
+        # Credential without a close method (spec=[] removes all attributes)
+        mock_credential = MagicMock(spec=[])
+        mock_default_cred.return_value = mock_credential
+        mock_client_instance = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_cls.return_value = mock_client_instance
 
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_without_credentials.conn_id)
+        async with hook.get_async_conn():
+            pass
+
+        mock_client_instance.close.assert_called_once()
+        assert not hasattr(mock_credential, "close")
+
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
+    @pytest.mark.asyncio
+    async def test_get_async_conn_closes_on_exception(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
+        mock_credential_cls.return_value = mock_credential
+        mock_client_instance = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_cls.return_value = mock_client_instance
+
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        with pytest.raises(RuntimeError, match="boom"):
+            async with hook.get_async_conn():
+                raise RuntimeError("boom")
+
+        mock_client_instance.close.assert_called_once()
+        mock_credential.close.assert_called_once()
+
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
+    @pytest.mark.asyncio
+    async def test_get_state(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential_cls.return_value = AsyncMock(spec=AsyncClientSecretCredential)
+        mock_cg = MagicMock(spec=ContainerGroup)
+        mock_client = MagicMock()
+        mock_client.close = AsyncMock()
+        mock_client.container_groups.get = AsyncMock(return_value=mock_cg)
+        mock_client_cls.return_value = mock_client
+
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         result = await hook.get_state("my-rg", "my-container")
 
         mock_client.container_groups.get.assert_called_once_with("my-rg", "my-container")
         assert result is mock_cg
 
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
     @pytest.mark.asyncio
-    async def test_get_logs(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_client = MagicMock()
+    async def test_get_logs(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential_cls.return_value = AsyncMock(spec=AsyncClientSecretCredential)
         mock_logs = MagicMock(spec=Logs)
         mock_logs.content = "line1\nline2\n"
+        mock_client = MagicMock()
+        mock_client.close = AsyncMock()
         mock_client.containers.list_logs = AsyncMock(return_value=mock_logs)
-        hook._async_conn = mock_client
+        mock_client_cls.return_value = mock_client
 
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         result = await hook.get_logs("my-rg", "my-container")
 
         mock_client.containers.list_logs.assert_called_once_with(
@@ -407,63 +469,47 @@ class TestAzureContainerInstanceAsyncHook:
         )
         assert result == ["line1\n", "line2\n"]
 
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
     @pytest.mark.asyncio
-    async def test_get_logs_returns_none_sentinel_when_content_is_none(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_client = MagicMock()
+    async def test_get_logs_returns_none_sentinel_when_content_is_none(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential_cls.return_value = AsyncMock(spec=AsyncClientSecretCredential)
         mock_logs = MagicMock(spec=Logs)
         mock_logs.content = None
+        mock_client = MagicMock()
+        mock_client.close = AsyncMock()
         mock_client.containers.list_logs = AsyncMock(return_value=mock_logs)
-        hook._async_conn = mock_client
+        mock_client_cls.return_value = mock_client
 
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         result = await hook.get_logs("my-rg", "my-container")
         assert result == [None]
 
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
     @pytest.mark.asyncio
-    async def test_delete(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+    async def test_delete(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential_cls.return_value = AsyncMock(spec=AsyncClientSecretCredential)
         mock_client = MagicMock()
+        mock_client.close = AsyncMock()
         mock_client.container_groups.begin_delete = AsyncMock()
-        hook._async_conn = mock_client
+        mock_client_cls.return_value = mock_client
 
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         await hook.delete("my-rg", "my-container")
 
         mock_client.container_groups.begin_delete.assert_called_once_with("my-rg", "my-container")
-
-    @pytest.mark.asyncio
-    async def test_close(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
-        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
-        hook._async_conn = mock_client
-        hook._async_credential = mock_credential
-
-        await hook.close()
-
-        mock_client.close.assert_called_once()
-        mock_credential.close.assert_called_once()
-        assert hook._async_conn is None
-        assert hook._async_credential is None
-
-    @pytest.mark.asyncio
-    async def test_close_when_no_connection(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        hook._async_conn = None
-        hook._async_credential = None
-        await hook.close()
-
-    @pytest.mark.asyncio
-    async def test_async_context_manager_calls_close(self, async_conn_with_credentials):
-        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
-        mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
-        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
-        hook._async_conn = mock_client
-        hook._async_credential = mock_credential
-
-        async with hook as h:
-            assert h is hook
-
-        mock_client.close.assert_called_once()
-        mock_credential.close.assert_called_once()
-        assert hook._async_conn is None
-        assert hook._async_credential is None

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
@@ -354,6 +354,30 @@ class TestAzureContainerInstanceAsyncHook:
         conn = await hook.get_async_conn()
         assert conn is mock_conn
 
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient",
+        autospec=True,
+    )
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential",
+        autospec=True,
+    )
+    @pytest.mark.asyncio
+    async def test_get_async_conn_returns_same_instance_on_repeated_calls(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_client_cls.return_value = MagicMock(spec=AsyncContainerInstanceManagementClient)
+
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        conn1 = await hook.get_async_conn()
+        conn2 = await hook.get_async_conn()
+
+        assert conn1 is conn2
+        mock_client_cls.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_get_state(self, async_conn_with_credentials):
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
@@ -410,27 +434,36 @@ class TestAzureContainerInstanceAsyncHook:
     async def test_close(self, async_conn_with_credentials):
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
         hook._async_conn = mock_client
+        hook._async_credential = mock_credential
 
         await hook.close()
 
         mock_client.close.assert_called_once()
+        mock_credential.close.assert_called_once()
         assert hook._async_conn is None
+        assert hook._async_credential is None
 
     @pytest.mark.asyncio
     async def test_close_when_no_connection(self, async_conn_with_credentials):
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         hook._async_conn = None
+        hook._async_credential = None
         await hook.close()
 
     @pytest.mark.asyncio
     async def test_async_context_manager_calls_close(self, async_conn_with_credentials):
         hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
         mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        mock_credential = AsyncMock(spec=AsyncClientSecretCredential)
         hook._async_conn = mock_client
+        hook._async_credential = mock_credential
 
         async with hook as h:
             assert h is hook
 
         mock_client.close.assert_called_once()
+        mock_credential.close.assert_called_once()
         assert hook._async_conn is None
+        assert hook._async_credential is None

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
@@ -17,19 +17,27 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import AzureAuthorityHosts
+from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
+from azure.mgmt.containerinstance.aio import (
+    ContainerInstanceManagementClient as AsyncContainerInstanceManagementClient,
+)
 from azure.mgmt.containerinstance.models import (
+    ContainerGroup,
     Logs,
     ResourceRequests,
     ResourceRequirements,
 )
 
 from airflow.models import Connection
-from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceHook
+from airflow.providers.microsoft.azure.hooks.container_instance import (
+    AzureContainerInstanceAsyncHook,
+    AzureContainerInstanceHook,
+)
 
 
 @pytest.fixture
@@ -252,3 +260,177 @@ class TestAzureContainerInstanceHookCloudEnvironment:
             base_url=expected_base_url,
             credential_scopes=expected_scopes,
         )
+
+
+@pytest.fixture
+def async_conn_with_credentials(create_mock_connection):
+    return create_mock_connection(
+        Connection(
+            conn_id="azure_aci_async_test",
+            conn_type="azure_container_instance",
+            login="client-id",
+            password="client-secret",
+            extra={
+                "tenantId": "tenant-id",
+                "subscriptionId": "subscription-id",
+            },
+        )
+    )
+
+
+@pytest.fixture
+def async_conn_without_credentials(create_mock_connection):
+    return create_mock_connection(
+        Connection(
+            conn_id="azure_aci_async_no_creds",
+            conn_type="azure_container_instance",
+            extra={"subscriptionId": "subscription-id"},
+        )
+    )
+
+
+class TestAzureContainerInstanceAsyncHook:
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.AsyncClientSecretCredential")
+    @pytest.mark.asyncio
+    async def test_get_async_conn_with_client_secret(
+        self,
+        mock_credential_cls,
+        mock_client_cls,
+        async_conn_with_credentials,
+    ):
+        mock_credential = MagicMock(spec=AsyncClientSecretCredential)
+        mock_credential_cls.return_value = mock_credential
+        mock_client_instance = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_cls.return_value = mock_client_instance
+
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        conn = await hook.get_async_conn()
+
+        mock_credential_cls.assert_called_once_with(
+            client_id="client-id",
+            client_secret="client-secret",
+            tenant_id="tenant-id",
+        )
+        mock_client_cls.assert_called_once_with(
+            credential=mock_credential,
+            subscription_id="subscription-id",
+        )
+        assert conn == mock_client_instance
+
+    @patch(
+        "airflow.providers.microsoft.azure.hooks.container_instance.AsyncContainerInstanceManagementClient"
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.container_instance.get_async_default_azure_credential")
+    @pytest.mark.asyncio
+    async def test_get_async_conn_with_default_credential(
+        self,
+        mock_default_cred,
+        mock_client_cls,
+        async_conn_without_credentials,
+    ):
+        mock_credential = MagicMock(spec=AsyncClientSecretCredential)
+        mock_default_cred.return_value = mock_credential
+        mock_client_instance = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        mock_client_cls.return_value = mock_client_instance
+
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_without_credentials.conn_id)
+        conn = await hook.get_async_conn()
+
+        mock_default_cred.assert_called_once_with(
+            managed_identity_client_id=None,
+            workload_identity_tenant_id=None,
+        )
+        assert conn == mock_client_instance
+
+    @pytest.mark.asyncio
+    async def test_get_async_conn_returns_cached_connection(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_conn = MagicMock(spec=AsyncContainerInstanceManagementClient)
+        hook._async_conn = mock_conn
+
+        conn = await hook.get_async_conn()
+        assert conn is mock_conn
+
+    @pytest.mark.asyncio
+    async def test_get_state(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = MagicMock()
+        mock_cg = MagicMock(spec=ContainerGroup)
+        mock_client.container_groups.get = AsyncMock(return_value=mock_cg)
+        hook._async_conn = mock_client
+
+        result = await hook.get_state("my-rg", "my-container")
+
+        mock_client.container_groups.get.assert_called_once_with("my-rg", "my-container")
+        assert result is mock_cg
+
+    @pytest.mark.asyncio
+    async def test_get_logs(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = MagicMock()
+        mock_logs = MagicMock(spec=Logs)
+        mock_logs.content = "line1\nline2\n"
+        mock_client.containers.list_logs = AsyncMock(return_value=mock_logs)
+        hook._async_conn = mock_client
+
+        result = await hook.get_logs("my-rg", "my-container")
+
+        mock_client.containers.list_logs.assert_called_once_with(
+            "my-rg", "my-container", "my-container", tail=1000
+        )
+        assert result == ["line1\n", "line2\n"]
+
+    @pytest.mark.asyncio
+    async def test_get_logs_returns_none_sentinel_when_content_is_none(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = MagicMock()
+        mock_logs = MagicMock(spec=Logs)
+        mock_logs.content = None
+        mock_client.containers.list_logs = AsyncMock(return_value=mock_logs)
+        hook._async_conn = mock_client
+
+        result = await hook.get_logs("my-rg", "my-container")
+        assert result == [None]
+
+    @pytest.mark.asyncio
+    async def test_delete(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = MagicMock()
+        mock_client.container_groups.begin_delete = AsyncMock()
+        hook._async_conn = mock_client
+
+        await hook.delete("my-rg", "my-container")
+
+        mock_client.container_groups.begin_delete.assert_called_once_with("my-rg", "my-container")
+
+    @pytest.mark.asyncio
+    async def test_close(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        hook._async_conn = mock_client
+
+        await hook.close()
+
+        mock_client.close.assert_called_once()
+        assert hook._async_conn is None
+
+    @pytest.mark.asyncio
+    async def test_close_when_no_connection(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        hook._async_conn = None
+        await hook.close()
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager_calls_close(self, async_conn_with_credentials):
+        hook = AzureContainerInstanceAsyncHook(azure_conn_id=async_conn_with_credentials.conn_id)
+        mock_client = AsyncMock(spec=AsyncContainerInstanceManagementClient)
+        hook._async_conn = mock_client
+
+        async with hook as h:
+            assert h is hook
+
+        mock_client.close.assert_called_once()
+        assert hook._async_conn is None

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
@@ -648,10 +648,8 @@ class TestACIOperator:
         "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
         autospec=True,
     )
-    def test_execute_deferrable_defers_when_container_running(self, aci_mock):
-        """When deferrable=True and the container is still running, defer() is called."""
-        running_cg = make_mock_container(state="Running", exit_code=0, detail_status="test")
-        aci_mock.return_value.get_state.return_value = running_cg
+    def test_execute_deferrable_defers_unconditionally(self, aci_mock):
+        """When deferrable=True, defer() is called immediately after create_or_update."""
         aci_mock.return_value.exists.return_value = False
 
         aci = AzureContainerInstancesOperator(
@@ -668,37 +666,14 @@ class TestACIOperator:
         with pytest.raises(TaskDeferred) as exc_info:
             aci.execute(None)
 
+        assert aci_mock.return_value.create_or_update.call_count == 1
         assert isinstance(exc_info.value.trigger, AzureContainerInstanceTrigger)
         assert exc_info.value.trigger.resource_group == "resource-group"
         assert exc_info.value.trigger.name == "container-name"
         assert exc_info.value.trigger.polling_interval == 10.0
         assert exc_info.value.method_name == "execute_complete"
-        # Container must NOT be deleted when deferring — it is still running
         assert aci_mock.return_value.delete.call_count == 0
-
-    @mock.patch(
-        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
-        autospec=True,
-    )
-    def test_execute_deferrable_completes_synchronously_if_already_terminated(self, aci_mock):
-        """When deferrable=True but container is already terminal, no deferral — sync completion."""
-        terminated_cg = make_mock_container(state="Terminated", exit_code=0, detail_status="test")
-        aci_mock.return_value.get_state.return_value = terminated_cg
-        aci_mock.return_value.exists.return_value = False
-
-        aci = AzureContainerInstancesOperator(
-            ci_conn_id="azure_default",
-            registry_conn_id=None,
-            resource_group="resource-group",
-            name="container-name",
-            image="container-image",
-            region="region",
-            task_id="task",
-            deferrable=True,
-        )
-        result = aci.execute(None)
-        assert result == 0
-        assert aci_mock.return_value.create_or_update.call_count == 1
+        assert aci_mock.return_value.get_state.call_count == 0
 
     @mock.patch(
         "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
@@ -768,7 +743,7 @@ class TestACIOperator:
         autospec=True,
     )
     def test_execute_complete_error_event_raises(self, aci_mock):
-        """execute_complete raises AirflowException when event has status=error."""
+        """execute_complete raises RuntimeError when event has status=error."""
         aci = AzureContainerInstancesOperator(
             ci_conn_id="azure_default",
             registry_conn_id=None,

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
@@ -780,7 +780,7 @@ class TestACIOperator:
             deferrable=True,
             remove_on_error=False,
         )
-        with pytest.raises(AirflowException, match="Container group failed"):
+        with pytest.raises(RuntimeError, match="Container group failed"):
             aci.execute_complete(
                 context=None,
                 event={
@@ -810,7 +810,7 @@ class TestACIOperator:
             deferrable=True,
             remove_on_error=True,
         )
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             aci.execute_complete(
                 context=None,
                 event={
@@ -829,7 +829,7 @@ class TestACIOperator:
         autospec=True,
     )
     def test_execute_complete_none_event_raises(self, aci_mock):
-        """execute_complete raises AirflowException when event is None."""
+        """execute_complete raises ValueError when event is None."""
         aci = AzureContainerInstancesOperator(
             ci_conn_id="azure_default",
             registry_conn_id=None,
@@ -840,7 +840,7 @@ class TestACIOperator:
             task_id="task",
             deferrable=True,
         )
-        with pytest.raises(AirflowException, match="event is None"):
+        with pytest.raises(ValueError, match="event is None"):
             aci.execute_complete(context=None, event=None)
 
     @mock.patch(

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_container_instances.py
@@ -32,8 +32,10 @@ from azure.mgmt.containerinstance.models import (
     Event,
 )
 
+from airflow.exceptions import TaskDeferred
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.operators.container_instances import AzureContainerInstancesOperator
+from airflow.providers.microsoft.azure.triggers.container_instance import AzureContainerInstanceTrigger
 
 from tests_common.test_utils.compat import Context
 
@@ -641,6 +643,317 @@ class TestACIOperator:
         assert called_cg.identity is not None
         # user_assigned_identities should contain the resource id as a key
         assert resource_id in (called_cg.identity.user_assigned_identities or {})
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_deferrable_defers_when_container_running(self, aci_mock):
+        """When deferrable=True and the container is still running, defer() is called."""
+        running_cg = make_mock_container(state="Running", exit_code=0, detail_status="test")
+        aci_mock.return_value.get_state.return_value = running_cg
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            polling_interval=10.0,
+        )
+        with pytest.raises(TaskDeferred) as exc_info:
+            aci.execute(None)
+
+        assert isinstance(exc_info.value.trigger, AzureContainerInstanceTrigger)
+        assert exc_info.value.trigger.resource_group == "resource-group"
+        assert exc_info.value.trigger.name == "container-name"
+        assert exc_info.value.trigger.polling_interval == 10.0
+        assert exc_info.value.method_name == "execute_complete"
+        # Container must NOT be deleted when deferring — it is still running
+        assert aci_mock.return_value.delete.call_count == 0
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_deferrable_completes_synchronously_if_already_terminated(self, aci_mock):
+        """When deferrable=True but container is already terminal, no deferral — sync completion."""
+        terminated_cg = make_mock_container(state="Terminated", exit_code=0, detail_status="test")
+        aci_mock.return_value.get_state.return_value = terminated_cg
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+        )
+        result = aci.execute(None)
+        assert result == 0
+        assert aci_mock.return_value.create_or_update.call_count == 1
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_success(self, aci_mock):
+        """execute_complete succeeds, does not raise, and deletes the container group."""
+        aci_mock.return_value.get_logs.return_value = None
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            remove_on_success=True,
+        )
+        result = aci.execute_complete(
+            context=None,
+            event={
+                "status": "success",
+                "exit_code": 0,
+                "detail_status": "Completed",
+                "resource_group": "resource-group",
+                "name": "container-name",
+            },
+        )
+        assert result == 0
+        assert aci_mock.return_value.delete.call_count == 1
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_success_with_remove_on_success_false(self, aci_mock):
+        """execute_complete with remove_on_success=False should NOT delete the container."""
+        aci_mock.return_value.get_logs.return_value = None
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            remove_on_success=False,
+        )
+        aci.execute_complete(
+            context=None,
+            event={
+                "status": "success",
+                "exit_code": 0,
+                "detail_status": "Completed",
+                "resource_group": "resource-group",
+                "name": "container-name",
+            },
+        )
+        assert aci_mock.return_value.delete.call_count == 0
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_error_event_raises(self, aci_mock):
+        """execute_complete raises AirflowException when event has status=error."""
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            remove_on_error=False,
+        )
+        with pytest.raises(AirflowException, match="Container group failed"):
+            aci.execute_complete(
+                context=None,
+                event={
+                    "status": "error",
+                    "exit_code": 1,
+                    "detail_status": "OOMKilled",
+                    "message": "Container group failed with exit code 1",
+                    "resource_group": "resource-group",
+                    "name": "container-name",
+                },
+            )
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_error_event_removes_on_error(self, aci_mock):
+        """execute_complete with remove_on_error=True deletes the container on error."""
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            remove_on_error=True,
+        )
+        with pytest.raises(AirflowException):
+            aci.execute_complete(
+                context=None,
+                event={
+                    "status": "error",
+                    "exit_code": 1,
+                    "detail_status": "Failed",
+                    "message": "Container group failed with exit code 1",
+                    "resource_group": "resource-group",
+                    "name": "container-name",
+                },
+            )
+        assert aci_mock.return_value.delete.call_count == 1
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_none_event_raises(self, aci_mock):
+        """execute_complete raises AirflowException when event is None."""
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+        )
+        with pytest.raises(AirflowException, match="event is None"):
+            aci.execute_complete(context=None, event=None)
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_pushes_all_logs_to_xcom(self, aci_mock):
+        """execute_complete pushes all logs to XCom when xcom_all=True."""
+        aci_mock.return_value.get_logs.return_value = ["line1\n", "line2\n"]
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            xcom_all=True,
+            remove_on_success=False,
+        )
+        context = Context(ti=XcomMock())
+        aci.execute_complete(
+            context=context,
+            event={
+                "status": "success",
+                "exit_code": 0,
+                "detail_status": "Completed",
+                "resource_group": "resource-group",
+                "name": "container-name",
+            },
+        )
+        assert context["ti"].xcom_pull(key="logs") == ["line1\n", "line2\n"]
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_complete_pushes_last_log_to_xcom(self, aci_mock):
+        """execute_complete pushes only last log line to XCom when xcom_all=False."""
+        aci_mock.return_value.get_logs.return_value = ["line1\n", "line2\n"]
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id="azure_default",
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            deferrable=True,
+            xcom_all=False,
+            remove_on_success=False,
+        )
+        context = Context(ti=XcomMock())
+        aci.execute_complete(
+            context=context,
+            event={
+                "status": "success",
+                "exit_code": 0,
+                "detail_status": "Completed",
+                "resource_group": "resource-group",
+                "name": "container-name",
+            },
+        )
+        assert context["ti"].xcom_pull(key="logs") == ["line2\n"]
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_remove_on_success_false_sync_path(self, aci_mock):
+        """Non-deferrable: remove_on_success=False should NOT delete the container on success."""
+        terminated_cg = make_mock_container(state="Terminated", exit_code=0, detail_status="test")
+        aci_mock.return_value.get_state.return_value = terminated_cg
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id=None,
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            remove_on_success=False,
+        )
+        aci.execute(None)
+        assert aci_mock.return_value.delete.call_count == 0
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook",
+        autospec=True,
+    )
+    def test_execute_remove_on_success_true_sync_path(self, aci_mock):
+        """Non-deferrable: remove_on_success=True (default) deletes the container on success."""
+        terminated_cg = make_mock_container(state="Terminated", exit_code=0, detail_status="test")
+        aci_mock.return_value.get_state.return_value = terminated_cg
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id=None,
+            registry_conn_id=None,
+            resource_group="resource-group",
+            name="container-name",
+            image="container-image",
+            region="region",
+            task_id="task",
+            remove_on_success=True,
+        )
+        aci.execute(None)
+        assert aci_mock.return_value.delete.call_count == 1
 
 
 class XcomMock:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_container_instance.py
@@ -1,0 +1,251 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+from azure.mgmt.containerinstance.models import (
+    Container,
+    ContainerGroup,
+    ContainerPropertiesInstanceView,
+    ContainerState,
+)
+
+from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceAsyncHook
+from airflow.providers.microsoft.azure.triggers.container_instance import AzureContainerInstanceTrigger
+from airflow.triggers.base import TriggerEvent
+
+RESOURCE_GROUP = "test-resource-group"
+CONTAINER_NAME = "test-container"
+CI_CONN_ID = "azure_container_instance_test"
+POLLING_INTERVAL = 5.0
+
+MODULE = "airflow.providers.microsoft.azure.triggers.container_instance"
+
+
+def _make_cg_state(state: str, exit_code: int = 0, detail_status: str = "test") -> ContainerGroup:
+    """Build a minimal fake ContainerGroup using real SDK models (read-only attrs use type: ignore)."""
+    container_state = ContainerState()
+    container_state.state = state  # type: ignore[assignment]
+    container_state.exit_code = exit_code  # type: ignore[assignment]
+    container_state.detail_status = detail_status  # type: ignore[assignment]
+    instance_view = ContainerPropertiesInstanceView()
+    instance_view.current_state = container_state  # type: ignore[assignment]
+    container = Container(name="test", image="test", resources="test")  # type: ignore[arg-type]
+    container.instance_view = instance_view  # type: ignore[assignment]
+    cg = ContainerGroup(containers=[container], os_type="Linux")
+    cg.provisioning_state = state  # type: ignore[assignment]
+    return cg
+
+
+def _make_provisioning_state(state: str) -> ContainerGroup:
+    """Build a ContainerGroup where instance_view is None (provisioning phase)."""
+    container = Container(name="test", image="test", resources="test")  # type: ignore[arg-type]
+    container.instance_view = None  # type: ignore[assignment]
+    cg = ContainerGroup(containers=[container], os_type="Linux")
+    cg.provisioning_state = state  # type: ignore[assignment]
+    return cg
+
+
+class TestAzureContainerInstanceTrigger:
+    def test_serialize(self):
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+            polling_interval=POLLING_INTERVAL,
+        )
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == (
+            "airflow.providers.microsoft.azure.triggers.container_instance.AzureContainerInstanceTrigger"
+        )
+        assert kwargs == {
+            "resource_group": RESOURCE_GROUP,
+            "name": CONTAINER_NAME,
+            "ci_conn_id": CI_CONN_ID,
+            "polling_interval": POLLING_INTERVAL,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_yields_success_on_terminated_with_exit_code_zero(self, mock_hook_cls):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=0))
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+            polling_interval=POLLING_INTERVAL,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert isinstance(events[0], TriggerEvent)
+        assert events[0].payload["status"] == "success"
+        assert events[0].payload["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_yields_success_on_succeeded_state(self, mock_hook_cls):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Succeeded", exit_code=0))
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert events[0].payload["status"] == "success"
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_yields_error_on_terminated_with_nonzero_exit_code(self, mock_hook_cls):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=1))
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert events[0].payload["status"] == "error"
+        assert events[0].payload["exit_code"] == 1
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    @pytest.mark.parametrize("terminal_state", ["Failed", "Unhealthy"])
+    async def test_run_yields_error_on_failed_states(self, mock_hook_cls, terminal_state):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(return_value=_make_cg_state(terminal_state, exit_code=1))
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert events[0].payload["status"] == "error"
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock)
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_polls_through_non_terminal_states(self, mock_hook_cls, mock_sleep):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(
+            side_effect=[
+                _make_provisioning_state("Creating"),
+                _make_cg_state("Running", exit_code=0),
+                _make_cg_state("Terminated", exit_code=0),
+            ]
+        )
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+            polling_interval=POLLING_INTERVAL,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert mock_hook.get_state.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(POLLING_INTERVAL)
+        assert events[0].payload["status"] == "success"
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_yields_error_event_on_exception(self, mock_hook_cls):
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_hook.get_state = AsyncMock(side_effect=Exception("Azure API error"))
+
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+        )
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "error"
+        assert "Azure API error" in events[0].payload["message"]
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
+    async def test_run_provisioning_state_does_not_yield_until_terminal(self, mock_hook_cls):
+        """Container in 'Creating' (no instance_view) should keep polling."""
+        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
+        mock_hook_cls.return_value = mock_hook
+        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
+        mock_hook.__aexit__ = AsyncMock(return_value=None)
+
+        with mock.patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock):
+            mock_hook.get_state = AsyncMock(
+                side_effect=[
+                    _make_provisioning_state("Creating"),
+                    _make_cg_state("Terminated", exit_code=0),
+                ]
+            )
+
+            trigger = AzureContainerInstanceTrigger(
+                resource_group=RESOURCE_GROUP,
+                name=CONTAINER_NAME,
+                ci_conn_id=CI_CONN_ID,
+            )
+            events = [event async for event in trigger.run()]
+
+        assert mock_hook.get_state.call_count == 2
+        assert events[0].payload["status"] == "success"
+
+    def test_serialize_deserialize_roundtrip(self):
+        original = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+            polling_interval=10.0,
+        )
+        classpath, kwargs = original.serialize()
+        reconstructed = AzureContainerInstanceTrigger(**kwargs)
+        _, kwargs2 = reconstructed.serialize()
+        assert kwargs == kwargs2

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_container_instance.py
@@ -17,8 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from unittest import mock
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from azure.mgmt.containerinstance.models import (
@@ -28,7 +29,6 @@ from azure.mgmt.containerinstance.models import (
     ContainerState,
 )
 
-from airflow.providers.microsoft.azure.hooks.container_instance import AzureContainerInstanceAsyncHook
 from airflow.providers.microsoft.azure.triggers.container_instance import AzureContainerInstanceTrigger
 from airflow.triggers.base import TriggerEvent
 
@@ -64,6 +64,18 @@ def _make_provisioning_state(state: str) -> ContainerGroup:
     return cg
 
 
+def _make_mock_hook(mock_client):
+    """Create a mock hook whose get_async_conn yields the given mock client."""
+    mock_hook = MagicMock()
+
+    @asynccontextmanager
+    async def _get_async_conn():
+        yield mock_client
+
+    mock_hook.get_async_conn = _get_async_conn
+    return mock_hook
+
+
 class TestAzureContainerInstanceTrigger:
     def test_serialize(self):
         trigger = AzureContainerInstanceTrigger(
@@ -87,11 +99,9 @@ class TestAzureContainerInstanceTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     async def test_run_yields_success_on_terminated_with_exit_code_zero(self, mock_hook_cls):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=0))
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=0))
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -109,11 +119,9 @@ class TestAzureContainerInstanceTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     async def test_run_yields_success_on_succeeded_state(self, mock_hook_cls):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Succeeded", exit_code=0))
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(return_value=_make_cg_state("Succeeded", exit_code=0))
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -127,11 +135,9 @@ class TestAzureContainerInstanceTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     async def test_run_yields_error_on_terminated_with_nonzero_exit_code(self, mock_hook_cls):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=1))
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(return_value=_make_cg_state("Terminated", exit_code=1))
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -147,11 +153,9 @@ class TestAzureContainerInstanceTrigger:
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     @pytest.mark.parametrize("terminal_state", ["Failed", "Unhealthy"])
     async def test_run_yields_error_on_failed_states(self, mock_hook_cls, terminal_state):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(return_value=_make_cg_state(terminal_state, exit_code=1))
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(return_value=_make_cg_state(terminal_state, exit_code=1))
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -166,17 +170,15 @@ class TestAzureContainerInstanceTrigger:
     @mock.patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock)
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     async def test_run_polls_through_non_terminal_states(self, mock_hook_cls, mock_sleep):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(
             side_effect=[
                 _make_provisioning_state("Creating"),
                 _make_cg_state("Running", exit_code=0),
                 _make_cg_state("Terminated", exit_code=0),
             ]
         )
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -186,7 +188,7 @@ class TestAzureContainerInstanceTrigger:
         )
         events = [event async for event in trigger.run()]
 
-        assert mock_hook.get_state.call_count == 3
+        assert mock_client.container_groups.get.call_count == 3
         assert mock_sleep.call_count == 2
         mock_sleep.assert_called_with(POLLING_INTERVAL)
         assert events[0].payload["status"] == "success"
@@ -194,11 +196,9 @@ class TestAzureContainerInstanceTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
     async def test_run_yields_error_event_on_exception(self, mock_hook_cls):
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
-        mock_hook.get_state = AsyncMock(side_effect=Exception("Azure API error"))
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(side_effect=Exception("Azure API error"))
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
         trigger = AzureContainerInstanceTrigger(
             resource_group=RESOURCE_GROUP,
@@ -212,30 +212,27 @@ class TestAzureContainerInstanceTrigger:
         assert "Azure API error" in events[0].payload["message"]
 
     @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock)
     @mock.patch(f"{MODULE}.AzureContainerInstanceAsyncHook")
-    async def test_run_provisioning_state_does_not_yield_until_terminal(self, mock_hook_cls):
+    async def test_run_provisioning_state_does_not_yield_until_terminal(self, mock_hook_cls, mock_sleep):
         """Container in 'Creating' (no instance_view) should keep polling."""
-        mock_hook = AsyncMock(spec=AzureContainerInstanceAsyncHook)
-        mock_hook_cls.return_value = mock_hook
-        mock_hook.__aenter__ = AsyncMock(return_value=mock_hook)
-        mock_hook.__aexit__ = AsyncMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.container_groups.get = AsyncMock(
+            side_effect=[
+                _make_provisioning_state("Creating"),
+                _make_cg_state("Terminated", exit_code=0),
+            ]
+        )
+        mock_hook_cls.return_value = _make_mock_hook(mock_client)
 
-        with mock.patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock):
-            mock_hook.get_state = AsyncMock(
-                side_effect=[
-                    _make_provisioning_state("Creating"),
-                    _make_cg_state("Terminated", exit_code=0),
-                ]
-            )
+        trigger = AzureContainerInstanceTrigger(
+            resource_group=RESOURCE_GROUP,
+            name=CONTAINER_NAME,
+            ci_conn_id=CI_CONN_ID,
+        )
+        events = [event async for event in trigger.run()]
 
-            trigger = AzureContainerInstanceTrigger(
-                resource_group=RESOURCE_GROUP,
-                name=CONTAINER_NAME,
-                ci_conn_id=CI_CONN_ID,
-            )
-            events = [event async for event in trigger.run()]
-
-        assert mock_hook.get_state.call_count == 2
+        assert mock_client.container_groups.get.call_count == 2
         assert events[0].payload["status"] == "success"
 
     def test_serialize_deserialize_roundtrip(self):


### PR DESCRIPTION
Add `deferrable=True` support to `AzureContainerInstancesOperator` so
tasks release their worker slot while waiting for long-running containers,
offloading polling to the lightweight Triggerer process.

## Changes

- **New `AzureContainerInstanceAsyncHook`** — async counterpart to the
  existing sync hook, using `azure.mgmt.containerinstance.aio` for
  non-blocking state/log/delete calls.

- **New `AzureContainerInstanceTrigger`** — polls ACI at a configurable
  interval and yields a `TriggerEvent` when the container reaches a
  terminal state.

- **`AzureContainerInstancesOperator`** — three new parameters:
  - `deferrable` (default from `conf`) — enables deferrable mode
  - `polling_interval` (default `30.0s`) — trigger poll frequency
  - `remove_on_success` (default `True`) — controls cleanup on success
  - Also fixes a bug where the `finally` cleanup block would delete a
    still-running container group immediately after `self.defer()` raised
    `TaskDeferred`.

- **`provider.yaml` + `get_provider_info.py`** updated to register the
  new trigger.

closes: #62433

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor, following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)