### PR TITLE
fix(task-sdk): add greenback fallback for Variable access in triggerer

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -113,6 +113,26 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
             if isinstance(msg, VariableResult):
                 return msg.value  # Already a string | None
             return None
+        except RuntimeError as e:
+            # TriggerCommsDecoder.send() uses async_to_sync internally, which raises RuntimeError
+            # when called within an async event loop. In greenback portal contexts (triggerer),
+            # we catch this and use greenback to call the async version instead.
+            if str(e).startswith("You cannot use AsyncToSync in the same thread as an async event loop"):
+                import asyncio
+
+                import greenback
+
+                task = asyncio.current_task()
+                if greenback.has_portal(task):
+                    import warnings
+
+                    warnings.warn(
+                        "You should not use sync calls here -- use `await aget_variable` instead",
+                        stacklevel=2,
+                    )
+                    return greenback.await_(self.aget_variable(key))
+            # Fall through to the general exception handler for other RuntimeErrors
+            return None
         except Exception:
             # If SUPERVISOR_COMMS fails for any reason, return None
             # to allow fallback to other backends

--- a/task-sdk/tests/task_sdk/execution_time/test_secrets.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_secrets.py
@@ -178,6 +178,49 @@ class TestExecutionAPISecretsBackend:
         # Verify send was attempted first (and raised RuntimeError)
         mock_supervisor_comms.send.assert_called_once()
 
+    def test_get_variable_runtime_error_triggers_greenback_fallback(self, mocker, mock_supervisor_comms):
+        """
+        Test that RuntimeError from async_to_sync triggers greenback fallback for variables.
+
+        Same as the connection test but for get_variable — verifies the fix for #61676:
+        triggers calling Variable.get() fail because SUPERVISOR_COMMS.send() raises
+        RuntimeError in the async event loop, but the greenback fallback was missing.
+        """
+        expected_value = "10"
+
+        # Simulate the RuntimeError that triggers greenback fallback
+        mock_supervisor_comms.send.side_effect = RuntimeError(
+            "You cannot use AsyncToSync in the same thread as an async event loop"
+        )
+
+        # Mock the greenback and asyncio modules
+        mocker.patch("greenback.has_portal", return_value=True)
+        mocker.patch("asyncio.current_task")
+
+        import asyncio
+
+        def greenback_await_side_effect(coro):
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(coro)
+            finally:
+                loop.close()
+
+        mock_greenback_await = mocker.patch("greenback.await_", side_effect=greenback_await_side_effect)
+
+        # Mock aget_variable to return the expected value
+        async def mock_aget_variable(self, key):
+            return expected_value
+
+        mocker.patch.object(ExecutionAPISecretsBackend, "aget_variable", mock_aget_variable)
+
+        backend = ExecutionAPISecretsBackend()
+        result = backend.get_variable("retries")
+
+        assert result == expected_value
+        mock_greenback_await.assert_called_once()
+        mock_supervisor_comms.send.assert_called_once()
+
 
 class TestContextDetection:
     """Test context detection in ensure_secrets_backend_loaded."""


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
closes: #61676
-->

`ExecutionAPISecretsBackend.get_variable()` is missing the `RuntimeError` + greenback fallback that `get_connection()` already has (added in #57154). When a deferrable operator's trigger calls `Variable.get()` inside the triggerer's async event loop, `SUPERVISOR_COMMS.send()` raises `RuntimeError` from `async_to_sync`. The bare `except Exception` swallows it and returns `None`, so every backend returns nothing and the variable is reported as not found.

Added the same greenback portal detection and `aget_variable()` fallback that `get_connection()` uses. Added a matching unit test.

Closes: #61676

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
