### PR TITLE
Rename connection type pydantic_ai to pydanticai (RFC 3986)

### DIFF
--- a/providers/common/ai/docs/connections/pydantic_ai.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai.rst
@@ -28,7 +28,7 @@ Mistral, Ollama, vLLM, and others.
 Default Connection IDs
 ----------------------
 
-The ``PydanticAIHook`` uses ``pydantic_ai_default`` by default.
+The ``PydanticAIHook`` uses ``pydanticai_default`` by default.
 
 Configuring the Connection
 --------------------------
@@ -66,7 +66,7 @@ Examples
 .. code-block:: json
 
     {
-        "conn_type": "pydantic_ai",
+        "conn_type": "pydanticai",
         "password": "sk-...",
         "extra": "{\"model\": \"openai:gpt-5.3\"}"
     }
@@ -76,7 +76,7 @@ Examples
 .. code-block:: json
 
     {
-        "conn_type": "pydantic_ai",
+        "conn_type": "pydanticai",
         "password": "sk-ant-...",
         "extra": "{\"model\": \"anthropic:claude-opus-4-6\"}"
     }
@@ -86,7 +86,7 @@ Examples
 .. code-block:: json
 
     {
-        "conn_type": "pydantic_ai",
+        "conn_type": "pydanticai",
         "host": "http://localhost:11434/v1",
         "extra": "{\"model\": \"openai:llama3\"}"
     }
@@ -98,7 +98,7 @@ Leave password empty and configure ``AWS_PROFILE`` or IAM role in the environmen
 .. code-block:: json
 
     {
-        "conn_type": "pydantic_ai",
+        "conn_type": "pydanticai",
         "extra": "{\"model\": \"bedrock:us.anthropic.claude-opus-4-6-v1:0\"}"
     }
 
@@ -109,6 +109,6 @@ Leave password empty and configure ``GOOGLE_APPLICATION_CREDENTIALS`` in the env
 .. code-block:: json
 
     {
-        "conn_type": "pydantic_ai",
+        "conn_type": "pydanticai",
         "extra": "{\"model\": \"google:gemini-2.0-flash\"}"
     }

--- a/providers/common/ai/docs/operators/llm_sql.rst
+++ b/providers/common/ai/docs/operators/llm_sql.rst
@@ -86,7 +86,7 @@ execution step:
     generate_sql = LLMSQLQueryOperator(
         task_id="generate_sql",
         prompt="Find the top 5 products by total sales amount",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         datasource_config=datasource_config,
     )
 

--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -47,7 +47,7 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook
-    connection-type: pydantic_ai
+    connection-type: pydanticai
     ui-field-behaviour:
       hidden-fields:
         - schema

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm.py
@@ -30,7 +30,7 @@ def example_llm_operator():
     LLMOperator(
         task_id="summarize",
         prompt="Summarize the key findings from the Q4 earnings report.",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="You are a financial analyst. Be concise.",
     )
 
@@ -50,7 +50,7 @@ def example_llm_operator_structured():
     LLMOperator(
         task_id="extract_entities",
         prompt="Extract all named entities from the article.",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Extract named entities.",
         output_type=Entities,
     )
@@ -67,7 +67,7 @@ def example_llm_operator_agent_params():
     LLMOperator(
         task_id="creative_writing",
         prompt="Write a haiku about data pipelines.",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="You are a creative writer.",
         agent_params={"model_settings": {"temperature": 0.9}, "retries": 3},
     )
@@ -81,7 +81,7 @@ example_llm_operator_agent_params()
 # [START howto_decorator_llm]
 @dag
 def example_llm_decorator():
-    @task.llm(llm_conn_id="pydantic_ai_default", system_prompt="Summarize concisely.")
+    @task.llm(llm_conn_id="pydanticai_default", system_prompt="Summarize concisely.")
     def summarize(text: str):
         return f"Summarize this article: {text}"
 
