### PR TITLE
fix(api): handle undecryptable connection fields after Fernet key change

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -129,13 +129,21 @@ def _connection_decryption_error_response(detail: str) -> JSONResponse:
     return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": detail})
 
 
-def _has_connection_decryption_error(exc: BaseException) -> bool:
+def _iter_exception_chain(exc: BaseException):
     current: BaseException | None = exc
     while current is not None:
-        if isinstance(current, ConnectionFieldDecryptionError):
-            return True
+        yield current
         current = current.__cause__ or current.__context__
-    return False
+
+
+def _has_connection_decryption_error(exc: BaseException) -> bool:
+    return any(isinstance(error, ConnectionFieldDecryptionError) for error in _iter_exception_chain(exc))
+
+
+def _mentions_connection_decryption_error(exc: BaseException) -> bool:
+    # Pydantic serialization errors may flatten the original exception into the message
+    # without preserving it in __cause__ / __context__.
+    return "ConnectionFieldDecryptionError" in str(exc)
 
 
 class ConnectionFieldDecryptionErrorHandler(BaseErrorHandler[ConnectionFieldDecryptionError]):
@@ -174,7 +182,7 @@ class PydanticSerializationErrorHandler(BaseErrorHandler[PydanticSerializationEr
     def exception_handler(self, request: Request, exc: PydanticSerializationError):
         """Handle serialization errors."""
         if "/connections" in request.url.path and (
-            _has_connection_decryption_error(exc) or "ConnectionFieldDecryptionError" in str(exc)
+            _has_connection_decryption_error(exc) or _mentions_connection_decryption_error(exc)
         ):
             return _connection_decryption_error_response(
                 "Failed to serialize connection because an encrypted field could not be decrypted. "

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -24,10 +24,14 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 from fastapi import HTTPException, Request, status
+from fastapi.exceptions import ResponseValidationError
+from fastapi.responses import JSONResponse
+from pydantic_core import PydanticSerializationError
 from sqlalchemy.exc import IntegrityError
 
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
+from airflow.models.connection import ConnectionFieldDecryptionError
 from airflow.utils.strings import get_random_string
 
 T = TypeVar("T", bound=Exception)
@@ -122,4 +126,57 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
         )
 
 
-ERROR_HANDLERS: list[BaseErrorHandler] = [_UniqueConstraintErrorHandler(), DagErrorHandler()]
+def _connection_decryption_error_response(detail: str) -> JSONResponse:
+    return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": detail})
+
+
+class ConnectionFieldDecryptionErrorHandler(BaseErrorHandler[ConnectionFieldDecryptionError]):
+    """Handle undecryptable connection fields in API responses."""
+
+    def __init__(self):
+        super().__init__(ConnectionFieldDecryptionError)
+
+    def exception_handler(self, request: Request, exc: ConnectionFieldDecryptionError):
+        """Handle connection field decryption errors."""
+        return _connection_decryption_error_response(str(exc))
+
+
+class ResponseValidationErrorHandler(BaseErrorHandler[ResponseValidationError]):
+    """Handle response validation errors caused by undecryptable connection fields."""
+
+    def __init__(self):
+        super().__init__(ResponseValidationError)
+
+    def exception_handler(self, request: Request, exc: ResponseValidationError):
+        """Handle response validation errors."""
+        if "/connections" in request.url.path:
+            return _connection_decryption_error_response(
+                "Failed to serialize connection because an encrypted field could not be decrypted. "
+                "This may happen after migrating with a different Fernet key."
+            )
+        raise exc
+
+
+class PydanticSerializationErrorHandler(BaseErrorHandler[PydanticSerializationError]):
+    """Handle serialization errors caused by undecryptable connection fields."""
+
+    def __init__(self):
+        super().__init__(PydanticSerializationError)
+
+    def exception_handler(self, request: Request, exc: PydanticSerializationError):
+        """Handle serialization errors."""
+        if "/connections" in request.url.path and "ConnectionFieldDecryptionError" in str(exc):
+            return _connection_decryption_error_response(
+                "Failed to serialize connection because an encrypted field could not be decrypted. "
+                "This may happen after migrating with a different Fernet key."
+            )
+        raise exc
+
+
+ERROR_HANDLERS: list[BaseErrorHandler] = [
+    _UniqueConstraintErrorHandler(),
+    DagErrorHandler(),
+    ConnectionFieldDecryptionErrorHandler(),
+    ResponseValidationErrorHandler(),
+    PydanticSerializationErrorHandler(),
+]

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -30,8 +30,7 @@ from pydantic_core import PydanticSerializationError
 from sqlalchemy.exc import IntegrityError
 
 from airflow.configuration import conf
-from airflow.exceptions import DeserializationError
-from airflow.models.connection import ConnectionFieldDecryptionError
+from airflow.exceptions import ConnectionFieldDecryptionError, DeserializationError
 from airflow.utils.strings import get_random_string
 
 T = TypeVar("T", bound=Exception)
@@ -130,6 +129,15 @@ def _connection_decryption_error_response(detail: str) -> JSONResponse:
     return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": detail})
 
 
+def _has_connection_decryption_error(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    while current is not None:
+        if isinstance(current, ConnectionFieldDecryptionError):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 class ConnectionFieldDecryptionErrorHandler(BaseErrorHandler[ConnectionFieldDecryptionError]):
     """Handle undecryptable connection fields in API responses."""
 
@@ -165,7 +173,9 @@ class PydanticSerializationErrorHandler(BaseErrorHandler[PydanticSerializationEr
 
     def exception_handler(self, request: Request, exc: PydanticSerializationError):
         """Handle serialization errors."""
-        if "/connections" in request.url.path and "ConnectionFieldDecryptionError" in str(exc):
+        if "/connections" in request.url.path and (
+            _has_connection_decryption_error(exc) or "ConnectionFieldDecryptionError" in str(exc)
+        ):
             return _connection_decryption_error_response(
                 "Failed to serialize connection because an encrypted field could not be decrypted. "
                 "This may happen after migrating with a different Fernet key."

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -160,6 +160,18 @@ class SerializationError(AirflowException):
     """A problem occurred when trying to serialize something."""
 
 
+class ConnectionFieldDecryptionError(AirflowException):
+    """Raised when an encrypted connection field cannot be decrypted."""
+
+    def __init__(self, conn_id: str | None, field_name: str):
+        self.conn_id = conn_id
+        self.field_name = field_name
+        super().__init__(
+            f"Failed to decrypt {field_name} for connection {conn_id!r}. "
+            "This may happen after migrating with a different Fernet key."
+        )
+
+
 class TaskInstanceNotFound(AirflowNotFoundException):
     """Raise when a task instance is not available in the system."""
 

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -362,7 +362,15 @@ class Connection(Base, LoggingMixin):
                     f"Can't decrypt encrypted password for login={self.login}  "
                     f"FERNET_KEY configuration is missing"
                 )
-            return fernet.decrypt(bytes(self._password, "utf-8")).decode()
+            try:
+                return fernet.decrypt(bytes(self._password, "utf-8")).decode()
+            except Exception:
+                log.warning(
+                    "Failed to decrypt password for connection %s. "
+                    "This may happen after migrating with a different Fernet key.",
+                    self.conn_id,
+                )
+                return None
         return self._password
 
     def set_password(self, value: str | None):
@@ -387,7 +395,15 @@ class Connection(Base, LoggingMixin):
                     f"Can't decrypt `extra` params for login={self.login}, "
                     f"FERNET_KEY configuration is missing"
                 )
-            extra_val = fernet.decrypt(bytes(self._extra, "utf-8")).decode()
+            try:
+                extra_val = fernet.decrypt(bytes(self._extra, "utf-8")).decode()
+            except Exception:
+                log.warning(
+                    "Failed to decrypt `extra` for connection %s. "
+                    "This may happen after migrating with a different Fernet key.",
+                    self.conn_id,
+                )
+                return None
         else:
             extra_val = self._extra
         if extra_val:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -40,6 +40,20 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
 log = logging.getLogger(__name__)
+
+
+class ConnectionFieldDecryptionError(AirflowException):
+    """Raised when an encrypted connection field cannot be decrypted."""
+
+    def __init__(self, conn_id: str | None, field_name: str):
+        self.conn_id = conn_id
+        self.field_name = field_name
+        super().__init__(
+            f"Failed to decrypt {field_name} for connection {conn_id!r}. "
+            "This may happen after migrating with a different Fernet key."
+        )
+
+
 # sanitize the `conn_id` pattern by allowing alphanumeric characters plus
 # the symbols #,!,-,_,.,:,\,/ and () requiring at least one match.
 #
@@ -356,6 +370,8 @@ class Connection(Base, LoggingMixin):
     def get_password(self) -> str | None:
         """Return encrypted password."""
         if self._password and self.is_encrypted:
+            from cryptography.fernet import InvalidToken as InvalidFernetToken
+
             fernet = get_fernet()
             if not fernet.is_encrypted:
                 raise AirflowException(
@@ -364,13 +380,8 @@ class Connection(Base, LoggingMixin):
                 )
             try:
                 return fernet.decrypt(bytes(self._password, "utf-8")).decode()
-            except Exception:
-                log.warning(
-                    "Failed to decrypt password for connection %s. "
-                    "This may happen after migrating with a different Fernet key.",
-                    self.conn_id,
-                )
-                return None
+            except InvalidFernetToken as e:
+                raise ConnectionFieldDecryptionError(self.conn_id, "password") from e
         return self._password
 
     def set_password(self, value: str | None):
@@ -389,6 +400,8 @@ class Connection(Base, LoggingMixin):
         """Return encrypted extra-data."""
         extra_val: str | None
         if self._extra and self.is_extra_encrypted:
+            from cryptography.fernet import InvalidToken as InvalidFernetToken
+
             fernet = get_fernet()
             if not fernet.is_encrypted:
                 raise AirflowException(
@@ -397,13 +410,8 @@ class Connection(Base, LoggingMixin):
                 )
             try:
                 extra_val = fernet.decrypt(bytes(self._extra, "utf-8")).decode()
-            except Exception:
-                log.warning(
-                    "Failed to decrypt `extra` for connection %s. "
-                    "This may happen after migrating with a different Fernet key.",
-                    self.conn_id,
-                )
-                return None
+            except InvalidFernetToken as e:
+                raise ConnectionFieldDecryptionError(self.conn_id, "extra") from e
         else:
             extra_val = self._extra
         if extra_val:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, reconstructor, 
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_masker import mask_secret
-from airflow.exceptions import AirflowException, AirflowNotFoundException
+from airflow.exceptions import AirflowException, AirflowNotFoundException, ConnectionFieldDecryptionError
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
 from airflow.utils.helpers import prune_dict
@@ -40,19 +40,6 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
 log = logging.getLogger(__name__)
-
-
-class ConnectionFieldDecryptionError(AirflowException):
-    """Raised when an encrypted connection field cannot be decrypted."""
-
-    def __init__(self, conn_id: str | None, field_name: str):
-        self.conn_id = conn_id
-        self.field_name = field_name
-        super().__init__(
-            f"Failed to decrypt {field_name} for connection {conn_id!r}. "
-            "This may happen after migrating with a different Fernet key."
-        )
-
 
 # sanitize the `conn_id` pattern by allowing alphanumeric characters plus
 # the symbols #,!,-,_,.,:,\,/ and () requiring at least one match.

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -198,8 +198,7 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["extra"] == '{"key": "value"}'
 
     def test_get_connection_with_undecryptable_password(self, test_client, session):
-        """Connection with an undecryptable password (e.g. migrated with a different Fernet key)
-        should return 200 with password=None instead of a 500 serialization error."""
+        """Connection with an undecryptable password should return a clear 500 error."""
         conn = Connection(conn_id="bad_fernet_conn", conn_type="generic")
         session.add(conn)
         session.flush()
@@ -214,13 +213,11 @@ class TestGetConnection(TestConnectionEndpoint):
         session.commit()
 
         response = test_client.get("/connections/bad_fernet_conn")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["connection_id"] == "bad_fernet_conn"
-        assert body["password"] is None
+        assert response.status_code == 500
+        assert "different Fernet key" in response.json()["detail"]
 
     def test_get_connection_with_undecryptable_extra(self, test_client, session):
-        """Connection with undecryptable extra should return 200 with extra=None."""
+        """Connection with undecryptable extra should return a clear 500 error."""
         conn = Connection(conn_id="bad_extra_conn", conn_type="generic")
         session.add(conn)
         session.flush()
@@ -233,13 +230,11 @@ class TestGetConnection(TestConnectionEndpoint):
         session.commit()
 
         response = test_client.get("/connections/bad_extra_conn")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["connection_id"] == "bad_extra_conn"
-        assert body["extra"] is None
+        assert response.status_code == 500
+        assert "different Fernet key" in response.json()["detail"]
 
     def test_get_connections_with_undecryptable_fields(self, test_client, session):
-        """Listing connections should not 500 when some have undecryptable password/extra."""
+        """Listing connections should return a clear 500 error for undecryptable fields."""
         conn = Connection(conn_id="bad_conn", conn_type="generic")
         session.add(conn)
         session.flush()
@@ -257,12 +252,8 @@ class TestGetConnection(TestConnectionEndpoint):
         session.commit()
 
         response = test_client.get("/connections")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["total_entries"] == 1
-        assert body["connections"][0]["connection_id"] == "bad_conn"
-        assert body["connections"][0]["password"] is None
-        assert body["connections"][0]["extra"] is None
+        assert response.status_code == 500
+        assert "different Fernet key" in response.json()["detail"]
 
 
 class TestGetConnections(TestConnectionEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -197,6 +197,73 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["login"] == "a"
         assert body["extra"] == '{"key": "value"}'
 
+    def test_get_connection_with_undecryptable_password(self, test_client, session):
+        """Connection with an undecryptable password (e.g. migrated with a different Fernet key)
+        should return 200 with password=None instead of a 500 serialization error."""
+        conn = Connection(conn_id="bad_fernet_conn", conn_type="generic")
+        session.add(conn)
+        session.flush()
+        # Simulate a password encrypted with a different Fernet key by writing
+        # directly to _password and marking as encrypted.
+        session.execute(
+            Connection.__table__.update()
+            .where(Connection.__table__.c.conn_id == "bad_fernet_conn")
+            .values(password="not-a-valid-fernet-token", is_encrypted=True)
+        )
+        session.expire_all()
+        session.commit()
+
+        response = test_client.get("/connections/bad_fernet_conn")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["connection_id"] == "bad_fernet_conn"
+        assert body["password"] is None
+
+    def test_get_connection_with_undecryptable_extra(self, test_client, session):
+        """Connection with undecryptable extra should return 200 with extra=None."""
+        conn = Connection(conn_id="bad_extra_conn", conn_type="generic")
+        session.add(conn)
+        session.flush()
+        session.execute(
+            Connection.__table__.update()
+            .where(Connection.__table__.c.conn_id == "bad_extra_conn")
+            .values(extra="not-a-valid-fernet-token", is_extra_encrypted=True)
+        )
+        session.expire_all()
+        session.commit()
+
+        response = test_client.get("/connections/bad_extra_conn")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["connection_id"] == "bad_extra_conn"
+        assert body["extra"] is None
+
+    def test_get_connections_with_undecryptable_fields(self, test_client, session):
+        """Listing connections should not 500 when some have undecryptable password/extra."""
+        conn = Connection(conn_id="bad_conn", conn_type="generic")
+        session.add(conn)
+        session.flush()
+        session.execute(
+            Connection.__table__.update()
+            .where(Connection.__table__.c.conn_id == "bad_conn")
+            .values(
+                password="not-a-valid-fernet-token",
+                is_encrypted=True,
+                extra="not-a-valid-fernet-token",
+                is_extra_encrypted=True,
+            )
+        )
+        session.expire_all()
+        session.commit()
+
+        response = test_client.get("/connections")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_entries"] == 1
+        assert body["connections"][0]["connection_id"] == "bad_conn"
+        assert body["connections"][0]["password"] is None
+        assert body["connections"][0]["extra"] is None
+
 
 class TestGetConnections(TestConnectionEndpoint):
     @pytest.mark.parametrize(


### PR DESCRIPTION
After migrating from Airflow 2.x with a different Fernet key, `GET /api/v2/connections` and `GET /api/v2/connections/{id}` crash with a 500 `PydanticSerializationError` caused by `InvalidToken` from the cryptography library. The encrypted `password` and `extra` fields can't be decrypted, and the exception propagates through SQLAlchemy's property accessor into Pydantic's serializer.

`Connection.get_password()` and `get_extra()` now catch decryption failures, log a warning, and return `None`. Same pattern as the Variable model. Added three tests covering single connection, single connection with bad extra, and the list endpoint.

Closes: #63340

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
