### PR TITLE
Unify executor workload queues with tier-based scheduling

### DIFF
--- a/airflow-core/src/airflow/executors/workloads/__init__.py
+++ b/airflow-core/src/airflow/executors/workloads/__init__.py
@@ -22,7 +22,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from airflow.executors.workloads.base import BaseWorkload, BundleInfo
+from airflow.executors.workloads.base import WORKLOAD_TYPE_TIER, BaseWorkload, BundleInfo, WorkloadType
 from airflow.executors.workloads.callback import CallbackFetchMethod, ExecuteCallback
 from airflow.executors.workloads.task import ExecuteTask, TaskInstanceDTO
 from airflow.executors.workloads.trigger import RunTrigger
@@ -43,4 +43,6 @@ __all__ = [
     "ExecuteTask",
     "TaskInstance",
     "TaskInstanceDTO",
+    "WORKLOAD_TYPE_TIER",
+    "WorkloadType",
 ]

--- a/airflow-core/src/airflow/executors/workloads/base.py
+++ b/airflow-core/src/airflow/executors/workloads/base.py
@@ -20,12 +20,30 @@ from __future__ import annotations
 
 import os
 from abc import ABC
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
+
+
+class WorkloadType(StrEnum):
+    """Central registry of all workload types."""
+
+    EXECUTE_TASK = "ExecuteTask"
+    EXECUTE_CALLBACK = "ExecuteCallback"
+    RUN_TRIGGER = "RunTrigger"
+
+
+# Central priority registry: Tuple is ordered from highest priority to lowest.
+_workload_type_priority_order = (
+    WorkloadType.EXECUTE_CALLBACK,
+    WorkloadType.EXECUTE_TASK,
+)
+
+WORKLOAD_TYPE_TIER: dict[str, int] = {name: idx for idx, name in enumerate(_workload_type_priority_order)}
 
 
 class BaseWorkload:
@@ -75,6 +93,23 @@ class BaseWorkloadSchema(BaseModel):
     @staticmethod
     def generate_token(sub_id: str, generator: JWTGenerator | None = None) -> str:
         return generator.generate({"sub": sub_id}) if generator else ""
+
+    @property
+    def queue_key(self):
+        """Return a unique key used to store/lookup this workload in the executor queue."""
+        raise NotImplementedError
+
+    @property
+    def sort_key(self) -> int:
+        """
+        Return the sort key for ordering workloads within the same tier.
+
+        The default of ``0`` gives FIFO behaviour (Python's stable sort preserves
+        insertion order among equal keys).  Override in subclasses that need
+        priority ordering within their tier — for example, ``ExecuteTask`` returns
+        ``self.ti.priority_weight`` so that higher-priority tasks are scheduled first.
+        """
+        return 0
 
 
 class BaseDagBundleWorkload(BaseWorkloadSchema, ABC):

--- a/airflow-core/src/airflow/executors/workloads/callback.py
+++ b/airflow-core/src/airflow/executors/workloads/callback.py
@@ -27,7 +27,7 @@ from uuid import UUID
 import structlog
 from pydantic import BaseModel, Field, field_validator
 
-from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo
+from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo, WorkloadType
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
@@ -73,7 +73,11 @@ class ExecuteCallback(BaseDagBundleWorkload):
 
     callback: CallbackDTO
 
-    type: Literal["ExecuteCallback"] = Field(init=False, default="ExecuteCallback")
+    type: Literal[WorkloadType.EXECUTE_CALLBACK] = Field(init=False, default=WorkloadType.EXECUTE_CALLBACK)
+
+    @property
+    def queue_key(self) -> str:
+        return self.callback.id
 
     @classmethod
     def make(

--- a/airflow-core/src/airflow/executors/workloads/task.py
+++ b/airflow-core/src/airflow/executors/workloads/task.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
-from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo
+from airflow.executors.workloads.base import BaseDagBundleWorkload, BundleInfo, WorkloadType
 
 if TYPE_CHECKING:
     from airflow.api_fastapi.auth.tokens import JWTGenerator
@@ -71,7 +71,15 @@ class ExecuteTask(BaseDagBundleWorkload):
     ti: TaskInstanceDTO
     sentry_integration: str = ""
 
-    type: Literal["ExecuteTask"] = Field(init=False, default="ExecuteTask")
+    type: Literal[WorkloadType.EXECUTE_TASK] = Field(init=False, default=WorkloadType.EXECUTE_TASK)
+
+    @property
+    def queue_key(self) -> TaskInstanceKey:
+        return self.ti.key
+
+    @property
+    def sort_key(self) -> int:
+        return self.ti.priority_weight
 
     @classmethod
     def make(

--- a/airflow-core/src/airflow/executors/workloads/trigger.py
+++ b/airflow-core/src/airflow/executors/workloads/trigger.py
@@ -23,6 +23,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from airflow.executors.workloads.base import WorkloadType
+
 # Using noqa because Ruff wants this in a TYPE_CHECKING block but Pydantic fails if it is.
 from airflow.executors.workloads.task import TaskInstanceDTO  # noqa: TCH001
 
@@ -39,4 +41,4 @@ class RunTrigger(BaseModel):
     classpath: str  # Dot-separated name of the module+fn to import and run this workload.
     encrypted_kwargs: str
     timeout_after: datetime | None = None
-    type: Literal["RunTrigger"] = Field(init=False, default="RunTrigger")
+    type: Literal[WorkloadType.RUN_TRIGGER] = Field(init=False, default=WorkloadType.RUN_TRIGGER)


### PR DESCRIPTION
  <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

  ## Summary

Refactors executor workload queue management for extensibility. No behavioral change , scheduling order, slot accounting, and all provider executors work identically to before.


Follows the direction proposed by @ferruzzi  https://github.com/apache/airflow/pull/62343#discussion_r2127826554.

## Problem

Adding a new workload type (like ExecuteCallback or TestConnection) required touching ~6 places in BaseExecutor: a new queue dict, a new `supports_*` flag,slots calculation, an isinstance branch in queue_workload, a dedicated scheduling method, and isinstance branches in dequeue/trigger logic. Each provider executor that overrode `queue_workload` also needed updating. This made extending the executor interface unnecessarily painful.

## What this does

Replaces the per-type queue dicts and boolean capability flags with three simple primitives:

- `executor_queues` :  a single dict keyed by workload type string (e.g. `"ExecuteTask"`, `"ExecuteCallback"`) instead of separate `queued_tasks`, `queued_callbacks`, `queued_connection_tests` dicts
- `supported_workload_types` :  a frozenset of type strings instead of iindividual `supports_callbacks`, `supports_connection_test` booleans
- `WorkloadQueueDef(scheduling_tier, sort_key)`, a small NamedTuple on each workload class that controls scheduling priority. Callbacks get tier 0, tasks get tier 1, same order as before, just explicit now.

The base class `queue_workload` is now generic: validate the type, store by key. Four provider executors (K8s, ECS, Batch, Lambda) no longer need their own `queue_workload` overrides. `trigger_tasks` becomes `trigger_workloads` since it handles all workload types now.

## Adding a new workload type after this refactor

1. Define `key` and `queue_def` on the workload dataclass
2. Add the type string to `supported_workload_types` on supporting executors
3. Handle the type in `_process_workloads` done

No changes needed in BaseExecutor itself.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
