### PR TITLE
docs: add host vs container context note to Breeze quick start for new contributors

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -240,6 +240,9 @@ Forking and cloning Project
 Configuring prek
 ----------------
 
+.. note::
+   Run the commands in this section in your **local terminal** (on your host machine), not inside a Breeze shell. Prek hooks run on your host to check and format code before you commit.
+
 Before committing changes to github or raising a pull request, the code needs to be checked for certain quality standards
 such as spell check, code syntax, code formatting, compatibility with Apache License requirements etc. This set of
 tests are applied when you commit your code.


### PR DESCRIPTION
Currently the "Configuring prek" section in the contributor quick start
does not specify where to run the commands. New contributors who have
just entered a Breeze shell may try running prek inside the container
and get confusing errors.

This change adds a short note at the start of the section clarifying
that prek commands should be run on the host machine, not inside Breeze.

This directly addresses the host vs. container context confusion that
affects both human contributors and AI coding agents working on Airflow.

Related: #62500