### PR TITLE
Fix airflowctl dags list failure when connecting to pre-3.2.0 Airflow server

### DIFF
--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -1357,7 +1357,7 @@ class DAGDetailsResponse(BaseModel):
     description: Annotated[str | None, Field(title="Description")] = None
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
-    timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
+    timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")] = False
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None
@@ -1422,7 +1422,7 @@ class DAGResponse(BaseModel):
     description: Annotated[str | None, Field(title="Description")] = None
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
-    timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
+    timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")] = False
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None


### PR DESCRIPTION
timetable_partitioned was added in 3.2.0 but the client model required it, causing a Pydantic validation error against older servers. Add = False default to tolerate its absence.

```
Traceback (most recent call last):
  File "/usr/python/bin/airflowctl", line 6, in <module>
    sys.exit(main())
  File "/usr/python/lib/python3.10/site-packages/airflowctl/__main__.py", line 34, in main
    safe_call_command(args.func, args=args)
  File "/usr/python/lib/python3.10/site-packages/airflowctl/ctl/cli_config.py", line 77, in safe_call_command
    function(args)
  File "/usr/python/lib/python3.10/site-packages/airflowctl/api/client.py", line 465, in wrapper
    return func(*args, api_client=api_client, **kwargs)
  File "/usr/python/lib/python3.10/site-packages/airflowctl/ctl/cli_config.py", line 663, in _get_func
    method_output = operation_method_object(**method_params)
  File "/usr/python/lib/python3.10/site-packages/airflowctl/api/operations.py", line 126, in wrapped
    return _exit_if_server_response_error(response=func(self, *args, **kwargs))
  File "/usr/python/lib/python3.10/site-packages/airflowctl/api/operations.py", line 481, in list
    return super().execute_list(path="dags", data_model=DAGCollectionResponse)
  File "/usr/python/lib/python3.10/site-packages/airflowctl/api/operations.py", line 169, in execute_list
    first_pass = data_model.model_validate_json(self.response.content)
  File "/usr/python/lib/python3.10/site-packages/pydantic/main.py", line 766, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
pydantic_core._pydantic_core.ValidationError: 50 validation errors for DAGCollectionResponse
dags.0.timetable_partitioned
  Field required [type=missing, input_value={'dag_id': 'asset1_produc...7xnjr2trU3Ef8Nqf1CFBIE'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```