### PR TITLE
Add `deserialize_payload` option to LambdaInvokeFunctionOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/lambda_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/lambda_function.py
@@ -174,6 +174,10 @@ class LambdaInvokeFunctionOperator(AwsBaseOperator[LambdaHook]):
     :param invocation_type: AWS Lambda invocation type (RequestResponse, Event, DryRun)
     :param client_context: Data about the invoking client to pass to the function in the context object
     :param payload: JSON provided as input to the Lambda function
+    :param deserialize_payload: If True, the response payload will be deserialized from JSON
+        before being pushed to XCom. This allows downstream tasks to access individual keys
+        via bracket notation (e.g., ``ti.xcom_pull(task_ids='...')['key']``).
+        When False (default), the payload is returned as a string for backward compatibility.
     :param aws_conn_id: The AWS connection ID to use
     """
 
@@ -196,6 +200,7 @@ class LambdaInvokeFunctionOperator(AwsBaseOperator[LambdaHook]):
         invocation_type: str | None = None,
         client_context: str | None = None,
         payload: bytes | str | None = None,
+        deserialize_payload: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -206,6 +211,7 @@ class LambdaInvokeFunctionOperator(AwsBaseOperator[LambdaHook]):
         self.qualifier = qualifier
         self.invocation_type = invocation_type
         self.client_context = client_context
+        self.deserialize_payload = deserialize_payload
 
     def execute(self, context: Context):
         """
@@ -248,4 +254,6 @@ class LambdaInvokeFunctionOperator(AwsBaseOperator[LambdaHook]):
                 {"ResponseMetadata": response.get("ResponseMetadata"), "Payload": payload},
             )
         self.log.info("Lambda function invocation succeeded: %r", response.get("ResponseMetadata"))
+        if self.deserialize_payload:
+            payload = json.loads(payload)
         return payload

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_lambda_function.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_lambda_function.py
@@ -295,6 +295,45 @@ class TestLambdaInvokeFunctionOperator:
         with pytest.raises(ValueError, match=LAMBDA_FUNC_NO_EXECUTION):
             operator.execute(None)
 
+    @mock.patch.object(LambdaHook, "invoke_lambda")
+    @mock.patch.object(LambdaHook, "conn")
+    def test_invoke_lambda_deserialize_payload(self, mock_conn, mock_invoke):
+        operator = LambdaInvokeFunctionOperator(
+            task_id="task_test",
+            function_name="a",
+            payload='{}',
+            deserialize_payload=True,
+        )
+        returned_payload = Mock()
+        returned_payload.read().decode.return_value = '{"bucket": "my-bucket", "prefix": "data/"}'
+        mock_invoke.return_value = {
+            "ResponseMetadata": "",
+            "StatusCode": 200,
+            "Payload": returned_payload,
+        }
+        value = operator.execute(None)
+        assert value == {"bucket": "my-bucket", "prefix": "data/"}
+        assert isinstance(value, dict)
+
+    @mock.patch.object(LambdaHook, "invoke_lambda")
+    @mock.patch.object(LambdaHook, "conn")
+    def test_invoke_lambda_deserialize_payload_default_false(self, mock_conn, mock_invoke):
+        operator = LambdaInvokeFunctionOperator(
+            task_id="task_test",
+            function_name="a",
+            payload='{}',
+        )
+        returned_payload = Mock()
+        returned_payload.read().decode.return_value = '{"bucket": "my-bucket"}'
+        mock_invoke.return_value = {
+            "ResponseMetadata": "",
+            "StatusCode": 200,
+            "Payload": returned_payload,
+        }
+        value = operator.execute(None)
+        assert value == '{"bucket": "my-bucket"}'
+        assert isinstance(value, str)
+
     def test_template_fields(self):
         operator = LambdaInvokeFunctionOperator(
             task_id="task_test",


### PR DESCRIPTION
## Description

`LambdaInvokeFunctionOperator.execute()` currently always returns the Lambda response payload as a string via `payload_stream.read().decode()`. When a Lambda function returns a JSON object (e.g., `{"bucket": "my-bucket", "prefix": "data/"}`), the XCom value is stored as the string `'{"bucket": "my-bucket", "prefix": "data/"}'`, not as a Python dict.

This makes it impossible to access individual keys from the response in downstream task templates:

```python
# Raises TypeError because XCom value is a string, not a dict
bucket = "{{ ti.xcom_pull(task_ids='get_config')['bucket'] }}"
```

This PR adds a `deserialize_payload` boolean parameter (default `False` for backward compatibility) that, when set to `True`, applies `json.loads()` to the payload before returning it from `execute()`.

```python
# In execute():
payload = payload_stream.read().decode()
if self.deserialize_payload:
    payload = json.loads(payload)
return payload
```

## Use case / motivation

I'm using [Amazon MWAA Serverless](https://docs.aws.amazon.com/mwaa/latest/mwaa-serverless-userguide/what-is-mwaa-serverless.html), which defines workflows in YAML rather than Python DAGs. In this environment:

- There is no `PythonOperator` available to post-process XCom values with `json.loads()`
- `render_template_as_native_obj` cannot be set (no DAG-level Python configuration)
- Subclassing the operator is not possible (YAML references operators by class path)
- Jinja2 `| fromjson` filter is not registered

The only workaround is to split the Lambda invocation into separate tasks — one per output value — which increases both complexity and cost (MWAA Serverless charges per task instance with a 1-minute minimum).

A simple `deserialize_payload: true` in the YAML definition solves this entirely:

```yaml
get_config:
  operator: airflow.providers.amazon.aws.operators.lambda_function.LambdaInvokeFunctionOperator
  task_id: get_config
  function_name: get-config
  payload: '{}'
  deserialize_payload: true
use_config:
  operator: ...
  bucket: "{{ ti.xcom_pull(task_ids='get_config')['bucket'] }}"
  dependencies:
    - get_config
```

A callable-based approach like `SimpleHttpOperator`'s `response_filter` would not work in YAML-only environments since callables cannot be specified in YAML workflow definitions. A simple boolean flag is more appropriate for this use case, and also benefits standard Airflow users who currently need an extra task or custom operator subclass just to parse the Lambda response.

## Tests

- Added test for `deserialize_payload=True`: verifies that `execute()` returns a dict
- Added test for default behavior (`deserialize_payload=False`): verifies backward compatibility (returns string)