### PR TITLE
Fix S3DagBundle to delete stale dags recursively (#62622)

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1735,27 +1735,37 @@ class S3Hook(AwsBaseHook):
         s3_client.delete_bucket_tagging(Bucket=bucket_name)
 
     def _sync_to_local_dir_delete_stale_local_files(self, current_s3_objects: list[Path], local_dir: Path):
-        current_s3_keys = {key for key in current_s3_objects}
+        current_s3_keys = {p.resolve() for p in current_s3_objects}
 
-        for item in local_dir.iterdir():
-            item: Path  # type: ignore[no-redef]
-            absolute_item_path = item.resolve()
+        # Recursively collect all paths (Path.iterdir() is not recursive; rglob is)
+        try:
+            all_paths = list(local_dir.rglob("*"))
+        except OSError as e:
+            self.log.error("Error listing local dir %s: %s", local_dir, e)
+            raise e
 
-            if absolute_item_path not in current_s3_keys:
+        files = [p for p in all_paths if p.is_file()]
+        dirs = [p for p in all_paths if p.is_dir()]
+        # Remove empty dirs deepest-first so parent dirs become empty after children
+        dirs_sorted = sorted(dirs, key=lambda p: len(p.parts), reverse=True)
+
+        for item in files:
+            if item.resolve() not in current_s3_keys:
                 try:
-                    if item.is_file():
-                        item.unlink(missing_ok=True)
-                        self.log.debug("Deleted stale local file: %s", item)
-                    elif item.is_dir():
-                        # delete only when the folder is empty
-                        if not os.listdir(item):
-                            item.rmdir()
-                            self.log.debug("Deleted stale empty directory: %s", item)
-                    else:
-                        self.log.debug("Skipping stale item of unknown type: %s", item)
+                    item.unlink(missing_ok=True)
+                    self.log.debug("Deleted stale local file: %s", item)
                 except OSError as e:
-                    self.log.error("Error deleting stale item %s: %s", item, e)
+                    self.log.error("Error deleting stale file %s: %s", item, e)
                     raise e
+
+        for item in dirs_sorted:
+            try:
+                if item.exists() and not any(item.iterdir()):
+                    item.rmdir()
+                    self.log.debug("Deleted stale empty directory: %s", item)
+            except OSError as e:
+                self.log.error("Error deleting stale directory %s: %s", item, e)
+                raise e
 
     def _sync_to_local_dir_if_changed(self, s3_bucket, s3_object, local_target_path: Path):
         should_download = False

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1879,6 +1879,20 @@ class TestAwsS3Hook:
 
         assert f"Deleted stale empty directory: {local_folder_should_be_deleted.as_posix()}" in logs_string
 
+        # Recursive stale delete: stale file in a subfolder must be removed (#62622)
+        nested_stale_dir = Path(sync_local_dir).joinpath("nested").joinpath("subdir")
+        nested_stale_dir.mkdir(parents=True, exist_ok=True)
+        nested_stale_file = nested_stale_dir / "stale_in_subdir.py"
+        nested_stale_file.write_text("stale")
+        hook.log.debug = MagicMock()
+        hook.sync_to_local_dir(
+            bucket_name=s3_bucket, local_dir=sync_local_dir, s3_prefix="", delete_stale=True
+        )
+        logs_string = get_logs_string(hook.log.debug.call_args_list)
+        assert f"Deleted stale local file: {nested_stale_file.as_posix()}" in logs_string
+        assert not nested_stale_file.exists()
+        assert not nested_stale_dir.exists()
+
         s3_client.put_object(Bucket=s3_bucket, Key="dag_03.py", Body=b"test data-changed")
         hook.log.debug = MagicMock()
         hook.sync_to_local_dir(


### PR DESCRIPTION
## Summary

`S3DagBundle` / `sync_to_local_dir` used `Path.iterdir()`, which only lists direct children. Stale DAG files in subfolders were never removed. This change uses `Path.rglob("*")` to traverse the local directory recursively, delete any file not in the current S3 object set, then remove empty directories (deepest first).

## Change

- **providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py**: `_sync_to_local_dir_delete_stale_local_files` now recursively collects all paths under `local_dir` with `rglob("*")`, deletes stale files, then removes empty dirs in depth-descending order so nested stale folders are fully removed.
- **providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py**: Extended `test_sync_to_local_dir_behaviour` with a case that creates a stale file in a nested subfolder (`nested/subdir/stale_in_subdir.py`), runs sync with `delete_stale=True`, and asserts the file and empty subdirs are deleted.

## JIRA

Fixes #62622
