### PR TITLE
Add commit_offset option to AwaitMessageSensor and AwaitMessageTrigger

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
@@ -35,6 +35,7 @@ class AwaitMessageSensor(BaseSensorOperator):
     - poll the Kafka topics for a message
     - if no message returned, sleep
     - process the message with provided callable and commit the message offset
+    - if commit_offset is True (default), commit the message offset after processing
     - if callable returns any data, raise a TriggerEvent with the return data
     - else continue to next message
     - return event (as default xcom or specific xcom key)
@@ -53,6 +54,9 @@ class AwaitMessageSensor(BaseSensorOperator):
     :param poll_interval: How long the kafka consumer should sleep after reaching the end of the Kafka log,
         defaults to 5
     :param xcom_push_key: the name of a key to push the returned message to, defaults to None
+    :param commit_offset: Whether to commit the message offset after processing.
+        If False, the offset is not committed by the sensor, allowing downstream
+        tasks to commit it manually (e.g., after successful processing). Defaults to True.
     :param soft_fail: Set to true to mark the task as SKIPPED on failure
     :param timeout: Time elapsed before the task times out and fails (in seconds)
     :param poke_interval: This parameter is inherited but not used in this deferrable implementation
@@ -70,18 +74,20 @@ class AwaitMessageSensor(BaseSensorOperator):
         "apply_function_args",
         "apply_function_kwargs",
         "kafka_config_id",
+        "commit_offset",
     )
 
     def __init__(
         self,
         topics: Sequence[str],
-        apply_function: str,
+        apply_function: str | None,
         kafka_config_id: str = "kafka_default",
         apply_function_args: Sequence[Any] | None = None,
         apply_function_kwargs: dict[Any, Any] | None = None,
         poll_timeout: float = 1,
         poll_interval: float = 5,
-        xcom_push_key=None,
+        xcom_push_key: str | None = None,
+        commit_offset: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -94,6 +100,7 @@ class AwaitMessageSensor(BaseSensorOperator):
         self.poll_timeout = poll_timeout
         self.poll_interval = poll_interval
         self.xcom_push_key = xcom_push_key
+        self.commit_offset = commit_offset
 
     def execute(self, context) -> Any:
         self.defer(
@@ -105,6 +112,7 @@ class AwaitMessageSensor(BaseSensorOperator):
                 kafka_config_id=self.kafka_config_id,
                 poll_timeout=self.poll_timeout,
                 poll_interval=self.poll_interval,
+                commit_offset=self.commit_offset,
             ),
             method_name="execute_complete",
         )
