### PR TITLE
fix(task-sdk): exclude pathlib.Path from resolve() call in templater

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/templater.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -186,7 +187,7 @@ class Templater:
         if isinstance(value, ObjectStoragePath):
             return self._render_object_storage_path(value, context, jinja_env)
 
-        if resolve := getattr(value, "resolve", None):
+        if not isinstance(value, os.PathLike) and (resolve := getattr(value, "resolve", None)):
             return resolve(context)
 
         # Fast path for common built-in collections.

--- a/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
+++ b/task-sdk/tests/task_sdk/definitions/_internal/test_templater.py
@@ -81,6 +81,26 @@ class TestTemplater:
 
         assert rendered_content == "Hello {{ name }}"
 
+    def test_render_template_pathlib_path_not_resolved(self):
+        """Test that pathlib.Path objects are not incorrectly resolved via their resolve() method.
+
+        pathlib.Path has a resolve() method for filesystem resolution, which should not be
+        confused with the Resolvable.resolve(context) protocol used by the templater.
+        See: https://github.com/apache/airflow/issues/55412
+        """
+        import pathlib
+
+        templater = Templater()
+        templater.template_ext = []
+        context = {"ds": "2006-02-01"}
+        path = pathlib.PurePosixPath("/some/path/to/file.txt")
+
+        rendered = templater.render_template(path, context)
+
+        # The path should be returned as-is, not passed through resolve(context)
+        assert rendered == path
+        assert isinstance(rendered, pathlib.PurePosixPath)
+
     def test_not_render_file_literal_value(self):
         templater = Templater()
         templater.template_ext = [".txt"]


### PR DESCRIPTION
Closes: #55412

`pathlib.Path.resolve()` takes an optional `strict` parameter, not a `context` dict. The templater's duck-typed `getattr(value, "resolve", None)` check matches pathlib objects, then calls `path.resolve(context)` — the dict is interpreted as `strict=True`, raising `FileNotFoundError` if the path doesn't exist.

Added an `isinstance(value, os.PathLike)` guard to skip pathlib-like objects before the resolve check.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
