### PR TITLE
Fix datafusion import breaking provider yaml validation

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/datafusion/object_storage_provider.py
@@ -16,8 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from datafusion.object_store import AmazonS3, LocalFileSystem
-
 from airflow.providers.common.sql.config import ConnectionConfig, StorageType
 from airflow.providers.common.sql.datafusion.base import ObjectStorageProvider
 from airflow.providers.common.sql.datafusion.exceptions import ObjectStoreCreationException
@@ -33,6 +31,8 @@ class S3ObjectStorageProvider(ObjectStorageProvider):
 
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
         """Create an S3 object store using DataFusion's AmazonS3."""
+        from datafusion.object_store import AmazonS3
+
         if connection_config is None:
             raise ValueError("connection_config must be provided for %s", self.get_storage_type)
 
@@ -63,6 +63,8 @@ class LocalObjectStorageProvider(ObjectStorageProvider):
 
     def create_object_store(self, path: str, connection_config: ConnectionConfig | None = None):
         """Create a Local object store."""
+        from datafusion.object_store import LocalFileSystem
+
         return LocalFileSystem()
 
     def get_scheme(self) -> str:


### PR DESCRIPTION
The `object_storage_provider.py` in the `common.sql` provider has top-level imports from `datafusion.object_store` which is not a required dependency. This breaks the `Validate provider.yaml files` CI check because the module fails to import when `datafusion` is not installed.

Move the `from datafusion.object_store import AmazonS3` and `from datafusion.object_store import LocalFileSystem` imports inside their respective `create_object_store()` methods where they are actually used, following the lazy-import pattern already used elsewhere in the codebase.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)