### PR TITLE
fix: prune deadline alerts when DAG run fails, not just on success

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1202,18 +1202,6 @@ class DagRun(Base, LoggingMixin):
                     execute=execute_callbacks,
                 )
 
-            if dag.deadline:
-                # The dagrun has succeeded.  If there were any Deadlines for it which were not breached, they are no longer needed.
-                deadline_alerts = [
-                    DeadlineAlertModel.get_by_id(alert_id, session) for alert_id in dag.deadline
-                ]
-
-                if any(
-                    deadline_alert.reference_class in SerializedReferenceModels.TYPES.DAGRUN
-                    for deadline_alert in deadline_alerts
-                ):
-                    Deadline.prune_deadlines(session=session, conditions={DagRun.id: self.id})
-
         # if *all tasks* are deadlocked, the run failed
         elif unfinished.should_schedule and not are_runnable_tasks:
             self.log.error("Task deadlock (no runnable tasks); marking run %s failed", self)
@@ -1267,6 +1255,22 @@ class DagRun(Base, LoggingMixin):
                 self.data_interval_start,
                 self.data_interval_end,
             )
+
+            self.end_dr_span_if_needed()
+
+            if dag.deadline:
+                # The dagrun has reached a terminal state. Prune any pending deadlines
+                # so they don't fire after the run is already finished.
+                deadline_alerts = [
+                    DeadlineAlertModel.get_by_id(alert_id, session) for alert_id in dag.deadline
+                ]
+
+                if any(
+                    deadline_alert.reference_class in SerializedReferenceModels.TYPES.DAGRUN
+                    for deadline_alert in deadline_alerts
+                ):
+                    Deadline.prune_deadlines(session=session, conditions={DagRun.id: self.id})
+
             session.flush()
             self._emit_dagrun_span(state=self.state)
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1256,7 +1256,6 @@ class DagRun(Base, LoggingMixin):
                 self.data_interval_end,
             )
 
-
             if dag.deadline:
                 # The dagrun has reached a terminal state. Prune any pending deadlines
                 # so they don't fire after the run is already finished.

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1256,7 +1256,6 @@ class DagRun(Base, LoggingMixin):
                 self.data_interval_end,
             )
 
-            self.end_dr_span_if_needed()
 
             if dag.deadline:
                 # The dagrun has reached a terminal state. Prune any pending deadlines

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1360,6 +1360,36 @@ class TestDagRun:
         mock_prune.assert_not_called()
         assert dag_run.state == DagRunState.SUCCESS
 
+    @mock.patch.object(Deadline, "prune_deadlines")
+    @mock.patch.object(DeadlineAlertModel, "get_by_id")
+    def test_dagrun_failure_prunes_dagrun_deadlines(
+        self, mock_get_by_id, mock_prune, session, deadline_test_dag
+    ):
+        """Deadlines should be pruned when a DAG run fails, not just on success."""
+        mock_deadline_alert = mock.MagicMock()
+        mock_deadline_alert.reference_class = SerializedReferenceModels.FixedDatetimeDeadline
+        mock_get_by_id.return_value = mock_deadline_alert
+
+        scheduler_dag = deadline_test_dag()
+
+        deadline_ids = ["deadline-uuid-1", "deadline-uuid-2"]
+        scheduler_dag.deadline = deadline_ids
+
+        dag_run = self.create_dag_run(
+            dag=scheduler_dag,
+            task_states={"task_1": TaskInstanceState.SUCCESS, "task_2": TaskInstanceState.FAILED},
+            session=session,
+        )
+        dag_run.dag = scheduler_dag
+
+        dag_run.update_state(session=session)
+
+        assert mock_get_by_id.call_count == len(deadline_ids)
+        for deadline_id in deadline_ids:
+            mock_get_by_id.assert_any_call(deadline_id, session)
+        mock_prune.assert_called_once_with(session=session, conditions={DagRun.id: dag_run.id})
+        assert dag_run.state == DagRunState.FAILED
+
 
 @pytest.mark.parametrize(
     ("run_type", "expected_tis"),


### PR DESCRIPTION
## Problem

Deadline alerts fire even after a DAG run has failed. A user configured a 180-minute deadline, the DAG failed within 10 minutes, but the deadline alert still triggered 3 hours later.

## Root Cause

`DagRun.update_state()` only calls `Deadline.prune_deadlines()` in the success path. When a DAG run fails (task failure or deadlock), pending deadlines are never cleaned up, so the scheduler still fires them later.

## Fix

Moved deadline pruning from the success-only block to the shared terminal state block that runs for both SUCCESS and FAILED states. Added a test for the failure case.

Closes: #60927

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=6856b62 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @YoannAbriel** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Unaddressed Copilot review** — a Copilot review thread has been open for ≥7 days with no reply; please respond to or resolve it. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->