### PR TITLE
fix(ui): Improve DurationChart labels and disable animation during auto-refresh

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DurationChart.tsx
@@ -35,8 +35,9 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import type { TaskInstanceResponse, GridRunsResponse } from "openapi/requests/types.gen";
+import { useTimezone } from "src/context/timezone";
 import { getComputedCSSVariableValue } from "src/theme";
-import { DEFAULT_DATETIME_FORMAT, renderDuration } from "src/utils/datetimeUtils";
+import { DEFAULT_DATETIME_FORMAT, formatDate, renderDuration } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 
 ChartJS.register(
@@ -69,15 +70,35 @@ const getDuration = (start: string, end: string | null) => {
   return dayjs.duration(endDate.diff(startDate)).asSeconds();
 };
 
+const getTickLabelFormat = (entries: Array<RunResponse>): string => {
+  if (entries.length < 2) {
+    return "HH:mm:ss";
+  }
+
+  const first = dayjs(entries[0]?.run_after);
+  const last = dayjs(entries[entries.length - 1]?.run_after);
+
+  if (!first.isValid() || !last.isValid()) {
+    return "MMM DD";
+  }
+
+  const diffInDays = Math.abs(last.diff(first, "day"));
+
+  return diffInDays < 1 ? "HH:mm:ss" : "MMM DD HH:mm";
+};
+
 export const DurationChart = ({
   entries,
+  isAutoRefreshing = false,
   kind,
 }: {
   readonly entries: Array<RunResponse> | undefined;
+  readonly isAutoRefreshing?: boolean;
   readonly kind: "Dag Run" | "Task Instance";
 }) => {
   const { t: translate } = useTranslation(["components", "common"]);
   const navigate = useNavigate();
+  const { selectedTimezone } = useTimezone();
   const [queuedColorToken] = useToken("colors", ["queued.solid"]);
 
   // Get states and create color tokens for them
@@ -175,6 +196,7 @@ export const DurationChart = ({
         }}
         datasetIdKey="id"
         options={{
+          animation: isAutoRefreshing ? false : undefined,
           onClick: (_event, elements) => {
             const [element] = elements;
 
@@ -239,6 +261,8 @@ export const DurationChart = ({
             x: {
               stacked: true,
               ticks: {
+                callback: (_value, index) =>
+                  formatDate(entries[index]?.run_after, selectedTimezone, getTickLabelFormat(entries)),
                 maxTicksLimit: 3,
               },
               title: { align: "end", display: true, text: translate("common:dagRun.runAfter") },

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -35,6 +35,7 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { dagRunsLimitKey } from "src/constants/localStorage";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { isStatePending, useAutoRefresh } from "src/utils";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
 
 const FailedLogs = lazy(() => import("./FailedLogs"));
@@ -68,6 +69,8 @@ export const Overview = () => {
     state: ["failed"],
   });
   const { data: gridRuns, isLoading: isLoadingRuns } = useGridRuns({ limit });
+  const refetchInterval = useAutoRefresh({ dagId });
+  const isAutoRefreshing = Boolean(refetchInterval) && (gridRuns ?? []).some((run) => isStatePending(run.state));
   const { data: assetEventsData, isLoading: isLoadingAssetEvents } = useAssetServiceGetAssetEvents({
     limit,
     orderBy: [assetSortBy],
@@ -125,7 +128,7 @@ export const Overview = () => {
           {isLoadingRuns ? (
             <Skeleton height="200px" w="full" />
           ) : (
-            <DurationChart entries={gridRuns?.slice().reverse()} kind="Dag Run" />
+            <DurationChart entries={gridRuns?.slice().reverse()} isAutoRefreshing={isAutoRefreshing} kind="Dag Run" />
           )}
         </Box>
         {assetEventsData && assetEventsData.total_entries > 0 ? (

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx
@@ -35,8 +35,8 @@ import TimeRangeSelector from "src/components/TimeRangeSelector";
 import { TrendCountButton } from "src/components/TrendCountButton";
 import { dagRunsLimitKey } from "src/constants/localStorage";
 import { SearchParamsKeys } from "src/constants/searchParams";
-import { isStatePending, useAutoRefresh } from "src/utils";
 import { useGridRuns } from "src/queries/useGridRuns.ts";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 const FailedLogs = lazy(() => import("./FailedLogs"));
 
@@ -70,7 +70,8 @@ export const Overview = () => {
   });
   const { data: gridRuns, isLoading: isLoadingRuns } = useGridRuns({ limit });
   const refetchInterval = useAutoRefresh({ dagId });
-  const isAutoRefreshing = Boolean(refetchInterval) && (gridRuns ?? []).some((run) => isStatePending(run.state));
+  const isAutoRefreshing =
+    Boolean(refetchInterval) && (gridRuns ?? []).some((run) => isStatePending(run.state));
   const { data: assetEventsData, isLoading: isLoadingAssetEvents } = useAssetServiceGetAssetEvents({
     limit,
     orderBy: [assetSortBy],
@@ -128,7 +129,11 @@ export const Overview = () => {
           {isLoadingRuns ? (
             <Skeleton height="200px" w="full" />
           ) : (
-            <DurationChart entries={gridRuns?.slice().reverse()} isAutoRefreshing={isAutoRefreshing} kind="Dag Run" />
+            <DurationChart
+              entries={gridRuns?.slice().reverse()}
+              isAutoRefreshing={isAutoRefreshing}
+              kind="Dag Run"
+            />
           )}
         </Box>
         {assetEventsData && assetEventsData.total_entries > 0 ? (


### PR DESCRIPTION
## Summary

Closes #54786

This PR improves the Duration Chart on the DAG Overview page with two changes:

- **Shorten x-axis tick labels**: Labels now adapt based on the time span of displayed entries. When all runs are within 24 hours, labels show `HH:mm:ss`. For longer ranges, they show `MMM DD HH:mm`. Full datetime is still available in tooltips. Labels also respect the user's selected timezone via `formatDate`.
- **Disable animation during auto-refresh**: When the DAG has pending runs and the chart is auto-refreshing, chart animation is disabled to reduce visual noise.

### Before
X-axis labels use the full `YYYY-MM-DD HH:mm:ss` format, taking significant space and shrinking the graph area. Animation replays on every auto-refresh cycle.

### After
X-axis labels are compact and timezone-aware. Animation only plays on initial render, not during auto-refresh.

## Details

**Label format logic** (`getTickLabelFormat`, defined outside the component per review feedback on #55339):
- `< 2 entries` → `HH:mm:ss`
- `< 1 day span` → `HH:mm:ss`
- `≥ 1 day span` → `MMM DD HH:mm`

**Auto-refresh detection** (in `Overview.tsx`):
- Uses existing `useAutoRefresh` hook + `isStatePending` to determine if the chart is actively refreshing
- Passes `isAutoRefreshing` prop to `DurationChart`
- When `true`, `animation` is set to `false`

## Files Changed
- `airflow-core/src/airflow/ui/src/components/DurationChart.tsx` — tick label formatting + animation control
- `airflow-core/src/airflow/ui/src/pages/Dag/Overview/Overview.tsx` — pass `isAutoRefreshing` prop

## Test Plan
- [ ] Verify x-axis labels show `HH:mm:ss` when runs span less than 24 hours
- [ ] Verify x-axis labels show `MMM DD HH:mm` when runs span more than 1 day
- [ ] Verify tooltip still shows full datetime on hover
- [ ] Verify labels respect timezone selection
- [ ] Verify animation plays on initial page load
- [ ] Verify animation is disabled during auto-refresh with pending runs
- [ ] Verify no animation flicker when auto-refresh updates data