### PR TITLE
feat(logging): Add json_format config option to enable JSON console logging

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
@@ -133,3 +133,23 @@ To control the log level for that custom name, use :ref:`config:logging__namespa
 
         [logging]
         namespace_levels = sql.big_query=WARNING
+
+
+JSON console output
+-------------------
+
+To emit logs as one JSON object per line (useful for log aggregation systems such as Loki,
+Elasticsearch, or Splunk), enable the ``json_format`` option:
+
+.. code-block:: ini
+
+    [logging]
+    json_format = True
+
+When enabled, each log line is a JSON object containing fields such as ``timestamp``,
+``level``, ``event``, and ``logger``. This replaces the default human-readable console output.
+
+.. note::
+
+   ``json_format`` affects only the Airflow component (scheduler, webserver, triggerer, …) console
+   output. Task logs written to files or remote storage use their own formatting.

--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/advanced-logging-configuration.rst
@@ -49,6 +49,16 @@ You can read more about standard python logging classes (Loggers, Handlers, Form
 Create a custom logging class
 -----------------------------
 
+.. important::
+
+   In Airflow 3.x, logging uses `structlog <https://www.structlog.org/>`_ and ``DEFAULT_LOGGING_CONFIG``
+   is no longer respected. The ``logging_config_class`` option still works, but the dict you provide is
+   merged *before* structlog applies its own configuration. Specifically, Airflow will override the
+   formatter, root handler, and strip ``formatter``/``stream`` keys from any handler you define, so
+   custom formatters have no effect. The most useful thing you can do with this dict is add extra loggers
+   with custom ``level`` settings. For per-namespace log level overrides, consider using the
+   :ref:`config:logging__namespace_levels` option in ``airflow.cfg`` instead.
+
 Configuring your logging classes can be done via the ``logging_config_class`` option in ``airflow.cfg`` file.
 This configuration should specify the import path to a configuration compatible with
 :func:`logging.config.dictConfig`. If your file is a standard import location, then you should set a
@@ -67,30 +77,19 @@ Follow the steps below to enable custom logging config class:
 
     .. code-block:: python
 
-      from copy import deepcopy
-      from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
+        LOGGING_CONFIG = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "loggers": {},
+        }
 
-      LOGGING_CONFIG = deepcopy(DEFAULT_LOGGING_CONFIG)
-
-#.  At the end of the file, add code to modify the default dictionary configuration.
+#.  At the end of the file, add code to modify the dictionary configuration.
 #. Update ``$AIRFLOW_HOME/airflow.cfg`` to contain:
 
     .. code-block:: ini
 
         [logging]
         logging_config_class = log_config.LOGGING_CONFIG
-
-You can also use the ``logging_config_class`` together with remote logging if you plan to just extend/update
-the configuration with remote logging enabled. Then the deep-copied dictionary will contain the remote logging
-configuration generated for you and your modification will apply after remote logging configuration has
-been added:
-
-    .. code-block:: ini
-
-        [logging]
-        remote_logging = True
-        logging_config_class = log_config.LOGGING_CONFIG
-
 
 #. Restart the application.
 
@@ -107,35 +106,15 @@ Custom logger for Operators, Hooks and Tasks
 
 You can create custom logging handlers and apply them to specific Operators, Hooks and tasks. By default, the Operators
 and Hooks loggers are child of the ``airflow.task`` logger: They follow respectively the naming convention
-``airflow.task.operators.<package>.<module_name>`` and ``airflow.task.hooks.<package>.<module_name>``. After
-:doc:`creating a custom logging class </administration-and-deployment/logging-monitoring/advanced-logging-configuration>`,
-you can assign specific loggers to them.
+``airflow.task.operators.<package>.<module_name>`` and ``airflow.task.hooks.<package>.<module_name>``.
 
-Example of custom logging for the ``SQLExecuteQueryOperator`` and the ``HttpHook``:
+To set a custom log level for a specific operator or hook namespace, use the
+:ref:`config:logging__namespace_levels` option in ``airflow.cfg``:
 
-    .. code-block:: python
+.. code-block:: ini
 
-      from copy import deepcopy
-      from pydantic.utils import deep_update
-      from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-
-      LOGGING_CONFIG = deep_update(
-          deepcopy(DEFAULT_LOGGING_CONFIG),
-          {
-              "loggers": {
-                  "airflow.task.operators.airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator": {
-                      "handlers": ["task"],
-                      "level": "DEBUG",
-                      "propagate": True,
-                  },
-                  "airflow.task.hooks.airflow.providers.http.hooks.http.HttpHook": {
-                      "handlers": ["task"],
-                      "level": "WARNING",
-                      "propagate": False,
-                  },
-              }
-          },
-      )
+    [logging]
+    namespace_levels = airflow.task.operators.airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator=DEBUG airflow.task.hooks.airflow.providers.http.hooks.http.HttpHook=WARNING
 
 
 You can also set a custom name to a Dag's task with the ``logger_name`` attribute. This can be useful if multiple tasks
