### PR TITLE
Run DB check only for core components in prod entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1417,6 +1417,10 @@ EOF
 COPY <<"EOF" /entrypoint_prod.sh
 #!/usr/bin/env bash
 AIRFLOW_COMMAND="${1:-}"
+AIRFLOW_COMMAND_TO_RUN="${AIRFLOW_COMMAND}"
+if [[ "${AIRFLOW_COMMAND}" == "airflow" ]]; then
+    AIRFLOW_COMMAND_TO_RUN="${2:-}"
+fi
 
 set -euo pipefail
 
@@ -1668,7 +1672,8 @@ readonly CONNECTION_CHECK_SLEEP_TIME
 
 create_system_user_if_missing
 set_pythonpath_for_root_user
-if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
+if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]] \
+    && [[ ${AIRFLOW_COMMAND_TO_RUN} =~ ^(scheduler|dag-processor|triggerer|api-server)$ ]]; then
     wait_for_airflow_db
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1420,6 +1420,10 @@ AIRFLOW_COMMAND="${1:-}"
 AIRFLOW_COMMAND_TO_RUN="${AIRFLOW_COMMAND}"
 if [[ "${AIRFLOW_COMMAND}" == "airflow" ]]; then
     AIRFLOW_COMMAND_TO_RUN="${2:-}"
+elif [[ "${AIRFLOW_COMMAND}" =~ ^(bash|sh)$ ]] \
+    && [[ "${2:-}" == "-c" ]] \
+    && [[ "${3:-}" =~ (^|[[:space:]])(exec[[:space:]]+)?airflow[[:space:]]+(scheduler|dag-processor|triggerer|api-server)([[:space:]]|$) ]]; then
+    AIRFLOW_COMMAND_TO_RUN="${BASH_REMATCH[3]}"
 fi
 
 set -euo pipefail

--- a/scripts/docker/entrypoint_prod.sh
+++ b/scripts/docker/entrypoint_prod.sh
@@ -17,6 +17,10 @@
 # under the License.
 # Might be empty
 AIRFLOW_COMMAND="${1:-}"
+AIRFLOW_COMMAND_TO_RUN="${AIRFLOW_COMMAND}"
+if [[ "${AIRFLOW_COMMAND}" == "airflow" ]]; then
+    AIRFLOW_COMMAND_TO_RUN="${2:-}"
+fi
 
 set -euo pipefail
 
@@ -283,7 +287,8 @@ readonly CONNECTION_CHECK_SLEEP_TIME
 
 create_system_user_if_missing
 set_pythonpath_for_root_user
-if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
+if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]] \
+    && [[ ${AIRFLOW_COMMAND_TO_RUN} =~ ^(scheduler|dag-processor|triggerer|api-server)$ ]]; then
     wait_for_airflow_db
 fi
 
@@ -316,8 +321,7 @@ if [[ -n "${_PIP_ADDITIONAL_REQUIREMENTS=}" ]] ; then
 fi
 
 
-# The `bash` and `python` commands should also verify the basic connections
-# So they are run after the DB check
+# Handle direct `bash` and `python` passthrough commands.
 exec_to_bash_or_python_command_if_specified "${@}"
 
 # Remove "airflow" if it is specified as airflow command

--- a/scripts/docker/entrypoint_prod.sh
+++ b/scripts/docker/entrypoint_prod.sh
@@ -20,6 +20,10 @@ AIRFLOW_COMMAND="${1:-}"
 AIRFLOW_COMMAND_TO_RUN="${AIRFLOW_COMMAND}"
 if [[ "${AIRFLOW_COMMAND}" == "airflow" ]]; then
     AIRFLOW_COMMAND_TO_RUN="${2:-}"
+elif [[ "${AIRFLOW_COMMAND}" =~ ^(bash|sh)$ ]] \
+    && [[ "${2:-}" == "-c" ]] \
+    && [[ "${3:-}" =~ (^|[[:space:]])(exec[[:space:]]+)?airflow[[:space:]]+(scheduler|dag-processor|triggerer|api-server)([[:space:]]|$) ]]; then
+    AIRFLOW_COMMAND_TO_RUN="${BASH_REMATCH[3]}"
 fi
 
 set -euo pipefail


### PR DESCRIPTION
Closes #60271 

Restrict entrypoint DB check to scheduler, dag-processor, triggerer, and api-server. Skip DB check for worker/task/interactive commands to avoid direct metadata DB dependency in worker pods.