### PR TITLE
fix(providers/smtp): fix OAuth2 XOAUTH2 auth and EHLO after STARTTLS in SmtpHook

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
@@ -184,10 +184,7 @@ class SmtpHook(BaseHook):
                             raise AirflowException(
                                 "smtp_user or from_email must be set for OAuth2 authentication"
                             )
-                        await async_client.auth(
-                            "XOAUTH2",
-                            lambda _=None: build_xoauth2_string(user_identity, self._access_token),
-                        )
+                        await async_client.auth_xoauth2(user_identity, self._access_token)
                     elif self.smtp_user and self.smtp_password:
                         await async_client.auth_login(self.smtp_user, self.smtp_password)
                     break

--- a/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
@@ -127,9 +127,10 @@ class SmtpHook(BaseHook):
                 else:
                     if self.smtp_starttls:
                         self._smtp_client.starttls()
+                        self._smtp_client.ehlo()
 
                     # choose auth
-                    if self._auth_type == "oauth2":
+                    if self.auth_type == "oauth2":
                         if not self._access_token:
                             self._access_token = self._get_oauth2_token()
                         user_identity = self.smtp_user or self.from_email
@@ -172,8 +173,22 @@ class SmtpHook(BaseHook):
                 else:
                     if self.smtp_starttls:
                         await async_client.starttls()
+                        await async_client.ehlo()
 
-                    if self.smtp_user and self.smtp_password:
+                    # choose auth
+                    if self.auth_type == "oauth2":
+                        if not self._access_token:
+                            self._access_token = self._get_oauth2_token()
+                        user_identity = self.smtp_user or self.from_email
+                        if user_identity is None:
+                            raise AirflowException(
+                                "smtp_user or from_email must be set for OAuth2 authentication"
+                            )
+                        await async_client.auth(
+                            "XOAUTH2",
+                            lambda _=None: build_xoauth2_string(user_identity, self._access_token),
+                        )
+                    elif self.smtp_user and self.smtp_password:
                         await async_client.auth_login(self.smtp_user, self.smtp_password)
                     break
 

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -486,6 +486,59 @@ class TestSmtpHook:
 
         assert not mock_conn.auth.called
 
+    @patch(smtplib_string)
+    def test_oauth2_uses_auth_type_property(self, mock_smtplib, create_connection_without_db):
+        """Test that get_conn reads auth_type from connection extras, not just __init__ arg."""
+        mock_conn = _create_fake_smtp(mock_smtplib, use_ssl=False)
+
+        create_connection_without_db(
+            Connection(
+                conn_id="smtp_oauth2_extra",
+                conn_type=CONN_TYPE,
+                host=SMTP_HOST,
+                login=SMTP_LOGIN,
+                password=SMTP_PASSWORD,
+                port=NONSSL_PORT,
+                extra=json.dumps(
+                    dict(
+                        disable_ssl=True,
+                        from_email=FROM_EMAIL,
+                        auth_type="oauth2",
+                        access_token=ACCESS_TOKEN,
+                    )
+                ),
+            )
+        )
+
+        # Note: auth_type NOT passed to constructor -- should be read from extras
+        with SmtpHook(smtp_conn_id="smtp_oauth2_extra") as smtp_hook:
+            smtp_hook.send_email_smtp(
+                to=TO_EMAIL,
+                subject=TEST_SUBJECT,
+                html_content=TEST_BODY,
+                from_email=FROM_EMAIL,
+            )
+
+        assert mock_conn.auth.called
+        args, _ = mock_conn.auth.call_args
+        assert args[0] == "XOAUTH2"
+
+    @patch(smtplib_string)
+    def test_ehlo_called_after_starttls(self, mock_smtplib):
+        """Test that ehlo() is called after starttls() to re-establish session state."""
+        mock_conn = _create_fake_smtp(mock_smtplib, use_ssl=False)
+        manager = Mock()
+        mock_conn.starttls = manager.starttls
+        mock_conn.ehlo = manager.ehlo
+        mock_conn.login = manager.login
+
+        with SmtpHook(smtp_conn_id=CONN_ID_NONSSL):
+            pass
+
+        # Verify ehlo is called after starttls and before login
+        expected_calls = [call.starttls(), call.ehlo(), call.login(SMTP_LOGIN, SMTP_PASSWORD)]
+        assert manager.mock_calls == expected_calls
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Async support was added to BaseNotifier in 3.1.0")
@@ -650,3 +703,47 @@ class TestSmtpHookAsync:
             )
 
         mock_smtp_client.sendmail.assert_not_awaited()
