### PR TITLE
fix: block path traversal via ".." in dag_id and run_id

### DIFF
--- a/airflow-core/newsfragments/63296.significant.rst
+++ b/airflow-core/newsfragments/63296.significant.rst
@@ -1,0 +1,16 @@
+Block path traversal via ``..`` in ``dag_id`` and ``run_id``
+
+DAG IDs and run IDs containing ``..`` are now rejected by default to prevent path traversal.
+A configuration flag ``[core] allow_dotdot_in_ids`` (default: ``False``) is available for
+environments that rely on ``..`` in identifiers.
+
+* Types of change
+
+  * [ ] Dag changes
+  * [x] Config changes
+  * [x] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes

--- a/airflow-core/newsfragments/63296.significant.rst
+++ b/airflow-core/newsfragments/63296.significant.rst
@@ -1,7 +1,7 @@
 Block path traversal via ``..`` in ``dag_id`` and ``run_id``
 
 DAG IDs and run IDs containing ``..`` are now rejected by default to prevent path traversal.
-A configuration flag ``[core] allow_dotdot_in_ids`` (default: ``False``) is available for
+A configuration flag ``[core] allow_double_dot_in_ids`` (default: ``False``) is available for
 environments that rely on ``..`` in identifiers.
 
 * Types of change

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -439,6 +439,16 @@ core:
       example: ~
       default: "1024"
 
+    allow_dotdot_in_ids:
+      description: |
+        Allow ``..`` (consecutive dots) in DAG IDs and run IDs. By default, ``..`` is blocked to prevent
+        path traversal attacks. Set to ``True`` only if you have existing DAGs or runs whose IDs contain
+        ``..`` and cannot be renamed.
+      version_added: 3.0.0
+      type: boolean
+      example: ~
+      default: "False"
+
     daemon_umask:
       description: |
         The default umask to use for process when run in daemon mode (scheduler, worker,  etc.)

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -439,12 +439,12 @@ core:
       example: ~
       default: "1024"
 
-    allow_dotdot_in_ids:
+    allow_double_dot_in_ids:
       description: |
         Allow ``..`` (consecutive dots) in DAG IDs and run IDs. By default, ``..`` is blocked to prevent
         path traversal attacks. Set to ``True`` only if you have existing DAGs or runs whose IDs contain
         ``..`` and cannot be renamed.
-      version_added: 3.0.0
+      version_added: 3.3.0
       type: boolean
       example: ~
       default: "False"

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -395,6 +395,10 @@ class DagRun(Base, LoggingMixin):
     def validate_run_id(self, key: str, run_id: str) -> str | None:
         if not run_id:
             return None
+        if ".." in run_id:
+            raise ValueError(
+                f"The run_id '{run_id}' must not contain '..' to prevent path traversal"
+            )
         if re.match(RUN_ID_REGEX, run_id):
             return run_id
         regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -395,7 +395,7 @@ class DagRun(Base, LoggingMixin):
     def validate_run_id(self, key: str, run_id: str) -> str | None:
         if not run_id:
             return None
-        if ".." in run_id and not airflow_conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
+        if ".." in run_id and not airflow_conf.getboolean("core", "allow_double_dot_in_ids", fallback=False):
             raise ValueError(f"The run_id '{run_id}' must not contain '..' to prevent path traversal")
         if re.match(RUN_ID_REGEX, run_id):
             return run_id

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -395,10 +395,8 @@ class DagRun(Base, LoggingMixin):
     def validate_run_id(self, key: str, run_id: str) -> str | None:
         if not run_id:
             return None
-        if ".." in run_id:
-            raise ValueError(
-                f"The run_id '{run_id}' must not contain '..' to prevent path traversal"
-            )
+        if ".." in run_id and not airflow_conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
+            raise ValueError(f"The run_id '{run_id}' must not contain '..' to prevent path traversal")
         if re.match(RUN_ID_REGEX, run_id):
             return run_id
         regex = airflow_conf.get("scheduler", "allowed_run_id_pattern").strip()

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -548,6 +548,9 @@ class SerializedDAG:
         if not isinstance(run_id, str):
             raise ValueError(f"`run_id` should be a str, not {type(run_id)}")
 
