### PR TITLE
fix(providers/git): force HTTP auth for public repos via extraHeader

### DIFF
--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -288,8 +288,8 @@ class GitDagBundle(BaseDagBundle):
     def _fetch_bare_repo(self):
         refspecs = ["+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"]
         cm = nullcontext()
-        if self.hook and (cmd := self.hook.env.get("GIT_SSH_COMMAND")):
-            cm = self.bare_repo.git.custom_environment(GIT_SSH_COMMAND=cmd)
+        if self.hook and self.hook.env:
+            cm = self.bare_repo.git.custom_environment(**self.hook.env)
         with cm:
             self.bare_repo.remotes.origin.fetch(refspecs)
             self.bare_repo.close()

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -360,8 +360,8 @@ class GitDagBundle(BaseDagBundle):
     def _fetch_bare_repo(self):
         refspecs = ["+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"]
         cm = nullcontext()
-        if self.hook and (cmd := self.hook.env.get("GIT_SSH_COMMAND")):
-            cm = self.bare_repo.git.custom_environment(GIT_SSH_COMMAND=cmd)
+        if self.hook and self.hook.env:
+            cm = self.bare_repo.git.custom_environment(**self.hook.env)
         with cm:
             self.bare_repo.remotes.origin.fetch(refspecs)
             self.bare_repo.close()

--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 import logging
@@ -149,15 +150,34 @@ class GitHook(BaseHook):
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("https://", f"https://{encoded_user}:{encoded_token}@", 1)
+            self._set_http_auth_env()
         elif self.auth_token and self.repo_url.startswith("http://"):
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("http://", f"http://{encoded_user}:{encoded_token}@", 1)
+            self._set_http_auth_env()
         elif self.repo_url.startswith("http://"):
             # if no auth token, use the repo url as is
             pass
         elif not self.repo_url.startswith("git@") and not self.repo_url.startswith("https://"):
             self.repo_url = os.path.expanduser(self.repo_url)
+
+    def _set_http_auth_env(self):
+        """
+        Set git config env vars to force HTTP authentication via extraHeader.
+
+        Git does not send credentials for public repositories since the server
+        does not respond with a 401 challenge. This forces the Authorization
+        header to be sent on every request, allowing authenticated rate limits.
+
+        Uses GIT_CONFIG_* environment variables (git >= 2.31) to inject an
+        ``http.extraHeader`` with a Basic auth token.
+        """
+        credentials = f"{self.user_name}:{self.auth_token}"
+        encoded = base64.b64encode(credentials.encode()).decode()
+        self.env["GIT_CONFIG_COUNT"] = "1"
+        self.env["GIT_CONFIG_KEY_0"] = "http.extraHeader"
+        self.env["GIT_CONFIG_VALUE_0"] = f"Authorization: Basic {encoded}"
 
     def set_git_env(self, key: str | None = None) -> None:
         self.env["GIT_SSH_COMMAND"] = self._build_ssh_command(key)

--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -25,8 +25,11 @@ import os
 import shlex
 import stat
 import tempfile
+from functools import lru_cache
 from typing import Any
 from urllib.parse import quote as urlquote
+
+from git import Git
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook
 
@@ -113,6 +116,14 @@ class GitHook(BaseHook):
 
     _VALID_STRICT_HOST_KEY_CHECKING = frozenset({"yes", "no", "accept-new", "off", "ask"})
 
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _get_git_version_info() -> tuple[int, ...] | None:
+        try:
+            return Git().version_info
+        except Exception:
+            return None
+
     def _build_ssh_command(self, key_path: str | None = None) -> str:
         parts = ["ssh"]
 
@@ -151,18 +162,33 @@ class GitHook(BaseHook):
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("https://", f"https://{encoded_user}:{encoded_token}@", 1)
-            self._set_http_auth_env(original_url)
+            self._set_http_auth_env_if_supported(original_url)
         elif self.auth_token and self.repo_url.startswith("http://"):
             original_url = self.repo_url
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("http://", f"http://{encoded_user}:{encoded_token}@", 1)
-            self._set_http_auth_env(original_url)
+            self._set_http_auth_env_if_supported(original_url)
         elif self.repo_url.startswith("http://"):
             # if no auth token, use the repo url as is
             pass
         elif not self.repo_url.startswith("git@") and not self.repo_url.startswith("https://"):
             self.repo_url = os.path.expanduser(self.repo_url)
