### PR TITLE
Update provider metadata to skip Airflow 2 for post-May 2025 releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,6 +102,9 @@ airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/ @Lee-W @jason810496 @guan
 /providers/snowflake/ @potiuk
 
 
+# Generated metadata
+/generated/provider_metadata.json @potiuk @eladkal @shahar1 @vincbeck @jscheffl
+
 # Dev tools
 /.github/workflows/ @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @jason810496
 /dev/ @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @kaxil @jason810496 @jedcunningham @ephraimbuddy

--- a/generated/provider_metadata.json
+++ b/generated/provider_metadata.json
@@ -105,7 +105,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "5.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.2.0": {
@@ -259,7 +259,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.2.0": {
@@ -597,7 +597,7 @@
             "date_released": "2025-05-10T12:38:32Z"
         },
         "9.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "9.9.0": {
@@ -819,7 +819,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "6.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "6.1.1": {
@@ -861,6 +861,10 @@
         "6.2.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:32Z"
+        },
+        "6.2.3": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:50Z"
         }
     },
     "apache.cassandra": {
@@ -957,7 +961,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -1103,7 +1107,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.1.1": {
@@ -1129,6 +1133,10 @@
         "3.2.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:32Z"
+        },
+        "3.3.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:47Z"
         }
     },
     "apache.druid": {
@@ -1277,7 +1285,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "4.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.2.1": {
@@ -1303,6 +1311,10 @@
         "4.4.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:32Z"
+        },
+        "4.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:55Z"
         }
     },
     "apache.flink": {
@@ -1371,7 +1383,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "1.7.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.7.1": {
@@ -1533,7 +1545,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "4.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.10.0": {
@@ -1787,7 +1799,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "9.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "9.1.1": {
@@ -1829,6 +1841,10 @@
         "9.2.5": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "9.3.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:22Z"
         }
     },
     "apache.iceberg": {
@@ -1849,7 +1865,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "1.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.3.1": {
@@ -1943,7 +1959,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "1.7.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "1.7.1": {
@@ -1969,6 +1985,10 @@
         "1.8.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "1.9.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:35Z"
         }
     },
     "apache.kafka": {
@@ -2033,7 +2053,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "1.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.10.0": {
@@ -2175,7 +2195,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "3.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.9.1": {
@@ -2345,7 +2365,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "4.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.4.1": {
@@ -2463,7 +2483,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "4.7.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.7.1": {
@@ -2609,7 +2629,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "4.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.8.1": {
@@ -2639,6 +2659,10 @@
         "4.9.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "4.10.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:49Z"
         }
     },
     "apache.spark": {
@@ -2815,7 +2839,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "5.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "5.3.1": {
@@ -2849,6 +2873,10 @@
         "5.5.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "5.5.1": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:27Z"
         }
     },
     "apache.tinkerpop": {
@@ -2947,7 +2975,7 @@
             "date_released": "2025-03-31T07:51:21Z"
         },
         "2.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.1.1": {
@@ -3045,7 +3073,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "2.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.8.1": {
@@ -3159,7 +3187,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "2.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.10.1": {
@@ -3261,7 +3289,7 @@
             "date_released": "2025-03-31T07:51:21Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.1.1": {
@@ -3459,7 +3487,7 @@
             "date_released": "2025-04-14T07:15:27Z"
         },
         "3.11.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.12.0": {
@@ -3613,7 +3641,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "4.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.2.1": {
@@ -3943,7 +3971,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "10.5.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-21T10:26:22Z"
         },
         "10.6.0": {
@@ -4009,6 +4037,10 @@
         "10.12.4": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "10.13.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:52Z"
         }
     },
     "cohere": {
@@ -4057,7 +4089,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "1.5.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.5.1": {
@@ -4131,7 +4163,7 @@
             "date_released": "2025-04-28T07:39:18Z"
         },
         "1.7.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "1.7.1": {
@@ -4181,6 +4213,10 @@
         "1.13.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "1.14.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:45Z"
         }
     },
     "common.io": {
@@ -4245,7 +4281,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "1.6.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "1.6.1": {
@@ -4493,7 +4529,7 @@
             "date_released": "2025-05-08T08:02:07Z"
         },
         "1.27.1": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.27.2": {
@@ -4551,6 +4587,10 @@
         "1.31.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "1.32.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:42Z"
         }
     },
     "databricks": {
@@ -4763,7 +4803,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "7.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "7.5.0": {
@@ -4821,6 +4861,10 @@
         "7.9.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "7.10.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:24Z"
         }
     },
     "datadog": {
@@ -4917,7 +4961,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.9.1": {
@@ -5099,7 +5143,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "4.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.4.1": {
@@ -5141,6 +5185,10 @@
         "4.6.4": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-02T15:39:05Z"
+        },
+        "4.6.5": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:19Z"
         }
     },
     "dingding": {
@@ -5225,7 +5273,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -5355,7 +5403,7 @@
             "date_released": "2025-04-14T07:15:27Z"
         },
         "3.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.10.1": {
@@ -5589,7 +5637,7 @@
             "date_released": "2025-04-14T07:15:27Z"
         },
         "4.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.4.1": {
@@ -5885,7 +5933,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "6.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "6.3.1": {
@@ -6087,7 +6135,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "4.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.8.1": {
@@ -6121,6 +6169,10 @@
         "4.9.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "4.10.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:37Z"
         }
     },
     "fab": {
@@ -6275,6 +6327,10 @@
         "3.3.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "3.4.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:51Z"
         }
     },
     "facebook": {
@@ -6379,7 +6435,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -6537,7 +6593,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "3.13.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.13.1": {
@@ -6621,6 +6677,10 @@
         "0.2.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "0.2.4": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:40Z"
         }
     },
     "github": {
@@ -6709,7 +6769,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "2.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.9.1": {
@@ -7081,6 +7141,10 @@
         "19.5.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-02T15:39:06Z"
+        },
+        "20.0.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:49Z"
         }
     },
     "grpc": {
@@ -7177,7 +7241,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.8.1": {
@@ -7335,7 +7399,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "4.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.3.0": {
@@ -7541,7 +7605,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "5.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "5.3.1": {
@@ -7587,6 +7651,10 @@
         "5.6.4": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-02T15:39:06Z"
+        },
+        "6.0.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:33Z"
         }
     },
     "imap": {
@@ -7695,7 +7763,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.9.1": {
@@ -7825,7 +7893,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "2.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.9.1": {
@@ -7983,7 +8051,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "5.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "5.2.1": {
@@ -8017,6 +8085,10 @@
         "5.3.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "5.4.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:41Z"
         }
     },
     "jenkins": {
@@ -8145,7 +8217,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.1.1": {
@@ -8217,6 +8289,10 @@
         "0.5.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "0.5.3": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:26Z"
         }
     },
     "microsoft.azure": {
@@ -8489,7 +8565,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "12.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "12.4.1": {
@@ -8543,6 +8619,10 @@
         "12.10.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-02T15:39:06Z"
+        },
+        "13.0.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:44Z"
         }
     },
     "microsoft.mssql": {
@@ -8679,7 +8759,7 @@
             "date_released": "2025-04-09T12:10:55Z"
         },
         "4.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.3.1": {
@@ -8701,6 +8781,10 @@
         "4.4.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "4.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:36Z"
         }
     },
     "microsoft.psrp": {
@@ -8793,7 +8877,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.1.1": {
@@ -8943,7 +9027,7 @@
             "date_released": "2025-03-31T07:51:21Z"
         },
         "3.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.10.1": {
@@ -8981,6 +9065,10 @@
         "3.13.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "3.14.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:21Z"
         }
     },
     "mongo": {
@@ -9105,7 +9193,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "5.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.2.0": {
@@ -9327,7 +9415,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "6.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "6.3.1": {
@@ -9365,6 +9453,10 @@
         "6.4.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "6.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:34Z"
         }
     },
     "neo4j": {
@@ -9469,7 +9561,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.9.1": {
@@ -9643,7 +9735,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "4.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.10.1": {
@@ -9665,6 +9757,10 @@
         "4.11.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "4.12.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:46Z"
         }
     },
     "openai": {
@@ -9721,7 +9817,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "1.6.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.6.1": {
@@ -9831,7 +9927,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -9981,7 +10077,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "2.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "2.4.0": {
@@ -10043,6 +10139,10 @@
         "2.10.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "2.11.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:29Z"
         }
     },
     "opensearch": {
@@ -10099,7 +10199,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "1.7.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.7.1": {
@@ -10245,7 +10345,7 @@
             "date_released": "2025-03-31T07:51:20Z"
         },
         "5.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "5.9.1": {
@@ -10423,7 +10523,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.1.1": {
@@ -10457,6 +10557,10 @@
         "4.4.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "4.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:28Z"
         }
     },
     "pagerduty": {
@@ -10573,7 +10677,7 @@
             "date_released": "2025-03-31T07:51:20Z"
         },
         "5.0.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "5.0.1": {
