### PR TITLE
fix: Replace expunge_all with expunge in MetastoreBackend

### DIFF
--- a/airflow-core/src/airflow/secrets/metastore.py
+++ b/airflow-core/src/airflow/secrets/metastore.py
@@ -57,7 +57,8 @@ class MetastoreBackend(BaseSecretsBackend):
             )
             .limit(1)
         )
-        session.expunge_all()
+        if conn:
+            session.expunge(conn)
         return conn
 
     @provide_session
@@ -79,7 +80,7 @@ class MetastoreBackend(BaseSecretsBackend):
             .where(Variable.key == key, or_(Variable.team_name == team_name, Variable.team_name.is_(None)))
             .limit(1)
         )
-        session.expunge_all()
         if var_value:
+            session.expunge(var_value)
             return var_value.val
         return None

--- a/airflow-core/tests/unit/always/test_secrets_metastore.py
+++ b/airflow-core/tests/unit/always/test_secrets_metastore.py
@@ -1,0 +1,110 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.models.connection import Connection
+from airflow.models.variable import Variable
+from airflow.secrets.metastore import MetastoreBackend
+from airflow.utils.session import create_session
+
+from tests_common.test_utils.db import clear_db_connections, clear_db_variables
+
+pytestmark = pytest.mark.db_test
+
+
+class TestMetastoreBackendSessionSafety:
+    """MetastoreBackend must not corrupt the shared scoped session.
+
+    Regression tests for https://github.com/apache/airflow/issues/62244.
+    """
+
+    def setup_method(self) -> None:
+        clear_db_connections()
+        clear_db_variables()
+
+    def teardown_method(self) -> None:
+        clear_db_connections()
+        clear_db_variables()
+
+    @pytest.mark.parametrize("conn_exists", [True, False], ids=["found", "not_found"])
+    def test_get_connection_preserves_pending_session_objects(self, conn_exists):
+        """get_connection must not remove unrelated pending objects from session.new."""
+        if conn_exists:
+            with create_session() as session:
+                session.add(Connection(conn_id="target_conn", conn_type="mysql"))
+                session.commit()
+
+        with create_session() as session:
+            # Simulate pending work from another function sharing the session
+            pending = Connection(conn_id="pending_conn", conn_type="http")
+            session.add(pending)
+
+            # Same session passed to simulate shared scoped session behavior
+            backend = MetastoreBackend()
+            result = backend.get_connection("target_conn", session=session)
+
+            if conn_exists:
+                assert result is not None
+                assert result.conn_id == "target_conn"
+            else:
+                assert result is None
+            # The pending object must still be in session.new — expunge(conn) should only
+            # detach the queried Connection, not wipe unrelated pending objects.
+            assert pending in session.new
+
+    @pytest.mark.parametrize("var_exists", [True, False], ids=["found", "not_found"])
+    def test_get_variable_preserves_pending_session_objects(self, var_exists):
+        """get_variable must not remove unrelated pending objects from session.new."""
+        if var_exists:
+            Variable.set(key="test_key", value="test_value")
+
+        with create_session() as session:
+            # Use any ORM model as the pending object to detect session corruption
+            pending = Connection(conn_id="pending_conn", conn_type="http")
+            session.add(pending)
+
+            backend = MetastoreBackend()
+            result = backend.get_variable("test_key", session=session)
+
+            if var_exists:
+                assert result == "test_value"
+            else:
+                assert result is None
+            # The pending object must still be in session.new — expunge(var_value) should only
+            # detach the queried Variable, not wipe unrelated pending objects.
+            assert pending in session.new
+
+    def test_get_connection_returns_detached_object(self):
+        """Returned connection must be detached so callers can use it freely."""
+        from sqlalchemy import inspect as sa_inspect
+
+        with create_session() as session:
+            session.add(Connection(conn_id="test_conn", conn_type="mysql", host="localhost"))
+            session.commit()
+
+        backend = MetastoreBackend()
+        conn = backend.get_connection("test_conn")
+
+        assert conn is not None
+        # Object should be detached — not tracked by any session
+        assert sa_inspect(conn).detached
+        # Attributes should still be accessible
+        assert conn.conn_id == "test_conn"
+        assert conn.host == "localhost"


### PR DESCRIPTION
## What

Replace `session.expunge_all()` with `session.expunge(obj)` in `MetastoreBackend.get_connection()` and `MetastoreBackend.get_variable()`.

## Why

`expunge_all()` removes every object from the SQLAlchemy session — not just the queried Connection or Variable. Since Airflow uses scoped (thread-local) sessions, any code sharing the same thread gets its pending objects destroyed.

This causes team-scoped S3DagBundles to silently fail to persist. During `sync_bundles_to_db`, the call chain is:

1. `session.add(DagBundleModel("team_alpha"))` — pending in session
2. Next iteration calls `_extract_and_sign_template("team_beta")`
3. → `S3DagBundle.view_url_template()` → `S3Hook` → `AwsGenericHook.conn_config` → `get_connection("aws_default")`
4. → `MetastoreBackend.get_connection()` → `session.expunge_all()`
5. → `team_alpha` DagBundleModel is gone from the session
6. At commit time, nothing is left to persist

Non-team bundles (like `shared_dags`) survive only because they happen to be processed last — no subsequent `expunge_all()` wipes them.

## How

`expunge(obj)` detaches only the specific queried object, preserving all other session state. The original intent (return a detached object safe for callers to use freely) is maintained without the collateral damage.

When the query returns no result (`conn is None`), we skip the expunge entirely — nothing to detach.

## Testing

### Unit tests (5 new in `test_secrets_metastore.py`)

- Added new unit tests that pass sessions with pending objects to the metastore and verify that the pending objects are still available after `get_connection` and `get_variable` are called.
- A unit test also ensures that the original intent of expunge to detach the returned object is maintained.
- All 6 existing `test_secrets_backends.py` tests pass unchanged.


### End-to-end on EC2 (PostgreSQL 16, multi-team, S3DagBundles)

- Fresh DB reset, 2 teams, 3 S3 bundles (2 team-scoped + 1 shared)
- All bundles persisted to `dag_bundle` table (previously only shared survived)
- Dag-processor successfully persisted all team-scoped bundles (previously only shared bundles survived)
- `airflow connections get aws_default` — all fields returned correctly
- `airflow variables set/get` — round-trip works
- No `DetachedInstanceError` or session errors in any service logs

closes: #62244

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kiro (Claude Opus 4.6)
