### PR TITLE
Fix Rich markup not rendered in breeze auto triage action prompt

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/confirm.py
+++ b/dev/breeze/src/airflow_breeze/utils/confirm.py
@@ -20,6 +20,7 @@ import os
 import sys
 from enum import Enum
 
+from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.shared_options import get_forced_answer
 
 STANDARD_TIMEOUT = 10
@@ -172,7 +173,8 @@ def prompt_triage_action(
                     choices.append(f"[{letter}]{label}")
             choices_str = " / ".join(choices)
 
-            prompt_text = f"\n{message}\n{choices_str}"
+            get_console().print(f"\n{message}")
+            prompt_text = choices_str
             if timeout:
                 prompt_text += (
                     f"  (auto-select {_LABELS[default]} in {timeout}s"


### PR DESCRIPTION
## Summary

The prompt_triage_action function previously passed Rich markup text (e.g., `[link=URL]#number[/link]`) directly to `inputimeout()`.

However, `inputimeout()` relies on the standard `input()` function internally and cannot render Rich markup, which results in the markup being displayed as plain text.

## Change
This PR separates the output so that:
* the message is printed using `get_console().print()` (which supports Rich markup)
* only the choice options are passed to `inputimeout()`.

## Before
<img width="746" height="113" alt="image" src="https://github.com/user-attachments/assets/1654aec7-3144-4dd1-910a-84a48ed9bb0a" />


## After

<img width="773" height="217" alt="image" src="https://github.com/user-attachments/assets/9fe355ce-9139-4eeb-8084-b809df9ebd14" />


<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude code sonnet 4.6
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
