### PR TITLE
Instruct agents to never add Co-Authored-By for themselves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ Write commit messages focused on user impact, not implementation details.
 Add a newsfragment for user-visible changes:
 `echo "Brief description" > airflow-core/newsfragments/{PR_NUMBER}.{bugfix|feature|improvement|doc|misc|significant}.rst`
 
+- NEVER add Co-Authored-By with yourself as co-author of the commit. Agents cannot be authors, humans can be, Agents are assistants.
+
 ### Creating Pull Requests
 
 **Always push to the user's fork**, not to the upstream `apache/airflow` repo. Never push


### PR DESCRIPTION
Adds a rule to AGENTS.md instructing AI agents not to add Co-Authored-By
with themselves as co-author. Agents are assistants, not authors — only
humans should be listed as co-authors in commit messages.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)