### PR TITLE
 Intermittent failures due to not properly shutting down the span exporter in tests

### DIFF
--- a/airflow-core/tests/unit/observability/traces/test_otel_tracer.py
+++ b/airflow-core/tests/unit/observability/traces/test_otel_tracer.py
@@ -81,22 +81,25 @@ class TestOtelTrace:
         exporter.return_value = in_mem_exporter
 
         tracer = otel_tracer.get_otel_tracer(Trace)
-        assert otel_env_conf.called
-        otel_env_conf.assert_called_once()
-        with tracer.start_span(span_name="span1") as s1:
-            with tracer.start_span(span_name="span2") as s2:
-                s2.set_attribute("attr2", "val2")
-                span2 = json.loads(s2.to_json())
-            span1 = json.loads(s1.to_json())
-        # assert the two span data
-        assert span1["name"] == "span1"
-        assert span2["name"] == "span2"
-        trace_id = span1["context"]["trace_id"]
-        s1_span_id = span1["context"]["span_id"]
-        assert span2["context"]["trace_id"] == trace_id
-        assert span2["parent_id"] == s1_span_id
-        assert span2["attributes"]["attr2"] == "val2"
-        assert span2["resource"]["attributes"]["service.name"] == "my_test_service"
+        try:
+            assert otel_env_conf.called
+            otel_env_conf.assert_called_once()
+            with tracer.start_span(span_name="span1") as s1:
+                with tracer.start_span(span_name="span2") as s2:
+                    s2.set_attribute("attr2", "val2")
+                    span2 = json.loads(s2.to_json())
+                span1 = json.loads(s1.to_json())
+            # assert the two span data
+            assert span1["name"] == "span1"
+            assert span2["name"] == "span2"
+            trace_id = span1["context"]["trace_id"]
+            s1_span_id = span1["context"]["span_id"]
+            assert span2["context"]["trace_id"] == trace_id
+            assert span2["parent_id"] == s1_span_id
+            assert span2["attributes"]["attr2"] == "val2"
+            assert span2["resource"]["attributes"]["service.name"] == "my_test_service"
+        finally:
+            tracer.shutdown()
 
     @patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter")
     @env_vars(
@@ -117,19 +120,22 @@ class TestOtelTrace:
         now = datetime.now()
 
         tracer = otel_tracer.get_otel_tracer(Trace)
-        with tracer.start_root_span(span_name="span1", start_time=now) as s1:
-            with tracer.start_span(span_name="span2") as s2:
-                s2.set_attribute("attr2", "val2")
-                span2 = json.loads(s2.to_json())
-            span1 = json.loads(s1.to_json())
+        try:
+            with tracer.start_root_span(span_name="span1", start_time=now) as s1:
+                with tracer.start_span(span_name="span2") as s2:
+                    s2.set_attribute("attr2", "val2")
+                    span2 = json.loads(s2.to_json())
+                span1 = json.loads(s1.to_json())
 
-        # The otel sdk, accepts an int for the start_time, and converts it to an iso string,
-        # using `util.ns_to_iso_str()`.
-        nano_time = datetime_to_nano(now)
-        assert span1["start_time"] == util.ns_to_iso_str(nano_time)
-        # Same trace_id
-        assert span1["context"]["trace_id"] == span2["context"]["trace_id"]
-        assert span1["context"]["span_id"] == span2["parent_id"]
+            # The otel sdk, accepts an int for the start_time, and converts it to an iso string,
+            # using `util.ns_to_iso_str()`.
+            nano_time = datetime_to_nano(now)
+            assert span1["start_time"] == util.ns_to_iso_str(nano_time)
+            # Same trace_id
+            assert span1["context"]["trace_id"] == span2["context"]["trace_id"]
+            assert span1["context"]["span_id"] == span2["parent_id"]
+        finally:
+            tracer.shutdown()
 
     @patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter")
     @env_vars(
@@ -161,25 +167,27 @@ class TestOtelTrace:
             return json_span
 
         tracer = otel_tracer.get_otel_tracer(Trace)
+        try:
+            root_span = tracer.start_root_span(span_name="root_span", start_as_current=False)
+            # The context is available, it can be injected into the carrier.
+            context_carrier = tracer.inject()
 
-        root_span = tracer.start_root_span(span_name="root_span", start_as_current=False)
-        # The context is available, it can be injected into the carrier.
-        context_carrier = tracer.inject()
+            # Some function that uses the carrier to create a new span.
+            json_span2 = _task_func(otel_tr=tracer, carrier=context_carrier)
 
-        # Some function that uses the carrier to create a new span.
-        json_span2 = _task_func(otel_tr=tracer, carrier=context_carrier)
+            json_span1 = json.loads(root_span.to_json())
+            # Manually end the span.
+            root_span.end()
 
-        json_span1 = json.loads(root_span.to_json())
-        # Manually end the span.
-        root_span.end()
-
-        # Verify that span1 is a root span.
-        assert json_span1["parent_id"] is None
-        # Check span2 parent_id to verify that it's a child of span1.
-        assert json_span2["parent_id"] == json_span1["context"]["span_id"]
-        # The trace_id and the span_id are randomly generated by the otel sdk.
-        # Both spans should belong to the same trace.
-        assert json_span1["context"]["trace_id"] == json_span2["context"]["trace_id"]
+            # Verify that span1 is a root span.
+            assert json_span1["parent_id"] is None
+            # Check span2 parent_id to verify that it's a child of span1.
+            assert json_span2["parent_id"] == json_span1["context"]["span_id"]
+            # The trace_id and the span_id are randomly generated by the otel sdk.
+            # Both spans should belong to the same trace.
+            assert json_span1["context"]["trace_id"] == json_span2["context"]["trace_id"]
+        finally:
+            tracer.shutdown()
 
     @pytest.mark.parametrize(
         ("provided_env_vars", "expected_endpoint", "expected_exporter_module"),
@@ -250,10 +258,12 @@ class TestOtelTrace:
     def test_config_priorities(self, provided_env_vars, expected_endpoint, expected_exporter_module):
         with env_vars(provided_env_vars):
             tracer = otel_tracer.get_otel_tracer(Trace)
+            try:
+                assert tracer.span_exporter._endpoint == expected_endpoint
 
-            assert tracer.span_exporter._endpoint == expected_endpoint
-
-            assert (
-                tracer.span_exporter.__class__.__module__
-                == f"opentelemetry.exporter.otlp.proto.{expected_exporter_module}.trace_exporter"
-            )
+                assert (
+                    tracer.span_exporter.__class__.__module__
+                    == f"opentelemetry.exporter.otlp.proto.{expected_exporter_module}.trace_exporter"
+                )
+            finally:
+                tracer.shutdown()

--- a/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
+++ b/shared/observability/src/airflow_shared/observability/traces/otel_tracer.py
@@ -86,6 +86,9 @@ class OtelTrace:
         self.resource = Resource.create(attributes={SERVICE_NAME: self.otel_service})
         self.debug = debug
 
+    def shutdown(self):
+        self.span_processor.shutdown()
+
     def get_otel_tracer_provider(
         self,
         trace_id: int | None = None,


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This patch is fixing the OTel errors from this CI step

https://github.com/apache/airflow/actions/runs/22871464785/job/66353899660#step:8:694

The same errors were printed when running `test_otel_tracer.py`

https://github.com/apache/airflow/blob/main/airflow-core/tests/unit/observability/traces/test_otel_tracer.py

The unit test was running before the rest and it was creating actual span exporters that were never shut down. The exporters would still run in the background during the test suite execution, and try to export span swithout having an otel-collector available.

I was able to reproduce the CI errors locally like so
```
> ./scripts/ci/testing/run_unit_tests.sh "core" "Non-DB"
```

but with the new changes I don't see them anymore.

This is the offending line

https://github.com/apache/airflow/blob/main/airflow-core/tests/unit/observability/traces/test_otel_tracer.py#L83

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] Νο

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
