### PR TITLE
Fix wait_for_termination in PowerBITrigger

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/powerbi.py
@@ -152,8 +152,23 @@ class PowerBITrigger(BasePowerBITrigger):
                 request_body=self.request_body,
             )
 
-            if dataset_refresh_id:
-                self.log.info("Triggered dataset refresh %s", dataset_refresh_id)
+            if not dataset_refresh_id:
+                yield TriggerEvent(
+                    {
+                        "status": "error",
+                        "dataset_refresh_status": None,
+                        "message": "Failed to trigger the dataset refresh.",
+                        "dataset_refresh_id": None,
+                    }
+                )
+                return
+
+            self.log.info("Triggered dataset refresh %s", dataset_refresh_id)
+            # Set the dataset_refresh_id for polling
+            self.dataset_refresh_id = dataset_refresh_id
+
+            # If wait_for_termination is False, return immediately after triggering
+            if not self.wait_for_termination:
                 yield TriggerEvent(
                     {
                         "status": "success",
@@ -163,16 +178,6 @@ class PowerBITrigger(BasePowerBITrigger):
                     }
                 )
                 return
-
-            yield TriggerEvent(
-                {
-                    "status": "error",
-                    "dataset_refresh_status": None,
-                    "message": "Failed to trigger the dataset refresh.",
-                    "dataset_refresh_id": None,
-                }
-            )
-            return
 
         # The dataset refresh is already triggered. Poll for the dataset refresh status.
         @tenacity.retry(

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_powerbi.py
@@ -178,6 +178,7 @@ class TestPowerBITrigger:
     async def test_powerbi_trigger_run_trigger_refresh(self, mock_trigger_dataset_refresh, powerbi_trigger):
         """Assert event is triggered upon successful new refresh trigger."""
         powerbi_trigger.dataset_refresh_id = None
+        powerbi_trigger.wait_for_termination = False
         mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
 
         task = [i async for i in powerbi_trigger.run()]
@@ -354,4 +355,58 @@ class TestPowerBITrigger:
             }
         )
 
+        assert expected == actual
+
+    @pytest.mark.asyncio
+    @mock.patch.object(PowerBIHook, "get_refresh_details_by_refresh_id")
+    @mock.patch.object(PowerBIHook, "trigger_dataset_refresh")
+    async def test_powerbi_trigger_waits_for_completion_when_wait_for_termination_true(
+        self, mock_trigger_dataset_refresh, mock_get_refresh_details_by_refresh_id
+    ):
+        # Create trigger without dataset_refresh_id (simulating first-time trigger)
+        trigger = PowerBITrigger(
+            conn_id=POWERBI_CONN_ID,
+            proxies=None,
+            api_version=API_VERSION,
+            dataset_id=DATASET_ID,
+            dataset_refresh_id=None,  # No refresh ID - will trigger new refresh
+            group_id=GROUP_ID,
+            check_interval=CHECK_INTERVAL,
+            wait_for_termination=True,
+            timeout=TIMEOUT,
+            request_body=REQUEST_BODY,
+        )
+
+        # Mock trigger_dataset_refresh to return a new refresh ID
+        mock_trigger_dataset_refresh.return_value = DATASET_REFRESH_ID
+
+        # Mock get_refresh_details to simulate the refresh completing
+        mock_get_refresh_details_by_refresh_id.return_value = {
+            "status": PowerBIDatasetRefreshStatus.COMPLETED,
+            "error": None,
+        }
+
+        # Run the trigger
+        generator = trigger.run()
+        actual = await generator.asend(None)
+
+        # Verify trigger was called
+        mock_trigger_dataset_refresh.assert_called_once_with(
+            dataset_id=DATASET_ID,
+            group_id=GROUP_ID,
+            request_body=REQUEST_BODY,
+        )
+
+        # Verify get_refresh_details was called (proving it's polling, not returning immediately)
+        assert mock_get_refresh_details_by_refresh_id.call_count >= 1
+
+        # Verify the final event shows COMPLETED status (not None)
+        expected = TriggerEvent(
+            {
+                "status": "success",
+                "dataset_refresh_status": PowerBIDatasetRefreshStatus.COMPLETED,
+                "message": f"The dataset refresh {DATASET_REFRESH_ID} has {PowerBIDatasetRefreshStatus.COMPLETED}.",
+                "dataset_refresh_id": DATASET_REFRESH_ID,
+            }
+        )
         assert expected == actual


### PR DESCRIPTION
## Why
When the user sets `wait_for_completion=True`, the operator doesn't actually wait for the Power BI dataset refresh to complete. Instead, it just triggers the refresh and returns success immediately.

## What

1. Add validation to check the trigger operation result (`if not dataset_refresh_id`).
2. Store the retrieved ID in `self.dataset_refresh_id` for subsequent polling.
3. Return success immediately **only when** `wait_for_termination=False`.
4. Execute the asynchronous polling logic to wait for the final status when `wait_for_termination=True`.


closes: #62789


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