@@ -148,35 +127,9 @@ Example of custom logger name:
       # In your Dag file
       SQLExecuteQueryOperator(..., logger_name="sql.big_query")
 
-      # In your custom `log_config.py`
-      LOGGING_CONFIG = deep_update(
-          deepcopy(DEFAULT_LOGGING_CONFIG),
-          {
-              "loggers": {
-                  "airflow.task.operators.sql.big_query": {
-                      "handlers": ["task"],
-                      "level": "WARNING",
-                      "propagate": True,
-                  },
-              }
-          },
-      )
+To control the log level for that custom name, use :ref:`config:logging__namespace_levels`:
 
-If you want to limit the log size of the tasks, you can add the handlers.task.max_bytes parameter.
+    .. code-block:: ini
 
-Example of limiting the size of tasks:
-
-    .. code-block:: python
-
-      from copy import deepcopy
-      from pydantic.utils import deep_update
-      from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-
-      LOGGING_CONFIG = deep_update(
-          deepcopy(DEFAULT_LOGGING_CONFIG),
-          {
-              "handlers": {
-                  "task": {"max_bytes": 104857600, "backup_count": 1}  # 100MB and keep 1 history rotate log.
-              }
-          },
-      )
+        [logging]
+        namespace_levels = sql.big_query=WARNING

--- a/airflow-core/newsfragments/61175.feature.rst
+++ b/airflow-core/newsfragments/61175.feature.rst
@@ -1,0 +1,1 @@
+Add ``json_format`` config option to enable JSON console logging

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -878,6 +878,16 @@ logging:
       type: string
       example: ~
       default: "True"
+    json_format:
+      description: |
+        Enables JSON-formatted console logs (one JSON object per line).
+        When enabled, each log line is a JSON object with fields such as
+        ``timestamp``, ``level``, ``event``, and ``logger``.
+        This replaces the default human-readable console output.
+      version_added: 3.2.0
+      type: string
+      example: ~
+      default: "False"
     log_format:
       description: |
         Format of Log line

--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -109,6 +109,7 @@ def configure_logging():
             "COLORED_LOG",
             conf.getboolean("logging", "colored_console_log", fallback=True),
         )
+        json_format = conf.getboolean("logging", "json_format", fallback=False)
         # Try to init logging
 
         log_fmt, callsite_params = translate_config_values(
@@ -131,6 +132,7 @@ def configure_logging():
         stdlib_config = {**stdlib_config, "loggers": {**stdlib_config.get("loggers", {}), **extra_loggers}}
 
         configure_logging(
+            json_output=json_format,
             log_level=level,
             namespace_log_levels=conf.get("logging", "namespace_levels", fallback=None),
             stdlib_config=stdlib_config,

--- a/airflow-core/tests/unit/utils/test_logging_config.py
+++ b/airflow-core/tests/unit/utils/test_logging_config.py
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tests_common.test_utils.config import conf_vars
+
+_FAKE_LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "loggers": {},
+}
+
+_FALLBACK_CLASS_PATH = "airflow.config_templates.airflow_local_settings.DEFAULT_LOGGING_CONFIG"
+
+
+@pytest.mark.parametrize(
+    ("json_format_value", "expected_json_output"),
+    [
+        ("True", True),
+        ("False", False),
+    ],
+)
+def test_json_format_passed_to_shared_configure_logging(json_format_value, expected_json_output):
+    """json_output kwarg forwarded to shared configure_logging based on json_format config."""
+    mock_shared_configure = mock.MagicMock()
+
+    with (
+        conf_vars({("logging", "json_format"): json_format_value}),
+        mock.patch(
+            "airflow.logging_config.load_logging_config",
+            return_value=(_FAKE_LOGGING_CONFIG, _FALLBACK_CLASS_PATH),
+        ),
+        mock.patch("airflow.logging_config.validate_logging_config"),
+        # Patch the shared module that configure_logging() imports from locally
+        mock.patch("airflow._shared.logging.configure_logging", mock_shared_configure),
+        mock.patch("airflow._shared.logging.init_log_folder", return_value="/tmp/airflow/logs"),
+        mock.patch("airflow._shared.logging.translate_config_values", return_value=("", [])),
+    ):
+        from airflow.logging_config import configure_logging
+
+        configure_logging()
+
+    mock_shared_configure.assert_called_once()
+    assert mock_shared_configure.call_args.kwargs.get("json_output") is expected_json_output


### PR DESCRIPTION
## Changes

**feat: Add `json_format` config option**

Adds a new `[logging] json_format` boolean option (default `False`) that enables
structured JSON console output. When `True`, each log line is emitted as a JSON
object — useful for log aggregation systems such as Loki, Elasticsearch, or Splunk.

Also adds a "JSON console output" subsection to the advanced logging configuration
docs explaining the option with an example.

**docs: Fix outdated examples after structlog migration in Airflow 3.x**

Removes broken `DEFAULT_LOGGING_CONFIG` deepcopy and `pydantic.utils.deep_update`
examples, adds a note explaining `logging_config_class` behaviour in Airflow 3.x.

closes: #61175

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code