### PR TITLE
Fix task logs unavailable while waiting for retry

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -913,6 +913,7 @@ class FileTaskHandler(logging.Handler):
             else:
                 # Check if the resource was properly fetched
                 response.raise_for_status()
+
                 if int(response.headers.get("Content-Length", 0)) > 0:
                     sources.append(url)
                     log_streams.append(

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -651,7 +651,9 @@ class FileTaskHandler(logging.Handler):
         if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_k8s_exec_pod:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)
-        elif ti.state not in State.unfinished and not (local_logs or remote_logs):
+        elif (ti.state not in State.unfinished or ti.state in _STATES_WITH_COMPLETED_ATTEMPT) and not (
+            local_logs or remote_logs
+        ):
             # ordinarily we don't check served logs, with the assumption that users set up
             # remote logging or shared drive for logs for persistence, but that's not always true
             # so even if task is done, if no local logs or remote logs are found, we'll check the worker
@@ -891,6 +893,23 @@ class FileTaskHandler(logging.Handler):
                     "See more at https://airflow.apache.org/docs/apache-airflow/"
                     "stable/configurations-ref.html#secret-key"
                 )
+            elif response.status_code == 404:
+                # Log file not found on the worker's log server.
+                # This typically happens when a task retried on a different worker
+                # and the original worker's logs are no longer accessible.
+                # Fall back to local filesystem read if available.
+                worker_log_full_path = Path(self.local_base, worker_log_rel_path)
+                fallback_sources, fallback_streams = self._read_from_local(worker_log_full_path)
+                if fallback_sources:
+                    sources.extend(fallback_sources)
+                    log_streams.extend(fallback_streams)
+                else:
+                    sources.append(
+                        f"Log file not found on worker '{ti.hostname}'. "
+                        f"This attempt may have run on a different worker whose logs "
+                        f"are no longer accessible. "
+                        f"Consider configuring remote logging (S3, GCS, etc.) for log persistence."
+                    )
             else:
                 # Check if the resource was properly fetched
                 response.raise_for_status()

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -651,9 +651,7 @@ class FileTaskHandler(logging.Handler):
         if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_k8s_exec_pod:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)
-        elif (ti.state not in State.unfinished or ti.state in _STATES_WITH_COMPLETED_ATTEMPT) and not (
-            local_logs or remote_logs
-        ):
+        elif ti.state not in State.unfinished and not (local_logs or remote_logs):
             # ordinarily we don't check served logs, with the assumption that users set up
             # remote logging or shared drive for logs for persistence, but that's not always true
             # so even if task is done, if no local logs or remote logs are found, we'll check the worker

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -651,9 +651,7 @@ class FileTaskHandler(logging.Handler):
         if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_k8s_exec_pod:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)
-        elif (ti.state not in State.unfinished or ti.state in _STATES_WITH_COMPLETED_ATTEMPT) and not (
-            local_logs or remote_logs
-        ):
+        elif ti.state not in State.unfinished and not (local_logs or remote_logs):
             # ordinarily we don't check served logs, with the assumption that users set up
             # remote logging or shared drive for logs for persistence, but that's not always true
             # so even if task is done, if no local logs or remote logs are found, we'll check the worker
@@ -893,27 +891,9 @@ class FileTaskHandler(logging.Handler):
                     "See more at https://airflow.apache.org/docs/apache-airflow/"
                     "stable/configurations-ref.html#secret-key"
                 )
-            elif response.status_code == 404:
-                # Log file not found on the worker's log server.
-                # This typically happens when a task retried on a different worker
-                # and the original worker's logs are no longer accessible.
-                # Fall back to local filesystem read if available.
-                worker_log_full_path = Path(self.local_base, worker_log_rel_path)
-                fallback_sources, fallback_streams = self._read_from_local(worker_log_full_path)
-                if fallback_sources:
-                    sources.extend(fallback_sources)
-                    log_streams.extend(fallback_streams)
-                else:
-                    sources.append(
-                        f"Log file not found on worker '{ti.hostname}'. "
-                        f"This attempt may have run on a different worker whose logs "
-                        f"are no longer accessible. "
-                        f"Consider configuring remote logging (S3, GCS, etc.) for log persistence."
-                    )
             else:
                 # Check if the resource was properly fetched
                 response.raise_for_status()
-
                 if int(response.headers.get("Content-Length", 0)) > 0:
                     sources.append(url)
                     log_streams.append(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
![img_v3_02vk_324ee027-f033-4871-ad38-fe4dbc88a93g](https://github.com/user-attachments/assets/f2018532-c8a1-40c3-a4a8-1a88318843d1)
![img_v3_02vk_d3524100-db85-448a-bc2c-7ec39965c0dg](https://github.com/user-attachments/assets/594b22d2-c777-4f01-887f-d6f251ea5837)
### Symptom Explanation
1. Task failure (Try 12) : The task attempt fails and the task instance transitions to UP_FOR_RETRY (waiting for the next retry).
2. Logs disappear : While the task instance is in UP_FOR_RETRY , Airflow treats it as neither “running” ( RUNNING ) nor “finished” (terminal states).
   
   - Airflow’s log-reading logic only proactively fetches served logs from the worker log server when the task is RUNNING or DEFERRED .
   - For UP_FOR_RETRY , the task is not running but also not considered finished, so Airflow skips fetching served logs from the worker, resulting in an empty/placeholder log response.

### Brief description of the changes.

- Fix an issue where task instance logs could become temporarily unavailable after a failed try when the task transitions to UP_FOR_RETRY (or UP_FOR_RESCHEDULE ).
- In this window, the log endpoint could return only the “Log message source details” header without actual log content.
- Update FileTaskHandler to also attempt fetching served logs from the worker log server for UP_FOR_RETRY / UP_FOR_RESCHEDULE states when no local or remote logs are found.
Why this change is needed.

- UP_FOR_RETRY is treated as an “unfinished” state, so the existing logic did not fetch served logs (which was only done for RUNNING / DEFERRED or finished tasks), causing a gap where logs from the failed attempt were not accessible until the next try started.
What was changed.

- In airflow-core/src/airflow/utils/log/file_task_handler.py , extend the condition that triggers reading served logs to include TaskInstanceState.UP_FOR_RETRY and TaskInstanceState.UP_FOR_RESCHEDULE .
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
