### PR TITLE
fix(providers/cncf-kubernetes): apply verify_ssl=False to returned ApiClient in KubernetesHook

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -295,6 +295,8 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
 
         if disable_verify_ssl is True:
             _disable_verify_ssl()
+            if self.client_configuration is None:
+                self.client_configuration = client.Configuration.get_default_copy()
         if disable_tcp_keepalive is not True:
             _enable_tcp_keepalive()
 
@@ -312,6 +314,9 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
+            if disable_verify_ssl is True:
+                self.client_configuration.verify_ssl = False
+                return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
 
         if kubeconfig is not None:
@@ -327,6 +332,9 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                     client_configuration=self.client_configuration,
                     context=cluster_context,
                 )
+            if disable_verify_ssl is True:
+                self.client_configuration.verify_ssl = False
+                return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
 
         if self.config_dict:
@@ -337,11 +345,18 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
+            if disable_verify_ssl is True:
+                self.client_configuration.verify_ssl = False
+                return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
 
-        return self._get_default_client(cluster_context=cluster_context)
+        return self._get_default_client(
+            cluster_context=cluster_context, disable_verify_ssl=disable_verify_ssl
+        )
 
-    def _get_default_client(self, *, cluster_context: str | None = None) -> client.ApiClient:
+    def _get_default_client(
+        self, *, cluster_context: str | None = None, disable_verify_ssl: bool | None = None
+    ) -> client.ApiClient:
         # if we get here, then no configuration has been supplied
         # we should try in_cluster since that's most likely
         # but failing that just load assuming a kubeconfig file
@@ -356,6 +371,9 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
+        if disable_verify_ssl is True:
+            self.client_configuration.verify_ssl = False
+            return _TimeoutK8sApiClient(configuration=self.client_configuration)
         return _TimeoutK8sApiClient()
 
     @property

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -81,7 +81,25 @@ def _get_request_timeout(timeout_seconds: int | None) -> float:
 
 
 class _TimeoutK8sApiClient(client.ApiClient):
-    """Wrapper around kubernetes sync ApiClient to set default timeout."""
+    """
+    Wrapper around kubernetes sync ApiClient to set default timeout.
+
+    When *disable_verify_ssl* is True the TLS certificate check is turned off
+    on the *client_configuration* that is passed (or on a fresh default copy)
+    so that callers do not need to repeat this logic at every call-site.
+    """
+
+    def __init__(
+        self,
+        configuration: client.Configuration | None = None,
+        *,
+        disable_verify_ssl: bool = False,
+    ) -> None:
+        if disable_verify_ssl:
+            if configuration is None:
+                configuration = client.Configuration.get_default_copy()
+            configuration.verify_ssl = False
+        super().__init__(configuration=configuration)
 
     def call_api(self, *args, **kwargs):
         timeout_seconds = kwargs.get("timeout_seconds")  # get server-side timeout
@@ -295,8 +313,6 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
 
         if disable_verify_ssl is True:
             _disable_verify_ssl()
-            if self.client_configuration is None:
-                self.client_configuration = client.Configuration.get_default_copy()
         if disable_tcp_keepalive is not True:
             _enable_tcp_keepalive()
 
@@ -304,7 +320,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             self.log.debug("loading kube_config from: in_cluster configuration")
             self._is_in_cluster = True
             config.load_incluster_config()
-            return _TimeoutK8sApiClient()
+            return _TimeoutK8sApiClient(
+                configuration=self.client_configuration,
+                disable_verify_ssl=disable_verify_ssl is True,
+            )
 
         if kubeconfig_path is not None:
             self.log.debug("loading kube_config from: %s", kubeconfig_path)
@@ -314,10 +333,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-            if disable_verify_ssl is True and self.client_configuration is not None:
-                self.client_configuration.verify_ssl = False
-                return _TimeoutK8sApiClient(configuration=self.client_configuration)
-            return _TimeoutK8sApiClient()
+            return _TimeoutK8sApiClient(
+                configuration=self.client_configuration,
+                disable_verify_ssl=disable_verify_ssl is True,
+            )
 
         if kubeconfig is not None:
             with tempfile.NamedTemporaryFile() as temp_config:
@@ -332,10 +351,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                     client_configuration=self.client_configuration,
                     context=cluster_context,
                 )
-            if disable_verify_ssl is True and self.client_configuration is not None:
-                self.client_configuration.verify_ssl = False
-                return _TimeoutK8sApiClient(configuration=self.client_configuration)
-            return _TimeoutK8sApiClient()
+            return _TimeoutK8sApiClient(
+                configuration=self.client_configuration,
+                disable_verify_ssl=disable_verify_ssl is True,
+            )
 
         if self.config_dict:
             self.log.debug(LOADING_KUBE_CONFIG_FILE_RESOURCE.format("config dictionary"))
