### PR TITLE
Fix duplicate plugin names by surfacing import errors

### DIFF
--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -94,15 +94,35 @@ def _get_plugins() -> tuple[list[AirflowPlugin], dict[str, str]]:
 
     plugins: list[AirflowPlugin] = []
     import_errors: dict[str, str] = {}
-    loaded_plugins: set[str | None] = set()
+    loaded_plugins: dict[str | None, str | None] = {}
 
     def __register_plugins(plugin_instances: list[AirflowPlugin], errors: dict[str, str]) -> None:
         for plugin_instance in plugin_instances:
-            if plugin_instance.name in loaded_plugins:
-                log.warning("Plugin %r already registered, skipping", plugin_instance.name)
+            plugin_name = plugin_instance.name
+            plugin_source = str(plugin_instance.source) if plugin_instance.source else None
+
+            if plugin_name in loaded_plugins:
+                existing_source = loaded_plugins[plugin_name]
+                duplicate_source_suffix = (
+                    f" from {existing_source}" if existing_source else ""
+                )
+                log.warning(
+                    "Plugin %r already registered%s, skipping",
+                    plugin_name,
+                    duplicate_source_suffix,
+                )
+                error_name = plugin_source or plugin_name or ""
+                import_errors[error_name] = (
+                    f"Plugin {plugin_name!r} is already registered"
+                    + (
+                        f" (existing source: {existing_source})"
+                        if existing_source
+                        else ""
+                    )
+                )
                 continue
 
-            loaded_plugins.add(plugin_instance.name)
+            loaded_plugins[plugin_name] = plugin_source
             try:
                 plugin_instance.on_load()
                 plugins.append(plugin_instance)

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -103,22 +103,15 @@ def _get_plugins() -> tuple[list[AirflowPlugin], dict[str, str]]:
 
             if plugin_name in loaded_plugins:
                 existing_source = loaded_plugins[plugin_name]
-                duplicate_source_suffix = (
-                    f" from {existing_source}" if existing_source else ""
-                )
+                duplicate_source_suffix = f" from {existing_source}" if existing_source else ""
                 log.warning(
                     "Plugin %r already registered%s, skipping",
                     plugin_name,
                     duplicate_source_suffix,
                 )
                 error_name = plugin_source or plugin_name or ""
-                import_errors[error_name] = (
-                    f"Plugin {plugin_name!r} is already registered"
-                    + (
-                        f" (existing source: {existing_source})"
-                        if existing_source
-                        else ""
-                    )
+                import_errors[error_name] = f"Plugin {plugin_name!r} is already registered" + (
+                    f" (existing source: {existing_source})" if existing_source else ""
                 )
                 continue
 

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -160,9 +160,7 @@ class TestPluginsManager:
         assert "plugin_b" in plugin_names
         assert "plugin_c" in plugin_names
         assert len(plugins) == 3
-        assert import_errors == {
-            "plugin_b": "Plugin 'plugin_b' is already registered"
-        }
+        assert import_errors == {"plugin_b": "Plugin 'plugin_b' is already registered"}
 
     def test_should_warning_about_incompatible_plugins(self, caplog):
         class AirflowAdminViewsPlugin(AirflowPlugin):

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -125,7 +125,7 @@ class TestPluginsManager:
         assert "Failed to load plugin" in received_logs
         assert "testplugin.py" in received_logs
 
-    def test_duplicate_plugin_name_does_not_prevent_loading_subsequent_plugins(self):
+    def test_duplicate_plugin_name_is_reported_and_does_not_prevent_loading_subsequent_plugins(self):
         from airflow import plugins_manager
 
         class PluginA(AirflowPlugin):
@@ -160,7 +160,9 @@ class TestPluginsManager:
         assert "plugin_b" in plugin_names
         assert "plugin_c" in plugin_names
         assert len(plugins) == 3
-        assert not import_errors
+        assert import_errors == {
+            "plugin_b": "Plugin 'plugin_b' is already registered"
+        }
 
     def test_should_warning_about_incompatible_plugins(self, caplog):
         class AirflowAdminViewsPlugin(AirflowPlugin):


### PR DESCRIPTION
## Summary
Fixes #55140.

When two plugins share the same `AirflowPlugin.name`, Airflow currently logs a warning and silently skips the duplicate. This can hide the real problem from users (especially when only one plugin appears in UI/API).

This change keeps the current non-blocking behavior (subsequent plugins still load), but also records duplicate plugin-name conflicts as import errors so the issue is visible and actionable.

## Changes
- In `airflow.plugins_manager._get_plugins()`:
  - track loaded plugin names with their source
  - on duplicate name:
    - keep warning log
    - add an explicit entry to `import_errors`
- Update unit test coverage in `test_plugins_manager.py`:
  - `test_duplicate_plugin_name_is_reported_and_does_not_prevent_loading_subsequent_plugins`
  - verifies duplicate is reported in `import_errors` while unique plugins still load

## Why this approach
- Surfaces the conflict as a concrete error instead of only a warning.
- Preserves existing resilience: one bad/duplicate plugin does not block other plugins.
