### PR TITLE
issue-37213: Standardizing `FTPToS3Operator`

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/ftp_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/ftp_to_s3.py
@@ -42,12 +42,6 @@ class FTPToS3Operator(BaseOperator):
     :param s3_bucket: The targeted s3 bucket in which to upload the file(s).
     :param s3_key: The targeted s3 key. For one file it must include the file path. For several,
         it must end with "/".
-    :param ftp_filenames: Only used if you want to move multiple files. You can pass a list
-        with exact filenames present in the ftp path, or a prefix that all files must meet. It
-        can also be the string '*' for moving all the files within the ftp path.
-    :param s3_filenames: Only used if you want to move multiple files and name them different from
-        the originals from the ftp. It can be a list of filenames or file prefix (that will replace
-        the ftp prefix).
     :param ftp_conn_id: The ftp connection id. The name or identifier for
         establishing a connection to the FTP server.
     :param aws_conn_id: The s3 connection id. The name or identifier for
@@ -62,7 +56,11 @@ class FTPToS3Operator(BaseOperator):
         uploaded to the S3 bucket.
     """
 
-    template_fields: Sequence[str] = ("ftp_path", "s3_bucket", "s3_key", "ftp_filenames", "s3_filenames")
+    template_fields: Sequence[str] = (
+        "ftp_path",
+        "s3_bucket",
+        "s3_key",
+    )
 
     def __init__(
         self,
@@ -70,8 +68,6 @@ class FTPToS3Operator(BaseOperator):
         ftp_path: str,
         s3_bucket: str,
         s3_key: str,
-        ftp_filenames: str | list[str] | None = None,
-        s3_filenames: str | list[str] | None = None,
         ftp_conn_id: str = "ftp_default",
         aws_conn_id: str | None = "aws_default",
         replace: bool = False,
@@ -84,69 +80,31 @@ class FTPToS3Operator(BaseOperator):
         self.ftp_path = ftp_path
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
-        self.ftp_filenames = ftp_filenames
-        self.s3_filenames = s3_filenames
-        self.aws_conn_id = aws_conn_id
         self.ftp_conn_id = ftp_conn_id
+        self.aws_conn_id = aws_conn_id
         self.replace = replace
         self.encrypt = encrypt
         self.gzip = gzip
         self.acl_policy = acl_policy
-        self.s3_hook: S3Hook | None = None
-        self.ftp_hook: FTPHook | None = None
 
-    def __upload_to_s3_from_ftp(self, remote_filename, s3_file_key):
+    def execute(self, context: Context):
+        """Transfer file from an FTP site to S3."""
+        ftp_hook = FTPHook(ftp_conn_id=self.ftp_conn_id)
+        s3_hook = S3Hook(self.aws_conn_id)
+
         with NamedTemporaryFile() as local_tmp_file:
-            self.ftp_hook.retrieve_file(
-                remote_full_path=remote_filename, local_full_path_or_buffer=local_tmp_file.name
+            # Write the file to local storage before writing the persisted file to S3
+            ftp_hook.retrieve_file(
+                remote_full_path=self.ftp_path, local_full_path_or_buffer=local_tmp_file.name
             )
 
-            self.s3_hook.load_file(
+            s3_hook.load_file(
                 filename=local_tmp_file.name,
-                key=s3_file_key,
+                key=self.s3_key,
                 bucket_name=self.s3_bucket,
                 replace=self.replace,
                 encrypt=self.encrypt,
                 gzip=self.gzip,
                 acl_policy=self.acl_policy,
             )
-            self.log.info("File upload to %s", s3_file_key)
-
-    def execute(self, context: Context):
-        self.ftp_hook = FTPHook(ftp_conn_id=self.ftp_conn_id)
-        self.s3_hook = S3Hook(self.aws_conn_id)
-
-        if self.ftp_filenames:
-            if isinstance(self.ftp_filenames, str):
-                self.log.info("Getting files in %s", self.ftp_path)
-
-                list_dir = self.ftp_hook.list_directory(
-                    path=self.ftp_path,
-                )
-
-                if self.ftp_filenames == "*":
-                    files = list_dir
-                else:
-                    ftp_filename: str = self.ftp_filenames
-                    files = [f for f in list_dir if ftp_filename in f]
-
-                for file in files:
-                    self.log.info("Moving file %s", file)
-
-                    if self.s3_filenames and isinstance(self.s3_filenames, str):
-                        filename = file.replace(self.ftp_filenames, self.s3_filenames)
-                    else:
-                        filename = file
-
-                    s3_file_key = f"{self.s3_key}{filename}"
-                    self.__upload_to_s3_from_ftp(file, s3_file_key)
-
-            else:
-                if self.s3_filenames:
-                    for ftp_file, s3_file in zip(self.ftp_filenames, self.s3_filenames):
-                        self.__upload_to_s3_from_ftp(self.ftp_path + ftp_file, self.s3_key + s3_file)
-                else:
-                    for ftp_file in self.ftp_filenames:
-                        self.__upload_to_s3_from_ftp(self.ftp_path + ftp_file, self.s3_key + ftp_file)
-        else:
-            self.__upload_to_s3_from_ftp(self.ftp_path, self.s3_key)
+            self.log.info("File upload to %s", self.s3_key)

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_ftp_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_ftp_to_s3.py
@@ -19,37 +19,17 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.amazon.aws.transfers.ftp_to_s3 import FTPToS3Operator
 
 TASK_ID = "test_ftp_to_s3"
 BUCKET = "test-s3-bucket"
 S3_KEY = "test/test_1_file.csv"
 FTP_PATH = "/tmp/remote_path.txt"
-AWS_CONN_ID = "aws_default"
-FTP_CONN_ID = "ftp_default"
-S3_KEY_MULTIPLE = "test/"
-FTP_PATH_MULTIPLE = "/tmp/"
 
 
 class TestFTPToS3Operator:
-    def assert_execute(
-        self, mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file, ftp_file, s3_file
-    ):
-        mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
-        mock_ftp_hook_retrieve_file.assert_called_once_with(
-            local_full_path_or_buffer=mock_local_tmp_file_value.name, remote_full_path=ftp_file
-        )
-
-        mock_s3_hook_load_file.assert_called_once_with(
-            filename=mock_local_tmp_file_value.name,
-            key=s3_file,
-            bucket_name=BUCKET,
-            acl_policy=None,
-            encrypt=False,
-            gzip=False,
-            replace=False,
-        )
-
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.retrieve_file")
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_file")
     @mock.patch("airflow.providers.amazon.aws.transfers.ftp_to_s3.NamedTemporaryFile")
@@ -57,74 +37,92 @@ class TestFTPToS3Operator:
         operator = FTPToS3Operator(task_id=TASK_ID, s3_bucket=BUCKET, s3_key=S3_KEY, ftp_path=FTP_PATH)
         operator.execute(None)
 
-        self.assert_execute(
-            mock_local_tmp_file,
-            mock_s3_hook_load_file,
-            mock_ftp_hook_retrieve_file,
-            ftp_file=operator.ftp_path,
-            s3_file=operator.s3_key,
+        mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
+        mock_ftp_hook_retrieve_file.assert_called_once_with(
+            local_full_path_or_buffer=mock_local_tmp_file_value.name, remote_full_path=operator.ftp_path
         )
 
+        mock_s3_hook_load_file.assert_called_once_with(
+            filename=mock_local_tmp_file_value.name,
+            key=operator.s3_key,
+            bucket_name=BUCKET,
+            acl_policy=None,
+            encrypt=False,
+            gzip=False,
+            replace=False,
+        )
+
+    @pytest.mark.parametrize(
+        ("replace", "encrypt", "gzip"),
+        [
+            (True, False, False),
+            (False, True, False),
+            (False, False, True),
+        ],
+    )
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.retrieve_file")
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_file")
     @mock.patch("airflow.providers.amazon.aws.transfers.ftp_to_s3.NamedTemporaryFile")
-    def test_execute_multiple_files_different_names(
-        self, mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file
-    ):
-        operator = FTPToS3Operator(
-            task_id=TASK_ID,
-            s3_bucket=BUCKET,
-            s3_key=S3_KEY_MULTIPLE,
-            ftp_path=FTP_PATH_MULTIPLE,
-            ftp_filenames=["test1.txt"],
-            s3_filenames=["test1_s3.txt"],
-        )
-        operator.execute(None)
-
-        self.assert_execute(
-            mock_local_tmp_file,
-            mock_s3_hook_load_file,
-            mock_ftp_hook_retrieve_file,
-            ftp_file=operator.ftp_path + operator.ftp_filenames[0],
-            s3_file=operator.s3_key + operator.s3_filenames[0],
-        )
-
-    @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.retrieve_file")
-    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_file")
-    @mock.patch("airflow.providers.amazon.aws.transfers.ftp_to_s3.NamedTemporaryFile")
-    def test_execute_multiple_files_same_names(
-        self, mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file
-    ):
-        operator = FTPToS3Operator(
-            task_id=TASK_ID,
-            s3_bucket=BUCKET,
-            s3_key=S3_KEY_MULTIPLE,
-            ftp_path=FTP_PATH_MULTIPLE,
-            ftp_filenames=["test1.txt"],
-        )
-        operator.execute(None)
-
-        self.assert_execute(
-            mock_local_tmp_file,
-            mock_s3_hook_load_file,
-            mock_ftp_hook_retrieve_file,
-            ftp_file=operator.ftp_path + operator.ftp_filenames[0],
-            s3_file=operator.s3_key + operator.ftp_filenames[0],
-        )
-
-    @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.list_directory")
-    def test_execute_multiple_files_prefix(
+    def test_execute_with_config(
         self,
-        mock_ftp_hook_list_directory,
+        mock_local_tmp_file,
+        mock_s3_hook_load_file,
+        mock_ftp_hook_retrieve_file,
+        replace,
+        encrypt,
+        gzip,
     ):
         operator = FTPToS3Operator(
             task_id=TASK_ID,
             s3_bucket=BUCKET,
-            s3_key=S3_KEY_MULTIPLE,
-            ftp_path=FTP_PATH_MULTIPLE,
-            ftp_filenames="test_prefix",
-            s3_filenames="s3_prefix",
+            s3_key=S3_KEY,
+            ftp_path=FTP_PATH,
+            replace=replace,
+            encrypt=encrypt,
+            gzip=gzip,
         )
         operator.execute(None)
 
-        mock_ftp_hook_list_directory.assert_called_once_with(path=FTP_PATH_MULTIPLE)
+        mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
+        mock_ftp_hook_retrieve_file.assert_called_once_with(
+            local_full_path_or_buffer=mock_local_tmp_file_value.name, remote_full_path=operator.ftp_path
+        )
+
+        mock_s3_hook_load_file.assert_called_once_with(
+            filename=mock_local_tmp_file_value.name,
+            key=operator.s3_key,
+            bucket_name=BUCKET,
+            acl_policy=None,
+            encrypt=encrypt,
+            gzip=gzip,
+            replace=replace,
+        )
+
+    @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.retrieve_file")
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_file")
+    @mock.patch("airflow.providers.amazon.aws.transfers.ftp_to_s3.NamedTemporaryFile")
+    def test_execute_with_acl_policy(
+        self, mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file
+    ):
+        operator = FTPToS3Operator(
+            task_id=TASK_ID,
+            s3_bucket=BUCKET,
+            s3_key=S3_KEY,
+            ftp_path=FTP_PATH,
+            acl_policy="bucket-owner-full-control",
+        )
+        operator.execute(None)
+
+        mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
+        mock_s3_hook_load_file.assert_called_once_with(
+            filename=mock_local_tmp_file_value.name,
+            key=operator.s3_key,
+            bucket_name=BUCKET,
+            acl_policy="bucket-owner-full-control",
+            encrypt=False,
+            gzip=False,
+            replace=False,
+        )
+
+    def test_template_fields(self):
+        assert FTPToS3Operator.template_fields == ("ftp_path", "s3_bucket", "s3_key")


### PR DESCRIPTION
## Description

Per #37213:

> There seems to be substantial discrepancies between transfer operators, especially those using S3 as a source or destination. For example, in the `S3ToSFTPOperator`, only a single file can be transferred from the SFTP to the S3 bucket. However, in the `FTPToS3Operator` an arbitrary number of files can be transferred from S3 to an FTP site. To add to this, the `S3ToFTPOperator` only supports a single file being transferred.

The PR refactors the `FTPToS3Operator` to mirror the functionality of the `S3ToFTPOperator` (it's "inverse" counterpart) and `SFTPToS3Operator` (it's sibling). This meant removing the ability to move multiple files and sticking with a single-file approach. This matches the behavior of its close relatives and helps to maintain Airflow DAG-authoring best practices.


## Testing

These changes were tested E2E, as well as with updated unit tests. These unit tests can be run as follows:

```bash
git fetch origin
git checkout origin/issue-37213
git pull

breeze testing providers-tests providers/amazon/tests/unit/amazon/aws/transfers/test_ftp_to_s3.py
```

closes: #37213 