### PR TITLE
Send `limit` parameter in `execute_list` server requests

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -164,7 +164,7 @@ class BaseOperations:
         limit: int = 50,
         params: dict | None = None,
     ) -> T | ServerResponseError:
-        shared_params = {**(params or {})}
+        shared_params = {"limit": limit, **(params or {})}
         self.response = self.client.get(path, params=shared_params)
         first_pass = data_model.model_validate_json(self.response.content)
         total_entries = first_pass.total_entries  # type: ignore[attr-defined]

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -194,6 +194,39 @@ class TestBaseOperations:
 
         assert expected_response == response
 
+    def test_execute_list_sends_limit_to_server(self):
+        """``limit`` must be included in request params so the server returns
+        the expected page size.  Without it the server uses its own default
+        (e.g. 100) which causes duplicate entries when ``limit`` differs."""
+        mock_client = Mock()
+        mock_client.get.return_value = Mock(
+            content=json.dumps({"hellos": [{"name": "hello"}] * 3, "total_entries": 3})
+        )
+        base_operation = BaseOperations(client=mock_client)
+
+        base_operation.execute_list(path="hello", data_model=HelloCollectionResponse, limit=50)
+
+        call_params = mock_client.get.call_args_list[0]
+        assert call_params.kwargs["params"]["limit"] == 50
+
+    def test_execute_list_sends_limit_on_subsequent_pages(self):
+        """Every paginated request must include ``limit`` so that offset
+        arithmetic stays consistent with the actual page size returned."""
+        limit = 2
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            Mock(content=json.dumps({"hellos": [{"name": "a"}, {"name": "b"}], "total_entries": 3})),
+            Mock(content=json.dumps({"hellos": [{"name": "c"}], "total_entries": 3})),
+        ]
+        base_operation = BaseOperations(client=mock_client)
+
+        response = base_operation.execute_list(path="hello", data_model=HelloCollectionResponse, limit=limit)
+
+        assert len(response.hellos) == 3
+        # Verify limit is sent on both the first and second request
+        for call in mock_client.get.call_args_list:
+            assert call.kwargs["params"]["limit"] == limit
+
 
 class TestAssetsOperations:
     asset_id: int = 1

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -212,7 +212,6 @@ class TestBaseOperations:
     def test_execute_list_sends_limit_on_subsequent_pages(self):
         """Every paginated request must include ``limit`` so that offset
         arithmetic stays consistent with the actual page size returned."""
-        limit = 2
         mock_client = Mock()
         mock_client.get.side_effect = [
             Mock(content=json.dumps({"hellos": [{"name": "a"}, {"name": "b"}], "total_entries": 3})),
@@ -220,12 +219,12 @@ class TestBaseOperations:
         ]
         base_operation = BaseOperations(client=mock_client)
 
-        response = base_operation.execute_list(path="hello", data_model=HelloCollectionResponse, limit=limit)
+        response = base_operation.execute_list(path="hello", data_model=HelloCollectionResponse, limit=2)
 
         assert len(response.hellos) == 3
         # Verify limit is sent on both the first and second request
         for call in mock_client.get.call_args_list:
-            assert call.kwargs["params"]["limit"] == limit
+            assert call.kwargs["params"]["limit"] == 2
 
 
 class TestAssetsOperations:


### PR DESCRIPTION
- `execute_list` uses `limit` (default 50) for offset arithmetic but did not include it in server requests
- Server falls back to its own `fallback_page_limit` — currently also 50, so behavior is correct with defaults
- If the server's `fallback_page_limit` is configured differently, offsets diverge and pages overlap
- Fix: include `limit` in `shared_params` so pagination is robust regardless of server config
- This was suggested by @uranusjr in #50132 review but deferred at merge time

closes: #63047

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)