@@ -10735,7 +10839,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "3.11.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.11.1": {
@@ -10797,7 +10901,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "1.5.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.5.1": {
@@ -10823,6 +10927,10 @@
         "1.6.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "1.7.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:20Z"
         }
     },
     "pinecone": {
@@ -10871,7 +10979,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "2.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.3.1": {
@@ -11089,7 +11197,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "6.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "6.2.1": {
@@ -11135,6 +11243,10 @@
         "6.5.4": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "6.6.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:48Z"
         }
     },
     "presto": {
@@ -11299,7 +11411,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "5.9.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.9.1": {
@@ -11333,6 +11445,10 @@
         "5.10.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "5.11.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:23Z"
         }
     },
     "qdrant": {
@@ -11369,7 +11485,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "1.4.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "1.4.1": {
@@ -11399,6 +11515,10 @@
         "1.5.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "1.5.3": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:53Z"
         }
     },
     "redis": {
@@ -11503,7 +11623,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.1.1": {
@@ -11681,7 +11801,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "5.11.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.11.1": {
@@ -11807,7 +11927,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "4.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.10.1": {
@@ -11921,7 +12041,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -12031,7 +12151,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.1.1": {
@@ -12249,7 +12369,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "5.3.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.3.1": {
@@ -12379,7 +12499,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "3.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.8.1": {
@@ -12577,7 +12697,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "9.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "9.1.1": {
@@ -12623,6 +12743,10 @@
         "9.6.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "9.7.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:18Z"
         }
     },
     "smtp": {
@@ -12711,7 +12835,7 @@
             "date_released": "2025-04-19T17:32:23Z"
         },
         "2.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.1.1": {
@@ -12997,7 +13121,7 @@
             "date_released": "2025-05-10T12:38:32Z"
         },
         "6.3.1": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "6.4.0": {
@@ -13055,6 +13179,10 @@
         "6.9.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "6.10.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:39Z"
         }
     },
     "sqlite": {
@@ -13187,7 +13315,7 @@
             "date_released": "2025-04-14T07:15:27Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.1.1": {
@@ -13209,6 +13337,10 @@
         "4.2.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "4.3.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:38Z"
         }
     },
     "ssh": {
@@ -13369,7 +13501,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.1.1": {
@@ -13521,6 +13653,10 @@
         "1.11.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "1.12.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:25Z"
         }
     },
     "tableau": {
@@ -13645,7 +13781,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "5.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "5.1.1": {
@@ -13783,7 +13919,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "4.8.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "4.8.1": {
@@ -13869,7 +14005,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:29Z"
         },
         "3.2.0": {
@@ -13911,6 +14047,10 @@
         "3.4.3": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "3.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:54Z"
         }
     },
     "trino": {
@@ -14087,7 +14227,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "6.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "6.3.0": {
@@ -14125,6 +14265,10 @@
         "6.4.2": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "6.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:30Z"
         }
     },
     "vertica": {
@@ -14245,7 +14389,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.1.1": {
@@ -14271,6 +14415,10 @@
         "4.2.1": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-01-17T10:59:33Z"
+        },
+        "4.3.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:43Z"
         }
     },
     "weaviate": {
@@ -14339,7 +14487,7 @@
             "date_released": "2025-04-19T17:32:22Z"
         },
         "3.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "3.2.0": {
