### PR TITLE
improve e2e tests for dag audit log

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -38,7 +38,7 @@ export class EventsPage extends BasePage {
     this.extraColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "Extra" });
     this.filterBar = page
       .locator("div")
-      .filter({ has: page.getByRole("button", { name: "Filter" }) })
+      .filter({ has: page.getByTestId("add-filter-button") })
       .first();
     this.ownerColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "User" });
     this.tableRows = this.eventsTable.locator("tbody").getByRole("row");
@@ -50,7 +50,7 @@ export class EventsPage extends BasePage {
   }
 
   public async addFilter(filterName: string): Promise<void> {
-    const filterButton = this.page.getByRole("button", { name: "Filter" });
+    const filterButton = this.page.getByTestId("add-filter-button");
 
     await filterButton.click();
 

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -56,7 +56,7 @@ export class EventsPage extends BasePage {
 
     const filterMenu = this.page.getByRole("menu");
 
-    await expect(filterMenu).toBeVisible({ timeout: 5000 });
+    await expect(filterMenu).toBeVisible({ timeout: 10_000 });
 
     const menuItem = filterMenu.getByRole("menuitem", { name: filterName });
 
@@ -136,10 +136,13 @@ export class EventsPage extends BasePage {
       await filterPill.click();
     }
 
-    // Wait for input to appear and fill it
-    const filterInput = this.page.getByPlaceholder(filterLabel, { exact: false });
+    const filterInput = this.page
+      .locator("div")
+      .filter({ hasText: `${filterLabel}:` })
+      .locator("input")
+      .first();
 
-    await expect(filterInput).toBeVisible({ timeout: 5000 });
+    await expect(filterInput).toBeVisible({ timeout: 10_000 });
     await filterInput.fill(value);
     await filterInput.press("Enter");
     await this.waitForTableLoad();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -54,9 +54,9 @@ export class EventsPage extends BasePage {
 
     await filterButton.click();
 
-    const filterMenu = this.page.locator('[role="menu"][data-state="open"]');
+    const filterMenu = this.page.getByRole("menu");
 
-    await filterMenu.waitFor({ state: "visible", timeout: 5000 });
+    await expect(filterMenu).toBeVisible({ timeout: 5000 });
 
     const menuItem = filterMenu.getByRole("menuitem", { name: filterName });
 
@@ -106,7 +106,7 @@ export class EventsPage extends BasePage {
   }
 
   public getFilterPill(filterLabel: string): Locator {
-    return this.page.locator(`button:has-text("${filterLabel}:")`);
+    return this.page.getByRole("button", { name: `${filterLabel}:` });
   }
 
   public async getTableRowCount(): Promise<number> {
@@ -132,54 +132,37 @@ export class EventsPage extends BasePage {
   public async setFilterValue(filterLabel: string, value: string): Promise<void> {
     const filterPill = this.getFilterPill(filterLabel);
 
-    if ((await filterPill.count()) > 0) {
+    if (await filterPill.isVisible()) {
       await filterPill.click();
     }
 
     // Wait for input to appear and fill it
-    const filterInput = this.page.locator(`input[placeholder*="${filterLabel}" i], input`).last();
+    const filterInput = this.page.getByPlaceholder(filterLabel, { exact: false });
 
-    await filterInput.waitFor({ state: "visible", timeout: 5000 });
+    await expect(filterInput).toBeVisible({ timeout: 5000 });
     await filterInput.fill(value);
     await filterInput.press("Enter");
     await this.waitForTableLoad();
   }
 
   public async verifyLogEntriesWithData(): Promise<void> {
-    const rows = await this.getEventLogRows();
+    await expect(this.tableRows).not.toHaveCount(0);
 
-    if (rows.length === 0) {
-      throw new Error("No log entries found");
-    }
-
-    const [firstRow] = rows;
-
-    if (!firstRow) {
-      throw new Error("First row is undefined");
-    }
-
+    const firstRow = this.tableRows.first();
     const whenCell = await this.getCellByColumnName(firstRow, "When");
     const eventCell = await this.getCellByColumnName(firstRow, "Event");
     const userCell = await this.getCellByColumnName(firstRow, "User");
 
-    const whenText = await whenCell.textContent();
-    const eventText = await eventCell.textContent();
-    const userText = await userCell.textContent();
-
-    expect(whenText?.trim()).toBeTruthy();
-    expect(eventText?.trim()).toBeTruthy();
-    expect(userText?.trim()).toBeTruthy();
+    await expect(whenCell).toHaveText(/.+/);
+    await expect(eventCell).toHaveText(/.+/);
+    await expect(userCell).toHaveText(/.+/);
   }
 
   public async verifyTableColumns(): Promise<void> {
-    const headers = await this.eventsTable.locator("thead th").allTextContents();
-    const expectedColumns = ["When", "Event", "User", "Extra"];
-
-    for (const col of expectedColumns) {
-      if (!headers.some((h) => h.toLowerCase().includes(col.toLowerCase()))) {
-        throw new Error(`Expected column "${col}" not found in headers: ${headers.join(", ")}`);
-      }
-    }
+    await expect(this.whenColumn).toBeVisible();
+    await expect(this.eventColumn).toBeVisible();
+    await expect(this.ownerColumn).toBeVisible();
+    await expect(this.extraColumn).toBeVisible();
   }
 
   public async waitForEventsTable(): Promise<void> {

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -156,9 +156,9 @@ export class EventsPage extends BasePage {
     const eventCell = await this.getCellByColumnName(firstRow, "Event");
     const userCell = await this.getCellByColumnName(firstRow, "User");
 
-    await expect(whenCell).toHaveText(/.+/);
-    await expect(eventCell).toHaveText(/.+/);
-    await expect(userCell).toHaveText(/.+/);
+    await expect(whenCell).toHaveText(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+    await expect(eventCell).toHaveText(/[a-z][_a-z]*/);
+    await expect(userCell).toHaveText(/\w+/);
   }
 
   public async verifyTableColumns(): Promise<void> {

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -136,11 +136,7 @@ export class EventsPage extends BasePage {
       await filterPill.click();
     }
 
-    const filterInput = this.page
-      .locator("div")
-      .filter({ hasText: `${filterLabel}:` })
-      .locator("input")
-      .first();
+    const filterInput = this.page.getByRole("textbox", { name: filterLabel });
 
     await expect(filterInput).toBeVisible({ timeout: 10_000 });
     await filterInput.fill(value);

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -175,7 +175,7 @@ export class EventsPage extends BasePage {
   public async waitForTableLoad(): Promise<void> {
     await expect(this.eventsTable).toBeVisible({ timeout: 60_000 });
 
-    const skeleton = this.eventsTable.locator('[data-scope="skeleton"]');
+    const skeleton = this.eventsTable.locator('[data-testid="skeleton"]');
 
     await expect(skeleton).toHaveCount(0, { timeout: 60_000 });
 

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -32,17 +32,17 @@ export class EventsPage extends BasePage {
 
   public constructor(page: Page) {
     super(page);
-    this.eventsPageTitle = page.locator('h2:has-text("Audit Log")');
-    this.eventsTable = page.locator('[data-testid="table-list"]');
-    this.eventColumn = this.eventsTable.locator('th:has-text("Event")');
-    this.extraColumn = this.eventsTable.locator('th:has-text("Extra")');
+    this.eventsPageTitle = page.getByRole("heading", { level: 2, name: "Audit Log" });
+    this.eventsTable = page.getByTestId("table-list");
+    this.eventColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "Event" });
+    this.extraColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "Extra" });
     this.filterBar = page
       .locator("div")
-      .filter({ has: page.locator('button:has-text("Filter")') })
+      .filter({ has: page.getByRole("button", { name: "Filter" }) })
       .first();
-    this.ownerColumn = this.eventsTable.locator('th:has-text("User")');
-    this.tableRows = this.eventsTable.locator("tbody tr");
-    this.whenColumn = this.eventsTable.locator('th:has-text("When")');
+    this.ownerColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "User" });
+    this.tableRows = this.eventsTable.locator("tbody").getByRole("row");
+    this.whenColumn = this.eventsTable.getByRole("columnheader").filter({ hasText: "When" });
   }
 
   public static getEventsUrl(dagId: string): string {
@@ -50,7 +50,7 @@ export class EventsPage extends BasePage {
   }
 
   public async addFilter(filterName: string): Promise<void> {
-    const filterButton = this.page.locator('button:has-text("Filter")');
+    const filterButton = this.page.getByRole("button", { name: "Filter" });
 
     await filterButton.click();
 
@@ -58,7 +58,7 @@ export class EventsPage extends BasePage {
 
     await filterMenu.waitFor({ state: "visible", timeout: 5000 });
 
-    const menuItem = filterMenu.locator(`[role="menuitem"]:has-text("${filterName}")`);
+    const menuItem = filterMenu.getByRole("menuitem", { name: filterName });
 
     await menuItem.click();
   }
@@ -190,44 +190,20 @@ export class EventsPage extends BasePage {
    * Wait for table to finish loading
    */
   public async waitForTableLoad(): Promise<void> {
-    await this.eventsTable.waitFor({ state: "visible", timeout: 60_000 });
+    await expect(this.eventsTable).toBeVisible({ timeout: 60_000 });
 
-    await this.page.waitForFunction(
-      () => {
-        const table = document.querySelector('[data-testid="table-list"]');
+    const skeleton = this.eventsTable.locator('[data-scope="skeleton"]');
 
-        if (!table) {
-          return false;
-        }
+    await expect(skeleton).toHaveCount(0, { timeout: 60_000 });
 
-        const skeletons = table.querySelectorAll('[data-scope="skeleton"]');
+    const noDataMessage = this.page.getByText(/no.*events.*found/iu);
 
-        if (skeletons.length > 0) {
-          return false;
-        }
+    await expect(async () => {
+      const rowCount = await this.tableRows.count();
 
-        const rows = table.querySelectorAll("tbody tr");
-
-        for (const row of rows) {
-          const cells = row.querySelectorAll("td");
-          let hasContent = false;
-
-          for (const cell of cells) {
-            if (cell.textContent && cell.textContent.trim().length > 0) {
-              hasContent = true;
-              break;
-            }
-          }
-
-          if (!hasContent) {
-            return false;
-          }
-        }
-
-        return true;
-      },
-      undefined,
-      { timeout: 60_000 },
-    );
+      await (rowCount > 0
+        ? expect(this.tableRows.first().locator("td").first()).toHaveText(/.+/)
+        : expect(noDataMessage).toBeVisible());
+    }).toPass({ timeout: 60_000 });
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -136,7 +136,11 @@ export class EventsPage extends BasePage {
       await filterPill.click();
     }
 
-    const filterInput = this.page.getByRole("textbox", { name: filterLabel });
+    const filterInput = this.page
+      .locator("div")
+      .filter({ has: this.page.getByText(`${filterLabel}:`) })
+      .locator("input")
+      .first();
 
     await expect(filterInput).toBeVisible({ timeout: 10_000 });
     await filterInput.fill(value);

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -42,20 +42,11 @@ test.describe("DAG Audit Log", () => {
     }
 
     await setupEventsPage.navigateToAuditLog(testDagId);
-    await page.waitForFunction(
-      (minCount) => {
-        const table = document.querySelector('[data-testid="table-list"]');
+    await expect(async () => {
+      const count = await setupEventsPage.tableRows.count();
 
-        if (!table) {
-          return false;
-        }
-        const rows = table.querySelectorAll("tbody tr");
-
-        return rows.length >= minCount;
-      },
-      expectedEventCount,
-      { timeout: 60_000 },
-    );
+      expect(count).toBeGreaterThanOrEqual(expectedEventCount);
+    }).toPass({ timeout: 60_000 });
 
     await context.close();
   });
@@ -82,7 +73,7 @@ test.describe("DAG Audit Log", () => {
     await expect(eventsPage.ownerColumn).toBeVisible();
     await expect(eventsPage.extraColumn).toBeVisible();
 
-    const dagIdColumn = eventsPage.eventsTable.locator('th:has-text("DAG ID")');
+    const dagIdColumn = eventsPage.eventsTable.getByRole("columnheader").filter({ hasText: "DAG ID" });
 
     await expect(dagIdColumn).not.toBeVisible();
   });

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -28,7 +28,7 @@ test.describe("DAG Audit Log", () => {
   const triggerCount = 3;
   const expectedEventCount = triggerCount + 1;
 
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
 
   test.beforeAll(async ({ browser }) => {
     test.setTimeout(3 * 60 * 1000);

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -59,10 +59,7 @@ test.describe("DAG Audit Log", () => {
     await eventsPage.navigateToAuditLog(testDagId);
 
     await expect(eventsPage.eventsTable).toBeVisible();
-
-    const rowCount = await eventsPage.tableRows.count();
-
-    expect(rowCount).toBeGreaterThan(0);
+    await expect(eventsPage.tableRows).not.toHaveCount(0);
   });
 
   test("verify expected columns are visible", async () => {
@@ -81,31 +78,15 @@ test.describe("DAG Audit Log", () => {
   test("verify audit log entries display valid data", async () => {
     await eventsPage.navigateToAuditLog(testDagId);
 
-    const rows = await eventsPage.getEventLogRows();
+    await expect(eventsPage.tableRows).not.toHaveCount(0);
 
-    expect(rows.length).toBeGreaterThan(0);
-
-    const [firstRow] = rows;
-
-    if (!firstRow) {
-      throw new Error("No rows found");
-    }
-
+    const firstRow = eventsPage.tableRows.first();
     const whenCell = await eventsPage.getCellByColumnName(firstRow, "When");
     const eventCell = await eventsPage.getCellByColumnName(firstRow, "Event");
     const userCell = await eventsPage.getCellByColumnName(firstRow, "User");
 
-    const whenText = await whenCell.textContent();
-    const eventText = await eventCell.textContent();
-    const userText = await userCell.textContent();
-
-    expect(whenText).toBeTruthy();
-    expect(whenText?.trim()).not.toBe("");
-
-    expect(eventText).toBeTruthy();
-    expect(eventText?.trim()).not.toBe("");
-
-    expect(userText).toBeTruthy();
-    expect(userText?.trim()).not.toBe("");
+    await expect(whenCell).toHaveText(/.+/);
+    await expect(eventCell).toHaveText(/.+/);
+    await expect(userCell).toHaveText(/.+/);
   });
 });

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/dag-audit-log.spec.ts
@@ -85,8 +85,8 @@ test.describe("DAG Audit Log", () => {
     const eventCell = await eventsPage.getCellByColumnName(firstRow, "Event");
     const userCell = await eventsPage.getCellByColumnName(firstRow, "User");
 
-    await expect(whenCell).toHaveText(/.+/);
-    await expect(eventCell).toHaveText(/.+/);
-    await expect(userCell).toHaveText(/.+/);
+    await expect(whenCell).toHaveText(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+    await expect(eventCell).toHaveText(/[a-z][_a-z]*/);
+    await expect(userCell).toHaveText(/\w+/);
   });
 });


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

* closes: #63408
* closes: #63427 
* related: #63036 

### Summary

#### 1. `page.locator('[data-testid="..."]')` → `page.getByTestId("...")`**

`getByTestId` is a semantic, first-class Playwright API for test-id lookups. It's shorter and communicates intent clearly.

#### 2. `:has-text()` → `getByRole()`**

`:has-text()` is a Playwright-specific CSS pseudo-selector extension rather than standard CSS and not resilient to structural changes. `getByRole` queries the accessibility tree, matching how real users and assistive technologies perceive the element.

#### 3. `:has-text()` → `getByRole().filter()`

Capture column header and avoid time-out due to matching issue, narrow by visible text. The `filter()` method uses Playwright's internal text matching rather than a CSS `:has-text()`.

#### 4. `filterBar`, `addFilter()`, `:has-text()` button selectors → `getByRole()`

`getByRole("button", { name: "Filter" })` queries by accessible name, which is exactly how screen readers identify buttons. For the menu items, the accessible name is the item's text, so this works directly without a CSS pseudo-selector.

#### 5. `tableRows`, `locator("tbody tr")` → `locator("tbody").getByRole("row")`

`getByRole("row")` queries by ARIA role rather than HTML tag, making it resilient to markup changes (e.g., if `<tr>` were ever replaced with a `role="row" <div>`). Chaining `.locator("tbody")` first scopes the search to body rows only, excluding the header row.

####  6. `waitForTableLoad()`, `waitForFunction()` → web-first assertions; `beforeAll` polling, `waitForFunction()` → `expect().toPass()`

Same `waitForFunction` anti-pattern. `expect().toPass()` keeps all locator logic in Playwright's layer (with proper retries and error messages), instead of dropping into raw DOM manipulation inside a browser-evaluated function.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude Code (claude-sonnet-4-6)] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
