### PR TITLE
Fix git-sync rotated credentials support in Helm chart

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -257,6 +257,9 @@ spec:
   {{- if and  .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
     {{- include "git_sync_ssh_key_volume" . | nindent 2 }}
   {{- end }}
+  {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
+    {{- include "git_sync_credentials_volume" . | nindent 2 }}
+  {{- end }}
   - configMap:
       name: {{ include "airflow_config" . }}
     name: config

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -204,6 +204,14 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
+{{/*  Git credentials volume */}}
+{{- define "git_sync_credentials_volume" }}
+- name: git-sync-credentials
+  secret:
+    secretName: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+    defaultMode: 288
+{{- end }}
+
 {{/*  Git sync container */}}
 {{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
@@ -247,16 +255,10 @@ If release name contains chart name it will be used as a full name.
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_USERNAME
-    - name: GIT_SYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GIT_SYNC_PASSWORD
-    - name: GITSYNC_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
-          key: GITSYNC_PASSWORD
+    - name: GIT_SYNC_PASSWORD_FILE
+      value: "/etc/git-secret/credentials/GIT_SYNC_PASSWORD"
+    - name: GITSYNC_PASSWORD_FILE
+      value: "/etc/git-secret/credentials/GITSYNC_PASSWORD"
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}
@@ -350,6 +352,11 @@ If release name contains chart name it will be used as a full name.
     readOnly: true
     subPath: known_hosts
   {{- end }}
+  {{- end }}
+  {{- if .Values.dags.gitSync.credentialsSecret }}
+  - name: git-sync-credentials
+    mountPath: /etc/git-secret/credentials
+    readOnly: true
   {{- end }}
   {{- if .Values.dags.gitSync.extraVolumeMounts }}
     {{- tpl (toYaml .Values.dags.gitSync.extraVolumeMounts) . | nindent 2 }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -204,7 +204,7 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
-{{/*  Git credentials volume */}}
+{{/* Git credentials volume */}}
 {{- define "git_sync_credentials_volume" }}
 - name: git-sync-credentials
   secret:
@@ -255,10 +255,23 @@ If release name contains chart name it will be used as a full name.
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_USERNAME
+    {{- if .Values.dags.gitSync.usePasswordFile }}
     - name: GIT_SYNC_PASSWORD_FILE
       value: "/etc/git-secret/credentials/GIT_SYNC_PASSWORD"
     - name: GITSYNC_PASSWORD_FILE
       value: "/etc/git-secret/credentials/GITSYNC_PASSWORD"
+    {{- else }}
+    - name: GIT_SYNC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GIT_SYNC_PASSWORD
+    - name: GITSYNC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
+          key: GITSYNC_PASSWORD
+    {{- end }}
     {{- end }}
     - name: GIT_SYNC_REV
       value: {{ .Values.dags.gitSync.rev | quote }}
@@ -353,7 +366,7 @@ If release name contains chart name it will be used as a full name.
     subPath: known_hosts
   {{- end }}
   {{- end }}
-  {{- if .Values.dags.gitSync.credentialsSecret }}
+  {{- if and .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
   - name: git-sync-credentials
     mountPath: /etc/git-secret/credentials
     readOnly: true

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -270,6 +270,9 @@ spec:
         {{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.credentialsSecret }}
+          {{- include "git_sync_credentials_volume" . | indent 8 }}
+        {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}
         {{- end }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -270,7 +270,7 @@ spec:
         {{- if and .Values.dags.gitSync.enabled (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
-        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.credentialsSecret }}
+        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
           {{- include "git_sync_credentials_volume" . | indent 8 }}
         {{- end }}
         {{- if .Values.volumes }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -344,6 +344,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.credentialsSecret }}
+          {{- include "git_sync_credentials_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.volumes }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -344,7 +344,7 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.credentialsSecret }}
+        {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
           {{- include "git_sync_credentials_volume" . | indent 8 }}
         {{- end }}
         {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -300,7 +300,7 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | nindent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.credentialsSecret }}
+        {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
           {{- include "git_sync_credentials_volume" . | nindent 8 }}
         {{- end }}
         {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -300,6 +300,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | nindent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.credentialsSecret }}
+          {{- include "git_sync_credentials_volume" . | nindent 8 }}
+        {{- end }}
         {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -482,7 +482,7 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
-        {{- if .Values.dags.gitSync.credentialsSecret }}
+        {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) .Values.dags.gitSync.credentialsSecret .Values.dags.gitSync.usePasswordFile }}
           {{- include "git_sync_credentials_volume" . | indent 8 }}
         {{- end }}
         {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -482,6 +482,9 @@ spec:
         {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey}}
           {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- if .Values.dags.gitSync.credentialsSecret }}
+          {{- include "git_sync_credentials_volume" . | indent 8 }}
+        {{- end }}
         {{- end }}
   {{- if .Values.logs.persistence.enabled }}
         - name: logs

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1076,7 +1076,7 @@
                         "tag": {
                             "description": "The gitSync image tag.",
                             "type": "string",
-                            "default": "v4.6.0"
+                            "default": "v4.4.2"
                         },
                         "pullPolicy": {
                             "description": "The gitSync image pull policy.",
@@ -10801,12 +10801,17 @@
                             }
                         },
                         "credentialsSecret": {
-                            "description": "Name of a Secret containing `GIT_SYNC_USERNAME`, `GITSYNC_USERNAME`, `GIT_SYNC_PASSWORD`, and `GITSYNC_PASSWORD` keys. The password keys are mounted as files and used via `*_PASSWORD_FILE` env vars so rotated credentials can be re-read.",
+                            "description": "Name of a Secret containing git credentials (`GIT_SYNC_USERNAME`/`GIT_SYNC_PASSWORD` and optionally `GITSYNC_USERNAME`/`GITSYNC_PASSWORD`).",
                             "type": [
                                 "string",
                                 "null"
                             ],
                             "default": null
+                        },
+                        "usePasswordFile": {
+                            "description": "When true and `credentialsSecret` is set, mount the credentials secret and pass password keys via `*_PASSWORD_FILE` env vars.",
+                            "type": "boolean",
+                            "default": false
                         },
                         "sshKey": {
                             "description": "SSH private key",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10801,7 +10801,7 @@
                             }
                         },
                         "credentialsSecret": {
-                            "description": "Name of a Secret containing the repo `GIT_SYNC_USERNAME` and `GIT_SYNC_PASSWORD`.",
+                            "description": "Name of a Secret containing `GIT_SYNC_USERNAME`, `GITSYNC_USERNAME`, `GIT_SYNC_PASSWORD`, and `GITSYNC_PASSWORD` keys. The password keys are mounted as files and used via `*_PASSWORD_FILE` env vars so rotated credentials can be re-read.",
                             "type": [
                                 "string",
                                 "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1076,7 +1076,7 @@
                         "tag": {
                             "description": "The gitSync image tag.",
                             "type": "string",
-                            "default": "v4.4.2"
+                            "default": "v4.6.0"
                         },
                         "pullPolicy": {
                             "description": "The gitSync image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3558,7 +3558,11 @@ dags:
     #     # For git-sync v4
     #     GITSYNC_USERNAME: <base64_encoded_git_username>
     #     GITSYNC_PASSWORD: <base64_encoded_git_password>
-    # and specify the name of the secret below
+    # and specify the name of the secret below.
+    #
+    # The secret will be mounted into git-sync at /etc/git-secret/credentials
+    # and passwords will be read from files so rotated tokens can be picked up
+    # without restarting the git-sync container.
     #
     # credentialsSecret: git-credentials
     #

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,7 +124,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
-    tag: v4.4.2
+    tag: v4.6.0
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -124,7 +124,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: registry.k8s.io/git-sync/git-sync
-    tag: v4.6.0
+    tag: v4.4.2
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
@@ -3560,11 +3560,14 @@ dags:
     #     GITSYNC_PASSWORD: <base64_encoded_git_password>
     # and specify the name of the secret below.
     #
-    # The secret will be mounted into git-sync at /etc/git-secret/credentials
-    # and passwords will be read from files so rotated tokens can be picked up
-    # without restarting the git-sync container.
-    #
     # credentialsSecret: git-credentials
+    #
+    # If set to true, credentialsSecret will also be mounted into git-sync at
+    # /etc/git-secret/credentials and password keys will be passed via
+    # GIT_SYNC_PASSWORD_FILE/GITSYNC_PASSWORD_FILE.
+    #
+    # usePasswordFile: true
+    usePasswordFile: false
     #
     #
     # If you are using an ssh clone url, you can load

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -261,6 +261,7 @@ class TestPodTemplateFile:
                     "gitSync": {
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
+                        "usePasswordFile": True,
                         "sshKeySecret": None,
                     }
                 }
@@ -287,6 +288,49 @@ class TestPodTemplateFile:
             "name": "GITSYNC_PASSWORD_FILE",
             "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
         } in jmespath.search("spec.initContainers[0].env", docs[0])
+        assert {
+            "mountPath": "/etc/git-secret/credentials",
+            "name": "git-sync-credentials",
+            "readOnly": True,
+        } in jmespath.search("spec.initContainers[0].volumeMounts", docs[0])
+        assert {
+            "name": "git-sync-credentials",
+            "secret": {"defaultMode": 288, "secretName": "user-pass-secret"},
+        } in jmespath.search("spec.volumes", docs[0])
+
+    def test_should_set_username_and_pass_env_variables_by_default(self):
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "credentialsSecret": "user-pass-secret",
+                        "sshKeySecret": None,
+                    }
+                }
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "name": "GIT_SYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+        assert {
+            "name": "GIT_SYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_PASSWORD"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+
+        assert {
+            "name": "GITSYNC_USERNAME",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_PASSWORD"}},
+        } in jmespath.search("spec.initContainers[0].env", docs[0])
+        assert "git-sync-credentials" not in jmespath.search("spec.volumes[].name", docs[0])
 
     def test_should_set_the_dags_volume_claim_correctly_when_using_an_existing_claim(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -274,8 +274,8 @@ class TestPodTemplateFile:
             "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
         } in jmespath.search("spec.initContainers[0].env", docs[0])
         assert {
-            "name": "GIT_SYNC_PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_PASSWORD"}},
+            "name": "GIT_SYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GIT_SYNC_PASSWORD",
         } in jmespath.search("spec.initContainers[0].env", docs[0])
 
         # Testing git-sync v4
@@ -284,8 +284,8 @@ class TestPodTemplateFile:
             "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
         } in jmespath.search("spec.initContainers[0].env", docs[0])
         assert {
-            "name": "GITSYNC_PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_PASSWORD"}},
+            "name": "GITSYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
         } in jmespath.search("spec.initContainers[0].env", docs[0])
 
     def test_should_set_the_dags_volume_claim_correctly_when_using_an_existing_claim(self):

