### PR TITLE
fix: prevent SQL parameterization of duplicate_key_handling in MySQL bulk_load_custom

### DIFF
--- a/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
+++ b/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
@@ -350,6 +350,14 @@ class MySqlHook(DbApiHook):
                 f"Must be one of {_VALID_DUPLICATE_KEY_HANDLING}."
             )
 
+        import re
+
+        if extra_options and not re.match(r"^[A-Z @=',;()\w\s.*/-]+$", extra_options):
+            raise ValueError(
+                f"Invalid extra_options: {extra_options!r}. "
+                "Only alphanumeric characters, spaces, and common SQL clauses are allowed."
+            )
+
         conn = self.get_conn()
         cursor = conn.cursor()
 

--- a/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
+++ b/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
@@ -342,8 +342,13 @@ class MySqlHook(DbApiHook):
         conn = self.get_conn()
         cursor = conn.cursor()
 
-        sql_statement = f"LOAD DATA LOCAL INFILE %s %s INTO TABLE `{table}` %s"
-        parameters = (tmp_file, duplicate_key_handling, extra_options)
+        # duplicate_key_handling and extra_options are SQL keywords (e.g. IGNORE, REPLACE)
+        # and must be interpolated into the statement, not passed as query parameters,
+        # because parameterized values get quoted as strings which produces invalid SQL.
+        sql_statement = (
+            f"LOAD DATA LOCAL INFILE %s {duplicate_key_handling} INTO TABLE `{table}` {extra_options}"
+        )
+        parameters = (tmp_file,)
         cursor.execute(
             sql_statement,
             parameters,

--- a/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
+++ b/providers/mysql/src/airflow/providers/mysql/hooks/mysql.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 from urllib.parse import quote_plus, urlencode
 
 from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
@@ -318,7 +318,11 @@ class MySqlHook(DbApiHook):
         return token, port
 
     def bulk_load_custom(
-        self, table: str, tmp_file: str, duplicate_key_handling: str = "IGNORE", extra_options: str = ""
+        self,
+        table: str,
+        tmp_file: str,
+        duplicate_key_handling: Literal["IGNORE", "REPLACE", ""] = "IGNORE",
+        extra_options: str = "",
     ) -> None:
         """
         Load local data from a file into the database in a more configurable way.
@@ -339,6 +343,13 @@ class MySqlHook(DbApiHook):
 
             .. seealso:: https://dev.mysql.com/doc/refman/8.0/en/load-data.html
         """
+        _VALID_DUPLICATE_KEY_HANDLING = {"IGNORE", "REPLACE", ""}
+        if duplicate_key_handling not in _VALID_DUPLICATE_KEY_HANDLING:
+            raise ValueError(
+                f"Invalid duplicate_key_handling: {duplicate_key_handling!r}. "
+                f"Must be one of {_VALID_DUPLICATE_KEY_HANDLING}."
+            )
+
         conn = self.get_conn()
         cursor = conn.cursor()
 

--- a/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
+++ b/providers/mysql/tests/unit/mysql/hooks/test_mysql.py
@@ -506,15 +506,24 @@ class TestMySqlHook:
             IGNORE 1 LINES""",
         )
         self.cur.execute.assert_called_once_with(
-            f"LOAD DATA LOCAL INFILE %s %s INTO TABLE `{table}` %s",
-            (
-                "/tmp/file",
-                "IGNORE",
-                """FIELDS TERMINATED BY ';'
-            OPTIONALLY ENCLOSED BY '"'
-            IGNORE 1 LINES""",
-            ),
+            f"LOAD DATA LOCAL INFILE %s IGNORE INTO TABLE `{table}` FIELDS TERMINATED BY ';'\n            OPTIONALLY ENCLOSED BY '\"'\n            IGNORE 1 LINES",
+            ("/tmp/file",),
         )
+
+    @pytest.mark.parametrize("duplicate_key_handling", ["IGNORE", "REPLACE"])
+    def test_bulk_load_custom_duplicate_key_not_parameterized(self, duplicate_key_handling):
+        """Verify duplicate_key_handling is interpolated into SQL, not passed as a query parameter."""
+        self.db_hook.bulk_load_custom(
+            "table",
+            "/tmp/file",
+            duplicate_key_handling,
+            "",
+        )
+        executed_sql = self.cur.execute.call_args[0][0]
+        # The keyword must appear literally in the SQL, not as a %s placeholder
+        assert duplicate_key_handling in executed_sql
+        # Only tmp_file should be parameterized
+        assert self.cur.execute.call_args[0][1] == ("/tmp/file",)
 
     @mock.patch("airflow.providers.mysql.hooks.mysql.send_sql_hook_lineage")
     def test_bulk_load_custom_hook_lineage(self, mock_send_lineage):
@@ -527,8 +536,10 @@ class TestMySqlHook:
         mock_send_lineage.assert_called_once()
         call_kw = mock_send_lineage.call_args.kwargs
         assert call_kw["context"] is self.db_hook
-        assert call_kw["sql"] == "LOAD DATA LOCAL INFILE %s %s INTO TABLE `table` %s"
-        assert call_kw["sql_parameters"] == ("/tmp/file", "IGNORE", "FIELDS TERMINATED BY ';'")
+        assert (
+            call_kw["sql"] == "LOAD DATA LOCAL INFILE %s IGNORE INTO TABLE `table` FIELDS TERMINATED BY ';'"
+        )
+        assert call_kw["sql_parameters"] == ("/tmp/file",)
         assert call_kw["cur"] is self.cur
 
     def test_reserved_words(self):


### PR DESCRIPTION
# fix: stop parameterizing SQL keywords in MySQL bulk_load_custom

## Problem

`MySqlHook.bulk_load_custom()` passes `duplicate_key_handling` (e.g. `IGNORE`, `REPLACE`) and `extra_options` as parameterized query values via `cursor.execute(sql, parameters)`. The MySQL driver treats parameterized values as data and quotes them as string literals, producing invalid SQL like:

```sql
LOAD DATA LOCAL INFILE '/tmp/file' 'IGNORE' INTO TABLE `my_table` 'FIELDS TERMINATED BY ...'
```

This was introduced in PR #33328 which changed from string concatenation to parameterization for these keywords. A prior fix attempt existed (#41078) but was closed without merge.

## Root Cause

In `providers/mysql/src/airflow/providers/mysql/hooks/mysql.py`, the `bulk_load_custom` method builds the SQL as:

```python
sql_statement = f"LOAD DATA LOCAL INFILE %s %s INTO TABLE `{table}` %s"
parameters = (tmp_file, duplicate_key_handling, extra_options)
```

Both `duplicate_key_handling` and `extra_options` are SQL syntax keywords, not data values. Only `tmp_file` is actual data that should be parameterized.

## Fix

Changed `bulk_load_custom` to interpolate `duplicate_key_handling` and `extra_options` directly into the SQL statement via f-string, while keeping `tmp_file` as the sole parameterized value:

```python
sql_statement = f"LOAD DATA LOCAL INFILE %s {duplicate_key_handling} INTO TABLE `{table}` {extra_options}"
parameters = (tmp_file,)
```

Updated existing tests (`test_bulk_load_custom`, `test_bulk_load_custom_hook_lineage`) to assert the new SQL shape and parameter tuple. Added a new parametrized test `test_bulk_load_custom_duplicate_key_not_parameterized` that validates both `IGNORE` and `REPLACE` appear literally in the executed SQL and only `tmp_file` is parameterized.

Closes: #62506

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).