### PR TITLE
Fix CI regression of "Improve OpenAI provider metadata"

### DIFF
--- a/providers/openai/provider.yaml
+++ b/providers/openai/provider.yaml
@@ -63,14 +63,14 @@ integrations:
     how-to-guide:
       - /docs/apache-airflow-providers-openai/operators/openai.rst
     tags:
-  - ai
-  - openai
-  - machine-learning
-  - generative-ai
-  - llm
-  - text-generation
-  - embeddings
-  - ai-inference
+      - ai
+      - openai
+      - machine-learning
+      - generative-ai
+      - llm
+      - text-generation
+      - embeddings
+      - ai-inference
 
 hooks:
   - integration-name: OpenAI


### PR DESCRIPTION
 
* related: #61054

## Why

Fix main CI failure:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

instance = {'connection-types': [{'connection-type': 'openai', 'hook-class-name': 'airflow.providers.openai.hooks.openai.OpenAIHo...go': '/docs/integration-logos/OpenAI.png', ...}, 'ai', 'openai', 'machine-learning', 'generative-ai', 'llm', ...], ...}
schema = {'$schema': 'http://json-schema.org/draft-07/schema#', 'definitions': {'option': {'additional_properties': False, 'pro...egration-name', 'python-modules'], 'type': 'object'}, 'type': 'array'}, ...}, 'required': ['name', 'description'], ...}
cls = <class 'jsonschema.validators.Draft7Validator'>, args = (), kwargs = {}
validator = Draft7Validator(schema={'$schema': 'http://json-...ft-07/schema#', 'definitions': {'option': {'additional_properties':...n-modules'], 'type': 'object'}, 'type': 'array'}, ...}, 'required': ['name', 'description'], ...}, format_checker=None)
error = <ValidationError: "'ai-inference' is not of type 'object'">

    def validate(instance, schema, cls=None, *args, **kwargs):  # noqa: D417
        """
        Validate an instance under the given schema.
    
            >>> validate([2, 3, 4], {"maxItems": 2})
            Traceback (most recent call last):
                ...
            ValidationError: [2, 3, 4] is too long
    
        :func:`~jsonschema.validators.validate` will first verify that the
        provided schema is itself valid, since not doing so can lead to less
        obvious error messages and fail in less obvious or consistent ways.
    
        If you know you have a valid schema already, especially
        if you intend to validate multiple instances with
        the same schema, you likely would prefer using the
        `jsonschema.protocols.Validator.validate` method directly on a
        specific validator (e.g. ``Draft202012Validator.validate``).
    
    
        Arguments:
    
            instance:
    
                The instance to validate
    
            schema:
    
                The schema to validate with
    
            cls (jsonschema.protocols.Validator):
    
                The class that will be used to validate the instance.
    
        If the ``cls`` argument is not provided, two things will happen
        in accordance with the specification. First, if the schema has a
        :kw:`$schema` keyword containing a known meta-schema [#]_ then the
        proper validator will be used. The specification recommends that
        all schemas contain :kw:`$schema` properties for this reason. If no
        :kw:`$schema` property is found, the default validator class is the
        latest released draft.
    
        Any other provided positional and keyword arguments will be passed
        on when instantiating the ``cls``.
    
        Raises:
    
            `jsonschema.exceptions.ValidationError`:
    
                if the instance is invalid
    
            `jsonschema.exceptions.SchemaError`:
    
                if the schema itself is invalid
    
        .. rubric:: Footnotes
        .. [#] known by a validator registered with
            `jsonschema.validators.validates`
    
        """
        if cls is None:
            cls = validator_for(schema)
    
        cls.check_schema(schema)
        validator = cls(schema, *args, **kwargs)
        error = exceptions.best_match(validator.iter_errors(instance))
        if error is not None:
>           raise error
E           jsonschema.exceptions.ValidationError: 'ai-inference' is not of type 'object'
E           
E           Failed validating 'type' in schema['properties']['integrations']['items']:
E               {'type': 'object',
E                'properties': {'integration-name': {'description': 'Name of the '
E                                                                   'integrations to '
E                                                                   'expose by the '
E                                                                   'provider',
E                                                    'type': 'string'},
E                               'external-doc-url': {'description': 'URL that '
E                                                                   'describes the '
E                                                                   'integration',
E                                                    'type': 'string'},
E                               'logo': {'description': 'URL or  path on the airflow '
E                                                       'side where you can find the '
E                                                       'logo',
E                                        'type': 'string'},
E                               'tags': {'description': 'Tags describing the '
E                                                       'integration (free-form)',
E                                        'type': 'array',
E                                        'items': {'type': 'string'}}}}
E           
E           On instance['integrations'][8]:
E               'ai-inference'

/home/runner/.local/share/uv/tools/apache-airflow-breeze/lib/python3.10/site-packages/jsonschema/validators.py:1332: ValidationError

During handling of the above exception, another exception occurred:

    def test_validate_provider_info_with_schema():
        for provider in get_available_distributions():
>           validate_provider_info_with_runtime_schema(get_provider_info_dict(provider))

/home/runner/work/airflow/airflow/dev/breeze/tests/test_packages.py:252: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/runner/work/airflow/airflow/dev/breeze/src/airflow_breeze/utils/packages.py:254: in get_provider_info_dict
    validate_provider_info_with_runtime_schema(provider_yaml_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below) OpenAI Codex
