### PR TITLE
fix(providers/google): sanitize Dataproc batch labels to use dashes instead of underscores

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataproc.py
@@ -2602,10 +2602,10 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
             )
 
     def __update_batch_labels(self):
-        dag_id = re.sub(r"[.\s]", "_", self.dag_id.lower())
-        task_id = re.sub(r"[.\s]", "_", self.task_id.lower())
+        dag_id = re.sub(r"[^a-z0-9-]", "-", self.dag_id.lower())
+        task_id = re.sub(r"[^a-z0-9-]", "-", self.task_id.lower())
 
-        labels_regex = re.compile(r"^[a-z][\w-]{0,62}$")
+        labels_regex = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
         if not labels_regex.match(dag_id) or not labels_regex.match(task_id):
             return
 
@@ -2613,8 +2613,8 @@ class DataprocCreateBatchOperator(GoogleCloudBaseOperator):
         new_labels = {"airflow-dag-id": dag_id, "airflow-task-id": task_id}
 
         if self._dag:
-            dag_display_name = re.sub(r"[.\s]", "_", self._dag.dag_display_name.lower())
-            if labels_regex.match(dag_id):
+            dag_display_name = re.sub(r"[^a-z0-9-]", "-", self._dag.dag_display_name.lower())
+            if labels_regex.match(dag_display_name):
                 new_labels["airflow-dag-display-name"] = dag_display_name
 
         if isinstance(self.batch, Batch):

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -4050,14 +4050,14 @@ class TestDataprocCreateBatchOperator:
     @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_create_batch_labels_sanitize_underscores_and_dots(self, mock_hook, to_dict_mock):
-        """Labels with dots, underscores, or spaces should be replaced with dashes (GCP requirement)."""
-        dag_id_with_dots = "my.dag_id with.spaces"
+        """Labels with dots and underscores should be replaced with dashes (GCP requirement)."""
+        dag_id_with_dots = "my.dag_id.with.dots"
         task_id_with_underscores = "process_data.step_one"
         expected_batch = {
             **BATCH,
             "labels": {
-                "airflow-dag-id": "my-dag-id-with-spaces",
-                "airflow-dag-display-name": "my-dag-id-with-spaces",
+                "airflow-dag-id": "my-dag-id-with-dots",
+                "airflow-dag-display-name": "my-dag-id-with-dots",
                 "airflow-task-id": "process-data-step-one",
             },
         }

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -4046,7 +4046,6 @@ class TestDataprocCreateBatchOperator:
         )
         TestDataprocCreateBatchOperator.__assert_batch_create(mock_hook, expected_batch)
 
-
     @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_create_batch_labels_sanitize_underscores_and_dots(self, mock_hook, to_dict_mock):

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -4047,6 +4047,30 @@ class TestDataprocCreateBatchOperator:
         TestDataprocCreateBatchOperator.__assert_batch_create(mock_hook, expected_batch)
 
 
+    @mock.patch(DATAPROC_PATH.format("Batch.to_dict"))
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_create_batch_labels_sanitize_underscores_and_dots(self, mock_hook, to_dict_mock):
+        """Labels with dots, underscores, or spaces should be replaced with dashes (GCP requirement)."""
+        dag_id_with_dots = "my.dag_id with.spaces"
+        task_id_with_underscores = "process_data.step_one"
+        expected_batch = {
+            **BATCH,
+            "labels": {
+                "airflow-dag-id": "my-dag-id-with-spaces",
+                "airflow-dag-display-name": "my-dag-id-with-spaces",
+                "airflow-task-id": "process-data-step-one",
+            },
+        }
+        DataprocCreateBatchOperator(
+            task_id=task_id_with_underscores,
+            dag=DAG(dag_id=dag_id_with_dots),
+            batch=BATCH,
+            region=GCP_REGION,
+        ).execute(context=EXAMPLE_CONTEXT)
+
+        TestDataprocCreateBatchOperator.__assert_batch_create(mock_hook, expected_batch)
+
+
 class TestDataprocDeleteBatchOperator:
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook):


### PR DESCRIPTION
## Problem

`DataprocCreateBatchOperator.__update_batch_labels()` replaces dots and spaces with underscores when building GCP labels from DAG/task IDs. GCP labels only allow lowercase letters, numbers, and dashes — underscores are invalid. This causes `InvalidArgument` errors when task IDs contain underscores (common with task groups, e.g. `process_data`).

## Root Cause

`re.sub(r"[.\s]", "_", ...)` only strips dots and whitespace, converting them to underscores. Any existing underscores in the ID pass through unchanged. The validation regex `r"^[a-z][\w-]{0,62}$"` also incorrectly allows underscores via `\w`.

Additionally, the `dag_display_name` validation was checking `dag_id` instead of the actual `dag_display_name` value.

## Fix

- Replace the substitution pattern with `re.sub(r"[^a-z0-9-]", "-", ...)` — strips everything except valid label characters
- Update the validation regex to `r"^[a-z0-9][a-z0-9-]{0,62}$"` matching GCP's actual requirements
- Fix the `dag_display_name` validation to check the right variable
- Added test for underscore/dot sanitization

Closes: #59332

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