@@ -163,7 +171,7 @@ class AwaitMessageTriggerFunctionSensor(BaseSensorOperator):
     def __init__(
         self,
         topics: Sequence[str],
-        apply_function: str,
+        apply_function: str | None,
         event_triggered_function: Callable,
         kafka_config_id: str = "kafka_default",
         apply_function_args: Sequence[Any] | None = None,

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -46,6 +46,10 @@ class AwaitMessageTrigger(BaseEventTrigger):
         - if callable is provided and returns any data, raise a TriggerEvent with the return data
         - else raise a TriggerEvent with the original message
 
+    - by default, the message offset is committed after processing. This can be
+      disabled by setting ``commit_offset=False``, allowing manual offset management
+      in downstream tasks.
+
     :param kafka_config_id: The connection object to use, defaults to "kafka_default"
     :param topics: The topic (or topic regex) that should be searched for messages
     :param apply_function: the location of the function to apply to messages for determination of matching
@@ -57,6 +61,10 @@ class AwaitMessageTrigger(BaseEventTrigger):
         Kafka (seconds), defaults to 1
     :param poll_interval: How long the trigger should sleep after reaching the end of the Kafka log
         (seconds), defaults to 5
+    :param commit_offset: Whether to commit the message offset after poll.
+        If set to False, the offset is not committed automatically, allowing
+        downstream tasks to handle offset committing manually (e.g., after
+        successful processing). Defaults to True.
 
     """
 
@@ -69,6 +77,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
         apply_function_kwargs: dict[Any, Any] | None = None,
         poll_timeout: float = 1,
         poll_interval: float = 5,
+        commit_offset: bool = True,
     ) -> None:
         self.topics = topics
         self.apply_function = apply_function
@@ -77,6 +86,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
         self.kafka_config_id = kafka_config_id
         self.poll_timeout = poll_timeout
         self.poll_interval = poll_interval
+        self.commit_offset = commit_offset
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return (
@@ -89,6 +99,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
                 "kafka_config_id": self.kafka_config_id,
                 "poll_timeout": self.poll_timeout,
                 "poll_interval": self.poll_interval,
+                "commit_offset": self.commit_offset,
             },
         )
 
@@ -122,9 +133,11 @@ class AwaitMessageTrigger(BaseEventTrigger):
                     else message.value().decode("utf-8")
                 )
                 if event:
-                    await async_commit(message=message, asynchronous=False)
+                    if self.commit_offset:
+                        await async_commit(message=message, asynchronous=False)
                     yield TriggerEvent(event)
                     break
                 else:
-                    await async_commit(message=message, asynchronous=False)
+                    if self.commit_offset:
+                        await async_commit(message=message, asynchronous=False)
                     await asyncio.sleep(self.poll_interval)

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -82,6 +82,7 @@ class TestTrigger:
             apply_function_kwargs=dict(one=1, two=2),
             poll_timeout=10,
             poll_interval=5,
+            commit_offset=True,
         )
 
         assert isinstance(trigger, AwaitMessageTrigger)
@@ -97,6 +98,7 @@ class TestTrigger:
             apply_function_kwargs=dict(one=1, two=2),
             poll_timeout=10,
             poll_interval=5,
+            commit_offset=True,
         )
 
     @pytest.mark.parametrize(

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_msg_queue.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_msg_queue.py
@@ -112,6 +112,7 @@ class TestMessageQueueTrigger:
             "apply_function_kwargs": {"one": 1, "two": 2},
             "poll_timeout": 10,
             "poll_interval": 5,
+            "commit_offset": True,
         }
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Requires Airflow 3.0.+")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
# Add `commit_offset` option to `AwaitMessageSensor` for manual offset management

This PR adds a new parameter `commit_offset` (default `True`) to `AwaitMessageSensor` and its underlying `AwaitMessageTrigger`. When set to `False`, the sensor does **not** automatically commit the Kafka message offset after processing, allowing downstream tasks to handle offset committing manually (e.g., after successful business logic execution).

## Motivation
In certain use cases, it is desirable to commit the offset only after the entire DAG or a subsequent task has successfully processed the message. Currently, the sensor always commits the offset immediately when a matching message is found, which may lead to data loss if the downstream processing fails. This change gives users control over offset commit behavior.

## Changes
- Added `commit_offset: bool = True` parameter to `AwaitMessageSensor.__init__`
- Added `commit_offset` to `template_fields` of `AwaitMessageSensor`
- Pass `commit_offset` from sensor to `AwaitMessageTrigger`
- Added `commit_offset` parameter to `AwaitMessageTrigger.__init__` and `serialize`
- Modified trigger's `run()` method to conditionally call `async_commit()` based on `commit_offset`
- Updated docstrings to document the new parameter and adjust behavior descriptions
- Fixed type hints for `apply_function` in `AwaitMessageTrigger` and `AwaitMessageTriggerFunctionSensor` (`str | None` instead `str` to match with `AwaitMessageTrigger`); related to #55437
- Add typehint for `xcom_push_key` in `AwaitMessageSensor` (`str | None`) for better clarity

## Testing
- [x] Pre-commit checks `prek --all-files` passed
- [x] Unit tests `breeze testing providers-tests --test-type "Providers[apache.kafka]"` passed
- [x] Integration tests `breeze testing providers-integration-tests --integration "kafka"` passed 

## Notes
- The `AwaitMessageTriggerFunctionSensor` was intentionally **not** modified because its behavior is more complex and may require separate consideration. If needed, support can be added in a future PR.
- This change is backward compatible: existing DAGs using the sensor will keep the same behavior (commit always) because `commit_offset` defaults to `True`.
- Related discussion: #62854 