@@ -14489,7 +14637,7 @@
             "date_released": "2025-03-31T07:51:21Z"
         },
         "4.1.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.1.1": {
@@ -14559,7 +14707,7 @@
             "date_released": "2025-03-13T17:46:49Z"
         },
         "2.2.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "2.2.1": {
@@ -14589,6 +14737,10 @@
         "2.4.0": {
             "associated_airflow_version": "3.1.7",
             "date_released": "2026-02-14T13:25:37Z"
+        },
+        "2.5.0": {
+            "associated_airflow_version": "3.1.7",
+            "date_released": "2026-03-02T21:08:32Z"
         }
     },
     "zendesk": {
@@ -14681,7 +14833,7 @@
             "date_released": "2025-03-13T17:46:48Z"
         },
         "4.10.0": {
-            "associated_airflow_version": "2.11.0",
+            "associated_airflow_version": "3.0.2",
             "date_released": "2025-05-18T10:44:30Z"
         },
         "4.10.1": {


### PR DESCRIPTION
Regenerated `provider_metadata.json` after #62800. Providers released
after May 2025 are now associated with Airflow 3.x versions instead of
2.x. Also picks up newly released provider versions.

Adds CODEOWNERS entry for `generated/provider_metadata.json` with
release managers as owners.

related: #62800

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)