### PR TITLE
Remove unnecessary `id-token: write` from registry workflow

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -70,7 +70,6 @@ jobs:
       REGISTRY_CACHE_CONTROL: public, max-age=300
     permissions:
       contents: read
-      id-token: write
     if: >
       github.event_name == 'workflow_call' ||
       contains(fromJSON('[


### PR DESCRIPTION
The registry build job uses static AWS credentials (access key + secret), not OIDC, so `id-token: write` is not needed. Removing it fixes the `workflow_call` from `publish-docs-to-s3.yml` which only grants `contents: read` — callers cannot escalate permissions for nested jobs.

Failure:

https://github.com/apache/airflow/actions/runs/22871911680

```
[Invalid workflow file: .github/workflows/publish-docs-to-s3.yml#L395](https://github.com/apache/airflow/actions/runs/22871911680/workflow)
The workflow is not valid. .github/workflows/publish-docs-to-s3.yml (Line: 395, Col: 3): Error calling workflow 'apache/airflow/.github/workflows/registry-build.yml@fe5730407ee4c7e172399fcca25b2c984ebcb5b5'. The nested job 'build-and-publish-registry' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
