### PR TITLE
fix(task-sdk): set default Content-Type header on execution API client

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -960,6 +960,7 @@ class Client(httpx.Client):
         super().__init__(
             auth=auth,
             headers={
+                "content-type": "application/json",
                 "user-agent": f"apache-airflow-task-sdk/{__version__} (Python/{pyver})",
                 "airflow-api-version": API_VERSION,
             },

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -120,6 +120,17 @@ class TestClient:
         )
         assert client.timeout == httpx.Timeout(120.0)
 
+    def test_default_content_type_header(self):
+        """Verify the client sets a default Content-Type: application/json header."""
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.headers["content-type"] == "application/json"
+            return httpx.Response(status_code=200, json={"ok": True})
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        # A PATCH with content= should carry the default content-type header
+        client.patch("task-instances/fake-id/run", content=b'{"pid": 1}')
+
     def test_error_parsing(self):
         responses = [
             httpx.Response(422, json={"detail": [{"loc": ["#0"], "msg": "err", "type": "required"}]})


### PR DESCRIPTION
## Problem

Task subprocesses get killed with SIGKILL immediately after starting. The API server returns 422 on `PATCH /execution/task-instances/{id}/run` because the request body is received as a raw string instead of parsed JSON.

## Root Cause

`client.py` uses httpx's `content=body.model_dump_json()` to send requests. The `content=` parameter sets the raw body but does not set a `Content-Type` header — so the API server (cadwyn/FastAPI) can't identify the payload as JSON, passes it to Pydantic as a plain string, and rejects it with a `model_attributes_type` validation error.

## Fix

Added `content-type: application/json` to the default headers in `Client.__init__()`. This covers all call sites that use `content=` (start, heartbeat, state transitions, etc.) without touching each one individually.

Added a test that verifies the header is present on outgoing requests.

Closes: #63209

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
