### PR TITLE
Fix UnicodeDecodeError crash in KubernetesPodOperator deferrable log fetching

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1004,6 +1004,13 @@ class AsyncKubernetesHook(KubernetesHook):
                 )
                 logs_list: list[str] = logs.splitlines()
                 return logs_list
+            except UnicodeDecodeError as e:
+                self.log.warning(
+                    "Failed to decode pod logs as UTF-8 (possibly truncated multi-byte sequence). "
+                    "Skipping this log interval: %s",
+                    e,
+                )
+                return []
             except HTTPError as e:
                 raise KubernetesApiError from e
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1580,6 +1580,26 @@ class TestAsyncKubernetesHook:
         assert "2023-01-11 Some string logs..." in logs
 
     @pytest.mark.asyncio
+    @mock.patch(KUBE_API.format("read_namespaced_pod_log"))
+    async def test_read_logs_unicode_decode_error(self, lib_method, kube_config_loader):
+        lib_method.side_effect = UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+        hook = AsyncKubernetesHook(
+            conn_id=None,
+            in_cluster=False,
+            config_file=None,
+            cluster_context=None,
+        )
+
+        logs = await hook.read_logs(
+            name=POD_NAME,
+            namespace=NAMESPACE,
+            container_name=CONTAINER_NAME,
+            since_seconds=10,
+        )
+
+        assert logs == []
+
+    @pytest.mark.asyncio
     @mock.patch(KUBE_BATCH_API.format("read_namespaced_job_status"))
     async def test_get_job_status(self, lib_method, kube_config_loader):
         lib_method.return_value = self.mock_await_result(None)


### PR DESCRIPTION
When running KubernetesPodOperator in deferrable mode, pod logs that contain
non-UTF-8 bytes (truncated multi-byte sequences, tqdm progress bars, binary
output, etc.) caused a UnicodeDecodeError to propagate up from
`AsyncKubernetesHook.read_logs()`. Since only `HTTPError` was being caught,
this bubbled up as an unhandled exception and crashed the task entirely.

The fix catches `UnicodeDecodeError` in `read_logs`, logs a warning with the
exception details, and returns an empty list for that interval. The next
polling cycle will attempt to fetch logs again, so nothing is lost except
one log window — much better than the whole task failing.

Also added a unit test that mocks `read_namespaced_pod_log` to raise
`UnicodeDecodeError` and asserts the method returns `[]` without raising.

Fixes #63173