### PR TITLE
fix: always include kid in JWT header for symmetric key tokens

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -382,11 +382,12 @@ def _load_key_from_configured_file() -> AllowedPrivateKeys | None:
 
 
 def _generate_kid(gen) -> str:
-    if not gen._private_key:
-        return "not-used"
-
+    # Always check config first — both symmetric and asymmetric keys can have a configured kid
     if kid := _conf_factory("api_auth", "jwt_kid", fallback=None)():
         return kid
+
+    if not gen._private_key:
+        return "not-used"
 
     # Generate it from the thumbprint of the private key
     info = key_to_jwk_dict(gen._private_key)
@@ -467,8 +468,7 @@ class JWTGenerator:
         if extras is not None:
             claims = extras | claims
         headers = {"alg": self.algorithm, **(headers or {})}
-        if self._private_key:
-            headers["kid"] = self.kid
+        headers["kid"] = self.kid
         return jwt.encode(claims, self.signing_arg, algorithm=self.algorithm, headers=headers)
 
 

--- a/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
@@ -136,6 +136,30 @@ def test_with_secret_key():
     assert generator.signing_arg == "abc"
 
 
+def test_secret_key_token_includes_kid_in_header():
+    """Symmetric (secret_key) tokens must include 'kid' in the JWT header so the validator accepts them."""
+    generator = JWTGenerator(secret_key="test-secret", audience="test", valid_for=60)
+    token = generator.generate({"sub": "user"})
+    header = jwt.get_unverified_header(token)
+    assert "kid" in header, "kid must always be present in the JWT header"
+    assert header["kid"] == "not-used"
+
+
+def test_secret_key_with_configured_kid():
+    """When jwt_kid is configured, symmetric key generators should use it."""
+    from unittest.mock import patch
+
+    with patch.dict(
+        "os.environ",
+        {"AIRFLOW__API_AUTH__JWT_KID": "my-custom-kid"},
+    ):
+        generator = JWTGenerator(secret_key="test-secret", audience="test", valid_for=60)
+        assert generator.kid == "my-custom-kid"
+        token = generator.generate({"sub": "user"})
+        header = jwt.get_unverified_header(token)
+        assert header["kid"] == "my-custom-kid"
+
+
 @pytest.fixture
 def jwt_generator(ed25519_private_key: Ed25519PrivateKey):
     key = ed25519_private_key


### PR DESCRIPTION
## Problem

When using `KeycloakAuthManager` (or any auth manager) with symmetric JWT signing (HS256 + secret key), the authentication flow enters an infinite redirect loop. After successful login, the internal session JWT is rejected by the FastAPI `JWTValidator` with: `Missing 'kid' in token header`.

## Root Cause

`JWTGenerator.generate()` only added the `kid` field to the JWT header when using asymmetric (private key) signing. Symmetric (secret key) tokens never got `kid` in the header. However, `JWTValidator._get_kid_from_header()` unconditionally requires `kid` in the token header, causing all symmetric-key tokens to fail validation.

Additionally, `_generate_kid()` returned `"not-used"` immediately for symmetric keys without checking the `api_auth.jwt_kid` configuration, so operators couldn't set a meaningful `kid` for their symmetric setup.

## Fix

Two changes in `airflow-core/src/airflow/api_fastapi/auth/tokens.py`:

1. **Always include `kid` in the JWT header** — removed the `if self._private_key:` guard so `headers["kid"] = self.kid` runs for both symmetric and asymmetric keys.
2. **Check configured `jwt_kid` before falling back** — reordered `_generate_kid()` to check the `api_auth.jwt_kid` config option first, before returning the `"not-used"` fallback for symmetric keys. This lets operators configure a custom `kid` regardless of key type.

Added two unit tests: one verifying symmetric tokens include `kid` in the header, another verifying the configured `jwt_kid` is respected for symmetric keys.

Closes: #62876

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
