### PR TITLE
Fix AzureContainerInstanceHook.get_logs returning [None] when logs are empty

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/container_instance.py
@@ -136,7 +136,7 @@ class AzureContainerInstanceHook(AzureBaseHook):
         """
         logs = self.connection.containers.list_logs(resource_group, name, name, tail=tail)
         if logs.content is None:
-            return [None]
+            return []
         return logs.content.splitlines(True)
 
     def delete(self, resource_group: str, name: str) -> None:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_container_instance.py
@@ -80,15 +80,21 @@ class TestAzureContainerInstanceHook:
         self.hook.get_state("resource_group", "aci-test")
         get_state_mock.assert_called_once_with("resource_group", "aci-test")
 
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ("log line 1\nlog line 2\nlog line 3\n", ["log line 1\n", "log line 2\n", "log line 3\n"]),
+            (None, []),
+        ],
+    )
     @patch("azure.mgmt.containerinstance.operations.ContainersOperations.list_logs")
-    def test_get_logs(self, list_logs_mock):
-        expected_messages = ["log line 1\n", "log line 2\n", "log line 3\n"]
-        logs = Logs(content="".join(expected_messages))
+    def test_get_logs(self, list_logs_mock, content, expected):
+        logs = Logs(content=content)
         list_logs_mock.return_value = logs
 
-        logs = self.hook.get_logs("resource_group", "name", "name")
+        result = self.hook.get_logs("resource_group", "name", "name")
 
-        assert logs == expected_messages
+        assert result == expected
 
     @patch("azure.mgmt.containerinstance.operations.ContainerGroupsOperations.begin_delete")
     def test_delete(self, delete_mock):


### PR DESCRIPTION
**Description**

This change fixes incorrect handling of empty container logs in `AzureContainerInstanceHook.get_logs`. Previously, when the Azure SDK returned `Logs(content=None)`, the hook returned `[None]`. The hook now returns an empty list (`[]`) to correctly represent the absence of log messages.

**Rationale**

The hook documentation specifies that `get_logs` returns a list of log messages. Returning `[None]` introduces a non-string value and can break downstream code expecting log lines to be strings. Aligning the `None` case with the existing `"" → []` behavior ensures consistent semantics for empty logs.

**Tests**

Refactored the existing `test_get_logs` test to use parametrization and added coverage for the `Logs(content=None)` case.

**Backwards Compatibility**

Only affects the edge case where `Logs.content` is `None`, returning `[]` instead of `[None]`. Original behavior is otherwise preserved. 