### PR TITLE
Fix: Replace print with logger in Hive Hook kill method

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py
@@ -519,7 +519,7 @@ class HiveCliHook(BaseHook):
         """Kill Hive cli command."""
         if hasattr(self, "sub_process"):
             if self.sub_process.poll() is None:
-                print("Killing the Hive job")
+                self.log.info("Killing the Hive job")
                 self.sub_process.terminate()
                 time.sleep(60)
                 self.sub_process.kill()


### PR DESCRIPTION
## Description

During static analysis, I noticed that `print("Killing the Hive job")` is being used rather than the standard Airflow structured logging in `HiveCliHook.kill()`.

This PR replaces `print` with `self.log.info` so the message surfaces correctly in Airflow logs (e.g. Elasticsearch, CloudWatch, or local task logs) rather than bypassing it, making debugging job interruptions easier.

## Tests
Tested manually with existing tests via CI.

- [x] The code is tested
- [ ] - [ ] My PR has system tests (Not strictly required for this)
- [ ] - [ ] The code is documented