### PR TITLE
Add template_fields and expand tests for SalesforceApexRestOperator

### DIFF
--- a/providers/salesforce/src/airflow/providers/salesforce/operators/salesforce_apex_rest.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/operators/salesforce_apex_rest.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from airflow.providers.common.compat.sdk import BaseOperator
@@ -38,6 +39,8 @@ class SalesforceApexRestOperator(BaseOperator):
     :param payload: A dict of parameters to send in a POST / PUT request
     :param salesforce_conn_id: The :ref:`Salesforce Connection id <howto/connection:SalesforceHook>`.
     """
+
+    template_fields: Sequence[str] = ("endpoint", "method", "payload")
 
     def __init__(
         self,

--- a/providers/salesforce/tests/unit/salesforce/operators/test_salesforce_apex_rest.py
+++ b/providers/salesforce/tests/unit/salesforce/operators/test_salesforce_apex_rest.py
@@ -26,10 +26,18 @@ class TestSalesforceApexRestOperator:
     Test class for SalesforceApexRestOperator
     """
 
+    def test_template_fields(self):
+        """Test that template_fields are defined correctly."""
+        assert SalesforceApexRestOperator.template_fields == (
+            "endpoint",
+            "method",
+            "payload",
+        )
+
     @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
-    def test_execute_salesforce_apex_rest(self, mock_get_conn):
+    def test_execute_salesforce_apex_rest_post(self, mock_get_conn):
         """
-        Test execute apex rest
+        Test execute apex rest with POST method
         """
 
         endpoint = "User/Activity"
@@ -44,6 +52,138 @@ class TestSalesforceApexRestOperator:
 
         operator.execute(context={})
 
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method=method, data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_salesforce_apex_rest_get(self, mock_get_conn):
+        """
+        Test execute apex rest with GET method
+        """
+
+        endpoint = "User/Activity"
+        method = "GET"
+        payload = {"user": "12345"}
+
+        mock_get_conn.return_value.apexecute = Mock()
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, method=method, payload=payload
+        )
+
+        operator.execute(context={})
+
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method=method, data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_salesforce_apex_rest_put(self, mock_get_conn):
+        """
+        Test execute apex rest with PUT method
+        """
+
+        endpoint = "User/Activity"
+        method = "PUT"
+        payload = {"user": "12345", "action": "replace page"}
+
+        mock_get_conn.return_value.apexecute = Mock()
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, method=method, payload=payload
+        )
+
+        operator.execute(context={})
+
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method=method, data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_salesforce_apex_rest_delete(self, mock_get_conn):
+        """
+        Test execute apex rest with DELETE method
+        """
+
+        endpoint = "User/Activity"
+        method = "DELETE"
+        payload = {"user": "12345"}
+
+        mock_get_conn.return_value.apexecute = Mock()
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, method=method, payload=payload
+        )
+
+        operator.execute(context={})
+
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method=method, data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_salesforce_apex_rest_patch(self, mock_get_conn):
+        """
+        Test execute apex rest with PATCH method
+        """
+
+        endpoint = "User/Activity"
+        method = "PATCH"
+        payload = {"user": "12345", "action": "partial update"}
+
+        mock_get_conn.return_value.apexecute = Mock()
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, method=method, payload=payload
+        )
+
+        operator.execute(context={})
+
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method=method, data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_default_method_is_get(self, mock_get_conn):
+        """
+        Test that default method is GET when not specified
+        """
+
+        endpoint = "User/Activity"
+        payload = {"user": "12345"}
+
+        mock_get_conn.return_value.apexecute = Mock()
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, payload=payload
+        )
+
+        operator.execute(context={})
+
+        mock_get_conn.return_value.apexecute.assert_called_once_with(
+            action=endpoint, method="GET", data=payload
+        )
+
+    @patch("airflow.providers.salesforce.operators.salesforce_apex_rest.SalesforceHook.get_conn")
+    def test_execute_xcom_push_disabled(self, mock_get_conn):
+        """
+        Test that empty dict is returned when do_xcom_push is False
+        """
+
+        endpoint = "User/Activity"
+        method = "GET"
+        payload = {"user": "12345"}
+
+        mock_get_conn.return_value.apexecute = Mock(return_value={"id": "001"})
+
+        operator = SalesforceApexRestOperator(
+            task_id="task", endpoint=endpoint, method=method, payload=payload, do_xcom_push=False
+        )
+
+        result = operator.execute(context={})
+
+        assert result == {}
         mock_get_conn.return_value.apexecute.assert_called_once_with(
             action=endpoint, method=method, data=payload
         )


### PR DESCRIPTION
Related to #62375

## Summary
- Add `template_fields` to `SalesforceApexRestOperator` to enable Jinja templating for `endpoint`, `method`, and `payload` parameters — matching the pattern used in `SalesforceBulkOperator`
- Expand test coverage from 1 test to 8, covering all HTTP methods (GET, PUT, DELETE, PATCH), default method verification, xcom push disabled behavior, and template_fields validation

## Test plan
- [x] All 8 tests pass: `pytest tests/unit/salesforce/operators/test_salesforce_apex_rest.py -v`
- [x] Follows existing test patterns from `test_bulk.py`
- [x] No changes to existing operator behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)