### PR TITLE
fix: get the correct schedule for asset-triggered Dags

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/AssetSchedule.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from "react-i18next";
 import { FiDatabase } from "react-icons/fi";
 import { Link as RouterLink } from "react-router-dom";
 
-import { useAssetServiceNextRunAssets } from "openapi/queries";
+import { useAssetServiceGetDagAssetQueuedEvents, useAssetServiceNextRunAssets } from "openapi/queries";
 import { AssetExpression, type ExpressionType } from "src/components/AssetExpression";
 import type { NextRunEvent } from "src/components/AssetExpression/types";
 import { TruncatedText } from "src/components/TruncatedText";
@@ -61,22 +61,52 @@ const PartitionSchedule = ({ dagId, isLoading, pendingCount }: PartitionSchedule
 
 export const AssetSchedule = ({ assetExpression, dagId, latestRunAfter, timetableSummary }: Props) => {
   const { t: translate } = useTranslation(["dags", "common"]);
-  const { data: nextRun, isLoading } = useAssetServiceNextRunAssets({ dagId });
 
   const isPartitioned = timetableSummary === "Partitioned Asset";
+  const { data: nextRun, isLoading: isNextRunLoading } = useAssetServiceNextRunAssets({ dagId });
+  const {
+    data: queuedEventsData,
+    error: queuedEventsError,
+    isLoading: isQueuedEventsLoading,
+  } = useAssetServiceGetDagAssetQueuedEvents({ dagId }, undefined, { enabled: !isPartitioned });
 
   const nextRunEvents = (nextRun?.events ?? []) as Array<NextRunEvent>;
+  const queuedEventsErrorStatus =
+    typeof queuedEventsError === "object" && queuedEventsError !== null && "status" in queuedEventsError
+      ? (queuedEventsError as { status?: number }).status
+      : undefined;
+  const hasQueuedEventsError = Boolean(queuedEventsError) && queuedEventsErrorStatus !== 404;
+  const queuedAssetEvents = new Map<number, string>();
 
-  const pendingEvents = nextRunEvents.filter((ev) => {
-    if (ev.lastUpdate === null) {
-      return false;
+  if (!isPartitioned && !hasQueuedEventsError) {
+    for (const event of queuedEventsData?.queued_events ?? []) {
+      // Keep a single event timestamp per asset, using the latest one when duplicates exist.
+      const existingEventDate = queuedAssetEvents.get(event.asset_id);
+
+      if (existingEventDate === undefined || dayjs(event.created_at).isAfter(existingEventDate)) {
+        queuedAssetEvents.set(event.asset_id, event.created_at);
+      }
     }
+  }
+
+  const pendingEvents = nextRunEvents.flatMap((event) => {
     if (isPartitioned) {
-      return true;
+      return event.lastUpdate === null ? [] : [event];
     }
 
-    return latestRunAfter !== undefined && dayjs(ev.lastUpdate).isAfter(latestRunAfter);
+    if (hasQueuedEventsError) {
+      if (event.lastUpdate === null) {
+        return [];
+      }
+
+      return latestRunAfter !== undefined && dayjs(event.lastUpdate).isAfter(latestRunAfter) ? [event] : [];
+    }
+
+    const queuedAt = queuedAssetEvents.get(event.id);
+
+    return queuedAt === undefined ? [] : [{ ...event, lastUpdate: event.lastUpdate ?? queuedAt }];
   });
+  const isLoading = isNextRunLoading || (!isPartitioned && isQueuedEventsLoading);
 
   if (!nextRunEvents.length) {
     return (


### PR DESCRIPTION
## Why
Closes: https://github.com/apache/airflow/issues/55515

The original logic is not accurate. We should get the number of queued events

## What

Get the number of queued events instead of depending on the last run which can be a manual one

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
