### PR TITLE
Weekly updates, add more groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,8 +81,28 @@ updates:
     directories:
       - /airflow-core/src/airflow/ui
     schedule:
-      interval: daily
+      interval: "weekly"
     groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      chakra-ui:
+        patterns:
+          - "@chakra-ui/*"
+          - "@emotion/*"
+          - "framer-motion"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+      typescript:
+        patterns:
+          - "typescript*"
+          - "@typescript-eslint/*"
+          - "@types/typescript"
       core-ui-package-updates:
         patterns:
           - "*"
@@ -102,9 +122,9 @@ updates:
     directories:
       - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
     schedule:
-      interval: daily
+      interval: "weekly"
     groups:
-      core-ui-package-updates:
+      auth-ui-package-updates:
         patterns:
           - "*"
         update-types:
@@ -123,7 +143,7 @@ updates:
     directories:
       - /dev/react-plugin-tools/react_plugin_template
     schedule:
-      interval: daily
+      interval: "weekly"
     groups:
       ui-plugin-template-package-updates:
         patterns:
@@ -131,12 +151,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      ui-plugin-template-major-version-updates:
-        patterns:
-          - "*"
-        applies-to: security-updates
-        update-types:
-          - "major"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     cooldown:
@@ -144,7 +161,7 @@ updates:
     directories:
       - /providers/edge3/src/airflow/providers/edge3/plugins/www
     schedule:
-      interval: daily
+      interval: "weekly"
     groups:
       edge-ui-package-updates:
         patterns:
@@ -168,7 +185,7 @@ updates:
     directories:
       - /registry
     schedule:
-      interval: daily
+      interval: "weekly"
     groups:
       core-ui-package-updates:
         patterns:
@@ -211,10 +228,10 @@ updates:
     directories:
       - /airflow-core/src/airflow/ui
     schedule:
-      interval: daily
+      interval: "weekly"
     target-branch: v3-1-test
     groups:
-      core-ui-package-updates:
+      3-1-core-ui-package-updates:
         patterns:
           - "*"
         update-types:
@@ -230,10 +247,10 @@ updates:
     directories:
       - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
     schedule:
-      interval: daily
+      interval: "weekly"
     target-branch: v3-1-test
     groups:
-      core-ui-package-updates:
+      3-1-auth-ui-package-updates:
         patterns:
           - "*"
         update-types:
@@ -253,7 +270,7 @@ updates:
       - /docker_tests
       - /
     schedule:
-      interval: daily
+      interval: "weekly"
     target-branch: v2-11-test
     groups:
       pip-dependency-updates:
@@ -266,12 +283,15 @@ updates:
     directories:
       - /airflow/www/
     schedule:
-      interval: daily
+      interval: "weekly"
     target-branch: v2-11-test
     groups:
-      core-ui-package-updates:
+      legacy-ui-package-updates:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "uv"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,7 +109,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      major-version-updates:
+      core-ui-major-version-updates:
         patterns:
           - "*"
         applies-to: security-updates
@@ -130,7 +130,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      major-version-updates:
+      auth-ui-major-version-updates:
         patterns:
           - "*"
         applies-to: security-updates
@@ -187,13 +187,13 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      core-ui-package-updates:
+      registry-package-updates:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-      major-version-updates:
+      registry-major-version-updates:
         patterns:
           - "*"
         applies-to: security-updates


### PR DESCRIPTION
Switch from daily dependabot PRs to weekly.

Add more groups to the core-ui updates for packages that need to be updated together

Ignore automatic major updates for the react plugin template

Update group names to make it easy to distinguish dependabot pr targets at a glance

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
