### PR TITLE
feat(airflowctl): add --print-token flag to auth login command

### DIFF
--- a/airflow-ctl/docs/images/command_hashes.txt
+++ b/airflow-ctl/docs/images/command_hashes.txt
@@ -11,4 +11,4 @@ pools:03fc7d948cbecf16ff8d640eb8f0ce43
 providers:1c0afb2dff31d93ab2934b032a2250ab
 variables:0354f8f4b0dde1c3771ed1568692c6ae
 version:31f4efdf8de0dbaaa4fac71ff7efecc3
-auth login:9fe2bb1dd5c602beea2eefb33a2b20a8
+auth login:214f6c3437bcd7765d98185913d48c62

--- a/airflow-ctl/docs/images/output_auth_login.svg
+++ b/airflow-ctl/docs/images/output_auth_login.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 933 440.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 933 538.0" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,103 +19,119 @@
         font-weight: 700;
     }
 
-    .terminal-2514228680-matrix {
+    .terminal-3105520729-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2514228680-title {
+    .terminal-3105520729-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2514228680-r1 { fill: #ff8700 }
-.terminal-2514228680-r2 { fill: #c5c8c6 }
-.terminal-2514228680-r3 { fill: #808080 }
-.terminal-2514228680-r4 { fill: #68a0b3 }
-.terminal-2514228680-r5 { fill: #00af87 }
+    .terminal-3105520729-r1 { fill: #ff8700 }
+.terminal-3105520729-r2 { fill: #c5c8c6 }
+.terminal-3105520729-r3 { fill: #808080 }
+.terminal-3105520729-r4 { fill: #68a0b3 }
+.terminal-3105520729-r5 { fill: #00af87 }
     </style>
 
     <defs>
-    <clipPath id="terminal-2514228680-clip-terminal">
-      <rect x="0" y="0" width="914.0" height="389.4" />
+    <clipPath id="terminal-3105520729-clip-terminal">
+      <rect x="0" y="0" width="914.0" height="487.0" />
     </clipPath>
-    <clipPath id="terminal-2514228680-line-0">
+    <clipPath id="terminal-3105520729-line-0">
     <rect x="0" y="1.5" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-1">
+<clipPath id="terminal-3105520729-line-1">
     <rect x="0" y="25.9" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-2">
+<clipPath id="terminal-3105520729-line-2">
     <rect x="0" y="50.3" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-3">
+<clipPath id="terminal-3105520729-line-3">
     <rect x="0" y="74.7" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-4">
+<clipPath id="terminal-3105520729-line-4">
     <rect x="0" y="99.1" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-5">
+<clipPath id="terminal-3105520729-line-5">
     <rect x="0" y="123.5" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-6">
+<clipPath id="terminal-3105520729-line-6">
     <rect x="0" y="147.9" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-7">
+<clipPath id="terminal-3105520729-line-7">
     <rect x="0" y="172.3" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-8">
+<clipPath id="terminal-3105520729-line-8">
     <rect x="0" y="196.7" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-9">
+<clipPath id="terminal-3105520729-line-9">
     <rect x="0" y="221.1" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-10">
+<clipPath id="terminal-3105520729-line-10">
     <rect x="0" y="245.5" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-11">
+<clipPath id="terminal-3105520729-line-11">
     <rect x="0" y="269.9" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-12">
+<clipPath id="terminal-3105520729-line-12">
     <rect x="0" y="294.3" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-13">
+<clipPath id="terminal-3105520729-line-13">
     <rect x="0" y="318.7" width="915" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2514228680-line-14">
+<clipPath id="terminal-3105520729-line-14">
     <rect x="0" y="343.1" width="915" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3105520729-line-15">
+    <rect x="0" y="367.5" width="915" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3105520729-line-16">
+    <rect x="0" y="391.9" width="915" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3105520729-line-17">
+    <rect x="0" y="416.3" width="915" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3105520729-line-18">
+    <rect x="0" y="440.7" width="915" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="931" height="438.4" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="931" height="536" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2514228680-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3105520729-clip-terminal)">
     
-    <g class="terminal-2514228680-matrix">
-    <text class="terminal-2514228680-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-2514228680-line-0)">Usage:</text><text class="terminal-2514228680-r3" x="85.4" y="20" textLength="256.2" clip-path="url(#terminal-2514228680-line-0)">airflowctl&#160;auth&#160;login</text><text class="terminal-2514228680-r2" x="341.6" y="20" textLength="24.4" clip-path="url(#terminal-2514228680-line-0)">&#160;[</text><text class="terminal-2514228680-r4" x="366" y="20" textLength="24.4" clip-path="url(#terminal-2514228680-line-0)">-h</text><text class="terminal-2514228680-r2" x="390.4" y="20" textLength="36.6" clip-path="url(#terminal-2514228680-line-0)">]&#160;[</text><text class="terminal-2514228680-r4" x="427" y="20" textLength="134.2" clip-path="url(#terminal-2514228680-line-0)">--api-token</text><text class="terminal-2514228680-r5" x="573.4" y="20" textLength="109.8" clip-path="url(#terminal-2514228680-line-0)">API_TOKEN</text><text class="terminal-2514228680-r2" x="683.2" y="20" textLength="12.2" clip-path="url(#terminal-2514228680-line-0)">]</text><text class="terminal-2514228680-r2" x="915" y="20" textLength="12.2" clip-path="url(#terminal-2514228680-line-0)">
-</text><text class="terminal-2514228680-r2" x="0" y="44.4" textLength="366" clip-path="url(#terminal-2514228680-line-1)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-2514228680-r4" x="366" y="44.4" textLength="109.8" clip-path="url(#terminal-2514228680-line-1)">--api-url</text><text class="terminal-2514228680-r5" x="488" y="44.4" textLength="85.4" clip-path="url(#terminal-2514228680-line-1)">API_URL</text><text class="terminal-2514228680-r2" x="573.4" y="44.4" textLength="36.6" clip-path="url(#terminal-2514228680-line-1)">]&#160;[</text><text class="terminal-2514228680-r4" x="610" y="44.4" textLength="24.4" clip-path="url(#terminal-2514228680-line-1)">-e</text><text class="terminal-2514228680-r5" x="646.6" y="44.4" textLength="36.6" clip-path="url(#terminal-2514228680-line-1)">ENV</text><text class="terminal-2514228680-r2" x="683.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2514228680-line-1)">]</text><text class="terminal-2514228680-r2" x="915" y="44.4" textLength="12.2" clip-path="url(#terminal-2514228680-line-1)">
-</text><text class="terminal-2514228680-r2" x="0" y="68.8" textLength="366" clip-path="url(#terminal-2514228680-line-2)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-2514228680-r4" x="366" y="68.8" textLength="122" clip-path="url(#terminal-2514228680-line-2)">--password</text><text class="terminal-2514228680-r5" x="500.2" y="68.8" textLength="97.6" clip-path="url(#terminal-2514228680-line-2)">PASSWORD</text><text class="terminal-2514228680-r2" x="597.8" y="68.8" textLength="36.6" clip-path="url(#terminal-2514228680-line-2)">]&#160;[</text><text class="terminal-2514228680-r4" x="634.4" y="68.8" textLength="170.8" clip-path="url(#terminal-2514228680-line-2)">--skip-keyring</text><text class="terminal-2514228680-r2" x="805.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2514228680-line-2)">]</text><text class="terminal-2514228680-r2" x="915" y="68.8" textLength="12.2" clip-path="url(#terminal-2514228680-line-2)">
-</text><text class="terminal-2514228680-r2" x="0" y="93.2" textLength="366" clip-path="url(#terminal-2514228680-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-2514228680-r4" x="366" y="93.2" textLength="122" clip-path="url(#terminal-2514228680-line-3)">--username</text><text class="terminal-2514228680-r5" x="500.2" y="93.2" textLength="97.6" clip-path="url(#terminal-2514228680-line-3)">USERNAME</text><text class="terminal-2514228680-r2" x="597.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2514228680-line-3)">]</text><text class="terminal-2514228680-r2" x="915" y="93.2" textLength="12.2" clip-path="url(#terminal-2514228680-line-3)">
-</text><text class="terminal-2514228680-r2" x="915" y="117.6" textLength="12.2" clip-path="url(#terminal-2514228680-line-4)">
-</text><text class="terminal-2514228680-r2" x="0" y="142" textLength="366" clip-path="url(#terminal-2514228680-line-5)">Login&#160;to&#160;the&#160;metadata&#160;database</text><text class="terminal-2514228680-r2" x="915" y="142" textLength="12.2" clip-path="url(#terminal-2514228680-line-5)">
-</text><text class="terminal-2514228680-r2" x="915" y="166.4" textLength="12.2" clip-path="url(#terminal-2514228680-line-6)">
-</text><text class="terminal-2514228680-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-2514228680-line-7)">Options:</text><text class="terminal-2514228680-r2" x="915" y="190.8" textLength="12.2" clip-path="url(#terminal-2514228680-line-7)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-2514228680-line-8)">-h</text><text class="terminal-2514228680-r2" x="48.8" y="215.2" textLength="24.4" clip-path="url(#terminal-2514228680-line-8)">,&#160;</text><text class="terminal-2514228680-r4" x="73.2" y="215.2" textLength="73.2" clip-path="url(#terminal-2514228680-line-8)">--help</text><text class="terminal-2514228680-r2" x="292.8" y="215.2" textLength="378.2" clip-path="url(#terminal-2514228680-line-8)">show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2514228680-r2" x="915" y="215.2" textLength="12.2" clip-path="url(#terminal-2514228680-line-8)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="239.6" textLength="134.2" clip-path="url(#terminal-2514228680-line-9)">--api-token</text><text class="terminal-2514228680-r5" x="170.8" y="239.6" textLength="109.8" clip-path="url(#terminal-2514228680-line-9)">API_TOKEN</text><text class="terminal-2514228680-r2" x="915" y="239.6" textLength="12.2" clip-path="url(#terminal-2514228680-line-9)">
-</text><text class="terminal-2514228680-r2" x="292.8" y="264" textLength="427" clip-path="url(#terminal-2514228680-line-10)">The&#160;token&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-2514228680-r2" x="915" y="264" textLength="12.2" clip-path="url(#terminal-2514228680-line-10)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="288.4" textLength="109.8" clip-path="url(#terminal-2514228680-line-11)">--api-url</text><text class="terminal-2514228680-r5" x="146.4" y="288.4" textLength="85.4" clip-path="url(#terminal-2514228680-line-11)">API_URL</text><text class="terminal-2514228680-r2" x="292.8" y="288.4" textLength="439.2" clip-path="url(#terminal-2514228680-line-11)">The&#160;URL&#160;of&#160;the&#160;metadata&#160;database&#160;API</text><text class="terminal-2514228680-r2" x="915" y="288.4" textLength="12.2" clip-path="url(#terminal-2514228680-line-11)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="312.8" textLength="24.4" clip-path="url(#terminal-2514228680-line-12)">-e</text><text class="terminal-2514228680-r2" x="48.8" y="312.8" textLength="24.4" clip-path="url(#terminal-2514228680-line-12)">,&#160;</text><text class="terminal-2514228680-r4" x="73.2" y="312.8" textLength="61" clip-path="url(#terminal-2514228680-line-12)">--env</text><text class="terminal-2514228680-r5" x="146.4" y="312.8" textLength="36.6" clip-path="url(#terminal-2514228680-line-12)">ENV</text><text class="terminal-2514228680-r2" x="292.8" y="312.8" textLength="451.4" clip-path="url(#terminal-2514228680-line-12)">The&#160;environment&#160;to&#160;run&#160;the&#160;command&#160;in</text><text class="terminal-2514228680-r2" x="915" y="312.8" textLength="12.2" clip-path="url(#terminal-2514228680-line-12)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="337.2" textLength="122" clip-path="url(#terminal-2514228680-line-13)">--password</text><text class="terminal-2514228680-r5" x="158.6" y="337.2" textLength="97.6" clip-path="url(#terminal-2514228680-line-13)">PASSWORD</text><text class="terminal-2514228680-r2" x="292.8" y="337.2" textLength="463.6" clip-path="url(#terminal-2514228680-line-13)">The&#160;password&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-2514228680-r2" x="915" y="337.2" textLength="12.2" clip-path="url(#terminal-2514228680-line-13)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="361.6" textLength="170.8" clip-path="url(#terminal-2514228680-line-14)">--skip-keyring</text><text class="terminal-2514228680-r2" x="292.8" y="361.6" textLength="427" clip-path="url(#terminal-2514228680-line-14)">Skip&#160;storing&#160;credentials&#160;in&#160;keyring</text><text class="terminal-2514228680-r2" x="915" y="361.6" textLength="12.2" clip-path="url(#terminal-2514228680-line-14)">
-</text><text class="terminal-2514228680-r4" x="24.4" y="386" textLength="122" clip-path="url(#terminal-2514228680-line-15)">--username</text><text class="terminal-2514228680-r5" x="158.6" y="386" textLength="97.6" clip-path="url(#terminal-2514228680-line-15)">USERNAME</text><text class="terminal-2514228680-r2" x="292.8" y="386" textLength="463.6" clip-path="url(#terminal-2514228680-line-15)">The&#160;username&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-2514228680-r2" x="915" y="386" textLength="12.2" clip-path="url(#terminal-2514228680-line-15)">
+    <g class="terminal-3105520729-matrix">
+    <text class="terminal-3105520729-r1" x="0" y="20" textLength="73.2" clip-path="url(#terminal-3105520729-line-0)">Usage:</text><text class="terminal-3105520729-r3" x="85.4" y="20" textLength="256.2" clip-path="url(#terminal-3105520729-line-0)">airflowctl&#160;auth&#160;login</text><text class="terminal-3105520729-r2" x="341.6" y="20" textLength="24.4" clip-path="url(#terminal-3105520729-line-0)">&#160;[</text><text class="terminal-3105520729-r4" x="366" y="20" textLength="24.4" clip-path="url(#terminal-3105520729-line-0)">-h</text><text class="terminal-3105520729-r2" x="390.4" y="20" textLength="36.6" clip-path="url(#terminal-3105520729-line-0)">]&#160;[</text><text class="terminal-3105520729-r4" x="427" y="20" textLength="134.2" clip-path="url(#terminal-3105520729-line-0)">--api-token</text><text class="terminal-3105520729-r5" x="573.4" y="20" textLength="109.8" clip-path="url(#terminal-3105520729-line-0)">API_TOKEN</text><text class="terminal-3105520729-r2" x="683.2" y="20" textLength="12.2" clip-path="url(#terminal-3105520729-line-0)">]</text><text class="terminal-3105520729-r2" x="915" y="20" textLength="12.2" clip-path="url(#terminal-3105520729-line-0)">
+</text><text class="terminal-3105520729-r2" x="0" y="44.4" textLength="366" clip-path="url(#terminal-3105520729-line-1)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-3105520729-r4" x="366" y="44.4" textLength="109.8" clip-path="url(#terminal-3105520729-line-1)">--api-url</text><text class="terminal-3105520729-r5" x="488" y="44.4" textLength="85.4" clip-path="url(#terminal-3105520729-line-1)">API_URL</text><text class="terminal-3105520729-r2" x="573.4" y="44.4" textLength="36.6" clip-path="url(#terminal-3105520729-line-1)">]&#160;[</text><text class="terminal-3105520729-r4" x="610" y="44.4" textLength="24.4" clip-path="url(#terminal-3105520729-line-1)">-e</text><text class="terminal-3105520729-r5" x="646.6" y="44.4" textLength="36.6" clip-path="url(#terminal-3105520729-line-1)">ENV</text><text class="terminal-3105520729-r2" x="683.2" y="44.4" textLength="12.2" clip-path="url(#terminal-3105520729-line-1)">]</text><text class="terminal-3105520729-r2" x="915" y="44.4" textLength="12.2" clip-path="url(#terminal-3105520729-line-1)">
+</text><text class="terminal-3105520729-r2" x="0" y="68.8" textLength="366" clip-path="url(#terminal-3105520729-line-2)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-3105520729-r4" x="366" y="68.8" textLength="122" clip-path="url(#terminal-3105520729-line-2)">--password</text><text class="terminal-3105520729-r5" x="500.2" y="68.8" textLength="97.6" clip-path="url(#terminal-3105520729-line-2)">PASSWORD</text><text class="terminal-3105520729-r2" x="597.8" y="68.8" textLength="36.6" clip-path="url(#terminal-3105520729-line-2)">]&#160;[</text><text class="terminal-3105520729-r4" x="634.4" y="68.8" textLength="158.6" clip-path="url(#terminal-3105520729-line-2)">--print-token</text><text class="terminal-3105520729-r2" x="793" y="68.8" textLength="12.2" clip-path="url(#terminal-3105520729-line-2)">]</text><text class="terminal-3105520729-r2" x="915" y="68.8" textLength="12.2" clip-path="url(#terminal-3105520729-line-2)">
+</text><text class="terminal-3105520729-r2" x="0" y="93.2" textLength="366" clip-path="url(#terminal-3105520729-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;[</text><text class="terminal-3105520729-r4" x="366" y="93.2" textLength="170.8" clip-path="url(#terminal-3105520729-line-3)">--skip-keyring</text><text class="terminal-3105520729-r2" x="536.8" y="93.2" textLength="36.6" clip-path="url(#terminal-3105520729-line-3)">]&#160;[</text><text class="terminal-3105520729-r4" x="573.4" y="93.2" textLength="122" clip-path="url(#terminal-3105520729-line-3)">--username</text><text class="terminal-3105520729-r5" x="707.6" y="93.2" textLength="97.6" clip-path="url(#terminal-3105520729-line-3)">USERNAME</text><text class="terminal-3105520729-r2" x="805.2" y="93.2" textLength="36.6" clip-path="url(#terminal-3105520729-line-3)">]&#160;[</text><text class="terminal-3105520729-r4" x="841.8" y="93.2" textLength="24.4" clip-path="url(#terminal-3105520729-line-3)">-y</text><text class="terminal-3105520729-r2" x="866.2" y="93.2" textLength="12.2" clip-path="url(#terminal-3105520729-line-3)">]</text><text class="terminal-3105520729-r2" x="915" y="93.2" textLength="12.2" clip-path="url(#terminal-3105520729-line-3)">
+</text><text class="terminal-3105520729-r2" x="915" y="117.6" textLength="12.2" clip-path="url(#terminal-3105520729-line-4)">
+</text><text class="terminal-3105520729-r2" x="0" y="142" textLength="366" clip-path="url(#terminal-3105520729-line-5)">Login&#160;to&#160;the&#160;metadata&#160;database</text><text class="terminal-3105520729-r2" x="915" y="142" textLength="12.2" clip-path="url(#terminal-3105520729-line-5)">
+</text><text class="terminal-3105520729-r2" x="915" y="166.4" textLength="12.2" clip-path="url(#terminal-3105520729-line-6)">
+</text><text class="terminal-3105520729-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-3105520729-line-7)">Options:</text><text class="terminal-3105520729-r2" x="915" y="190.8" textLength="12.2" clip-path="url(#terminal-3105520729-line-7)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="215.2" textLength="24.4" clip-path="url(#terminal-3105520729-line-8)">-h</text><text class="terminal-3105520729-r2" x="48.8" y="215.2" textLength="24.4" clip-path="url(#terminal-3105520729-line-8)">,&#160;</text><text class="terminal-3105520729-r4" x="73.2" y="215.2" textLength="73.2" clip-path="url(#terminal-3105520729-line-8)">--help</text><text class="terminal-3105520729-r2" x="292.8" y="215.2" textLength="378.2" clip-path="url(#terminal-3105520729-line-8)">show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3105520729-r2" x="915" y="215.2" textLength="12.2" clip-path="url(#terminal-3105520729-line-8)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="239.6" textLength="134.2" clip-path="url(#terminal-3105520729-line-9)">--api-token</text><text class="terminal-3105520729-r5" x="170.8" y="239.6" textLength="109.8" clip-path="url(#terminal-3105520729-line-9)">API_TOKEN</text><text class="terminal-3105520729-r2" x="915" y="239.6" textLength="12.2" clip-path="url(#terminal-3105520729-line-9)">
+</text><text class="terminal-3105520729-r2" x="292.8" y="264" textLength="427" clip-path="url(#terminal-3105520729-line-10)">The&#160;token&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-3105520729-r2" x="915" y="264" textLength="12.2" clip-path="url(#terminal-3105520729-line-10)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="288.4" textLength="109.8" clip-path="url(#terminal-3105520729-line-11)">--api-url</text><text class="terminal-3105520729-r5" x="146.4" y="288.4" textLength="85.4" clip-path="url(#terminal-3105520729-line-11)">API_URL</text><text class="terminal-3105520729-r2" x="292.8" y="288.4" textLength="439.2" clip-path="url(#terminal-3105520729-line-11)">The&#160;URL&#160;of&#160;the&#160;metadata&#160;database&#160;API</text><text class="terminal-3105520729-r2" x="915" y="288.4" textLength="12.2" clip-path="url(#terminal-3105520729-line-11)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="312.8" textLength="24.4" clip-path="url(#terminal-3105520729-line-12)">-e</text><text class="terminal-3105520729-r2" x="48.8" y="312.8" textLength="24.4" clip-path="url(#terminal-3105520729-line-12)">,&#160;</text><text class="terminal-3105520729-r4" x="73.2" y="312.8" textLength="61" clip-path="url(#terminal-3105520729-line-12)">--env</text><text class="terminal-3105520729-r5" x="146.4" y="312.8" textLength="36.6" clip-path="url(#terminal-3105520729-line-12)">ENV</text><text class="terminal-3105520729-r2" x="292.8" y="312.8" textLength="451.4" clip-path="url(#terminal-3105520729-line-12)">The&#160;environment&#160;to&#160;run&#160;the&#160;command&#160;in</text><text class="terminal-3105520729-r2" x="915" y="312.8" textLength="12.2" clip-path="url(#terminal-3105520729-line-12)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="337.2" textLength="122" clip-path="url(#terminal-3105520729-line-13)">--password</text><text class="terminal-3105520729-r5" x="158.6" y="337.2" textLength="97.6" clip-path="url(#terminal-3105520729-line-13)">PASSWORD</text><text class="terminal-3105520729-r2" x="292.8" y="337.2" textLength="463.6" clip-path="url(#terminal-3105520729-line-13)">The&#160;password&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-3105520729-r2" x="915" y="337.2" textLength="12.2" clip-path="url(#terminal-3105520729-line-13)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="361.6" textLength="158.6" clip-path="url(#terminal-3105520729-line-14)">--print-token</text><text class="terminal-3105520729-r2" x="292.8" y="361.6" textLength="610" clip-path="url(#terminal-3105520729-line-14)">Print&#160;the&#160;auth&#160;token&#160;to&#160;stdout&#160;after&#160;a&#160;successful&#160;</text><text class="terminal-3105520729-r2" x="915" y="361.6" textLength="12.2" clip-path="url(#terminal-3105520729-line-14)">
+</text><text class="terminal-3105520729-r2" x="0" y="386" textLength="61" clip-path="url(#terminal-3105520729-line-15)">login</text><text class="terminal-3105520729-r2" x="915" y="386" textLength="12.2" clip-path="url(#terminal-3105520729-line-15)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="410.4" textLength="170.8" clip-path="url(#terminal-3105520729-line-16)">--skip-keyring</text><text class="terminal-3105520729-r2" x="292.8" y="410.4" textLength="427" clip-path="url(#terminal-3105520729-line-16)">Skip&#160;storing&#160;credentials&#160;in&#160;keyring</text><text class="terminal-3105520729-r2" x="915" y="410.4" textLength="12.2" clip-path="url(#terminal-3105520729-line-16)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="434.8" textLength="122" clip-path="url(#terminal-3105520729-line-17)">--username</text><text class="terminal-3105520729-r5" x="158.6" y="434.8" textLength="97.6" clip-path="url(#terminal-3105520729-line-17)">USERNAME</text><text class="terminal-3105520729-r2" x="292.8" y="434.8" textLength="463.6" clip-path="url(#terminal-3105520729-line-17)">The&#160;username&#160;to&#160;use&#160;for&#160;authentication</text><text class="terminal-3105520729-r2" x="915" y="434.8" textLength="12.2" clip-path="url(#terminal-3105520729-line-17)">
+</text><text class="terminal-3105520729-r4" x="24.4" y="459.2" textLength="24.4" clip-path="url(#terminal-3105520729-line-18)">-y</text><text class="terminal-3105520729-r2" x="48.8" y="459.2" textLength="24.4" clip-path="url(#terminal-3105520729-line-18)">,&#160;</text><text class="terminal-3105520729-r4" x="73.2" y="459.2" textLength="61" clip-path="url(#terminal-3105520729-line-18)">--yes</text><text class="terminal-3105520729-r2" x="292.8" y="459.2" textLength="414.8" clip-path="url(#terminal-3105520729-line-18)">Skip&#160;the&#160;confirmation&#160;prompt&#160;when&#160;</text><text class="terminal-3105520729-r4" x="707.6" y="459.2" textLength="158.6" clip-path="url(#terminal-3105520729-line-18)">--print-token</text><text class="terminal-3105520729-r2" x="866.2" y="459.2" textLength="48.8" clip-path="url(#terminal-3105520729-line-18)">&#160;is&#160;</text><text class="terminal-3105520729-r2" x="915" y="459.2" textLength="12.2" clip-path="url(#terminal-3105520729-line-18)">
+</text><text class="terminal-3105520729-r2" x="0" y="483.6" textLength="48.8" clip-path="url(#terminal-3105520729-line-19)">used</text><text class="terminal-3105520729-r2" x="915" y="483.6" textLength="12.2" clip-path="url(#terminal-3105520729-line-19)">
 </text>
     </g>
     </g>

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -246,6 +246,20 @@ ARG_AUTH_PASSWORD = Arg(
     dest="password",
     help="The password to use for authentication",
 )
+ARG_AUTH_PRINT_TOKEN = Arg(
+    flags=("--print-token",),
+    dest="print_token",
+    default=False,
+    action="store_true",
+    help="Print the auth token to stdout after a successful login",
+)
+ARG_AUTH_YES = Arg(
+    flags=("-y", "--yes"),
+    dest="yes",
+    default=False,
+    action="store_true",
+    help="Skip the confirmation prompt when --print-token is used",
+)
 
 # Dag Commands Args
 ARG_DAG_ID = Arg(
@@ -833,6 +847,8 @@ AUTH_COMMANDS = (
             ARG_AUTH_USERNAME,
             ARG_AUTH_PASSWORD,
             ARG_AUTH_SKIP_KEYRING,
+            ARG_AUTH_PRINT_TOKEN,
+            ARG_AUTH_YES,
         ),
     ),
     ActionCommand(

--- a/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
@@ -76,9 +76,6 @@ def login(args, api_client=NEW_API_CLIENT) -> None:
 
     # Username + password login (from args or interactively prompted)
     if username and password:
-        if args.skip_keyring:
-            rich.print("[red]The --skip-keyring is not compatible with username and password login.")
-            sys.exit(1)
         credentials = Credentials(
             api_url=args.api_url,
             api_token="",
@@ -95,7 +92,7 @@ def login(args, api_client=NEW_API_CLIENT) -> None:
                 )
             )
             credentials.api_token = login_response.access_token
-            credentials.save()
+            credentials.save(args.skip_keyring)
             rich.print(success_message, file=sys.stderr)
             if args.print_token:
                 _maybe_print_token(credentials.api_token, args.yes)

--- a/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
@@ -33,6 +33,22 @@ from airflowctl.api.datamodels.auth_generated import LoginBody
 from airflowctl.ctl.console_formatting import AirflowConsole
 
 
+def _maybe_print_token(token: str, yes: bool) -> None:
+    """Warn the user on stderr, confirm, then print the token to stdout."""
+    if not yes:
+        rich.print(
+            "[yellow]Warning: printing your auth token to stdout exposes it in your terminal "
+            "history and to anyone who can see your screen.[/yellow]",
+            file=sys.stderr,
+        )
+        rich.print("Are you sure you want to print the token? [y/N]: ", end="", file=sys.stderr)
+        answer = input().strip().lower()
+        if answer not in ("y", "yes"):
+            rich.print("[red]Aborted.[/red]")
+            return
+    print(token)
+
+
 @provide_api_client(kind=ClientKind.AUTH)
 def login(args, api_client=NEW_API_CLIENT) -> None:
     """Login to a provider."""
@@ -81,6 +97,8 @@ def login(args, api_client=NEW_API_CLIENT) -> None:
             credentials.api_token = login_response.access_token
             credentials.save()
             rich.print(success_message)
+            if args.print_token:
+                _maybe_print_token(credentials.api_token, args.yes)
             return
         except Exception as e:
             rich.print(f"[red]Login failed: {e}")
@@ -102,6 +120,8 @@ def login(args, api_client=NEW_API_CLIENT) -> None:
         api_environment=args.env,
     ).save(args.skip_keyring)
     rich.print(success_message)
+    if args.print_token:
+        _maybe_print_token(token, args.yes)
 
 
 def list_envs(args) -> None:

--- a/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/auth_command.py
@@ -96,7 +96,7 @@ def login(args, api_client=NEW_API_CLIENT) -> None:
             )
             credentials.api_token = login_response.access_token
             credentials.save()
-            rich.print(success_message)
+            rich.print(success_message, file=sys.stderr)
             if args.print_token:
                 _maybe_print_token(credentials.api_token, args.yes)
             return

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_auth_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_auth_command.py
@@ -226,6 +226,41 @@ class TestCliAuthCommands:
             )
 
     @patch("airflowctl.api.client.keyring")
+    def test_login_with_username_password_skip_keyring_and_print_token(
+        self, mock_keyring, api_client_maker, capsys
+    ):
+        """--username --password --skip-keyring --print-token --yes succeeds without touching keyring."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        auth_command.login(
+            self.parser.parse_args(
+                [
+                    "auth",
+                    "login",
+                    "--api-url",
+                    "http://localhost:8080",
+                    "--username",
+                    "test_user",
+                    "--password",
+                    "test_password",
+                    "--skip-keyring",
+                    "--print-token",
+                    "--yes",
+                ]
+            ),
+            api_client=api_client,
+        )
+
+        mock_keyring.set_password.assert_not_called()
+        assert "TEST_TOKEN" in capsys.readouterr().out
+
+    @patch("airflowctl.api.client.keyring")
     def test_login_with_username_and_password_no_keyring_backend(self, mock_keyring, api_client_maker):
         """Test that login fails when no keyring backend is available."""
         from keyring.errors import NoKeyringError

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_auth_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_auth_command.py
@@ -256,6 +256,137 @@ class TestCliAuthCommands:
             )
 
 
+class TestPrintToken:
+    """Tests for --print-token and --yes flags on auth login."""
+
+    parser = cli_parser.get_parser()
+    login_response = LoginResponse(access_token="TEST_TOKEN")
+
+    def _make_args(self, extra: list[str]):
+        return self.parser.parse_args(["auth", "login", "--api-url", "http://localhost:8080"] + extra)
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_print_token_with_yes_prints_to_stdout(self, mock_keyring, api_client_maker, capsys):
+        """--print-token --yes prints the token to stdout without prompting."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        auth_command.login(self._make_args(["--print-token", "--yes"]), api_client=api_client)
+
+        captured = capsys.readouterr()
+        assert "TEST_TOKEN" in captured.out
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_print_token_user_confirms(self, mock_keyring, api_client_maker, capsys):
+        """--print-token prints the token when the user answers 'y' at the prompt."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        with patch("builtins.input", return_value="y"):
+            auth_command.login(self._make_args(["--print-token"]), api_client=api_client)
+
+        captured = capsys.readouterr()
+        assert "TEST_TOKEN" in captured.out
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_print_token_user_declines(self, mock_keyring, api_client_maker, capsys):
+        """--print-token does not print the token when the user answers 'n'."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        with patch("builtins.input", return_value="n"):
+            auth_command.login(self._make_args(["--print-token"]), api_client=api_client)
+
+        captured = capsys.readouterr()
+        assert "TEST_TOKEN" not in captured.out
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_no_print_token_flag_does_not_print(self, mock_keyring, api_client_maker, capsys):
+        """Without --print-token, the token never appears on stdout."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        auth_command.login(self._make_args([]), api_client=api_client)
+
+        captured = capsys.readouterr()
+        assert "TEST_TOKEN" not in captured.out
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_print_token_warning_goes_to_stderr(self, mock_keyring, api_client_maker, capsys):
+        """The security warning is written to stderr, not stdout."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        with patch("builtins.input", return_value="y"):
+            auth_command.login(self._make_args(["--print-token"]), api_client=api_client)
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "TEST_TOKEN" not in captured.err
+
+    @patch("airflowctl.api.client.keyring")
+    def test_print_token_with_username_password_and_yes(self, mock_keyring, api_client_maker, capsys):
+        """--print-token --yes also works for username/password login."""
+        api_client = api_client_maker(
+            path="/auth/token/cli",
+            response_json=self.login_response.model_dump(),
+            expected_http_status_code=201,
+            kind=ClientKind.AUTH,
+        )
+        mock_keyring.set_password = mock.MagicMock()
+
+        auth_command.login(
+            self.parser.parse_args(
+                [
+                    "auth",
+                    "login",
+                    "--api-url",
+                    "http://localhost:8080",
+                    "--username",
+                    "user",
+                    "--password",
+                    "pass",
+                    "--print-token",
+                    "--yes",
+                ]
+            ),
+            api_client=api_client,
+        )
+
+        captured = capsys.readouterr()
+        assert "TEST_TOKEN" in captured.out
+
+
 class TestListEnvs:
     parser = cli_parser.get_parser()
 


### PR DESCRIPTION
Prints the auth token to stdout after a successful login. A confirmation prompt (with warning) is shown on stderr to prevent accidental exposure. Use --yes to bypass the prompt for scripting.

<img width="1628" height="442" alt="image" src="https://github.com/user-attachments/assets/1fe3a4b8-6802-406b-85ce-2c8aba851441" />

Alternative to #62843

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
ClaudeCode