### PR TITLE
Add missing HTTP timeout to FAB JWKS fetching

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -396,7 +396,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def _get_authentik_jwks(self, jwks_url) -> dict:
         import requests
 
-        resp = requests.get(jwks_url)
+        resp = requests.get(jwks_url, timeout=30)
         if resp.status_code == 200:
             return resp.json()
         return {}
@@ -2326,7 +2326,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def _get_microsoft_jwks(self) -> list[dict[str, Any]]:
         import requests
 
-        return requests.get(MICROSOFT_KEY_SET_URL).json()
+        return requests.get(MICROSOFT_KEY_SET_URL, timeout=30).json()
 
     def _decode_and_validate_azure_jwt(self, id_token: str) -> dict[str, str]:
         verify_signature = self.oauth_remotes["azure"].client_kwargs.get("verify_signature", False)


### PR DESCRIPTION
This PR adds a 30s timeout to `requests.get` calls in the FAB security manager override when fetching JSON Web Key Sets (JWKS) from Authentik or Microsoft.

### Justification:
Fetching JWKS is a fast metadata operation. If the remote server hangs, it will block the authentication process indefinitely, consuming worker resources. A 30-second timeout ensures it fails fast.

Split from #63042 and closes #63033.