### PR TITLE
Fix flaky backfill e2e tests: increase timeouts for CI/PROD image

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/specs/backfill.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/backfill.spec.ts
@@ -218,8 +218,8 @@ test.describe("Backfill pause, resume, and cancel controls", () => {
     await expect(async () => {
       await backfillPage.page.reload();
       await expect(backfillPage.triggerButton).toBeVisible({ timeout: 10_000 });
-      await expect(backfillPage.pauseButton).toBeVisible({ timeout: 5000 });
-    }).toPass({ timeout: 60_000 });
+      await expect(backfillPage.pauseButton).toBeVisible({ timeout: 15_000 });
+    }).toPass({ timeout: 120_000 });
   });
 
   test.afterEach(async () => {


### PR DESCRIPTION
Increases timeouts in the backfill pause/resume/cancel e2e spec so the test is less flaky when the backfill takes longer to show controls (e.g. in CI or with PROD image).

- `pauseButton` visibility: 5s → 15s
- `toPass` retry loop: 60s → 120s

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor Agent

Generated-by: Cursor Agent following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)