@@ -101,7 +101,7 @@ def example_llm_decorator_structured():
         locations: list[str]
 
     @task.llm(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Extract named entities.",
         output_type=Entities,
     )

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_analysis_pipeline.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_analysis_pipeline.py
@@ -53,7 +53,7 @@ def example_llm_analysis_pipeline():
         ]
 
     @task.llm(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt=(
             "Analyze the support ticket and extract: "
             "priority (critical/high/medium/low), "

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_branch.py
@@ -28,7 +28,7 @@ def example_llm_branch_operator():
     route = LLMBranchOperator(
         task_id="route_ticket",
         prompt="User says: 'My password reset email never arrived.'",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Route support tickets to the right team.",
     )
 
@@ -58,7 +58,7 @@ def example_llm_branch_multi():
     route = LLMBranchOperator(
         task_id="classify",
         prompt="This product is great but shipping was slow and the box was damaged.",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Select all applicable categories for this customer review.",
         allow_multiple_branches=True,
     )
@@ -87,7 +87,7 @@ example_llm_branch_multi()
 @dag
 def example_llm_branch_decorator():
     @task.llm_branch(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Route support tickets to the right team.",
     )
     def route_ticket(message: str):
@@ -121,7 +121,7 @@ example_llm_branch_decorator()
 @dag
 def example_llm_branch_decorator_multi():
     @task.llm_branch(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt="Select all applicable categories for this customer review.",
         allow_multiple_branches=True,
     )

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_classification.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_classification.py
@@ -27,7 +27,7 @@ from airflow.providers.common.compat.sdk import dag, task
 @dag
 def example_llm_classification():
     @task.llm(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         system_prompt=(
             "Classify the severity of the given pipeline incident. "
             "Use 'critical' for data loss or complete pipeline failure, "

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_sql.py
@@ -29,7 +29,7 @@ def example_llm_sql_basic():
     LLMSQLQueryOperator(
         task_id="generate_sql",
         prompt="Find the top 10 customers by total revenue",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         schema_context=(
             "Table: customers\n"
             "Columns: id INT, name TEXT, email TEXT\n\n"
@@ -50,7 +50,7 @@ def example_llm_sql_schema_introspection():
     LLMSQLQueryOperator(
         task_id="generate_sql",
         prompt="Calculate monthly revenue for 2024",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         db_conn_id="postgres_default",
         table_names=["orders", "customers"],
         dialect="postgres",
@@ -66,7 +66,7 @@ example_llm_sql_schema_introspection()
 @dag
 def example_llm_sql_decorator():
     @task.llm_sql(
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         schema_context="Table: users\nColumns: id INT, name TEXT, signup_date DATE",
     )
     def build_churn_query(ds=None):
@@ -85,7 +85,7 @@ example_llm_sql_decorator()
 def example_llm_sql_expand():
     LLMSQLQueryOperator.partial(
         task_id="generate_sql",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         schema_context=(
             "Table: orders\nColumns: id INT, customer_id INT, total DECIMAL, created_at TIMESTAMP"
         ),
@@ -116,7 +116,7 @@ def example_llm_sql_with_object_storage():
     LLMSQLQueryOperator(
         task_id="generate_sql",
         prompt="Find the top 5 products by total sales amount",
-        llm_conn_id="pydantic_ai_default",
+        llm_conn_id="pydanticai_default",
         datasource_config=datasource_config,
     )
 

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_pydantic_ai_hook.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_pydantic_ai_hook.py
@@ -29,7 +29,7 @@ from airflow.providers.common.compat.sdk import dag, task
 def example_pydantic_ai_hook():
     @task
     def generate_summary(text: str) -> str:
-        hook = PydanticAIHook(llm_conn_id="pydantic_ai_default")
+        hook = PydanticAIHook(llm_conn_id="pydanticai_default")
         agent = hook.create_agent(output_type=str, instructions="Summarize concisely.")
         result = agent.run_sync(text)
         return result.output
@@ -51,7 +51,7 @@ def example_pydantic_ai_structured_output():
             query: str
             explanation: str
 
-        hook = PydanticAIHook(llm_conn_id="pydantic_ai_default")
+        hook = PydanticAIHook(llm_conn_id="pydanticai_default")
         agent = hook.create_agent(
             output_type=SQLResult,
             instructions="Generate a SQL query and explain it.",

--- a/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
@@ -52,7 +52,7 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook",
-                "connection-type": "pydantic_ai",
+                "connection-type": "pydanticai",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],
                     "relabeling": {"password": "API Key"},

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
@@ -53,8 +53,8 @@ class PydanticAIHook(BaseHook):
     """
 
     conn_name_attr = "llm_conn_id"
-    default_conn_name = "pydantic_ai_default"
-    conn_type = "pydantic_ai"
+    default_conn_name = "pydanticai_default"
+    conn_type = "pydanticai"
     hook_name = "Pydantic AI"
 
     def __init__(

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -28,7 +28,7 @@ from airflow.providers.common.ai.hooks.pydantic_ai import PydanticAIHook
 class TestPydanticAIHookInit:
     def test_default_conn_id(self):
         hook = PydanticAIHook()
-        assert hook.llm_conn_id == "pydantic_ai_default"
+        assert hook.llm_conn_id == "pydanticai_default"
         assert hook.model_id is None
 
     def test_custom_conn_id(self):
@@ -50,7 +50,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             password="sk-test-key",
             host="https://api.openai.com/v1",
         )
@@ -82,7 +82,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             password="sk-test-key",
             extra='{"model": "anthropic:claude-opus-4-6"}',
         )
@@ -101,7 +101,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             password="sk-test-key",
             extra='{"model": "anthropic:claude-opus-4-6"}',
         )
@@ -115,7 +115,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             password="sk-test-key",
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -131,7 +131,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="bedrock:us.anthropic.claude-v2")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
@@ -149,7 +149,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:llama3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             host="http://localhost:11434/v1",
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -167,7 +167,7 @@ class TestPydanticAIHookGetConn:
         mock_infer_model.return_value = mock_model
 
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
-        conn = Connection(conn_id="test_conn", conn_type="pydantic_ai")
+        conn = Connection(conn_id="test_conn", conn_type="pydanticai")
         with patch.object(hook, "get_connection", return_value=conn):
             first = hook.get_conn()
             second = hook.get_conn()
@@ -191,7 +191,7 @@ class TestPydanticAIHookGetConn:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="google:gemini-2.0-flash")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
             password="some-key",
         )
         with patch.object(hook, "get_connection", return_value=conn):
@@ -216,7 +216,7 @@ class TestPydanticAIHookCreateAgent:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             hook.create_agent(instructions="You are a helpful assistant.")
@@ -236,7 +236,7 @@ class TestPydanticAIHookCreateAgent:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             hook.create_agent(
@@ -262,7 +262,7 @@ class TestPydanticAIHookTestConnection:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             success, message = hook.test_connection()
@@ -277,7 +277,7 @@ class TestPydanticAIHookTestConnection:
         hook = PydanticAIHook(llm_conn_id="test_conn", model_id="badprovider:model")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             success, message = hook.test_connection()
@@ -289,7 +289,7 @@ class TestPydanticAIHookTestConnection:
         hook = PydanticAIHook(llm_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
-            conn_type="pydantic_ai",
+            conn_type="pydanticai",
         )
         with patch.object(hook, "get_connection", return_value=conn):
             success, message = hook.test_connection()


### PR DESCRIPTION
## Summary

RFC 3986 Section 3.1 defines URI scheme syntax as `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`. The underscore in `pydantic_ai` is not allowed and triggers a validation warning:

```
WARNING - Connection schemes (type: pydantic_ai) shall not contain '_' according to RFC3986.
```

Renamed to `pydanticai` (no separator), consistent with existing Airflow providers like `openai` and `cohere`.

## Changes

- `conn_type`: `pydantic_ai` -> `pydanticai`
- `default_conn_name`: `pydantic_ai_default` -> `pydanticai_default`
- Updated all example DAGs, docs, and tests to use the new names