+
+    async def test_async_ehlo_called_after_starttls(
+        self, mock_smtp, mock_smtp_client, mock_get_connection
+    ):
+        """Test that ehlo() is called after starttls() in async path."""
+        async with SmtpHook(smtp_conn_id=CONN_ID_NONSSL):
+            pass
+
+        # For non-SSL, starttls is called followed by ehlo
+        assert mock_smtp_client.starttls.await_count == 1
+        assert mock_smtp_client.ehlo.await_count >= 2  # once in _abuild_client + once after starttls
+
+    async def test_async_oauth2_auth(self, mock_smtp, mock_smtp_client, mock_get_connection, create_connection_without_db):
+        """Test that async path supports OAuth2 authentication."""
+        create_connection_without_db(
+            Connection(
+                conn_id=CONN_ID_OAUTH,
+                conn_type=CONN_TYPE,
+                host=SMTP_HOST,
+                login=SMTP_LOGIN,
+                password=SMTP_PASSWORD,
+                port=NONSSL_PORT,
+                extra=json.dumps(
+                    dict(
+                        disable_ssl=True,
+                        from_email=FROM_EMAIL,
+                        auth_type="oauth2",
+                        access_token=ACCESS_TOKEN,
+                    )
+                ),
+            )
+        )
+
+        async with SmtpHook(smtp_conn_id=CONN_ID_OAUTH) as hook:
+            await hook.asend_email_smtp(
+                to=TO_EMAIL,
+                subject=TEST_SUBJECT,
+                html_content=TEST_BODY,
+                from_email=FROM_EMAIL,
+            )
+
+        assert mock_smtp_client.auth.called
+        args, _ = mock_smtp_client.auth.call_args
+        assert args[0] == "XOAUTH2"

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -704,9 +704,7 @@ class TestSmtpHookAsync:
 
         mock_smtp_client.sendmail.assert_not_awaited()
 
-    async def test_async_ehlo_called_after_starttls(
-        self, mock_smtp, mock_smtp_client, mock_get_connection
-    ):
+    async def test_async_ehlo_called_after_starttls(self, mock_smtp, mock_smtp_client, mock_get_connection):
         """Test that ehlo() is called after starttls() in async path."""
         async with SmtpHook(smtp_conn_id=CONN_ID_NONSSL):
             pass
@@ -715,7 +713,9 @@ class TestSmtpHookAsync:
         assert mock_smtp_client.starttls.await_count == 1
         assert mock_smtp_client.ehlo.await_count >= 2  # once in _abuild_client + once after starttls
 
-    async def test_async_oauth2_auth(self, mock_smtp, mock_smtp_client, mock_get_connection, create_connection_without_db):
+    async def test_async_oauth2_auth(
+        self, mock_smtp, mock_smtp_client, mock_get_connection, create_connection_without_db
+    ):
         """Test that async path supports OAuth2 authentication."""
         create_connection_without_db(
             Connection(

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -744,6 +744,5 @@ class TestSmtpHookAsync:
                 from_email=FROM_EMAIL,
             )
 
-        assert mock_smtp_client.auth.called
-        args, _ = mock_smtp_client.auth.call_args
-        assert args[0] == "XOAUTH2"
+        assert mock_smtp_client.auth_xoauth2.called
+        mock_smtp_client.auth_xoauth2.assert_awaited_once_with(SMTP_LOGIN, ACCESS_TOKEN)

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -576,6 +576,7 @@ class TestSmtpHookAsync:
         mock_client = AsyncMock(spec=aiosmtplib.SMTP)
         mock_client.starttls = AsyncMock()
         mock_client.auth_login = AsyncMock()
+        mock_client.auth_xoauth2 = AsyncMock()
         mock_client.sendmail = AsyncMock()
         mock_client.quit = AsyncMock()
         return mock_client
@@ -605,6 +606,7 @@ class TestSmtpHookAsync:
         mock_client = AsyncMock(spec=aiosmtplib.SMTP)
         mock_client.starttls = AsyncMock()
         mock_client.auth_login = AsyncMock()
+        mock_client.auth_xoauth2 = AsyncMock()
         mock_client.sendmail = AsyncMock()
         mock_client.quit = AsyncMock()
         mock_smtp.return_value = mock_client


### PR DESCRIPTION
## Problem

When using `SmtpHook` with `auth_type="oauth2"` against a server that requires STARTTLS (e.g., Microsoft 365 / smtp.office365.com:587), sending an email fails with `530 5.7.57 Client not authenticated to send mail`. The XOAUTH2 AUTH command succeeds, but the subsequent MAIL FROM is rejected because the SMTP session state was reset by STARTTLS without a follow-up EHLO.

## Root Cause

Three separate bugs in `SmtpHook`:

1. **`get_conn()` uses `self._auth_type` instead of `self.auth_type` property.** The `auth_type` property reads from connection extras and falls back to the constructor argument. Using the raw `_auth_type` attribute means setting `auth_type` in the connection extras JSON has no effect — the constructor default `"basic"` always wins.

2. **Missing `ehlo()` after `starttls()`.** Per RFC 3207, after STARTTLS completes, the client must re-issue EHLO to re-establish the session. Without it, the server considers the session unauthenticated after AUTH succeeds, causing MAIL FROM to be rejected.

3. **Async path (`aget_conn`) has no OAuth2 support.** It only handles basic auth via `auth_login`, silently ignoring `auth_type="oauth2"`.

## Fix

- Changed `self._auth_type` to `self.auth_type` in `get_conn()` so connection extras are respected.
- Added `self._smtp_client.ehlo()` after `starttls()` in both sync and async paths.
- Added OAuth2/XOAUTH2 authentication support to `aget_conn()`, mirroring the sync implementation.
- Added tests for all three fixes: auth_type property usage, ehlo-after-starttls ordering, and async OAuth2 auth.

Closes: #62775

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
