### PR TITLE
Fix missing index recreation in downgrade of migration 0096_3_2_0_remove_team_id

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
+++ b/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
@@ -139,6 +139,7 @@ def downgrade():
             )
 
     with op.batch_alter_table("dag_bundle_team") as batch_op:
+        batch_op.create_index("idx_dag_bundle_team_team_id", ["team_id"])
         batch_op.create_foreign_key(
             "dag_bundle_team_team_id_fkey",
             "team",


### PR DESCRIPTION
Added the missing create_index("idx_dag_bundle_team_team_id", ["team_id"]) in the downgrade() of migration 0096.

closes: [63423](https://github.com/apache/airflow/issues/63423)

- [ ] Yes (please specify the tool below)
   No

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
