### PR TITLE
Remove astroid<4 pin now that sphinx-autoapi>=3.6.1 supports astroid 4

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -75,8 +75,7 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
-    # Astroid 4 released 5 Oct 2025 breaks autoapi https://github.com/apache/airflow/issues/56420
-    "astroid>=3,<4",
+    "astroid>=3",
     "checksumdir>=1.2.0",
     "rich-click>=1.9.7",
     "click>=8.3.0",
@@ -87,7 +86,7 @@ dependencies = [
     "pagefind-bin>=1.5.0a3",
     "sphinx-airflow-theme@https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.0-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
-    "sphinx-autoapi>=3",
+    "sphinx-autoapi>=3.6.1",
     "sphinx-autobuild>=2024.10.2",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.5.0",


### PR DESCRIPTION
sphinx-autoapi 3.6.1 (released Oct 2025) added support for astroid 4 by fixing the breaking `AstroidBuilder` change. The `astroid<4` workaround pin is no longer needed.

closes: #56420