### PR TITLE
[v3-1-test] Backport UI of Scope session token in cookie to base_url (#62771)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/login/Login.tsx
@@ -27,6 +27,13 @@ import { ErrorAlert } from "src/alert/ErrorAlert";
 import { LoginForm } from "src/login/LoginForm";
 import { useCreateToken } from "src/queries/useCreateToken";
 
+// Derive the cookie path from the <base> tag so the _token cookie is scoped
+// to the Airflow subpath (e.g. "/team-a/") instead of "/".
+const cookiePath = new URL(
+  document.querySelector("head>base")?.getAttribute("href") ?? "/",
+  globalThis.location.origin,
+).pathname;
+
 export type LoginBody = {
   password: string;
   username: string;
@@ -47,20 +54,30 @@ const LOCAL_STORAGE_DISABLE_BANNER_KEY = "disable-sam-banner";
 
 export const Login = () => {
   const [searchParams] = useSearchParams();
-  const [, setCookie] = useCookies(["_token"]);
+  const [, setCookie, removeCookie] = useCookies(["_token"]);
   const [isBannerDisabled, setIsBannerDisabled] = useState(
     localStorage.getItem(LOCAL_STORAGE_DISABLE_BANNER_KEY),
   );
 
   const onSuccess = (data: LoginResponse) => {
-    // Fallback similar to FabAuthManager, strip off the next
-    const fallback = "/";
+    // Fall back to the Airflow base path (e.g. "/team-a/") so that
+    // logins without a "next" parameter (e.g. after logout) redirect
+    // to the correct subpath instead of the server root "/".
+    const fallback = cookiePath;
 
     // Redirect to appropriate page with the token
     const next = searchParams.get("next") ?? fallback;
 
+    // Remove any stale _token cookie at root path to prevent duplicate
+    // cookies.  When two _token cookies exist (one at "/" and one at the
+    // subpath), the server's SimpleCookie parser picks the last one which
+    // may be the stale value, causing authentication failures.
+    if (cookiePath !== "/") {
+      removeCookie("_token", { path: "/" });
+    }
+
     setCookie("_token", data.access_token, {
-      path: "/",
+      path: cookiePath,
       secure: globalThis.location.protocol !== "http:",
     });
 


### PR DESCRIPTION
Backport of https://github.com/apache/airflow/pull/62771

* Scope session token in cookie to base_url

* Make get_cookie_path import backwards compatible

(cherry picked from commit 43ee8c48c9bf6ec3de382052602a43afc4a0da34)

---

The UI part depends on https://github.com/apache/airflow/pull/62858, so the UI part will be separated from https://github.com/apache/airflow/pull/62851 and handle here.