### PR TITLE
fix(api): allow null value in VariableResponse for undecryptable variables

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -32,7 +32,7 @@ class VariableResponse(BaseModel):
     """Variable serializer for responses."""
 
     key: str
-    val: str = Field(alias="value")
+    val: str | None = Field(alias="value")
     description: str | None
     is_encrypted: bool
     team_name: str | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13571,7 +13571,9 @@ components:
           type: string
           title: Key
         value:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Value
         description:
           anyOf:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1654,7 +1654,7 @@ export type VariableCollectionResponse = {
  */
 export type VariableResponse = {
     key: string;
-    value: string;
+    value: string | null;
     description: string | null;
     is_encrypted: boolean;
     team_name: string | null;

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -32,7 +32,11 @@ type Props = {
   readonly variable: VariableResponse;
 };
 
-const formatValue = (value: string): string => {
+const formatValue = (value: string | null): string => {
+  if (value === null) {
+    return "";
+  }
+
   try {
     const parsed: unknown = JSON.parse(value);
 

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -93,7 +93,7 @@ const getColumns = ({
       cell: ({ row }) => (
         <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
           <TrimText
-            charLimit={open ? row.original.value.length : undefined}
+            charLimit={open ? row.original.value?.length : undefined}
             showTooltip
             text={row.original.value}
           />

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -254,6 +254,38 @@ class TestGetVariable(TestVariableEndpoint):
         body = response.json()
         assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
 
+    def test_get_variable_with_undecryptable_val(self, test_client, session):
+        """Variable with an undecryptable _val (e.g. migrated with a different Fernet key) should
+        return 200 with value=None instead of raising a 500 serialization error."""
+        var = Variable(key="bad_encrypted_var")
+        var._val = "not-a-valid-fernet-token"
+        var.is_encrypted = True
+        var.description = "migrated variable"
+        session.add(var)
+        session.commit()
+
+        response = test_client.get("/variables/bad_encrypted_var")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["key"] == "bad_encrypted_var"
+        assert body["value"] is None
+
+    def test_get_variables_with_undecryptable_val(self, test_client, session):
+        """Listing variables should not fail with 500 when some variables have undecryptable values."""
+        var = Variable(key="bad_encrypted_var")
+        var._val = "not-a-valid-fernet-token"
+        var.is_encrypted = True
+        var.description = "migrated variable"
+        session.add(var)
+        session.commit()
+
+        response = test_client.get("/variables")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_entries"] == 1
+        assert body["variables"][0]["key"] == "bad_encrypted_var"
+        assert body["variables"][0]["value"] is None
+
 
 class TestGetVariables(TestVariableEndpoint):
     @pytest.mark.enable_redact

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -978,7 +978,7 @@ class VariableResponse(BaseModel):
     """
 
     key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
+    value: Annotated[str | None, Field(title="Value")] = None
     description: Annotated[str | None, Field(title="Description")] = None
     is_encrypted: Annotated[bool, Field(title="Is Encrypted")]
     team_name: Annotated[str | None, Field(title="Team Name")] = None


### PR DESCRIPTION
After migrating from Airflow 2.x with a different Fernet key, encrypted variables fail to decrypt — `Variable.get_val()` returns `None`. The `VariableResponse` Pydantic model has `val: str` which rejects `None`, so both `GET /variables` and `GET /variables/{key}` blow up with a 500 `PydanticSerializationError`.

Changed `val` field type from `str` to `str | None` in `VariableResponse`. The existing `redact_val` validator already handles `None` correctly (early return).

Added two tests that insert a variable with a garbage encrypted value and verify both the single-get and list endpoints return 200 with `value: null`.

Closes: #63341

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
