### PR TITLE
Expose queueing/scheduled time in the Gantt Chart

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/gantt.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/gantt.py
@@ -30,6 +30,7 @@ class GanttTaskInstance(BaseModel):
     task_display_name: str
     try_number: int
     state: TaskInstanceState | None
+    scheduled_dttm: datetime | None
     queued_dttm: datetime | None
     start_date: datetime | None
     end_date: datetime | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/gantt.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/gantt.py
@@ -30,6 +30,7 @@ class GanttTaskInstance(BaseModel):
     task_display_name: str
     try_number: int
     state: TaskInstanceState | None
+    queued_dttm: datetime | None
     start_date: datetime | None
     end_date: datetime | None
     is_group: bool = False

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -2469,6 +2469,12 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TaskInstanceState'
           - type: 'null'
+        scheduled_dttm:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Scheduled Dttm
         queued_dttm:
           anyOf:
           - type: string
@@ -2501,6 +2507,7 @@ components:
       - task_display_name
       - try_number
       - state
+      - scheduled_dttm
       - queued_dttm
       - start_date
       - end_date

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -2469,6 +2469,12 @@ components:
           anyOf:
           - $ref: '#/components/schemas/TaskInstanceState'
           - type: 'null'
+        queued_dttm:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Queued Dttm
         start_date:
           anyOf:
           - type: string
@@ -2495,6 +2501,7 @@ components:
       - task_display_name
       - try_number
       - state
