### PR TITLE
Exit with code 1 on network and server errors in `safe_call_command`

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -90,10 +90,12 @@ def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
                 f"[red]Server response error: {e}. "
                 "Please check if the server is running and the API URL is correct.[/red]"
             )
+        sys.exit(1)
     except httpx.ReadTimeout as e:
         rich.print(f"[red]Read timeout error: {e}[/red]")
         if "timed out" in str(e):
             rich.print("[red]Please check if the server is running and the API ready to accept calls.[/red]")
+        sys.exit(1)
     except ServerResponseError as e:
         rich.print(f"Server response error: {e}")
         if "Client error message:" in str(e):
@@ -102,6 +104,7 @@ def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
                 "Please check the command and its parameters. "
                 "If you need help, run the command with --help."
             )
+        sys.exit(1)
 
 
 class DefaultHelpParser(argparse.ArgumentParser):

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -30,6 +30,7 @@ from airflowctl.ctl.cli_config import (
     GroupCommand,
     add_auth_token_to_all_commands,
     merge_commands,
+    safe_call_command,
 )
 
 
@@ -537,3 +538,38 @@ class TestCliConfigMethods:
 
         # Should return params unchanged for other datamodels
         assert result == params, "Params should be unchanged for non-TriggerDAGRunPostBody datamodels"
+
+
+class TestSafeCallCommand:
+    """safe_call_command must exit with code 1 on every caught exception."""
+
+    def test_exits_on_remote_protocol_error(self):
+        import httpx
+
+        def _raise(args):
+            raise httpx.RemoteProtocolError("Server disconnected without sending a response.")
+
+        with pytest.raises(SystemExit, match="1"):
+            safe_call_command(_raise, args=None)
+
+    def test_exits_on_read_timeout(self):
+        import httpx
+
+        def _raise(args):
+            raise httpx.ReadTimeout("timed out")
+
+        with pytest.raises(SystemExit, match="1"):
+            safe_call_command(_raise, args=None)
+
+    def test_exits_on_server_response_error(self):
+        import httpx
+
+        from airflowctl.api.operations import ServerResponseError
+
+        def _raise(args):
+            request = httpx.Request("GET", "http://localhost/api/v2/dags")
+            response = httpx.Response(400, request=request)
+            raise ServerResponseError("Client error message: bad request", request=request, response=response)
+
+        with pytest.raises(SystemExit, match="1"):
+            safe_call_command(_raise, args=None)


### PR DESCRIPTION
- `safe_call_command` already calls `sys.exit(1)` for credential errors
- The handlers for `RemoteProtocolError`, `ReadTimeout`, and `ServerResponseError` printed an error but exited with code 0
- Scripts and CI pipelines that check `$?` treated these failures as success
- Fix: add `sys.exit(1)` to the three missing handlers

closes: #63054

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)