### PR TITLE
fix(providers/amazon): handle multi-node job log streams in BatchClientHook

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -483,6 +483,7 @@ class BatchClientHook(AwsBaseHook):
                 container_stream = attempt.get("container", {}).get("logStreamName")
                 if container_stream:
                     stream_names.append(container_stream)
+                    continue
                 # Multi-node: attempts[].taskProperties[].containers[].logStreamName
                 for task_prop in attempt.get("taskProperties", []):
                     for container in task_prop.get("containers", []):

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -476,8 +476,19 @@ class BatchClientHook(AwsBaseHook):
                 p.get("container", {}).get("logConfiguration", {})
                 for p in job_node_properties.get("nodeRangeProperties", {})
             ]
-            # one stream name per attempt
-            stream_names = [a.get("container", {}).get("logStreamName") for a in job_desc.get("attempts", [])]
+            # one stream name per attempt — handles both single-node and multi-node schemas
+            stream_names = []
+            for attempt in job_desc.get("attempts", []):
+                # Single-node: attempts[].container.logStreamName
+                container_stream = attempt.get("container", {}).get("logStreamName")
+                if container_stream:
+                    stream_names.append(container_stream)
+                # Multi-node: attempts[].taskProperties[].containers[].logStreamName
+                for task_prop in attempt.get("taskProperties", []):
+                    for container in task_prop.get("containers", []):
+                        task_stream = container.get("logStreamName")
+                        if task_stream:
+                            stream_names.append(task_stream)
         elif job_container_desc:
             log_configs = [job_container_desc.get("logConfiguration", {})]
             stream_name = job_container_desc.get("logStreamName")

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_batch_client.py
@@ -400,6 +400,85 @@ class TestBatchClient:
         # all combinations listed above should have been seen
         assert all(combinations.values())
 
+    def test_job_awslogs_multinode_job_task_properties(self):
+        """Test multi-node jobs using taskProperties schema (issue #54254)."""
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [
+                {
+                    "jobId": JOB_ID,
+                    "attempts": [
+                        {
+                            "taskProperties": [
+                                {
+                                    "containers": [
+                                        {"exitCode": 0, "logStreamName": "test/stream/node0"},
+                                        {"exitCode": 0, "logStreamName": "test/stream/node1"},
+                                    ]
+                                }
+                            ]
+                        },
+                    ],
+                    "nodeProperties": {
+                        "mainNode": 0,
+                        "nodeRangeProperties": [
+                            {
+                                "targetNodes": "0:",
+                                "container": {
+                                    "logConfiguration": {
+                                        "logDriver": "awslogs",
+                                        "options": {
+                                            "awslogs-group": "/test/batch/job-a",
+                                            "awslogs-region": AWS_REGION,
+                                        },
+                                    }
+                                },
+                            },
+                        ],
+                    },
+                }
+            ]
+        }
+        awslogs = self.batch_client.get_job_all_awslogs_info(JOB_ID)
+        assert len(awslogs) == 2
+        assert all(log["awslogs_region"] == AWS_REGION for log in awslogs)
+        stream_names = [log["awslogs_stream_name"] for log in awslogs]
+        assert "test/stream/node0" in stream_names
+        assert "test/stream/node1" in stream_names
+
+    def test_job_awslogs_multinode_no_container_log_stream(self, caplog):
+        """Test multi-node job where attempts[].container has no logStreamName (issue #54254)."""
+        self.client_mock.describe_jobs.return_value = {
+            "jobs": [
+                {
+                    "jobId": JOB_ID,
+                    "attempts": [
+                        {"container": {"exitCode": 0}},
+                    ],
+                    "nodeProperties": {
+                        "mainNode": 0,
+                        "nodeRangeProperties": [
+                            {
+                                "targetNodes": "0:",
+                                "container": {
+                                    "logConfiguration": {
+                                        "logDriver": "awslogs",
+                                        "options": {
+                                            "awslogs-group": "/test/batch/job-a",
+                                            "awslogs-region": AWS_REGION,
+                                        },
+                                    }
+                                },
+                            },
+                        ],
+                    },
+                }
+            ]
+        }
+        with caplog.at_level(level=logging.WARNING):
+            awslogs = self.batch_client.get_job_all_awslogs_info(JOB_ID)
+            assert awslogs == []
+            assert "doesn't have any AWS CloudWatch Stream" in caplog.messages[0]
+
 
 class TestBatchClientDelays:
     @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)


### PR DESCRIPTION
## Summary

- Fix `get_job_all_awslogs_info()` to extract log stream names from both single-node (`attempts[].container.logStreamName`) and multi-node (`attempts[].taskProperties[].containers[].logStreamName`) AWS Batch job schemas
- Filter out `None` values that previously bypassed the `if not stream_names:` guard, causing `TypeError` in `urllib.parse.quote_plus()` downstream

## Root Cause

Multi-node AWS Batch jobs return log stream names under `attempts[].taskProperties[].containers[].logStreamName`, not the single-node path `attempts[].container.logStreamName`. The existing code only checked the single-node path, producing `stream_names = [None]` for multi-node jobs. Since `[None]` is truthy, it passed the emptiness guard and propagated `None` downstream.

## Test Plan

- [x] New test: multi-node job with `taskProperties` schema extracts stream names correctly
- [x] New test: multi-node job with no `logStreamName` in `container` falls through to warning path
- [x] All 41 tests pass (39 existing + 2 new)
- [x] All pre-commit hooks pass (`prek`)

Closes #54254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>