### PR TITLE
Bump astroid>=4 

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -75,8 +75,7 @@ dependencies = [
     "twine>=4.0.2",
 ]
 "docs" = [
-    # Astroid 4 released 5 Oct 2025 breaks autoapi https://github.com/apache/airflow/issues/56420
-    "astroid>=3,<4",
+    "astroid>=4",
     "checksumdir>=1.2.0",
     "rich-click>=1.9.7",
     "click>=8.3.0",
@@ -87,7 +86,7 @@ dependencies = [
     "pagefind-bin>=1.5.0a3",
     "sphinx-airflow-theme@https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.0-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
-    "sphinx-autoapi>=3",
+    "sphinx-autoapi>=3.8.0",
     "sphinx-autobuild>=2024.10.2",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.5.0",


### PR DESCRIPTION
Now that sphinx-autoapi released a version that supports astroid 4 in Python>=3.10 we can safely upgrade astroid
closes: https://github.com/apache/airflow/issues/56420