### PR TITLE
Fix task group lookup using wrong DAG version for historical runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -70,11 +70,19 @@ def get_dag_for_run(dag_bag: DBDagBag, dag_run: DagRun, session: Session) -> Ser
 def get_dag_for_run_or_latest_version(
     dag_bag: DBDagBag, dag_run: DagRun | None, dag_id: str | None, session: Session
 ) -> SerializedDAG:
+    """
+    Retrieve the serialized DAG for a specific run, or the latest version if no run is given.
+
+    When a dag_run is provided, we prefer the exact DAG version the run was created with
+    (``created_dag_version_id``) so that task group lookups, operator metadata, etc. match
+    the DAG structure at the time of the run.
+
+    This is necessary because ``get_dag_for_run`` delegates to ``_version_from_dag_run``
+    which, for unversioned bundles (e.g. ``LocalDagBundle``), falls back to the *latest*
+    ``DagVersion``.
+    """
     dag: SerializedDAG | None = None
     if dag_run:
-        # Use the version the run was created with so that task group lookups,
-        # operator metadata, etc. match the DAG structure at the time of the run
-        # — not a potentially newer version where groups may have been renamed.
         if dag_run.created_dag_version_id:
             dag = dag_bag._get_dag(dag_run.created_dag_version_id, session=session)
         if not dag:

--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -72,7 +72,13 @@ def get_dag_for_run_or_latest_version(
 ) -> SerializedDAG:
     dag: SerializedDAG | None = None
     if dag_run:
-        dag = dag_bag.get_dag_for_run(dag_run, session=session)
+        # Use the version the run was created with so that task group lookups,
+        # operator metadata, etc. match the DAG structure at the time of the run
+        # — not a potentially newer version where groups may have been renamed.
+        if dag_run.created_dag_version_id:
+            dag = dag_bag._get_dag(dag_run.created_dag_version_id, session=session)
+        if not dag:
+            dag = dag_bag.get_dag_for_run(dag_run, session=session)
     elif dag_id:
         dag = dag_bag.get_latest_version_of_dag(dag_id, session=session)
     if not dag:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -39,7 +39,8 @@ from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.taskmap import TaskMap
 from airflow.models.trigger import Trigger
-from airflow.sdk import BaseOperator
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import BaseOperator, TaskGroup
 from airflow.utils.platform import getuser
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -1645,6 +1646,47 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
         assert response_batch1.json()["total_entries"] == response_batch2.json()["total_entries"] == ti_count
         assert (num_entries_batch1 + num_entries_batch2) == ti_count
         assert response_batch1 != response_batch2
+
+    def test_task_group_filter_uses_run_version_not_latest(self, test_client, dag_maker, session):
+        """
+        Task group lookup should use the DAG version from the run, not the latest version.
+
+        When a task group is renamed between versions, clicking on a historical run's
+        task group in the grid should still resolve correctly against the version
+        that run was created with — not the latest version where the group may have
+        a different name, i.e serialized_dag might not have that taskgroup anymore.
+        """
+        dag_id = "test_tg_version"
+
+        # Version 1: task group named "process_data"
+        with dag_maker(dag_id, session=session):
+            with TaskGroup(group_id="process_data"):
+                EmptyOperator(task_id="step_1")
+        dag_maker.create_dagrun(run_id="run_v1")
+        session.commit()
+
+        # Version 2: task group renamed to "process_data_v2"
+        with dag_maker(dag_id, session=session):
+            with TaskGroup(group_id="process_data_v2"):
+                EmptyOperator(task_id="step_1")
+        session.commit()
+
+        # The run was created with v1 which had "process_data".
+        # Querying with the old group name must succeed.
+        response = test_client.get(
+            f"/dags/{dag_id}/dagRuns/run_v1/taskInstances",
+            params={"task_group_id": "process_data"},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["total_entries"] == 1
+        assert response.json()["task_instances"][0]["task_id"] == "process_data.step_1"
+
+        # The new group name should NOT be found in the old run's version.
+        response = test_client.get(
+            f"/dags/{dag_id}/dagRuns/run_v1/taskInstances",
+            params={"task_group_id": "process_data_v2"},
+        )
+        assert response.status_code == 404
 
 
 class TestGetTaskDependencies(TestTaskInstanceEndpoint):


### PR DESCRIPTION
When a task group is renamed between DAG versions, the API's get_task_instances endpoint was resolving task groups against the latest DAG version instead of the version the run was created with. This caused 404 errors when clicking on task groups in the grid view for historical runs.

The fix changes get_dag_for_run_or_latest_version to prefer the run's created_dag_version_id, falling back to the existing behavior only when unavailable.


To reproduce use this Dag:
- Start a run and wait for it to finish
- Flip the rename flag to true and reparse the Dag or wait a little bit for v2 to come up
- Start a 2nd run

Then clicking on first run "process_data" task group will fail like the screenshot below
```
from __future__ import annotations

from datetime import datetime

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.sdk import DAG, TaskGroup

RENAME = False  # flip to True after step 2

group_id = "process_data_v2" if RENAME else "process_data"

with DAG(
    dag_id="repro_task_group_not_found",
    start_date=datetime(2024, 1, 1),
    schedule=None,
):
    with TaskGroup(group_id=group_id) as tg:
        EmptyOperator(task_id="step_1")
        EmptyOperator(task_id="step_2")

    EmptyOperator(task_id="done") << tg

```
### Before
<img width="1920" height="806" alt="Screenshot 2026-03-11 at 17 54 49" src="https://github.com/user-attachments/assets/569cad5c-ca75-4e2f-b537-46c09678a4b9" />


### After
<img width="1917" height="943" alt="Screenshot 2026-03-11 at 17 53 27" src="https://github.com/user-attachments/assets/789f814f-172a-424e-b485-2011b928be76" />

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