+        if ".." in run_id and not airflow_conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
+            raise ValueError(f"The run_id '{run_id}' must not contain '..' to prevent path traversal")
+
         # This is also done on the DagRun model class, but SQLAlchemy column
         # validator does not work well for some reason.
         if not re.match(RUN_ID_REGEX, run_id):

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -548,7 +548,7 @@ class SerializedDAG:
         if not isinstance(run_id, str):
             raise ValueError(f"`run_id` should be a str, not {type(run_id)}")
 
-        if ".." in run_id and not airflow_conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
+        if ".." in run_id and not airflow_conf.getboolean("core", "allow_double_dot_in_ids", fallback=False):
             raise ValueError(f"The run_id '{run_id}' must not contain '..' to prevent path traversal")
 
         # This is also done on the DagRun model class, but SQLAlchemy column

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -61,6 +61,10 @@ def validate_key(k: str, max_length: int = 250):
             f"The key {k!r} has to be made of alphanumeric characters, dashes, "
             f"dots and underscores exclusively"
         )
+    if ".." in k:
+        raise AirflowException(
+            f"The key {k!r} must not contain consecutive dots ('..') to prevent path traversal"
+        )
 
 
 def ask_yesno(question: str, default: bool | None = None, output_fn=print) -> bool:

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -61,7 +61,7 @@ def validate_key(k: str, max_length: int = 250):
             f"The key {k!r} has to be made of alphanumeric characters, dashes, "
             f"dots and underscores exclusively"
         )
-    if ".." in k:
+    if ".." in k and not conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
         raise AirflowException(
             f"The key {k!r} must not contain consecutive dots ('..') to prevent path traversal"
         )

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -61,7 +61,7 @@ def validate_key(k: str, max_length: int = 250):
             f"The key {k!r} has to be made of alphanumeric characters, dashes, "
             f"dots and underscores exclusively"
         )
-    if ".." in k and not conf.getboolean("core", "allow_dotdot_in_ids", fallback=False):
+    if ".." in k and not conf.getboolean("core", "allow_double_dot_in_ids", fallback=False):
         raise AirflowException(
             f"The key {k!r} must not contain consecutive dots ('..') to prevent path traversal"
         )

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -3169,6 +3169,24 @@ def test_dag_run_id_config(session, dag_maker, pattern, run_id, result):
                 dag_maker.create_dagrun(run_id=run_id, run_type=run_type)
 
 
+@pytest.mark.db_test
+@pytest.mark.need_serialized_dag(False)
+@pytest.mark.parametrize(
+    "run_id",
+    [
+        "manual__..%2F..%2Fetc%2Fpasswd",
+        "my..run",
+        "..",
+    ],
+)
+def test_dag_run_id_rejects_path_traversal(session, dag_maker, run_id):
+    """run_id containing '..' should be rejected to prevent path traversal."""
+    with dag_maker():
+        pass
+    with pytest.raises(ValueError, match=r"must not contain '\.\.'"):
+        dag_maker.create_dagrun(run_id=run_id, run_type=DagRunType.MANUAL)
+
+
 def _get_states(dr):
     """
     For a given dag run, get a dict of states.

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -140,6 +140,16 @@ class TestHelpers:
                 AirflowException,
             ),
             (" " * 251, f"The key: {' ' * 251} has to be less than 250 characters", AirflowException),
+            (
+                "my..key",
+                "The key 'my..key' must not contain consecutive dots ('..') to prevent path traversal",
+                AirflowException,
+            ),
+            (
+                "..",
+                "The key '..' must not contain consecutive dots ('..') to prevent path traversal",
+                AirflowException,
+            ),
         ],
     )
     def test_validate_key(self, key_id, message, exception):


### PR DESCRIPTION
## Problem

`validate_key()` and `validate_run_id()` both allow `..` in their values. Since `dag_id` and `run_id` are used in log file paths (e.g. `dag_id=.../run_id=.../`), a crafted value containing `..` could theoretically traverse outside the intended log directory.

## Root Cause

`KEY_REGEX` (`^[\w.-]+$`) matches `..` as valid consecutive dots. `validate_run_id` uses a configurable `allowed_run_id_pattern` that could also permit `..`. Neither function checks for path traversal sequences.

## Fix

Added an explicit `..` check in both `validate_key()` (raises `AirflowException`) and `validate_run_id()` (raises `ValueError`) before any other validation. Added corresponding unit tests for both functions.

Closes: #63295

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
