### PR TITLE
fix: separate handler kwargs from RemoteLogIO kwargs in remote logging config

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -161,6 +161,14 @@ if REMOTE_LOGGING:
         )
     delete_local_copy = conf.getboolean("logging", "delete_local_logs")
 
+    # Separate handler-level kwargs (for FileTaskHandler) from remote I/O kwargs (for RemoteLogIO).
+    # In Airflow 2, remote_task_handler_kwargs configured the handler directly. In Airflow 3,
+    # RemoteLogIO classes were introduced and only accept I/O-specific parameters. Handler-level
+    # parameters like max_bytes, backup_count, and delay must be preserved for the handler config.
+    _HANDLER_ONLY_KWARGS = {"max_bytes", "backup_count", "delay"}
+    _handler_kwargs = {k: v for k, v in remote_task_handler_kwargs.items() if k in _HANDLER_ONLY_KWARGS}
+    _remote_io_kwargs = {k: v for k, v in remote_task_handler_kwargs.items() if k not in _HANDLER_ONLY_KWARGS}
+
     if remote_base_log_folder.startswith("s3://"):
         from airflow.providers.amazon.aws.log.s3_task_handler import S3RemoteLogIO
 
@@ -172,10 +180,9 @@ if REMOTE_LOGGING:
                     "remote_base": remote_base_log_folder,
                     "delete_local_copy": delete_local_copy,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
 
     elif remote_base_log_folder.startswith("cloudwatch://"):
         from airflow.providers.amazon.aws.log.cloudwatch_task_handler import CloudWatchRemoteLogIO
@@ -190,10 +197,9 @@ if REMOTE_LOGGING:
                     "delete_local_copy": delete_local_copy,
                     "log_group_arn": url_parts.netloc + url_parts.path,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("gs://"):
         from airflow.providers.google.cloud.log.gcs_task_handler import GCSRemoteLogIO
 
@@ -208,10 +214,9 @@ if REMOTE_LOGGING:
                     "delete_local_copy": delete_local_copy,
                     "gcp_key_path": key_path,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("wasb"):
         from airflow.providers.microsoft.azure.log.wasb_task_handler import WasbRemoteLogIO
 
@@ -231,10 +236,9 @@ if REMOTE_LOGGING:
                     "delete_local_copy": delete_local_copy,
                     "wasb_container": wasb_log_container,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("stackdriver://"):
         key_path = conf.get_mandatory_value("logging", "GOOGLE_KEY_PATH", fallback=None)
         # stackdriver:///airflow-tasks => airflow-tasks
@@ -261,10 +265,9 @@ if REMOTE_LOGGING:
                     "remote_base": remote_base_log_folder,
                     "delete_local_copy": delete_local_copy,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
     elif remote_base_log_folder.startswith("hdfs://"):
         from airflow.providers.apache.hdfs.log.hdfs_task_handler import HdfsRemoteLogIO
 
@@ -277,10 +280,9 @@ if REMOTE_LOGGING:
                     "remote_base": urlsplit(remote_base_log_folder).path,
                     "delete_local_copy": delete_local_copy,
                 }
-                | remote_task_handler_kwargs
+                | _remote_io_kwargs
             )
         )
-        remote_task_handler_kwargs = {}
     elif ELASTICSEARCH_HOST:
         ELASTICSEARCH_END_OF_LOG_MARK: str = conf.get_mandatory_value("elasticsearch", "END_OF_LOG_MARK")
         ELASTICSEARCH_FRONTEND: str = conf.get_mandatory_value("elasticsearch", "frontend")
@@ -346,4 +348,4 @@ if REMOTE_LOGGING:
             "section 'elasticsearch' if you are using Elasticsearch. In the other case, "
             "'remote_base_log_folder' option in the 'logging' section."
         )
-    DEFAULT_LOGGING_CONFIG["handlers"]["task"].update(remote_task_handler_kwargs)
+    DEFAULT_LOGGING_CONFIG["handlers"]["task"].update(_handler_kwargs)

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+class TestRemoteTaskHandlerKwargsSeparation:
+    """Test that remote_task_handler_kwargs are correctly separated into handler and IO kwargs."""
+
+    def test_handler_kwargs_separated_from_io_kwargs(self):
+        """Verify that handler-level kwargs (max_bytes, backup_count, delay) are not passed to RemoteLogIO."""
+        remote_task_handler_kwargs = {
+            "max_bytes": 5000000,
+            "backup_count": 5,
+            "delay": True,
+            "delete_local_copy": False,
+        }
+
+        # This mirrors the logic in airflow_local_settings.py
+        _HANDLER_ONLY_KWARGS = {"max_bytes", "backup_count", "delay"}
+        _handler_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k in _HANDLER_ONLY_KWARGS
+        }
+        _remote_io_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k not in _HANDLER_ONLY_KWARGS
+        }
+
+        assert _handler_kwargs == {"max_bytes": 5000000, "backup_count": 5, "delay": True}
+        assert _remote_io_kwargs == {"delete_local_copy": False}
+
+    def test_empty_kwargs_produces_empty_dicts(self):
+        """Both handler and IO kwargs should be empty when input is empty."""
+        remote_task_handler_kwargs: dict = {}
+
+        _HANDLER_ONLY_KWARGS = {"max_bytes", "backup_count", "delay"}
+        _handler_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k in _HANDLER_ONLY_KWARGS
+        }
+        _remote_io_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k not in _HANDLER_ONLY_KWARGS
+        }
+
+        assert _handler_kwargs == {}
+        assert _remote_io_kwargs == {}
+
+    def test_only_io_kwargs(self):
+        """When only IO kwargs are provided, handler kwargs should be empty."""
+        remote_task_handler_kwargs = {"delete_local_copy": True}
+
+        _HANDLER_ONLY_KWARGS = {"max_bytes", "backup_count", "delay"}
+        _handler_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k in _HANDLER_ONLY_KWARGS
+        }
+        _remote_io_kwargs = {
+            k: v for k, v in remote_task_handler_kwargs.items() if k not in _HANDLER_ONLY_KWARGS
+        }
+
+        assert _handler_kwargs == {}
+        assert _remote_io_kwargs == {"delete_local_copy": True}


### PR DESCRIPTION
## Problem

When using remote logging in Airflow 3.x with `remote_task_handler_kwargs` containing `FileTaskHandler` parameters like `max_bytes`, `backup_count`, or `delay`, the application crashes on startup with:

```
TypeError: WasbRemoteLogIO.__init__() got an unexpected keyword argument 'max_bytes'
```

This is a regression from PR #48491 which introduced separate `RemoteLogIO` classes for remote storage operations.

## Root Cause

In Airflow 2.x, `remote_task_handler_kwargs` configured the handler directly. In Airflow 3.x, the same kwargs dict is passed entirely to `RemoteLogIO` constructors (which only accept I/O-specific parameters like `remote_base`, `base_log_folder`, `delete_local_copy`), and then the dict is cleared to `{}`. This means:

1. Handler-level params (`max_bytes`, `backup_count`, `delay`) cause `TypeError` in `RemoteLogIO.__init__`
2. Even if they didn't error, they'd be lost before reaching the handler config update at the end

## Fix

Separate `remote_task_handler_kwargs` into two groups before processing:
- **Handler kwargs** (`max_bytes`, `backup_count`, `delay`) → preserved and applied to `FileTaskHandler` config
- **Remote I/O kwargs** (everything else) → passed to `RemoteLogIO` constructors

This restores backward compatibility with Airflow 2.x configuration while working correctly with the new RemoteLogIO architecture.

Closes: #58770

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
