### PR TITLE
fix: clean up Docker resources after executing commands in Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -1131,7 +1131,12 @@ def run(
     from airflow_breeze.commands.ci_image_commands import rebuild_or_pull_ci_image_if_needed
     from airflow_breeze.params.shell_params import ShellParams
     from airflow_breeze.utils.ci_group import ci_group
-    from airflow_breeze.utils.docker_command_utils import execute_command_in_shell
+    from airflow_breeze.utils.docker_command_utils import (
+        bring_compose_project_down,
+        execute_command_in_shell,
+        fix_ownership_using_docker,
+        remove_docker_networks,
+    )
     from airflow_breeze.utils.platforms import get_normalized_platform
 
     # Generate a unique project name to avoid conflicts with other running instances
@@ -1178,21 +1183,22 @@ def run(
     # Build or pull the CI image if needed
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
 
-    # Execute the command in the shell
-    with ci_group(f"Running command: {command}"):
-        result = execute_command_in_shell(
-            shell_params=shell_params,
-            project_name=unique_project_name,
-            command=full_command,
-            # Always preserve the backend specified by user (or resolved from default)
-            preserve_backend=True,
-            forward_ports=forward_ports,
-        )
-
-    # Clean up ownership
-    from airflow_breeze.utils.docker_command_utils import fix_ownership_using_docker
-
-    fix_ownership_using_docker()
+    # Execute the command in the shell, cleaning up Docker resources afterward
+    try:
+        with ci_group(f"Running command: {command}"):
+            result = execute_command_in_shell(
+                shell_params=shell_params,
+                project_name=unique_project_name,
+                command=full_command,
+                # Always preserve the backend specified by user (or resolved from default)
+                preserve_backend=True,
+                forward_ports=forward_ports,
+            )
+    finally:
+        # Clean up ownership, the unique compose project and its network
+        bring_compose_project_down(preserve_volumes=False, shell_params=shell_params)
+        remove_docker_networks([f"{unique_project_name}_default"])
+        fix_ownership_using_docker()
 
     # Exit with the same code as the command
     sys.exit(result.returncode)


### PR DESCRIPTION
Fix `breeze run` leaking a Docker network on every invocation

Each `breeze run` creates a unique compose project (`breeze-run-<uuid>`) but never tears it down afterward. The `--rm` flag on `docker compose run` removes the container but not the network.

Over time, stale networks accumulate and Docker's IPAM exhausts its default address pool. In my case, it ended with docker Docker allocate an ip identical to my wifi router's IP. This created a bridge interface that captured traffic meant for the real gateway, silently breaking all my IPv4 connectivity.

My implementation wrap the command execution in `try/finally` and call `bring_compose_project_down` + `remove_docker_networks`, matching the existing pattern in [`testing_commands.py`](https://github.com/apache/airflow/blob/main/dev/breeze/src/airflow_breeze/commands/testing_commands.py).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
