### PR TITLE
fix: clear next_method and next_kwargs on task retry

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -848,6 +848,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
 
         TaskInstanceHistory.record_ti(self, session=session)
         session.execute(delete(TaskReschedule).filter_by(ti_id=self.id))
+        self.clear_next_method_args()
         self.id = uuid7()
 
     @provide_session

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -2304,6 +2304,28 @@ class TestTaskInstance:
         ti.handle_failure("test queued ti", test_mode=True)
         assert ti.state == State.UP_FOR_RETRY
 
+    def test_handle_failure_clears_next_method_on_retry(self, dag_maker):
+        """Test that handle_failure clears next_method/next_kwargs for deferred tasks on retry (#62845)."""
+        session = settings.Session()
+        with dag_maker():
+            task = EmptyOperator(task_id="mytask", retries=1)
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance(task.task_id)
+        ti.state = State.RUNNING
+        ti.next_method = "execute_complete"
+        ti.next_kwargs = {"event": "test_event"}
+        session.merge(ti)
+        session.flush()
+
+        ti.handle_failure("test deferred retry", test_mode=False)
+
+        # After handle_failure with retries available, state should be UP_FOR_RETRY
+        # and next_method/next_kwargs should be cleared
+        reloaded_ti = session.scalar(select(TaskInstance))
+        assert reloaded_ti.state == State.UP_FOR_RETRY
+        assert reloaded_ti.next_method is None
+        assert reloaded_ti.next_kwargs is None
+
     @patch.object(Stats, "incr")
     def test_handle_failure_no_task(self, Stats_incr, dag_maker):
         """
@@ -2600,6 +2622,34 @@ class TestTaskInstance:
         assert len(tih) == 1
         # the new try_id should be different from what's recorded in tih
         assert tih[0].task_instance_id == try_id
+
+    def test_prepare_db_for_next_try_clears_next_method_and_next_kwargs(self, dag_maker, session):
+        """Test that prepare_db_for_next_try clears next_method and next_kwargs (issue #62845)."""
+        with dag_maker(serialized=True):
+            BashOperator(
+                task_id="test_clear_deferred_fields_on_retry",
+                bash_command="echo",
+                retries=1,
+            )
+
+        dr = dag_maker.create_dagrun()
+        ti = dr.task_instances[0]
+        ti.state = State.RUNNING
+        # Simulate a task that was deferred and has next_method/next_kwargs set
+        ti.next_method = "execute_complete"
+        ti.next_kwargs = {"event": "test_event"}
+        session.merge(ti)
+        session.flush()
+
+        old_id = ti.id
+        ti.prepare_db_for_next_try(session)
+        session.flush()
+
+        # next_method and next_kwargs should be cleared
+        assert ti.next_method is None
+        assert ti.next_kwargs is None
+        # ID should have changed
+        assert ti.id != old_id
 
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])


### PR DESCRIPTION
# fix: clear next_method and next_kwargs on task retry

## Problem

When a deferrable operator fails during trigger resumption and enters retry, `next_method` and `next_kwargs` are not cleared in Airflow 3.x. This means the retry attempt skips `execute()` entirely and jumps straight to the stale `next_method(**next_kwargs)` callback from the previous attempt.

This causes two failure modes:
1. The task processes "zombie" trigger events from the previous attempt
2. The task fails because initial setup logic in `execute()` was bypassed

This was a known issue in Airflow 2.x, fixed in #18146 / #18210 by nullifying `next_method` and `next_kwargs` on retry. With the transition to the Task SDK and Internal API in 3.x, the reset logic was not carried over to the new `prepare_db_for_next_try()` method.

## Root Cause

`TaskInstance.prepare_db_for_next_try()` is the central method in 3.x for preparing a TI for its next attempt (generating new UUID, incrementing try_number, resetting state). It was missing a call to `clear_next_method_args()`, so the deferred execution state persisted across retries.

## Fix

Added `self.clear_next_method_args()` in `prepare_db_for_next_try()`, right before the new attempt UUID is generated. This ensures the retry always starts fresh from `execute()`.

One line change in `airflow-core/src/airflow/models/taskinstance.py`, plus two tests:
- `test_prepare_db_for_next_try_clears_next_method` — verifies `prepare_db_for_next_try()` resets deferred fields
- `test_handle_failure_clears_next_method_on_retry` — verifies the full `handle_failure()` path clears deferred state when retries remain

All 216 model tests + 127 execution API tests pass.

Closes: #62845

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).