### PR TITLE
Fix standardization for pydanticai connection as per issue #63348

### DIFF
--- a/providers/common/ai/docs/connections/pydantic_ai.rst
+++ b/providers/common/ai/docs/connections/pydantic_ai.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:pydantic_ai:
+.. _howto/connection:pydanticai:
 
 Pydantic AI Connection
 ======================


### PR DESCRIPTION
We still need some amount of changes; e.g. for the google providers; however this should fix the mistype of pedantic_ai to pedanticai per the established naming scheme issue, that was raised by issue #63348. The only code changed is the naming convention of pydantic_ai to pydanticai (no underscore) which was an example given from the aformentioned issue.