+      - queued_dttm
       - start_date
       - end_date
       title: GanttTaskInstance

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/gantt.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/gantt.py
@@ -67,6 +67,7 @@ def get_gantt_data(
         TaskInstance.task_display_name.label("task_display_name"),  # type: ignore[attr-defined]
         TaskInstance.try_number.label("try_number"),
         TaskInstance.state.label("state"),
+        TaskInstance.scheduled_dttm.label("scheduled_dttm"),
         TaskInstance.queued_dttm.label("queued_dttm"),
         TaskInstance.start_date.label("start_date"),
         TaskInstance.end_date.label("end_date"),
@@ -82,6 +83,7 @@ def get_gantt_data(
         TaskInstanceHistory.task_display_name.label("task_display_name"),
         TaskInstanceHistory.try_number.label("try_number"),
         TaskInstanceHistory.state.label("state"),
+        TaskInstanceHistory.scheduled_dttm.label("scheduled_dttm"),
         TaskInstanceHistory.queued_dttm.label("queued_dttm"),
         TaskInstanceHistory.start_date.label("start_date"),
         TaskInstanceHistory.end_date.label("end_date"),
@@ -108,6 +110,7 @@ def get_gantt_data(
             task_display_name=row.task_display_name,
             try_number=row.try_number,
             state=row.state,
+            scheduled_dttm=row.scheduled_dttm,
             queued_dttm=row.queued_dttm,
             start_date=row.start_date,
             end_date=row.end_date,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/gantt.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/gantt.py
@@ -67,6 +67,7 @@ def get_gantt_data(
         TaskInstance.task_display_name.label("task_display_name"),  # type: ignore[attr-defined]
         TaskInstance.try_number.label("try_number"),
         TaskInstance.state.label("state"),
+        TaskInstance.queued_dttm.label("queued_dttm"),
         TaskInstance.start_date.label("start_date"),
         TaskInstance.end_date.label("end_date"),
     ).where(
@@ -81,6 +82,7 @@ def get_gantt_data(
         TaskInstanceHistory.task_display_name.label("task_display_name"),
         TaskInstanceHistory.try_number.label("try_number"),
         TaskInstanceHistory.state.label("state"),
+        TaskInstanceHistory.queued_dttm.label("queued_dttm"),
         TaskInstanceHistory.start_date.label("start_date"),
         TaskInstanceHistory.end_date.label("end_date"),
     ).where(
@@ -106,6 +108,7 @@ def get_gantt_data(
             task_display_name=row.task_display_name,
             try_number=row.try_number,
             state=row.state,
+            queued_dttm=row.queued_dttm,
             start_date=row.start_date,
             end_date=row.end_date,
         )

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -8220,6 +8220,18 @@ export const $GanttTaskInstance = {
                 }
             ]
         },
+        queued_dttm: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Queued Dttm'
+        },
         start_date: {
             anyOf: [
                 {
@@ -8256,7 +8268,7 @@ export const $GanttTaskInstance = {
         }
     },
     type: 'object',
-    required: ['task_id', 'task_display_name', 'try_number', 'state', 'start_date', 'end_date'],
+    required: ['task_id', 'task_display_name', 'try_number', 'state', 'queued_dttm', 'start_date', 'end_date'],
     title: 'GanttTaskInstance',
     description: 'Task instance data for Gantt chart.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -8220,6 +8220,18 @@ export const $GanttTaskInstance = {
                 }
             ]
         },
+        scheduled_dttm: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Scheduled Dttm'
+        },
         queued_dttm: {
             anyOf: [
                 {
@@ -8268,7 +8280,7 @@ export const $GanttTaskInstance = {
         }
     },
     type: 'object',
-    required: ['task_id', 'task_display_name', 'try_number', 'state', 'queued_dttm', 'start_date', 'end_date'],
+    required: ['task_id', 'task_display_name', 'try_number', 'state', 'scheduled_dttm', 'queued_dttm', 'start_date', 'end_date'],
     title: 'GanttTaskInstance',
     description: 'Task instance data for Gantt chart.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2015,6 +2015,7 @@ export type GanttTaskInstance = {
     task_display_name: string;
     try_number: number;
     state: TaskInstanceState | null;
+    queued_dttm: string | null;
     start_date: string | null;
     end_date: string | null;
     is_group?: boolean;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2015,6 +2015,7 @@ export type GanttTaskInstance = {
     task_display_name: string;
     try_number: number;
     state: TaskInstanceState | null;
+    scheduled_dttm: string | null;
     queued_dttm: string | null;
     start_date: string | null;
     end_date: string | null;

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -166,6 +168,10 @@ describe("transformGanttData", () => {
           end_date: null,
           is_mapped: false,
           // eslint-disable-next-line unicorn/no-null
+          queued_dttm: null,
+          // eslint-disable-next-line unicorn/no-null
+          scheduled_dttm: null,
+          // eslint-disable-next-line unicorn/no-null
           start_date: null,
           // eslint-disable-next-line unicorn/no-null
           state: null,
@@ -189,6 +195,10 @@ describe("transformGanttData", () => {
           // eslint-disable-next-line unicorn/no-null
           end_date: null,
           is_mapped: false,
+          // eslint-disable-next-line unicorn/no-null
+          queued_dttm: null,
+          // eslint-disable-next-line unicorn/no-null
+          scheduled_dttm: null,
           start_date: "2024-03-14T10:00:00+00:00",
           state: "running",
           task_display_name: "task_1",
@@ -237,6 +247,10 @@ describe("transformGanttData", () => {
         {
           end_date: "2024-03-14T10:05:00+00:00",
           is_mapped: false,
+          // eslint-disable-next-line unicorn/no-null
+          queued_dttm: null,
+          // eslint-disable-next-line unicorn/no-null
+          scheduled_dttm: null,
           start_date: "2024-03-14T10:00:00+00:00",
           state: "success",
           task_display_name: "task_1",
@@ -257,5 +271,80 @@ describe("transformGanttData", () => {
     expect(end.isValid()).toBe(true);
     expect(Number.isNaN(start.valueOf())).toBe(false);
     expect(Number.isNaN(end.valueOf())).toBe(false);
+  });
+
+  it("should produce 3 segments when scheduled_dttm and queued_dttm are present", () => {
+    const result = transformGanttData({
+      allTries: [
+        {
+          end_date: "2024-03-14T10:05:00+00:00",
+          is_mapped: false,
+          queued_dttm: "2024-03-14T09:59:00+00:00",
+          scheduled_dttm: "2024-03-14T09:58:00+00:00",
+          start_date: "2024-03-14T10:00:00+00:00",
+          state: "success",
+          task_display_name: "task_1",
+          task_id: "task_1",
+          try_number: 1,
+        },
+      ],
+      flatNodes: [{ depth: 0, id: "task_1", is_mapped: false, label: "task_1" }],
+      gridSummaries: [],
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.state).toBe("scheduled");
+    expect(result[1]?.state).toBe("queued");
+    expect(result[2]?.state).toBe("success");
+  });
+
+  it("should produce 2 segments when only queued_dttm is present", () => {
+    const result = transformGanttData({
+      allTries: [
+        {
+          end_date: "2024-03-14T10:05:00+00:00",
+          is_mapped: false,
+          queued_dttm: "2024-03-14T09:59:00+00:00",
+          // eslint-disable-next-line unicorn/no-null
+          scheduled_dttm: null,
+          start_date: "2024-03-14T10:00:00+00:00",
+          state: "success",
+          task_display_name: "task_1",
+          task_id: "task_1",
+          try_number: 1,
+        },
+      ],
+      flatNodes: [{ depth: 0, id: "task_1", is_mapped: false, label: "task_1" }],
+      gridSummaries: [],
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.state).toBe("queued");
+    expect(result[1]?.state).toBe("success");
+  });
+
+  it("should produce 1 segment when scheduled_dttm and queued_dttm are null", () => {
+    const result = transformGanttData({
+      allTries: [
+        {
+          end_date: "2024-03-14T10:05:00+00:00",
+          is_mapped: false,
+          // eslint-disable-next-line unicorn/no-null
+          queued_dttm: null,
+          // eslint-disable-next-line unicorn/no-null
+          scheduled_dttm: null,
+          start_date: "2024-03-14T10:00:00+00:00",
+          state: "success",
+          task_display_name: "task_1",
+          task_id: "task_1",
+          try_number: 1,
+        },
+      ],
+      flatNodes: [{ depth: 0, id: "task_1", is_mapped: false, label: "task_1" }],
+      gridSummaries: [],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.state).toBe("success");
   });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -38,6 +38,7 @@ import { buildTaskInstanceUrl } from "src/utils/links";
 export type GanttDataItem = {
   isGroup?: boolean | null;
   isMapped?: boolean | null;
+  isQueued?: boolean;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;
@@ -122,22 +123,44 @@ export const transformGanttData = ({
         if (tries && tries.length > 0) {
           return tries
             .filter((tryInstance) => tryInstance.start_date !== null)
-            .map((tryInstance) => {
+            .flatMap((tryInstance) => {
               const hasTaskRunning = isStatePending(tryInstance.state);
               const endTime =
                 hasTaskRunning || tryInstance.end_date === null
                   ? dayjs().toISOString()
                   : tryInstance.end_date;
+              const items: Array<GanttDataItem> = [];
 
-              return {
+              // Queue segment: from queued_dttm to start_date
+              if (tryInstance.queued_dttm !== null) {
+                items.push({
+                  isGroup: false,
+                  isMapped: tryInstance.is_mapped,
+                  isQueued: true,
+                  state: "queued" as TaskInstanceState,
+                  taskId: tryInstance.task_id,
+                  tryNumber: tryInstance.try_number,
+                  x: [
+                    dayjs(tryInstance.queued_dttm).toISOString(),
+                    dayjs(tryInstance.start_date).toISOString(),
+                  ],
+                  y: tryInstance.task_display_name,
+                });
+              }
+
+              // Execution segment: from start_date to end_date
+              items.push({
                 isGroup: false,
                 isMapped: tryInstance.is_mapped,
+                isQueued: false,
                 state: tryInstance.state,
                 taskId: tryInstance.task_id,
                 tryNumber: tryInstance.try_number,
                 x: [dayjs(tryInstance.start_date).toISOString(), dayjs(endTime).toISOString()],
                 y: tryInstance.task_display_name,
-              };
+              });
+
+              return items;
             });
         }
       }
@@ -330,6 +353,10 @@ export const createChartOptions = ({
           },
           label(tooltipItem: TooltipItem<"bar">) {
             const taskInstance = data[tooltipItem.dataIndex];
+
+            if (taskInstance?.isQueued) {
+              return `${translate("state")}: ${translate("states.queued")}`;
+            }
 
             return `${translate("state")}: ${translate(`states.${taskInstance?.state}`)}`;
           },

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -38,8 +38,6 @@ import { buildTaskInstanceUrl } from "src/utils/links";
 export type GanttDataItem = {
   isGroup?: boolean | null;
   isMapped?: boolean | null;
-  isQueued?: boolean;
-  isScheduled?: boolean;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;
@@ -139,7 +137,6 @@ export const transformGanttData = ({
                 items.push({
                   isGroup: false,
                   isMapped: tryInstance.is_mapped,
-                  isScheduled: true,
                   state: "scheduled" as TaskInstanceState,
                   taskId: tryInstance.task_id,
                   tryNumber: tryInstance.try_number,
@@ -153,7 +150,6 @@ export const transformGanttData = ({
                 items.push({
                   isGroup: false,
                   isMapped: tryInstance.is_mapped,
-                  isQueued: true,
                   state: "queued" as TaskInstanceState,
                   taskId: tryInstance.task_id,
                   tryNumber: tryInstance.try_number,
@@ -169,7 +165,6 @@ export const transformGanttData = ({
               items.push({
                 isGroup: false,
                 isMapped: tryInstance.is_mapped,
-                isQueued: false,
                 state: tryInstance.state,
                 taskId: tryInstance.task_id,
                 tryNumber: tryInstance.try_number,
@@ -299,6 +294,11 @@ export const createChartOptions = ({
       duration: 150,
       easing: "linear" as const,
     },
+    datasets: {
+      bar: {
+        minBarLength: 4,
+      },
+    },
     indexAxis: "y" as const,
     maintainAspectRatio: false,
     onClick: handleBarClick,
@@ -371,15 +371,7 @@ export const createChartOptions = ({
           label(tooltipItem: TooltipItem<"bar">) {
             const taskInstance = data[tooltipItem.dataIndex];
 
-            if (taskInstance?.isScheduled) {
-              return `${translate("state")}: ${translate("states.scheduled")}`;
-            }
-
-            if (taskInstance?.isQueued) {
-              return `${translate("state")}: ${translate("states.queued")}`;
-            }
-
-            return `${translate("state")}: ${translate(`states.${taskInstance?.state}`)}`;
+            return `${translate("state")}: ${translate(`common:states.${taskInstance?.state}`)}`;
           },
         },
       },

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -132,7 +132,7 @@ export const transformGanttData = ({
 
               // Scheduled segment: from scheduled_dttm to queued_dttm (or start_date if no queued_dttm)
               if (tryInstance.scheduled_dttm !== null) {
-                const scheduledEnd = tryInstance.queued_dttm ?? tryInstance.start_date;
+                const scheduledEnd = tryInstance.queued_dttm ?? tryInstance.start_date ?? undefined;
 
                 items.push({
                   isGroup: false,
@@ -155,7 +155,7 @@ export const transformGanttData = ({
                   tryNumber: tryInstance.try_number,
                   x: [
                     dayjs(tryInstance.queued_dttm).toISOString(),
-                    dayjs(tryInstance.start_date).toISOString(),
+                    dayjs(tryInstance.start_date ?? undefined).toISOString(),
                   ],
                   y: tryInstance.task_display_name,
                 });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -39,6 +39,7 @@ export type GanttDataItem = {
   isGroup?: boolean | null;
   isMapped?: boolean | null;
   isQueued?: boolean;
+  isScheduled?: boolean;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;
@@ -130,6 +131,22 @@ export const transformGanttData = ({
                   ? dayjs().toISOString()
                   : tryInstance.end_date;
               const items: Array<GanttDataItem> = [];
+
+              // Scheduled segment: from scheduled_dttm to queued_dttm (or start_date if no queued_dttm)
+              if (tryInstance.scheduled_dttm !== null) {
+                const scheduledEnd = tryInstance.queued_dttm ?? tryInstance.start_date;
+
+                items.push({
+                  isGroup: false,
+                  isMapped: tryInstance.is_mapped,
+                  isScheduled: true,
+                  state: "scheduled" as TaskInstanceState,
+                  taskId: tryInstance.task_id,
+                  tryNumber: tryInstance.try_number,
+                  x: [dayjs(tryInstance.scheduled_dttm).toISOString(), dayjs(scheduledEnd).toISOString()],
+                  y: tryInstance.task_display_name,
+                });
+              }
 
               // Queue segment: from queued_dttm to start_date
               if (tryInstance.queued_dttm !== null) {
@@ -353,6 +370,10 @@ export const createChartOptions = ({
           },
           label(tooltipItem: TooltipItem<"bar">) {
             const taskInstance = data[tooltipItem.dataIndex];
+
+            if (taskInstance?.isScheduled) {
+              return `${translate("state")}: ${translate("states.scheduled")}`;
+            }
 
             if (taskInstance?.isQueued) {
               return `${translate("state")}: ${translate("states.queued")}`;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_gantt.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_gantt.py
@@ -51,6 +51,7 @@ GANTT_TASK_1 = {
     "task_display_name": TASK_DISPLAY_NAME,
     "try_number": 1,
     "state": "success",
+    "queued_dttm": "2024-11-30T09:55:00Z",
     "start_date": "2024-11-30T10:00:00Z",
     "end_date": "2024-11-30T10:05:00Z",
     "is_group": False,
@@ -62,6 +63,7 @@ GANTT_TASK_2 = {
     "task_display_name": TASK_DISPLAY_NAME_2,
     "try_number": 1,
     "state": "failed",
+    "queued_dttm": "2024-11-30T10:03:00Z",
     "start_date": "2024-11-30T10:05:00Z",
     "end_date": "2024-11-30T10:10:00Z",
     "is_group": False,
@@ -73,6 +75,7 @@ GANTT_TASK_3 = {
     "task_display_name": TASK_DISPLAY_NAME_3,
     "try_number": 1,
     "state": "running",
+    "queued_dttm": None,
     "start_date": "2024-11-30T10:10:00Z",
     "end_date": None,
     "is_group": False,
@@ -116,16 +119,19 @@ def setup(dag_maker, session=None):
         if ti.task_id == TASK_ID:
             ti.state = TaskInstanceState.SUCCESS
             ti.try_number = 1
+            ti.queued_dttm = pendulum.DateTime(2024, 11, 30, 9, 55, 0, tzinfo=pendulum.UTC)
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 0, 0, tzinfo=pendulum.UTC)
             ti.end_date = pendulum.DateTime(2024, 11, 30, 10, 5, 0, tzinfo=pendulum.UTC)
         elif ti.task_id == TASK_ID_2:
             ti.state = TaskInstanceState.FAILED
             ti.try_number = 1
+            ti.queued_dttm = pendulum.DateTime(2024, 11, 30, 10, 3, 0, tzinfo=pendulum.UTC)
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 5, 0, tzinfo=pendulum.UTC)
             ti.end_date = pendulum.DateTime(2024, 11, 30, 10, 10, 0, tzinfo=pendulum.UTC)
         elif ti.task_id == TASK_ID_3:
             ti.state = TaskInstanceState.RUNNING
             ti.try_number = 1
+            ti.queued_dttm = None
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 10, 0, tzinfo=pendulum.UTC)
             ti.end_date = None
 
@@ -305,6 +311,15 @@ class TestGetGanttDataEndpoint:
         task_instances = data["task_instances"]
         sorted_tis = sorted(task_instances, key=lambda x: (x["task_id"], x["try_number"]))
         assert task_instances == sorted_tis
+
+    def test_queued_dttm_is_returned(self, test_client):
+        response = test_client.get(f"/gantt/{DAG_ID}/run_1")
+        assert response.status_code == 200
+        data = response.json()
+        tis = {ti["task_id"]: ti for ti in data["task_instances"]}
+        assert tis[TASK_ID]["queued_dttm"] == "2024-11-30T09:55:00Z"
+        assert tis[TASK_ID_2]["queued_dttm"] == "2024-11-30T10:03:00Z"
+        assert tis[TASK_ID_3]["queued_dttm"] is None
 
     def test_should_response_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(f"/gantt/{DAG_ID}/run_1")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_gantt.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_gantt.py
@@ -51,6 +51,7 @@ GANTT_TASK_1 = {
     "task_display_name": TASK_DISPLAY_NAME,
     "try_number": 1,
     "state": "success",
+    "scheduled_dttm": "2024-11-30T09:50:00Z",
     "queued_dttm": "2024-11-30T09:55:00Z",
     "start_date": "2024-11-30T10:00:00Z",
     "end_date": "2024-11-30T10:05:00Z",
@@ -63,6 +64,7 @@ GANTT_TASK_2 = {
     "task_display_name": TASK_DISPLAY_NAME_2,
     "try_number": 1,
     "state": "failed",
+    "scheduled_dttm": "2024-11-30T10:02:00Z",
     "queued_dttm": "2024-11-30T10:03:00Z",
     "start_date": "2024-11-30T10:05:00Z",
     "end_date": "2024-11-30T10:10:00Z",
@@ -75,6 +77,7 @@ GANTT_TASK_3 = {
     "task_display_name": TASK_DISPLAY_NAME_3,
     "try_number": 1,
     "state": "running",
+    "scheduled_dttm": None,
     "queued_dttm": None,
     "start_date": "2024-11-30T10:10:00Z",
     "end_date": None,
@@ -119,18 +122,21 @@ def setup(dag_maker, session=None):
         if ti.task_id == TASK_ID:
             ti.state = TaskInstanceState.SUCCESS
             ti.try_number = 1
+            ti.scheduled_dttm = pendulum.DateTime(2024, 11, 30, 9, 50, 0, tzinfo=pendulum.UTC)
             ti.queued_dttm = pendulum.DateTime(2024, 11, 30, 9, 55, 0, tzinfo=pendulum.UTC)
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 0, 0, tzinfo=pendulum.UTC)
             ti.end_date = pendulum.DateTime(2024, 11, 30, 10, 5, 0, tzinfo=pendulum.UTC)
         elif ti.task_id == TASK_ID_2:
             ti.state = TaskInstanceState.FAILED
             ti.try_number = 1
+            ti.scheduled_dttm = pendulum.DateTime(2024, 11, 30, 10, 2, 0, tzinfo=pendulum.UTC)
             ti.queued_dttm = pendulum.DateTime(2024, 11, 30, 10, 3, 0, tzinfo=pendulum.UTC)
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 5, 0, tzinfo=pendulum.UTC)
             ti.end_date = pendulum.DateTime(2024, 11, 30, 10, 10, 0, tzinfo=pendulum.UTC)
         elif ti.task_id == TASK_ID_3:
             ti.state = TaskInstanceState.RUNNING
             ti.try_number = 1
+            ti.scheduled_dttm = None
             ti.queued_dttm = None
             ti.start_date = pendulum.DateTime(2024, 11, 30, 10, 10, 0, tzinfo=pendulum.UTC)
             ti.end_date = None
@@ -312,13 +318,16 @@ class TestGetGanttDataEndpoint:
         sorted_tis = sorted(task_instances, key=lambda x: (x["task_id"], x["try_number"]))
         assert task_instances == sorted_tis
 
-    def test_queued_dttm_is_returned(self, test_client):
+    def test_timing_fields_are_returned(self, test_client):
         response = test_client.get(f"/gantt/{DAG_ID}/run_1")
         assert response.status_code == 200
         data = response.json()
         tis = {ti["task_id"]: ti for ti in data["task_instances"]}
+        assert tis[TASK_ID]["scheduled_dttm"] == "2024-11-30T09:50:00Z"
         assert tis[TASK_ID]["queued_dttm"] == "2024-11-30T09:55:00Z"
+        assert tis[TASK_ID_2]["scheduled_dttm"] == "2024-11-30T10:02:00Z"
         assert tis[TASK_ID_2]["queued_dttm"] == "2024-11-30T10:03:00Z"
+        assert tis[TASK_ID_3]["scheduled_dttm"] is None
         assert tis[TASK_ID_3]["queued_dttm"] is None
 
     def test_should_response_401(self, unauthenticated_test_client):


### PR DESCRIPTION
Adds `queued_dttm` to the Gantt chart so users can see how long tasks spent waiting in the queue before execution started.

**Changes:**
- Backend: Added `queued_dttm` `scheduled_dttm`field to `GanttTaskInstance` datamodel and SQL queries (both `TaskInstance` and `TaskInstanceHistory`)
- Frontend: Renders a separate queue segment on the Gantt bar (from `queued_dttm` `scheduled_dttm` to `start_date`) using the existing `queued` and `scheduled`  state color
- OpenAPI spec regenerated via `scripts/in_container/run_generate_openapi_spec.py`
- TypeScript types regenerated via `npm run codegen`
- Tests updated and a new test added to verify `queued_dttm/scheduled_dttm` is returned

This mirrors the Airflow 2 Gantt chart behavior which was missing in Airflow 3.

closes: #63356

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)