### PR TITLE
Add GCS and Azure Blob Storage support to AnalyticsOperator

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -2250,7 +2250,7 @@ def test_upgrade_to_newer_dependencies(
             {
                 "docs-list-as-string": "amazon apache.drill apache.druid apache.hive apache.iceberg "
                 "apache.impala apache.pinot common.ai common.compat common.sql databricks elasticsearch "
-                "exasol google jdbc microsoft.mssql mysql odbc openlineage "
+                "exasol google jdbc microsoft.azure microsoft.mssql mysql odbc openlineage "
                 "oracle pgvector postgres presto slack snowflake sqlite teradata trino vertica ydb",
             },
             id="Common SQL provider package python files changed",

--- a/providers/common/sql/docs/index.rst
+++ b/providers/common/sql/docs/index.rst
@@ -122,14 +122,16 @@ You can install such cross-provider dependencies when installing from PyPI. For 
     pip install apache-airflow-providers-common-sql[amazon]
 
 
-====================================================================================================================  ==================
-Dependent package                                                                                                     Extra
-====================================================================================================================  ==================
-`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                  ``amazon``
-`apache-airflow-providers-apache-iceberg <https://airflow.apache.org/docs/apache-airflow-providers-apache-iceberg>`_  ``apache.iceberg``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_    ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_        ``openlineage``
-====================================================================================================================  ==================
+======================================================================================================================  ===================
+Dependent package                                                                                                       Extra
+======================================================================================================================  ===================
+`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
+`apache-airflow-providers-apache-iceberg <https://airflow.apache.org/docs/apache-airflow-providers-apache-iceberg>`_    ``apache.iceberg``
+`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                    ``google``
+`apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
+======================================================================================================================  ===================
 
 Downloading official packages
 -----------------------------

--- a/providers/common/sql/docs/operators.rst
+++ b/providers/common/sql/docs/operators.rst
@@ -267,10 +267,12 @@ The Analytics Operator is ideal for performing efficient, high-performance analy
 Supported Storage Systems
 -------------------------
 - S3
+- GCS (Google Cloud Storage)
+- Azure Blob Storage
 - Local File System
 
 .. note::
-   GCS, Azure, HTTP, Delta, Iceberg are not yet supported but will be added in the future.
+   HTTP and Delta are not yet supported but will be added in the future.
 
 
 
@@ -311,6 +313,22 @@ S3 Storage
     :dedent: 4
     :start-after: [START howto_analytics_operator_with_s3]
     :end-before: [END howto_analytics_operator_with_s3]
+
+GCS Storage
+-----------
+.. exampleinclude:: /../../sql/src/airflow/providers/common/sql/example_dags/example_analytics.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_analytics_operator_with_gcs]
+    :end-before: [END howto_analytics_operator_with_gcs]
+
+Azure Blob Storage
+------------------
+.. exampleinclude:: /../../sql/src/airflow/providers/common/sql/example_dags/example_analytics.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_analytics_operator_with_azure]
+    :end-before: [END howto_analytics_operator_with_azure]
 
 Local File System Storage
 -------------------------