+
+    def _set_http_auth_env_if_supported(self, repo_url: str) -> None:
+        git_version = self._get_git_version_info()
+        if git_version is None or git_version >= (2, 31):
+            self._set_http_auth_env(repo_url)
+            return
+
+        version = ".".join(map(str, git_version))
+        log.warning(
+            "Configured auth token for git repository %s, but installed git %s does not support "
+            "the GIT_CONFIG_* env vars required to force HTTP auth for public repositories. "
+            "git >= 2.31 is required.",
+            repo_url,
+            version,
+        )
 
     def _set_http_auth_env(self, repo_url: str) -> None:
         """

--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -147,22 +147,24 @@ class GitHook(BaseHook):
         if not isinstance(self.repo_url, str):
             return
         if self.auth_token and self.repo_url.startswith("https://"):
+            original_url = self.repo_url
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("https://", f"https://{encoded_user}:{encoded_token}@", 1)
-            self._set_http_auth_env()
+            self._set_http_auth_env(original_url)
         elif self.auth_token and self.repo_url.startswith("http://"):
+            original_url = self.repo_url
             encoded_user = urlquote(self.user_name, safe="")
             encoded_token = urlquote(self.auth_token, safe="")
             self.repo_url = self.repo_url.replace("http://", f"http://{encoded_user}:{encoded_token}@", 1)
-            self._set_http_auth_env()
+            self._set_http_auth_env(original_url)
         elif self.repo_url.startswith("http://"):
             # if no auth token, use the repo url as is
             pass
         elif not self.repo_url.startswith("git@") and not self.repo_url.startswith("https://"):
             self.repo_url = os.path.expanduser(self.repo_url)
 
-    def _set_http_auth_env(self):
+    def _set_http_auth_env(self, repo_url: str) -> None:
         """
         Set git config env vars to force HTTP authentication via extraHeader.
 
@@ -171,12 +173,15 @@ class GitHook(BaseHook):
         header to be sent on every request, allowing authenticated rate limits.
 
         Uses GIT_CONFIG_* environment variables (git >= 2.31) to inject an
-        ``http.extraHeader`` with a Basic auth token.
+        ``http.<URL>.extraHeader`` scoped to ``repo_url``. The URL-scoped form
+        ensures the Authorization header is only attached when git contacts
+        the configured repository, not when it follows cross-host redirects
+        or fetches submodules from other origins.
         """
         credentials = f"{self.user_name}:{self.auth_token}"
         encoded = base64.b64encode(credentials.encode()).decode()
         self.env["GIT_CONFIG_COUNT"] = "1"
-        self.env["GIT_CONFIG_KEY_0"] = "http.extraHeader"
+        self.env["GIT_CONFIG_KEY_0"] = f"http.{repo_url}.extraHeader"
         self.env["GIT_CONFIG_VALUE_0"] = f"Authorization: Basic {encoded}"
 
     def set_git_env(self, key: str | None = None) -> None:

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import base64
 import os
 
 import pytest
@@ -352,3 +353,33 @@ class TestGitHook:
             assert os.path.exists(askpass_path)
         # Both the askpass script and the temp key file should be cleaned up
         assert not os.path.exists(askpass_path)
+
+    def test_https_auth_sets_extra_header(self):
+        """Test that HTTPS connections with auth token set http.extraHeader env vars.
+
+        This forces git to send credentials on the first request, even for public
+        repositories that don't issue a 401 challenge (issue #54829).
+        """
+        hook = GitHook(git_conn_id=CONN_HTTPS)
+        expected_creds = base64.b64encode(f"user:{ACCESS_TOKEN}".encode()).decode()
+        assert hook.env["GIT_CONFIG_COUNT"] == "1"
+        assert hook.env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+        assert hook.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected_creds}"
+
+    def test_http_auth_sets_extra_header(self):
+        """Test that HTTP connections with auth token also set http.extraHeader."""
+        hook = GitHook(git_conn_id=CONN_HTTP)
+        expected_creds = base64.b64encode(f"user:{ACCESS_TOKEN}".encode()).decode()
+        assert hook.env["GIT_CONFIG_COUNT"] == "1"
+        assert hook.env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+        assert hook.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected_creds}"
+
+    def test_no_auth_does_not_set_extra_header(self):
+        """Test that connections without auth token do not set http.extraHeader."""
+        hook = GitHook(git_conn_id=CONN_HTTP_NO_AUTH)
+        assert "GIT_CONFIG_COUNT" not in hook.env
+
+    def test_ssh_does_not_set_extra_header(self):
+        """Test that SSH connections do not set http.extraHeader."""
+        hook = GitHook(git_conn_id=CONN_DEFAULT)
+        assert "GIT_CONFIG_COUNT" not in hook.env

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -355,23 +355,25 @@ class TestGitHook:
         assert not os.path.exists(askpass_path)
 
     def test_https_auth_sets_extra_header(self):
-        """Test that HTTPS connections with auth token set http.extraHeader env vars.
+        """Test that HTTPS connections with auth token set URL-scoped http.<URL>.extraHeader env vars.
 
         This forces git to send credentials on the first request, even for public
-        repositories that don't issue a 401 challenge (issue #54829).
+        repositories that don't issue a 401 challenge (issue #54829). The URL
+        scope limits the Authorization header to the configured repository so it
+        is not leaked to cross-host redirects or submodule origins.
         """
         hook = GitHook(git_conn_id=CONN_HTTPS)
         expected_creds = base64.b64encode(f"user:{ACCESS_TOKEN}".encode()).decode()
         assert hook.env["GIT_CONFIG_COUNT"] == "1"
