### PR TITLE
fix(api): allow null dag_run_conf in BackfillResponse serialization

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -46,7 +46,7 @@ class BackfillResponse(BaseModel):
     dag_id: str
     from_date: datetime
     to_date: datetime
-    dag_run_conf: dict
+    dag_run_conf: dict | None
     is_paused: bool
     reprocess_behavior: ReprocessBehavior
     max_active_runs: int

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1421,8 +1421,10 @@ components:
           format: date-time
           title: To Date
         dag_run_conf:
-          additionalProperties: true
-          type: object
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
           title: Dag Run Conf
         is_paused:
           type: boolean

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -9266,8 +9266,10 @@ components:
           format: date-time
           title: To Date
         dag_run_conf:
-          additionalProperties: true
-          type: object
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
           title: Dag Run Conf
         is_paused:
           type: boolean

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -494,8 +494,15 @@ export const $BackfillResponse = {
             title: 'To Date'
         },
         dag_run_conf: {
-            additionalProperties: true,
-            type: 'object',
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Dag Run Conf'
         },
         is_paused: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -138,8 +138,8 @@ export type BackfillResponse = {
     from_date: string;
     to_date: string;
     dag_run_conf: {
-        [key: string]: unknown;
-    };
+    [key: string]: unknown;
+} | null;
     is_paused: boolean;
     reprocess_behavior: ReprocessBehavior;
     max_active_runs: number;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -176,6 +176,18 @@ class TestGetBackfill(TestBackfillEndpoint):
             "updated_at": mock.ANY,
         }
 
+    def test_get_backfill_with_null_conf(self, session, test_client):
+        """dag_run_conf can be NULL in the DB; the API should still serialize it."""
+        (dag,) = self._create_dag_models()
+        from_date = timezone.utcnow()
+        to_date = timezone.utcnow()
+        backfill = Backfill(dag_id=dag.dag_id, from_date=from_date, to_date=to_date, dag_run_conf=None)
+        session.add(backfill)
+        session.commit()
+        response = test_client.get(f"/backfills/{backfill.id}")
+        assert response.status_code == 200
+        assert response.json()["dag_run_conf"] is None
+
     def test_no_exist(self, session, test_client):
         response = test_client.get(f"/backfills/{231984098}")
         assert response.status_code == 404

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1127,7 +1127,7 @@ class BackfillResponse(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]
-    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")]
+    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = None
     is_paused: Annotated[bool, Field(title="Is Paused")]
     reprocess_behavior: ReprocessBehavior
     max_active_runs: Annotated[int, Field(title="Max Active Runs")]

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1127,7 +1127,7 @@ class BackfillResponse(BaseModel):
     dag_id: Annotated[str, Field(title="Dag Id")]
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]
-    dag_run_conf: Annotated[dict[str, Any], Field(title="Dag Run Conf")]
+    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")]
     is_paused: Annotated[bool, Field(title="Is Paused")]
     reprocess_behavior: ReprocessBehavior
     max_active_runs: Annotated[int, Field(title="Max Active Runs")]


### PR DESCRIPTION
## Problem

Accessing the backfills API (`GET /ui/backfills`) returns a 500 error with `PydanticSerializationError` when a backfill row has `dag_run_conf` set to `None` in the database.

## Root Cause

`BackfillResponse.dag_run_conf` is typed as `dict`, which rejects `None` during Pydantic serialization. Although the DB column is defined with `nullable=False, default={}`, existing rows or edge cases can still have a `None` value.

## Fix

Changed the type annotation from `dict` to `dict | None` in `BackfillResponse` and the corresponding generated client model. Added a test that creates a backfill with `dag_run_conf=None` and verifies the API returns 200.

Closes: #63257

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