@@ -345,10 +364,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-            if disable_verify_ssl is True and self.client_configuration is not None:
-                self.client_configuration.verify_ssl = False
-                return _TimeoutK8sApiClient(configuration=self.client_configuration)
-            return _TimeoutK8sApiClient()
+            return _TimeoutK8sApiClient(
+                configuration=self.client_configuration,
+                disable_verify_ssl=disable_verify_ssl is True,
+            )
 
         return self._get_default_client(
             cluster_context=cluster_context, disable_verify_ssl=disable_verify_ssl
@@ -371,10 +390,10 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-        if disable_verify_ssl is True and self.client_configuration is not None:
-            self.client_configuration.verify_ssl = False
-            return _TimeoutK8sApiClient(configuration=self.client_configuration)
-        return _TimeoutK8sApiClient()
+        return _TimeoutK8sApiClient(
+            configuration=self.client_configuration,
+            disable_verify_ssl=disable_verify_ssl is True,
+        )
 
     @property
     def is_in_cluster(self) -> bool:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -314,7 +314,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-            if disable_verify_ssl is True:
+            if disable_verify_ssl is True and self.client_configuration is not None:
                 self.client_configuration.verify_ssl = False
                 return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
@@ -332,7 +332,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                     client_configuration=self.client_configuration,
                     context=cluster_context,
                 )
-            if disable_verify_ssl is True:
+            if disable_verify_ssl is True and self.client_configuration is not None:
                 self.client_configuration.verify_ssl = False
                 return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
@@ -345,7 +345,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-            if disable_verify_ssl is True:
+            if disable_verify_ssl is True and self.client_configuration is not None:
                 self.client_configuration.verify_ssl = False
                 return _TimeoutK8sApiClient(configuration=self.client_configuration)
             return _TimeoutK8sApiClient()
@@ -371,7 +371,7 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-        if disable_verify_ssl is True:
+        if disable_verify_ssl is True and self.client_configuration is not None:
             self.client_configuration.verify_ssl = False
             return _TimeoutK8sApiClient(configuration=self.client_configuration)
         return _TimeoutK8sApiClient()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -330,6 +330,49 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
+        "config_source",
+        [
+            pytest.param("kube_config_path", id="kube_config_path"),
+            pytest.param("kube_config", id="kube_config"),
+            pytest.param("config_dict", id="config_dict"),
+            pytest.param("default", id="default_client"),
+        ],
+    )
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
+    @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
+    @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
+    def test_disable_verify_ssl_applies_to_client_configuration(self, config_source):
+        """
+        Verifies that when disable_verify_ssl=True, the returned ApiClient has verify_ssl=False.
+
+        Previously, _disable_verify_ssl() only mutated the global default configuration via
+        Configuration.set_default(), but config.load_kube_config() would subsequently overwrite
+        that default with verify_ssl=True from the kubeconfig file. This test ensures that
+        verify_ssl=False is correctly propagated to the returned ApiClient's configuration.
+        """
+        if config_source == "kube_config_path":
+            kubernetes_hook = KubernetesHook(
+                conn_id="kube_config_path",
+                disable_verify_ssl=True,
+            )
+        elif config_source == "kube_config":
+            kubernetes_hook = KubernetesHook(
+                conn_id="kube_config",
+                disable_verify_ssl=True,
+            )
+        elif config_source == "config_dict":
+            kubernetes_hook = KubernetesHook(
+                config_dict={"apiVersion": "v1", "kind": "Config"},
+                disable_verify_ssl=True,
+            )
+        else:
+            kubernetes_hook = KubernetesHook(disable_verify_ssl=True)
+
+        api_conn = kubernetes_hook.get_conn()
+        assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
+        assert api_conn.configuration.verify_ssl is False
+
+    @pytest.mark.parametrize(
         ("disable_tcp_keepalive", "conn_id", "expected"),
         (
             (True, None, False),
@@ -514,7 +557,7 @@ class TestKubernetesHook:
         with mock.patch.dict("os.environ", AIRFLOW_CONN_KUBERNETES_DEFAULT=conn_uri):
             kubernetes_hook = KubernetesHook(conn_id="kubernetes_default")
             kubernetes_hook.get_conn()
-            mock_get_client.assert_called_with(cluster_context="test")
+            mock_get_client.assert_called_with(cluster_context="test", disable_verify_ssl=None)
             assert kubernetes_hook.get_namespace() == "test"
 
     def test_missing_default_connection_is_ok(self, remove_default_conn, sdk_connection_not_found):


### PR DESCRIPTION
## Summary

- Fix `KubernetesHook` so that `disable_verify_ssl=True` actually disables SSL verification on the returned `ApiClient`
- The root cause: `load_kube_config()` overwrites `Configuration.set_default()` with a fresh `Configuration(verify_ssl=True)`, so the earlier `_disable_verify_ssl()` call is lost
- Fix: re-apply `verify_ssl=False` after each config load, and pass the configuration explicitly to `_TimeoutK8sApiClient`

## Root Cause

`_disable_verify_ssl()` calls `Configuration.set_default()` to register `verify_ssl=False` globally. However, `load_kube_config()` (called right after) creates a new `Configuration` instance with `verify_ssl=True` by default and overwrites the global default. The `_TimeoutK8sApiClient()` then gets `verify_ssl=True` from `get_default_copy()`.

## Test Plan

- [x] New parametrized test covering all 4 config paths (`kube_config_path`, `kube_config`, `config_dict`, `default_client`)
- [x] All 138 tests pass
- [x] All pre-commit hooks pass (`prek`)

Closes #56432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>