### PR TITLE
Fix _execution_api_server_url() reading edge.api_url when execution_api_server_url is already set

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -82,10 +82,10 @@ def _edge_hostname() -> str:
 @cache
 def _execution_api_server_url() -> str:
     """Get the execution api server url from config or environment."""
-    api_url = conf.get("edge", "api_url")
     execution_api_server_url = conf.get("core", "execution_api_server_url", fallback="")
-    if not execution_api_server_url and api_url:
+    if not execution_api_server_url:
         # Derive execution api url from edge api url as fallback
+        api_url = conf.get("edge", "api_url")
         execution_api_server_url = api_url.replace("edge_worker/v1/rpcapi", "execution")
     logger.info("Using execution api server url: %s", execution_api_server_url)
     return execution_api_server_url

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -161,6 +161,10 @@ class TestEdgeWorker:
                 },
                 "https://other-endpoint",
             ),
+            (
+                {("core", "execution_api_server_url"): "https://direct-execution-endpoint"},
+                "https://direct-execution-endpoint",
+            ),
         ],
     )
     def test_execution_api_server_url(
@@ -173,11 +177,16 @@ class TestEdgeWorker:
             url = _execution_api_server_url()
             assert url == expected_url
 
+    @patch(
+        "airflow.providers.edge3.cli.worker._execution_api_server_url",
+        return_value="https://mock-execution-api",
+    )
     @patch("airflow.sdk.execution_time.supervisor.supervise")
     @pytest.mark.asyncio
     async def test_supervise_launch(
         self,
         mock_supervise,
+        mock_execution_api_url,
         worker_with_job: EdgeWorker,
     ):
         edge_job = worker_with_job.jobs.pop().edge_job
@@ -187,11 +196,16 @@ class TestEdgeWorker:
         assert result == 0
         q.put.assert_not_called()
 
+    @patch(
+        "airflow.providers.edge3.cli.worker._execution_api_server_url",
+        return_value="https://mock-execution-api",
+    )
     @patch("airflow.sdk.execution_time.supervisor.supervise")
     @pytest.mark.asyncio
     async def test_supervise_launch_fail(
         self,
         mock_supervise,
+        mock_execution_api_url,
         worker_with_job: EdgeWorker,
     ):
         mock_supervise.side_effect = Exception("Supervise failed")


### PR DESCRIPTION
  Previously, _execution_api_server_url() unconditionally read edge.api_url
  even when core.execution_api_server_url was explicitly configured, causing
  an unnecessary AirflowConfigException if only the latter was set. This also
  caused test_supervise_launch and test_supervise_launch_fail to fail since
  the test environment does not load provider config.

  Reorder config reads so core.execution_api_server_url is checked first and
  edge.api_url is only read as a fallback when needed. Mock
  _execution_api_server_url in test_supervise_launch and test_supervise_launch_fail
  to isolate them from config requirements. Add a test case covering
  core.execution_api_server_url set without edge.api_url.

  Issue stemming from #56457

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode
