### PR TITLE
Fix POST /pools to return 409 when pool already exists  

### DIFF
--- a/airflow-core/docs/core-concepts/xcoms.rst
+++ b/airflow-core/docs/core-concepts/xcoms.rst
@@ -78,6 +78,39 @@ An example of pushing multiple XComs and pulling them individually:
         # Pulling entire XCom data from push_multiple task
         data = context["ti"].xcom_pull(task_ids="push_multiple", key="return_value")
 
+Pulling XComs from a Triggered DAG
+------------------------------------
+
+When using :class:`~airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunOperator` to trigger a
+child DAG, the operator automatically pushes the triggered DAG run's ``run_id`` to XCom with the key
+``XCOM_RUN_ID`` (``"trigger_run_id"``). A downstream task can then use this ``run_id`` to pull XCom values
+produced by tasks inside the child DAG.
+
+.. code-block:: python
+
+    from airflow.providers.standard.operators.trigger_dagrun import XCOM_RUN_ID, TriggerDagRunOperator
+    from airflow.sdk import dag, task, get_current_context
+
+
+    @dag()
+    def parent_dag():
+        @task
+        def postprocess(trigger_result):
+            context = get_current_context()
+            ti = context["ti"]
+            # Step 1: Get the run_id of the triggered child DAG run
+            child_run_id = ti.xcom_pull(task_ids="trigger_child", key=XCOM_RUN_ID)
+            # Step 2: Pull XCom from the child DAG using the specific run_id
+            child_result = ti.xcom_pull(dag_id="child_dag", task_ids="produce", run_id=child_run_id)
+            return child_result
+
+        trigger = TriggerDagRunOperator(
+            task_id="trigger_child",
+            trigger_dag_id="child_dag",
+            wait_for_completion=True,
+        )
+        postprocess(trigger)
+
 .. note::
 
   If the first task was not successful then on every retry task XComs will be cleared to make the task run idempotent. XComs therefore can't be used to persist state across task retries or :doc:`./sensors` poke.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/pools.py
@@ -158,7 +158,7 @@ def patch_pool(
     status_code=status.HTTP_201_CREATED,
     responses=create_openapi_http_exception_doc(
         [status.HTTP_409_CONFLICT]
-    ),  # handled by global exception handler
+    ),
     dependencies=[Depends(requires_access_pool(method="POST")), Depends(action_logging())],
 )
 def post_pool(
@@ -166,6 +166,12 @@ def post_pool(
     session: SessionDep,
 ) -> PoolResponse:
     """Create a Pool."""
+    existing_pool = session.scalar(select(Pool).where(Pool.pool == body.pool).limit(1))
+    if existing_pool:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"The Pool with name: `{body.pool}` already exists",
+        )
     pool = Pool(**body.model_dump())
     session.add(pool)
     return pool

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -166,6 +166,7 @@
     "mappedTaskInstances_one": "Task Instance [{{count}}]",
     "mappedTaskInstances_other": "Task Instances [{{count}}]",
     "overview": "Overview",
+    "partitionedRuns": "Partitioned Runs",
     "renderedTemplates": "Rendered Templates",
     "requiredActions": "Required Actions",
     "runs": "Runs",

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 import { ReactFlowProvider } from "@xyflow/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiBarChart, FiCode, FiUser, FiCalendar } from "react-icons/fi";
+import { FiBarChart, FiCode, FiUser, FiCalendar, FiLayers } from "react-icons/fi";
 import { LuChartColumn } from "react-icons/lu";
 import { MdDetails, MdOutlineEventNote } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
