### PR TITLE
Fix mypy issues from trinodb 0.337.0

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -51,7 +52,7 @@ class _TrinoToGCSTrinoCursorAdapter:
         self.initialized: bool = False
 
     @property
-    def description(self) -> list[tuple]:
+    def description(self) -> Sequence[tuple[Any, ...]]:
         """
         This read-only attribute is a sequence of 7-item sequences.
 

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -163,7 +163,7 @@ class TrinoHook(DbApiHook):
             raise AirflowException(
                 f"Multiple authentication methods specified: {', '.join(auth_methods)}. Only one is allowed."
             )
-        if db.password:
+        if db.password and db.login:
             auth = trino.auth.BasicAuthentication(db.login, db.password)
         elif extra.get("auth") == "jwt":
             if not exactly_one(jwt_file := "jwt__file" in extra, jwt_token := "jwt__token" in extra):
@@ -183,8 +183,8 @@ class TrinoHook(DbApiHook):
             auth = trino.auth.JWTAuthentication(token=token)
         elif extra.get("auth") == "certs":
             auth = trino.auth.CertificateAuthentication(
-                extra.get("certs__client_cert_path"),
-                extra.get("certs__client_key_path"),
+                extra["certs__client_cert_path"],
+                extra["certs__client_key_path"],
             )
         elif extra.get("auth") == "kerberos":
             auth = trino.auth.KerberosAuthentication(

--- a/providers/trino/src/airflow/providers/trino/hooks/trino.py
+++ b/providers/trino/src/airflow/providers/trino/hooks/trino.py
@@ -148,7 +148,7 @@ class TrinoHook(DbApiHook):
         """Return a connection object."""
         db = self.get_connection(self.get_conn_id())
         extra = db.extra_dejson
-        auth = None
+        auth: trino.auth.Authentication | None = None
         user = db.login
         auth_methods = []
         if db.password:


### PR DESCRIPTION
Fixing
```
providers/trino/src/airflow/providers/trino/hooks/trino.py:167: error: Argument 1 to "BasicAuthentication" has incompatible type "str | None"; expected "str"  [arg-type]
                  auth = trino.auth.BasicAuthentication(db.login, db.password)
                                                        ^~~~~~~~
  providers/trino/src/airflow/providers/trino/hooks/trino.py:183: error: Incompatible types in assignment (expression has type "JWTAuthentication", variable has type "BasicAuthentication | None") 
  [assignment]
                  auth = trino.auth.JWTAuthentication(token=token)
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  providers/trino/src/airflow/providers/trino/hooks/trino.py:185: error: Incompatible types in assignment (expression has type "CertificateAuthentication", variable has type "BasicAuthentication | None")
   [assignment]
                  auth = trino.auth.CertificateAuthentication(
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  providers/trino/src/airflow/providers/trino/hooks/trino.py:186: error: Argument 1 to "CertificateAuthentication" has incompatible type "Any | None"; expected "str"  [arg-type]
                      extra.get("certs__client_cert_path"),
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  providers/trino/src/airflow/providers/trino/hooks/trino.py:187: error: Argument 2 to "CertificateAuthentication" has incompatible type "Any | None"; expected "str"  [arg-type]
                      extra.get("certs__client_key_path"),
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  providers/trino/src/airflow/providers/trino/hooks/trino.py:190: error: Incompatible types in assignment (expression has type "KerberosAuthentication", variable has type "BasicAuthentication | None") 
  [assignment]
                  auth = trino.auth.KerberosAuthentication(
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py:74: error: Incompatible return value type (got "list[ColumnDescription]", expected "list[tuple[Any, ...]]")  [return-value]
              return self.cursor.description
                     ^~~~~~~~~~~~~~~~~~~~~~~
  providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py:74: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
  providers/google/src/airflow/providers/google/cloud/transfers/trino_to_gcs.py:74: note: Consider using "Sequence" instead, which is covariant
  Found 7 errors in 2 files (checked 4242 source files)
  ```