-        assert hook.env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+        assert hook.env["GIT_CONFIG_KEY_0"] == f"http.{AIRFLOW_HTTPS_URL}.extraHeader"
         assert hook.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected_creds}"
 
     def test_http_auth_sets_extra_header(self):
-        """Test that HTTP connections with auth token also set http.extraHeader."""
+        """Test that HTTP connections with auth token also set URL-scoped http.<URL>.extraHeader."""
         hook = GitHook(git_conn_id=CONN_HTTP)
         expected_creds = base64.b64encode(f"user:{ACCESS_TOKEN}".encode()).decode()
         assert hook.env["GIT_CONFIG_COUNT"] == "1"
-        assert hook.env["GIT_CONFIG_KEY_0"] == "http.extraHeader"
+        assert hook.env["GIT_CONFIG_KEY_0"] == f"http.{AIRFLOW_HTTP_URL}.extraHeader"
         assert hook.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected_creds}"
 
     def test_no_auth_does_not_set_extra_header(self):

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -376,6 +376,15 @@ class TestGitHook:
         assert hook.env["GIT_CONFIG_KEY_0"] == f"http.{AIRFLOW_HTTP_URL}.extraHeader"
         assert hook.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected_creds}"
 
+    def test_old_git_does_not_set_extra_header(self, monkeypatch):
+        """Test that git<2.31 skips GIT_CONFIG_* injection used to force HTTP auth."""
+        monkeypatch.setattr(GitHook, "_get_git_version_info", staticmethod(lambda: (2, 30, 0)))
+
+        hook = GitHook(git_conn_id=CONN_HTTPS)
+
+        assert hook.repo_url == f"https://user:{ACCESS_TOKEN}@github.com/apache/airflow.git"
+        assert "GIT_CONFIG_COUNT" not in hook.env
+
     def test_no_auth_does_not_set_extra_header(self):
         """Test that connections without auth token do not set http.extraHeader."""
         hook = GitHook(git_conn_id=CONN_HTTP_NO_AUTH)


### PR DESCRIPTION
## Description

Git does not send credentials for public repositories because the server never responds with a 401 challenge. This causes Airflow's DAG bundle git fetches to hit **anonymous rate limits** even when valid credentials are configured in the connection.

### Root cause

Git's HTTPS behavior: it always tries anonymous access first and only sends credentials if the server responds with 401. Public repos don't issue 401, so credentials embedded in the URL are never sent.

### Fix

When an HTTP/HTTPS connection has an `auth_token`, set `GIT_CONFIG_*` environment variables to inject an `http.extraHeader` with a `Basic` auth token:

```
GIT_CONFIG_COUNT=1
GIT_CONFIG_KEY_0=http.extraHeader
GIT_CONFIG_VALUE_0=Authorization: Basic <base64(username:password)>
```

This forces git to send the `Authorization` header on every request (git >= 2.31), allowing authenticated rate limits to apply even for public repositories.

Also updated `_fetch_bare_repo` in `GitDagBundle` to pass **all** hook env vars via `custom_environment(**self.hook.env)` instead of only `GIT_SSH_COMMAND`. This ensures the auth header is used during both clone and fetch operations.

### Changes

- `GitHook._set_http_auth_env()`: New method that encodes credentials and sets `GIT_CONFIG_*` env vars.
- `GitHook._process_git_auth_url()`: Calls `_set_http_auth_env()` when HTTPS/HTTP + auth_token.
- `GitDagBundle._fetch_bare_repo()`: Passes all env vars (SSH + HTTP auth) instead of only SSH.

### Backward compatibility

- URL-embedded credentials are **kept** for backward compatibility (they still work for private repos via 401 challenge).
- SSH connections are not affected (no `GIT_CONFIG_*` vars are set for SSH URLs).
- The `GIT_CONFIG_*` env vars require git >= 2.31 (March 2021).

### Tests

- 4 new tests: HTTPS auth sets header, HTTP auth sets header, no auth skips header, SSH skips header.
- All 17 hook tests + 80 bundle tests pass.

Closes #54829

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=fa7dc51 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @antonio-mello-ai** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
