### PR TITLE
Fix OpenAI provider get_provider_info

### DIFF
--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -84,29 +84,35 @@
                         "type": "string"
                     },
                     "tags": {
-                        "description": "List of tags describing the integration. While we're using RST, only one tag is supported per integration.",
+                        "description": "List of tags describing the integration.",
                         "type": "array",
                         "items": {
                             "type": "string",
                             "enum": [
                                 "ai",
+                                "ai-inference",
                                 "alibaba",
                                 "apache",
                                 "aws",
                                 "azure",
                                 "dbt",
+                                "embeddings",
                                 "gcp",
+                                "generative-ai",
                                 "gmp",
                                 "google",
                                 "kafka",
+                                "llm",
+                                "machine-learning",
+                                "openai",
                                 "protocol",
                                 "service",
                                 "software",
+                                "text-generation",
                                 "yandex"
                             ]
                         },
-                        "minItems": 1,
-                        "maxItems": 1
+                        "minItems": 1
                     }
                 },
                 "additionalProperties": false,

--- a/dev/breeze/src/airflow_breeze/commands/pr_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/pr_commands.py
@@ -422,9 +422,7 @@ def _process_check_contexts(contexts: list[dict], total_count: int) -> tuple[str
     return summary, failed, has_test_checks
 
 
-def _fetch_check_status_counts(
-    token: str, github_repository: str, head_sha: str
-) -> dict[str, int]:
+def _fetch_check_status_counts(token: str, github_repository: str, head_sha: str) -> dict[str, int]:
     """Fetch counts of checks by status for a commit. Returns a dict like {"SUCCESS": 5, "FAILURE": 2, ...}.
 
     Also includes an "IN_PROGRESS" key for checks still running.
@@ -491,10 +489,20 @@ def _format_check_status_counts(counts: dict[str, int]) -> str:
     parts = []
     # Show in a consistent order: failures first, then in-progress, then success, then others
     order = [
-        "FAILURE", "TIMED_OUT", "ERROR", "STARTUP_FAILURE", "ACTION_REQUIRED",
-        "IN_PROGRESS", "QUEUED", "PENDING",
-        "SUCCESS", "EXPECTED",
-        "CANCELLED", "SKIPPED", "NEUTRAL", "STALE",
+        "FAILURE",
+        "TIMED_OUT",
+        "ERROR",
+        "STARTUP_FAILURE",
+        "ACTION_REQUIRED",
+        "IN_PROGRESS",
+        "QUEUED",
+        "PENDING",
+        "SUCCESS",
+        "EXPECTED",
+        "CANCELLED",
+        "SKIPPED",
+        "NEUTRAL",
+        "STALE",
     ]
     shown = set()
     for status in order:
@@ -839,10 +847,7 @@ def _classify_already_triaged_prs(
             for comment in comments:
                 comment_author = (comment.get("author") or {}).get("login", "")
                 comment_date = comment.get("createdAt", "")
-                if (
-                    comment_author == pr.author_login
-                    and comment_date > triage_comment_date
-                ):
+                if comment_author == pr.author_login and comment_date > triage_comment_date:
                     author_responded = True
                     break
 
@@ -2213,10 +2218,10 @@ def _display_pr_overview_table(
         )
     get_console().print(pr_table)
     get_console().print(
-        f"  Triage: [green]Ready for review[/] = ready for maintainer review  "
-        f"[yellow]Waiting for Author[/] = triaged, no response  "
-        f"[bright_cyan]Responded[/] = author replied  "
-        f"[blue]-[/] = not yet triaged"
+        "  Triage: [green]Ready for review[/] = ready for maintainer review  "
+        "[yellow]Waiting for Author[/] = triaged, no response  "
+        "[bright_cyan]Responded[/] = author replied  "
+        "[blue]-[/] = not yet triaged"
     )
     if collab_count:
         get_console().print(

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -72,6 +72,7 @@ apache-airflow-providers-openai package
 Enables interaction with OpenAI APIs for text generation, embeddings,
 and other AI-powered workflows directly from Airflow DAGs.
 
+
 Release: 1.7.2
 
 Provider package

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -68,8 +68,9 @@
 apache-airflow-providers-openai package
 ------------------------------------------------------
 
-`OpenAI <https://platform.openai.com/docs/introduction>`__
-
+`OpenAI <https://platform.openai.com/docs/introduction>`__ provider for Apache Airflow.
+Enables interaction with OpenAI APIs for text generation, embeddings,
+and other AI-powered workflows directly from Airflow DAGs.
 
 Release: 1.7.2
 

--- a/providers/openai/src/airflow/providers/openai/get_provider_info.py
+++ b/providers/openai/src/airflow/providers/openai/get_provider_info.py
@@ -25,14 +25,23 @@ def get_provider_info():
     return {
         "package-name": "apache-airflow-providers-openai",
         "name": "OpenAI",
-        "description": "`OpenAI <https://platform.openai.com/docs/introduction>`__\n",
+        "description": "`OpenAI <https://platform.openai.com/docs/introduction>`__ provider for Apache Airflow.\nEnables interaction with OpenAI APIs for text generation, embeddings,\nand other AI-powered workflows directly from Airflow DAGs.\n",
         "integrations": [
             {
                 "integration-name": "OpenAI",
                 "external-doc-url": "https://platform.openai.com/docs/introduction",
                 "logo": "/docs/integration-logos/OpenAI.png",
                 "how-to-guide": ["/docs/apache-airflow-providers-openai/operators/openai.rst"],
-                "tags": ["software"],
+                "tags": [
+                    "ai",
+                    "openai",
+                    "machine-learning",
+                    "generative-ai",
+                    "llm",
+                    "text-generation",
+                    "embeddings",
+                    "ai-inference",
+                ],
             }
         ],
         "hooks": [


### PR DESCRIPTION
- realted: https://github.com/apache/airflow/pull/63403

## Why

The `/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py` is still failing. We need to edit the `airflow-core/src/airflow/provider.yaml.schema.json` and `providers/openai/src/airflow/providers/openai/get_provider_info.py` to get them pass.


```
  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py", line 771, in <module>
      all_parsed_yaml_files: dict[str, dict] = _load_package_data(paths)
    File "/opt/airflow/scripts/in_container/run_provider_yaml_files_check.py", line 163, in _load_package_data
      raise RuntimeError(msg)
  RuntimeError: Unable to parse: /opt/airflow/providers/openai/provider.yaml. Original error ValidationError: ['ai', 'openai', 'machine-learning', 'generative-ai', 'llm', 'text-generation', 'embeddings', 'ai-inference'] is too long

  Failed validating 'maxItems' in schema['properties']['integrations']['items']['properties']['tags']:
      {'description': "List of tags describing the integration. While we're "
                      'using RST, only one tag is supported per integration.',
       'type': 'array',
       'items': {'type': 'string',
                 'enum': ['ai',
                          'alibaba',
                          'apache',
                          'aws',
                          'azure',
                          'dbt',
                          'gcp',
                          'gmp',
                          'google',
                          'kafka',
                          'protocol',
                          'service',
                          'software',
                          'yandex']},
       'minItems': 1,
       'maxItems': 1}

  On instance['integrations'][0]['tags']:
      ['ai',
       'openai',
       'machine-learning',
       'generative-ai',
       'llm',
       'text-generation',
       'embeddings',
       'ai-inference']
  Error 1 returned
```