### PR TITLE
Fix Breeze unit tests for milestone tagging

### DIFF
--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -446,6 +446,8 @@ class TestSetMilestoneCommand:
                 "testuser",
                 "--github-token",
                 "fake-token",
+                "--github-repository",
+                "apache/airflow",
             ],
         )
 
@@ -550,6 +552,8 @@ If this milestone is not correct, please update it to the appropriate milestone.
                 "testuser",
                 "--github-token",
                 "fake-token",
+                "--github-repository",
+                "apache/airflow",
             ],
         )
 


### PR DESCRIPTION
The `.github/workflows/ci.yml` run for `Breeze unit tests` is failing in forks because the `GITHUB_REPOSITORY` environment variable overrules `option_github_repository` default of `apache/airflow`. 

This causes two test assertions to fail when checking the comment URL generated. Explicitly passing `--github-repository apache/airflow` in these tests stabilizes them for forks.