### PR TITLE
Add ExecuteCallback support to AwsLambdaExecutor

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -231,15 +231,15 @@ class AwsLambdaExecutor(BaseExecutor):
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         from airflow.executors import workloads
 
-        for w in workload_items:
+        for workload in workload_items:
             queue: str | None
             key: WorkloadKey
             command: CommandType
-            if isinstance(w, workloads.ExecuteTask):
-                command = [w]
-                key = w.ti.key
-                queue = w.ti.queue
-                executor_config = w.ti.executor_config or {}
+            if isinstance(workload, workloads.ExecuteTask):
+                command = [workload]
+                key = workload.ti.key
+                queue = workload.ti.queue
+                executor_config = workload.ti.executor_config or {}
 
                 del self.queued_tasks[key]
 
@@ -253,13 +253,13 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.running.add(key)
                 continue
 
-            if AIRFLOW_V_3_2_PLUS and isinstance(w, workloads.ExecuteCallback):
-                command = [w]
-                key = w.callback.id
+            if AIRFLOW_V_3_2_PLUS and isinstance(workload, workloads.ExecuteCallback):
+                command = [workload]
+                key = workload.callback.id
                 queue = None
 
-                if isinstance(w.callback.data, dict) and "queue" in w.callback.data:
-                    queue = w.callback.data["queue"]
+                if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
+                    queue = workload.callback.data["queue"]
 
                 del self.queued_callbacks[key]
 
@@ -272,7 +272,7 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.running.add(key)
                 continue
 
-            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(w)}")
+            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
     def execute_async(
         self,

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -20,7 +20,7 @@ import json
 import time
 from collections import deque
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from boto3.session import NoCredentialsError
 from botocore.utils import ClientError
@@ -46,10 +46,15 @@ from airflow.providers.common.compat.sdk import AirflowException, Stats, timezon
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
 
-if AIRFLOW_V_3_0_PLUS:
-    from airflow.executors import workloads
+    if AIRFLOW_V_3_2_PLUS:
+        from airflow.executors.workloads.types import WorkloadKey as _WorkloadKey
+
+        WorkloadKey: TypeAlias = _WorkloadKey
+    else:
+        WorkloadKey: TypeAlias = TaskInstanceKey  # type: ignore[no-redef, misc]
 
 
 class AwsLambdaExecutor(BaseExecutor):
@@ -57,10 +62,10 @@ class AwsLambdaExecutor(BaseExecutor):
     An Airflow Executor that submits workloads (tasks and callbacks) to AWS Lambda asynchronously.
 
     When execute_async() is called, the executor invokes a specified AWS Lambda function (asynchronously)
-    with a payload that includes the task command and a unique task key.
+    with a payload that includes the workload command and a unique workload key.
 
     The Lambda function writes its result directly to an SQS queue, which is then polled by this executor
-    to update task state in Airflow.
+    to update workload state in Airflow.
     """
 
     supports_multi_team: bool = True
@@ -70,16 +75,13 @@ class AwsLambdaExecutor(BaseExecutor):
 
     if TYPE_CHECKING and AIRFLOW_V_3_0_PLUS:
         # In the v3 path, we store workloads, not commands as strings.
-        # TODO: TaskSDK: move this type change into BaseExecutor
-        queued_tasks: dict[TaskInstanceKey, workloads.All]  # type: ignore[assignment]
+        # TODO: TaskSDK: move this type change into BaseExecutor.
+        queued_tasks: dict[WorkloadKey, workloads.All]  # type: ignore[assignment]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.pending_tasks: deque = deque()
-        self.running_tasks: dict[str, TaskInstanceKey | str] = {}
-
-        if AIRFLOW_V_3_2_PLUS:
-            self.queued_callbacks: dict[str, workloads.ExecuteCallback] = {}
+        self.pending_workloads: deque = deque()
+        self.running_workloads: dict[str, WorkloadKey] = {}
 
         # Check if self has the ExecutorConf set on the self.conf attribute, and if not, set it to the global
         # configuration object. This allows the changes to be backwards compatible with older versions of
@@ -145,7 +147,7 @@ class AwsLambdaExecutor(BaseExecutor):
 
         self.log.info("Checking Lambda and SQS connections")
         try:
-            # Check Lambda health
+            # Check Lambda health.
             lambda_get_response = self.lambda_client.get_function(FunctionName=self.lambda_function_name)
             if self.lambda_function_name not in lambda_get_response["Configuration"]["FunctionName"]:
                 raise AirflowException("Lambda function %s not found.", self.lambda_function_name)
@@ -153,12 +155,12 @@ class AwsLambdaExecutor(BaseExecutor):
                 "Lambda connection is healthy and function %s is present.", self.lambda_function_name
             )
 
-            # Check SQS results queue
+            # Check SQS results queue.
             _check_queue(self.sqs_queue_url)
-            # Check SQS dead letter queue
+            # Check SQS dead letter queue.
             _check_queue(self.dlq_url)
 
-            # If we reach this point, both connections are healthy and all resources are present
+            # If we reach this point, both connections are healthy and all resources are present.
             self.IS_BOTO_CONNECTION_HEALTHY = True
         except Exception:
             self.log.exception("Lambda Executor health check failed")
@@ -189,7 +191,7 @@ class AwsLambdaExecutor(BaseExecutor):
         """
         Sync the executor with the current state of workloads.
 
-        Check in on currently running workloads and attempt to run any new workloads that have been queued.
+        Check in on currently running tasks and callbacks and attempt to run any new workloads that have been queued.
         """
         if not self.IS_BOTO_CONNECTION_HEALTHY:
             exponential_backoff_retry(
@@ -200,8 +202,8 @@ class AwsLambdaExecutor(BaseExecutor):
             if not self.IS_BOTO_CONNECTION_HEALTHY:
                 return
         try:
-            self.sync_running_tasks()
-            self.attempt_task_runs()
+            self.sync_running_workloads()
+            self.attempt_workload_runs()
         except (ClientError, NoCredentialsError) as error:
             error_code = error.response["Error"]["Code"]
             if error_code in INVALID_CREDENTIALS_EXCEPTIONS:
@@ -210,9 +212,10 @@ class AwsLambdaExecutor(BaseExecutor):
                     "AWS credentials are either missing or expired: %s.\nRetrying connection", error
                 )
         except Exception:
-            self.log.exception("An error occurred while syncing tasks")
+            self.log.exception("An error occurred while syncing workloads.")
 
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
+        from airflow.executors import workloads
 
         if isinstance(workload, workloads.ExecuteTask):
             ti = workload.ti
@@ -226,11 +229,12 @@ class AwsLambdaExecutor(BaseExecutor):
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
+        from airflow.executors import workloads
 
         for w in workload_items:
-            key: TaskInstanceKey | str
-            command: list[workloads.All]
             queue: str | None
+            key: WorkloadKey
+            command: CommandType
             if isinstance(w, workloads.ExecuteTask):
                 command = [w]
                 key = w.ti.key
@@ -272,8 +276,8 @@ class AwsLambdaExecutor(BaseExecutor):
 
     def execute_async(
         self,
-        key: TaskInstanceKey | str,
-        command: CommandType | Sequence[workloads.All],
+        key: WorkloadKey,
+        command: CommandType,
         queue=None,
         executor_config=None,
     ):
@@ -281,19 +285,21 @@ class AwsLambdaExecutor(BaseExecutor):
         Save the workload to be executed in the next sync by inserting the commands into a queue.
 
         :param key: Unique workload key. Task workloads use TaskInstanceKey, callback workloads use a string id.
-        :param command: The shell command string to execute.
+        :param command: The workload command or serialized shell command to execute.
         :param executor_config:  (Unused) to keep the same signature as the base.
         :param queue: (Unused) to keep the same signature as the base.
         """
         if len(command) == 1:
-            if AIRFLOW_V_3_2_PLUS:
-                if not isinstance(command[0], (workloads.ExecuteTask, workloads.ExecuteCallback)):
-                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(command[0])}")
-            else:
-                if not isinstance(command[0], workloads.ExecuteTask):
-                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(command[0])}")
+            from airflow.executors import workloads
 
             workload = command[0]
+
+            if AIRFLOW_V_3_2_PLUS:
+                if not isinstance(workload, (workloads.ExecuteTask, workloads.ExecuteCallback)):
+                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
+            else:
+                if not isinstance(workload, workloads.ExecuteTask):
+                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
             ser_input = workload.model_dump_json()
 
@@ -305,43 +311,45 @@ class AwsLambdaExecutor(BaseExecutor):
                 ser_input,
             ]
 
