### PR TITLE
Add missing HTTP timeouts across multiple providers

### DIFF
--- a/providers/apache/druid/src/airflow/providers/apache/druid/hooks/druid.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/hooks/druid.py
@@ -143,7 +143,8 @@ class DruidHook(BaseHook):
 
         self.log.info("Druid ingestion spec: %s", json_index_spec)
         req_index = requests.post(
-            url, data=json_index_spec, headers=self.header, auth=self.get_auth(), verify=self.get_verify()
+            url, data=json_index_spec, headers=self.header, auth=self.get_auth(), verify=self.get_verify(),
+            timeout=30,
         )
 
         code = req_index.status_code
@@ -165,14 +166,15 @@ class DruidHook(BaseHook):
 
         sec = 0
         while running:
-            req_status = requests.get(druid_task_status_url, auth=self.get_auth(), verify=self.get_verify())
+            req_status = requests.get(druid_task_status_url, auth=self.get_auth(), verify=self.get_verify(), timeout=30)
 
             self.log.info("Job still running for %s seconds...", sec)
 
             if self.max_ingestion_time and sec > self.max_ingestion_time:
                 # ensure that the job gets killed if the max ingestion time is exceeded
                 requests.post(
-                    f"{url}/{druid_task_id}/shutdown", auth=self.get_auth(), verify=self.get_verify()
+                    f"{url}/{druid_task_id}/shutdown", auth=self.get_auth(), verify=self.get_verify(),
+                    timeout=30,
                 )
                 raise AirflowException(f"Druid ingestion took more than {self.max_ingestion_time} seconds")
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -778,7 +778,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
     @staticmethod
     def get_yaml_content_from_file(kueue_yaml_url) -> list[dict]:
         """Download content of YAML file and separate it into several dictionaries."""
-        response = requests.get(kueue_yaml_url, allow_redirects=True)
+        response = requests.get(kueue_yaml_url, allow_redirects=True, timeout=30)
         if response.status_code != 200:
             raise AirflowException("Was not able to read the yaml file from given URL")
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -396,7 +396,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def _get_authentik_jwks(self, jwks_url) -> dict:
         import requests
 
-        resp = requests.get(jwks_url)
+        resp = requests.get(jwks_url, timeout=30)
         if resp.status_code == 200:
             return resp.json()
         return {}
@@ -2326,7 +2326,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def _get_microsoft_jwks(self) -> list[dict[str, Any]]:
         import requests
 
-        return requests.get(MICROSOFT_KEY_SET_URL).json()
+        return requests.get(MICROSOFT_KEY_SET_URL, timeout=30).json()
 
     def _decode_and_validate_azure_jwt(self, id_token: str) -> dict[str, str]:
         verify_signature = self.oauth_remotes["azure"].client_kwargs.get("verify_signature", False)

--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataprep.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataprep.py
@@ -99,7 +99,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint_path = f"{self.api_version}/jobGroups/{job_id}/jobs"
         url: str = urljoin(self._base_url, endpoint_path)
-        response = requests.get(url, headers=self._headers)
+        response = requests.get(url, headers=self._headers, timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -117,7 +117,7 @@ class GoogleDataprepHook(BaseHook):
         params: dict[str, Any] = {"embed": embed, "includeDeleted": include_deleted}
         endpoint_path = f"{self.api_version}/jobGroups/{job_group_id}"
         url: str = urljoin(self._base_url, endpoint_path)
-        response = requests.get(url, headers=self._headers, params=params)
+        response = requests.get(url, headers=self._headers, params=params, timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -135,7 +135,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint_path = f"{self.api_version}/jobGroups"
         url: str = urljoin(self._base_url, endpoint_path)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -149,7 +149,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/flows"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -172,7 +172,7 @@ class GoogleDataprepHook(BaseHook):
             "description": description,
             "copyDatasources": copy_datasources,
         }
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -185,7 +185,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint_path = f"{self.api_version}/flows/{flow_id}"
         url: str = urljoin(self._base_url, endpoint_path)
-        response = requests.delete(url, headers=self._headers)
+        response = requests.delete(url, headers=self._headers, timeout=30)
         self._raise_for_status(response)
 
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, max=10))
@@ -198,7 +198,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"{self.api_version}/flows/{flow_id}/run"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -211,7 +211,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/jobGroups/{job_group_id}/status"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.get(url, headers=self._headers)
+        response = requests.get(url, headers=self._headers, timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -232,7 +232,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/importedDatasets"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -247,7 +247,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/wrangledDatasets"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -262,7 +262,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/outputObjects"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -277,7 +277,7 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/writeSettings"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.post(url, headers=self._headers, data=json.dumps(body_request))
+        response = requests.post(url, headers=self._headers, data=json.dumps(body_request), timeout=30)
         self._raise_for_status(response)
         return response.json()
 
@@ -290,5 +290,5 @@ class GoogleDataprepHook(BaseHook):
         """
         endpoint = f"/{self.api_version}/importedDatasets/{dataset_id}"
         url: str = urljoin(self._base_url, endpoint)
-        response = requests.delete(url, headers=self._headers)
+        response = requests.delete(url, headers=self._headers, timeout=30)
         self._raise_for_status(response)

--- a/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/hooks/openfaas.py
@@ -71,7 +71,7 @@ class OpenFaasHook(BaseHook):
         else:
             url = self.get_conn().host + self.DEPLOY_FUNCTION
             self.log.info("Deploying function %s", url)
-            response = requests.post(url, body)
+            response = requests.post(url, body, timeout=30)
             if response.status_code != OK_STATUS_CODE:
                 self.log.error("Response status %d", response.status_code)
                 self.log.error("Failed to deploy")
@@ -82,7 +82,7 @@ class OpenFaasHook(BaseHook):
         """Invoke function asynchronously."""
         url = self.get_conn().host + self.INVOKE_ASYNC_FUNCTION + self.function_name
         self.log.info("Invoking function asynchronously %s", url)
-        response = requests.post(url, body)
+        response = requests.post(url, body, timeout=30)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
         else:
@@ -93,7 +93,7 @@ class OpenFaasHook(BaseHook):
         """Invoke function synchronously. This will block until function completes and returns."""
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
-        response = requests.post(url, body)
+        response = requests.post(url, body, timeout=30)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)
@@ -106,7 +106,7 @@ class OpenFaasHook(BaseHook):
         """Update OpenFaaS function."""
         url = self.get_conn().host + self.UPDATE_FUNCTION
         self.log.info("Updating function %s", url)
-        response = requests.put(url, body)
+        response = requests.put(url, body, timeout=30)
         if response.status_code != OK_STATUS_CODE:
             self.log.error("Response status %d", response.status_code)
             self.log.error("Failed to update response %s", response.content.decode("utf-8"))
@@ -117,7 +117,7 @@ class OpenFaasHook(BaseHook):
         """Whether OpenFaaS function exists or not."""
         url = self.get_conn().host + self.GET_FUNCTION + self.function_name
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         if response.ok:
             return True
         self.log.error("Failed to find function %s", self.function_name)


### PR DESCRIPTION
This PR adds a default timeout of 30 seconds to several HTTP requests across multiple providers that were missing it. This prevents tasks from hanging indefinitely in case of network issues or unresponsive servers.

### Affected providers:
- OpenFaaS (`OpenFaasHook`)
- - Apache Druid (`DruidHook`)
- - FAB (`FabAirflowSecurityManagerOverride`)
- - CNCF Kubernetes (`KubernetesHook`)
- - Google Cloud Dataprep (`DataprepHook`)
Closes: #63033