### PR TITLE
Fix RenderedJsonField not displaying in table cells

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, type FlexProps } from "@chakra-ui/react";
+import { Box, Flex, type FlexProps } from "@chakra-ui/react";
 import Editor, { type OnMount } from "@monaco-editor/react";
 import { useCallback } from "react";
 
@@ -46,30 +46,34 @@ const RenderedJsonField = ({ collapsed = false, content, enableClipboard = true,
   );
 
   return (
-    <Flex {...rest}>
-      <Editor
-        height={height}
-        language="json"
-        onMount={handleMount}
-        options={{
-          automaticLayout: true,
-          contextmenu: false,
-          folding: true,
-          fontSize: 13,
-          glyphMargin: false,
-          lineDecorationsWidth: 0,
-          lineNumbers: "off",
-          minimap: { enabled: false },
-          overviewRulerLanes: 0,
-          readOnly: true,
-          renderLineHighlight: "none",
-          scrollbar: { vertical: "hidden", verticalScrollbarSize: 0 },
-          scrollBeyondLastLine: false,
-          wordWrap: "on",
-        }}
-        theme={theme}
-        value={contentFormatted}
-      />
+    <Flex flex={1} minW={200} {...rest}>
+      <Box h={height} minW={0} position="relative" w="100%">
+        <Box bottom={0} left={0} position="absolute" right={0} top={0}>
+          <Editor
+            height={height}
+            language="json"
+            onMount={handleMount}
+            options={{
+              automaticLayout: true,
+              contextmenu: false,
+              folding: true,
+              fontSize: 13,
+              glyphMargin: false,
+              lineDecorationsWidth: 0,
+              lineNumbers: "off",
+              minimap: { enabled: false },
+              overviewRulerLanes: 0,
+              readOnly: true,
+              renderLineHighlight: "none",
+              scrollbar: { vertical: "hidden", verticalScrollbarSize: 0 },
+              scrollBeyondLastLine: false,
+              wordWrap: "on",
+            }}
+            theme={theme}
+            value={contentFormatted}
+          />
+        </Box>
+      </Box>
       {enableClipboard ? (
         <ClipboardRoot value={contentFormatted}>
           <ClipboardIconButton h={7} minW={7} />


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

XCom values were not displaying correctly.
This issue likely appeared after PR #62708 , though that is speculative.

The fix updates RenderedJsonField with:
- `flex={1}` and `minW={200}` on the Flex container
- A `Box` wrapper with position: `relative/absolute` so Monaco Editor renders correctly in flex layouts

## Before
<img width="1192" height="112" alt="image" src="https://github.com/user-attachments/assets/83187efe-42d6-4738-a6f5-853e97792e50" />

## After
<img width="1194" height="190" alt="image" src="https://github.com/user-attachments/assets/29b919e0-2aca-4ae6-a774-d620089d29a3" />

The connection form also displays JSON correctly with this change.
<img width="586" height="409" alt="image" src="https://github.com/user-attachments/assets/2644fa35-0a2b-4042-be92-0a9e453a0925" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
