### PR TITLE
Do not get `logout_callback_url` from request in keycloak auth manager

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 import json
 import logging
 from typing import cast
-from urllib.parse import quote
+from urllib.parse import quote, urljoin
 
 from fastapi import Request  # noqa: TC002
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from airflow.api_fastapi.app import get_auth_manager
+from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX, get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.providers.keycloak.version_compat import AIRFLOW_V_3_1_1_PLUS
 
@@ -110,7 +110,8 @@ def logout(request: Request):
     end_session_endpoint = keycloak_config["end_session_endpoint"]
 
     id_token = request.cookies.get(COOKIE_NAME_ID_TOKEN)
-    post_logout_redirect_uri = request.url_for("logout_callback")
+    base_url = conf.get("api", "base_url", fallback="/")
+    post_logout_redirect_uri = urljoin(base_url, f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/logout_callback")
 
     if id_token:
         encoded_id_token = quote(id_token, safe="")

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -82,10 +82,10 @@ class TestLoginRouter:
     @pytest.mark.parametrize(
         ("id_token", "logout_callback_url"),
         [
-            (None, "http://testserver/auth/logout_callback"),
+            (None, "/auth/logout_callback"),
             (
                 "id_token",
-                "logout_url?post_logout_redirect_uri=http://testserver/auth/logout_callback&id_token_hint=id_token",
+                "logout_url?post_logout_redirect_uri=/auth/logout_callback&id_token_hint=id_token",
             ),
         ],
     )


### PR DESCRIPTION
Getting `logout_callback_url` from the request is a security risk. Instead, I set it using `[api] base_url`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
