### PR TITLE
fix(providers/standard): improve error message for non-serializable op_kwargs in virtualenv operators

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -579,9 +579,30 @@ class _BasePythonVirtualenvOperator(PythonOperator, metaclass=ABCMeta):
 
         if self.op_args or self.op_kwargs:
             self.log.info("Use %r as serializer.", self.serializer)
-            file.write_bytes(
-                self.pickling_library.dumps({"args": self.op_args, "kwargs": resolve_proxies(self.op_kwargs)})
-            )
+            resolved_kwargs = resolve_proxies(self.op_kwargs)
+            try:
+                file.write_bytes(
+                    self.pickling_library.dumps({"args": self.op_args, "kwargs": resolved_kwargs})
+                )
+            except Exception:
+                # Identify which specific kwarg(s) failed to serialize so the
+                # user gets a clear error instead of an opaque PicklingError.
+                bad_keys: list[str] = []
+                for key, value in resolved_kwargs.items():
+                    try:
+                        self.pickling_library.dumps(value)
+                    except Exception:
+                        bad_keys.append(key)
+                if bad_keys:
+                    raise AirflowException(
+                        f"Failed to serialize op_kwargs. The following keys contain objects that "
+                        f"cannot be pickled: {bad_keys}. This often happens when "
+                        f"render_template_as_native_obj=True and templates like '{{{{ ti }}}}' "
+                        f"resolve to live Airflow objects instead of strings. Use string "
+                        f"representations or pass only the specific attributes you need "
+                        f"(e.g. '{{{{ ti.task_id }}}}', '{{{{ ti.run_id }}}}')."
+                    )
+                raise
 
     def _write_string_args(self, file: Path):
         file.write_text("\n".join(map(str, self.string_args)))

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -1092,6 +1092,25 @@ class BaseTestPythonVirtualenvOperator(BasePythonTest):
         op = self.opcls(task_id="task", python_callable=f, **self.default_kwargs())
         copy.deepcopy(op)
 
+    def test_write_args_non_serializable_op_kwargs(self, tmp_path):
+        """Non-serializable op_kwargs should raise AirflowException with helpful message."""
+
+        class NonSerializable:
+            def __reduce__(self):
+                raise TypeError("cannot pickle this")
+
+        def f(x):
+            return x
+
+        op = self.opcls(
+            task_id="task",
+            python_callable=f,
+            op_kwargs={"bad_obj": NonSerializable(), "good_obj": "hello"},
+            **self.default_kwargs(),
+        )
+        with pytest.raises(AirflowException, match=r"cannot be pickled.*\['bad_obj'\]"):
+            op._write_args(tmp_path / "args.pkl")
+
     def test_virtualenv_serializable_context_fields(self, create_task_instance):
         """Ensure all template context fields are listed in the operator.
 


### PR DESCRIPTION
## Problem

When `render_template_as_native_obj=True` on a DAG, templates like `{{ ti }}` in `op_kwargs` resolve to live `TaskInstance` objects instead of strings. When `PythonVirtualenvOperator._write_args` tries to pickle these for the subprocess, it fails with a `PicklingError` from structlog internals (`Only BytesLoggers to sys.stdout and sys.stderr can be pickled`). The error gives no indication that the root cause is a non-serializable kwarg value.

## Root Cause

`_write_args` calls `self.pickling_library.dumps(...)` on the full args dict without any pre-validation. When a value can't be pickled, the raw exception propagates — and since `TaskInstance` contains structlog loggers, the error message references structlog internals rather than the actual problem.

## Fix

Wrap the `dumps` call in a try/except. On failure, iterate over `op_kwargs` to identify which specific keys hold non-serializable values, then raise an `AirflowException` naming the bad keys and suggesting alternatives (e.g. `{{ ti.task_id }}` instead of `{{ ti }}`).

Added a unit test that verifies the improved error message when a non-serializable object is passed in `op_kwargs`.

Closes: #61741

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
