### PR TITLE
fix: use configured schema in TableauHook Server construction

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/hooks/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/hooks/tableau.py
@@ -86,7 +86,8 @@ class TableauHook(BaseHook):
         self.tableau_conn_id = tableau_conn_id
         self.conn = self.get_connection(self.tableau_conn_id)
         self.site_id = site_id or self.conn.extra_dejson.get("site_id", "")
-        self.server = Server(self.conn.host)
+        server_address = f"{self.conn.schema}://{self.conn.host}" if self.conn.schema else self.conn.host
+        self.server = Server(server_address)
         verify: Any = self.conn.extra_dejson.get("verify", True)
         if isinstance(verify, str):
             verify = parse_boolean(verify)

--- a/providers/tableau/tests/unit/tableau/hooks/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/hooks/test_tableau.py
@@ -110,6 +110,17 @@ class TestTableauHook:
                 extra='{"auth": "jwt", "jwt_token": "fake_jwt_token", "site_id": ""}',
             )
         )
+        create_connection_without_db(
+            models.Connection(
+                conn_id="tableau_test_with_schema",
+                conn_type="tableau",
+                host="tableau",
+                schema="https",
+                login="user",
+                password="password",
+                extra='{"site_id": "my_site"}',
+            )
+        )
 
     @patch("airflow.providers.tableau.hooks.tableau.TableauAuth")
     @patch("airflow.providers.tableau.hooks.tableau.Server")
@@ -325,6 +336,26 @@ class TestTableauHook:
                 site_id="",
             )
             mock_server.return_value.auth.sign_in.assert_called_once_with(mock_tableau_auth.return_value)
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch("airflow.providers.tableau.hooks.tableau.TableauAuth")
+    @patch("airflow.providers.tableau.hooks.tableau.Server")
+    def test_get_conn_uses_schema_when_configured(self, mock_server, mock_tableau_auth):
+        """
+        Test that Server is constructed with the schema prepended to the host when schema is configured.
+        """
+        with TableauHook(tableau_conn_id="tableau_test_with_schema") as tableau_hook:
+            mock_server.assert_called_once_with(f"{tableau_hook.conn.schema}://{tableau_hook.conn.host}")
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch("airflow.providers.tableau.hooks.tableau.TableauAuth")
+    @patch("airflow.providers.tableau.hooks.tableau.Server")
+    def test_get_conn_uses_host_only_without_schema(self, mock_server, mock_tableau_auth):
+        """
+        Test that Server is constructed with the host only when no schema is configured (backward compatibility).
+        """
+        with TableauHook(tableau_conn_id="tableau_test_password") as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
         mock_server.return_value.auth.sign_out.assert_called_once_with()
 
     @patch("airflow.providers.tableau.hooks.tableau.TableauAuth")


### PR DESCRIPTION
Previously, TableauHook.__init__ ignored the schema field from the connection configuration, always creating HTTP connections. Now it prepends the schema (e.g., https) to the host when configured.

Fixes apache/airflow#62459

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
