### PR TITLE
Replace GitHub outline hints with RST table of contents

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -22,7 +22,9 @@ Before reading this document, you should be familiar with the `Contributors' gui
 This document assumes that you are a bit familiar with how Airflow's community works, but you would like to learn more
 about the rules by which we add new committers and PMC members.
 
-**The outline for this document in GitHub is available at the top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Committers vs. Maintainers
 --------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,7 +18,6 @@
 Contributing
 ============
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
 
 Contributions are welcome and are greatly appreciated! Every little bit helps, and credit will always be given.
 

--- a/PROVIDERS.rst
+++ b/PROVIDERS.rst
@@ -19,7 +19,9 @@
 Apache Airflow Providers
 ************************
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 What is a provider?
 ===================

--- a/contributing-docs/01_roles_in_airflow_project.rst
+++ b/contributing-docs/01_roles_in_airflow_project.rst
@@ -22,7 +22,9 @@ There are several roles within the Airflow Open-Source community.
 
 For detailed information for each role, see: `Committers and PMC members <../COMMITTERS.rst>`__.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 PMC Member
 ----------

--- a/contributing-docs/02_how_to_communicate.rst
+++ b/contributing-docs/02_how_to_communicate.rst
@@ -26,7 +26,9 @@ This means that communication plays a big role in it, and this chapter is all ab
 
 In our communication, everyone is expected to follow the `ASF Code of Conduct <https://www.apache.org/foundation/policies/conduct>`_.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Various Communication channels
 ------------------------------

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -19,7 +19,9 @@
 Contributor's Quick Start
 *************************
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Note to Starters
 ################

--- a/contributing-docs/04_how_to_contribute.rst
+++ b/contributing-docs/04_how_to_contribute.rst
@@ -21,7 +21,9 @@ How to contribute
 There are various ways how you can contribute to Apache Airflow. Here is a short overview of
 some of those ways that involve creating issues and pull requests on GitHub.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Report Bugs
 -----------

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -22,7 +22,9 @@ Pull Requests
 This document describes how you can create Pull Requests (PRs) and describes coding standards we use when
 implementing them.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Protect your commit identity
 ----------------------------

--- a/contributing-docs/06_development_environments.rst
+++ b/contributing-docs/06_development_environments.rst
@@ -21,7 +21,9 @@ Development Environments
 There are two environments, available on Linux and macOS, that you can use to
 develop Apache Airflow.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Local virtualenv Development Environment
 ----------------------------------------

--- a/contributing-docs/07_local_virtualenv.rst
+++ b/contributing-docs/07_local_virtualenv.rst
@@ -26,7 +26,9 @@ harder to debug the tests and to use your IDE to run them.
 
 That's why we recommend using local virtualenv for development and testing.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Required Software Packages
 --------------------------

--- a/contributing-docs/08_static_code_checks.rst
+++ b/contributing-docs/08_static_code_checks.rst
@@ -26,7 +26,9 @@ for the first time.
 
 You can also run the checks via `Breeze <../dev/breeze/doc/README.rst>`_ environment.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Prek hooks
 ----------

--- a/contributing-docs/10_working_with_git.rst
+++ b/contributing-docs/10_working_with_git.rst
@@ -22,7 +22,9 @@ Working with Git
 In this document you can learn basics of how you should use Git in Airflow project. It explains branching model and stresses
 that we are using rebase workflow. It also explains how to sync your fork with the main repository.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Airflow Git Branches
 ====================

--- a/contributing-docs/12_provider_distributions.rst
+++ b/contributing-docs/12_provider_distributions.rst
@@ -25,7 +25,9 @@ Airflow is split into core and providers. They are delivered as separate distrib
 * ``apache-airflow-task-sdk`` - task-sdk distribution that are imported by the providers
 * ``apache-airflow-providers-*`` - More than 90 providers to communicate with external services
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Where providers are kept in our repository
 ------------------------------------------

--- a/contributing-docs/13_airflow_dependencies_and_extras.rst
+++ b/contributing-docs/13_airflow_dependencies_and_extras.rst
@@ -419,9 +419,6 @@ You can read more about those extras in the
 `extras reference <https://airflow.apache.org/docs/apache-airflow/stable/extra-packages-ref.html>`_.
 
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
-
 -----
 
 You can now check how to update Airflow's `metadata database <14_metadata_database_updates.rst>`__ if you need

--- a/contributing-docs/15_node_environment_setup.rst
+++ b/contributing-docs/15_node_environment_setup.rst
@@ -107,8 +107,6 @@ Project Structure
 - ``/src/theme.ts`` the theme for the UI, update this to change the colors, fonts, etc.
 - ``/src/queryClient.ts`` the query client for the UI, update this to change the default options for the API requests
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 
 React, JSX and Chakra
 ---------------------

--- a/contributing-docs/16_adding_api_endpoints.rst
+++ b/contributing-docs/16_adding_api_endpoints.rst
@@ -20,7 +20,9 @@ Adding a New API Endpoint in Apache Airflow
 
 This documentation outlines the steps required to add a new API endpoint in Apache Airflow. It includes implementing the logic, running prek hooks, and documenting the changes.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 
 Introduction

