### PR TITLE
fix: Exclude JWT token from workload repr to prevent log exposure 

### DIFF
--- a/airflow-core/newsfragments/62964.bugfix.rst
+++ b/airflow-core/newsfragments/62964.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent JWT tokens from appearing in task logs by excluding the token field from workload object representations.

--- a/airflow-core/src/airflow/executors/workloads.py
+++ b/airflow-core/src/airflow/executors/workloads.py
@@ -40,7 +40,7 @@ log = structlog.get_logger(__name__)
 
 
 class BaseWorkload(BaseModel):
-    token: str
+    token: str = Field(repr=False)
     """The identity token for this workload"""
 
 

--- a/airflow-core/tests/unit/executors/test_workloads.py
+++ b/airflow-core/tests/unit/executors/test_workloads.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from uuid import uuid4
+
+from airflow.executors.workloads import BundleInfo, ExecuteTask, TaskInstance
+
+
+def test_token_excluded_from_workload_repr():
+    """Ensure JWT tokens do not leak into log output via repr()."""
+    fake_token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.secret_payload.signature"
+    ti = TaskInstance(
+        id=uuid4(),
+        dag_version_id=uuid4(),
+        task_id="test_task",
+        dag_id="test_dag",
+        run_id="test_run",
+        try_number=1,
+        map_index=-1,
+        pool_slots=1,
+        queue="default",
+        priority_weight=1,
+    )
+    workload = ExecuteTask(
+        ti=ti,
+        dag_rel_path=PurePosixPath("test_dag.py"),
+        token=fake_token,
+        bundle_info=BundleInfo(name="dags-folder", version=None),
+        log_path="test.log",
+    )
+
+    workload_repr = repr(workload)
+
+    # Token MUST NOT appear in repr (prevents leaking into logs)
+    assert fake_token not in workload_repr, f"JWT token leaked into repr! Found token in: {workload_repr}"
+    # But token should still be accessible as an attribute
+    assert workload.token == fake_token


### PR DESCRIPTION

(cherry picked from commit b196cf3d1c5ed20667f39742cd4f8151b18123c9)


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
