### PR TITLE
fix: ensure execute_command is registered with Celery app at worker s…

### DIFF
--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -54,10 +54,7 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor
-# Must be imported at module level to register execute_command with the Celery app
-# and connect the celery_import_modules signal handler at worker startup.
-# See: https://github.com/apache/airflow/issues/63043
-from airflow.providers.celery.executors import celery_executor_utils as _celery_executor_utils  # noqa: F401
+from airflow.providers.celery.executors import celery_executor_utils as _celery_executor_utils  # noqa: F401 # Needed to register execute_command with Celery app at worker startup, see #63043
 from airflow.stats import Stats
 from airflow.utils.state import TaskInstanceState
 

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -56,6 +56,10 @@ from airflow.exceptions import AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor
 from airflow.stats import Stats
 from airflow.utils.state import TaskInstanceState
+# Must be imported at module level to register execute_command with the Celery app
+# and connect the celery_import_modules signal handler at worker startup.
+# See: https://github.com/apache/airflow/issues/63043
+from airflow.providers.celery.executors import celery_executor_utils as _celery_executor_utils  # noqa: F401
 
 log = logging.getLogger(__name__)
 

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -54,7 +54,9 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor
-from airflow.providers.celery.executors import celery_executor_utils as _celery_executor_utils  # noqa: F401 # Needed to register execute_command with Celery app at worker startup, see #63043
+from airflow.providers.celery.executors import (
+    celery_executor_utils as _celery_executor_utils,  # noqa: F401 # Needed to register execute_command with Celery app at worker startup, see #63043
+)
 from airflow.stats import Stats
 from airflow.utils.state import TaskInstanceState
 

--- a/airflow/providers/celery/executors/celery_executor.py
+++ b/airflow/providers/celery/executors/celery_executor.py
@@ -54,12 +54,12 @@ from airflow.cli.cli_config import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor
-from airflow.stats import Stats
-from airflow.utils.state import TaskInstanceState
 # Must be imported at module level to register execute_command with the Celery app
 # and connect the celery_import_modules signal handler at worker startup.
 # See: https://github.com/apache/airflow/issues/63043
 from airflow.providers.celery.executors import celery_executor_utils as _celery_executor_utils  # noqa: F401
+from airflow.stats import Stats
+from airflow.utils.state import TaskInstanceState
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
When the Celery worker starts, it imports `app` from `celery_executor.py` but `celery_executor_utils.py` was never imported at module level. This means `execute_command` never gets registered as a Celery task when the worker boots, and the `celery_import_modules` signal handler never connects.

This worked before because older Celery versions were more lenient about when tasks got registered. Celery provider 3.17.0 exposed this — workers start receiving messages before `_process_tasks()` is ever called, so `execute_command` is unknown and messages get discarded:
KeyError: 'execute_command'
Received unregistered task of type 'execute_command'. The message has been ignored and discarded.

Fix is a single import in `celery_executor.py` so `celery_executor_utils` is loaded when the worker imports `app` at startup.

Fixes #63043