### PR TITLE
Fix codespell failures on main

### DIFF
--- a/airflow-core/docs/tutorial/hitl.rst
+++ b/airflow-core/docs/tutorial/hitl.rst
@@ -159,7 +159,7 @@ The method ``HITLOperator.generate_link_to_ui_from_context`` can be used to gene
 
 - ``context`` – automatically passed to ``notify`` by the notifier
 - ``base_url`` – (optional) the base URL of the Airflow UI; if not provided, ``api.base_url`` in the configuration will be used
-- ``options`` – (optional) pre-selected options for the UI page
+- ``options`` – (optional) preselected options for the UI page
 - ``params_inputs`` – (optional) pre-loaded inputs for the UI page
 
 This makes it easy to include actionable links in notifications or logs.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -133,7 +133,7 @@ def ti_run(
             TI.hostname,
             TI.unixname,
             TI.pid,
-            # This selects the raw JSON value, by-passing the deserialization -- we want that to happen on the
+            # This selects the raw JSON value, bypassing the deserialization -- we want that to happen on the
             # client
             column("next_kwargs", JSON),
         )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -394,7 +394,7 @@ class TestXComsSetEndpoint:
         Test that deserialization works when XCom values are stored directly in the DB with API Server.
 
         This tests the case where the XCom value is stored from the Task API where the value is serialized
-        via Client SDK into JSON object and passed via the API Server to the DB. It by-passes
+        via Client SDK into JSON object and passed via the API Server to the DB. It bypasses
         the XComModel.serialize_value and stores valid Python JSON compatible objects to DB.
 
         This test is to ensure that the deserialization works correctly in this case as well as

--- a/go-sdk/pkg/api/client.go
+++ b/go-sdk/pkg/api/client.go
@@ -61,7 +61,7 @@ func (c *Client) WithBearerToken(token string) (ClientInterface, error) {
 
 	// We don't use SetAuthToken/SetAuthScheme, as that produces a (valid, but annoying) warning about using Auth
 	// over HTTP: "Using sensitive credentials in HTTP mode is not secure." It's a time-limited-token though, so we
-	// can reasonably ignore that here and setting the header directly by-passes that
+	// can reasonably ignore that here and setting the header directly bypasses that
 	rc.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	opts := []ClientOption{


### PR DESCRIPTION
Failure on main: https://github.com/apache/airflow/actions/runs/22880944534/job/66384313793?pr=63234

Fix four codespell violations causing the `codespell` pre-commit hook to fail on main:

- `by-passes` → `bypasses` (go-sdk, tests)
- `by-passing` → `bypassing` (execution API)
- `pre-selected` → `preselected` (HITL docs)