--- a/contributing-docs/18_contribution_workflow.rst
+++ b/contributing-docs/18_contribution_workflow.rst
@@ -18,7 +18,9 @@
 Contribution Workflow
 =====================
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Typically, you start your first contribution by reviewing open tickets
 at `GitHub issues <https://github.com/apache/airflow/issues>`__.

--- a/contributing-docs/23_provider_hook_migration_to_yaml.rst
+++ b/contributing-docs/23_provider_hook_migration_to_yaml.rst
@@ -21,7 +21,9 @@ Provider hook to YAML Migration
 We can now, redefine connection form metadata declaratively in ``provider.yaml`` of a provider instead of Python hook code,
 reducing dependencies and improving API server startup performance.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Background
 ----------

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -15,7 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Connect your project to Gitpod
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_pycharm.rst
@@ -15,7 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Setup your project
 ##################

--- a/contributing-docs/quick-start-ide/contributors_quick_start_vscode.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_vscode.rst
@@ -15,7 +15,9 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Setup your project
 ##################

--- a/contributing-docs/testing/docker_compose_tests.rst
+++ b/contributing-docs/testing/docker_compose_tests.rst
@@ -20,7 +20,9 @@ Airflow Docker Compose Tests
 
 This document describes how to run tests for Airflow Docker Compose deployment.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Running Docker Compose Tests with Breeze
 ----------------------------------------

--- a/contributing-docs/testing/integration_tests.rst
+++ b/contributing-docs/testing/integration_tests.rst
@@ -24,7 +24,9 @@ These tests require ``airflow`` Docker image and extra images with integrations 
 The integration tests are all stored in the ``tests/integration`` folder, and similarly to the unit tests they all run
 using `pytest <http://doc.pytest.org/en/latest/>`_, but they are skipped by default unless ``--integration`` flag is passed to pytest.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Enabling Integrations
 ---------------------

--- a/contributing-docs/testing/k8s_tests.rst
+++ b/contributing-docs/testing/k8s_tests.rst
@@ -25,7 +25,9 @@ deploy and run the cluster tests in our repository and into Breeze development e
 KinD has a really nice ``kind`` tool that you can use to interact with the cluster. Run ``kind --help`` to
 learn more.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 K8S test environment
 --------------------

--- a/contributing-docs/testing/system_tests.rst
+++ b/contributing-docs/testing/system_tests.rst
@@ -25,7 +25,9 @@ external services. A system test tries to look as close to a regular Dag as poss
 System tests need to communicate with external services/systems that are available
 if you have appropriate credentials configured for your tests.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Purpose of System Tests
 -----------------------

--- a/contributing-docs/testing/testing_packages.rst
+++ b/contributing-docs/testing/testing_packages.rst
@@ -22,7 +22,9 @@ Breeze can be used to test new release candidates of distributions - both Airflo
 configure the CI image of Breeze to install and start Airflow for both Airflow and providers, whether they
 are built from sources or downloaded from PyPI as release candidates.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Prerequisites
 -------------

--- a/contributing-docs/testing/unit_tests.rst
+++ b/contributing-docs/testing/unit_tests.rst
@@ -20,7 +20,9 @@ Airflow Unit Tests
 
 All unit tests for Apache Airflow are run using `pytest <http://doc.pytest.org/en/latest/>`_.
 
-**The outline for this document in GitHub is available via the button in the top-right corner (icon with 3 dots and 3 lines).**
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
 
 Writing Unit Tests
 ------------------

--- a/providers/ACCEPTING_PROVIDERS.rst
+++ b/providers/ACCEPTING_PROVIDERS.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 Accepting New Community Providers
 ==================================
 

--- a/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
+++ b/providers/MANAGING_PROVIDERS_LIFECYCLE.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 Managing Provider's Lifecycle
 ==============================
 

--- a/providers/PROVIDER_GOVERNANCE.rst
+++ b/providers/PROVIDER_GOVERNANCE.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 Provider Governance
 ====================
 

--- a/providers/PROVIDER_RELEASES.rst
+++ b/providers/PROVIDER_RELEASES.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 Provider Releases and Versioning
 =================================
 

--- a/providers/SUSPENDING_AND_REMOVING_PROVIDERS.rst
+++ b/providers/SUSPENDING_AND_REMOVING_PROVIDERS.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 Suspending and Removing Providers
 ==================================
 

--- a/providers/THIRD_PARTY_PROVIDERS.rst
+++ b/providers/THIRD_PARTY_PROVIDERS.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-**The outline for this document in GitHub is available at top-right corner button (with 3-dots and 3 lines).**
-
 3rd-Party Providers
 ====================
 


### PR DESCRIPTION
GitHub has restored native TOC rendering for RST files (via the top-right outline button),
making the manual "outline is available at top-right corner" hints unnecessary.

## Summary

- Replace the GitHub-specific outline hint with a proper `.. contents::` RST directive
  across 33 non-doc RST files, providing a rendered TOC that works everywhere (GitHub,
  local builds, readthedocs)
- For very short files (CONTRIBUTING.rst) and mid-document occurrences, the hint line is
  simply removed
- Files that already have a `.. contents::` TOC from a previous PR just have the hint removed

## Test plan

- [x] Verify RST files render correctly on GitHub with the `.. contents::` directive
- [x] Confirm no remaining "outline" hints in non-doc RST files

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)