### PR TITLE
fix(api): prevent duplicate Date headers in responses

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -173,6 +173,10 @@ def init_middlewares(app: FastAPI) -> None:
 
         app.add_middleware(SimpleAllAdminMiddleware)
 
+    from airflow.api_fastapi.core_api.middlewares import add_middleware
+
+    add_middleware(app)
+
     # GZipMiddleware must be inside HttpAccessLogMiddleware so that access logs capture
     # the full end-to-end duration including compression time.
     # See https://github.com/apache/airflow/issues/60165

--- a/airflow-core/src/airflow/api_fastapi/core_api/middlewares/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/middlewares/__init__.py
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+
+def add_middleware(app: FastAPI) -> None:
+    from airflow.api_fastapi.core_api.middlewares.header import StripAppDateMiddleware
+
+    app.add_middleware(StripAppDateMiddleware)

--- a/airflow-core/src/airflow/api_fastapi/core_api/middlewares/header.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/middlewares/header.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class StripAppDateMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to strip date headers.
+
+    This middleware is used to ensure that the date header is not duplicated
+    in the response.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        del response.headers["date"]
+        return response

--- a/airflow-core/tests/unit/api_fastapi/core_api/middlewares/__init__.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/middlewares/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/api_fastapi/core_api/middlewares/test_header.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/middlewares/test_header.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Request, Response
+from starlette.datastructures import MutableHeaders
+
+from airflow.api_fastapi.core_api.middlewares.header import StripAppDateMiddleware
+
+
+class TestStripAppDateMiddleware:
+    @pytest.fixture
+    def middleware(self):
+        return StripAppDateMiddleware(app=MagicMock())
+
+    @pytest.fixture
+    def mock_request(self):
+        request = MagicMock(spec=Request)
+        return request
+
+    @pytest.fixture
+    def mock_response(self):
+        response = MagicMock(spec=Response)
+        response.headers = MutableHeaders({"content-type": "application/json"})
+        return response
+
+    @pytest.mark.asyncio
+    async def test_dispatch_removes_date_header(self, middleware, mock_request, mock_response):
+        """Ensure the middleware removes the 'date' header from the response."""
+        mock_response.headers["date"] = "Thu, 12 Mar 2026 12:00:00 GMT"
+        call_next = AsyncMock(return_value=mock_response)
+        result = await middleware.dispatch(mock_request, call_next)
+
+        assert "date" not in result.headers
+        assert result.headers["content-type"] == "application/json"
+        call_next.assert_called_once_with(mock_request)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_handles_missing_date_header(self, middleware, mock_request, mock_response):
+        """Ensure the middleware doesn't crash if 'date' is already absent."""
+        call_next = AsyncMock(return_value=mock_response)
+        await middleware.dispatch(mock_request, call_next)
+
+        assert "date" not in mock_response.headers
+        assert mock_response.headers["content-type"] == "application/json"
+        call_next.assert_called_once_with(mock_request)


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/64678

##### Description
The deployment environments result in a duplicated Date header—one generated by the Flask application layer and another by the ASGI server. This PR introduce `StripAppDateMiddleware` to remove the 'Date' header generated by the application layer, ensuring that only one 'Date' header exists in the final response.
```
$ curl -I localhost:8080/auth/static/pin_32.png 
HTTP/1.1 200 OK
date: Thu, 12 Mar 2026 04:38:44 GMT <-- SENT BY uvicorn
server: uvicorn
content-disposition: inline; filename=pin_32.png
content-type: image/png
content-length: 1201
last-modified: Thu, 12 Mar 2026 01:43:44 GMT
cache-control: no-cache
etag: "1773279824.6871002-1201-1792155666"
date: Thu, 12 Mar 2026 04:38:44 GMT <-- DUPLICATE SENT BY FLASK
vary: Cookie
```
##### Changes
- New Middleware: Added `StripAppDateMiddleware` to intercept outgoing responses.
- App Integration: Registered the middleware in the `FastAPI` initialization flow.
- Unit Tests: Added automated tests to verify the header is removed from the response.
##### How to Verify
Unit test suite:
1. Mocks a FastAPI request through the middleware.
2. Asserts that the `date` key is no longer present in the `response.headers`.

Manual:
1. Run the api-server.
2. Make a request using curl.
    ```
    $ curl -I localhost:8080/auth/static/pin_32.png 
    ```
4. Confirm no duplicate date header.