### PR TITLE
fix(ui): show permission error when triggering DAG without permission

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -168,7 +168,6 @@
     "intervalStart": "البداية",
     "loading": "جارٍ تحميل معلومات Dag...",
     "loadingFailed": "فشل تحميل معلومات Dag. يرجى المحاولة مرة أخرى.",
-    "permissionDenied": "You do not have permission to trigger this DAG.",
     "runIdHelp": "اختياري - سيتم توليده تلقائيًا إذا لم يتم توفيره.",
     "selectDescription": "تشغيل عملية واحدة من هذا Dag",
     "selectLabel": "تشغيلة واحدة",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/components.json
@@ -168,6 +168,7 @@
     "intervalStart": "البداية",
     "loading": "جارٍ تحميل معلومات Dag...",
     "loadingFailed": "فشل تحميل معلومات Dag. يرجى المحاولة مرة أخرى.",
+    "permissionDenied": "You do not have permission to trigger this DAG.",
     "runIdHelp": "اختياري - سيتم توليده تلقائيًا إذا لم يتم توفيره.",
     "selectDescription": "تشغيل عملية واحدة من هذا Dag",
     "selectLabel": "تشغيلة واحدة",

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -62,28 +62,28 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
     }
   };
 
- const onError = (err: unknown) => {
-  let message = "Unknown error";
+  const onError = (err: unknown) => {
+    let message = "Unknown error";
 
- if (err instanceof Error) {
-  const { message: errMessage } = err;
+    if (err instanceof Error) {
+      const { message: errMessage } = err;
 
-  message = errMessage;
-}
-if (typeof err === "object" && err !== null && "response" in err) {
-  const { response } = err as { response?: { status?: number } };
+      message = errMessage;
+    }
+    if (typeof err === "object" && err !== null && "response" in err) {
+      const { response } = err as { response?: { status?: number } };
 
-  if (response?.status === 403) {
-    message = translate("triggerDag.permissionDenied");
-  }
-}
-  toaster.create({
-    description: message,
-    title: translate("triggerDag.toaster.error.title"),
-    type: "error",
-  });
-  setError(err);
-};
+      if (response?.status === 403) {
+        message = translate("triggerDag.permissionDenied");
+      }
+    }
+    toaster.create({
+      description: message,
+      title: translate("triggerDag.toaster.error.title"),
+      type: "error",
+    });
+    setError(err);
+  };
   const { isPending, mutate } = useDagRunServiceTriggerDagRun({
     onError,
     onSuccess,

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -62,15 +62,28 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
     }
   };
 
-  const onError = (_error: Error) => {
-    toaster.create({
-      description: _error.message,
-      title: translate("triggerDag.toaster.error.title"),
-      type: "error",
-    });
-    setError(_error);
-  };
+ const onError = (err: unknown) => {
+  let message = "Unknown error";
 
+ if (err instanceof Error) {
+  const { message: errMessage } = err;
+
+  message = errMessage;
+}
+if (typeof err === "object" && err !== null && "response" in err) {
+  const { response } = err as { response?: { status?: number } };
+
+  if (response?.status === 403) {
+    message = translate("triggerDag.permissionDenied");
+  }
+}
+  toaster.create({
+    description: message,
+    title: translate("triggerDag.toaster.error.title"),
+    type: "error",
+  });
+  setError(err);
+};
   const { isPending, mutate } = useDagRunServiceTriggerDagRun({
     onError,
     onSuccess,


### PR DESCRIPTION
### What this PR does

Improves error handling when triggering a DAG without sufficient permissions.

Previously the UI displayed a generic "Forbidden" error message when the backend returned a 403 response.  
This change detects the 403 response and shows a clearer permission-related message in the UI toast.

### Changes

- Detect 403 responses in `useTrigger`
- Show `triggerDag.permissionDenied` message instead of generic error
- Added missing i18n key for the permission error message

### How it was tested

- Ran Airflow locally using Breeze
- Triggered a DAG as a user without permission
- Verified that the UI now shows a clear permission error message
- Verified UI builds successfully (`pnpm build`)
- Verified lint passes (`pnpm lint`)