### PR TITLE
fix: pass through user-provided password in HiveServer2Hook for all auth modes

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -877,8 +877,11 @@ class HiveServer2Hook(DbApiHook):
             auth_mechanism = db.extra_dejson.get("auth_mechanism", "KERBEROS")
             kerberos_service_name = db.extra_dejson.get("kerberos_service_name", "hive")
 
-        # Password should be set if in LDAP, CUSTOM or PLAIN mode
-        if auth_mechanism in ("LDAP", "CUSTOM", "PLAIN"):
+        # Pass through the password whenever the user has explicitly set one.
+        # Previously this was restricted to LDAP/CUSTOM/PLAIN, which caused
+        # user-provided passwords to be silently dropped for other auth modes
+        # (pyhive defaults to sending "x" when password is None).
+        if db.password:
             password = db.password
 
         from pyhive.hive import connect

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -697,6 +697,27 @@ class TestHiveServer2Hook:
                 database="default",
             )
 
+    @mock.patch("pyhive.hive.connect")
+    def test_get_conn_with_password_none_auth(self, mock_connect):
+        """Test that password is passed through even when auth_mechanism is NONE."""
+        conn_id = "conn_none_with_password"
+        conn_env = CONN_ENV_PREFIX + conn_id.upper()
+
+        with mock.patch.dict(
+            "os.environ",
+            {conn_env: "jdbc+hive2://user:mypassword@localhost:10000/default"},
+        ):
+            HiveServer2Hook(hiveserver2_conn_id=conn_id).get_conn()
+            mock_connect.assert_called_once_with(
+                host="localhost",
+                port=10000,
+                auth="NONE",
+                kerberos_service_name=None,
+                username="user",
+                password="mypassword",
+                database="default",
+            )
+
     @pytest.mark.parametrize(
         ("host", "port", "schema", "message"),
         [


### PR DESCRIPTION
## Problem

`HiveServer2Hook.get_conn()` silently drops user-provided passwords when `auth_mechanism` is anything other than `LDAP`, `CUSTOM`, or `PLAIN`. When `auth_mechanism` defaults to `NONE` (the most common case), the password is never passed to `pyhive.hive.connect()`, which then defaults to sending `"x"` as the password on the wire. Users see their configured password ignored regardless of what they set in the connection form.

## Root Cause

The password assignment in `get_conn()` was gated behind `if auth_mechanism in ("LDAP", "CUSTOM", "PLAIN")`. For any other auth mode, `password` stayed `None` even when `db.password` was explicitly set by the user.

## Fix

Changed the condition to `if db.password:` so the user-provided password is always passed through to pyhive when set, regardless of the auth mechanism. Added a test verifying password pass-through with the default `NONE` auth mechanism.

Closes: #62338

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