--- a/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
@@ -802,6 +802,39 @@ class TestDagProcessor:
             "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
 
+    def test_should_set_password_file_env_variables_when_credentials_secret_is_configured(self):
+        docs = render_chart(
+            values={
+                "dagProcessor": {"enabled": True},
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "credentialsSecret": "user-pass-secret",
+                    },
+                    "persistence": {"enabled": False},
+                },
+            },
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+
+        assert {
+            "name": "GIT_SYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GIT_SYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "mountPath": "/etc/git-secret/credentials",
+            "name": "git-sync-credentials",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[1].volumeMounts", docs[0])
+        assert {
+            "name": "git-sync-credentials",
+            "secret": {"defaultMode": 288, "secretName": "user-pass-secret"},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
 
 class TestDagProcessorLogGroomer(LogGroomerTestBase):
     """DAG processor log groomer."""

--- a/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_dag_processor.py
@@ -810,6 +810,7 @@ class TestDagProcessor:
                     "gitSync": {
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
+                        "usePasswordFile": True,
                     },
                     "persistence": {"enabled": False},
                 },

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -292,6 +292,7 @@ class TestGitSyncSchedulerTest:
                     "gitSync": {
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
+                        "usePasswordFile": True,
                         "sshKeySecret": None,
                     }
                 },

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -284,7 +284,7 @@ class TestGitSyncSchedulerTest:
         )
         assert "git-sync-ssh-key" not in jmespath.search("spec.template.spec.volumes[].name", docs[0])
 
