### PR TITLE
Enable Elasticsearch provider integration tests in CI

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -87,7 +87,6 @@ TESTABLE_PROVIDERS_INTEGRATIONS = [
     "ydb",
 ]
 DISABLE_TESTABLE_INTEGRATIONS_FROM_CI = [
-    "elasticsearch",
     "mssql",
     "localstack",  # just for local integration testing for now
 ]

--- a/dev/breeze/tests/test_pytest_args_for_test_types.py
+++ b/dev/breeze/tests/test_pytest_args_for_test_types.py
@@ -65,6 +65,7 @@ def _find_all_integration_folders() -> list[str]:
                 "providers/apache/pinot/tests/integration",
                 "providers/apache/tinkerpop/tests/integration",
                 "providers/celery/tests/integration",
+                "providers/elasticsearch/tests/integration",
                 "providers/google/tests/integration",
                 "providers/microsoft/mssql/tests/integration",
                 "providers/mongo/tests/integration",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1126,7 +1126,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                     "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "testable-core-integrations": "['kerberos', 'otel', 'redis']",
-                    "testable-providers-integrations": "['celery', 'cassandra', 'drill', 'tinkerpop', 'kafka', "
+                    "testable-providers-integrations": "['celery', 'cassandra', 'drill', 'elasticsearch', 'tinkerpop', 'kafka', "
                     "'mongo', 'pinot', 'qdrant', 'redis', 'trino', 'ydb']",
                     "run-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
