### PR TITLE
fix: correct airflowignore negation pattern handling for directory-only patterns

### DIFF
--- a/shared/module_loading/src/airflow_shared/module_loading/file_discovery.py
+++ b/shared/module_loading/src/airflow_shared/module_loading/file_discovery.py
@@ -79,6 +79,7 @@ class _GlobIgnoreRule(NamedTuple):
 
     wild_match_pattern: GitWildMatchPattern
     relative_to: Path | None = None
+    dir_only: bool = False
 
     @staticmethod
     def compile(pattern: str, base_dir: Path, definition_file: Path) -> _IgnoreRule | None:
@@ -95,8 +96,15 @@ class _GlobIgnoreRule(NamedTuple):
             # > Otherwise the pattern may also match at any level below the .gitignore level.
             relative_to = definition_file.parent
 
+        # See https://git-scm.com/docs/gitignore
+        # > If there is a separator at the end of the pattern then the pattern will only match
+        # > directories, otherwise the pattern can match both files and directories.
+        # Strip the negation prefix before checking for trailing separator.
+        raw_pattern = pattern.lstrip("!")
+        dir_only = raw_pattern.rstrip() != raw_pattern.rstrip().rstrip("/")
+
         ignore_pattern = GitWildMatchPattern(pattern)
-        return _GlobIgnoreRule(wild_match_pattern=ignore_pattern, relative_to=relative_to)
+        return _GlobIgnoreRule(wild_match_pattern=ignore_pattern, relative_to=relative_to, dir_only=dir_only)
 
     @staticmethod
     def match(path: Path, rules: list[_IgnoreRule]) -> bool:
@@ -105,8 +113,14 @@ class _GlobIgnoreRule(NamedTuple):
         for rule in rules:
             if not isinstance(rule, _GlobIgnoreRule):
                 raise ValueError(f"_GlobIgnoreRule cannot match rules of type: {type(rule)}")
+            # See https://git-scm.com/docs/gitignore
+            # > If there is a separator at the end of the pattern then the pattern will only match
+            # > directories, otherwise the pattern can match both files and directories.
+            is_dir = path.is_dir()
+            if rule.dir_only and not is_dir:
+                continue
             rel_obj = path.relative_to(rule.relative_to) if rule.relative_to else Path(path.name)
-            if path.is_dir():
+            if is_dir:
                 rel_path = f"{rel_obj.as_posix()}/"
             else:
                 rel_path = rel_obj.as_posix()

--- a/shared/module_loading/tests/module_loading/test_file_discovery.py
+++ b/shared/module_loading/tests/module_loading/test_file_discovery.py
@@ -137,3 +137,44 @@ class TestFindPathFromDirectory:
                 detected.add(p.relative_to(dags_root).as_posix())
 
         assert detected == {"a/b/subfolder/keep.py"}
+
+    def test_airflowignore_negation_directory_only_patterns_do_not_unignore_files(self, tmp_path):
+        """Directory-only negation patterns should only unignore directories, not files inside them.
+
+        Regression test for https://github.com/apache/airflow/issues/62716
+
+        Patterns:
+          *                     -> ignore everything
+          !abc/                 -> unignore abc dir (for traversal), NOT its contents
+          !abc/def/             -> unignore abc/def dir (for traversal), NOT its contents
+          !abc/def/xyz/         -> unignore abc/def/xyz dir (for traversal), NOT its contents
+          !abc/def/xyz/*        -> unignore contents of abc/def/xyz
+        """
+        dags_root = tmp_path / "dags"
+        (dags_root / "abc" / "def" / "xyz").mkdir(parents=True)
+
+        # files at various levels – only xyz_dag.py should be discovered
+        (dags_root / "root_dag.py").write_text("raise Exception('ignored')\n")
+        (dags_root / "abc" / "abc_dag.py").write_text("raise Exception('ignored')\n")
+        (dags_root / "abc" / "def" / "def_dag.py").write_text("raise Exception('ignored')\n")
+        (dags_root / "abc" / "def" / "xyz" / "xyz_dag.py").write_text("# should be discovered\n")
+
+        (dags_root / ".airflowignore").write_text(
+            "\n".join(
+                [
+                    "*",
+                    "!abc/",
+                    "!abc/def/",
+                    "!abc/def/xyz/",
+                    "!abc/def/xyz/*",
+                ]
+            )
+        )
+
+        detected = set()
+        for raw in find_path_from_directory(dags_root, ".airflowignore", "glob"):
+            p = Path(raw)
+            if p.is_file() and p.suffix == ".py":
+                detected.add(p.relative_to(dags_root).as_posix())
+
+        assert detected == {"abc/def/xyz/xyz_dag.py"}


### PR DESCRIPTION
## Problem

When using `.airflowignore` with negation patterns to selectively un-ignore deeply nested directories, directory-only patterns (ending with `/`) incorrectly un-ignore files inside those directories. 

For example, with this `.airflowignore`:
```
*
!abc/
!abc/def/
!abc/def/xyz/
!abc/def/xyz/*
```

Files in `abc/` and `abc/def/` are incorrectly discovered, when only files in `abc/def/xyz/` should be.

## Root Cause

`_GlobIgnoreRule.match()` passes file paths to `GitWildMatchPattern.match_file()` without distinguishing between directory-only patterns and general patterns. The `GitWildMatchPattern` treats a pattern like `abc/def/` as matching everything under `abc/def/` (including files), but per the [gitignore specification](https://git-scm.com/docs/gitignore):

> If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.

So `!abc/def/` should only un-ignore the *directory* `abc/def` (allowing traversal), not files within it.

## Fix

- Added a `dir_only` flag to `_GlobIgnoreRule` that is set when the pattern (after stripping `!` prefix) ends with `/`.
- In `_GlobIgnoreRule.match()`, directory-only rules are skipped when matching non-directory paths, ensuring they only affect directory traversal decisions.
- Added a regression test reproducing the exact scenario from the issue.

All 6 existing + new tests pass.

Closes: #62716

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).