### PR TITLE
Fix XCom edit modal value not repopulating on reopen.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
@@ -58,7 +58,6 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
       dagRunId: runId,
       deserialize: true,
       mapIndex,
-      stringify: false,
       taskId,
       xcomKey: xcomKey ?? "",
     },

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
@@ -114,24 +114,12 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
         type: "error",
       });
     },
-    onSuccess: async (response) => {
-      queryClient.setQueryData(
-        [
-          useXcomServiceGetXcomEntryKey,
-          {
-            dagId,
-            dagRunId: runId,
-            deserialize: true,
-            mapIndex,
-            stringify: false,
-            taskId,
-            xcomKey,
-          },
-        ],
-        response,
-      );
+    onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: [useXcomServiceGetXcomEntriesKey],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: [useXcomServiceGetXcomEntryKey],
       });
       onClose();
       toaster.create({

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
@@ -58,25 +58,22 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
       dagRunId: runId,
       deserialize: true,
       mapIndex,
+      stringify: false,
       taskId,
       xcomKey: xcomKey ?? "",
     },
     undefined,
-    {
-      enabled: isOpen && isEditMode && Boolean(xcomKey),
-      refetchOnMount: "always",
-      staleTime: 0,
-    }
+    { enabled: isOpen && isEditMode && Boolean(xcomKey) },
   );
 
   // Populate form when editing
   useEffect(() => {
-    if (isEditMode && data) {
+    if (isOpen && isEditMode && data) {
       const val = data.value;
 
       setValue(typeof val === "string" ? val : JSON.stringify(val, undefined, 2));
     }
-  }, [data, isEditMode]);
+  }, [data, isEditMode, isOpen]);
 
   // Reset form when modal closes
   useEffect(() => {
@@ -117,12 +114,24 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
         type: "error",
       });
     },
-    onSuccess: async () => {
+    onSuccess: async (response) => {
+      queryClient.setQueryData(
+        [
+          useXcomServiceGetXcomEntryKey,
+          {
+            dagId,
+            dagRunId: runId,
+            deserialize: true,
+            mapIndex,
+            stringify: false,
+            taskId,
+            xcomKey,
+          },
+        ],
+        response,
+      );
       await queryClient.invalidateQueries({
         queryKey: [useXcomServiceGetXcomEntriesKey],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: [useXcomServiceGetXcomEntryKey],
       });
       onClose();
       toaster.create({
@@ -171,7 +180,7 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
   const title = isEditMode ? translate("browse:xcom.edit.title") : translate("browse:xcom.add.title");
 
   return (
-    <Dialog.Root onOpenChange={onClose} open={isOpen} size="lg">
+    <Dialog.Root lazyMount onOpenChange={onClose} open={isOpen} size="lg">
       <Dialog.Content backdrop>
         <Dialog.Header>
           <Heading size="lg">{title}</Heading>

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComModal.tsx
@@ -62,12 +62,16 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
       xcomKey: xcomKey ?? "",
     },
     undefined,
-    { enabled: isOpen && isEditMode && Boolean(xcomKey) },
+    {
+      enabled: isOpen && isEditMode && Boolean(xcomKey),
+      refetchOnMount: "always",
+      staleTime: 0,
+    }
   );
 
   // Populate form when editing
   useEffect(() => {
-    if (isEditMode && data?.value !== undefined) {
+    if (isEditMode && data) {
       const val = data.value;
 
       setValue(typeof val === "string" ? val : JSON.stringify(val, undefined, 2));
@@ -167,7 +171,7 @@ const XComModal = ({ dagId, isOpen, mapIndex, mode, onClose, runId, taskId, xcom
   const title = isEditMode ? translate("browse:xcom.edit.title") : translate("browse:xcom.add.title");
 
   return (
-    <Dialog.Root lazyMount onOpenChange={onClose} open={isOpen} size="lg">
+    <Dialog.Root onOpenChange={onClose} open={isOpen} size="lg">
       <Dialog.Content backdrop>
         <Dialog.Header>
           <Heading size="lg">{title}</Heading>


### PR DESCRIPTION
## Summary

This PR fixes an issue where the XCom value was not displayed when reopening the edit modal after updating it.

## Root Cause

The modal lifecycle and query behavior caused stale or skipped state updates when reopening the modal, leading to an empty value field.

## Changes

- Removed `lazyMount` from the dialog to ensure proper unmount/remount behavior.
- Enabled refetch on mount for the XCom entry query.
- Adjusted the population effect to rely on `data` instead of `data?.value !== undefined`.
- Ensured query invalidation for both `GetXcomEntries` and `GetXcomEntry` after update.

## Result

The XCom edit modal now consistently repopulates the latest value when reopened.

Fixes #61486 