### PR TITLE
Fix grid view URL for dynamic task groups

### DIFF
--- a/airflow-core/newsfragments/63205.bugfix.rst
+++ b/airflow-core/newsfragments/63205.bugfix.rst
@@ -1,0 +1,1 @@
+Fix grid view URL for dynamic task groups producing 404 by not appending ``/mapped`` to group URLs.

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -243,7 +243,7 @@ describe("buildTaskInstanceUrl", () => {
       }),
     ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group");
 
-    // Groups should never preserve tabs even for mapped groups
+    // Groups should never get /mapped appended — no such route exists for task groups
     expect(
       buildTaskInstanceUrl({
         currentPathname: "/dags/old/runs/old/tasks/group/old_group/events",
@@ -254,6 +254,21 @@ describe("buildTaskInstanceUrl", () => {
         runId: "new_run",
         taskId: "new_group",
       }),
-    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group/mapped/3");
+    ).toBe("/dags/new_dag/runs/new_run/tasks/group/new_group");
+  });
+
+  it("should not append /mapped for dynamic task groups from grid view", () => {
+    // Regression test for https://github.com/apache/airflow/issues/63197
+    // Dynamic task groups have isMapped=true but no route exists for group/:groupId/mapped
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/my_dag/runs/run_1/tasks/group/my_group",
+        dagId: "my_dag",
+        isGroup: true,
+        isMapped: true,
+        runId: "run_1",
+        taskId: "my_group",
+      }),
+    ).toBe("/dags/my_dag/runs/run_1/tasks/group/my_group");
   });
 });

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -89,7 +89,7 @@ export const buildTaskInstanceUrl = (params: {
 
   let basePath = `/dags/${dagId}/runs/${runId}/tasks/${groupPath}${taskId}`;
 
-  if (isMapped) {
+  if (isMapped && !isGroup) {
     basePath += `/mapped`;
     if (mapIndex !== undefined && mapIndex !== "-1") {
       basePath += `/${mapIndex}`;


### PR DESCRIPTION
Dynamic task groups with [isMapped=true](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) were getting /mapped appended to their URL in the grid view, producing URLs like /tasks/group/{groupId}/mapped — which has no matching route, resulting in a 404.

The graph view already handles this correctly by skipping /mapped for groups. This fix adds the same [!isGroup](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) guard to [buildTaskInstanceUrl](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [links.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

closes: #63197