### PR TITLE
Add CI workflow to validate newsfragment PR numbers

### DIFF
--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -44,8 +44,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: "${{ github.event.pull_request.number }}"
         run: |
-          # Find newsfragment files whose PR number doesn't match this PR
-          bad=$(gh pr diff "$PR_NUMBER" --name-only \
+          # Find newsfragment files whose PR number doesn't match this PR.
+          # Use the REST API to get file statuses so we can exclude deleted files.
+          bad=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | select(.status != "removed") | .filename' \
             | grep '/newsfragments/.*\.rst$' \
             | grep -v "/newsfragments/${PR_NUMBER}\." || true)
 

--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Check newsfragment PR number
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+      - v[0-9]+-[0-9]+-test
+      - v[0-9]+-[0-9]+-stable
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: check-newsfragment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-newsfragment-pr-number:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check newsfragment PR number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: "${{ github.event.pull_request.number }}"
+        run: |
+          # Find newsfragment files whose PR number doesn't match this PR
+          bad=$(gh pr diff "$PR_NUMBER" --name-only \
+            | grep '/newsfragments/.*\.rst$' \
+            | grep -v "/newsfragments/${PR_NUMBER}\." || true)
+
+          if [ -n "$bad" ]; then
+            echo "::error::Newsfragment PR number mismatch. Expected ${PR_NUMBER} but found: ${bad}"
+            exit 1
+          fi


### PR DESCRIPTION
Newsfragment files follow the naming convention `{pr_number}.{type}.rst`, but nothing currently validates that the PR number in the filename matches the actual PR number. This can be because a contributor copies a newsfragment from another PR or made a typo (**this literally happened today in a PR I reviewed https://github.com/apache/airflow/pull/62964#discussion_r2893133305**), and the mismatch goes unnoticed until a reviewer catches it manually or cause confusion in the final release note.

The existing `scripts/ci/prek/newsfragments.py` validation script runs as a local pre-commit hook where the PR number is not yet known, so it cannot perform this check. Rather than extending that script with optional CLI args and a separate CI invocation, this adds a standalone lightweight workflow that uses `gh pr diff --name-only` to get the list of changed files, greps for newsfragment `.rst` files, and checks that none have a mismatched PR number — all in a single piped command, no checkout needed.

Notes for reviewers:
- `gh pr diff --name-only` includes deleted files. In practice, newsfragment deletions only happen during towncrier releases on main, not in contributor PRs, so this is not a concern for the `pull_request` trigger.
- The `pull-requests: read` permission is required for `gh pr diff` to work on fork PRs.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
