### PR TITLE
fix(providers/fab): pass role name string to delete_role instead of Role object

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/roles.py
@@ -112,7 +112,7 @@ class FABAuthManagerRoles:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Role with name {name!r} does not exist.",
             )
-        security_manager.delete_role(existing)
+        security_manager.delete_role(existing.name)
 
     @classmethod
     def get_role(cls, name: str) -> RoleResponse:

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/services/test_roles.py
@@ -227,7 +227,7 @@ class TestRolesService:
 
         FABAuthManagerRoles.delete_role(name="roleA")
 
-        security_manager.delete_role.assert_called_once()
+        security_manager.delete_role.assert_called_once_with("roleA")
 
     def test_delete_role_not_found(self, get_fab_auth_manager, fab_auth_manager, security_manager):
         security_manager.find_role.return_value = None


### PR DESCRIPTION
`FABAuthManagerRoles.delete_role()` passes the `Role` ORM object to `security_manager.delete_role()` which expects a string. SQLAlchemy then tries to use the Role object as a SQL literal in the `WHERE` clause, raising `ArgumentError: Object TestRole is not legal as a SQL literal value`.

Fix: pass `existing.name` (the role name string) instead of the Role object.

Closes: #63336

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
