### PR TITLE
fix(task-sdk): include error details in ServerResponseError string representation

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1064,8 +1064,8 @@ class ServerResponseError(httpx.HTTPStatusError):
 
     def __str__(self) -> str:
         base = super().__str__()
-        if self.detail:
-            return f"{base}\nDetail: {self.detail}"
+        if detail := getattr(self, "detail", None):
+            return f"{base}\nDetail: {detail}"
         return base
 
     def __reduce__(self) -> tuple[Any, ...]:

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1062,6 +1062,12 @@ class ServerResponseError(httpx.HTTPStatusError):
 
     detail: list[RemoteValidationError] | str | dict[str, Any] | None
 
+    def __str__(self) -> str:
+        base = super().__str__()
+        if self.detail:
+            return f"{base}\nDetail: {self.detail}"
+        return base
+
     def __reduce__(self) -> tuple[Any, ...]:
         # Needed because https://github.com/encode/httpx/pull/3108 isn't merged yet.
         return Exception.__new__, (type(self),) + self.args, self.__dict__

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -177,7 +177,12 @@ class TestClient:
 
     def test_server_response_error_str_includes_detail(self):
         """Test that ServerResponseError string representation includes error details."""
-        responses = [httpx.Response(409, json={"detail": {"reason": "invalid_state", "message": "TI was not in the running state"}})]
+        responses = [
+            httpx.Response(
+                409,
+                json={"detail": {"reason": "invalid_state", "message": "TI was not in the running state"}},
+            )
+        ]
         client = make_client_w_responses(responses)
 
         with pytest.raises(ServerResponseError) as exc_info:

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -175,6 +175,34 @@ class TestClient:
         assert unpickled.response.status_code == 404
         assert unpickled.request.url == "http://error"
 
+    def test_server_response_error_str_includes_detail(self):
+        """Test that ServerResponseError string representation includes error details."""
+        responses = [httpx.Response(409, json={"detail": {"reason": "invalid_state", "message": "TI was not in the running state"}})]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.get("http://error")
+
+        err = exc_info.value
+        error_str = str(err)
+        assert "Detail:" in error_str
+        assert "invalid_state" in error_str
+
+    def test_server_response_error_str_without_detail(self):
+        """Test that ServerResponseError string without detail doesn't include Detail section."""
+        # 422 with a string detail: the string becomes the message, detail attr is None
+        responses = [httpx.Response(422, json={"detail": "Simple error"})]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.get("http://error")
+
+        err = exc_info.value
+        error_str = str(err)
+        assert "Simple error" in error_str
+        # detail is None when the detail string is used as the message itself
+        assert "Detail:" not in error_str
+
     def test_retry_handling_unrecoverable_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             responses: list[httpx.Response] = [

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -203,6 +203,12 @@ class TestClient:
         # detail is None when the detail string is used as the message itself
         assert "Detail:" not in error_str
 
+    def test_server_response_error_str_missing_detail_attr(self):
+        err = ServerResponseError.__new__(ServerResponseError)
+        err.args = ("Server returned error",)
+
+        assert "Detail:" not in str(err)
+
     def test_retry_handling_unrecoverable_error(self):
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             responses: list[httpx.Response] = [


### PR DESCRIPTION
## Problem

When `ServerResponseError` is raised and propagates up the call stack without being explicitly caught and handled, error details are lost. Logs show only:

```
airflow.sdk.api.client.ServerResponseError: Server returned error
```

...without any information about *what* actually went wrong. This makes debugging significantly harder, especially for `TaskInstanceOperations` calls where the exception is not caught and re-logged with `e.detail`.

## Root Cause

`ServerResponseError` stores error details in its `detail` attribute, but the `__str__()` method (inherited from `httpx.HTTPStatusError`) only returns the base message. When the exception is logged via traceback or `str(err)`, the detail is silently dropped.

Some call sites (e.g., `VariableOperations`) explicitly catch `ServerResponseError` and log `e.detail`, but many others (e.g., `TaskInstanceOperations.start()`) let it propagate, losing the detail entirely.

## Fix

Added a `__str__()` override to `ServerResponseError` that appends the `detail` attribute when present. This ensures error details are always visible in logs and tracebacks, regardless of how the exception is caught.

**Before:**
```
ServerResponseError: Server returned error
```

**After:**
```
ServerResponseError: Server returned error
Detail: {'reason': 'invalid_state', 'message': 'TI was not in the running state'}
```

Verified with unit tests. No external service access needed.

Closes: #57961

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=92e9202 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @YoannAbriel** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Unaddressed Copilot review** — a Copilot review thread has been open for ≥7 days with no reply; please respond to or resolve it. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->