--- a/providers/common/sql/pyproject.toml
+++ b/providers/common/sql/pyproject.toml
@@ -88,6 +88,9 @@ dependencies = [
 "amazon" = [
     "apache-airflow-providers-amazon"
 ]
+"google" = [
+    "apache-airflow-providers-google"
+]
 # DataFusion 52.0.0 crate is not supported at the moment with iceberg-core
 "datafusion" = [
     "datafusion>=50.0.0,<52.0.0",
@@ -98,6 +101,9 @@ dependencies = [
 "apache.iceberg" = [
     "apache-airflow-providers-apache-iceberg"
 ]
+"microsoft.azure" = [
+    "apache-airflow-providers-microsoft-azure"
+]
 
 [dependency-groups]
 dev = [
@@ -107,6 +113,8 @@ dev = [
     "apache-airflow-providers-amazon",
     "apache-airflow-providers-apache-iceberg",
     "apache-airflow-providers-common-compat",
+    "apache-airflow-providers-google",
+    "apache-airflow-providers-microsoft-azure",
     "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas]",

--- a/providers/common/sql/src/airflow/providers/common/sql/config.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/config.py
@@ -48,6 +48,8 @@ class StorageType(str, Enum):
 
     S3 = "s3"
     LOCAL = "local"
+    GCS = "gcs"
+    AZURE = "azure"
 
 
 @dataclass
@@ -106,4 +108,8 @@ class DataSourceConfig:
             return StorageType.S3
         if self.uri.startswith("file://"):
             return StorageType.LOCAL
+        if self.uri.startswith("gs://"):
+            return StorageType.GCS
+        if self.uri.startswith("az://"):
+            return StorageType.AZURE
         raise ValueError(f"Unsupported storage type for URI: {self.uri}")

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -175,25 +175,22 @@ class DataFusionEngine(LoggingMixin):
                 extra_config = {}
 
             case "wasb":
-                try:
-                    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
-                except ImportError:
-                    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
-
-                    raise AirflowOptionalProviderFeatureException(
-                        "Failed to import WasbHook. To use the Azure storage functionality, please install the "
-                        "apache-airflow-providers-microsoft-azure package."
-                    )
-                wasb_hook: WasbHook = WasbHook(wasb_conn_id=conn.conn_id)
-                wasb_conn = wasb_hook.get_connection(conn.conn_id)
-                account_name = wasb_conn.login
-                account_key = wasb_conn.password or wasb_conn.extra_dejson.get("account_key")
-                if account_name:
-                    credentials["account"] = account_name
-                if account_key:
-                    credentials["access_key"] = account_key
+                account_name = conn.host or conn.login
+                tenant_id = conn.extra_dejson.get("tenant_id")
+                if tenant_id:
+                    credentials = {
+                        "account": account_name,
+                        "client_id": conn.extra_dejson.get("client_id") or conn.login,
+                        "client_secret": conn.extra_dejson.get("client_secret") or conn.password,
+                        "tenant_id": tenant_id,
+                    }
+                else:
+                    credentials = {
+                        "account": account_name,
+                        "access_key": conn.password or conn.extra_dejson.get("account_key"),
+                    }
                 credentials = self._remove_none_values(credentials)
-                extra_config = _fetch_extra_configs(["endpoint"])
+                extra_config = {}
 
             case _:
                 raise ValueError(f"Unknown connection type {conn.conn_type}")

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -160,18 +160,16 @@ class DataFusionEngine(LoggingMixin):
 
             case "google_cloud_platform":
                 try:
-                    from airflow.providers.google.common.hooks.base_google import get_field as gcp_get_field
+                    # Imported as a feature gate only: verifies the Google provider is installed.
+                    from airflow.providers.google.common.hooks.base_google import GoogleBaseHook  # noqa: F401
                 except ImportError:
                     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 
                     raise AirflowOptionalProviderFeatureException(
-                        "Failed to import get_field. To use the GCS storage functionality, please install the "
+                        "Failed to import GoogleBaseHook. To use the GCS storage functionality, please install the "
                         "apache-airflow-providers-google package."
                     )
-                key_path = gcp_get_field(conn.extra_dejson, "key_path")
-                if key_path:
-                    credentials.update({"service_account_path": key_path})
-                # Without key_path, credentials stays empty and DataFusion falls back to ADC.
+                # Deferred to GCSObjectStorageProvider, provide_gcp_credential_file_as_context to handle key_path, keyfile_dict, and ADC.
                 extra_config = {}
 
             case "wasb":

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -192,7 +192,11 @@ class DataFusionEngine(LoggingMixin):
 
                     host = conn.host or ""
                     parsed = urlparse(host if "://" in host else f"https://{host}")
-                    account = parsed.netloc.split(".")[0] if "." in (parsed.netloc or "") else host
+                    account = (
+                        parsed.netloc.split(".")[0]
+                        if "." in (parsed.netloc or "")
+                        else (parsed.netloc or host)
+                    )
                     credentials = {
                         "account": account or None,
                         "client_id": conn.extra_dejson.get("client_id") or conn.login,
@@ -206,6 +210,11 @@ class DataFusionEngine(LoggingMixin):
                         "access_key": conn.password or conn.extra_dejson.get("account_key"),
                     }
                 credentials = self._remove_none_values(credentials)
+                if "account" not in credentials:
+                    raise ValueError(
+                        "Azure connection requires a storage account name. "
+                        "Set 'login' for key auth or 'host' for Service Principal auth."
+                    )
                 extra_config = {}
 
             case _:

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -160,22 +160,23 @@ class DataFusionEngine(LoggingMixin):
 
             case "google_cloud_platform":
                 try:
-                    from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+                    from airflow.providers.google.common.hooks.base_google import get_field as gcp_get_field
                 except ImportError:
                     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 
                     raise AirflowOptionalProviderFeatureException(
-                        "Failed to import GoogleBaseHook. To use the GCS storage functionality, please install the "
+                        "Failed to import get_field. To use the GCS storage functionality, please install the "
                         "apache-airflow-providers-google package."
                     )
-                gcp_hook: GoogleBaseHook = GoogleBaseHook(gcp_conn_id=conn.conn_id)
-                key_path = gcp_hook._get_field("key_path")
+                key_path = gcp_get_field(conn.extra_dejson, "key_path")
                 if key_path:
                     credentials.update({"service_account_path": key_path})
+                # Without key_path, credentials stays empty and DataFusion falls back to ADC.
                 extra_config = {}
 
             case "wasb":
                 try:
+                    # Imported as a feature gate only: verifies the Azure provider is installed
                     from airflow.providers.microsoft.azure.hooks.wasb import WasbHook  # noqa: F401
                 except ImportError:
                     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
@@ -184,18 +185,26 @@ class DataFusionEngine(LoggingMixin):
                         "Failed to import WasbHook. To use the Azure storage functionality, please install the "
                         "apache-airflow-providers-microsoft-azure package."
                     )
-                account_name = conn.host or conn.login
                 tenant_id = conn.extra_dejson.get("tenant_id")
                 if tenant_id:
+                    # Service Principal auth: conn.host holds the storage account (name or full URL);
+                    # conn.login is the client_id (AAD app ID), matching WasbHook convention.
+                    # DataFusion requires just the account name, so strip any URL components.
+                    from urllib.parse import urlparse
+
+                    host = conn.host or ""
+                    parsed = urlparse(host if "://" in host else f"https://{host}")
+                    account = parsed.netloc.split(".")[0] if "." in (parsed.netloc or "") else host
                     credentials = {
-                        "account": account_name,
+                        "account": account or None,
                         "client_id": conn.extra_dejson.get("client_id") or conn.login,
                         "client_secret": conn.extra_dejson.get("client_secret") or conn.password,
                         "tenant_id": tenant_id,
                     }
                 else:
+                    # Key auth: conn.login = storage account name
                     credentials = {
-                        "account": account_name,
+                        "account": conn.login,
                         "access_key": conn.password or conn.extra_dejson.get("account_key"),
                     }
                 credentials = self._remove_none_values(credentials)

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -158,6 +158,43 @@ class DataFusionEngine(LoggingMixin):
                 credentials = self._remove_none_values(credentials)
                 extra_config = _fetch_extra_configs(["region", "endpoint"])
 
+            case "google_cloud_platform":
+                try:
+                    from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+                except ImportError:
+                    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+                    raise AirflowOptionalProviderFeatureException(
+                        "Failed to import GoogleBaseHook. To use the GCS storage functionality, please install the "
+                        "apache-airflow-providers-google package."
+                    )
+                gcp_hook: GoogleBaseHook = GoogleBaseHook(gcp_conn_id=conn.conn_id)
+                key_path = gcp_hook._get_field("key_path")
+                if key_path:
+                    credentials.update({"service_account_path": key_path})
+                extra_config = {}
+
+            case "wasb":
+                try:
+                    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+                except ImportError:
+                    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+                    raise AirflowOptionalProviderFeatureException(
+                        "Failed to import WasbHook. To use the Azure storage functionality, please install the "
+                        "apache-airflow-providers-microsoft-azure package."
+                    )
+                wasb_hook: WasbHook = WasbHook(wasb_conn_id=conn.conn_id)
+                wasb_conn = wasb_hook.get_connection(conn.conn_id)
+                account_name = wasb_conn.login
+                account_key = wasb_conn.password or wasb_conn.extra_dejson.get("account_key")
+                if account_name:
+                    credentials["account"] = account_name
+                if account_key:
+                    credentials["access_key"] = account_key
+                credentials = self._remove_none_values(credentials)
+                extra_config = _fetch_extra_configs(["endpoint"])
+
             case _:
                 raise ValueError(f"Unknown connection type {conn.conn_type}")
         return credentials, extra_config

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/engine.py
@@ -175,6 +175,15 @@ class DataFusionEngine(LoggingMixin):
                 extra_config = {}
 
             case "wasb":
+                try:
+                    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook  # noqa: F401
+                except ImportError:
+                    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+                    raise AirflowOptionalProviderFeatureException(
+                        "Failed to import WasbHook. To use the Azure storage functionality, please install the "
+                        "apache-airflow-providers-microsoft-azure package."
+                    )
                 account_name = conn.host or conn.login
                 tenant_id = conn.extra_dejson.get("tenant_id")
                 if tenant_id:

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
@@ -34,7 +34,7 @@ class S3ObjectStorageProvider(ObjectStorageProvider):
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
         """Create an S3 object store using DataFusion's AmazonS3."""
         if connection_config is None:
-            raise ValueError("connection_config must be provided for %s", self.get_storage_type)
+            raise ValueError(f"connection_config must be provided for {self.get_storage_type}")
 
         try:
             credentials = connection_config.credentials
@@ -81,7 +81,7 @@ class GCSObjectStorageProvider(ObjectStorageProvider):
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
         """Create a GCS object store using DataFusion's GoogleCloud."""
         if connection_config is None:
-            raise ValueError("connection_config must be provided for %s", self.get_storage_type)
+            raise ValueError(f"connection_config must be provided for {self.get_storage_type}")
 
         try:
             credentials = connection_config.credentials
@@ -111,7 +111,7 @@ class AzureObjectStorageProvider(ObjectStorageProvider):
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
         """Create an Azure object store using DataFusion's MicrosoftAzure."""
         if connection_config is None:
-            raise ValueError("connection_config must be provided for %s", self.get_storage_type)
+            raise ValueError(f"connection_config must be provided for {self.get_storage_type}")
 
         try:
             credentials = connection_config.credentials

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
@@ -79,19 +79,67 @@ class GCSObjectStorageProvider(ObjectStorageProvider):
         return StorageType.GCS
 
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
-        """Create a GCS object store using DataFusion's GoogleCloud."""
+        """
+        Create a GCS object store using DataFusion's GoogleCloud.
+
+        Supported auth modes (in priority order):
+
+        - ``key_path`` / ``keyfile_dict``: resolved to a file path via
+          ``provide_gcp_credential_file_as_context`` and passed as ``service_account_path``.
+        - ``credential_config_file``: passed as ``service_account_path``. If the value is an
+          inline JSON string or dict it is written to a temporary file first.
+        - No credentials set: DataFusion falls back to Application Default Credentials (ADC).
+
+        Not supported: ``key_secret_name`` (Secret Manager) and ``impersonation_chain`` — these
+        require capabilities outside DataFusion's ``GoogleCloud`` object-store API.
+        """
         if connection_config is None:
             raise ValueError(f"connection_config must be provided for {self.get_storage_type}")
 
         try:
-            from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+            import json
+            import os
+            import tempfile
+
+            from airflow.providers.google.common.hooks.base_google import GoogleBaseHook, get_field
 
             bucket = self.get_bucket(path)
             gcp_hook = GoogleBaseHook(gcp_conn_id=connection_config.conn_id)
 
+            if get_field(gcp_hook.extras, "key_secret_name"):
+                raise ValueError(
+                    "GCS auth mode 'key_secret_name' (Secret Manager) is not supported by the "
+                    "DataFusion object store. Use 'key_path' or 'keyfile_dict' instead."
+                )
+
             with gcp_hook.provide_gcp_credential_file_as_context() as cred_file:
-                credentials = {"service_account_path": cred_file} if cred_file else {}
-                gcs_store = GoogleCloud(**credentials, bucket_name=bucket)
+                if cred_file is not None:
+                    # key_path or keyfile_dict
+                    gcs_store = GoogleCloud(service_account_path=cred_file, bucket_name=bucket)
+                else:
+                    credential_config_file = get_field(gcp_hook.extras, "credential_config_file")
+                    if credential_config_file is not None:
+                        # Workload Identity Federation via credential_config_file
+                        if isinstance(credential_config_file, str) and os.path.exists(credential_config_file):
+                            gcs_store = GoogleCloud(
+                                service_account_path=credential_config_file,
+                                bucket_name=bucket,
+                            )
+                        else:
+                            # Inline dict or JSON string — write to temp file
+                            with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as tmp:
+                                content = (
+                                    json.dumps(credential_config_file)
+                                    if isinstance(credential_config_file, dict)
+                                    else credential_config_file
+                                )
+                                tmp.write(content)
+                                tmp.flush()
+                                gcs_store = GoogleCloud(service_account_path=tmp.name, bucket_name=bucket)
+                    else:
+                        # ADC fallback
+                        gcs_store = GoogleCloud(bucket_name=bucket)
+
                 self.log.info("Created GCS object store for bucket %s", bucket)
                 return gcs_store
 

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from datafusion.object_store import AmazonS3, LocalFileSystem
+from datafusion.object_store import AmazonS3, GoogleCloud, LocalFileSystem, MicrosoftAzure
 
 from airflow.providers.common.sql.config import ConnectionConfig, StorageType
 from airflow.providers.common.sql.datafusion.base import ObjectStorageProvider
@@ -70,12 +70,75 @@ class LocalObjectStorageProvider(ObjectStorageProvider):
         return "file://"
 
 
+class GCSObjectStorageProvider(ObjectStorageProvider):
+    """GCS Object Storage Provider using DataFusion's GoogleCloud."""
+
+    @property
+    def get_storage_type(self) -> StorageType:
+        """Return the storage type."""
+        return StorageType.GCS
+
+    def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
+        """Create a GCS object store using DataFusion's GoogleCloud."""
+        if connection_config is None:
+            raise ValueError("connection_config must be provided for %s", self.get_storage_type)
+
+        try:
+            credentials = connection_config.credentials
+            bucket = self.get_bucket(path)
+
+            gcs_store = GoogleCloud(**credentials, bucket_name=bucket)
+            self.log.info("Created GCS object store for bucket %s", bucket)
+
+            return gcs_store
+
+        except Exception as e:
+            raise ObjectStoreCreationException(f"Failed to create GCS object store: {e}")
+
+    def get_scheme(self) -> str:
+        """Return the scheme for GCS."""
+        return "gs://"
+
+
+class AzureObjectStorageProvider(ObjectStorageProvider):
+    """Azure Blob Storage Object Storage Provider using DataFusion's MicrosoftAzure."""
+
+    @property
+    def get_storage_type(self) -> StorageType:
+        """Return the storage type."""
+        return StorageType.AZURE
+
+    def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
+        """Create an Azure object store using DataFusion's MicrosoftAzure."""
+        if connection_config is None:
+            raise ValueError("connection_config must be provided for %s", self.get_storage_type)
+
+        try:
+            credentials = connection_config.credentials
+            container = self.get_bucket(path)
+
+            azure_store = MicrosoftAzure(
+                **credentials, **connection_config.extra_config, container_name=container
+            )
+            self.log.info("Created Azure object store for container %s", container)
+
+            return azure_store
+
+        except Exception as e:
+            raise ObjectStoreCreationException(f"Failed to create Azure object store: {e}")
+
+    def get_scheme(self) -> str:
+        """Return the scheme for Azure Blob Storage."""
+        return "az://"
+
+
 def get_object_storage_provider(storage_type: StorageType) -> ObjectStorageProvider:
     """Get an object storage provider based on the storage type."""
-    # TODO: Add support for GCS, Azure, HTTP: https://datafusion.apache.org/python/autoapi/datafusion/object_store/index.html
     providers: dict[StorageType, type] = {
         StorageType.S3: S3ObjectStorageProvider,
         StorageType.LOCAL: LocalObjectStorageProvider,
+        StorageType.GCS: GCSObjectStorageProvider,
+        StorageType.AZURE: AzureObjectStorageProvider,
     }
 
     if storage_type not in providers:

--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
@@ -84,13 +84,16 @@ class GCSObjectStorageProvider(ObjectStorageProvider):
             raise ValueError(f"connection_config must be provided for {self.get_storage_type}")
 
         try:
-            credentials = connection_config.credentials
+            from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+
             bucket = self.get_bucket(path)
+            gcp_hook = GoogleBaseHook(gcp_conn_id=connection_config.conn_id)
 
-            gcs_store = GoogleCloud(**credentials, bucket_name=bucket)
-            self.log.info("Created GCS object store for bucket %s", bucket)
-
-            return gcs_store
+            with gcp_hook.provide_gcp_credential_file_as_context() as cred_file:
+                credentials = {"service_account_path": cred_file} if cred_file else {}
+                gcs_store = GoogleCloud(**credentials, bucket_name=bucket)
+                self.log.info("Created GCS object store for bucket %s", bucket)
+                return gcs_store
 
         except Exception as e:
             raise ObjectStoreCreationException(f"Failed to create GCS object store: {e}")

--- a/providers/common/sql/src/airflow/providers/common/sql/example_dags/example_analytics.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/example_dags/example_analytics.py
@@ -30,6 +30,20 @@ datasource_config_local = DataSourceConfig(
     conn_id="", table_name="users_data", uri="file:///path/to/", format="parquet"
 )
 
+datasource_config_gcs = DataSourceConfig(
+    conn_id="google_cloud_default",
+    table_name="sales_data",
+    uri="gs://bucket/sales/",
+    format="parquet",
+)
+
+datasource_config_azure = DataSourceConfig(
+    conn_id="wasb_default",
+    table_name="events_data",
+    uri="az://container/events/",
+    format="parquet",
+)
+
 datasource_config_iceberg = DataSourceConfig(
     conn_id="iceberg_default",
     table_name="users_data",
@@ -78,8 +92,23 @@ with DAG(
         datasource_configs=[datasource_config_local],
         queries=["SELECT * FROM users_data", "SELECT count(*) FROM users_data"],
     )
-    analytics_with_s3 >> analytics_with_local
     # [END howto_analytics_operator_with_local]
+
+    # [START howto_analytics_operator_with_gcs]
+    analytics_with_gcs = AnalyticsOperator(
+        task_id="analytics_with_gcs",
+        datasource_configs=[datasource_config_gcs],
+        queries=["SELECT * FROM sales_data", "SELECT count(*) FROM sales_data"],
+    )
+    # [END howto_analytics_operator_with_gcs]
+
+    # [START howto_analytics_operator_with_azure]
+    analytics_with_azure = AnalyticsOperator(
+        task_id="analytics_with_azure",
+        datasource_configs=[datasource_config_azure],
+        queries=["SELECT * FROM events_data", "SELECT count(*) FROM events_data"],
+    )
+    # [END howto_analytics_operator_with_azure]
 
     # [START howto_analytics_decorator]
     @task.analytics(datasource_configs=[datasource_config_s3])
@@ -96,4 +125,11 @@ with DAG(
 
     # [END howto_analytics_iceberg]
 
-    analytics_with_local >> get_user_summary_queries() >> get_users_product_queries_from_iceberg_catalog()
+    (
+        analytics_with_s3
+        >> analytics_with_local
+        >> analytics_with_gcs
+        >> analytics_with_azure
+        >> get_user_summary_queries()
+        >> get_users_product_queries_from_iceberg_catalog()
+    )

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -252,28 +252,25 @@ class TestDataFusionEngine:
         with pytest.raises(ValueError, match="Unknown connection type dummy"):
             engine._get_credentials(mock_conn)
 
-    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_get_credentials_google_cloud_platform(self, mock_hook_class):
-        mock_hook = mock_hook_class.return_value
-        mock_hook._get_field.return_value = "/path/to/keyfile.json"
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", autospec=True)
+    def test_get_credentials_google_cloud_platform(self, mock_get_field):
+        mock_get_field.return_value = "/path/to/keyfile.json"
 
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "google_cloud_platform"
         mock_conn.conn_id = "gcp_default"
-        mock_conn.extra_dejson = {}
+        mock_conn.extra_dejson = {"key_path": "/path/to/keyfile.json"}
 
         engine = DataFusionEngine()
         credentials, extra_config = engine._get_credentials(mock_conn)
 
-        mock_hook_class.assert_called_once_with(gcp_conn_id="gcp_default")
-        mock_hook._get_field.assert_called_once_with("key_path")
+        mock_get_field.assert_called_once_with(mock_conn.extra_dejson, "key_path")
         assert credentials == {"service_account_path": "/path/to/keyfile.json"}
         assert extra_config == {}
 
-    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_get_credentials_google_cloud_platform_no_key_path(self, mock_hook_class):
-        mock_hook = mock_hook_class.return_value
-        mock_hook._get_field.return_value = None
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", autospec=True)
+    def test_get_credentials_google_cloud_platform_no_key_path(self, mock_get_field):
+        mock_get_field.return_value = None
 
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "google_cloud_platform"
@@ -286,6 +283,18 @@ class TestDataFusionEngine:
         assert credentials == {}
         assert extra_config == {}
 
+    def test_get_credentials_google_cloud_platform_legacy_extra_format(self):
+        """key_path stored with legacy extra__google_cloud_platform__ prefix is resolved correctly."""
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "google_cloud_platform"
+        mock_conn.conn_id = "gcp_default"
+        mock_conn.extra_dejson = {"extra__google_cloud_platform__key_path": "/legacy/path/key.json"}
+
+        engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
+
+        assert credentials == {"service_account_path": "/legacy/path/key.json"}
+
     def test_get_credentials_google_missing_provider(self):
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "google_cloud_platform"
@@ -295,14 +304,14 @@ class TestDataFusionEngine:
         engine = DataFusionEngine()
 
         with patch.dict("sys.modules", {"airflow.providers.google.common.hooks.base_google": None}):
-            with pytest.raises(Exception, match="Failed to import GoogleBaseHook"):
+            with pytest.raises(Exception, match="Failed to import get_field"):
                 engine._get_credentials(mock_conn)
 
     def test_get_credentials_wasb(self):
+        """Key auth: conn.login is the storage account name."""
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"
         mock_conn.conn_id = "wasb_default"
-        mock_conn.host = None
         mock_conn.login = "myaccount"
         mock_conn.password = "mykey"
         mock_conn.extra_dejson = {}
@@ -318,7 +327,6 @@ class TestDataFusionEngine:
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"
         mock_conn.conn_id = "wasb_default"
-        mock_conn.host = None
         mock_conn.login = "myaccount"
         mock_conn.password = None
         mock_conn.extra_dejson = {"account_key": "key_from_extra"}
@@ -328,21 +336,6 @@ class TestDataFusionEngine:
 
         assert credentials["account"] == "myaccount"
         assert credentials["access_key"] == "key_from_extra"
-
-    def test_get_credentials_wasb_host_takes_priority_over_login(self):
-        """host is the storage account name when set; login falls back when host is absent."""
-        mock_conn = MagicMock(spec=Connection)
-        mock_conn.conn_type = "wasb"
-        mock_conn.conn_id = "wasb_default"
-        mock_conn.host = "hostaccount"
-        mock_conn.login = "loginaccount"
-        mock_conn.password = "mykey"
-        mock_conn.extra_dejson = {}
-
-        engine = DataFusionEngine()
-        credentials, _ = engine._get_credentials(mock_conn)
-
-        assert credentials["account"] == "hostaccount"
 
     def test_get_credentials_wasb_service_principal(self):
         mock_conn = MagicMock(spec=Connection)
@@ -361,6 +354,21 @@ class TestDataFusionEngine:
         assert credentials["client_secret"] == "my-client-secret"
         assert credentials["tenant_id"] == "my-tenant-id"
         assert "access_key" not in credentials
+
+    def test_get_credentials_wasb_service_principal_host_full_url(self):
+        """Account name is extracted from conn.host when it is a full URL, not passed raw."""
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.host = "https://mystorageaccount.blob.core.windows.net/"
+        mock_conn.login = "my-client-id"
+        mock_conn.password = "my-client-secret"
+        mock_conn.extra_dejson = {"tenant_id": "my-tenant-id"}
+
+        engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
+
+        assert credentials["account"] == "mystorageaccount"
 
     def test_get_credentials_wasb_service_principal_client_id_from_extra(self):
         """client_id in extra takes priority over login when tenant_id is present."""

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -360,6 +360,35 @@ class TestDataFusionEngine:
         assert credentials["client_id"] == "explicit-client-id"
         assert credentials["client_secret"] == "explicit-client-secret"
 
+    def test_get_credentials_wasb_missing_account(self):
+        """Raise early when both login and password/account_key are absent."""
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.login = None
+        mock_conn.password = None
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+
+        with pytest.raises(ValueError, match="Azure connection requires a storage account name"):
+            engine._get_credentials(mock_conn)
+
+    def test_get_credentials_wasb_service_principal_host_scheme_no_dots(self):
+        """Account name extracted from netloc even when host is scheme + bare name."""
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.host = "https://mystorageaccount"
+        mock_conn.login = "my-client-id"
+        mock_conn.password = "my-client-secret"
+        mock_conn.extra_dejson = {"tenant_id": "my-tenant-id"}
+
+        engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
+
+        assert credentials["account"] == "mystorageaccount"
+
     def test_get_credentials_azure_missing_provider(self):
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -298,40 +298,30 @@ class TestDataFusionEngine:
             with pytest.raises(Exception, match="Failed to import GoogleBaseHook"):
                 engine._get_credentials(mock_conn)
 
-    @patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook", autospec=True)
-    def test_get_credentials_wasb(self, mock_hook_class):
-        mock_hook = mock_hook_class.return_value
-        mock_wasb_conn = MagicMock(spec=Connection)
-        mock_wasb_conn.login = "myaccount"
-        mock_wasb_conn.password = "mykey"
-        mock_wasb_conn.extra_dejson = {}
-        mock_hook.get_connection.return_value = mock_wasb_conn
-
+    def test_get_credentials_wasb(self):
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"
         mock_conn.conn_id = "wasb_default"
+        mock_conn.host = None
+        mock_conn.login = "myaccount"
+        mock_conn.password = "mykey"
         mock_conn.extra_dejson = {}
 
         engine = DataFusionEngine()
         credentials, extra_config = engine._get_credentials(mock_conn)
 
-        mock_hook_class.assert_called_once_with(wasb_conn_id="wasb_default")
         assert credentials["account"] == "myaccount"
         assert credentials["access_key"] == "mykey"
+        assert extra_config == {}
 
-    @patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook", autospec=True)
-    def test_get_credentials_wasb_account_key_from_extra(self, mock_hook_class):
-        mock_hook = mock_hook_class.return_value
-        mock_wasb_conn = MagicMock(spec=Connection)
-        mock_wasb_conn.login = "myaccount"
-        mock_wasb_conn.password = None
-        mock_wasb_conn.extra_dejson = {"account_key": "key_from_extra"}
-        mock_hook.get_connection.return_value = mock_wasb_conn
-
+    def test_get_credentials_wasb_account_key_from_extra(self):
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"
         mock_conn.conn_id = "wasb_default"
-        mock_conn.extra_dejson = {}
+        mock_conn.host = None
+        mock_conn.login = "myaccount"
+        mock_conn.password = None
+        mock_conn.extra_dejson = {"account_key": "key_from_extra"}
 
         engine = DataFusionEngine()
         credentials, extra_config = engine._get_credentials(mock_conn)
@@ -339,17 +329,58 @@ class TestDataFusionEngine:
         assert credentials["account"] == "myaccount"
         assert credentials["access_key"] == "key_from_extra"
 
-    def test_get_credentials_azure_missing_provider(self):
+    def test_get_credentials_wasb_host_takes_priority_over_login(self):
+        """host is the storage account name when set; login falls back when host is absent."""
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "wasb"
         mock_conn.conn_id = "wasb_default"
+        mock_conn.host = "hostaccount"
+        mock_conn.login = "loginaccount"
+        mock_conn.password = "mykey"
         mock_conn.extra_dejson = {}
 
         engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
 
-        with patch.dict("sys.modules", {"airflow.providers.microsoft.azure.hooks.wasb": None}):
-            with pytest.raises(Exception, match="Failed to import WasbHook"):
-                engine._get_credentials(mock_conn)
+        assert credentials["account"] == "hostaccount"
+
+    def test_get_credentials_wasb_service_principal(self):
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.host = "mystorageaccount"
+        mock_conn.login = "my-client-id"
+        mock_conn.password = "my-client-secret"
+        mock_conn.extra_dejson = {"tenant_id": "my-tenant-id"}
+
+        engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
+
+        assert credentials["account"] == "mystorageaccount"
+        assert credentials["client_id"] == "my-client-id"
+        assert credentials["client_secret"] == "my-client-secret"
+        assert credentials["tenant_id"] == "my-tenant-id"
+        assert "access_key" not in credentials
+
+    def test_get_credentials_wasb_service_principal_client_id_from_extra(self):
+        """client_id in extra takes priority over login when tenant_id is present."""
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.host = "mystorageaccount"
+        mock_conn.login = "fallback-login"
+        mock_conn.password = "fallback-password"
+        mock_conn.extra_dejson = {
+            "tenant_id": "my-tenant-id",
+            "client_id": "explicit-client-id",
+            "client_secret": "explicit-client-secret",
+        }
+
+        engine = DataFusionEngine()
+        credentials, _ = engine._get_credentials(mock_conn)
+
+        assert credentials["client_id"] == "explicit-client-id"
+        assert credentials["client_secret"] == "explicit-client-secret"
 
     def test_get_schema_success(self):
         engine = DataFusionEngine()

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -252,6 +252,105 @@ class TestDataFusionEngine:
         with pytest.raises(ValueError, match="Unknown connection type dummy"):
             engine._get_credentials(mock_conn)
 
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_get_credentials_google_cloud_platform(self, mock_hook_class):
+        mock_hook = mock_hook_class.return_value
+        mock_hook._get_field.return_value = "/path/to/keyfile.json"
+
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "google_cloud_platform"
+        mock_conn.conn_id = "gcp_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+        credentials, extra_config = engine._get_credentials(mock_conn)
+
+        mock_hook_class.assert_called_once_with(gcp_conn_id="gcp_default")
+        mock_hook._get_field.assert_called_once_with("key_path")
+        assert credentials == {"service_account_path": "/path/to/keyfile.json"}
+        assert extra_config == {}
+
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_get_credentials_google_cloud_platform_no_key_path(self, mock_hook_class):
+        mock_hook = mock_hook_class.return_value
+        mock_hook._get_field.return_value = None
+
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "google_cloud_platform"
+        mock_conn.conn_id = "gcp_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+        credentials, extra_config = engine._get_credentials(mock_conn)
+
+        assert credentials == {}
+        assert extra_config == {}
+
+    def test_get_credentials_google_missing_provider(self):
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "google_cloud_platform"
+        mock_conn.conn_id = "gcp_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+
+        with patch.dict("sys.modules", {"airflow.providers.google.common.hooks.base_google": None}):
+            with pytest.raises(Exception, match="Failed to import GoogleBaseHook"):
+                engine._get_credentials(mock_conn)
+
+    @patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook", autospec=True)
+    def test_get_credentials_wasb(self, mock_hook_class):
+        mock_hook = mock_hook_class.return_value
+        mock_wasb_conn = MagicMock(spec=Connection)
+        mock_wasb_conn.login = "myaccount"
+        mock_wasb_conn.password = "mykey"
+        mock_wasb_conn.extra_dejson = {}
+        mock_hook.get_connection.return_value = mock_wasb_conn
+
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+        credentials, extra_config = engine._get_credentials(mock_conn)
+
+        mock_hook_class.assert_called_once_with(wasb_conn_id="wasb_default")
+        assert credentials["account"] == "myaccount"
+        assert credentials["access_key"] == "mykey"
+
+    @patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook", autospec=True)
+    def test_get_credentials_wasb_account_key_from_extra(self, mock_hook_class):
+        mock_hook = mock_hook_class.return_value
+        mock_wasb_conn = MagicMock(spec=Connection)
+        mock_wasb_conn.login = "myaccount"
+        mock_wasb_conn.password = None
+        mock_wasb_conn.extra_dejson = {"account_key": "key_from_extra"}
+        mock_hook.get_connection.return_value = mock_wasb_conn
+
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+        credentials, extra_config = engine._get_credentials(mock_conn)
+
+        assert credentials["account"] == "myaccount"
+        assert credentials["access_key"] == "key_from_extra"
+
+    def test_get_credentials_azure_missing_provider(self):
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+
+        with patch.dict("sys.modules", {"airflow.providers.microsoft.azure.hooks.wasb": None}):
+            with pytest.raises(Exception, match="Failed to import WasbHook"):
+                engine._get_credentials(mock_conn)
+
     def test_get_schema_success(self):
         engine = DataFusionEngine()
         engine.df_ctx = MagicMock(spec=SessionContext)

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -252,26 +252,8 @@ class TestDataFusionEngine:
         with pytest.raises(ValueError, match="Unknown connection type dummy"):
             engine._get_credentials(mock_conn)
 
-    @patch("airflow.providers.google.common.hooks.base_google.get_field", autospec=True)
-    def test_get_credentials_google_cloud_platform(self, mock_get_field):
-        mock_get_field.return_value = "/path/to/keyfile.json"
-
-        mock_conn = MagicMock(spec=Connection)
-        mock_conn.conn_type = "google_cloud_platform"
-        mock_conn.conn_id = "gcp_default"
-        mock_conn.extra_dejson = {"key_path": "/path/to/keyfile.json"}
-
-        engine = DataFusionEngine()
-        credentials, extra_config = engine._get_credentials(mock_conn)
-
-        mock_get_field.assert_called_once_with(mock_conn.extra_dejson, "key_path")
-        assert credentials == {"service_account_path": "/path/to/keyfile.json"}
-        assert extra_config == {}
-
-    @patch("airflow.providers.google.common.hooks.base_google.get_field", autospec=True)
-    def test_get_credentials_google_cloud_platform_no_key_path(self, mock_get_field):
-        mock_get_field.return_value = None
-
+    def test_get_credentials_google_cloud_platform(self):
+        """GCP case passes the import guard and returns empty credentials (hook handles creds in provider)."""
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "google_cloud_platform"
         mock_conn.conn_id = "gcp_default"
@@ -283,18 +265,6 @@ class TestDataFusionEngine:
         assert credentials == {}
         assert extra_config == {}
 
-    def test_get_credentials_google_cloud_platform_legacy_extra_format(self):
-        """key_path stored with legacy extra__google_cloud_platform__ prefix is resolved correctly."""
-        mock_conn = MagicMock(spec=Connection)
-        mock_conn.conn_type = "google_cloud_platform"
-        mock_conn.conn_id = "gcp_default"
-        mock_conn.extra_dejson = {"extra__google_cloud_platform__key_path": "/legacy/path/key.json"}
-
-        engine = DataFusionEngine()
-        credentials, _ = engine._get_credentials(mock_conn)
-
-        assert credentials == {"service_account_path": "/legacy/path/key.json"}
-
     def test_get_credentials_google_missing_provider(self):
         mock_conn = MagicMock(spec=Connection)
         mock_conn.conn_type = "google_cloud_platform"
@@ -304,7 +274,7 @@ class TestDataFusionEngine:
         engine = DataFusionEngine()
 
         with patch.dict("sys.modules", {"airflow.providers.google.common.hooks.base_google": None}):
-            with pytest.raises(Exception, match="Failed to import get_field"):
+            with pytest.raises(Exception, match="Failed to import GoogleBaseHook"):
                 engine._get_credentials(mock_conn)
 
     def test_get_credentials_wasb(self):

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_engine.py
@@ -382,6 +382,18 @@ class TestDataFusionEngine:
         assert credentials["client_id"] == "explicit-client-id"
         assert credentials["client_secret"] == "explicit-client-secret"
 
+    def test_get_credentials_azure_missing_provider(self):
+        mock_conn = MagicMock(spec=Connection)
+        mock_conn.conn_type = "wasb"
+        mock_conn.conn_id = "wasb_default"
+        mock_conn.extra_dejson = {}
+
+        engine = DataFusionEngine()
+
+        with patch.dict("sys.modules", {"airflow.providers.microsoft.azure.hooks.wasb": None}):
+            with pytest.raises(Exception, match="Failed to import WasbHook"):
+                engine._get_credentials(mock_conn)
+
     def test_get_schema_success(self):
         engine = DataFusionEngine()
         engine.df_ctx = MagicMock(spec=SessionContext)

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
@@ -69,9 +69,11 @@ class TestObjectStorageProvider:
         assert local_store == mock_local.return_value
 
     @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", return_value=None)
     @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_gcs_provider_key_path(self, mock_hook_cls, mock_gcs):
+    def test_gcs_provider_key_path(self, mock_hook_cls, mock_get_field, mock_gcs):
         """key_path credential is passed as service_account_path."""
+        mock_hook_cls.return_value.extras = {}
         mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/path/to/keyfile.json"
         provider = GCSObjectStorageProvider()
         connection_config = ConnectionConfig(conn_id="gcp_default")
@@ -86,9 +88,11 @@ class TestObjectStorageProvider:
         assert provider.get_scheme() == "gs://"
 
     @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", return_value=None)
     @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_gcs_provider_keyfile_dict(self, mock_hook_cls, mock_gcs):
+    def test_gcs_provider_keyfile_dict(self, mock_hook_cls, mock_get_field, mock_gcs):
         """keyfile_dict written to temp file by hook; path passed as service_account_path."""
+        mock_hook_cls.return_value.extras = {}
         mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/tmp/tmpABCDEF.json"
         provider = GCSObjectStorageProvider()
         connection_config = ConnectionConfig(conn_id="gcp_default")
@@ -99,9 +103,11 @@ class TestObjectStorageProvider:
         assert store == mock_gcs.return_value
 
     @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", return_value=None)
     @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_gcs_provider_adc_fallback(self, mock_hook_cls, mock_gcs):
+    def test_gcs_provider_adc_fallback(self, mock_hook_cls, mock_get_field, mock_gcs):
         """No credentials configured: hook yields None and GoogleCloud is built without a path (ADC)."""
+        mock_hook_cls.return_value.extras = {}
         mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = None
         provider = GCSObjectStorageProvider()
         connection_config = ConnectionConfig(conn_id="gcp_default")
@@ -111,6 +117,102 @@ class TestObjectStorageProvider:
         mock_gcs.assert_called_once_with(bucket_name="my-bucket")
         assert store == mock_gcs.return_value
 
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("os.path.exists", return_value=True)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_credential_config_file_path(self, mock_hook_cls, mock_exists, mock_gcs):
+        """credential_config_file as a file path is passed as service_account_path."""
+        mock_hook_cls.return_value.extras = {}
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = None
+
+        def get_field_side_effect(extras, field):
+            return "/path/to/credential_config.json" if field == "credential_config_file" else None
+
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        with patch(
+            "airflow.providers.google.common.hooks.base_google.get_field",
+            side_effect=get_field_side_effect,
+        ):
+            store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once_with(
+            service_account_path="/path/to/credential_config.json", bucket_name="my-bucket"
+        )
+        assert store == mock_gcs.return_value
+
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("os.path.exists", return_value=False)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_credential_config_file_inline_json(self, mock_hook_cls, mock_exists, mock_gcs):
+        """credential_config_file as inline JSON string is written to temp file."""
+        mock_hook_cls.return_value.extras = {}
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = None
+        inline_json = '{"type": "external_account", "audience": "//iam.googleapis.com/projects/123"}'
+
+        def get_field_side_effect(extras, field):
+            return inline_json if field == "credential_config_file" else None
+
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        with patch(
+            "airflow.providers.google.common.hooks.base_google.get_field",
+            side_effect=get_field_side_effect,
+        ):
+            store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once()
+        call_kwargs = mock_gcs.call_args.kwargs
+        assert "service_account_path" in call_kwargs
+        assert call_kwargs["bucket_name"] == "my-bucket"
+        assert store == mock_gcs.return_value
+
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("os.path.exists", return_value=False)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_credential_config_file_dict(self, mock_hook_cls, mock_exists, mock_gcs):
+        """credential_config_file as dict is serialised to JSON and written to temp file."""
+        mock_hook_cls.return_value.extras = {}
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = None
+        config_dict = {"type": "external_account", "audience": "//iam.googleapis.com/projects/123"}
+
+        def get_field_side_effect(extras, field):
+            return config_dict if field == "credential_config_file" else None
+
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        with patch(
+            "airflow.providers.google.common.hooks.base_google.get_field",
+            side_effect=get_field_side_effect,
+        ):
+            store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once()
+        call_kwargs = mock_gcs.call_args.kwargs
+        assert "service_account_path" in call_kwargs
+        assert call_kwargs["bucket_name"] == "my-bucket"
+        assert store == mock_gcs.return_value
+
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_key_secret_name_raises(self, mock_hook_cls):
+        """key_secret_name (Secret Manager) is not supported and raises ValueError."""
+        mock_hook_cls.return_value.extras = {}
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        def get_field_side_effect(extras, field):
+            return "my-secret-key" if field == "key_secret_name" else None
+
+        with patch(
+            "airflow.providers.google.common.hooks.base_google.get_field",
+            side_effect=get_field_side_effect,
+        ):
+            with pytest.raises(ObjectStoreCreationException, match="Failed to create GCS object store"):
+                provider.create_object_store("gs://my-bucket/path", connection_config)
+
     def test_gcs_provider_no_connection_config_raises(self):
         provider = GCSObjectStorageProvider()
 
@@ -118,8 +220,10 @@ class TestObjectStorageProvider:
             provider.create_object_store("gs://my-bucket/path", connection_config=None)
 
     @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.get_field", return_value=None)
     @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
-    def test_gcs_provider_failure(self, mock_hook_cls, mock_gcs):
+    def test_gcs_provider_failure(self, mock_hook_cls, mock_get_field, mock_gcs):
+        mock_hook_cls.return_value.extras = {}
         mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/path/to/key.json"
         mock_gcs.side_effect = Exception("GCS Error")
         provider = GCSObjectStorageProvider()

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
@@ -69,12 +69,12 @@ class TestObjectStorageProvider:
         assert local_store == mock_local.return_value
 
     @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
-    def test_gcs_provider_success(self, mock_gcs):
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_key_path(self, mock_hook_cls, mock_gcs):
+        """key_path credential is passed as service_account_path."""
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/path/to/keyfile.json"
         provider = GCSObjectStorageProvider()
-        connection_config = ConnectionConfig(
-            conn_id="gcp_default",
-            credentials={"service_account_path": "/path/to/keyfile.json"},
-        )
+        connection_config = ConnectionConfig(conn_id="gcp_default")
 
         store = provider.create_object_store("gs://my-bucket/path", connection_config)
 
@@ -85,19 +85,57 @@ class TestObjectStorageProvider:
         assert provider.get_storage_type == StorageType.GCS
         assert provider.get_scheme() == "gs://"
 
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_keyfile_dict(self, mock_hook_cls, mock_gcs):
+        """keyfile_dict written to temp file by hook; path passed as service_account_path."""
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/tmp/tmpABCDEF.json"
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once_with(service_account_path="/tmp/tmpABCDEF.json", bucket_name="my-bucket")
+        assert store == mock_gcs.return_value
+
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_adc_fallback(self, mock_hook_cls, mock_gcs):
+        """No credentials configured: hook yields None and GoogleCloud is built without a path (ADC)."""
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = None
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once_with(bucket_name="my-bucket")
+        assert store == mock_gcs.return_value
+
     def test_gcs_provider_no_connection_config_raises(self):
         provider = GCSObjectStorageProvider()
 
         with pytest.raises(ValueError, match="connection_config must be provided"):
             provider.create_object_store("gs://my-bucket/path", connection_config=None)
 
-    def test_gcs_provider_failure(self):
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    @patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook", autospec=True)
+    def test_gcs_provider_failure(self, mock_hook_cls, mock_gcs):
+        mock_hook_cls.return_value.provide_gcp_credential_file_as_context.return_value.__enter__.return_value = "/path/to/key.json"
+        mock_gcs.side_effect = Exception("GCS Error")
         provider = GCSObjectStorageProvider()
         connection_config = ConnectionConfig(conn_id="gcp_default")
 
-        with patch(
-            "airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud",
-            side_effect=Exception("GCS Error"),
+        with pytest.raises(ObjectStoreCreationException, match="Failed to create GCS object store"):
+            provider.create_object_store("gs://my-bucket/path", connection_config)
+
+    def test_gcs_provider_missing_google_provider(self):
+        """ImportError when apache-airflow-providers-google is not installed."""
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        with patch.dict(
+            "sys.modules",
+            {"airflow.providers.google.common.hooks.base_google": None},
         ):
             with pytest.raises(ObjectStoreCreationException, match="Failed to create GCS object store"):
                 provider.create_object_store("gs://my-bucket/path", connection_config)

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
@@ -88,7 +88,7 @@ class TestObjectStorageProvider:
     def test_gcs_provider_no_connection_config_raises(self):
         provider = GCSObjectStorageProvider()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="connection_config must be provided"):
             provider.create_object_store("gs://my-bucket/path", connection_config=None)
 
     def test_gcs_provider_failure(self):
@@ -122,7 +122,7 @@ class TestObjectStorageProvider:
     def test_azure_provider_no_connection_config_raises(self):
         provider = AzureObjectStorageProvider()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="connection_config must be provided"):
             provider.create_object_store("az://my-container/path", connection_config=None)
 
     def test_azure_provider_failure(self):

--- a/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
+++ b/providers/common/sql/tests/unit/common/sql/datafusion/test_object_storage_provider.py
@@ -23,6 +23,8 @@ import pytest
 from airflow.providers.common.sql.config import ConnectionConfig, StorageType
 from airflow.providers.common.sql.datafusion.exceptions import ObjectStoreCreationException
 from airflow.providers.common.sql.datafusion.object_storage_provider import (
+    AzureObjectStorageProvider,
+    GCSObjectStorageProvider,
     LocalObjectStorageProvider,
     S3ObjectStorageProvider,
     get_object_storage_provider,
@@ -66,9 +68,79 @@ class TestObjectStorageProvider:
         local_store = provider.create_object_store("file://path")
         assert local_store == mock_local.return_value
 
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud", autospec=True)
+    def test_gcs_provider_success(self, mock_gcs):
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(
+            conn_id="gcp_default",
+            credentials={"service_account_path": "/path/to/keyfile.json"},
+        )
+
+        store = provider.create_object_store("gs://my-bucket/path", connection_config)
+
+        mock_gcs.assert_called_once_with(
+            service_account_path="/path/to/keyfile.json", bucket_name="my-bucket"
+        )
+        assert store == mock_gcs.return_value
+        assert provider.get_storage_type == StorageType.GCS
+        assert provider.get_scheme() == "gs://"
+
+    def test_gcs_provider_no_connection_config_raises(self):
+        provider = GCSObjectStorageProvider()
+
+        with pytest.raises(ValueError):
+            provider.create_object_store("gs://my-bucket/path", connection_config=None)
+
+    def test_gcs_provider_failure(self):
+        provider = GCSObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="gcp_default")
+
+        with patch(
+            "airflow.providers.common.sql.datafusion.object_storage_provider.GoogleCloud",
+            side_effect=Exception("GCS Error"),
+        ):
+            with pytest.raises(ObjectStoreCreationException, match="Failed to create GCS object store"):
+                provider.create_object_store("gs://my-bucket/path", connection_config)
+
+    @patch("airflow.providers.common.sql.datafusion.object_storage_provider.MicrosoftAzure", autospec=True)
+    def test_azure_provider_success(self, mock_azure):
+        provider = AzureObjectStorageProvider()
+        connection_config = ConnectionConfig(
+            conn_id="wasb_default",
+            credentials={"account": "myaccount", "access_key": "mykey"},
+        )
+
+        store = provider.create_object_store("az://my-container/path", connection_config)
+
+        mock_azure.assert_called_once_with(
+            account="myaccount", access_key="mykey", container_name="my-container"
+        )
+        assert store == mock_azure.return_value
+        assert provider.get_storage_type == StorageType.AZURE
+        assert provider.get_scheme() == "az://"
+
+    def test_azure_provider_no_connection_config_raises(self):
+        provider = AzureObjectStorageProvider()
+
+        with pytest.raises(ValueError):
+            provider.create_object_store("az://my-container/path", connection_config=None)
+
+    def test_azure_provider_failure(self):
+        provider = AzureObjectStorageProvider()
+        connection_config = ConnectionConfig(conn_id="wasb_default")
+
+        with patch(
+            "airflow.providers.common.sql.datafusion.object_storage_provider.MicrosoftAzure",
+            side_effect=Exception("Azure Error"),
+        ):
+            with pytest.raises(ObjectStoreCreationException, match="Failed to create Azure object store"):
+                provider.create_object_store("az://my-container/path", connection_config)
+
     def test_get_object_storage_provider(self):
         assert isinstance(get_object_storage_provider(StorageType.S3), S3ObjectStorageProvider)
         assert isinstance(get_object_storage_provider(StorageType.LOCAL), LocalObjectStorageProvider)
+        assert isinstance(get_object_storage_provider(StorageType.GCS), GCSObjectStorageProvider)
+        assert isinstance(get_object_storage_provider(StorageType.AZURE), AzureObjectStorageProvider)
 
         with pytest.raises(ValueError, match="Unsupported storage type"):
             get_object_storage_provider("invalid")

--- a/providers/common/sql/tests/unit/common/sql/test_config.py
+++ b/providers/common/sql/tests/unit/common/sql/test_config.py
@@ -42,14 +42,6 @@ class TestDataSourceConfig:
         config = DataSourceConfig(conn_id="test", uri=uri, table_name="a_table" if expected_type else None)
         assert config.storage_type == expected_type
 
-    def test_gcs_storage_type_inferred(self):
-        config = DataSourceConfig(conn_id="gcp_conn", uri="gs://my-bucket/data/", table_name="gcs_table")
-        assert config.storage_type == StorageType.GCS
-
-    def test_azure_storage_type_inferred(self):
-        config = DataSourceConfig(conn_id="wasb_conn", uri="az://my-container/data/", table_name="az_table")
-        assert config.storage_type == StorageType.AZURE
-
     def test_invalid_storage_type_raises_error(self):
         with pytest.raises(ValueError, match="Unsupported storage type for URI"):
             DataSourceConfig(conn_id="test", uri="unknown://bucket/path", table_name="a_table")

--- a/providers/common/sql/tests/unit/common/sql/test_config.py
+++ b/providers/common/sql/tests/unit/common/sql/test_config.py
@@ -34,11 +34,21 @@ class TestDataSourceConfig:
         [
             ("s3://bucket/path", StorageType.S3),
             ("file:///path/to/file", StorageType.LOCAL),
+            ("gs://bucket/path", StorageType.GCS),
+            ("az://container/path", StorageType.AZURE),
         ],
     )
     def test_extract_storage_type(self, uri, expected_type):
         config = DataSourceConfig(conn_id="test", uri=uri, table_name="a_table" if expected_type else None)
         assert config.storage_type == expected_type
+
+    def test_gcs_storage_type_inferred(self):
+        config = DataSourceConfig(conn_id="gcp_conn", uri="gs://my-bucket/data/", table_name="gcs_table")
+        assert config.storage_type == StorageType.GCS
+
+    def test_azure_storage_type_inferred(self):
+        config = DataSourceConfig(conn_id="wasb_conn", uri="az://my-container/data/", table_name="az_table")
+        assert config.storage_type == StorageType.AZURE
 
     def test_invalid_storage_type_raises_error(self):
         with pytest.raises(ValueError, match="Unsupported storage type for URI"):

--- a/uv.lock
+++ b/uv.lock
@@ -4004,6 +4004,12 @@ apache-iceberg = [
 datafusion = [
     { name = "datafusion" },
 ]
+google = [
+    { name = "apache-airflow-providers-google" },
+]
+microsoft-azure = [
+    { name = "apache-airflow-providers-microsoft-azure" },
+]
 openlineage = [
     { name = "apache-airflow-providers-openlineage" },
 ]
@@ -4029,6 +4035,8 @@ dev = [
     { name = "apache-airflow-providers-apache-iceberg" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-sql", extra = ["pandas", "polars", "sqlalchemy"] },
+    { name = "apache-airflow-providers-google" },
+    { name = "apache-airflow-providers-microsoft-azure" },
     { name = "apache-airflow-providers-mysql" },
     { name = "apache-airflow-providers-odbc" },
     { name = "apache-airflow-providers-openlineage" },
@@ -4048,6 +4056,8 @@ requires-dist = [
     { name = "apache-airflow-providers-amazon", marker = "extra == 'amazon'", editable = "providers/amazon" },
     { name = "apache-airflow-providers-apache-iceberg", marker = "extra == 'apache-iceberg'", editable = "providers/apache/iceberg" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
+    { name = "apache-airflow-providers-google", marker = "extra == 'google'", editable = "providers/google" },
+    { name = "apache-airflow-providers-microsoft-azure", marker = "extra == 'microsoft-azure'", editable = "providers/microsoft/azure" },
     { name = "apache-airflow-providers-openlineage", marker = "extra == 'openlineage'", editable = "providers/openlineage" },
     { name = "datafusion", marker = "extra == 'datafusion'", specifier = ">=50.0.0,<52.0.0" },
     { name = "methodtools", specifier = ">=0.4.7" },
@@ -4059,7 +4069,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4.54" },
     { name = "sqlparse", specifier = ">=0.5.1" },
 ]
-provides-extras = ["pandas", "openlineage", "polars", "sqlalchemy", "amazon", "datafusion", "pyiceberg-core", "apache-iceberg"]
+provides-extras = ["pandas", "openlineage", "polars", "sqlalchemy", "amazon", "google", "datafusion", "pyiceberg-core", "apache-iceberg", "microsoft-azure"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4071,6 +4081,8 @@ dev = [
     { name = "apache-airflow-providers-common-sql", extras = ["pandas"], editable = "providers/common/sql" },
     { name = "apache-airflow-providers-common-sql", extras = ["polars"], editable = "providers/common/sql" },
     { name = "apache-airflow-providers-common-sql", extras = ["sqlalchemy"], editable = "providers/common/sql" },
+    { name = "apache-airflow-providers-google", editable = "providers/google" },
+    { name = "apache-airflow-providers-microsoft-azure", editable = "providers/microsoft/azure" },
     { name = "apache-airflow-providers-mysql", editable = "providers/mysql" },
     { name = "apache-airflow-providers-odbc", editable = "providers/odbc" },
     { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },


### PR DESCRIPTION
Extends the `AnalyticsOperator` (backed by Apache DataFusion) to support querying data stored in Google Cloud Storage (`gs://`) and Azure Blob Storage (`az://`).

Add on: Fixed logging for S3.

closes: #62735

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor

Generated-by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-06-18T13:59:43Z head=b27c327 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @cruseakshay** · by `@potiuk` · 2026-06-18 13:59 UTC
>
> This draft PR is being closed to keep the review queue clean — it's been an inactive draft for ~a month with no recent updates:
> - No action needed right now. **Reopen it or open a fresh PR** whenever you're ready to continue — no rush, and thanks for the contribution.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->