### PR TITLE
fix(scheduler): set end_date on tasks skipped by dagrun timeout

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2328,8 +2328,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 key=lambda ti: ti.start_date or timezone.make_aware(datetime.min),
                 default=None,
             )
+            now = timezone.utcnow()
             for task_instance in unfinished_task_instances:
                 task_instance.state = TaskInstanceState.SKIPPED
+                task_instance.end_date = now
                 session.merge(task_instance)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3387,6 +3387,46 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    def test_dagrun_timeout_sets_end_date_on_skipped_tasks(self, dag_maker):
+        """Test that when a DAG run times out, skipped tasks get end_date set."""
+        session = settings.Session()
+        with dag_maker(
+            dag_id="test_dagrun_timeout_sets_end_date",
+            dagrun_timeout=datetime.timedelta(seconds=60),
+            session=session,
+        ):
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+
+        dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
+
+        # Set tasks to running state with a start_date but no end_date
+        tis = dr.get_task_instances(session=session)
+        for ti in tis:
+            ti.state = State.RUNNING
+            ti.start_date = timezone.utcnow() - datetime.timedelta(hours=1)
+            ti.end_date = None
+            session.merge(ti)
+        session.flush()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        self.job_runner._schedule_dag_run(dr, session)
+        session.flush()
+
+        session.refresh(dr)
+        assert dr.state == State.FAILED
+
+        tis = dr.get_task_instances(session=session)
+        for ti in tis:
+            session.refresh(ti)
+            assert ti.state == TaskInstanceState.SKIPPED
+            assert ti.end_date is not None, f"end_date should be set for skipped task {ti.task_id}"
+
+        session.rollback()
+        session.close()
+
     def test_dagrun_timeout_fails_run_and_update_next_dagrun(self, dag_maker):
         """
         Test that dagrun timeout fails run and update the next dagrun


### PR DESCRIPTION
## Problem

When a DAG run times out via `dagrun_timeout`, unfinished task instances are marked `SKIPPED` but their `end_date` is never set. The UI computes duration as `now - start_date`, so skipped tasks show a continuously increasing duration — confusing and incorrect.

## Root Cause

In `SchedulerJobRunner._schedule_dag_run`, the timeout handler sets `task_instance.state = TaskInstanceState.SKIPPED` but doesn't touch `end_date`. Without an `end_date`, the UI falls back to computing live duration.

## Fix

Set `end_date = timezone.utcnow()` alongside the state change for all tasks skipped by dagrun timeout. Added a test that creates a timed-out DAG run with running tasks and verifies `end_date` is populated after the scheduler processes it.

Closes: #58536

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=8d5248c action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @YoannAbriel** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~65 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->