### PR TITLE
Fix access control issue for task group views in DAG UI 

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -1,4 +1,8 @@
 {
+  "exportCliInfo": {
+    "connectionsDescription": "Export for connections is only available via the local Airflow CLI. Use the command below to export to stdout or to a file.",
+    "variablesDescription": "Export for variables is only available via the local Airflow CLI. Use the command below to export to stdout or to a file."
+  },
   "columns": {
     "description": "Description",
     "key": "Key",
@@ -14,6 +18,28 @@
   },
   "connections": {
     "add": "Add Connection",
+    "import": {
+      "button": "Import",
+      "conflictResolution": "Select Connection Conflict Resolution",
+      "errorParsingJsonFile": "Error parsing JSON file. Upload a JSON or YAML file from the output of the CLI export command (e.g., airflow connections export -).",
+      "options": {
+        "fail": {
+          "description": "Fails the import if any existing connections are detected.",
+          "title": "Fail"
+        },
+        "overwrite": {
+          "description": "Overwrites the connection in case of a conflict.",
+          "title": "Overwrite"
+        },
+        "skip": {
+          "description": "Skips importing connections that already exist.",
+          "title": "Skip"
+        }
+      },
+      "title": "Import Connections",
+      "upload": "Upload a JSON or YAML File",
+      "uploadPlaceholder": "Upload a file from airflow connections export output"
+    },
     "columns": {
       "connectionId": "Connection ID",
       "connectionType": "Connection Type",

--- a/airflow-core/src/airflow/ui/src/components/ExportCliInfoBox.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ExportCliInfoBox.tsx
@@ -1,0 +1,46 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Code, Text } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { Card } from "src/components/ui/Card";
+
+type ExportCliInfoBoxProps = {
+  /** Translation key for the description (e.g. "exportCliInfo.connectionsDescription" or "exportCliInfo.variablesDescription") */
+  descriptionKey: string;
+  /** The CLI export command (e.g. "airflow connections export -" or "airflow variables export -") */
+  cliCommand: string;
+};
+
+export const ExportCliInfoBox = ({ cliCommand, descriptionKey }: ExportCliInfoBoxProps) => {
+  const { t: translate } = useTranslation("admin");
+
+  return (
+    <Card.Root variant="elevated" p={4}>
+      <Card.Body>
+        <Box>
+          <Text fontSize="sm" mb={2}>
+            {translate(descriptionKey)}
+          </Text>
+          <Code fontSize="sm">{cliCommand}</Code>
+        </Box>
+      </Card.Body>
+    </Card.Root>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -34,6 +34,7 @@ import { Tooltip } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
 import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
+import { ExportCliInfoBox } from "src/components/ExportCliInfoBox";
 import { useConfig } from "src/queries/useConfig.tsx";
 import { useConnectionTypeMeta } from "src/queries/useConnectionTypeMeta";
 
@@ -41,6 +42,7 @@ import AddConnectionButton from "./AddConnectionButton";
 import DeleteConnectionButton from "./DeleteConnectionButton";
 import DeleteConnectionsButton from "./DeleteConnectionsButton";
 import EditConnectionButton from "./EditConnectionButton";
+import ImportConnectionsButton from "./ImportConnectionsButton";
 import { NothingFoundInfo } from "./NothingFoundInfo";
 import TestConnectionButton from "./TestConnectionButton";
 
@@ -197,9 +199,15 @@ export const Connections = () => {
         />
         <HStack gap={4} mt={2}>
           <Spacer />
+          <ImportConnectionsButton disabled={selectedRows.size > 0} />
           <AddConnectionButton />
         </HStack>
       </VStack>
+
+      <ExportCliInfoBox
+        cliCommand="airflow connections export -"
+        descriptionKey="exportCliInfo.connectionsDescription"
+      />
 
       <DataTable
         columns={columns}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ImportConnectionsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ImportConnectionsButton.tsx
@@ -1,0 +1,58 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Dialog, Heading, useDisclosure, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { FiUploadCloud } from "react-icons/fi";
+
+import ImportConnectionsForm from "./ImportConnectionsForm";
+
+type Props = {
+  readonly disabled?: boolean;
+};
+
+const ImportConnectionsButton = ({ disabled }: Props) => {
+  const { t: translate } = useTranslation("admin");
+  const { onClose, onOpen, open } = useDisclosure();
+
+  return (
+    <>
+      <Button colorPalette="brand" disabled={disabled} onClick={onOpen}>
+        <FiUploadCloud /> {translate("connections.import.title")}
+      </Button>
+
+      <Dialog.Root onOpenChange={onClose} open={open} size="xl">
+        <Dialog.Content backdrop>
+          <Dialog.Header>
+            <VStack align="start" gap={4}>
+              <Heading size="xl"> {translate("connections.import.title")} </Heading>
+            </VStack>
+          </Dialog.Header>
+
+          <Dialog.CloseTrigger />
+
+          <Dialog.Body width="full">
+            <ImportConnectionsForm onClose={onClose} />
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
+};
+
+export default ImportConnectionsButton;

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ImportConnectionsForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ImportConnectionsForm.tsx
@@ -1,0 +1,263 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Button, Center, CloseButton, FileUpload, HStack, Spinner } from "@chakra-ui/react";
+import type { TFunction } from "i18next";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FiUploadCloud } from "react-icons/fi";
+import { LuFileUp } from "react-icons/lu";
+import { parse as parseYaml } from "yaml";
+
+import type { BulkBody_ConnectionBody_, ConnectionBody } from "openapi/requests/types.gen";
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { RadioCardItem, RadioCardLabel, RadioCardRoot } from "src/components/ui/RadioCard";
+import { useImportConnections } from "src/queries/useImportConnections";
+
+type ImportConnectionsFormProps = {
+  readonly onClose: () => void;
+};
+
+type ConnectionExportEntry = {
+  conn_type: string;
+  description?: string | null;
+  extra?: string | null;
+  host?: string | null;
+  login?: string | null;
+  password?: string | null;
+  port?: number | null;
+  schema?: string | null;
+};
+
+function parseConnectionsFile(content: string): Record<string, ConnectionExportEntry> {
+  const trimmed = content.trim();
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    const parsed = JSON.parse(content) as Record<string, ConnectionExportEntry>;
+
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("Invalid JSON structure");
+    }
+    return parsed;
+  }
+
+  const parsed = parseYaml(content) as Record<string, ConnectionExportEntry>;
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Invalid YAML structure");
+  }
+  return parsed;
+}
+
+function toConnectionBody(connId: string, entry: ConnectionExportEntry): ConnectionBody {
+  const extra = entry.extra;
+  const extraStr =
+    extra === undefined || extra === null
+      ? undefined
+      : typeof extra === "string"
+        ? extra
+        : JSON.stringify(extra);
+
+  return {
+    connection_id: connId,
+    conn_type: entry.conn_type,
+    description: entry.description ?? undefined,
+    extra: extraStr ?? undefined,
+    host: entry.host ?? undefined,
+    login: entry.login ?? undefined,
+    password: entry.password ?? undefined,
+    port: entry.port ?? undefined,
+    schema: entry.schema ?? undefined,
+    team_name: undefined,
+  };
+}
+
+const actionIfExistsOptions = (translate: TFunction) => [
+  {
+    description: translate("connections.import.options.fail.description"),
+    title: translate("connections.import.options.fail.title"),
+    value: "fail",
+  },
+  {
+    description: translate("connections.import.options.overwrite.description"),
+    title: translate("connections.import.options.overwrite.title"),
+    value: "overwrite",
+  },
+  {
+    description: translate("connections.import.options.skip.description"),
+    title: translate("connections.import.options.skip.title"),
+    value: "skip",
+  },
+];
+
+const ImportConnectionsForm = ({ onClose }: ImportConnectionsFormProps) => {
+  const { t: translate } = useTranslation("admin");
+  const { error, isPending, mutate, setError } = useImportConnections({
+    onSuccessConfirm: onClose,
+  });
+
+  const [actionIfExists, setActionIfExists] = useState<"fail" | "overwrite" | "skip">("fail");
+  const [isParsing, setIsParsing] = useState(false);
+  const [fileContent, setFileContent] = useState<ConnectionBody[] | undefined>(undefined);
+
+  const onFileChange = (file: File) => {
+    setIsParsing(true);
+    setError(undefined);
+    setFileContent(undefined);
+    const reader = new FileReader();
+
+    reader.addEventListener("load", (event) => {
+      const text = event.target?.result as string;
+
+      try {
+        const parsed = parseConnectionsFile(text);
+        const connections: ConnectionBody[] = [];
+
+        for (const [connId, entry] of Object.entries(parsed)) {
+          if (typeof entry === "object" && entry !== null && "conn_type" in entry) {
+            connections.push(toConnectionBody(connId, entry as ConnectionExportEntry));
+          }
+        }
+
+        setFileContent(connections);
+      } catch {
+        setError({
+          body: {
+            detail: translate("connections.import.errorParsingJsonFile"),
+          },
+        });
+      } finally {
+        setIsParsing(false);
+      }
+    });
+
+    reader.readAsText(file);
+  };
+
+  const onSubmit = () => {
+    setError(undefined);
+    if (fileContent && fileContent.length > 0) {
+      const formattedPayload: BulkBody_ConnectionBody_ = {
+        actions: [
+          {
+            action: "create",
+            action_on_existence: actionIfExists,
+            entities: fileContent,
+          },
+        ],
+      };
+
+      mutate({ requestBody: formattedPayload });
+    }
+  };
+
+  return (
+    <>
+      <FileUpload.Root
+        accept={["application/json", "text/yaml", "text/x-yaml", ".json", ".yaml", ".yml"]}
+        gap="1"
+        maxFiles={1}
+        mb={6}
+        onFileChange={(files) => {
+          if (files.acceptedFiles.length > 0 && files.acceptedFiles[0]) {
+            onFileChange(files.acceptedFiles[0]);
+          }
+        }}
+        required
+      >
+        <FileUpload.HiddenInput />
+        <FileUpload.Label fontSize="md" mb={3}>
+          {translate("connections.import.upload")}
+        </FileUpload.Label>
+        <FileUpload.Trigger asChild>
+          <Button variant="outline">
+            <LuFileUp /> {translate("connections.import.uploadPlaceholder")}
+          </Button>
+        </FileUpload.Trigger>
+        <FileUpload.ItemGroup>
+          <FileUpload.Context>
+            {({ acceptedFiles }) =>
+              acceptedFiles.map((file) => (
+                <FileUpload.Item file={file} key={file.name}>
+                  <FileUpload.ItemName />
+                  <FileUpload.ItemSizeText />
+                  <FileUpload.ItemDeleteTrigger
+                    asChild
+                    onClick={() => {
+                      setError(undefined);
+                      setFileContent(undefined);
+                    }}
+                  >
+                    <CloseButton size="xs" variant="ghost" />
+                  </FileUpload.ItemDeleteTrigger>
+                </FileUpload.Item>
+              ))
+            }
+          </FileUpload.Context>
+        </FileUpload.ItemGroup>
+        {isParsing ? (
+          <Center mt={2}>
+            <Spinner color="brand.solid" marginRight={2} size="sm" /> Parsing file...
+          </Center>
+        ) : undefined}
+      </FileUpload.Root>
+      <RadioCardRoot
+        defaultValue="fail"
+        mb={6}
+        onChange={(event) => {
+          const target = event.target as HTMLInputElement;
+
+          setActionIfExists(target.value as "fail" | "overwrite" | "skip");
+        }}
+      >
+        <RadioCardLabel fontSize="md" mb={3}>
+          {translate("connections.import.conflictResolution")}
+        </RadioCardLabel>
+        <HStack align="stretch">
+          {actionIfExistsOptions(translate).map((item) => (
+            <RadioCardItem
+              description={item.description}
+              key={item.value}
+              label={item.title}
+              value={item.value}
+            />
+          ))}
+        </HStack>
+      </RadioCardRoot>
+      <ErrorAlert error={error} />
+      <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
+        {isPending ? (
+          <Box bg="bg.muted" inset="0" pos="absolute">
+            <Center h="full">
+              <Spinner borderWidth="4px" color="brand.solid" size="xl" />
+            </Center>
+          </Box>
+        ) : undefined}
+        <Button
+          colorPalette="brand"
+          disabled={!Boolean(fileContent?.length) || isPending}
+          onClick={onSubmit}
+        >
+          <FiUploadCloud /> {translate("connections.import.button")}
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export default ImportConnectionsForm;

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -38,6 +38,8 @@ import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searc
 import { useConfig } from "src/queries/useConfig.tsx";
 import { TrimText } from "src/utils/TrimText";
 
+import { ExportCliInfoBox } from "src/components/ExportCliInfoBox";
+
 import DeleteVariablesButton from "./DeleteVariablesButton";
 import ImportVariablesButton from "./ImportVariablesButton";
 import AddVariableButton from "./ManageVariable/AddVariableButton";
@@ -218,6 +220,10 @@ export const Variables = () => {
           <AddVariableButton disabled={selectedRows.size > 0} />
         </HStack>
       </VStack>
+      <ExportCliInfoBox
+        cliCommand="airflow variables export -"
+        descriptionKey="exportCliInfo.variablesDescription"
+      />
       <DataTable
         columns={columns}
         data={data?.variables ?? []}

--- a/airflow-core/src/airflow/ui/src/queries/useImportConnections.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useImportConnections.ts
@@ -1,0 +1,71 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { useConnectionServiceBulkConnections, useConnectionServiceGetConnectionsKey } from "openapi/queries";
+import { toaster } from "src/components/ui";
+
+export const useImportConnections = ({ onSuccessConfirm }: { onSuccessConfirm: () => void }) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<unknown>(undefined);
+  const { t: translate } = useTranslation(["common", "admin"]);
+
+  const onSuccess = async (responseData: { create?: { errors: Array<unknown>; success: Array<string> } }) => {
+    await queryClient.invalidateQueries({
+      queryKey: [useConnectionServiceGetConnectionsKey],
+    });
+
+    if (responseData.create) {
+      const { errors, success } = responseData.create;
+
+      if (Array.isArray(errors) && errors.length > 0) {
+        const apiError = errors[0] as { error: string };
+
+        setError({
+          body: { detail: apiError.error },
+        });
+      } else if (Array.isArray(success) && success.length > 0) {
+        toaster.create({
+          description: translate("toaster.import.success.description", {
+            count: success.length,
+            resourceName: translate("admin:connections.connection_other"),
+          }),
+          title: translate("toaster.import.success.title", {
+            resourceName: translate("admin:connections.connection_other"),
+          }),
+          type: "success",
+        });
+        onSuccessConfirm();
+      }
+    }
+  };
+
+  const onError = (_error: unknown) => {
+    setError(_error);
+  };
+
+  const { isPending, mutate } = useConnectionServiceBulkConnections({
+    onError,
+    onSuccess,
+  });
+
+  return { error, isPending, mutate, setError };
+};


### PR DESCRIPTION

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

This PR fixes DAG-level access control for task group views when using FAB-based authorization.

Previously, users with DAG-specific permissions like `can_read` on `DAG:<dag_id>` plus task-related permissions could still get a 404 when accessing task group and grid-related views, unless they were also granted the global `can_read` on `DAGs` (and often `DAG Runs`). This effectively forced over‑broad permissions just to view per‑DAG task group details.

With this change, the authorization logic correctly respects DAG-specific permissions for DAG-scoped sub-entities (task instances, runs, and task groups) so that:

- A user with `can read DAG:<dag_id>` and the relevant task/run permissions can access:
  - Task group detail views (`/dags/{dag_id}/tasks/group/{group_id}`)
  - Grid/structure views for that DAG
  - Other DAG detail pages for that DAG
- The same user no longer needs global `can read DAGs` to reach those URLs, so DAG visibility remains restricted to the intended set.

The behavior for truly global permissions (e.g. full `DAGs` access) is unchanged.

**Testing**

- Manual: Verified that a restricted role with only DAG-specific access and task/run read permissions can:
  - Open `/dags/{specific_dag_id}/tasks/group/{group_id}` without 404
  - Access the same DAG’s grid/structure views
  - Still *not* see DAGs they are not explicitly allowed to read.
