### PR TITLE
Generate ERD diagrams at doc build time instead of committing them

### DIFF
--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -332,6 +332,7 @@ BASIC_AUTOAPI_IGNORE_PATTERNS = [
     "*/airflow/executors/*",
     "*/_internal*",
     "*/node_modules/*",
+    "*/.pnpm-store/*",
     "*/migrations/*",
     "*/contrib/*",
     "*/example_taskflow_api_docker_virtualenv.py",


### PR DESCRIPTION
The ERD diagram (airflow_erd.svg, ~320KB) was previously generated via a prek pre-commit hook and committed to the repository. This caused unnecessary merge conflicts and repo bloat every time migrations changed.

This PR replaces that with a `generate_erd` Sphinx extension that generates ERD diagrams at documentation build time directly from SQLAlchemy model metadata — no running database needed.

The diagram is also split into three separate per-package ERDs, each generated only when building docs for that package:

- **apache-airflow**: core models → `airflow_erd.svg` (54 tables)
- **apache-airflow-providers-fab**: FAB auth manager models → `fab_erd.svg` (11 tables)
- **apache-airflow-providers-edge3**: Edge3 worker models → `edge3_erd.svg` (3 tables)

On environments where eralchemy or graphviz system package is unavailable (e.g. local macOS without `brew install graphviz`), a placeholder SVG is written so the build still succeeds with a clear message.

## Summary
- Added `generate_erd` Sphinx extension that detects the package being built via `AIRFLOW_PACKAGE_NAME` and generates the relevant ERD from SQLAlchemy metadata
- Added the extension to both `airflow-core/docs/conf.py` and `provider_conf.py`
- Created `database-erd-ref.rst` pages for FAB and Edge3 providers, linked from their doc indexes
- Removed committed `airflow_erd.svg`, `airflow_erd.sha256` from the repo
- Removed `update-er-diagram` prek pre-commit hook and associated scripts
- Removed `checksumdir` dependency (only used by the removed script)
- Updated contributing docs to reflect the change

## Test plan
- [x] Run `breeze build-docs apache-airflow` — verify core ERD is generated
- [x] Run `breeze build-docs apache-airflow-providers-fab` — verify FAB ERD is generated
- [x] Run `breeze build-docs apache-airflow-providers-edge3` — verify Edge3 ERD is generated
- [x] Build docs on macOS without graphviz — verify placeholder SVG appears and build succeeds
- [x] Build docs for an unrelated provider — verify no ERD generation is attempted

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)