### PR TITLE
Fix flaky test_plugins_manager tests due to OTel exporter logs

### DIFF
--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -84,7 +84,7 @@ class TestPluginsManager:
 
             plugins_manager.ensure_plugins_loaded()
 
-        assert caplog.record_tuples == []
+        assert [r for r in caplog.record_tuples if not r[0].startswith("opentelemetry.")] == []
 
     def test_loads_filesystem_plugins(self, caplog):
         from airflow import plugins_manager
@@ -104,7 +104,7 @@ class TestPluginsManager:
         else:
             pytest.fail("Wasn't able to find a registered `AirflowTestOnLoadPlugin`")
 
-        assert caplog.record_tuples == []
+        assert [r for r in caplog.record_tuples if not r[0].startswith("opentelemetry.")] == []
 
     def test_loads_filesystem_plugins_exception(self, caplog, tmp_path):
         from airflow import plugins_manager


### PR DESCRIPTION
## Summary

- Fix intermittent failures in `test_no_log_when_no_plugins` and `test_loads_filesystem_plugins`
  caused by OpenTelemetry's `BatchSpanProcessor` logging transient connection errors when trying
  to export spans to `localhost:4318` (no collector running)
- Filter out `opentelemetry.*` log records from the `caplog.record_tuples == []` assertions since
  they are infrastructure noise unrelated to plugin loading behavior

## Test plan

- [ ] Run `uv run --project airflow-core pytest airflow-core/tests/unit/plugins/test_plugins_manager.py -xvs`
- [ ] Verify the two affected tests pass consistently

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)