### PR TITLE
Fix regression in security iframe navigation logic with basename

### DIFF
--- a/airflow-core/newsfragments/63141.bugfix.rst
+++ b/airflow-core/newsfragments/63141.bugfix.rst
@@ -1,0 +1,1 @@
+Fix security iframe navigation when AIRFLOW__API__BASE_URL basename is configured

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -48,7 +48,9 @@ export const Security = () => {
       const basename = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
       const iframePath = iframe.contentWindow.location.pathname;
-      const pathWithoutBase = iframePath.startsWith(basename) ? iframePath.slice(basename.length) : iframePath;
+      const pathWithoutBase = iframePath.startsWith(basename)
+        ? iframePath.slice(basename.length)
+        : iframePath;
 
       if (!pathWithoutBase.startsWith("/auth/")) {
         void Promise.resolve(navigate("/"));

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -43,8 +43,16 @@ export const Security = () => {
   const onLoad = () => {
     const iframe: HTMLIFrameElement | null = document.querySelector("#security-iframe");
 
-    if (iframe?.contentWindow && !iframe.contentWindow.location.pathname.startsWith("/auth/")) {
-      void Promise.resolve(navigate("/"));
+    if (iframe?.contentWindow) {
+      const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
+      const basename = new URL(baseUrl).pathname.replace(/\/$/u, "");
+
+      const iframePath = iframe.contentWindow.location.pathname;
+      const pathWithoutBase = iframePath.startsWith(basename) ? iframePath.slice(basename.length) : iframePath;
+
+      if (!pathWithoutBase.startsWith("/auth/")) {
+        void Promise.resolve(navigate("/"));
+      }
     }
   };
 

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -44,8 +44,8 @@ export const Security = () => {
     const iframe: HTMLIFrameElement | null = document.querySelector("#security-iframe");
 
     if (iframe?.contentWindow) {
-      const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
-      const basename = new URL(baseUrl).pathname.replace(/\/$/u, "");
+      const baseHref = document.querySelector("base")?.href;
+      const basename = baseHref === undefined ? "" : new URL(baseHref).pathname.replace(/\/$/u, "");
 
       const iframePath = iframe.contentWindow.location.pathname;
       const pathWithoutBase = iframePath.startsWith(basename)

--- a/airflow-core/src/airflow/ui/src/pages/Security.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Security.tsx
@@ -17,8 +17,7 @@
  * under the License.
  */
 import { Box } from "@chakra-ui/react";
-import { useParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useAuthLinksServiceGetAuthMenus } from "openapi/queries";
 import { ProgressBar } from "src/components/ui";
@@ -44,16 +43,10 @@ export const Security = () => {
     const iframe: HTMLIFrameElement | null = document.querySelector("#security-iframe");
 
     if (iframe?.contentWindow) {
-      const baseHref = document.querySelector("base")?.href;
-      const basename = baseHref === undefined ? "" : new URL(baseHref).pathname.replace(/\/$/u, "");
+      const base = new URL(document.baseURI).pathname.replace(/\/$/u, ""); // Remove trailing slash if exists
 
-      const iframePath = iframe.contentWindow.location.pathname;
-      const pathWithoutBase = iframePath.startsWith(basename)
-        ? iframePath.slice(basename.length)
-        : iframePath;
-
-      if (!pathWithoutBase.startsWith("/auth/")) {
-        void Promise.resolve(navigate("/"));
+      if (!iframe.contentWindow.location.pathname.startsWith(`${base}/auth/`)) {
+        void navigate("/");
       }
     }
   };


### PR DESCRIPTION
Fixes a regression where the security iframe ignores the configured `AIRFLOW__API__BASE_URL` (basename), causing valid navigation within the iframe to incorrectly redirect users to the root dashboard. 

The fix updates [Security.tsx](cci:7://file:///Users/subhamsangwan/airflow/airflow-core/src/airflow/ui/src/pages/Security.tsx:0:0-0:0) to read the `<base>` tag's `href` (the same approach used by [router.tsx](cci:7://file:///Users/subhamsangwan/airflow/airflow-core/src/airflow/ui/src/router.tsx:0:0-0:0)) and safely strips the basename from the iframe's pathname before checking if it starts with `/auth/`.

closes: #63111
