### PR TITLE
fix: skip transiently missing serialized DAGs instead of bulk-failing tasks

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -769,19 +769,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     serialized_dag = self.scheduler_dag_bag.get_dag_for_run(
                         dag_run=task_instance.dag_run, session=session
                     )
-                    # If the dag is missing, fail the task and continue to the next task.
+                    # If the dag is transiently missing, skip scheduling it this iteration
+                    # and try again next time instead of bulk-failing all scheduled tasks.
+                    # See: https://github.com/apache/airflow/issues/62050
                     if not serialized_dag:
-                        self.log.error(
-                            "DAG '%s' for task instance %s not found in serialized_dag table",
+                        self.log.warning(
+                            "DAG '%s' for task instance %s not found in serialized_dag table, "
+                            "skipping scheduling for this iteration and will retry next time",
                             dag_id,
                             task_instance,
                         )
-                        session.execute(
-                            update(TI)
-                            .where(TI.dag_id == dag_id, TI.state == TaskInstanceState.SCHEDULED)
-                            .values(state=TaskInstanceState.FAILED)
-                            .execution_options(synchronize_session="fetch")
-                        )
+                        starved_dags.add(dag_id)
                         continue
 
                     task_concurrency_limit: int | None = None

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1807,8 +1807,14 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_queued_task_instances_fails_with_missing_dag(self, dag_maker, session):
-        """Check that task instances of missing DAGs are failed"""
+    def test_queued_task_instances_skips_with_missing_dag(self, dag_maker, session):
+        """Check that task instances of transiently missing DAGs are skipped, not bulk-failed.
+
+        When the serialized DAG is transiently missing (e.g. during a DAG file parse cycle),
+        the scheduler should skip scheduling for that DAG in the current iteration and retry
+        next time, rather than bulk-failing all SCHEDULED task instances.
+        See: https://github.com/apache/airflow/issues/62050
+        """
         dag_id = "SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag"
         task_id_1 = "dummy"
         task_id_2 = "dummydummy"
@@ -1832,10 +1838,53 @@ class TestSchedulerJob:
         session.flush()
         res = self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
         session.flush()
+        # No tasks should be queued
         assert len(res) == 0
+        # Tasks should remain SCHEDULED (not be bulk-failed)
         tis = dr.get_task_instances(session=session)
         assert len(tis) == 2
-        assert all(ti.state == State.FAILED for ti in tis)
+        assert all(ti.state == State.SCHEDULED for ti in tis)
+
+    def test_missing_serialized_dag_does_not_bulk_fail_tasks(self, dag_maker, session):
+        """Regression test for https://github.com/apache/airflow/issues/62050
+
+        When the serialized DAG is transiently missing, all SCHEDULED task instances for the DAG
+        should remain SCHEDULED so the scheduler can pick them up in the next iteration.
+        Previously, the scheduler would bulk-fail all SCHEDULED tasks when it couldn't find the
+        serialized DAG in the DagBag.
+        """
+        dag_id = "SchedulerJobTest.test_missing_serialized_dag_bulk_fails"
+
+        with dag_maker(dag_id=dag_id, session=session, default_args={"max_active_tis_per_dag": 2}):
+            EmptyOperator(task_id="task_a")
+            EmptyOperator(task_id="task_b")
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        # Simulate serialized DAG being transiently missing
+        self.job_runner.scheduler_dag_bag = mock.MagicMock()
+        self.job_runner.scheduler_dag_bag.get_dag_for_run.return_value = None
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        for ti in dr.task_instances:
+            ti.state = State.SCHEDULED
+            session.merge(ti)
+        session.flush()
+
+        res = self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
+        session.flush()
+
+        # No tasks should be queued since serialized DAG is missing
+        assert len(res) == 0
+        # All tasks should remain SCHEDULED — not FAILED
+        tis = dr.get_task_instances(session=session)
+        assert len(tis) == 2
+        for ti in tis:
+            assert ti.state == State.SCHEDULED, (
+                f"Task {ti.task_id} was {ti.state} but expected SCHEDULED. "
+                "The scheduler should not bulk-fail tasks when serialized DAG is transiently missing."
+            )
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = "SchedulerJobTest.test_nonexistent_pool"


### PR DESCRIPTION
## Problem

On multi-scheduler Airflow deployments (e.g. AWS MWAA with 4+ schedulers), tasks intermittently fail in bulk with no apparent cause, but succeed on manual retry. The root issue is in `_executable_task_instances_to_queued`: when the scheduler checks task concurrency limits and cannot find the serialized DAG, it immediately bulk-fails **all** SCHEDULED task instances for that DAG via a raw SQL UPDATE. This is an overly aggressive response to what is often a transient race condition during DAG file parsing or serialization refresh cycles.

## Root Cause

In `scheduler_job_runner.py`, the `_executable_task_instances_to_queued` method loads the serialized DAG only when checking per-task or per-dagrun concurrency limits. If `scheduler_dag_bag.get_dag_for_run()` returns `None` (serialized DAG transiently absent), the code executed a bulk `UPDATE task_instance SET state='failed'` for all SCHEDULED tasks of that DAG — instead of treating it as a transient miss.

## Fix

Replace the bulk-fail with a graceful skip: when the serialized DAG is not found, log a `WARNING` (down from `ERROR`), add the `dag_id` to `starved_dags` so the rest of its tasks are also skipped in this iteration, and let the scheduler retry naturally on the next heartbeat.

**Changes:**
- `airflow-core/src/airflow/jobs/scheduler_job_runner.py`: removed the bulk `UPDATE … SET state=FAILED` block; replaced with `starved_dags.add(dag_id)` + warning log.
- `airflow-core/tests/unit/jobs/test_scheduler_job.py`:
  - Renamed `test_queued_task_instances_fails_with_missing_dag` → `test_queued_task_instances_skips_with_missing_dag` and updated assertions to expect `SCHEDULED` state (not `FAILED`).
  - Added new regression test `test_missing_serialized_dag_does_not_bulk_fail_tasks` (based on the reproducer from the issue) that explicitly asserts tasks remain `SCHEDULED` when the serialized DAG is transiently missing.

Both new/updated tests pass. The full `test_executable_task_instances` suite (24 tests) passes with no regressions.

Closes: #62050

---

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Claude Code)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
