### PR TITLE
Add template_fields support to SalesforceBulkOperator

### DIFF
--- a/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, cast
 
 from airflow.providers.common.compat.sdk import BaseOperator
@@ -48,6 +48,8 @@ class SalesforceBulkOperator(BaseOperator):
     :param salesforce_conn_id: The :ref:`Salesforce Connection id <howto/connection:SalesforceHook>`.
     """
 
+    template_fields: Sequence[str] = ("operation", "object_name", "payload", "external_id_field")
+
     available_operations = ("insert", "update", "upsert", "delete", "hard_delete")
 
     def __init__(
@@ -70,7 +72,6 @@ class SalesforceBulkOperator(BaseOperator):
         self.batch_size = batch_size
         self.use_serial = use_serial
         self.salesforce_conn_id = salesforce_conn_id
-        self._validate_inputs()
 
     def _validate_inputs(self) -> None:
         if not self.object_name:
@@ -89,6 +90,7 @@ class SalesforceBulkOperator(BaseOperator):
         :param context: The task context during execution.
         :return: API response if do_xcom_push is True
         """
+        self._validate_inputs()
         sf_hook = SalesforceHook(salesforce_conn_id=self.salesforce_conn_id)
         conn = sf_hook.get_conn()
         bulk: SFBulkHandler = cast("SFBulkHandler", conn.__getattr__("bulk"))

--- a/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
+++ b/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
@@ -29,6 +29,18 @@ class TestSalesforceBulkOperator:
     Test class for SalesforceBulkOperator
     """
 
+    def test_template_fields(self):
+        """
+        Test that template_fields are correctly defined.
+        """
+        operator = SalesforceBulkOperator(
+            task_id="test_template_fields",
+            operation="insert",
+            object_name="Account",
+            payload=[],
+        )
+        assert operator.template_fields == ("operation", "object_name", "payload", "external_id_field")
+
     def test_execute_missing_operation(self):
         """
         Test execute missing operation
@@ -40,13 +52,14 @@ class TestSalesforceBulkOperator:
                 payload=[],
             )
 
+        operator = SalesforceBulkOperator(
+            task_id="missing_operation",
+            operation="operation",
+            object_name="Account",
+            payload=[],
+        )
         with pytest.raises(ValueError, match="Operation 'operation' not found!"):
-            SalesforceBulkOperator(
-                task_id="missing_operation",
-                operation="operation",
-                object_name="Account",
-                payload=[],
-            )
+            operator.execute(context={})
 
     def test_execute_missing_object_name(self):
         """
@@ -59,15 +72,16 @@ class TestSalesforceBulkOperator:
                 payload=[],
             )
 
+        operator = SalesforceBulkOperator(
+            task_id="missing_object_name",
+            operation="insert",
+            object_name="",
+            payload=[],
+        )
         with pytest.raises(
             ValueError, match="The required parameter 'object_name' cannot have an empty value."
         ):
-            SalesforceBulkOperator(
-                task_id="missing_object_name",
-                operation="insert",
-                object_name="",
-                payload=[],
-            )
+            operator.execute(context={})
 
     @patch("airflow.providers.salesforce.operators.bulk.SalesforceHook.get_conn")
     def test_execute_salesforce_bulk_insert(self, mock_get_conn):


### PR DESCRIPTION
## Summary

- Add `template_fields` to `SalesforceBulkOperator` enabling Jinja templating for `operation`, `object_name`, `payload`, and `external_id_field` parameters
- Move input validation from `__init__` to `execute()` so validation runs after template rendering
- Add `test_template_fields` test and update existing validation tests

## Motivation

Closes #62375

Without `template_fields`, parameters like `payload` receive literal template strings (e.g., `{{ ti.xcom_pull(task_ids='upstream_task') }}`) instead of actual XCom values. This change enables dynamic parameterization of the Salesforce Bulk API operator, consistent with how other Airflow operators work.

## Changes
- `providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py`: Added `template_fields` tuple, moved `_validate_inputs()` from `__init__` to `execute()`
- `providers/salesforce/tests/unit/salesforce/operators/test_bulk.py`: Added template_fields test, updated validation tests

## Test plan
- [x] Added `test_template_fields` to verify the tuple is correctly defined
- [x] Updated `test_execute_missing_operation` to verify validation during `execute()`
- [x] Updated `test_execute_missing_object_name` to verify validation during `execute()`