### PR TITLE
fix: task_instance_mutation_hook receives a TI with run_id set

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1949,6 +1949,7 @@ class TaskInstance(Base, LoggingMixin):
         super().__init__()
         self.dag_id = task.dag_id
         self.task_id = task.task_id
+        self.run_id = run_id
         self.map_index = map_index
         self.refresh_from_task(task)
         if TYPE_CHECKING:

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -779,6 +779,34 @@ class TestDagRun:
         task = dagrun.get_task_instances()[0]
         assert task.queue == "queue1"
 
+    @mock.patch.object(settings, "task_instance_mutation_hook", autospec=True)
+    def test_task_instance_mutation_hook_has_run_id(self, mock_hook, session):
+        """Test that task_instance_mutation_hook receives a TI with run_id set (not None).
+
+        Regression test for https://github.com/apache/airflow/issues/61945
+        """
+        observed_run_ids = []
+
+        def mutate_task_instance(task_instance):
+            observed_run_ids.append(task_instance.run_id)
+            if task_instance.run_id and task_instance.run_id.startswith("manual__"):
+                task_instance.pool = "manual_pool"
+
+        mock_hook.side_effect = mutate_task_instance
+
+        dag = DAG(
+            "test_mutation_hook_run_id",
+            schedule=datetime.timedelta(days=1),
+            start_date=DEFAULT_DATE,
+        )
+        dag.add_task(EmptyOperator(task_id="mutated_task", owner="test"))
+
+        dagrun = self.create_dag_run(dag, session=session)
+        # The hook should have been called during TI creation with run_id set
+        assert any(rid is not None for rid in observed_run_ids), (
+            f"task_instance_mutation_hook was called with run_id=None. Observed run_ids: {observed_run_ids}"
+        )
+
     @pytest.mark.parametrize(
         "prev_ti_state, is_ti_success",
         [

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -801,7 +801,7 @@ class TestDagRun:
         )
         dag.add_task(EmptyOperator(task_id="mutated_task", owner="test"))
 
-        dagrun = self.create_dag_run(dag, session=session)
+        self.create_dag_run(dag, session=session)
         # The hook should have been called during TI creation with run_id set
         assert any(
             rid is not None for rid in observed_run_ids

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -803,9 +803,9 @@ class TestDagRun:
 
         dagrun = self.create_dag_run(dag, session=session)
         # The hook should have been called during TI creation with run_id set
-        assert any(rid is not None for rid in observed_run_ids), (
-            f"task_instance_mutation_hook was called with run_id=None. Observed run_ids: {observed_run_ids}"
-        )
+        assert any(
+            rid is not None for rid in observed_run_ids
+        ), f"task_instance_mutation_hook was called with run_id=None. Observed run_ids: {observed_run_ids}"
 
     @pytest.mark.parametrize(
         "prev_ti_state, is_ti_success",


### PR DESCRIPTION
## Summary

- Fix `task_instance_mutation_hook` receiving `run_id=None` during TaskInstance creation
- Add regression test verifying the hook sees the correct `run_id`

## Root Cause

In `airflow/models/taskinstance.py`, `TI.__init__()` calls `self.refresh_from_task(task)` which invokes `task_instance_mutation_hook(task_instance)` via `_refresh_from_task()`. However, `self.run_id` is not assigned until **after** this call, so any mutation hook that depends on `run_id` sees `None`.

```python
# Before (buggy order in TI.__init__):
self.refresh_from_task(task)  # calls hook — self.run_id is None here
...
self.run_id = run_id          # too late
```

This means a hook like the one in the issue:

```python
def task_instance_mutation_hook(task_instance):
    if task_instance.run_id.startswith("manual__"):
        task_instance.pool = "manual_pool"
```

fails with `AttributeError: 'NoneType' object has no attribute 'startswith'` (or silently does nothing if guarded with `getattr`).

## Fix

Move `self.run_id = run_id` before `self.refresh_from_task(task)` in `TI.__init__()`:

```python
# After (fixed):
self.run_id = run_id          # set BEFORE refresh_from_task
self.map_index = map_index
self.refresh_from_task(task)  # hook now sees correct run_id
```

The later `self.run_id = run_id` assignment is kept because the deprecated `execution_date` code path may resolve `run_id` from a database lookup and needs to overwrite the initial value.

## Test Plan

- [x] Added `test_task_instance_mutation_hook_has_run_id` in `tests/models/test_dagrun.py` that verifies the mutation hook receives a TI with `run_id` set (not `None`) during `create_dagrun()` / `verify_integrity()`


closes: #61945

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
