### PR TITLE
Fix recursive stale DAG cleanup in S3 local sync

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1736,7 +1736,7 @@ class S3Hook(AwsBaseHook):
     def _sync_to_local_dir_delete_stale_local_files(self, current_s3_objects: list[Path], local_dir: Path):
         current_s3_keys = {key for key in current_s3_objects}
 
-        for item in local_dir.iterdir():
+        for item in sorted(local_dir.rglob("*"), key=lambda path: len(path.parts), reverse=True):
             item: Path  # type: ignore[no-redef]
             absolute_item_path = item.resolve()
 

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1862,14 +1862,21 @@ class TestAwsS3Hook:
         local_file_that_should_be_deleted.write_text("test dag")
         local_folder_should_be_deleted = Path(sync_local_dir).joinpath("local_folder_should_be_deleted")
         local_folder_should_be_deleted.mkdir(exist_ok=True)
+        nested_folder_should_be_deleted = Path(sync_local_dir).joinpath("stale", "nested")
+        nested_folder_should_be_deleted.mkdir(parents=True, exist_ok=True)
+        nested_file_that_should_be_deleted = nested_folder_should_be_deleted.joinpath("dag_stale.py")
+        nested_file_that_should_be_deleted.write_text("test dag")
         hook.log.debug = MagicMock()
         hook.sync_to_local_dir(
             bucket_name=s3_bucket, local_dir=sync_local_dir, s3_prefix="", delete_stale=True
         )
         logs_string = get_logs_string(hook.log.debug.call_args_list)
         assert f"Deleted stale local file: {local_file_that_should_be_deleted.as_posix()}" in logs_string
+        assert f"Deleted stale local file: {nested_file_that_should_be_deleted.as_posix()}" in logs_string
 
         assert f"Deleted stale empty directory: {local_folder_should_be_deleted.as_posix()}" in logs_string
+        assert f"Deleted stale empty directory: {nested_folder_should_be_deleted.as_posix()}" in logs_string
+        assert f"Deleted stale empty directory: {nested_folder_should_be_deleted.parent.as_posix()}" in logs_string
 
         s3_client.put_object(Bucket=s3_bucket, Key="dag_03.py", Body=b"test data-changed")
         hook.log.debug = MagicMock()


### PR DESCRIPTION
### What this PR does
`S3Hook.sync_to_local_dir(..., delete_stale=True)` currently checks only the top-level entries of `local_dir` when deleting stale files. As a result, stale DAG files inside nested folders are never removed.

This PR makes stale cleanup recursive by traversing all descendants of `local_dir` (deepest path first), so stale nested files can be deleted and then their empty parent directories removed.

### Why this change
This addresses #62622 where `S3DagBundle` keeps stale DAGs in subfolders because `Path.iterdir()` is not recursive.

### Tests
Updated `test_sync_to_local_dir_behaviour` to cover nested stale cleanup:
- creates `stale/nested/dag_stale.py` locally (not in S3)
- verifies stale nested file is deleted
- verifies both `stale/nested` and `stale` empty directories are deleted

I also validated syntax compilation for the touched files locally.

Closes #62622
