### PR TITLE
Clean up NavButton titles

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/Nav.tsx
@@ -201,9 +201,7 @@ export const Nav = () => {
           version={data?.version}
         />
         <Tooltip content={tooltipLabel}>
-          <Box>
-            <NavButton icon={FiClock} onClick={onOpenTimezone} title={offset} />
-          </Box>
+          <NavButton icon={FiClock} onClick={onOpenTimezone} title={offset} />
         </Tooltip>
         <UserSettingsButton externalViews={userItems} />
       </Flex>

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/NavButton.tsx
@@ -72,6 +72,7 @@ export const NavButton = ({ icon, isExternal = false, pluginIcon, title, to, ...
           color: "fg",
         },
     alignItems: "center",
+    "aria-label": title,
     bg: isActive ? "brand.solid" : undefined,
     borderRadius: "md",
     borderWidth: 0,
@@ -84,7 +85,7 @@ export const NavButton = ({ icon, isExternal = false, pluginIcon, title, to, ...
     overflow: "hidden",
     padding: 0,
     textDecoration: "none",
-    title,
+
     transition: "background-color 0.2s ease, color 0.2s ease",
     variant: "plain",
     whiteSpace: "wrap",


### PR DESCRIPTION
We were passing the title to all Nav Buttons even when it is the same as the button text, and in the case of the timezone button there is already a tooltip. Therefore, we should remove the `title` prop but make sure we are passing an aria-label

Before:
<img width="264" height="186" alt="Screenshot 2026-03-11 at 2 38 29 PM" src="https://github.com/user-attachments/assets/3ef351da-c5f7-44d8-a204-9b64f031cedb" />

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
