### PR TITLE
Add log_timestamp_format config option for component log timestamps

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -917,11 +917,24 @@ logging:
       description: |
         Determines the formatter class used by Airflow for structuring its log messages
         The default formatter class is timezone-aware, which means that timestamps attached to log entries
-        will be adjusted to reflect the local timezone of the Airflow instance
+        will be adjusted to reflect the local timezone of the Airflow instance.
+        Note: This setting does NOT affect component logs (scheduler, api-server, triggerer, etc.) since
+        those use structlog directly. Use ``log_timestamp_format`` to control timestamps for those logs.
       version_added: 2.3.4
       type: string
       example: ~
       default: "airflow.utils.log.timezone_aware.TimezoneAware"
+    log_timestamp_format:
+      description: |
+        Timestamp format for component logs (scheduler, api-server, triggerer, etc.).
+        Use ``iso`` for ISO 8601 format (default), or a Python strftime format string
+        such as ``%Y-%m-%d %H:%M:%S``.
+        Note: This setting only applies to component logs rendered via structlog.
+        Task/DAG logs use ``log_format`` instead.
+      version_added: 3.0.4
+      type: string
+      example: "%Y-%m-%d %H:%M:%S"
+      default: "iso"
     secret_mask_adapter:
       description: |
         An import path to a function to add adaptations of each secret added with

--- a/airflow-core/src/airflow/logging_config.py
+++ b/airflow-core/src/airflow/logging_config.py
@@ -120,6 +120,7 @@ def configure_logging():
             namespace_log_levels=conf.get("logging", "namespace_levels", fallback=None),
             stdlib_config=logging_config,
             log_format=log_fmt,
+            log_timestamp_format=conf.get("logging", "log_timestamp_format", fallback="iso"),
             callsite_parameters=callsite_params,
             colors=colors,
         )

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1508,6 +1508,7 @@ StoredInfoType
 storedInfoType
 str
 Streamable
+strftime
 Stringified
 stringified
 Struct

--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -230,6 +230,7 @@ def structlog_processors(
     log_format: str = "",
     colors: bool = True,
     callsite_parameters: tuple[CallsiteParameter, ...] = (),
+    log_timestamp_format: str = "iso",
 ):
     """
     Create the correct list of structlog processors for the given config.
@@ -245,7 +246,7 @@ def structlog_processors(
 
     :meta private:
     """
-    timestamper = structlog.processors.MaybeTimeStamper(fmt="iso")
+    timestamper = structlog.processors.MaybeTimeStamper(fmt=log_timestamp_format)
 
     # Processors shared between stdlib handlers and structlog processors
     shared_processors: list[structlog.typing.Processor] = [
@@ -387,6 +388,7 @@ def configure_logging(
     json_output: bool = False,
     log_level: str = "DEBUG",
     log_format: str = "",
+    log_timestamp_format: str = "iso",
     stdlib_config: dict | None = None,
     extra_processors: Sequence[Processor] | None = None,
     callsite_parameters: Iterable[CallsiteParameter] | None = None,
@@ -404,6 +406,9 @@ def configure_logging(
     :param json_output: Set to true to write all logs as JSON (one per line)
     :param log_level: The default log level to use for most logs
     :param log_format: A percent-style log format to write non JSON logs with.
+    :param log_timestamp_format: Timestamp format for component logs. Use ``"iso"`` for ISO 8601 format
+        (the default), or a strftime format string such as ``"%Y-%m-%d %H:%M:%S"``. Note: this only
+        applies to component logs rendered via structlog (scheduler, api-server, triggerer, etc.).
     :param output: Where to write the logs to. If ``json_output`` is true this must be a binary stream
     :param colors: Whether to use colors for non-JSON logs. This only works if standard out is a TTY (that is,
         an interactive session), unless overridden by environment variables described below.
@@ -465,6 +470,7 @@ def configure_logging(
         log_format=log_format,
         colors=colors,
         callsite_parameters=tuple(callsite_parameters or ()),
+        log_timestamp_format=log_timestamp_format,
     )
     shared_pre_chain += list(extra_processors)
     pre_chain: list[structlog.typing.Processor] = [structlog.stdlib.add_logger_name] + shared_pre_chain

--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -206,6 +206,16 @@ def test_precent_fmt_force_no_colors(
     )
 
 
+def test_log_timestamp_format(structlog_config):
+    """Test that log_timestamp_format controls the timestamp format in component logs."""
+    with structlog_config(colors=False, log_timestamp_format="%Y-%m-%d %H:%M:%S") as sio:
+        logger = structlog.get_logger("my.logger")
+        logger.info("Hello")
+
+    written = sio.getvalue()
+    assert "1985-10-26 00:00:00" in written
+
+
 @pytest.mark.parametrize(
     ("get_logger", "config_kwargs", "log_kwargs", "expected_kwargs"),
     [


### PR DESCRIPTION
## Problem

Reported in #62937: users trying to customize timestamp formats for component logs
(scheduler, api-server, triggerer, etc.) via `AIRFLOW__LOGGING__LOG_FORMATTER_CLASS`
or `AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS` found that neither setting had any effect.

As identified in the issue thread, the root cause is that structlog unconditionally
strips user-configured formatters and hardcodes the timestamp as `fmt="iso"` in
`MaybeTimeStamper`. `LOG_FORMATTER_CLASS` only applies to task/DAG logs (the stdlib
logging pipeline), never to component logs rendered via structlog. The setting was
documented with no caveat, silently doing nothing and confusing users.

## Fix

- Added a new `log_timestamp_format` config option under `[logging]` (default: `iso`)
- Exposed the previously hardcoded `fmt="iso"` in `MaybeTimeStamper` as this config value
- Updated the `log_formatter_class` description to document that it does NOT affect
  component logs and to point users to `log_timestamp_format` instead

## Usage

```ini
[logging]
log_timestamp_format = %Y-%m-%d %H:%M:%S
```

or via environment variable:

```bash
AIRFLOW__LOGGING__LOG_TIMESTAMP_FORMAT="%Y-%m-%d %H:%M:%S"
```

Accepts `iso` (ISO 8601, the default) or any Python strftime format string.
Only affects component logs (scheduler, api-server, triggerer, dag-processor).
Task/DAG logs continue to use `LOG_FORMAT` with `%(asctime)s`.

closes: #62937