### PR TITLE
Fix cross-provider CI failures by avoiding global Tenacity sleep patch in Redshift cluster tests

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_cluster.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_cluster.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock
 import boto3
 import pytest
 from botocore.exceptions import ClientError, WaiterError
+from tenacity import wait_fixed
 
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
 from airflow.providers.amazon.aws.operators.redshift_cluster import (
@@ -251,14 +252,19 @@ class TestRedshiftCreateClusterOperator:
         )
         assert mock_delete_cluster.call_count >= 1
 
-    @mock.patch("tenacity.nap.time.sleep", mock.MagicMock())
+    @mock.patch(
+        "airflow.providers.amazon.aws.operators.redshift_cluster.wait_fixed",
+    )
     @mock.patch.object(RedshiftHook, "delete_cluster")
     @mock.patch.object(RedshiftHook, "conn")
     def test_create_cluster_cleanup_retries_on_active_operation(
         self,
         mock_conn,
         mock_delete_cluster,
+        mock_wait_fixed,
     ):
+
+        mock_wait_fixed.return_value = wait_fixed(0)
         # Simulate waiter failure (e.g. DescribeClusters denied).
         waiter_error = WaiterError(
             name="ClusterAvailable",


### PR DESCRIPTION
**Description**

Update tests to avoid patching `tenacity.nap.time.sleep` globally. The previous approach (refer to PR #63074) mocked Tenacity’s internal sleep function, which modifies a shared module and can inadvertently affect other tests that rely on Tenacity’s retry behavior. This could have potentially led to cross-provider CI failures due to cross-test interference. The following is the main test that has been affected:

`providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py::test_should_use_configured_log_name`

The tests now patch the retry behavior at the operator import level instead, ensuring the change is scoped only to the Redshift operator tests while leaving Tenacity’s global behavior untouched.