-    def test_should_set_username_and_pass_env_variables(self):
+    def test_should_set_username_and_password_file_env_variables(self):
         docs = render_chart(
             values={
                 "airflowVersion": "2.11.0",
@@ -304,8 +304,8 @@ class TestGitSyncSchedulerTest:
             "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_USERNAME"}},
         } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
         assert {
-            "name": "GIT_SYNC_PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GIT_SYNC_PASSWORD"}},
+            "name": "GIT_SYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GIT_SYNC_PASSWORD",
         } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
 
         # Testing git-sync v4
@@ -314,9 +314,18 @@ class TestGitSyncSchedulerTest:
             "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_USERNAME"}},
         } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
         assert {
-            "name": "GITSYNC_PASSWORD",
-            "valueFrom": {"secretKeyRef": {"name": "user-pass-secret", "key": "GITSYNC_PASSWORD"}},
+            "name": "GITSYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
         } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "mountPath": "/etc/git-secret/credentials",
+            "name": "git-sync-credentials",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[1].volumeMounts", docs[0])
+        assert {
+            "name": "git-sync-credentials",
+            "secret": {"defaultMode": 288, "secretName": "user-pass-secret"},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
 
     def test_should_set_the_volume_claim_correctly_when_using_an_existing_claim(self):
         docs = render_chart(

--- a/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
@@ -77,6 +77,37 @@ class TestGitSyncTriggerer:
             "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
 
+    def test_should_set_password_file_env_variables_when_credentials_secret_is_configured(self):
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "credentialsSecret": "user-pass-secret",
+                    }
+                }
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert {
+            "name": "GIT_SYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GIT_SYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "mountPath": "/etc/git-secret/credentials",
+            "name": "git-sync-credentials",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[1].volumeMounts", docs[0])
+        assert {
+            "name": "git-sync-credentials",
+            "secret": {"defaultMode": 288, "secretName": "user-pass-secret"},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
     def test_liveness_probe_configuration(self):
         livenessProbe = {
             "failureThreshold": 10,

--- a/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py
@@ -84,6 +84,7 @@ class TestGitSyncTriggerer:
                     "gitSync": {
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
+                        "usePasswordFile": True,
                     }
                 }
             },

--- a/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
@@ -168,6 +168,37 @@ class TestGitSyncWorker:
             "secret": {"secretName": "release-name-ssh-secret", "defaultMode": 288},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
 
+    def test_should_set_password_file_env_variables_when_credentials_secret_is_configured(self):
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "credentialsSecret": "user-pass-secret",
+                    }
+                }
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert {
+            "name": "GIT_SYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GIT_SYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "name": "GITSYNC_PASSWORD_FILE",
+            "value": "/etc/git-secret/credentials/GITSYNC_PASSWORD",
+        } in jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        assert {
+            "mountPath": "/etc/git-secret/credentials",
+            "name": "git-sync-credentials",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[1].volumeMounts", docs[0])
+        assert {
+            "name": "git-sync-credentials",
+            "secret": {"defaultMode": 288, "secretName": "user-pass-secret"},
+        } in jmespath.search("spec.template.spec.volumes", docs[0])
+
     def test_container_lifecycle_hooks(self):
         docs = render_chart(
             values={

--- a/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_worker.py
@@ -175,6 +175,7 @@ class TestGitSyncWorker:
                     "gitSync": {
                         "enabled": True,
                         "credentialsSecret": "user-pass-secret",
+                        "usePasswordFile": True,
                     }
                 }
             },


### PR DESCRIPTION
Fixes #63253

Hi team, this PR is to handle token rotation properly when `dags.gitSync.credentialsSecret` is used.

### Problem
Right now password/token is passed as env var (`GIT_SYNC_PASSWORD` / `GITSYNC_PASSWORD`).  
When secret is rotated (for example ESO GitHub App token), running git-sync container does not pick the new value until restart.

### What I changed
- Added secret volume mount for git-sync credentials (`git-sync-credentials`) in:
  - scheduler
  - worker
  - triggerer
  - dag-processor
- Switched password config to file-based envs:
  - `GIT_SYNC_PASSWORD_FILE=/etc/git-secret/credentials/GIT_SYNC_PASSWORD`
  - `GITSYNC_PASSWORD_FILE=/etc/git-secret/credentials/GITSYNC_PASSWORD`
- Kept username keys from secret as before (`GIT_SYNC_USERNAME` / `GITSYNC_USERNAME`).
- Updated chart values comments + schema description.
- Added/updated helm tests for scheduler/worker/triggerer/dag-processor.

### Why this fix
git-sync can re-read password from file path on sync loop, so rotated token is picked without forcing pod restart.

### Testing
Ran helm unit tests for the updated git-sync paths and related suites (`HELM_TEST_KUBERNETES_VERSION=1.32.8`), and selected tests are passing.

1. Ran focused Helm unit tests for the new credential-file behavior:
   - `test_git_sync_scheduler.py::test_should_set_username_and_password_file_env_variables`
   - `test_git_sync_worker.py::test_should_set_password_file_env_variables_when_credentials_secret_is_configured`
   - `test_git_sync_triggerer.py::test_should_set_password_file_env_variables_when_credentials_secret_is_configured`
   - `test_dag_processor.py::test_should_set_password_file_env_variables_when_credentials_secret_is_configured`
   Result: **4 passed**

2. Ran broader git-sync regression subset:
   - Full files:
     - `helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py`
     - `helm-tests/tests/helm_tests/other/test_git_sync_worker.py`
     - `helm-tests/tests/helm_tests/other/test_git_sync_triggerer.py`
   - Plus dag-processor git-sync checks:
     - `test_validate_if_ssh_params_are_added_with_git_ssh_key`
     - `test_should_set_password_file_env_variables_when_credentials_secret_is_configured`
   Result: **42 passed**

3. Sanity checks:
   - `jq empty chart/values.schema.json` (schema JSON valid)
   - Python compile check for modified tests (`compileall`) passed

Environment note: tests were run with `HELM_TEST_KUBERNETES_VERSION=1.32.8`.