### PR TITLE
Add template_fields support to SalesforceBulkOperator

### DIFF
--- a/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/operators/bulk.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, cast
 
 from airflow.providers.common.compat.sdk import BaseOperator
@@ -49,6 +49,13 @@ class SalesforceBulkOperator(BaseOperator):
     """
 
     available_operations = ("insert", "update", "upsert", "delete", "hard_delete")
+    template_fields: Sequence[str] = (
+        "payload",
+        "object_name",
+        "operation",
+        "external_id_field",
+        "salesforce_conn_id",
+    )
 
     def __init__(
         self,

--- a/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
+++ b/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
@@ -204,6 +204,13 @@ class TestSalesforceBulkOperator:
             use_serial=use_serial,
         )
 
+    def test_template_fields(self):
+        """
+        Test that template_fields contains the expected fields
+        """
+        expected_fields = ("payload", "object_name", "operation", "external_id_field", "salesforce_conn_id")
+        assert SalesforceBulkOperator.template_fields == expected_fields
+
     @patch("airflow.providers.salesforce.operators.bulk.SalesforceHook.get_conn")
     def test_execute_salesforce_bulk_hard_delete(self, mock_get_conn):
         """

--- a/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
+++ b/providers/salesforce/tests/unit/salesforce/operators/test_bulk.py
@@ -211,6 +211,30 @@ class TestSalesforceBulkOperator:
         expected_fields = ("payload", "object_name", "operation", "external_id_field", "salesforce_conn_id")
         assert SalesforceBulkOperator.template_fields == expected_fields
 
+    def test_template_fields_rendering(self):
+        """
+        Test that templated fields are actually rendered with Jinja context.
+        """
+        operator = SalesforceBulkOperator(
+            task_id="test_template_rendering",
+            operation="{{ var.value.op }}",
+            object_name="Account_{{ ds_nodash }}",
+            payload=[{"Name": "{{ ds }}"}],
+            external_id_field="{{ var.value.ext_id }}",
+        )
+
+        context = {
+            "ds": "2026-01-01",
+            "ds_nodash": "20260101",
+            "var": {"value": {"op": "insert", "ext_id": "Id"}},
+        }
+        operator.render_template_fields(context)
+
+        assert operator.operation == "insert"
+        assert operator.object_name == "Account_20260101"
+        assert operator.payload == [{"Name": "2026-01-01"}]
+        assert operator.external_id_field == "Id"
+
     @patch("airflow.providers.salesforce.operators.bulk.SalesforceHook.get_conn")
     def test_execute_salesforce_bulk_hard_delete(self, mock_get_conn):
         """


### PR DESCRIPTION
SalesforceBulkOperator doesn't define template_fields, so Jinja templating doesn't work for any of its parameters. This adds template_fields with payload, object_name, operation, external_id_field, and salesforce_conn_id, plus a unit test.

Closes: #62375

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
