### PR TITLE
Fix LLMSchemaCompareOperator source count for multi-table db inputs

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
@@ -140,7 +140,7 @@ class LLMSchemaCompareOperator(LLMOperator):
         if self.db_conn_ids and not self.table_names:
             raise ValueError("'table_names' is required when using 'db_conn_ids'.")
 
-        total_sources = len(self.db_conn_ids) + len(self.data_sources)
+        total_sources = len(self.db_conn_ids) * len(self.table_names) + len(self.data_sources)
         if total_sources < 2:
             raise ValueError(
                 "Provide at-least two combinations of 'db_conn_ids' and 'table_names' or 'data_sources' "

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
@@ -99,6 +99,11 @@ class TestLLMSchemaCompareOperator:
                 "at-least two combinations",
                 id="one_datasource_only",
             ),
+            pytest.param(
+                {"db_conn_ids": ["conn"], "table_names": ["t"], "data_sources": []},
+                "at-least two combinations",
+                id="one_db_table_combination_only",
+            ),
         ],
     )
     def test_init_validation(self, kwargs, expected_error):
@@ -123,6 +128,10 @@ class TestLLMSchemaCompareOperator:
                     "data_sources": [_make_ds_config()],
                 },
                 id="one_db_conn_plus_one_datasource",
+            ),
+            pytest.param(
+                {"db_conn_ids": ["postgres_default"], "table_names": ["orders", "customers"]},
+                id="one_db_conn_plus_two_tables",
             ),
             pytest.param(
                 {

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
@@ -99,11 +99,6 @@ class TestLLMSchemaCompareOperator:
                 "at-least two combinations",
                 id="one_datasource_only",
             ),
-            pytest.param(
-                {"db_conn_ids": ["conn"], "table_names": ["t"], "data_sources": []},
-                "at-least two combinations",
-                id="one_db_table_combination_only",
-            ),
         ],
     )
     def test_init_validation(self, kwargs, expected_error):


### PR DESCRIPTION
A single db_conn_id can be used to compare multiple tables in the same database, and those (db_conn_id, table_name) combinations should count toward the minimum required sources to compare tables.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
