### PR TITLE
fix: suppress warning for TYPE_CHECKING-only forward references in TaskFlow multiple_outputs inference

### DIFF
--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -195,17 +195,7 @@ class TestAirflowTaskDecorator(BasePythonTest):
             y: int,
         ) -> "UnresolveableName[int, int]": ...
 
-        with pytest.warns(UserWarning, match="Cannot infer multiple_outputs.*t3") as recwarn:
-            line = sys._getframe().f_lineno - 5 if PY38 else sys._getframe().f_lineno - 2
-
-        if PY311:
-            # extra line explaining the error location in Py311
-            line = line - 1
-
-        warn = recwarn[0]
-        assert warn.filename == __file__
-        assert warn.lineno == line
-
+        # No warning should be raised for TYPE_CHECKING-only forward references
         assert t3(5, 5).operator.multiple_outputs is False
 
     def test_infer_multiple_outputs_using_other_typing(self):

--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -20,7 +20,6 @@ import inspect
 import itertools
 import re
 import textwrap
-import warnings
 from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
 from contextlib import suppress
 from functools import cached_property, partial, update_wrapper
@@ -448,12 +447,9 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
             fake.__annotations__ = {"return": self.function.__annotations__["return"]}
 
             return_type = typing_extensions.get_type_hints(fake, self.function.__globals__).get("return", Any)
-        except NameError as e:
-            warnings.warn(
-                f"Cannot infer multiple_outputs for TaskFlow function {self.function.__name__!r} with forward"
-                f" type references that are not imported. (Error was {e})",
-                stacklevel=4,
-            )
+        except NameError:
+            # Forward references using TYPE_CHECKING-only imports are valid Python patterns.
+            # We cannot infer multiple_outputs when the type is not available at runtime.
             return False
         except TypeError:  # Can't evaluate return type.
             return False


### PR DESCRIPTION
When using string annotations with types imported under TYPE_CHECKING, the multiple_outputs inference raises a UserWarning:

Cannot infer multiple_outputs for TaskFlow function 'dataframe_task' with forward type references that are not imported. (Error was name 'DataFrame' is not defined)


This is a false alarm. Using `TYPE_CHECKING`-only imports with string annotations is a standard Python pattern to avoid circular imports or expensive runtime imports. The NameError is expected — the type is intentionally not available at runtime.

Previously this worked silently in Airflow 2.x. The warning was introduced in 3.x and is causing unnecessary noise for valid user code.

Fix: catch NameError silently and return False (same as TypeError), remove the warning entirely, and drop the now-unused `warnings` import.

Fixes #62945