@@ -2760,12 +2760,6 @@ def test_runner_type_schedule(mock_get):
     [
         # Test integrations disabled for all CI environments
         pytest.param(
-            "elasticsearch",
-            PUBLIC_AMD_RUNNERS,
-            True,
-            id="elasticsearch_disabled_on_amd",
-        ),
-        pytest.param(
             "mssql",
             PUBLIC_AMD_RUNNERS,
             True,
@@ -2881,9 +2875,9 @@ def test_testable_core_integrations_excludes_disabled():
     """Test that testable_core_integrations excludes disabled integrations."""
     with patch(
         "airflow_breeze.utils.selective_checks.TESTABLE_CORE_INTEGRATIONS",
-        ["postgres", "elasticsearch", "kerberos"],
+        ["postgres", "kerberos"],
     ):
-        # Test with AMD runner - should exclude elasticsearch (disabled for all CI)
+        # Test with AMD runner
         selective_checks_amd = SelectiveChecks(
             files=("airflow-core/tests/test_example.py",),
             commit_ref=NEUTRAL_COMMIT,
@@ -2895,7 +2889,6 @@ def test_testable_core_integrations_excludes_disabled():
             result = selective_checks_amd.testable_core_integrations
             assert "postgres" in result
             assert "kerberos" in result
-            assert "elasticsearch" not in result
 
 
 def test_testable_core_integrations_excludes_arm_disabled_on_arm():

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
     "apache-airflow-providers-common-sql",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-common-sql[pandas,polars]",
-    "testcontainers==4.12.0"
 ]
 
 # To build docs:

--- a/providers/elasticsearch/tests/integration/__init__.py
+++ b/providers/elasticsearch/tests/integration/__init__.py
@@ -14,6 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-pytest_plugins = "tests_common.pytest_plugin"
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/providers/elasticsearch/tests/integration/elasticsearch/__init__.py
+++ b/providers/elasticsearch/tests/integration/elasticsearch/__init__.py
@@ -14,6 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-pytest_plugins = "tests_common.pytest_plugin"

--- a/providers/elasticsearch/tests/integration/elasticsearch/log/__init__.py
+++ b/providers/elasticsearch/tests/integration/elasticsearch/log/__init__.py
@@ -14,6 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
-pytest_plugins = "tests_common.pytest_plugin"

--- a/providers/elasticsearch/tests/integration/elasticsearch/log/test_es_remote_log_io.py
+++ b/providers/elasticsearch/tests/integration/elasticsearch/log/test_es_remote_log_io.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import dataclasses
+import json
+import uuid
+from unittest.mock import patch
+
+import elasticsearch
+import pytest
+
+from airflow.providers.elasticsearch.log.es_task_handler import ElasticsearchRemoteLogIO
+
+# The ES service hostname as defined in scripts/ci/docker-compose/integration-elasticsearch.yml
+ES_HOST = "http://elasticsearch:9200"
+
+
+@dataclasses.dataclass
+class _MockTI:
+    """Minimal TaskInstance-like object satisfying the RuntimeTI protocol for log ID rendering."""
+
+    dag_id: str = "integration_test_dag"
+    task_id: str = "integration_test_task"
+    run_id: str = "integration_test_run"
+    try_number: int = 1
+    map_index: int = -1
+
+
+@pytest.mark.integration("elasticsearch")
+class TestElasticsearchRemoteLogIOIntegration:
+    """
+    Integration tests for ElasticsearchRemoteLogIO using the breeze elasticsearch service.
+
+    These tests require the elasticsearch integration to be running:
+        breeze testing providers-integration-tests --integration elasticsearch
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        # Use a unique index per test to avoid cross-test data pollution
+        self.target_index = f"airflow-logs-{uuid.uuid4()}"
+        self.elasticsearch_io = ElasticsearchRemoteLogIO(
+            write_to_es=True,
+            write_stdout=False,
+            delete_local_copy=False,
+            host=ES_HOST,
+            base_log_folder=tmp_path,
+        )
+        self.elasticsearch_io.target_index = self.target_index
+        # Point index_patterns at the unique index so reads don't scan unrelated indices
+        self.elasticsearch_io.index_patterns = self.target_index
+        self.elasticsearch_io.client = elasticsearch.Elasticsearch(ES_HOST)
+
+    @pytest.fixture
+    def ti(self):
+        return _MockTI()
+
+    @pytest.fixture
+    def tmp_json_log_file(self, tmp_path):
+        log_file = tmp_path / "1.log"
+        sample_logs = [
+            {"message": "start"},
+            {"message": "processing"},
+            {"message": "end"},
+        ]
+        with open(log_file, "w") as f:
+            for log in sample_logs:
+                f.write(json.dumps(log) + "\n")
+        return log_file
+
+    @patch(
+        "airflow.providers.elasticsearch.log.es_task_handler.TASK_LOG_FIELDS",
+        ["message"],
+    )
+    def test_upload_and_read(self, tmp_json_log_file, ti):
+        """Verify that logs uploaded to ES can be retrieved correctly."""
+        self.elasticsearch_io.upload(tmp_json_log_file, ti)
+        # Force index refresh so the documents are immediately searchable
+        self.elasticsearch_io.client.indices.refresh(index=self.target_index)
+
+        log_source_info, log_messages = self.elasticsearch_io.read("", ti)
+
+        assert log_source_info[0] == ES_HOST
+        assert len(log_messages) == 3
+
+        expected_messages = ["start", "processing", "end"]
+        for expected, log_message in zip(expected_messages, log_messages):
+            log_entry = json.loads(log_message)
+            assert "message" in log_entry
+            assert log_entry["message"] == expected
+
+    def test_read_missing_log(self, ti):
+        """Verify that a missing log returns the expected error message.
+
+        The index must exist first — _es_read raises NotFoundError (not returns None)
+        when the index itself is absent. We create the index explicitly so ES returns
+        count=0 (log not found) rather than a 404 (index not found).
+        """
+        self.elasticsearch_io.client.indices.create(index=self.target_index)
+
+        log_source_info, log_messages = self.elasticsearch_io.read("", ti)
+
+        assert log_source_info == []
+        assert len(log_messages) == 1
+        assert "not found in Elasticsearch" in log_messages[0]

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -1023,34 +1023,6 @@ class TestElasticsearchRemoteLogIO:
         """Generate a unique index name for each test."""
         return f"airflow-logs-{uuid.uuid4()}"
 
-    @pytest.mark.integration("elasticsearch")
-    @pytest.mark.setup_timeout(300)
-    @pytest.mark.execution_timeout(300)
-    @patch(
-        "airflow.providers.elasticsearch.log.es_task_handler.TASK_LOG_FIELDS",
-        ["message"],
-    )
-    def test_read_write_to_es(self, tmp_json_file, ti, es_8_container_url):
-        self.elasticsearch_io.host = es_8_container_url
-        self.elasticsearch_io.client = elasticsearch.Elasticsearch(es_8_container_url).options(
-            request_timeout=120, retry_on_timeout=True, max_retries=5
-        )
-        self.elasticsearch_io.write_stdout = False
-        self.elasticsearch_io.upload(tmp_json_file, ti)
-        self.elasticsearch_io.client.indices.refresh(
-            index=self.elasticsearch_io.target_index, request_timeout=120
-        )
-        log_source_info, log_messages = self.elasticsearch_io.read("", ti)
-        assert log_source_info[0] == es_8_container_url
-        assert len(log_messages) == 3
-
-        expected_msg = ["start", "processing", "end"]
-        for msg, log_message in zip(expected_msg, log_messages):
-            print(f"msg: {msg}, log_message: {log_message}")
-            json_log = json.loads(log_message)
-            assert "message" in json_log
-            assert json_log["message"] == msg
-
     def test_write_to_stdout(self, tmp_json_file, ti, capsys):
         self.elasticsearch_io.write_to_es = False
         self.elasticsearch_io.upload(tmp_json_file, ti)


### PR DESCRIPTION
`elasticsearch` was explicitly listed in `DISABLE_TESTABLE_INTEGRATIONS_FROM_CI`. This meant the test was never run in CI.

 Fix

- Create a proper integration test at `providers/elasticsearch/tests/integration/elasticsearch/log/test_es_remote_log_io.py` that uses the Breeze ES service (http://elasticsearch:9200) directly - the same pattern used by Mongo
  and Redis providers. 
- Move tests that involves IO with `elasticsearch` to integration test
- Remove the now-unused `testcontainers` fixture pyproject.toml.
- Remove `elasticsearch` from `DISABLE_TESTABLE_INTEGRATIONS_FROM_CI` so the integration test runs as a separate CI job whenever the Elasticsearch provider is affected.
