### PR TITLE
Fix migration 0096 downgrade failing when team table has rows

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
+++ b/airflow-core/src/airflow/migrations/versions/0096_3_2_0_remove_team_id.py
@@ -94,6 +94,8 @@ def upgrade():
 
 
 def downgrade():
+    import uuid as uuid_mod
+
     # Drop FKs pointing to name
     for table in ("connection", "variable", "slot_pool"):
         with op.batch_alter_table(table) as batch_op:
@@ -103,11 +105,23 @@ def downgrade():
         batch_op.drop_constraint("dag_bundle_team_team_name_fkey", type_="foreignkey")
         batch_op.drop_index("idx_dag_bundle_team_team_name")
 
-    # Add back team.id
+    # Add back team.id — nullable first so existing rows don't fail
     with op.batch_alter_table("team") as batch_op:
         batch_op.drop_constraint("team_pkey", type_="primary")
-        batch_op.add_column(sa.Column("id", sa.String(36), nullable=False))
+        batch_op.add_column(sa.Column("id", sa.String(36), nullable=True))
         batch_op.create_unique_constraint("team_name_uq", ["name"])
+
+    # Generate UUIDs for existing team rows
+    conn = op.get_bind()
+    teams = conn.execute(sa.text("SELECT name FROM team")).fetchall()
+    for team in teams:
+        conn.execute(
+            sa.text("UPDATE team SET id = :id WHERE name = :name"),
+            {"id": str(uuid_mod.uuid4()), "name": team.name},
+        )
+
+    with op.batch_alter_table("team") as batch_op:
+        batch_op.alter_column("id", existing_type=sa.String(36), nullable=False)
         batch_op.create_primary_key("team_pkey", ["id"])
 
     # Rename team_name → team_id
@@ -127,6 +141,21 @@ def downgrade():
             type_=sa.String(36),
             nullable=False,
         )
+
+    # Convert team name values back to generated UUIDs in referencing tables
+    for table in ("connection", "variable", "slot_pool"):
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET team_id = "
+                f"(SELECT id FROM team WHERE name = {table}.team_id) "
+                f"WHERE team_id IS NOT NULL"
+            )
+        )
+    conn.execute(
+        sa.text(
+            "UPDATE dag_bundle_team SET team_id = (SELECT id FROM team WHERE name = dag_bundle_team.team_id)"
+        )
+    )
 
     # Re-create FK on old id
     for table in ("connection", "variable", "slot_pool"):


### PR DESCRIPTION
The downgrade() in 0096_3_2_0_remove_team_id.py tries to ADD COLUMN id VARCHAR(36) NOT NULL on the team table without providing a default or populating existing rows first.


* closes: https://github.com/apache/airflow/issues/63444

**Testing**
<img width="1476" height="807" alt="image" src="https://github.com/user-attachments/assets/22db47eb-7925-4476-993d-6e4d78bdd5bd" />

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)
   Claude


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
