### PR TITLE
fix: use fresh session in FabAuthManager.deserialize_user (#62903)

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -19,20 +19,20 @@ from __future__ import annotations
 
 import logging
 import warnings
-from contextlib import suppress
+
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-from cachetools import TTLCache, cachedmethod
+from cachetools import TTLCache
 from connexion import FlaskApi
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
 from flask import Blueprint, current_app, g
 from flask_appbuilder.const import AUTH_LDAP
 from sqlalchemy import select
-from sqlalchemy.exc import NoResultFound, SQLAlchemyError
+
 from sqlalchemy.orm import Session, joinedload
 
 from airflow.api_fastapi.app import AUTH_MANAGER_FASTAPI_APP_PREFIX
@@ -99,7 +99,7 @@ from airflow.providers.fab.www.utils import (
     get_fab_action_from_method_map,
     get_method_from_fab_action_map,
 )
-from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.yaml import safe_load
 
 if TYPE_CHECKING:
@@ -286,22 +286,18 @@ class FabAuthManager(BaseAuthManager[User]):
 
         return current_user
 
-    @property
-    def session(self):
-        return self.appbuilder.session
-
-    @cachedmethod(lambda self: self.cache, key=lambda _, token: int(token["sub"]))
     def deserialize_user(self, token: dict[str, Any]) -> User:
-        try:
-            return self.session.scalars(select(User).where(User.id == int(token["sub"]))).one()
-        except NoResultFound:
+        # Namespace the cache key to avoid collisions with other entries in the shared cache.
+        user_id = int(token["sub"])
+        cache_key = ("user", user_id)
+        if cache_key in self.cache:
+            return self.cache[cache_key]
+        with create_session() as session:
+            user = session.get(User, user_id)
+        if user is None:
             raise ValueError(f"User with id {token['sub']} not found")
-        except SQLAlchemyError:
-            # Discard the poisoned scoped session so the next request gets a
-            # fresh connection from the pool instead of a PendingRollbackError.
-            with suppress(Exception):
-                self.session.remove()
-            raise
+        self.cache[cache_key] = user
+        return user
 
     def serialize_user(self, user: User) -> dict[str, Any]:
         return {"sub": str(user.id)}

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
-from cachetools import TTLCache
+from cachetools import TTLCache, cachedmethod
 from connexion import FlaskApi
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
@@ -286,17 +286,12 @@ class FabAuthManager(BaseAuthManager[User]):
 
         return current_user
 
+    @cachedmethod(lambda self: self.cache, key=lambda _, token: ("user", int(token["sub"])))
     def deserialize_user(self, token: dict[str, Any]) -> User:
-        # Namespace the cache key to avoid collisions with other entries in the shared cache.
-        user_id = int(token["sub"])
-        cache_key = ("user", user_id)
-        if cache_key in self.cache:
-            return self.cache[cache_key]
         with create_session() as session:
-            user = session.get(User, user_id)
+            user = session.get(User, int(token["sub"]))
         if user is None:
             raise ValueError(f"User with id {token['sub']} not found")
-        self.cache[cache_key] = user
         return user
 
     def serialize_user(self, user: User) -> dict[str, Any]:


### PR DESCRIPTION
FabAuthManager.deserialize_user was using self.session (FAB's appbuilder-scoped SQLAlchemy session). When that session becomes poisoned after a DB connection drop, the next request on the same worker raises an error due to attempting to use dropped connection. This can cause a Internal Server Error to the user.

Replace self.session with create_session() so each cache miss gets a fresh, short-lived session that is closed immediately after the query. Also replace manual query with `get` function which returns an optional value instead of exception when not found.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Used Claude code. Reviewed code and tested.

Fixes #62903

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
