### PR TITLE
Registry: Clean up stale pagefind index files from S3 during registry builds

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -239,7 +239,14 @@ jobs:
           S3_BUCKET: ${{ steps.destination.outputs.bucket }}
         run: |
           aws s3 sync registry/_site/ "${S3_BUCKET}" \
-            --cache-control "${REGISTRY_CACHE_CONTROL}"
+            --cache-control "${REGISTRY_CACHE_CONTROL}" \
+            --exclude "pagefind/*"
+          # Pagefind generates content-hashed filenames (e.g. en_181da6f.pf_index).
+          # Each rebuild produces new hashes, so --delete is needed to remove stale
+          # index files. This is separate from the main sync which intentionally
+          # omits --delete to preserve files written by other steps (publish-versions).
+          aws s3 sync registry/_site/pagefind/ "${S3_BUCKET}pagefind/" \
+            --cache-control "${REGISTRY_CACHE_CONTROL}" --delete
 
       - name: "Publish version metadata"
         env:


### PR DESCRIPTION
Pagefind generates content-hashed filenames (e.g. `en_181da6f.pf_index`, `pagefind.en_b52554cee1.pf_meta`). Each registry rebuild produces new hashes, but the S3 sync had no `--delete` flag, so old index files accumulated as orphans.

## Changes

Split the S3 sync into two commands:
- **Main sync** (`--exclude "pagefind/*"`) — uploads everything except pagefind, no `--delete` to preserve files written by the subsequent `publish-versions` step
- **Pagefind sync** (`--delete`) — uploads the new pagefind index and removes stale hashed files