-        self.pending_tasks.append(
+        self.pending_workloads.append(
             LambdaQueuedTask(
                 key, command, queue if queue else "", executor_config or {}, 1, timezone.utcnow()
             )
         )
 
-    def attempt_task_runs(self):
+    def attempt_workload_runs(self):
         """
-        Attempt to run workloads that are queued in the pending_tasks.
+        Attempt to run workloads that are queued in the pending_workloads.
 
-        Each task is submitted to AWS Lambda with a payload containing the task key and command.
-        The task key is used to track the task's state in Airflow.
+        Each workload is submitted to AWS Lambda with a payload containing the workload key and command.
+        The workload key is used to track the workload's state in Airflow.
         """
-        queue_len = len(self.pending_tasks)
+        queue_len = len(self.pending_workloads)
         for _ in range(queue_len):
-            task_to_run = self.pending_tasks.popleft()
-            task_key = task_to_run.key
-            cmd = task_to_run.command
-            attempt_number = task_to_run.attempt_number
+            workload_to_run = self.pending_workloads.popleft()
+            workload_key = workload_to_run.key
+            cmd = workload_to_run.command
+            attempt_number = workload_to_run.attempt_number
             failure_reasons = []
 
             try:
-                ser_task_key = json.dumps(task_key._asdict())
+                ser_workload_key = json.dumps(workload_key._asdict())
             except AttributeError:
                 # Callback workloads use string id.
-                ser_task_key = task_key
+                ser_workload_key = workload_key
 
             payload = {
-                "task_key": ser_task_key,
+                "task_key": ser_workload_key,
                 "command": cmd,
-                "executor_config": task_to_run.executor_config,
+                "executor_config": workload_to_run.executor_config,
             }
-            if timezone.utcnow() < task_to_run.next_attempt_time:
-                self.pending_tasks.append(task_to_run)
+            if timezone.utcnow() < workload_to_run.next_attempt_time:
+                self.pending_workloads.append(workload_to_run)
                 continue
 
-            self.log.info("Submitting workload %s to Lambda function %s", task_key, self.lambda_function_name)
+            self.log.info(
+                "Submitting workload %s to Lambda function %s", workload_key, self.lambda_function_name
+            )
 
             try:
                 invoke_kwargs = {
@@ -353,12 +361,12 @@ class AwsLambdaExecutor(BaseExecutor):
                     invoke_kwargs["Qualifier"] = self.qualifier
                 response = self.lambda_client.invoke(**invoke_kwargs)
             except NoCredentialsError:
-                self.pending_tasks.append(task_to_run)
+                self.pending_workloads.append(workload_to_run)
                 raise
             except ClientError as e:
                 error_code = e.response["Error"]["Code"]
                 if error_code in INVALID_CREDENTIALS_EXCEPTIONS:
-                    self.pending_tasks.append(task_to_run)
+                    self.pending_workloads.append(workload_to_run)
                     raise
                 failure_reasons.append(str(e))
             except Exception as e:
@@ -369,50 +377,50 @@ class AwsLambdaExecutor(BaseExecutor):
                 failure_reasons.append(str(e))
 
             if failure_reasons:
-                # Make sure the number of attempts does not exceed max invoke attempts
+                # Make sure the number of attempts does not exceed max invoke attempts.
                 if int(attempt_number) < int(self.max_invoke_attempts):
-                    task_to_run.attempt_number += 1
-                    task_to_run.next_attempt_time = timezone.utcnow() + calculate_next_attempt_delay(
+                    workload_to_run.attempt_number += 1
+                    workload_to_run.next_attempt_time = timezone.utcnow() + calculate_next_attempt_delay(
                         attempt_number
                     )
-                    self.pending_tasks.append(task_to_run)
+                    self.pending_workloads.append(workload_to_run)
                 else:
                     reasons_str = ", ".join(failure_reasons)
                     self.log.error(
                         "Lambda invoke %s has failed a maximum of %s times. Marking as failed. Reasons: %s",
-                        task_key,
+                        workload_key,
                         attempt_number,
                         reasons_str,
                     )
                     self.log_task_event(
                         event="lambda invoke failure",
-                        ti_key=task_key,
+                        ti_key=workload_key,
                         extra=(
-                            f"Task could not be queued after {attempt_number} attempts. "
+                            f"Workload could not be queued after {attempt_number} attempts. "
                             f"Marking as failed. Reasons: {reasons_str}"
                         ),
                     )
-                    self.fail(task_key)
+                    self.fail(workload_key)
             else:
                 status_code = response.get("StatusCode")
-                self.log.info("Invoked Lambda for workload %s with status %s", task_key, status_code)
-                self.running_tasks[ser_task_key] = task_key
-                # Add the serialized task key as the info, this will be assigned on the ti as the external_executor_id
-                self.running_state(task_key, ser_task_key)
+                self.log.info("Invoked Lambda for workload %s with status %s", workload_key, status_code)
+                self.running_workloads[ser_workload_key] = workload_key
+                # Add the serialized workload key as the info, this will be assigned on the ti as the external_executor_id.
+                self.running_state(workload_key, ser_workload_key)
 
-    def sync_running_tasks(self):
+    def sync_running_workloads(self):
         """
         Poll the SQS queue for messages indicating workload completion.
 
         Each message is expected to contain a JSON payload with 'task_key' and 'return_code'.
         Based on the return code, update the workload state accordingly.
         """
-        if not len(self.running_tasks):
+        if not len(self.running_workloads):
             self.log.debug("No running workloads to process.")
             return
 
         self.process_queue(self.sqs_queue_url)
-        if self.dlq_url and self.running_tasks:
+        if self.dlq_url and self.running_workloads:
             self.process_queue(self.dlq_url)
 
     def process_queue(self, queue_url: str):
@@ -462,17 +470,17 @@ class AwsLambdaExecutor(BaseExecutor):
                 continue
             return_code = body.get("return_code")
             ser_task_key = body.get("task_key")
-            # Fetch the real task key from the running_tasks dict, using the serialized task key.
+            # Fetch the real task key from the running_workloads dict, using the serialized task key.
             try:
-                task_key = self.running_tasks[ser_task_key]
+                workload_key = self.running_workloads[ser_task_key]
             except KeyError:
                 self.log.debug(
-                    "Received workload %s from the queue which is not found in running tasks, it is likely "
+                    "Received workload %s from the queue which is not found in running workloads, it is likely "
                     "from another Lambda Executor sharing this queue or might be a stale message that needs "
                     "deleting manually. Marking the message as visible again.",
                     ser_task_key,
                 )
-                # Mark task as visible again in SQS so that another executor can pick it up.
+                # Mark workload as visible again in SQS so that another executor can pick it up.
                 self.sqs_client.change_message_visibility(
                     QueueUrl=queue_url,
                     ReceiptHandle=receipt_handle,
@@ -480,44 +488,42 @@ class AwsLambdaExecutor(BaseExecutor):
                 )
                 continue
 
-            if task_key:
+            if workload_key:
                 if return_code == 0:
-                    self.success(task_key)  # type: ignore[arg-type]
+                    self.success(cast("TaskInstanceKey", workload_key))
                     self.log.info(
-                        "Successful Lambda invocation for workload %s received from SQS queue.", task_key
+                        "Successful Lambda invocation for workload %s received from SQS queue.",
+                        workload_key,
                     )
                 else:
-                    self.fail(task_key)  # type: ignore[arg-type]
+                    self.fail(cast("TaskInstanceKey", workload_key))
                     if queue_url == self.dlq_url and return_code is None:
-                        # DLQ failure: AWS Lambda service could not complete the invocation after retries.
-                        # This indicates a Lambda-level failure (timeout, memory limit, crash, etc.)
-                        # where the function was unable to successfully execute to return a result.
                         self.log.error(
-                            "DLQ message received: Lambda invocation for task: %s was unable to successfully execute. This likely indicates a Lambda-level failure (timeout, memory limit, crash, etc.).",
-                            task_key,
+                            "DLQ message received: Lambda invocation for workload %s was unable to "
+                            "successfully execute. This likely indicates a Lambda-level failure "
+                            "(timeout, memory limit, crash, etc.).",
+                            workload_key,
                         )
                     else:
-                        # In this case the Lambda likely started but failed at run time since we got a non-zero
-                        # return code. We could consider retrying these tasks within the executor, because this _likely_
-                        # means the Airflow task did not run to completion, however we can't be sure (maybe the
-                        # lambda runtime code has a bug and is returning a non-zero when it actually passed?). So
-                        # perhaps not retrying is the safest option.
                         self.log.debug(
                             "Lambda invocation for workload %s returned a non-zero exit code %s",
-                            task_key,
+                            workload_key,
                             return_code,
                         )
-                # Remove the task from the tracking mapping.
-                self.running_tasks.pop(ser_task_key)
+
+                # Remove the workload from the tracking mapping.
+                self.running_workloads.pop(ser_task_key)
 
             # Delete the message from the queue.
             self.sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt_handle)
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """
-        Adopt task instances which have an external_executor_id (the serialized task key).
+        Adopt task instances which have an external_executor_id (the serialized workload key).
 
-        The external_executor_id may contain either a serialized TaskInstanceKey or a callback identifier string.
+        The external_executor_id represents the workload identifier. In legacy executors (Airflow < 3.2)
+        this is the serialized TaskInstanceKey. In the workload-based executor model (Airflow ≥ 3.2)
+        this corresponds to the WorkloadKey.
 
         Anything that is not adopted will be cleared by the scheduler and becomes eligible for re-scheduling.
 
@@ -526,18 +532,18 @@ class AwsLambdaExecutor(BaseExecutor):
         with Stats.timer("lambda_executor.adopt_task_instances.duration"):
             adopted_tis: list[TaskInstance] = []
 
-            if serialized_task_keys := [
+            if serialized_workload_keys := [
                 (ti, ti.external_executor_id) for ti in tis if ti.external_executor_id
             ]:
-                for ti, ser_task_key in serialized_task_keys:
+                for ti, ser_workload_key in serialized_workload_keys:
                     try:
-                        data = json.loads(ser_task_key)
-                        task_key = TaskInstanceKey.from_dict(data)
+                        data = json.loads(ser_workload_key)
+                        workload_key = TaskInstanceKey.from_dict(data)
                     except Exception:
                         # Callback workloads use string keys.
-                        task_key = ser_task_key
+                        workload_key = ser_workload_key
 
-                    self.running_tasks[ser_task_key] = task_key
+                    self.running_workloads[ser_workload_key] = workload_key
                     adopted_tis.append(ti)
 
             if adopted_tis:
@@ -556,12 +562,12 @@ class AwsLambdaExecutor(BaseExecutor):
         """
         End execution. Poll until all outstanding workloads are marked as completed.
 
-        This is a blocking call and async Lambda workloads can not be cancelled, so this will wait until
+        This is a blocking call and async Lambda workloads cannot be cancelled, so this will wait until
         all workloads are either completed or the timeout is reached.
 
         :param heartbeat_interval: The interval in seconds to wait between checks for workload completion.
         """
-        self.log.info("Received signal to end, waiting for outstanding tasks to finish.")
+        self.log.info("Received signal to end, waiting for outstanding workloads to finish.")
         time_to_wait = int(
             self.conf.get(CONFIG_GROUP_NAME, AllLambdaConfigKeys.END_WAIT_TIMEOUT, fallback="0")
         )
@@ -572,17 +578,17 @@ class AwsLambdaExecutor(BaseExecutor):
                 elapsed_time = (current_time - start_time).total_seconds()
                 if elapsed_time > time_to_wait:
                     self.log.warning(
-                        "Timed out waiting for tasks to finish. Some tasks may not be handled gracefully"
+                        "Timed out waiting for workloads to finish. Some workloads may not be handled gracefully"
                         " as the executor is force ending due to timeout."
                     )
                     break
             self.sync()
-            if not self.running_tasks:
-                self.log.info("All tasks completed; executor ending.")
+            if not self.running_workloads:
+                self.log.info("All workloads completed; executor ending.")
                 break
-            self.log.info("Waiting for %d workload(s) to complete.", len(self.running_tasks))
+            self.log.info("Waiting for %d workload(s) to complete.", len(self.running_workloads))
             time.sleep(heartbeat_interval)
 
     def terminate(self):
         """Get called when the daemon receives a SIGTERM."""
-        self.log.warning("Terminating Lambda executor. In-flight tasks cannot be stopped.")
+        self.log.warning("Terminating Lambda executor. In-flight workloads cannot be stopped.")

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -40,19 +40,21 @@ from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry impo
 )
 from airflow.providers.amazon.aws.hooks.lambda_function import LambdaHook
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
-from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.executors import workloads
 
 
 class AwsLambdaExecutor(BaseExecutor):
     """
-    An Airflow Executor that submits tasks to AWS Lambda asynchronously.
+    An Airflow Executor that submits workloads (tasks and callbacks) to AWS Lambda asynchronously.
 
     When execute_async() is called, the executor invokes a specified AWS Lambda function (asynchronously)
     with a payload that includes the task command and a unique task key.
@@ -63,6 +65,9 @@ class AwsLambdaExecutor(BaseExecutor):
 
     supports_multi_team: bool = True
 
+    if AIRFLOW_V_3_2_PLUS:
+        supports_callbacks: bool = True
+
     if TYPE_CHECKING and AIRFLOW_V_3_0_PLUS:
         # In the v3 path, we store workloads, not commands as strings.
         # TODO: TaskSDK: move this type change into BaseExecutor
@@ -71,7 +76,10 @@ class AwsLambdaExecutor(BaseExecutor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.pending_tasks: deque = deque()
-        self.running_tasks: dict[str, TaskInstanceKey] = {}
+        self.running_tasks: dict[str, TaskInstanceKey | str] = {}
+
+        if AIRFLOW_V_3_2_PLUS:
+            self.queued_callbacks: dict[str, workloads.ExecuteCallback] = {}
 
         # Check if self has the ExecutorConf set on the self.conf attribute, and if not, set it to the global
         # configuration object. This allows the changes to be backwards compatible with older versions of
@@ -179,9 +187,9 @@ class AwsLambdaExecutor(BaseExecutor):
 
     def sync(self):
         """
-        Sync the executor with the current state of tasks.
+        Sync the executor with the current state of workloads.
 
-        Check in on currently running tasks and attempt to run any new tasks that have been queued.
+        Check in on currently running workloads and attempt to run any new workloads that have been queued.
         """
         if not self.IS_BOTO_CONNECTION_HEALTHY:
             exponential_backoff_retry(
@@ -205,55 +213,97 @@ class AwsLambdaExecutor(BaseExecutor):
             self.log.exception("An error occurred while syncing tasks")
 
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
-        from airflow.executors import workloads
 
-        if not isinstance(workload, workloads.ExecuteTask):
-            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
-        ti = workload.ti
-        self.queued_tasks[ti.key] = workload
+        if isinstance(workload, workloads.ExecuteTask):
+            ti = workload.ti
+            self.queued_tasks[ti.key] = workload
+            return
 
-    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
-        from airflow.executors.workloads import ExecuteTask
+        if AIRFLOW_V_3_2_PLUS and isinstance(workload, workloads.ExecuteCallback):
+            self.queued_callbacks[workload.callback.id] = workload
+            return
 
-        for w in workloads:
-            if not isinstance(w, ExecuteTask):
-                raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(w)}")
+        raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
-            command = [w]
-            key = w.ti.key
-            queue = w.ti.queue
-            executor_config = w.ti.executor_config or {}
+    def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
 
-            del self.queued_tasks[key]
-            self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)  # type: ignore[arg-type]
-            self.running.add(key)
+        for w in workload_items:
+            key: TaskInstanceKey | str
+            command: list[workloads.All]
+            queue: str | None
+            if isinstance(w, workloads.ExecuteTask):
+                command = [w]
+                key = w.ti.key
+                queue = w.ti.queue
+                executor_config = w.ti.executor_config or {}
 
-    def execute_async(self, key: TaskInstanceKey, command: CommandType, queue=None, executor_config=None):
+                del self.queued_tasks[key]
+
+                self.execute_async(
+                    key=key,
+                    command=command,
+                    queue=queue,
+                    executor_config=executor_config,
+                )
+
+                self.running.add(key)
+                continue
+
+            if AIRFLOW_V_3_2_PLUS and isinstance(w, workloads.ExecuteCallback):
+                command = [w]
+                key = w.callback.id
+                queue = None
+
+                if isinstance(w.callback.data, dict) and "queue" in w.callback.data:
+                    queue = w.callback.data["queue"]
+
+                del self.queued_callbacks[key]
+
+                self.execute_async(
+                    key=key,
+                    command=command,
+                    queue=queue,
+                )
+
+                self.running.add(key)
+                continue
+
+            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(w)}")
+
+    def execute_async(
+        self,
+        key: TaskInstanceKey | str,
+        command: CommandType | Sequence[workloads.All],
+        queue=None,
+        executor_config=None,
+    ):
         """
-        Save the task to be executed in the next sync by inserting the commands into a queue.
+        Save the workload to be executed in the next sync by inserting the commands into a queue.
 
-        :param key: A unique task key (typically a tuple identifying the task instance).
+        :param key: Unique workload key. Task workloads use TaskInstanceKey, callback workloads use a string id.
         :param command: The shell command string to execute.
         :param executor_config:  (Unused) to keep the same signature as the base.
         :param queue: (Unused) to keep the same signature as the base.
         """
         if len(command) == 1:
-            from airflow.executors.workloads import ExecuteTask
-
-            if isinstance(command[0], ExecuteTask):
-                workload = command[0]
-                ser_input = workload.model_dump_json()
-                command = [
-                    "python",
-                    "-m",
-                    "airflow.sdk.execution_time.execute_workload",
-                    "--json-string",
-                    ser_input,
-                ]
+            if AIRFLOW_V_3_2_PLUS:
+                if not isinstance(command[0], (workloads.ExecuteTask, workloads.ExecuteCallback)):
+                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(command[0])}")
             else:
-                raise RuntimeError(
-                    f"LambdaExecutor doesn't know how to handle workload of type: {type(command[0])}"
-                )
+                if not isinstance(command[0], workloads.ExecuteTask):
+                    raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(command[0])}")
+
+            workload = command[0]
+
+            ser_input = workload.model_dump_json()
+
+            command = [
+                "python",
+                "-m",
+                "airflow.sdk.execution_time.execute_workload",
+                "--json-string",
+                ser_input,
+            ]
 
         self.pending_tasks.append(
             LambdaQueuedTask(
@@ -263,7 +313,7 @@ class AwsLambdaExecutor(BaseExecutor):
 
     def attempt_task_runs(self):
         """
-        Attempt to run tasks that are queued in the pending_tasks.
+        Attempt to run workloads that are queued in the pending_tasks.
 
         Each task is submitted to AWS Lambda with a payload containing the task key and command.
         The task key is used to track the task's state in Airflow.
@@ -275,7 +325,13 @@ class AwsLambdaExecutor(BaseExecutor):
             cmd = task_to_run.command
             attempt_number = task_to_run.attempt_number
             failure_reasons = []
-            ser_task_key = json.dumps(task_key._asdict())
+
+            try:
+                ser_task_key = json.dumps(task_key._asdict())
+            except AttributeError:
+                # Callback workloads use string id.
+                ser_task_key = task_key
+
             payload = {
                 "task_key": ser_task_key,
                 "command": cmd,
@@ -285,7 +341,7 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.pending_tasks.append(task_to_run)
                 continue
 
-            self.log.info("Submitting task %s to Lambda function %s", task_key, self.lambda_function_name)
+            self.log.info("Submitting workload %s to Lambda function %s", task_key, self.lambda_function_name)
 
             try:
                 invoke_kwargs = {
@@ -339,20 +395,20 @@ class AwsLambdaExecutor(BaseExecutor):
                     self.fail(task_key)
             else:
                 status_code = response.get("StatusCode")
-                self.log.info("Invoked Lambda for task %s with status %s", task_key, status_code)
+                self.log.info("Invoked Lambda for workload %s with status %s", task_key, status_code)
                 self.running_tasks[ser_task_key] = task_key
                 # Add the serialized task key as the info, this will be assigned on the ti as the external_executor_id
                 self.running_state(task_key, ser_task_key)
 
     def sync_running_tasks(self):
         """
-        Poll the SQS queue for messages indicating task completion.
+        Poll the SQS queue for messages indicating workload completion.
 
         Each message is expected to contain a JSON payload with 'task_key' and 'return_code'.
-        Based on the return code, update the task state accordingly.
+        Based on the return code, update the workload state accordingly.
         """
         if not len(self.running_tasks):
-            self.log.debug("No running tasks to process.")
+            self.log.debug("No running workloads to process.")
             return
 
         self.process_queue(self.sqs_queue_url)
@@ -361,11 +417,11 @@ class AwsLambdaExecutor(BaseExecutor):
 
     def process_queue(self, queue_url: str):
         """
-        Poll the SQS queue for messages indicating task completion.
+        Poll the SQS queue for messages indicating workload completion.
 
         Each message is expected to contain a JSON payload with 'task_key' and 'return_code'.
 
-        Based on the return code, update the task state accordingly.
+        Based on the return code, update the workload state accordingly.
         """
         response = self.sqs_client.receive_message(
             QueueUrl=queue_url,
@@ -411,7 +467,7 @@ class AwsLambdaExecutor(BaseExecutor):
                 task_key = self.running_tasks[ser_task_key]
             except KeyError:
                 self.log.debug(
-                    "Received task %s from the queue which is not found in running tasks, it is likely "
+                    "Received workload %s from the queue which is not found in running tasks, it is likely "
                     "from another Lambda Executor sharing this queue or might be a stale message that needs "
                     "deleting manually. Marking the message as visible again.",
                     ser_task_key,
@@ -426,12 +482,12 @@ class AwsLambdaExecutor(BaseExecutor):
 
             if task_key:
                 if return_code == 0:
-                    self.success(task_key)
+                    self.success(task_key)  # type: ignore[arg-type]
                     self.log.info(
-                        "Successful Lambda invocation for task %s received from SQS queue.", task_key
+                        "Successful Lambda invocation for workload %s received from SQS queue.", task_key
                     )
                 else:
-                    self.fail(task_key)
+                    self.fail(task_key)  # type: ignore[arg-type]
                     if queue_url == self.dlq_url and return_code is None:
                         # DLQ failure: AWS Lambda service could not complete the invocation after retries.
                         # This indicates a Lambda-level failure (timeout, memory limit, crash, etc.)
@@ -447,7 +503,7 @@ class AwsLambdaExecutor(BaseExecutor):
                         # lambda runtime code has a bug and is returning a non-zero when it actually passed?). So
                         # perhaps not retrying is the safest option.
                         self.log.debug(
-                            "Lambda invocation for task: %s completed but the underlying Airflow task has returned a non-zero exit code %s",
+                            "Lambda invocation for workload %s returned a non-zero exit code %s",
                             task_key,
                             return_code,
                         )
@@ -461,6 +517,8 @@ class AwsLambdaExecutor(BaseExecutor):
         """
         Adopt task instances which have an external_executor_id (the serialized task key).
 
+        The external_executor_id may contain either a serialized TaskInstanceKey or a callback identifier string.
+
         Anything that is not adopted will be cleared by the scheduler and becomes eligible for re-scheduling.
 
         :param tis: The task instances to adopt.
@@ -473,13 +531,12 @@ class AwsLambdaExecutor(BaseExecutor):
             ]:
                 for ti, ser_task_key in serialized_task_keys:
                     try:
-                        task_key = TaskInstanceKey.from_dict(json.loads(ser_task_key))
+                        data = json.loads(ser_task_key)
+                        task_key = TaskInstanceKey.from_dict(data)
                     except Exception:
-                        # If that task fails to deserialize, we should just skip it.
-                        self.log.exception(
-                            "Task failed to be adopted because the key could not be deserialized"
-                        )
-                        continue
+                        # Callback workloads use string keys.
+                        task_key = ser_task_key
+
                     self.running_tasks[ser_task_key] = task_key
                     adopted_tis.append(ti)
 
@@ -497,12 +554,12 @@ class AwsLambdaExecutor(BaseExecutor):
 
     def end(self, heartbeat_interval=10):
         """
-        End execution. Poll until all outstanding tasks are marked as completed.
+        End execution. Poll until all outstanding workloads are marked as completed.
 
-        This is a blocking call and async Lambda tasks can not be cancelled, so this will wait until
-        all tasks are either completed or the timeout is reached.
+        This is a blocking call and async Lambda workloads can not be cancelled, so this will wait until
+        all workloads are either completed or the timeout is reached.
 
-        :param heartbeat_interval: The interval in seconds to wait between checks for task completion.
+        :param heartbeat_interval: The interval in seconds to wait between checks for workload completion.
         """
         self.log.info("Received signal to end, waiting for outstanding tasks to finish.")
         time_to_wait = int(
@@ -523,7 +580,7 @@ class AwsLambdaExecutor(BaseExecutor):
             if not self.running_tasks:
                 self.log.info("All tasks completed; executor ending.")
                 break
-            self.log.info("Waiting for %d task(s) to complete.", len(self.running_tasks))
+            self.log.info("Waiting for %d workload(s) to complete.", len(self.running_tasks))
             time.sleep(heartbeat_interval)
 
     def terminate(self):

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -109,6 +109,16 @@ class AwsLambdaExecutor(BaseExecutor):
         self.IS_BOTO_CONNECTION_HEALTHY = False
         self.load_connections(check_connection=False)
 
+    @property
+    def pending_tasks(self) -> deque:
+        """Deprecated: use pending_workloads."""
+        return self.pending_workloads
+
+    @property
+    def running_tasks(self) -> dict[str, WorkloadKey]:
+        """Deprecated: use running_workloads."""
+        return self.running_workloads
+
     def start(self):
         """Call this when the Executor is run for the first time by the scheduler."""
         check_health = self.conf.getboolean(CONFIG_GROUP_NAME, AllLambdaConfigKeys.CHECK_HEALTH_ON_STARTUP)

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -18,13 +18,15 @@ from __future__ import annotations
 
 import json
 import time
+import warnings
 from collections import deque
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 
 from boto3.session import NoCredentialsError
 from botocore.utils import ClientError
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.amazon.aws.executors.aws_lambda.utils import (
@@ -40,7 +42,7 @@ from airflow.providers.amazon.aws.executors.utils.exponential_backoff_retry impo
 )
 from airflow.providers.amazon.aws.hooks.lambda_function import LambdaHook
 from airflow.providers.amazon.aws.hooks.sqs import SqsHook
-from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
 
 if TYPE_CHECKING:
@@ -49,7 +51,7 @@ if TYPE_CHECKING:
     from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
 
-    if AIRFLOW_V_3_2_PLUS:
+    if AIRFLOW_V_3_3_PLUS:
         from airflow.executors.workloads.types import WorkloadKey as _WorkloadKey
 
         WorkloadKey: TypeAlias = _WorkloadKey
@@ -70,7 +72,7 @@ class AwsLambdaExecutor(BaseExecutor):
 
     supports_multi_team: bool = True
 
-    if AIRFLOW_V_3_2_PLUS:
+    if AIRFLOW_V_3_3_PLUS:
         supports_callbacks: bool = True
 
     if TYPE_CHECKING and AIRFLOW_V_3_0_PLUS:
@@ -214,18 +216,16 @@ class AwsLambdaExecutor(BaseExecutor):
         except Exception:
             self.log.exception("An error occurred while syncing workloads.")
 
+    # TODO: Remove this once the minimum supported version is 3.2+, and defer to BaseExecutor.queue_workload.
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads
 
         if isinstance(workload, workloads.ExecuteTask):
-            ti = workload.ti
-            self.queued_tasks[ti.key] = workload
+            self.queued_tasks[workload.ti.key] = workload
             return
-
-        if AIRFLOW_V_3_2_PLUS and isinstance(workload, workloads.ExecuteCallback):
-            self.queued_callbacks[workload.callback.id] = workload
+        if AIRFLOW_V_3_3_PLUS and isinstance(workload, workloads.ExecuteCallback):
+            self.queued_callbacks[workload.callback.key] = workload
             return
-
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
@@ -253,9 +253,9 @@ class AwsLambdaExecutor(BaseExecutor):
                 self.running.add(key)
                 continue
 
-            if AIRFLOW_V_3_2_PLUS and isinstance(workload, workloads.ExecuteCallback):
+            if AIRFLOW_V_3_3_PLUS and isinstance(workload, workloads.ExecuteCallback):
                 command = [workload]
-                key = workload.callback.id
+                key = workload.callback.key
                 queue = None
 
                 if isinstance(workload.callback.data, dict) and "queue" in workload.callback.data:
@@ -294,7 +294,7 @@ class AwsLambdaExecutor(BaseExecutor):
 
             workload = command[0]
 
-            if AIRFLOW_V_3_2_PLUS:
+            if AIRFLOW_V_3_3_PLUS:
                 if not isinstance(workload, (workloads.ExecuteTask, workloads.ExecuteCallback)):
                     raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
             else:
@@ -408,6 +408,15 @@ class AwsLambdaExecutor(BaseExecutor):
                 # Add the serialized workload key as the info, this will be assigned on the ti as the external_executor_id.
                 self.running_state(workload_key, ser_workload_key)
 
+    def attempt_task_runs(self):
+        """Use attempt_workload_runs as attempt_task_runs is deprecated."""
+        warnings.warn(
+            "attempt_task_runs is deprecated, use attempt_workload_runs instead.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.attempt_workload_runs()
+
     def sync_running_workloads(self):
         """
         Poll the SQS queue for messages indicating workload completion.
@@ -422,6 +431,15 @@ class AwsLambdaExecutor(BaseExecutor):
         self.process_queue(self.sqs_queue_url)
         if self.dlq_url and self.running_workloads:
             self.process_queue(self.dlq_url)
+
+    def sync_running_tasks(self):
+        """Use sync_running_workloads as sync_running_tasks is deprecated."""
+        warnings.warn(
+            "sync_running_tasks is deprecated, use sync_running_workloads instead.",
+            AirflowProviderDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.sync_running_workloads()
 
     def process_queue(self, queue_url: str):
         """
@@ -490,13 +508,13 @@ class AwsLambdaExecutor(BaseExecutor):
 
             if workload_key:
                 if return_code == 0:
-                    self.success(cast("TaskInstanceKey", workload_key))
+                    self.success(workload_key)
                     self.log.info(
                         "Successful Lambda invocation for workload %s received from SQS queue.",
                         workload_key,
                     )
                 else:
-                    self.fail(cast("TaskInstanceKey", workload_key))
+                    self.fail(workload_key)
                     if queue_url == self.dlq_url and return_code is None:
                         self.log.error(
                             "DLQ message received: Lambda invocation for workload %s was unable to "
@@ -521,8 +539,8 @@ class AwsLambdaExecutor(BaseExecutor):
         """
         Adopt task instances which have an external_executor_id (the serialized workload key).
 
-        The external_executor_id represents the workload identifier. In legacy executors (Airflow < 3.2)
-        this is the serialized TaskInstanceKey. In the workload-based executor model (Airflow ≥ 3.2)
+        The external_executor_id represents the workload identifier. In legacy executors (Airflow < 3.3)
+        this is the serialized TaskInstanceKey. In the workload-based executor model (Airflow ≥ 3.3)
         this corresponds to the WorkloadKey.
 
         Anything that is not adopted will be cleared by the scheduler and becomes eligible for re-scheduling.
@@ -539,7 +557,13 @@ class AwsLambdaExecutor(BaseExecutor):
                     try:
                         data = json.loads(ser_workload_key)
                         workload_key = TaskInstanceKey.from_dict(data)
-                    except Exception:
+                    except (json.JSONDecodeError, KeyError, TypeError) as e:
+                        self.log.warning(
+                            "Failed to deserialize workload_key '%s' (%s); "
+                            "skipping deserialization and treating as callback id.",
+                            ser_workload_key,
+                            str(e),
+                        )
                         # Callback workloads use string keys.
                         workload_key = ser_workload_key
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 import datetime
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from airflow.providers.amazon.aws.executors.utils.base_config_keys import BaseConfigKeys
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_2_PLUS
 
 if TYPE_CHECKING:
-    from airflow.models.taskinstancekey import TaskInstanceKey
+    if AIRFLOW_V_3_2_PLUS:
+        from airflow.executors.workloads.types import WorkloadKey
 
 CONFIG_GROUP_NAME = "aws_lambda_executor"
 INVALID_CREDENTIALS_EXCEPTIONS = [
@@ -36,9 +38,9 @@ INVALID_CREDENTIALS_EXCEPTIONS = [
 
 @dataclass
 class LambdaQueuedTask:
-    """Represents a Lambda workload that is queued. The task will be run in the next heartbeat."""
+    """Represents a Lambda workload that is queued. The workload will be run in the next heartbeat."""
 
-    key: TaskInstanceKey | str
+    key: WorkloadKey
     command: CommandType
     queue: str
     executor_config: ExecutorConfigType
@@ -65,5 +67,11 @@ class AllLambdaConfigKeys(InvokeLambdaKwargsConfigKeys):
     END_WAIT_TIMEOUT = "end_wait_timeout"
 
 
-CommandType = Sequence[Any]
+if AIRFLOW_V_3_2_PLUS:
+    from airflow.executors.workloads import ExecuteCallback, ExecuteTask
+
+    CommandType: TypeAlias = Sequence[str] | Sequence[ExecuteTask | ExecuteCallback]
+else:
+    CommandType: TypeAlias = Sequence[str]  # type: ignore[no-redef, misc]
+
 ExecutorConfigType = dict[str, Any]

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
@@ -26,7 +26,6 @@ from airflow.providers.amazon.aws.executors.utils.base_config_keys import BaseCo
 if TYPE_CHECKING:
     from airflow.models.taskinstancekey import TaskInstanceKey
 
-
 CONFIG_GROUP_NAME = "aws_lambda_executor"
 INVALID_CREDENTIALS_EXCEPTIONS = [
     "ExpiredTokenException",
@@ -37,9 +36,9 @@ INVALID_CREDENTIALS_EXCEPTIONS = [
 
 @dataclass
 class LambdaQueuedTask:
-    """Represents a Lambda task that is queued. The task will be run in the next heartbeat."""
+    """Represents a Lambda workload that is queued. The task will be run in the next heartbeat."""
 
-    key: TaskInstanceKey
+    key: TaskInstanceKey | str
     command: CommandType
     queue: str
     executor_config: ExecutorConfigType
@@ -66,5 +65,5 @@ class AllLambdaConfigKeys(InvokeLambdaKwargsConfigKeys):
     END_WAIT_TIMEOUT = "end_wait_timeout"
 
 
-CommandType = Sequence[str]
+CommandType = Sequence[Any]
 ExecutorConfigType = dict[str, Any]

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/utils.py
@@ -22,10 +22,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from airflow.providers.amazon.aws.executors.utils.base_config_keys import BaseConfigKeys
-from airflow.providers.amazon.version_compat import AIRFLOW_V_3_2_PLUS
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_3_PLUS
 
 if TYPE_CHECKING:
-    if AIRFLOW_V_3_2_PLUS:
+    if AIRFLOW_V_3_3_PLUS:
         from airflow.executors.workloads.types import WorkloadKey
 
 CONFIG_GROUP_NAME = "aws_lambda_executor"
@@ -67,7 +67,7 @@ class AllLambdaConfigKeys(InvokeLambdaKwargsConfigKeys):
     END_WAIT_TIMEOUT = "end_wait_timeout"
 
 
-if AIRFLOW_V_3_2_PLUS:
+if AIRFLOW_V_3_3_PLUS:
     from airflow.executors.workloads import ExecuteCallback, ExecuteTask
 
     CommandType: TypeAlias = Sequence[str] | Sequence[ExecuteTask | ExecuteCallback]

--- a/providers/amazon/src/airflow/providers/amazon/version_compat.py
+++ b/providers/amazon/src/airflow/providers/amazon/version_compat.py
@@ -40,6 +40,7 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_1_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 1)
 AIRFLOW_V_3_1_8_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 8)
+AIRFLOW_V_3_2_PLUS: bool = get_base_airflow_version_tuple() >= (3, 2, 0)
 
 try:
     from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
@@ -58,6 +59,7 @@ __all__ = [
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_1_1_PLUS",
     "AIRFLOW_V_3_1_8_PLUS",
+    "AIRFLOW_V_3_2_PLUS",
     "NOTSET",
     "ArgNotSet",
     "is_arg_set",

--- a/providers/amazon/src/airflow/providers/amazon/version_compat.py
+++ b/providers/amazon/src/airflow/providers/amazon/version_compat.py
@@ -40,7 +40,7 @@ AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_1_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 1)
 AIRFLOW_V_3_1_8_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 8)
-AIRFLOW_V_3_2_PLUS: bool = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 try:
     from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
@@ -59,7 +59,7 @@ __all__ = [
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_1_1_PLUS",
     "AIRFLOW_V_3_1_8_PLUS",
-    "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
     "NOTSET",
     "ArgNotSet",
     "is_arg_set",

--- a/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
@@ -89,7 +89,7 @@ def mock_executor(set_env_vars) -> AwsLambdaExecutor:
     executor = AwsLambdaExecutor()
     executor.IS_BOTO_CONNECTION_HEALTHY = True
 
-    # Replace boto3 clients with mocks
+    # Replace boto3 clients with mocks.
     lambda_mock = mock.Mock(spec=executor.lambda_client)
     lambda_mock.invoke.return_value = {"StatusCode": 0, "failures": []}
     executor.lambda_client = lambda_mock
@@ -110,18 +110,18 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 0
         mock_executor.execute_async(airflow_key, mock_cmd)
-        assert len(mock_executor.pending_tasks) == 1
+        assert len(mock_executor.pending_workloads) == 1
 
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
         mock_executor.lambda_client.invoke.assert_called_once()
         payload = json.loads(mock_executor.lambda_client.invoke.call_args.kwargs["Payload"])
         assert payload["executor_config"] == {}
 
-        # Task is stored in active worker.
-        assert len(mock_executor.running_tasks) == 1
-        assert json.dumps(airflow_key._asdict()) in mock_executor.running_tasks
+        # Workload is stored in active worker.
+        assert len(mock_executor.running_workloads) == 1
+        assert json.dumps(airflow_key._asdict()) in mock_executor.running_workloads
         change_state_mock.assert_called_once_with(
             airflow_key, TaskInstanceState.RUNNING, ser_airflow_key, remove_running=False
         )
@@ -148,14 +148,14 @@ class TestAwsLambdaExecutor:
         mock_executor.queue_workload(workload, mock.Mock())
 
         assert mock_executor.queued_tasks[workload.ti.key] == workload
-        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 0
         assert len(mock_executor.running) == 0
         mock_executor._process_workloads([workload])
         assert len(mock_executor.queued_tasks) == 0
         assert len(mock_executor.running) == 1
         assert workload.ti.key in mock_executor.running
-        assert len(mock_executor.pending_tasks) == 1
-        assert mock_executor.pending_tasks[0].command == [
+        assert len(mock_executor.pending_workloads) == 1
+        assert mock_executor.pending_workloads[0].command == [
             "python",
             "-m",
             "airflow.sdk.execution_time.execute_workload",
@@ -163,15 +163,15 @@ class TestAwsLambdaExecutor:
             '{"test_key": "test_value"}',
         ]
 
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
         mock_executor.lambda_client.invoke.assert_called_once()
         payload = json.loads(mock_executor.lambda_client.invoke.call_args.kwargs["Payload"])
         assert payload["executor_config"] == executor_config
-        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 0
 
-        # Task is stored in active worker.
-        assert len(mock_executor.running_tasks) == 1
-        assert mock_executor.running_tasks[ser_airflow_key] == workload.ti.key
+        # Workload is stored in active worker.
+        assert len(mock_executor.running_workloads) == 1
+        assert mock_executor.running_workloads[ser_airflow_key] == workload.ti.key
         change_state_mock.assert_called_once_with(
             workload.ti.key, TaskInstanceState.RUNNING, ser_airflow_key, remove_running=False
         )
@@ -194,14 +194,14 @@ class TestAwsLambdaExecutor:
         mock_executor.queue_workload(workload, mock.Mock())
 
         assert mock_executor.queued_callbacks[callback_id] == workload
-        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 0
         assert len(mock_executor.running) == 0
         mock_executor._process_workloads([workload])
         assert len(mock_executor.queued_callbacks) == 0
         assert len(mock_executor.running) == 1
         assert callback_id in mock_executor.running
-        assert len(mock_executor.pending_tasks) == 1
-        assert mock_executor.pending_tasks[0].command == [
+        assert len(mock_executor.pending_workloads) == 1
+        assert mock_executor.pending_workloads[0].command == [
             "python",
             "-m",
             "airflow.sdk.execution_time.execute_workload",
@@ -209,7 +209,7 @@ class TestAwsLambdaExecutor:
             ser_workload,
         ]
 
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
         mock_executor.lambda_client.invoke.assert_called_once()
         payload = json.loads(mock_executor.lambda_client.invoke.call_args.kwargs["Payload"])
         assert payload["task_key"] == callback_id
@@ -221,9 +221,9 @@ class TestAwsLambdaExecutor:
             ser_workload,
         ]
 
-        # Callback is stored in running tasks.
-        assert len(mock_executor.running_tasks) == 1
-        assert callback_id in mock_executor.running_tasks
+        # Callback is stored in running workloads.
+        assert len(mock_executor.running_workloads) == 1
+        assert callback_id in mock_executor.running_workloads
 
     @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
     def test_task_sdk_callback_with_queue(self, mock_airflow_key, mock_executor):
@@ -243,7 +243,7 @@ class TestAwsLambdaExecutor:
         mock_executor.queue_workload(workload, mock.Mock())
 
         assert mock_executor.queued_callbacks[callback_id] == workload
-        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 0
         assert len(mock_executor.running) == 0
 
         mock_executor._process_workloads([workload])
@@ -252,8 +252,8 @@ class TestAwsLambdaExecutor:
         assert len(mock_executor.running) == 1
         assert callback_id in mock_executor.running
 
-        assert len(mock_executor.pending_tasks) == 1
-        assert mock_executor.pending_tasks[0].queue == "fast-queue"
+        assert len(mock_executor.pending_workloads) == 1
+        assert mock_executor.pending_workloads[0].queue == "fast-queue"
 
     @mock.patch.object(lambda_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_success_execute_api_exception(self, mock_backoff, mock_executor, mock_cmd, mock_airflow_key):
@@ -269,20 +269,20 @@ class TestAwsLambdaExecutor:
 
         # Fail 2 times
         for _ in range(expected_retry_count):
-            mock_executor.attempt_task_runs()
-            # Task is not stored in active workers.
-            assert len(mock_executor.running_tasks) == 0
+            mock_executor.attempt_workload_runs()
+            # Workload is not stored in active workers.
+            assert len(mock_executor.running_workloads) == 0
 
         # Pass in last attempt
-        mock_executor.attempt_task_runs()
-        assert len(mock_executor.pending_tasks) == 0
-        assert ser_airflow_key in mock_executor.running_tasks
+        mock_executor.attempt_workload_runs()
+        assert len(mock_executor.pending_workloads) == 0
+        assert ser_airflow_key in mock_executor.running_workloads
         assert mock_backoff.call_count == expected_retry_count
         for attempt_number in range(1, expected_retry_count):
             mock_backoff.assert_has_calls([mock.call(attempt_number)])
 
     def test_failed_execute_api_exception(self, mock_executor, mock_cmd, mock_airflow_key):
-        """Test what happens when Lambda refuses to execute a task and throws an exception"""
+        """Test what happens when Lambda refuses to execute a workload and throws an exception"""
         mock_airflow_key = mock_airflow_key()
 
         mock_executor.lambda_client.invoke.side_effect = Exception("Test exception")
@@ -290,63 +290,63 @@ class TestAwsLambdaExecutor:
 
         # No matter what, don't schedule until invoke becomes successful.
         for _ in range(int(mock_executor.max_invoke_attempts) * 2):
-            mock_executor.attempt_task_runs()
-            # Task is not stored in running tasks
-            assert len(mock_executor.running_tasks) == 0
+            mock_executor.attempt_workload_runs()
+            # Workload is not stored in running workloads.
+            assert len(mock_executor.running_workloads) == 0
 
     def test_failed_execute_creds_exception(self, mock_executor, mock_cmd, mock_airflow_key):
-        """Test what happens when Lambda refuses to execute a task and throws an exception due to credentials"""
+        """Test what happens when Lambda refuses to execute a workload and throws an exception due to credentials"""
         airflow_key = mock_airflow_key()
 
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = True
         mock_executor.execute_async(airflow_key, mock_cmd)
-        assert mock_executor.pending_tasks[0].attempt_number == 1
+        assert mock_executor.pending_workloads[0].attempt_number == 1
 
         error_to_raise = ClientError(
             {"Error": {"Code": "ExpiredTokenException", "Message": "foobar"}}, "OperationName"
         )
         mock_executor.lambda_client.invoke.side_effect = error_to_raise
 
-        # Sync will ultimately call attempt_task_runs, which is the code under test
+        # Sync will ultimately call attempt_workload_runs, which is the code under test.
         mock_executor.sync()
 
-        # Task should end up back in the queue
-        assert mock_executor.pending_tasks[0].key == airflow_key
+        # Workload should end up back in the queue.
+        assert mock_executor.pending_workloads[0].key == airflow_key
         # The connection should get marked as unhealthy
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
         # We retry on connections issues indefinitely, so the attempt number should be 1
-        assert mock_executor.pending_tasks[0].attempt_number == 1
+        assert mock_executor.pending_workloads[0].attempt_number == 1
 
     def test_failed_execute_client_error_exception(self, mock_executor, mock_cmd, mock_airflow_key):
-        """Test what happens when Lambda refuses to execute a task and throws an exception for non-credentials issue"""
+        """Test what happens when Lambda refuses to execute a workload and throws an exception for non-credentials issue"""
         airflow_key = mock_airflow_key()
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = True
         mock_executor.execute_async(airflow_key, mock_cmd)
-        assert mock_executor.pending_tasks[0].attempt_number == 1
+        assert mock_executor.pending_workloads[0].attempt_number == 1
 
         error_to_raise = ClientError(
             {"Error": {"Code": "RandomeError", "Message": "foobar"}}, "OperationName"
         )
         mock_executor.lambda_client.invoke.side_effect = error_to_raise
 
-        # Sync will ultimately call attempt_task_runs, which is the code under test
+        # Sync will ultimately call attempt_workload_runs, which is the code under test.
         mock_executor.sync()
 
-        # Task should end up back in the queue
-        assert mock_executor.pending_tasks[0].key == airflow_key
-        # The connection should stay marked as healthy because the error is something else
+        # Workload should end up back in the queue.
+        assert mock_executor.pending_workloads[0].key == airflow_key
+        # The connection should stay marked as healthy because the error is something else.
         assert mock_executor.IS_BOTO_CONNECTION_HEALTHY
-        # Not a retry so increment attempts
-        assert mock_executor.pending_tasks[0].attempt_number == 2
+        # Not a retry so increment attempts.
+        assert mock_executor.pending_workloads[0].attempt_number == 2
 
     @mock.patch.object(lambda_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
-    def test_attempt_task_runs_attempts_when_tasks_fail(self, _, mock_executor):
+    def test_attempt_workload_runs_attempts_when_workloads_fail(self, _, mock_executor):
         """
-        Test case when all tasks fail to run.
+        Test case when all workloads fail to run.
 
-        The executor should attempt each task exactly once per sync() iteration.
-        It should preserve the order of tasks, and attempt each task up to
-        `max_invoke_attempts` times before dropping the task.
+        The executor should attempt each workload exactly once per sync() iteration.
+        It should preserve the order of workloads, and attempt each workload up to
+        `max_invoke_attempts` times before dropping the workload.
         """
         airflow_keys = [
             TaskInstanceKey("a", "task_a", "c", 1, -1),
@@ -361,40 +361,40 @@ class TestAwsLambdaExecutor:
         mock_executor.execute_async(airflow_keys[0], commands[0])
         mock_executor.execute_async(airflow_keys[1], commands[1])
 
-        assert len(mock_executor.pending_tasks) == 2
-        assert len(mock_executor.running_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 2
+        assert len(mock_executor.running_workloads) == 0
 
         mock_executor.lambda_client.invoke.side_effect = failures
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         for i in range(2):
             payload = json.loads(mock_executor.lambda_client.invoke.call_args_list[i].kwargs["Payload"])
             assert airflow_keys[i].task_id in payload["task_key"]
 
-        assert len(mock_executor.pending_tasks) == 2
-        assert len(mock_executor.running_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 2
+        assert len(mock_executor.running_workloads) == 0
 
         mock_executor.lambda_client.invoke.call_args_list.clear()
 
         mock_executor.lambda_client.invoke.side_effect = failures
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         for i in range(2):
             payload = json.loads(mock_executor.lambda_client.invoke.call_args_list[i].kwargs["Payload"])
             assert airflow_keys[i].task_id in payload["task_key"]
 
-        assert len(mock_executor.pending_tasks) == 2
-        assert len(mock_executor.running_tasks) == 0
+        assert len(mock_executor.pending_workloads) == 2
+        assert len(mock_executor.running_workloads) == 0
 
         mock_executor.lambda_client.invoke.call_args_list.clear()
 
         mock_executor.lambda_client.invoke.side_effect = failures
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         assert (
-            len(mock_executor.pending_tasks) == 0
-        )  # Pending now zero since we've had three failures to invoke
-        assert len(mock_executor.running_tasks) == 0
+            len(mock_executor.pending_workloads) == 0
+        )  # Pending now zero since we've had three failures to invoke.
+        assert len(mock_executor.running_workloads) == 0
 
         if airflow_version >= (2, 10, 0):
             events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
@@ -404,9 +404,9 @@ class TestAwsLambdaExecutor:
             ]
 
     @mock.patch.object(lambda_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
-    def test_attempt_task_runs_attempts_when_some_tasks_fal(self, _, mock_executor):
+    def test_attempt_workload_runs_attempts_when_some_workloads_fail(self, _, mock_executor):
         """
-        Test case when one task fail to run, others succeed, and a new task gets queued.
+        Test case when one workload fails to run, others succeed, and a new workload gets queued.
 
         """
         airflow_keys = [
@@ -424,46 +424,46 @@ class TestAwsLambdaExecutor:
         mock_executor.execute_async(airflow_keys[0], airflow_commands[0])
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
 
-        assert len(mock_executor.pending_tasks) == 2
+        assert len(mock_executor.pending_workloads) == 2
 
         mock_executor.lambda_client.invoke.side_effect = responses
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         for i in range(2):
             payload = json.loads(mock_executor.lambda_client.invoke.call_args_list[i].kwargs["Payload"])
             assert airflow_keys[i].task_id in payload["task_key"]
 
-        assert len(mock_executor.pending_tasks) == 1
-        assert len(mock_executor.running_tasks) == 1
+        assert len(mock_executor.pending_workloads) == 1
+        assert len(mock_executor.running_workloads) == 1
 
         mock_executor.lambda_client.invoke.call_args_list.clear()
 
-        # queue new task
+        # Queue new workload.
         airflow_keys[1] = TaskInstanceKey("a", "task_c", "c", 1, -1)
         airflow_commands[1] = _generate_mock_cmd()
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
 
-        assert len(mock_executor.pending_tasks) == 2
-        # assert that the order of pending tasks is preserved i.e. the first task is 1st etc.
-        assert mock_executor.pending_tasks[0].key == airflow_keys[0]
-        assert mock_executor.pending_tasks[0].command == airflow_commands[0]
+        assert len(mock_executor.pending_workloads) == 2
+        # Assert that the order of pending workloads is preserved.
+        assert mock_executor.pending_workloads[0].key == airflow_keys[0]
+        assert mock_executor.pending_workloads[0].command == airflow_commands[0]
 
         responses = [Exception("Failure 1"), success_response]
         mock_executor.lambda_client.invoke.side_effect = responses
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         for i in range(2):
             payload = json.loads(mock_executor.lambda_client.invoke.call_args_list[i].kwargs["Payload"])
             assert airflow_keys[i].task_id in payload["task_key"]
 
-        assert len(mock_executor.pending_tasks) == 1
-        assert len(mock_executor.running_tasks) == 2
+        assert len(mock_executor.pending_workloads) == 1
+        assert len(mock_executor.running_workloads) == 2
 
         mock_executor.lambda_client.invoke.call_args_list.clear()
 
         responses = [Exception("Failure 1")]
         mock_executor.lambda_client.invoke.side_effect = responses
-        mock_executor.attempt_task_runs()
+        mock_executor.attempt_workload_runs()
 
         payload = json.loads(mock_executor.lambda_client.invoke.call_args_list[0].kwargs["Payload"])
         assert airflow_keys[0].task_id in payload["task_key"]
@@ -478,19 +478,19 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
         mock_executor.sqs_client.receive_message.side_effect = [
-            {},  # First request from the results queue will be empty
+            {},  # First request from the results queue will be empty.
             {
-                # Second request from the DLQ will have a message
+                # Second request from the DLQ will have a message.
                 "Messages": [
                     {
                         "ReceiptHandle": "receipt_handle",
                         "Body": json.dumps(
                             {
                                 "task_key": ser_airflow_key,
-                                # DLQ messages will have the input (task_key, command) instead of return_code
+                                # DLQ messages will have the input (task_key, command) instead of return_code.
                                 "command": "command",
                             }
                         ),
@@ -499,8 +499,8 @@ class TestAwsLambdaExecutor:
             },
         ]
 
-        mock_executor.sync_running_tasks()
-        # Receive messages should be called twice
+        mock_executor.sync_running_workloads()
+        # Receive messages should be called twice.
         assert mock_executor.sqs_client.receive_message.call_count == 2
         assert mock_executor.sqs_client.receive_message.call_args_list[0].kwargs == {
             "QueueUrl": DEFAULT_QUEUE_URL,
@@ -512,8 +512,8 @@ class TestAwsLambdaExecutor:
             "MaxNumberOfMessages": 10,
         }
 
-        # Task is not stored in active workers.
-        assert len(mock_executor.running_tasks) == 0
+        # Workload is not stored in active workers.
+        assert len(mock_executor.running_workloads) == 0
         success_mock.assert_not_called()
         fail_mock.assert_called_once()
         assert mock_executor.sqs_client.delete_message.call_count == 1
@@ -528,9 +528,9 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        # Success message
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        # Success message.
         mock_executor.sqs_client.receive_message.return_value = {
             "Messages": [
                 {
@@ -545,16 +545,16 @@ class TestAwsLambdaExecutor:
             ]
         }
 
-        mock_executor.sync_running_tasks()
+        mock_executor.sync_running_workloads()
         mock_executor.sqs_client.receive_message.assert_called_once()
         assert mock_executor.sqs_client.receive_message.call_args_list[0].kwargs == {
             "QueueUrl": DEFAULT_QUEUE_URL,
             "MaxNumberOfMessages": 10,
         }
 
-        # Task is not stored in active workers.
-        assert len(mock_executor.running_tasks) == 0
-        # Task is immediately succeeded.
+        # Workload is not stored in active workers.
+        assert len(mock_executor.running_workloads) == 0
+        # Workload immediately succeeds.
         success_mock.assert_called_once()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 1
@@ -569,9 +569,9 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        # Failure message
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        # Failure message.
         mock_executor.sqs_client.receive_message.return_value = {
             "Messages": [
                 {
@@ -579,19 +579,19 @@ class TestAwsLambdaExecutor:
                     "Body": json.dumps(
                         {
                             "task_key": ser_airflow_key,
-                            "return_code": 1,  # Non-zero return code, task failed
+                            "return_code": 1,  # Non-zero return code, workload failed.
                         }
                     ),
                 }
             ]
         }
 
-        mock_executor.sync_running_tasks()
+        mock_executor.sync_running_workloads()
         mock_executor.sqs_client.receive_message.assert_called_once()
 
-        # Task is not stored in active workers.
-        assert len(mock_executor.running_tasks) == 0
-        # Task is immediately succeeded.
+        # Workload is not stored in active workers.
+        assert len(mock_executor.running_workloads) == 0
+        # Workload is immediately succeeded.
         success_mock.assert_not_called()
         fail_mock.assert_called_once()
         assert mock_executor.sqs_client.delete_message.call_count == 1
@@ -600,22 +600,22 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
         mock_executor.sqs_client.receive_message.side_effect = [
             {
                 "Messages": [
                     {
                         "ReceiptHandle": "receipt_handle",
-                        "Body": "Banana",  # Body not json format
+                        "Body": "Banana",  # Body not json format.
                     }
                 ]
             },
-            {},  # Second request from the DLQ will be empty
+            {},  # Second request from the DLQ will be empty.
         ]
 
-        mock_executor.sync_running_tasks()
-        # Assert that the message is deleted if the message is not formatted as json
+        mock_executor.sync_running_workloads()
+        # Assert that the message is deleted if the message is not formatted as json.
         assert mock_executor.sqs_client.receive_message.call_count == 2
         assert mock_executor.sqs_client.delete_message.call_count == 1
 
@@ -623,8 +623,8 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
         mock_executor.sqs_client.receive_message.side_effect = [
             {
                 "Messages": [
@@ -632,18 +632,18 @@ class TestAwsLambdaExecutor:
                         "ReceiptHandle": "receipt_handle",
                         "Body": json.dumps(
                             {
-                                "foo": "bar",  # Missing expected keys like "task_key"
-                                "return_code": 1,  # Non-zero return code, task failed
+                                "foo": "bar",  # Missing expected keys like "task_key".
+                                "return_code": 1,  # Non-zero return code, workload failed.
                             }
                         ),
                     }
                 ]
             },
-            {},  # Second request from the DLQ will be empty
+            {},  # Second request from the DLQ will be empty.
         ]
 
-        mock_executor.sync_running_tasks()
-        # Assert that the message is deleted if the message does not contain the expected keys
+        mock_executor.sync_running_workloads()
+        # Assert that the message is deleted if the message does not contain the expected keys.
         assert mock_executor.sqs_client.receive_message.call_count == 2
         assert mock_executor.sqs_client.delete_message.call_count == 1
 
@@ -651,19 +651,19 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        # Failure message
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        # Failure message.
         mock_executor.sqs_client.receive_message.side_effect = [
-            {},  # First request from the results queue will be empty
+            {},  # First request from the results queue will be empty.
             {
-                # Second request from the DLQ will have a message
+                # Second request from the DLQ will have a message.
                 "Messages": [
                     {
                         "ReceiptHandle": "receipt_handle",
                         "Body": json.dumps(
                             {
-                                "foo": "bar",  # Missing expected keys like "task_key"
+                                "foo": "bar",  # Missing expected keys like "task_key".
                                 "return_code": 1,
                             }
                         ),
@@ -672,23 +672,23 @@ class TestAwsLambdaExecutor:
             },
         ]
 
-        mock_executor.sync_running_tasks()
-        # Assert that the message is deleted if the message does not contain the expected keys
+        mock_executor.sync_running_workloads()
+        # Assert that the message is deleted if the message does not contain the expected keys.
         assert mock_executor.sqs_client.receive_message.call_count == 2
         assert mock_executor.sqs_client.delete_message.call_count == 1
 
     @mock.patch.object(BaseExecutor, "fail")
     @mock.patch.object(BaseExecutor, "success")
     def test_sync_running_short_circuit(self, success_mock, fail_mock, mock_executor, mock_airflow_key):
-        mock_executor.running_tasks.clear()
-        # No running tasks, so we will short circuit
+        mock_executor.running_workloads.clear()
+        # No running workloads, so we will short circuit.
 
-        mock_executor.sync_running_tasks()
+        mock_executor.sync_running_workloads()
         mock_executor.sqs_client.receive_message.assert_not_called()
 
-        # Task is still stored in active workers.
-        assert len(mock_executor.running_tasks) == 0
-        # Task is immediately succeeded.
+        # Workload is still stored in active workers.
+        assert len(mock_executor.running_workloads) == 0
+        # Workload immediately succeeds.
         success_mock.assert_not_called()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 0
@@ -699,25 +699,25 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        # No messages, so we will not loop
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        # No messages, so we will not loop.
         mock_executor.sqs_client.receive_message.return_value = {"Messages": []}
 
-        mock_executor.sync_running_tasks()
-        # Both the results queue and DLQ should have been checked
+        mock_executor.sync_running_workloads()
+        # Both the results queue and DLQ should have been checked.
         assert mock_executor.sqs_client.receive_message.call_count == 2
 
-        # Task is still stored in active workers.
-        assert len(mock_executor.running_tasks) == 1
-        # Task is immediately succeeded.
+        # Workload is still stored in active workers.
+        assert len(mock_executor.running_workloads) == 1
+        # Workload immediately succeeds.
         success_mock.assert_not_called()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 0
 
     @mock.patch.object(BaseExecutor, "fail")
     @mock.patch.object(BaseExecutor, "success")
-    def test_sync_running_two_tasks_one_relevant(
+    def test_sync_running_two_workloads_one_relevant(
         self, success_mock, fail_mock, mock_executor, mock_airflow_key
     ):
         airflow_key = mock_airflow_key()
@@ -725,10 +725,10 @@ class TestAwsLambdaExecutor:
         airflow_key_2 = mock_airflow_key()
         ser_airflow_key_2 = json.dumps(airflow_key_2._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        mock_executor.running_tasks[ser_airflow_key_2] = airflow_key_2
-        # Success message
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads[ser_airflow_key_2] = airflow_key_2
+        # Success message.
         mock_executor.sqs_client.receive_message.side_effect = [
             {
                 "Messages": [
@@ -743,41 +743,41 @@ class TestAwsLambdaExecutor:
                     }
                 ]
             },
-            {},  # No messages from DLQ
+            {},  # No messages from DLQ.
         ]
 
-        mock_executor.sync_running_tasks()
-        # Both the results queue and DLQ should have been checked
+        mock_executor.sync_running_workloads()
+        # Both the results queue and DLQ should have been checked.
         assert mock_executor.sqs_client.receive_message.call_count == 2
 
-        # One task left running
-        assert len(mock_executor.running_tasks) == 1
-        # Task one completed, task two is still running
-        assert ser_airflow_key_2 in mock_executor.running_tasks
-        # Task is immediately succeeded.
+        # One workload left running.
+        assert len(mock_executor.running_workloads) == 1
+        # Workload one completed, Workload two is still running.
+        assert ser_airflow_key_2 in mock_executor.running_workloads
+        # Workload immediately succeeds.
         success_mock.assert_called_once()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 1
 
     @mock.patch.object(BaseExecutor, "fail")
     @mock.patch.object(BaseExecutor, "success")
-    def test_sync_running_unknown_task(self, success_mock, fail_mock, mock_executor, mock_airflow_key):
+    def test_sync_running_unknown_workload(self, success_mock, fail_mock, mock_executor, mock_airflow_key):
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
         airflow_key_2 = mock_airflow_key()
         ser_airflow_key_2 = json.dumps(airflow_key_2._asdict())
 
-        mock_executor.running_tasks.clear()
-        # Only add one of the tasks to the running list, the other will be unknown
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        # Only add one of the workloads to the running list, the other will be unknown.
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
 
-        # Receive the known task and unknown task
-        known_task_receipt = "receipt_handle_known"
-        unknown_task_receipt = "receipt_handle_unknown"
+        # Receive the known workload and unknown workload.
+        known_workload_receipt = "receipt_handle_known"
+        unknown_workload_receipt = "receipt_handle_unknown"
         mock_executor.sqs_client.receive_message.return_value = {
             "Messages": [
                 {
-                    "ReceiptHandle": known_task_receipt,
+                    "ReceiptHandle": known_workload_receipt,
                     "Body": json.dumps(
                         {
                             "task_key": ser_airflow_key,
@@ -786,7 +786,7 @@ class TestAwsLambdaExecutor:
                     ),
                 },
                 {
-                    "ReceiptHandle": unknown_task_receipt,
+                    "ReceiptHandle": unknown_workload_receipt,
                     "Body": json.dumps(
                         {
                             "task_key": ser_airflow_key_2,
@@ -797,25 +797,25 @@ class TestAwsLambdaExecutor:
             ]
         }
 
-        mock_executor.sync_running_tasks()
+        mock_executor.sync_running_workloads()
         mock_executor.sqs_client.receive_message.assert_called_once()
 
-        # The known task is set to succeeded, unknown task is dropped
-        assert len(mock_executor.running_tasks) == 0
+        # The known workload is set to succeeded, unknown workload is dropped.
+        assert len(mock_executor.running_workloads) == 0
         success_mock.assert_called_once()
         fail_mock.assert_not_called()
-        # Only the known message from the queue should be deleted, the other should be marked as visible again
+        # Only the known message from the queue should be deleted, the other should be marked as visible again.
         assert mock_executor.sqs_client.delete_message.call_count == 1
         assert mock_executor.sqs_client.change_message_visibility.call_count == 1
-        # The argument to delete_message should be the known task
+        # The argument to delete_message should be the known workload.
         assert mock_executor.sqs_client.delete_message.call_args_list[0].kwargs == {
             "QueueUrl": DEFAULT_QUEUE_URL,
-            "ReceiptHandle": known_task_receipt,
+            "ReceiptHandle": known_workload_receipt,
         }
-        # The change_message_visibility should be called with the unknown task
+        # The change_message_visibility should be called with the unknown workload.
         assert mock_executor.sqs_client.change_message_visibility.call_args_list[0].kwargs == {
             "QueueUrl": DEFAULT_QUEUE_URL,
-            "ReceiptHandle": unknown_task_receipt,
+            "ReceiptHandle": unknown_workload_receipt,
             "VisibilityTimeout": 0,
         }
 
@@ -870,7 +870,7 @@ class TestAwsLambdaExecutor:
         with pytest.raises(AirflowException):
             mock_executor.check_health()
         assert mock_executor.lambda_client.get_function.call_count == 1
-        # Lambda has already failed so SQS should not be called
+        # Lambda has already failed so SQS should not be called.
         assert mock_executor.sqs_client.get_queue_attributes.call_count == 0
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
 
@@ -888,7 +888,7 @@ class TestAwsLambdaExecutor:
         with pytest.raises(AirflowException):
             mock_executor.check_health()
         assert mock_executor.lambda_client.get_function.call_count == 1
-        # Lambda has already failed so SQS should not be called
+        # Lambda has already failed so SQS should not be called.
         assert mock_executor.sqs_client.get_queue_attributes.call_count == 1
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
 
@@ -909,42 +909,42 @@ class TestAwsLambdaExecutor:
         with pytest.raises(AirflowException):
             mock_executor.check_health()
         assert mock_executor.lambda_client.get_function.call_count == 1
-        # Lambda has already failed so SQS should not be called
+        # Lambda has already failed so SQS should not be called.
         assert mock_executor.sqs_client.get_queue_attributes.call_count == 2
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
 
     def test_sync_already_unhealthy(self, mock_executor):
-        # Something has set the connection to unhealthy (tested elsewhere)
+        # Something has set the connection to unhealthy (tested elsewhere).
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = False
-        mock_executor.sync_running_tasks = mock.Mock()
-        mock_executor.attempt_task_runs = mock.Mock()
+        mock_executor.sync_running_workloads = mock.Mock()
+        mock_executor.attempt_workload_runs = mock.Mock()
         mock_executor.load_connections = mock.Mock()
-        # Set the last connection reload to be more than 60 seconds ago so that we get a reload
+        # Set the last connection reload to be more than 60 seconds ago so that we get a reload.
         mock_executor.last_connection_reload = timezone.utcnow() - dt.timedelta(seconds=100)
-        # We should not be able to sync
+        # We should not be able to sync.
         mock_executor.sync()
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
-        mock_executor.sync_running_tasks.assert_not_called()
-        mock_executor.attempt_task_runs.assert_not_called()
+        mock_executor.sync_running_workloads.assert_not_called()
+        mock_executor.attempt_workload_runs.assert_not_called()
         mock_executor.load_connections.assert_called_once()
 
     def test_sync_already_unhealthy_then_repaired(self, mock_executor):
-        # Something has set the connection to unhealthy (tested elsewhere)
+        # Something has set the connection to unhealthy (tested elsewhere).
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = False
-        mock_executor.sync_running_tasks = mock.Mock()
-        mock_executor.attempt_task_runs = mock.Mock()
+        mock_executor.sync_running_workloads = mock.Mock()
+        mock_executor.attempt_workload_runs = mock.Mock()
 
         def check_health_side_effect():
             mock_executor.IS_BOTO_CONNECTION_HEALTHY = True
 
         mock_executor.check_health = mock.Mock(side_effect=check_health_side_effect)
-        # Set the last connection reload to be more than 60 seconds ago so that we get a reload
+        # Set the last connection reload to be more than 60 seconds ago so that we get a reload.
         mock_executor.last_connection_reload = timezone.utcnow() - dt.timedelta(seconds=100)
-        # Sync should repair itself and continue to call the sync methods
+        # Sync should repair itself and continue to call the sync methods.
         mock_executor.sync()
         assert mock_executor.IS_BOTO_CONNECTION_HEALTHY
-        mock_executor.sync_running_tasks.assert_called_once()
-        mock_executor.attempt_task_runs.assert_called_once()
+        mock_executor.sync_running_workloads.assert_called_once()
+        mock_executor.attempt_workload_runs.assert_called_once()
 
     @pytest.mark.parametrize(
         "error_code",
@@ -955,19 +955,19 @@ class TestAwsLambdaExecutor:
         ],
     )
     def test_sync_become_unhealthy_no_creds(self, error_code, mock_executor):
-        # Something has set the connection to unhealthy (tested elsewhere)
+        # Something has set the connection to unhealthy (tested elsewhere).
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = True
         mock_executor.log.warning = mock.Mock()
-        mock_executor.attempt_task_runs = mock.Mock()
+        mock_executor.attempt_workload_runs = mock.Mock()
         error_to_raise = ClientError({"Error": {"Code": error_code, "Message": "foobar"}}, "OperationName")
-        mock_executor.sync_running_tasks = mock.Mock(side_effect=error_to_raise)
+        mock_executor.sync_running_workloads = mock.Mock(side_effect=error_to_raise)
 
-        # sync should catch the error and handle it, setting connection to unhealthy
+        # sync should catch the error and handle it, setting connection to unhealthy.
         mock_executor.sync()
         assert not mock_executor.IS_BOTO_CONNECTION_HEALTHY
-        mock_executor.sync_running_tasks.assert_called_once()
-        mock_executor.attempt_task_runs.assert_not_called()
-        # Check that the substring "AWS credentials are either missing or expired" was logged
+        mock_executor.sync_running_workloads.assert_called_once()
+        mock_executor.attempt_workload_runs.assert_not_called()
+        # Check that the substring "AWS credentials are either missing or expired" was logged.
         mock_executor.log.warning.assert_called_once()
         assert "AWS credentials are either missing or expired" in mock_executor.log.warning.call_args[0][0]
 
@@ -975,18 +975,18 @@ class TestAwsLambdaExecutor:
         # Something has set the connection to unhealthy (tested elsewhere)
         mock_executor.IS_BOTO_CONNECTION_HEALTHY = True
         mock_executor.log.exception = mock.Mock()
-        mock_executor.attempt_task_runs = mock.Mock()
-        mock_executor.sync_running_tasks = mock.Mock(side_effect=Exception())
+        mock_executor.attempt_workload_runs = mock.Mock()
+        mock_executor.sync_running_workloads = mock.Mock(side_effect=Exception())
 
         # sync should catch the error and log, don't kill scheduler by letting it raise up higher.
         mock_executor.sync()
-        # Not a credentials error that we can tell, so connection stays healthy
+        # Not a credentials error that we can tell, so connection stays healthy.
         assert mock_executor.IS_BOTO_CONNECTION_HEALTHY
-        mock_executor.sync_running_tasks.assert_called_once()
-        mock_executor.attempt_task_runs.assert_not_called()
-        # Check that the substring "AWS credentials are either missing or expired" was logged
+        mock_executor.sync_running_workloads.assert_called_once()
+        mock_executor.attempt_workload_runs.assert_not_called()
+        # Check that the substring "AWS credentials are either missing or expired" was logged.
         mock_executor.log.exception.assert_called_once()
-        assert "An error occurred while syncing tasks" in mock_executor.log.exception.call_args[0][0]
+        assert "An error occurred while syncing workloads" in mock_executor.log.exception.call_args[0][0]
 
     def test_try_adopt_task_instances(self, mock_executor, mock_airflow_key):
         """Test that executor can adopt orphaned task instances from a SchedulerJob shutdown event."""
@@ -1006,7 +1006,7 @@ class TestAwsLambdaExecutor:
         orphaned_tasks[1].external_executor_id = ser_airflow_key_2
         orphaned_tasks[
             2
-        ].external_executor_id = None  # One orphaned task has no external_executor_id, not adopted
+        ].external_executor_id = None  # One orphaned task has no external_executor_id, not adopted.
 
         for task in orphaned_tasks:
             task.try_number = 1
@@ -1014,12 +1014,12 @@ class TestAwsLambdaExecutor:
         not_adopted_tasks = mock_executor.try_adopt_task_instances(orphaned_tasks)
 
         # Two of the three tasks should be adopted.
-        assert len(orphaned_tasks) - 1 == len(mock_executor.running_tasks)
-        assert ser_airflow_key_1 in mock_executor.running_tasks
+        assert len(orphaned_tasks) - 1 == len(mock_executor.running_workloads)
+        assert ser_airflow_key_1 in mock_executor.running_workloads
 
-        assert mock_executor.running_tasks[ser_airflow_key_1] == airflow_key_1
-        assert ser_airflow_key_2 in mock_executor.running_tasks
-        assert mock_executor.running_tasks[ser_airflow_key_2] == airflow_key_2
+        assert mock_executor.running_workloads[ser_airflow_key_1] == airflow_key_1
+        assert ser_airflow_key_2 in mock_executor.running_workloads
+        assert mock_executor.running_workloads[ser_airflow_key_2] == airflow_key_2
 
         # The remaining one task is unable to be adopted.
         assert len(not_adopted_tasks) == 1
@@ -1028,13 +1028,13 @@ class TestAwsLambdaExecutor:
     @mock.patch.object(BaseExecutor, "fail")
     @mock.patch.object(BaseExecutor, "success")
     def test_end(self, success_mock, fail_mock, mock_executor, mock_airflow_key):
-        """Test that executor can end successfully; waiting for all tasks to naturally exit."""
+        """Test that executor can end successfully; waiting for all workloads to naturally exit."""
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
-        # First message is empty, so we loop again while waiting for tasks to finish
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
+        # First message is empty, so we loop again while waiting for workloads to finish.
         mock_executor.sqs_client.receive_message.side_effect = [
             {},
             {},
@@ -1053,11 +1053,11 @@ class TestAwsLambdaExecutor:
             },
         ]
         mock_executor.end(heartbeat_interval=0)
-        # Assert that the sqs_client mock method receive_message was called exactly twice
+        # Assert that the sqs_client mock method receive_message was called exactly twice.
         assert mock_executor.sqs_client.receive_message.call_count == 3
 
-        # Task is not stored in active workers.
-        assert len(mock_executor.running_tasks) == 0
+        # Workload is not stored in active workers.
+        assert len(mock_executor.running_workloads) == 0
         success_mock.assert_called_once()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 1
@@ -1074,16 +1074,16 @@ class TestAwsLambdaExecutor:
 
         not_adopted = mock_executor.try_adopt_task_instances([ti])
 
-        assert len(mock_executor.running_tasks) == 1
-        assert callback_id in mock_executor.running_tasks
-        assert mock_executor.running_tasks[callback_id] == callback_id
+        assert len(mock_executor.running_workloads) == 1
+        assert callback_id in mock_executor.running_workloads
+        assert mock_executor.running_workloads[callback_id] == callback_id
 
         assert len(not_adopted) == 0
 
     @mock.patch("airflow.providers.amazon.aws.executors.aws_lambda.lambda_executor.timezone")
     def test_end_timeout(self, mock_timezone, mock_executor, mock_airflow_key):
-        """Test that executor can end successfully; waiting for all tasks to naturally exit."""
-        # Mock the sync method of the mock_executor object so we can count how many times it was called
+        """Test that executor can end successfully; waiting for all workloads to naturally exit."""
+        # Mock the sync method of the mock_executor object so we can count how many times it was called.
         mock_executor.sync = mock.Mock()
         mock_executor.log.warning = mock.Mock()
         current_time = timezone.utcnow()
@@ -1097,17 +1097,17 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
 
         with conf_vars({(CONFIG_GROUP_NAME, AllLambdaConfigKeys.END_WAIT_TIMEOUT): "5"}):
             mock_executor.end(heartbeat_interval=0)
 
-        # Task is still stored in active workers.
-        assert len(mock_executor.running_tasks) == 1
+        # Workload is still stored in active workers.
+        assert len(mock_executor.running_workloads) == 1
         assert mock_executor.sync.call_count == 2
         mock_executor.log.warning.assert_called_once_with(
-            "Timed out waiting for tasks to finish. Some tasks may not be handled gracefully"
+            "Timed out waiting for workloads to finish. Some workloads may not be handled gracefully"
             " as the executor is force ending due to timeout."
         )
 
@@ -1116,22 +1116,22 @@ class TestAwsLambdaExecutor:
         airflow_key = mock_airflow_key()
         ser_airflow_key = json.dumps(airflow_key._asdict())
 
-        mock_executor.running_tasks.clear()
-        mock_executor.running_tasks[ser_airflow_key] = airflow_key
+        mock_executor.running_workloads.clear()
+        mock_executor.running_workloads[ser_airflow_key] = airflow_key
         mock_executor.log.warning = mock.Mock()
 
         mock_executor.terminate()
         mock_executor.log.warning.assert_called_once_with(
-            "Terminating Lambda executor. In-flight tasks cannot be stopped."
+            "Terminating Lambda executor. In-flight workloads cannot be stopped."
         )
-        assert len(mock_executor.running_tasks) == 1
+        assert len(mock_executor.running_workloads) == 1
 
     @pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Multi-team support requires Airflow 3.1+")
     def test_team_config(self):
         """Test that the executor uses team-specific configuration when provided via self.conf."""
         from unittest.mock import patch
 
-        # Team name to be used throughout
+        # Team name to be used throughout.
         team_name = "team_a"
         # Patch environment to include two sets of configs for the Lambda executor. One that is related to a
         # team and one that is not. Then we will create two executors (one with a team and one without) and
@@ -1179,7 +1179,7 @@ class TestAwsLambdaExecutor:
             ),
         ]
         with patch("os.environ", {key.upper(): value for key, value in config_overrides}):
-            # Create a team-specific executor
+            # Create a team-specific executor.
             team_executor = AwsLambdaExecutor(team_name=team_name)
 
             assert team_executor.lambda_function_name == "team_a_function"
@@ -1194,7 +1194,7 @@ class TestAwsLambdaExecutor:
                 == "True"
             )
 
-            # Now create an executor without a team and ensure the global configs are used
+            # Now create an executor without a team and ensure the global configs are used.
             global_executor = AwsLambdaExecutor()
 
             assert global_executor.lambda_function_name == "global-function"

--- a/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
@@ -36,7 +36,7 @@ from airflow.version import version as airflow_version_str
 
 from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
 
 airflow_version = VersionInfo(*map(int, airflow_version_str.split(".")[:3]))
 
@@ -175,6 +175,85 @@ class TestAwsLambdaExecutor:
         change_state_mock.assert_called_once_with(
             workload.ti.key, TaskInstanceState.RUNNING, ser_airflow_key, remove_running=False
         )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    def test_task_sdk_callback(self, mock_executor):
+        """Test task sdk callback execution end-to-end."""
+        from airflow.executors.workloads import ExecuteCallback
+
+        callback_id = "callback_123"
+
+        workload = mock.Mock(spec=ExecuteCallback)
+        workload.callback = mock.Mock()
+        workload.callback.id = callback_id
+        workload.callback.data = {}
+
+        ser_workload = json.dumps({"test_key": "test_value"})
+        workload.model_dump_json.return_value = ser_workload
+
+        mock_executor.queue_workload(workload, mock.Mock())
+
+        assert mock_executor.queued_callbacks[callback_id] == workload
+        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.running) == 0
+        mock_executor._process_workloads([workload])
+        assert len(mock_executor.queued_callbacks) == 0
+        assert len(mock_executor.running) == 1
+        assert callback_id in mock_executor.running
+        assert len(mock_executor.pending_tasks) == 1
+        assert mock_executor.pending_tasks[0].command == [
+            "python",
+            "-m",
+            "airflow.sdk.execution_time.execute_workload",
+            "--json-string",
+            ser_workload,
+        ]
+
+        mock_executor.attempt_task_runs()
+        mock_executor.lambda_client.invoke.assert_called_once()
+        payload = json.loads(mock_executor.lambda_client.invoke.call_args.kwargs["Payload"])
+        assert payload["task_key"] == callback_id
+        assert payload["command"] == [
+            "python",
+            "-m",
+            "airflow.sdk.execution_time.execute_workload",
+            "--json-string",
+            ser_workload,
+        ]
+
+        # Callback is stored in running tasks.
+        assert len(mock_executor.running_tasks) == 1
+        assert callback_id in mock_executor.running_tasks
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    def test_task_sdk_callback_with_queue(self, mock_airflow_key, mock_executor):
+        """Test callback workload execution with queue override."""
+        from airflow.executors.workloads import ExecuteCallback
+
+        callback_id = mock_airflow_key()
+
+        workload = mock.Mock(spec=ExecuteCallback)
+        workload.callback = mock.Mock()
+        workload.callback.id = callback_id
+        workload.callback.data = {"queue": "fast-queue"}
+
+        ser_workload = json.dumps({"test_key": "test_value"})
+        workload.model_dump_json.return_value = ser_workload
+
+        mock_executor.queue_workload(workload, mock.Mock())
+
+        assert mock_executor.queued_callbacks[callback_id] == workload
+        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.running) == 0
+
+        mock_executor._process_workloads([workload])
+
+        assert len(mock_executor.queued_callbacks) == 0
+        assert len(mock_executor.running) == 1
+        assert callback_id in mock_executor.running
+
+        assert len(mock_executor.pending_tasks) == 1
+        assert mock_executor.pending_tasks[0].queue == "fast-queue"
 
     @mock.patch.object(lambda_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_success_execute_api_exception(self, mock_backoff, mock_executor, mock_cmd, mock_airflow_key):
@@ -982,6 +1061,24 @@ class TestAwsLambdaExecutor:
         success_mock.assert_called_once()
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 1
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    def test_try_adopt_task_instances_callback(self, mock_executor):
+        """Test adoption of callback workloads using string external_executor_id."""
+
+        callback_id = "callback_123"
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.external_executor_id = callback_id
+        ti.try_number = 1
+
+        not_adopted = mock_executor.try_adopt_task_instances([ti])
+
+        assert len(mock_executor.running_tasks) == 1
+        assert callback_id in mock_executor.running_tasks
+        assert mock_executor.running_tasks[callback_id] == callback_id
+
+        assert len(not_adopted) == 0
 
     @mock.patch("airflow.providers.amazon.aws.executors.aws_lambda.lambda_executor.timezone")
     def test_end_timeout(self, mock_timezone, mock_executor, mock_airflow_key):

--- a/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
@@ -36,7 +36,7 @@ from airflow.version import version as airflow_version_str
 
 from tests_common.test_utils.compat import timezone
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
 
 airflow_version = VersionInfo(*map(int, airflow_version_str.split(".")[:3]))
 
@@ -176,7 +176,7 @@ class TestAwsLambdaExecutor:
             workload.ti.key, TaskInstanceState.RUNNING, ser_airflow_key, remove_running=False
         )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Test requires Airflow 3.3+")
     def test_task_sdk_callback(self, mock_executor):
         """Test task sdk callback execution end-to-end."""
         from airflow.executors.workloads import ExecuteCallback
@@ -185,7 +185,7 @@ class TestAwsLambdaExecutor:
 
         workload = mock.Mock(spec=ExecuteCallback)
         workload.callback = mock.Mock()
-        workload.callback.id = callback_id
+        workload.callback.key = callback_id
         workload.callback.data = {}
 
         ser_workload = json.dumps({"test_key": "test_value"})
@@ -225,7 +225,7 @@ class TestAwsLambdaExecutor:
         assert len(mock_executor.running_workloads) == 1
         assert callback_id in mock_executor.running_workloads
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Test requires Airflow 3.3+")
     def test_task_sdk_callback_with_queue(self, mock_airflow_key, mock_executor):
         """Test callback workload execution with queue override."""
         from airflow.executors.workloads import ExecuteCallback
@@ -234,7 +234,7 @@ class TestAwsLambdaExecutor:
 
         workload = mock.Mock(spec=ExecuteCallback)
         workload.callback = mock.Mock()
-        workload.callback.id = callback_id
+        workload.callback.key = callback_id
         workload.callback.data = {"queue": "fast-queue"}
 
         ser_workload = json.dumps({"test_key": "test_value"})
@@ -1062,7 +1062,7 @@ class TestAwsLambdaExecutor:
         fail_mock.assert_not_called()
         assert mock_executor.sqs_client.delete_message.call_count == 1
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test requires Airflow 3.2+")
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Test requires Airflow 3.3+")
     def test_try_adopt_task_instances_callback(self, mock_executor):
         """Test adoption of callback workloads using string external_executor_id."""
 


### PR DESCRIPTION
**Description**

This change adds support for callback workloads (`ExecuteCallback`) to the `AwsLambdaExecutor`.

Previously, the executor only supported task workloads (`ExecuteTask`). This update extends the executor to accept, queue, and execute callback workloads alongside task workloads. The executor now maintains a `queued_callbacks` structure and updates `queue_workload()` to register `ExecuteCallback` workloads using the callback identifier (`callback.id`) as the workload key.

The workload processing flow has been updated to support callbacks throughout the executor lifecycle. `_process_workloads()` now handles both `ExecuteTask` and `ExecuteCallback` workloads, dispatching them through the same execution pathway. `execute_async()` has been extended to serialize both workload types and forward them to the Lambda runtime using `python -m airflow.sdk.execution_time.execute_workload`. Additionally, `attempt_task_runs()` and related task tracking logic have been updated to support string-based workload identifiers for callbacks while maintaining JSON-serialized `TaskInstanceKey` identifiers for task workloads.

**Rationale**

The ExecutorCallback framework introduced in Airflow 3.3 allows executors to execute synchronous callbacks on worker infrastructure. Executors must therefore be able to accept and dispatch `ExecuteCallback` workloads in addition to task workloads.

`AwsLambdaExecutor` delegates execution to the Task SDK runtime by invoking `airflow.sdk.execution_time.execute_workload` inside the Lambda environment. As reflected in the direction of PR #62645, the expectation is that handling of both task and callback execution will ultimately occur within the Task SDK runtime rather than inside individual executors. Forwarding callback workloads to the same runtime entrypoint used for tasks aligns the Lambda executor with this model.

**Tests**

Added unit tests verifying that:

* Callback workloads are queued, processed, and dispatched to Lambda using the Task SDK runtime command.
* Callback workloads correctly propagate queue overrides specified in `callback.data["queue"]`.
* Callback workloads are correctly adopted using string-based `external_executor_id` values.

**Documentation**

Docstrings have been updated in `AwsLambdaExecutor` to describe support for both task and callback workloads.

**Backwards Compatibility**

This change preserves existing behavior for task workloads.

Task workloads continue to use JSON-serialized `TaskInstanceKey` identifiers for executor tracking and scheduler adoption. Callback workloads use their callback identifier string as the workload key.

Related: #62887