@@ -43,19 +43,6 @@ export const Dag = () => {
 
   // Get external views with dag destination
   const externalTabs = usePluginTabs("dag");
-
-  const tabs = [
-    { icon: <LuChartColumn />, label: translate("tabs.overview"), value: "" },
-    { icon: <FiBarChart />, label: translate("tabs.runs"), value: "runs" },
-    { icon: <TaskIcon />, label: translate("tabs.tasks"), value: "tasks" },
-    { icon: <FiCalendar />, label: translate("tabs.calendar"), value: "calendar" },
-    { icon: <FiUser />, label: translate("tabs.requiredActions"), value: "required_actions" },
-    { icon: <RiArrowGoBackFill />, label: translate("tabs.backfills"), value: "backfills" },
-    { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
-    { icon: <FiCode />, label: translate("tabs.code"), value: "code" },
-    { icon: <MdDetails />, label: translate("tabs.details"), value: "details" },
-    ...externalTabs,
-  ];
 
   const refetchInterval = useAutoRefresh({ dagId });
   const [hasPendingRuns, setHasPendingRuns] = useState<boolean | undefined>(false);
@@ -104,6 +91,32 @@ export const Dag = () => {
         return hasPendingRuns ? refetchInterval : false;
       },
     },
+  );
+
+  const isPartitionedAssetDag = dag?.timetable_summary === "Partitioned Asset";
+  const tabs = useMemo(
+    () => [
+      { icon: <LuChartColumn />, label: translate("tabs.overview"), value: "" },
+      { icon: <FiBarChart />, label: translate("tabs.runs"), value: "runs" },
+      ...(isPartitionedAssetDag
+        ? [
+            {
+              icon: <FiLayers />,
+              label: translate("tabs.partitionedRuns"),
+              value: "partitioned_runs",
+            },
+          ]
+        : []),
+      { icon: <TaskIcon />, label: translate("tabs.tasks"), value: "tasks" },
+      { icon: <FiCalendar />, label: translate("tabs.calendar"), value: "calendar" },
+      { icon: <FiUser />, label: translate("tabs.requiredActions"), value: "required_actions" },
+      { icon: <RiArrowGoBackFill />, label: translate("tabs.backfills"), value: "backfills" },
+      { icon: <MdOutlineEventNote />, label: translate("tabs.auditLog"), value: "events" },
+      { icon: <FiCode />, label: translate("tabs.code"), value: "code" },
+      { icon: <MdDetails />, label: translate("tabs.details"), value: "details" },
+      ...externalTabs,
+    ],
+    [translate, isPartitionedAssetDag, externalTabs]
   );
 
   const { tabs: processedTabs } = useRequiredActionTabs({ dagId }, tabs, {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/PartitionedRuns.tsx
@@ -1,0 +1,48 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Navigate, useLocation, useSearchParams } from "react-router-dom";
+
+import { SearchParamsKeys } from "src/constants/searchParams";
+
+import { DagRuns } from "../../DagRuns";
+
+const RUN_TYPE_PARAM = SearchParamsKeys.RUN_TYPE;
+
+/**
+ * PartitionedRuns displays dag runs filtered to asset-triggered (partitioned) runs
+ * for consumer DAGs using PartitionedAssetTimetable.
+ * It ensures run_type=asset_triggered is set when the user navigates to this tab.
+ */
+export const PartitionedRuns = () => {
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+
+  if (!searchParams.get(RUN_TYPE_PARAM)) {
+    const next = new URLSearchParams(searchParams);
+    next.set(RUN_TYPE_PARAM, "asset_triggered");
+    return (
+      <Navigate
+        replace
+        to={`${location.pathname}?${next.toString()}`}
+      />
+    );
+  }
+
+  return <DagRuns />;
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/index.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/PartitionedRuns/index.ts
@@ -1,0 +1,20 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { PartitionedRuns } from "./PartitionedRuns";

--- a/airflow-core/src/airflow/ui/src/router.tsx
+++ b/airflow-core/src/airflow/ui/src/router.tsx
@@ -32,6 +32,7 @@ import { Backfills } from "src/pages/Dag/Backfills";
 import { Calendar } from "src/pages/Dag/Calendar/Calendar";
 import { Code } from "src/pages/Dag/Code";
 import { Details as DagDetails } from "src/pages/Dag/Details";
+import { PartitionedRuns } from "src/pages/Dag/PartitionedRuns";
 import { Overview } from "src/pages/Dag/Overview";
 import { Tasks } from "src/pages/Dag/Tasks";
 import { DagRuns } from "src/pages/DagRuns";
@@ -166,6 +167,7 @@ export const routerConfig = [
         children: [
           { element: <Overview />, index: true },
           { element: <DagRuns />, path: "runs" },
+          { element: <PartitionedRuns />, path: "partitioned_runs" },
           { element: <Tasks />, path: "tasks" },
           { element: <Calendar />, path: "calendar" },
           { element: <HITLTaskInstances />, path: "required_actions" },

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -584,7 +584,7 @@ class TestPostPool(TestPoolsEndpoint):
         else:
             response_json = response.json()
             assert "detail" in response_json
-            assert list(response_json["detail"].keys()) == ["reason", "statement", "orig_error", "message"]
+            assert response_json["detail"] == f"The Pool with name: `{body['name']}` already exists"
 
         assert session.scalar(select(func.count()).select_from(Pool)) == n_pools + 1
 

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -80,6 +80,9 @@ spec:
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
         checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
         checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        {{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled (not .Values.jwtSecretName) }}
+        checksum/jwt-secret: {{ include (print $.Template.BasePath "/secrets/jwt-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.dagProcessor.safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -91,6 +91,9 @@ spec:
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
         checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
         checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        {{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled (not .Values.jwtSecretName) }}
+        checksum/jwt-secret: {{ include (print $.Template.BasePath "/secrets/jwt-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.triggerer.safeToEvict }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -121,6 +121,9 @@ spec:
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
         checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
         checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
+        {{- if and (semverCompare ">=3.0.0" .Values.airflowVersion) .Values.apiServer.enabled (not .Values.jwtSecretName) }}
+        checksum/jwt-secret: {{ include (print $.Template.BasePath "/secrets/jwt-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if $podAnnotations }}
           {{- toYaml $podAnnotations | nindent 8 }}
         {{- end }}

--- a/providers/google/docs/operators/cloud/cloud_sql.rst
+++ b/providers/google/docs/operators/cloud/cloud_sql.rst
@@ -359,6 +359,21 @@ as shown in the example:
     :start-after: [START howto_operator_cloudsql_import_gcs_permissions]
     :end-before: [END howto_operator_cloudsql_import_gcs_permissions]
 
+.. _howto/operator:CloudSQLInstanceOperationsSensor:
+
+CloudSQLInstanceOperationsSensor
+--------------------------------
+
+Waits until no Cloud SQL administrative operation is running on an instance. Cloud SQL allows only
+one such operation at a time per instance (import, export, clone, patch, etc.). When multiple
+operations are triggered concurrently, the API returns HTTP 409 with reason ``operationInProgress``.
+
+Use this sensor upstream of import/export/clone tasks to serialize access to a shared instance
+across DAGs or dynamically mapped tasks. Supports deferrable mode to avoid occupying worker slots.
+
+For parameter definition, take a look at
+:class:`~airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLInstanceOperationsSensor`.
+
 .. _howto/operator:CloudSQLCreateInstanceOperator:
 
 CloudSQLCreateInstanceOperator

--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -318,6 +318,7 @@ class CloudSQLHook(GoogleBaseHook):
         self._wait_for_operation_to_complete(project_id=project_id, operation_name=operation_name)
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @GoogleBaseHook.operation_in_progress_retry()
     def export_instance(self, instance: str, body: dict, project_id: str):
         """
         Export data from a Cloud SQL instance to a Cloud Storage bucket as a SQL dump or CSV file.
@@ -340,6 +341,7 @@ class CloudSQLHook(GoogleBaseHook):
         return operation_name
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @GoogleBaseHook.operation_in_progress_retry()
     def import_instance(self, instance: str, body: dict, project_id: str) -> None:
         """
         Import data into a Cloud SQL instance from a SQL dump or CSV file in Cloud Storage.
@@ -365,6 +367,7 @@ class CloudSQLHook(GoogleBaseHook):
             raise AirflowException(f"Importing instance {instance} failed: {ex.content}")
 
     @GoogleBaseHook.fallback_to_default_project_id
+    @GoogleBaseHook.operation_in_progress_retry()
     def clone_instance(self, instance: str, body: dict, project_id: str) -> None:
         """
         Clones an instance to a target instance.
@@ -413,6 +416,29 @@ class CloudSQLHook(GoogleBaseHook):
         operation_name = response.get("operation", {}).get("name", {})
         self._wait_for_operation_to_complete(project_id=project_id, operation_name=operation_name)
         return response
+
+    @GoogleBaseHook.fallback_to_default_project_id
+    def list_instance_operations(
+        self, instance: str, project_id: str, max_results: int = 100
+    ) -> list[dict[str, Any]]:
+        """
+        List operations for a Cloud SQL instance.
+
+        Used to detect if any administrative operation (import, export, clone, patch, etc.)
+        is currently running. Cloud SQL allows only one such operation at a time per instance.
+
+        :param instance: Database instance ID. This does not include the project ID.
+        :param project_id: Project ID of the project that contains the instance.
+        :param max_results: Maximum number of operations to return. Default 100.
+        :return: List of operation dicts with at least 'name' and 'status' keys.
+        """
+        response = (
+            self.get_conn()
+            .operations()
+            .list(project=project_id, instance=instance, maxResults=max_results)
+            .execute(num_retries=self.num_retries)
+        )
+        return response.get("items", [])
 
     @GoogleBaseHook.fallback_to_default_project_id
     def _wait_for_operation_to_complete(
@@ -481,6 +507,26 @@ class CloudSQLAsyncHook(GoogleBaseAsyncHook):
             )
             operation = await operation.json(content_type=None)
             return operation
+
+    async def list_instance_operations(
+        self, project_id: str, instance: str, max_results: int = 100
+    ) -> list[dict[str, Any]]:
+        """
+        List operations for a Cloud SQL instance (async).
+
+        :param project_id: Project ID of the project that contains the instance.
+        :param instance: Database instance ID. This does not include the project ID.
+        :param max_results: Maximum number of operations to return. Default 100.
+        :return: List of operation dicts with at least 'name' and 'status' keys.
+        """
+        url = (
+            f"https://sqladmin.googleapis.com/sql/v1beta4/projects/{quote_plus(project_id)}/"
+            f"operations?instance={quote_plus(instance)}&maxResults={max_results}"
+        )
+        async with ClientSession() as session:
+            response = await self._get_conn(session=session, url=url)
+            data = await response.json(content_type=None)
+            return data.get("items", [])
 
 
 class CloudSqlProxyRunner(LoggingMixin):

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_sql.py
@@ -1,0 +1,133 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains Google Cloud SQL sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator, conf
+from airflow.providers.google.cloud.hooks.cloud_sql import CloudSqlOperationStatus, CloudSQLHook
+from airflow.providers.google.cloud.links.cloud_sql import CloudSQLInstanceLink
+from airflow.providers.google.cloud.triggers.cloud_sql import CloudSQLInstanceOperationsTrigger
+from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
+
+if TYPE_CHECKING:
+    from airflow.providers.common.compat.sdk import Context
+
+
+class CloudSQLInstanceOperationsSensor(BaseSensorOperator):
+    """
+    Waits until no Cloud SQL administrative operation is running on an instance.
+
+    Cloud SQL allows only one administrative operation at a time per instance (import,
+    export, clone, patch, etc.). When multiple operations are triggered concurrently,
+    the API returns HTTP 409 with reason ``operationInProgress``. This sensor polls the
+    Operations API and returns when no PENDING or RUNNING operations remain, allowing
+    the next admin operation to proceed.
+
+    Use this sensor upstream of import/export/clone tasks to serialize access to a
+    shared instance across DAGs or dynamically mapped tasks.
+
+    .. seealso::
+        :ref:`howto/operator:CloudSQLImportInstanceOperator`
+        :ref:`howto/operator:CloudSQLExportInstanceOperator`
+        https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/operations/list
+
+    :param instance: Cloud SQL instance ID. This does not include the project ID.
+    :param project_id: Optional, Google Cloud Project ID. If set to None or missing,
+        the default project_id from the Google Cloud connection is used.
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud.
+    :param impersonation_chain: Optional service account to impersonate.
+    :param deferrable: Run sensor in deferrable mode (uses triggerer, no worker slot).
+    """
+
+    template_fields: Sequence[str] = ("instance", "project_id", "impersonation_chain")
+    operator_extra_links = (CloudSQLInstanceLink(),)
+
+    def __init__(
+        self,
+        *,
+        instance: str,
+        project_id: str = PROVIDE_PROJECT_ID,
+        gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: str | Sequence[str] | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.instance = instance
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
+        self.deferrable = deferrable
+
+    def poke(self, context: Context) -> bool:
+        hook = CloudSQLHook(
+            gcp_conn_id=self.gcp_conn_id,
+            api_version="v1beta4",
+            impersonation_chain=self.impersonation_chain,
+        )
+        project_id = self.project_id or hook.project_id
+        operations = hook.list_instance_operations(
+            instance=self.instance,
+            project_id=project_id,
+        )
+        active = [
+            op
+            for op in operations
+            if op.get("status") in (CloudSqlOperationStatus.PENDING, CloudSqlOperationStatus.RUNNING)
+        ]
+        if not active:
+            if project_id:
+                CloudSQLInstanceLink.persist(context=context, project_id=project_id, instance=self.instance)
+            return True
+        self.log.info(
+            "Instance %s has %d operation(s) in progress: %s",
+            self.instance,
+            len(active),
+            [op.get("name") for op in active],
+        )
+        return False
+
+    def execute(self, context: Context) -> None:
+        if not self.deferrable:
+            super().execute(context)
+        elif not self.poke(context=context):
+            hook = CloudSQLHook(
+                gcp_conn_id=self.gcp_conn_id,
+                api_version="v1beta4",
+                impersonation_chain=self.impersonation_chain,
+            )
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=CloudSQLInstanceOperationsTrigger(
+                    instance=self.instance,
+                    project_id=self.project_id or hook.project_id,
+                    gcp_conn_id=self.gcp_conn_id,
+                    impersonation_chain=self.impersonation_chain,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
+        if event.get("status") == "failed":
+            raise AirflowException(event["message"])
+        self.log.info("Instance %s has no operations in progress. Proceeding.", self.instance)

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_sql.py
@@ -27,6 +27,78 @@ from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
+class CloudSQLInstanceOperationsTrigger(BaseTrigger):
+    """
+    Trigger that waits until no Cloud SQL administrative operation is running on an instance.
+
+    Cloud SQL allows only one administrative operation at a time per instance (import, export,
+    clone, patch, etc.). When multiple operations are triggered concurrently, the API returns
+    HTTP 409 with reason ``operationInProgress``. This trigger polls the Operations API and
+    yields success when no PENDING or RUNNING operations remain, allowing the next admin
+    operation to proceed.
+
+    .. seealso::
+        https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/operations/list
+    """
+
+    def __init__(
+        self,
+        instance: str,
+        project_id: str = PROVIDE_PROJECT_ID,
+        gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: str | Sequence[str] | None = None,
+        poke_interval: int = 30,
+    ):
+        super().__init__()
+        self.instance = instance
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
+        self.poke_interval = poke_interval
+        self.hook = CloudSQLAsyncHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
+
+    def serialize(self):
+        return (
+            "airflow.providers.google.cloud.triggers.cloud_sql.CloudSQLInstanceOperationsTrigger",
+            {
+                "instance": self.instance,
+                "project_id": self.project_id,
+                "gcp_conn_id": self.gcp_conn_id,
+                "impersonation_chain": self.impersonation_chain,
+                "poke_interval": self.poke_interval,
+            },
+        )
+
+    async def run(self):
+        try:
+            while True:
+                operations = await self.hook.list_instance_operations(
+                    project_id=self.project_id,
+                    instance=self.instance,
+                )
+                active = [
+                    op
+                    for op in operations
+                    if op.get("status") in (CloudSqlOperationStatus.PENDING, CloudSqlOperationStatus.RUNNING)
+                ]
+                if not active:
+                    yield TriggerEvent({"status": "success"})
+                    return
+                self.log.info(
+                    "Instance %s has %d operation(s) in progress, sleeping for %s seconds.",
+                    self.instance,
+                    len(active),
+                    self.poke_interval,
+                )
+                await asyncio.sleep(self.poke_interval)
+        except Exception as e:
+            self.log.exception("Exception occurred while checking instance operations.")
+            yield TriggerEvent({"status": "failed", "message": str(e)})
+
+
 class CloudSQLExportTrigger(BaseTrigger):
     """
     Trigger that periodically polls information from Cloud SQL API to verify job status.

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -720,6 +720,10 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.google.cloud.sensors.cloud_composer"],
             },
             {
+                "integration-name": "Google Cloud SQL",
+                "python-modules": ["airflow.providers.google.cloud.sensors.cloud_sql"],
+            },
+            {
                 "integration-name": "Google Cloud Storage Transfer Service",
                 "python-modules": ["airflow.providers.google.cloud.sensors.cloud_storage_transfer_service"],
             },

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_sql.py
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
+from airflow.providers.google.cloud.sensors.cloud_sql import CloudSQLInstanceOperationsSensor
+
+INSTANCE_NAME = "test-instance"
+PROJECT_ID = "test-project"
+
+
+class TestCloudSQLInstanceOperationsSensor:
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLHook")
+    def test_poke_success_when_no_operations(self, mock_hook_class):
+        mock_hook = mock.Mock()
+        mock_hook.list_instance_operations.return_value = []
+        mock_hook.project_id = PROJECT_ID
+        mock_hook_class.return_value = mock_hook
+
+        sensor = CloudSQLInstanceOperationsSensor(
+            task_id="task",
+            instance=INSTANCE_NAME,
+            project_id=PROJECT_ID,
+        )
+        context = {"ti": mock.Mock(), "task": mock.MagicMock()}
+        assert sensor.poke(context) is True
+
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLHook")
+    def test_poke_success_when_all_done(self, mock_hook_class):
+        mock_hook = mock.Mock()
+        mock_hook.list_instance_operations.return_value = [
+            {"name": "op1", "status": "DONE"},
+        ]
+        mock_hook.project_id = PROJECT_ID
+        mock_hook_class.return_value = mock_hook
+
+        sensor = CloudSQLInstanceOperationsSensor(
+            task_id="task",
+            instance=INSTANCE_NAME,
+            project_id=PROJECT_ID,
+        )
+        context = {"ti": mock.Mock(), "task": mock.MagicMock()}
+        assert sensor.poke(context) is True
+
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLHook")
+    def test_poke_false_when_operation_running(self, mock_hook_class):
+        mock_hook = mock.Mock()
+        mock_hook.list_instance_operations.return_value = [
+            {"name": "op1", "status": "RUNNING"},
+        ]
+        mock_hook_class.return_value = mock_hook
+
+        sensor = CloudSQLInstanceOperationsSensor(
+            task_id="task",
+            instance=INSTANCE_NAME,
+            project_id=PROJECT_ID,
+        )
+        context = {"ti": mock.Mock(), "task": mock.MagicMock()}
+        assert sensor.poke(context) is False
+
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLHook")
+    def test_execute_deferrable_defers_when_not_ready(self, mock_hook_class):
+        mock_hook = mock.Mock()
+        mock_hook.list_instance_operations.return_value = [{"name": "op1", "status": "RUNNING"}]
+        mock_hook.project_id = PROJECT_ID
+        mock_hook_class.return_value = mock_hook
+
+        sensor = CloudSQLInstanceOperationsSensor(
+            task_id="task",
+            instance=INSTANCE_NAME,
+            project_id=PROJECT_ID,
+            deferrable=True,
+        )
+        context = {"ti": mock.Mock(), "task": mock.MagicMock()}
+        with pytest.raises(TaskDeferred):
+            sensor.execute(context)
+
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_sql.CloudSQLHook")
+    def test_execute_complete_raises_on_failure(self, mock_hook_class):
+        sensor = CloudSQLInstanceOperationsSensor(
+            task_id="task",
+            instance=INSTANCE_NAME,
+        )
+        context = {"ti": mock.Mock(), "task": mock.MagicMock()}
+        with pytest.raises(AirflowException, match="API failed"):
+            sensor.execute_complete(context, {"status": "failed", "message": "API failed"})

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_sql.py
@@ -22,10 +22,17 @@ from unittest import mock as async_mock
 
 import pytest
 
-from airflow.providers.google.cloud.triggers.cloud_sql import CloudSQLExportTrigger
+from airflow.providers.google.cloud.triggers.cloud_sql import (
+    CloudSQLExportTrigger,
+    CloudSQLInstanceOperationsTrigger,
+)
 from airflow.triggers.base import TriggerEvent
 
 CLASSPATH = "airflow.providers.google.cloud.triggers.cloud_sql.CloudSQLExportTrigger"
+INSTANCE_OPERATIONS_CLASSPATH = (
+    "airflow.providers.google.cloud.triggers.cloud_sql.CloudSQLInstanceOperationsTrigger"
+)
+INSTANCE_NAME = "test_instance"
 TASK_ID = "test_task"
 TEST_POLL_INTERVAL = 10
 TEST_GCP_CONN_ID = "test-project"
@@ -148,3 +155,65 @@ class TestCloudSQLExportTrigger:
         generator = trigger.run()
         actual = await generator.asend(None)
         assert TriggerEvent({"status": "failed", "message": "Test exception"}) == actual
+
+
+@pytest.fixture
+def instance_operations_trigger():
+    return CloudSQLInstanceOperationsTrigger(
+        instance=INSTANCE_NAME,
+        project_id=PROJECT_ID,
+        gcp_conn_id=TEST_GCP_CONN_ID,
+        poke_interval=TEST_POLL_INTERVAL,
+    )
+
+
+class TestCloudSQLInstanceOperationsTrigger:
+    def test_serialization(self, instance_operations_trigger):
+        classpath, kwargs = instance_operations_trigger.serialize()
+        assert classpath == INSTANCE_OPERATIONS_CLASSPATH
+        assert kwargs == {
+            "instance": INSTANCE_NAME,
+            "project_id": PROJECT_ID,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "impersonation_chain": None,
+            "poke_interval": TEST_POLL_INTERVAL,
+        }
+
+    @pytest.mark.asyncio
+    @async_mock.patch(HOOK_STR.format("CloudSQLAsyncHook.list_instance_operations"))
+    async def test_success_when_no_operations(self, mock_list_ops, instance_operations_trigger):
+        mock_list_ops.return_value = []
+        generator = instance_operations_trigger.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success"}) == actual
+
+    @pytest.mark.asyncio
+    @async_mock.patch(HOOK_STR.format("CloudSQLAsyncHook.list_instance_operations"))
+    async def test_success_when_all_done(self, mock_list_ops, instance_operations_trigger):
+        mock_list_ops.return_value = [{"name": "op1", "status": "DONE"}]
+        generator = instance_operations_trigger.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success"}) == actual
+
+    @pytest.mark.asyncio
+    @async_mock.patch("airflow.providers.google.cloud.triggers.cloud_sql.asyncio.sleep")
+    @async_mock.patch(HOOK_STR.format("CloudSQLAsyncHook.list_instance_operations"))
+    async def test_waits_when_operation_running(
+        self, mock_list_ops, mock_sleep, instance_operations_trigger
+    ):
+        mock_list_ops.side_effect = [
+            [{"name": "op1", "status": "RUNNING"}],
+            [],
+        ]
+        generator = instance_operations_trigger.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success"}) == actual
+        assert mock_list_ops.call_count == 2
+
+    @pytest.mark.asyncio
+    @async_mock.patch(HOOK_STR.format("CloudSQLAsyncHook.list_instance_operations"))
+    async def test_failed_on_exception(self, mock_list_ops, instance_operations_trigger):
+        mock_list_ops.side_effect = Exception("API error")
+        generator = instance_operations_trigger.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "failed", "message": "API error"}) == actual

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -152,6 +152,20 @@ class TriggerDagRunOperator(BaseOperator):
         and existing OpenLineage-related settings in the conf will not be overwritten. The injection process
         is safeguarded against exceptions - if any error occurs during metadata injection, it is gracefully
         handled and the conf remains unchanged - so it's safe to use. Default is ``True``
+
+    **Retrieving XCom values from the triggered DAG:**
+
+    After triggering a child DAG, this operator pushes the child DAG run's ``run_id`` to XCom with
+    the key ``XCOM_RUN_ID`` (``"trigger_run_id"``). Downstream tasks can retrieve XCom values produced
+    by tasks in the child DAG using this run_id:
+
+    .. code-block:: python
+
+        from airflow.providers.standard.operators.trigger_dagrun import XCOM_RUN_ID
+
+        # In a downstream task:
+        child_run_id = ti.xcom_pull(task_ids="<trigger_task_id>", key=XCOM_RUN_ID)
+        child_result = ti.xcom_pull(dag_id="<child_dag_id>", task_ids="<task_id>", run_id=child_run_id)
     """
 
     template_fields: Sequence[str] = (

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4227,6 +4227,42 @@ class TestTriggerDagRunOperator:
         ]
         mock_supervisor_comms.assert_has_calls(expected_calls)
 
+    def test_cross_dag_xcom_pull_using_triggered_run_id(self, create_runtime_ti, mock_supervisor_comms):
+        """Test that a task can pull XCom from a triggered child DAG using the run_id stored by TriggerDagRunOperator."""
+
+        class PullOperator(BaseOperator):
+            def execute(self, context):
+                return context["ti"].xcom_pull(
+                    dag_id="child_dag", task_ids="produce_task", run_id="child_run_id"
+                )
+
+        task = PullOperator(task_id="pull_task")
+        ti = create_runtime_ti(dag_id="parent_dag", run_id="parent_run", task=task)
+
+        ser_value = BaseXCom.serialize_value("child_result")
+
+        def mock_send_side_effect(*args, **kwargs):
+            msg = kwargs.get("msg") or args[0]
+            if isinstance(msg, GetXComSequenceSlice):
+                return XComSequenceSliceResult(root=[ser_value])
+            return XComResult(key="return_value", value=ser_value)
+
+        mock_supervisor_comms.send.side_effect = mock_send_side_effect
+
+        run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+        mock_supervisor_comms.send.assert_any_call(
+            msg=GetXComSequenceSlice(
+                key="return_value",
+                dag_id="child_dag",
+                run_id="child_run_id",
+                task_id="produce_task",
+                start=None,
+                stop=None,
+                step=None,
+            ),
+        )
+
     @pytest.mark.parametrize(
         ("skip_when_already_exists", "expected_state"),
         [


### PR DESCRIPTION
Fixes #62788    
1. What's happening
  'POST /pools' wasn't returning 409 when a pool with the same name already existed.
  The endpoint relied on '_UniqueConstraintErrorHandler' to catch the 'IntegrityError'
   and convert it to a 409, but that handler pattern-matches against DB driver error
  strings for SQLite/MySQL/Postgres. If the string doesn't match, it returns 'None'
  silently — so the error gets swallowed and the response is unpredictable (seen in 3.0.6).
2. Fix
  Added an explicit existence check in 'post_pool' before calling 'session.add()'.
  If a pool with that name exists, we raise 'HTTPException(409)' directly — same
  approach 'post_variable' already uses.
 '_UniqueConstraintErrorHandler' is left untouched, it's still used by connections.

 3.Testing

  - 'TestPostPool::test_should_response_409' updated to match the new plain-string detail
  - Full 'test_pools.py' suite passes
