### PR TITLE
Add Matomo analytics to the provider Registry

### DIFF
--- a/registry/src/_includes/base.njk
+++ b/registry/src/_includes/base.njk
@@ -34,6 +34,20 @@
   </script>
   <script>window.__REGISTRY_BASE__ = '{{ "/" | url }}';</script>
   <link rel="stylesheet" href="{{ '/css/main.css' | url }}">
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u='https://analytics.apache.org/';
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '13']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>


### PR DESCRIPTION
The Airflow landing pages and Sphinx docs both track page views via Apache's Matomo instance (`analytics.apache.org`, site ID `13`). The registry site was missing this tracking.

This adds the same Matomo snippet to the registry's base layout template (`registry/src/_includes/base.njk`) so all registry pages are tracked under the same Apache Airflow analytics property.
