### PR TITLE
fix(providers/alibaba): pass relative path to oss_write in OSSRemoteLogIO.upload

### DIFF
--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -49,15 +49,15 @@ class OSSRemoteLogIO(LoggingMixin):  # noqa: D101
         path = Path(path)
         if path.is_absolute():
             local_loc = path
-            remote_loc = os.path.join(self.remote_base, path.relative_to(self.base_log_folder))
+            relative_path = str(path.relative_to(self.base_log_folder))
         else:
             local_loc = self.base_log_folder.joinpath(path)
-            remote_loc = os.path.join(self.remote_base, path)
+            relative_path = str(path)
 
         if local_loc.is_file():
             # read log and remove old logs to get just the latest additions
             log = local_loc.read_text()
-            has_uploaded = self.oss_write(log, remote_loc)
+            has_uploaded = self.oss_write(log, relative_path)
             if has_uploaded and self.delete_local_copy:
                 shutil.rmtree(os.path.dirname(local_loc))
 

--- a/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
+++ b/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
@@ -184,6 +184,27 @@ class TestOSSTaskHandler:
         handler.close()
         assert os.path.exists(handler.handler.baseFilename) == expected_existence_of_local_copy
 
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_write"))
+    def test_upload_passes_relative_path_to_oss_write(self, mock_oss_write, tmp_path):
+        """Test that upload() passes only the relative path to oss_write(), not the full OSS URI."""
+        mock_oss_write.return_value = True
+        log_dir = tmp_path / "dag_id=test" / "run_id=test" / "task_id=test"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "attempt=1.log"
+        log_file.write_text("test log content")
+
+        handler = OSSTaskHandler(str(tmp_path), self.oss_log_folder)
+
+        # Test with relative path
+        relative_path = "dag_id=test/run_id=test/task_id=test/attempt=1.log"
+        handler.io.upload(relative_path, self.ti)
+        mock_oss_write.assert_called_once_with("test log content", relative_path)
+
+        # Test with absolute path — should also pass relative portion
+        mock_oss_write.reset_mock()
+        handler.io.upload(str(log_file), self.ti)
+        mock_oss_write.assert_called_once_with("test log content", relative_path)
+
     def test_filename_template_for_backward_compatibility(self):
         # filename_template arg support for running the latest provider on airflow 2
         OSSTaskHandler(self.base_log_folder, self.oss_log_folder, filename_template=None)


### PR DESCRIPTION
## Problem

`OSSRemoteLogIO.upload()` passes a full OSS URI to `oss_write()`, which internally prepends `base_folder` again. This produces malformed keys like `prefix/logs/oss://bucket/prefix/logs/dag_id=.../attempt=1.log`, making logs unreadable from the Airflow UI.

## Root Cause

`upload()` joins `self.remote_base` (the full `oss://bucket/prefix` URI) with the relative path, then passes the result to `oss_write()`. But `oss_write()` already prepends `self.base_folder` (extracted from `remote_base`), so the prefix gets doubled.

## Fix

Pass only the relative path (relative to `base_log_folder`) to `oss_write()` instead of the full OSS URI. Added a test to verify both absolute and relative input paths produce the correct relative argument to `oss_write()`.

Closes: #63242

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
