### PR TITLE
Fix ti_skip_downstream overwriting RUNNING tasks to SKIPPED

### DIFF
--- a/airflow-core/newsfragments/63266.bugfix.rst
+++ b/airflow-core/newsfragments/63266.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ti_skip_downstream`` overwriting RUNNING tasks to SKIPPED in HA deployments.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -596,9 +596,27 @@ def ti_skip_downstream(
     task_ids = [task if isinstance(task, tuple) else (task, -1) for task in tasks]
     log.debug("Prepared task IDs for skipping", task_ids=task_ids)
 
+    # Don't overwrite tasks that are already executing or finished.
+    # See: https://github.com/apache/airflow/issues/59378
+    # Note: SQL NULL NOT IN (...) is falsy, so we need an explicit IS NULL check.
+    skippable_state_clause = or_(
+        TI.state.is_(None),
+        TI.state.not_in(
+            [
+                TaskInstanceState.RUNNING,
+                TaskInstanceState.SUCCESS,
+                TaskInstanceState.FAILED,
+            ]
+        ),
+    )
     query = (
         update(TI)
-        .where(TI.dag_id == dag_id, TI.run_id == run_id, tuple_(TI.task_id, TI.map_index).in_(task_ids))
+        .where(
+            TI.dag_id == dag_id,
+            TI.run_id == run_id,
+            tuple_(TI.task_id, TI.map_index).in_(task_ids),
+            skippable_state_clause,
+        )
         .values(state=TaskInstanceState.SKIPPED, start_date=now, end_date=now)
         .execution_options(synchronize_session=False)
     )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1633,6 +1633,95 @@ class TestTISkipDownstream:
         assert ti1.state == State.SKIPPED
 
 
+class TestTISkipDownstreamRaceCondition:
+    """Regression tests for #59378: state guard in ti_skip_downstream()."""
+
+    def setup_method(self):
+        clear_db_runs()
+
+    def teardown_method(self):
+        clear_db_runs()
+
+    @pytest.mark.parametrize(
+        "initial_state",
+        [
+            State.RUNNING,
+            State.SUCCESS,
+            State.FAILED,
+        ],
+    )
+    def test_skip_downstream_does_not_overwrite_terminal_or_running_ti(
+        self, client, session, dag_maker, initial_state
+    ):
+        with dag_maker(f"skip_race_dag_{initial_state}", session=session):
+            branch = EmptyOperator(task_id="branch")
+            downstream = EmptyOperator(task_id="downstream")
+            branch >> downstream
+        dr = dag_maker.create_dagrun(run_id="run")
+
+        ti_branch = dr.get_task_instance("branch")
+        ti_branch.set_state(State.SUCCESS)
+
+        ti_downstream = dr.get_task_instance("downstream")
+        ti_downstream.set_state(initial_state)
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti_branch.id}/skip-downstream",
+            json={"tasks": ["downstream"]},
+        )
+        assert response.status_code == 204
+
+        session.expire_all()
+        ti_downstream = dr.get_task_instance("downstream")
+        assert ti_downstream.state == initial_state
+
+    def test_skip_downstream_does_skip_queued_ti(self, client, session, dag_maker):
+        with dag_maker("skip_race_dag_queued", session=session):
+            branch = EmptyOperator(task_id="branch")
+            downstream = EmptyOperator(task_id="downstream")
+            branch >> downstream
+        dr = dag_maker.create_dagrun(run_id="run")
+
+        ti_branch = dr.get_task_instance("branch")
+        ti_branch.set_state(State.SUCCESS)
+
+        ti_downstream = dr.get_task_instance("downstream")
+        ti_downstream.set_state(TaskInstanceState.QUEUED)
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti_branch.id}/skip-downstream",
+            json={"tasks": ["downstream"]},
+        )
+        assert response.status_code == 204
+
+        session.expire_all()
+        ti_downstream = dr.get_task_instance("downstream")
+        assert ti_downstream.state == State.SKIPPED
+
+    def test_skip_downstream_still_skips_none_state_ti(self, client, session, dag_maker):
+        with dag_maker("skip_race_dag_normal", session=session):
+            branch = EmptyOperator(task_id="branch")
+            downstream = EmptyOperator(task_id="downstream")
+            branch >> downstream
+        dr = dag_maker.create_dagrun(run_id="run")
+
+        ti_branch = dr.get_task_instance("branch")
+        ti_branch.set_state(State.SUCCESS)
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti_branch.id}/skip-downstream",
+            json={"tasks": ["downstream"]},
+        )
+        assert response.status_code == 204
+
+        session.expire_all()
+        ti_downstream = dr.get_task_instance("downstream")
+        assert ti_downstream.state == State.SKIPPED
+
+
 class TestTIHealthEndpoint:
     def setup_method(self):
         clear_db_runs()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

`ti_skip_downstream()` issues an UPDATE filtered by `(dag_id, run_id, task_id, map_index)` without a state guard. When a BranchOperator on one scheduler decides to skip downstream tasks, the UPDATE can overwrite a task already RUNNING on a worker. The worker's next heartbeat returns 409 with `current_state: skipped`, killing the task mid-execution.

This is a companion fix to #60330, which guards `schedule_tis()` against the same class of race condition. Different code path (Execution API routes vs `dagrun.py`), same root cause : unguarded bulk UPDATEs on TI state.

**Production data (12 days, 5 schedulers, ~500 concurrent workers)**

We deployed both fixes as monkey patches on our prod cluster and monitored 409 heartbeat errors via CloudWatch :

```
Before any fix       14-169 errors/day
After schedule_tis   3-4/day (all current_state: skipped)
After both fixes     0 errors for 18+ hours
```

| Metric | Before fixes | After schedule_tis only | After both fixes |
|--------|-------------|------------------------|-----------------|
| Total 409s/day | 14-169 | 3-4 | **0** |
| `current_state: scheduled` | present | **0** | 0 |
| `current_state: failed` | 47/day | **0** | 0 |
| `current_state: skipped` | 8/day | **2-5/day** | **0** |

**Fix**

Add `skippable_state_clause` to the UPDATE's WHERE clause :

```python
skippable_state_clause = or_(
    TI.state.is_(None),
    TI.state.not_in([RUNNING, SUCCESS, FAILED]),
)
```

The `or_(IS NULL, NOT IN)` pattern handles SQL NULL semantics : `NULL NOT IN (...)` evaluates to NULL (falsy), so tasks with `state=None` need an explicit `IS NULL` check to remain skippable.

QUEUED is intentionally NOT guarded : a QUEUED task hasn't started executing yet, so the BranchOperator's decision should take priority. The worker pod will get a benign 409 on `PATCH /run` and exit cleanly. Blocking QUEUED would cause a semantic error where the wrong branch executes.

**Tests**

5 regression tests in `TestTISkipDownstreamRaceCondition` :
- RUNNING / SUCCESS / FAILED tasks protected from overwrite (parametrized)
- QUEUED task correctly skipped (BranchOperator decision wins over queue)
- None-state task still correctly skipped (happy path)

related: #59378

related: #60330

related: #57618

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
