### PR TITLE
Allow direct queueing from triggerer

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2650,6 +2650,19 @@ triggerer:
       type: boolean
       example: ~
       default: "False"
+    direct_queueing_executors:
+      description: |
+        Comma-separated allowlist of executor names for which the triggerer will directly enqueue
+        workloads when a deferred task's trigger fires, bypassing the scheduler's scheduling loop.
+        Each entry may be an executor alias (e.g. ``CeleryExecutor``), a fully-qualified module
+        path (e.g. ``airflow.providers.celery.executors.celery_executor.CeleryExecutor``), or the
+        bare class name. Only executors that maintain their own external queue (such as Celery) should
+        be listed here. When empty (the default), all deferred tasks are returned
+        to the scheduler via the normal SCHEDULED state transition.
+      version_added: 3.2.0
+      type: string
+      example: "CeleryExecutor"
+      default: ~
 kerberos:
   description: ~
   options:

--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -312,6 +312,45 @@ class ExecutorLoader:
         return loaded_executors
 
     @classmethod
+    def find_executor(
+        cls,
+        executors: list[BaseExecutor],
+        executor_name: str | None,
+        team_name: str | None,
+    ) -> BaseExecutor | None:
+        """
+        Find the executor matching the given name and team from a list of executor instances.
+
+        :param executors: List of available executor instances to search through.
+        :param executor_name: The executor name (alias, module path, or class name) to find.
+                             Pass None to get the default executor for the given team.
+        :param team_name: The team to find the executor for (None for global executors).
+        :return: The matching executor instance, or None if not found.
+        """
+        if executor_name is None:
+            if not team_name:
+                # No team specified, return the global default (first in list)
+                return executors[0] if executors else None
+            # Find the default executor for the given team
+            for _executor in executors:
+                if _executor.team_name == team_name:
+                    return _executor
+            # No team-specific executor found, fall back to global default
+            return executors[0] if executors else None
+
+        # An executor name is specified — search by alias, module path, or class name
+        for _executor in executors:
+            if _executor.name and executor_name in (
+                _executor.name.alias,
+                _executor.name.module_path,
+                _executor.name.module_path.split(".")[-1],
+            ):
+                # Must match the team or be a global executor (team_name is None)
+                if team_name and _executor.team_name == team_name or _executor.team_name is None:
+                    return _executor
+        return None
+
+    @classmethod
     def lookup_executor_name_by_str(
         cls, executor_name_str: str, team_name: str | None = None, validate_teams: bool = True
     ) -> ExecutorName:

--- a/airflow-core/src/airflow/executors/executor_loader.py
+++ b/airflow-core/src/airflow/executors/executor_loader.py
@@ -328,13 +328,11 @@ class ExecutorLoader:
         :return: The matching executor instance, or None if not found.
         """
         if executor_name is None:
-            if not team_name:
-                # No team specified, return the global default (first in list)
-                return executors[0] if executors else None
-            # Find the default executor for the given team
-            for _executor in executors:
-                if _executor.team_name == team_name:
-                    return _executor
+            if team_name:
+                # Find the default executor for the given team
+                for _executor in executors:
+                    if _executor.team_name == team_name:
+                        return _executor
             # No team-specific executor found, fall back to global default
             return executors[0] if executors else None
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3130,40 +3130,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param team_name: Optional pre-resolved team name. If NOTSET and multi-team is enabled,
                          will query the database to resolve team name. None indicates global team.
         """
-        executor = None
         if conf.getboolean("core", "multi_team"):
             # Use provided team_name if available, otherwise query the database
             if team_name is NOTSET:
                 team_name = self._get_workload_team_name(workload, session)
         else:
             team_name = None
-        # If there is no executor set on the workload fetch the default (either globally or for the team)
-        if workload.get_executor_name() is None:
-            if not team_name:
-                # No team is specified, use the global default executor
-                executor = self.executor
-            else:
-                # We do have a team, use the default executor for that team
-                for _executor in self.executors:
-                    # First executor that resolves should be the default for that team
-                    if _executor.team_name == team_name:
-                        executor = _executor
-                        break
-                else:
-                    # No executor found for that team, fall back to global default
-                    executor = self.executor
-        else:
-            # An executor is specified on the workload (as a str), so we need to find it in the list of executors
-            for _executor in self.executors:
-                if _executor.name and workload.get_executor_name() in (
-                    _executor.name.alias,
-                    _executor.name.module_path,
-                    _executor.name.module_path.split(".")[-1],
-                ):
-                    # The executor must either match the team or be global (i.e. team_name is None)
-                    if team_name and _executor.team_name == team_name or _executor.team_name is None:
-                        executor = _executor
-                        break
+
+        executor = ExecutorLoader.find_executor(self.executors, workload.get_executor_name(), team_name)
 
         if executor is not None:
             self.log.debug(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -276,6 +276,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
         self._task_queued_timeout = conf.getfloat("scheduler", "task_queued_timeout")
         self._enable_tracemalloc = conf.getboolean("scheduler", "enable_tracemalloc")
+        self.multi_team = conf.getboolean("core", "multi_team")
 
         # this param is intentionally undocumented
         self._num_stuck_queued_retries = conf.getint(
@@ -655,7 +656,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self.log.info("%s tasks up for execution:\n%s", len(task_instances_to_examine), task_instance_str)
 
             dag_id_to_team_name: dict[str, str | None] = {}
-            if conf.getboolean("core", "multi_team"):
+            if self.multi_team:
                 # Batch query to resolve team names for all DAG IDs to optimize performance
                 # Instead of individual queries in _try_to_load_executor(), resolve all team names upfront
                 unique_dag_ids = {ti.dag_id for ti in task_instances_to_examine}
@@ -2835,7 +2836,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def _purge_task_instances_without_heartbeats(
         self, task_instances_without_heartbeats: list[TI], *, session: Session
     ) -> None:
-        if conf.getboolean("core", "multi_team"):
+        if self.multi_team:
             unique_dag_ids = {ti.dag_id for ti in task_instances_without_heartbeats}
             dag_id_to_team_name = self._get_team_names_for_dag_ids(unique_dag_ids, session)
         else:
@@ -3083,7 +3084,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     ) -> dict[BaseExecutor, list[SchedulerWorkload]]:
         """Organize workloads into lists per their respective executor."""
         workloads_iter: Iterable[SchedulerWorkload]
-        if conf.getboolean("core", "multi_team"):
+        if self.multi_team:
             if dag_id_to_team_name is None:
                 if isinstance(workloads, list):
                     workloads_list = workloads
@@ -3130,7 +3131,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param team_name: Optional pre-resolved team name. If NOTSET and multi-team is enabled,
                          will query the database to resolve team name. None indicates global team.
         """
-        if conf.getboolean("core", "multi_team"):
+        if self.multi_team:
             # Use provided team_name if available, otherwise query the database
             if team_name is NOTSET:
                 team_name = self._get_workload_team_name(workload, session)

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -72,6 +72,14 @@ class TriggerFailureReason(str, Enum):
     TRIGGER_FAILURE = "Trigger failure"
 
 
+@cache
+def get_executors():
+    """Load configured executors (cached) and find the one responsible for this task instance."""
+    from airflow.executors.executor_loader import ExecutorLoader
+
+    return ExecutorLoader.init_executors()
+
+
 class Trigger(Base):
     """
     Base Trigger class.
@@ -115,6 +123,9 @@ class Trigger(Base):
     callback = relationship("Callback", back_populates="trigger", uselist=False)
 
     max_trigger_to_select_per_loop = conf.getint("triggerer", "max_trigger_to_select_per_loop", fallback=50)
+    # Which executors are configured for direct queueing
+    direct_queueing_allowlist = conf.getlist("triggerer", "direct_queueing_executors", fallback=[])
+    multi_team = conf.getboolean("core", "multi_team")
 
     def __init__(
         self,
@@ -287,7 +298,6 @@ class Trigger(Base):
             trigger.callback.handle_event(event, session)
 
     @classmethod
-    @provide_session
     def return_to_worker(cls, task_instance: TaskInstance, session: Session) -> None:
         """
         Return a task instance to the worker for execution.
@@ -304,19 +314,11 @@ class Trigger(Base):
         task_instance.trigger_id = None
         task_instance.scheduled_dttm = timezone.utcnow()
 
-        # Check which executors are configured for direct queueing
-        direct_queueing_allowlist = conf.getlist("triggerer", "direct_queueing_executors", fallback=[])
-
-        if direct_queueing_allowlist:
+        if cls.direct_queueing_allowlist:
             # Resolve team name for multi-team setups
             team_name: str | None = None
-            if conf.getboolean("core", "multi_team"):
+            if cls.multi_team:
                 team_name = task_instance.dag_model.get_team_name(task_instance.dag_id, session=session)
-
-            # Load configured executors (cached) and find the one responsible for this task instance
-            @cache
-            def get_executors():
-                return ExecutorLoader.init_executors()
 
             executor = ExecutorLoader.find_executor(get_executors(), task_instance.executor, team_name)
 
@@ -327,7 +329,7 @@ class Trigger(Base):
                     executor.name.module_path,
                     executor.name.module_path.split(".")[-1],
                 }
-                if executor_identifiers & set(direct_queueing_allowlist):
+                if executor_identifiers & set(cls.direct_queueing_allowlist):
                     task_instance.state = TaskInstanceState.QUEUED
                     workload = workloads.ExecuteTask.make(ti=task_instance, generator=executor.jwt_generator)
                     executor.queue_workload(workload, session=session)

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -288,6 +288,64 @@ class Trigger(Base):
 
     @classmethod
     @provide_session
+    def return_to_worker(cls, task_instance: TaskInstance, session: Session) -> None:
+        """
+        Return a task instance to the worker for execution.
+
+        This is used when a trigger fires an event and we need to resume a deferred task instance.
+        It is optimized for configured executor types to directly enqueue to a worker without going
+        through the scheduler, but can also be used as a general utility to return a task instance
+        to the worker for execution.
+        """
+        from airflow.executors import workloads
+        from airflow.executors.executor_loader import ExecutorLoader
+
+        # Remove ourselves as its trigger
+        task_instance.trigger_id = None
+        task_instance.scheduled_dttm = timezone.utcnow()
+
+        # Check which executors are configured for direct queueing
+        direct_queueing_allowlist = conf.getlist("triggerer", "direct_queueing_executors", fallback=[])
+
+        if direct_queueing_allowlist:
+            # Resolve team name for multi-team setups
+            team_name: str | None = None
+            if conf.getboolean("core", "multi_team"):
+                from airflow.models.dag import DagModel
+                from airflow.models.dagbundle import DagBundleModel
+                from airflow.models.team import Team
+
+                result = session.execute(
+                    select(Team.name)
+                    .join(DagBundleModel.teams)
+                    .join(DagModel, DagModel.bundle_name == DagBundleModel.name)
+                    .where(DagModel.dag_id == task_instance.dag_id)
+                ).first()
+                team_name = result[0] if result else None
+
+            # Load configured executors and find the one responsible for this task instance
+            executors = ExecutorLoader.init_executors()
+            executor = ExecutorLoader.find_executor(executors, task_instance.executor, team_name)
+
+            # Only directly enqueue if the executor is in the configured allowlist
+            if executor is not None and executor.name is not None:
+                executor_identifiers = {
+                    executor.name.alias,
+                    executor.name.module_path,
+                    executor.name.module_path.split(".")[-1],
+                }
+                if executor_identifiers & set(direct_queueing_allowlist):
+                    task_instance.state = TaskInstanceState.QUEUED
+                    workload = workloads.ExecuteTask.make(ti=task_instance, generator=executor.jwt_generator)
+                    executor.queue_workload(workload, session=session)
+                    executor.trigger_tasks(1)  # Flush all == 1 tasks
+                    return
+
+        # Fall back to SCHEDULED so the scheduler picks it up via the normal scheduling loop
+        task_instance.state = TaskInstanceState.SCHEDULED
+
+    @classmethod
+    @provide_session
     def submit_failure(cls, trigger_id, exc=None, session: Session = NEW_SESSION) -> None:
         """
         When a trigger has failed unexpectedly, mark everything that depended on it as failed.
@@ -315,11 +373,7 @@ class Trigger(Base):
                 "error": TriggerFailureReason.TRIGGER_FAILURE,
                 "traceback": traceback,
             }
-            # Remove ourselves as its trigger
-            task_instance.trigger_id = None
-            # Finally, mark it as scheduled so it gets re-queued
-            task_instance.state = TaskInstanceState.SCHEDULED
-            task_instance.scheduled_dttm = timezone.utcnow()
+            cls.return_to_worker(task_instance, session)
 
     @classmethod
     @provide_session
@@ -464,7 +518,6 @@ def handle_event_submit(event: TriggerEvent, *, task_instance: TaskInstance, ses
     :param session: The session to be used for the database callback sink.
     """
     from airflow.sdk.serde import deserialize, serialize
-    from airflow.utils.state import TaskInstanceState
 
     next_kwargs_raw = task_instance.next_kwargs or {}
 
@@ -486,12 +539,7 @@ def handle_event_submit(event: TriggerEvent, *, task_instance: TaskInstance, ses
     # re-serialize the entire dict using serde to ensure consistent structure
     task_instance.next_kwargs = serialize(next_kwargs)
 
-    # Remove ourselves as its trigger
-    task_instance.trigger_id = None
-
-    # Set the state of the task instance to scheduled
-    task_instance.state = TaskInstanceState.SCHEDULED
-    task_instance.scheduled_dttm = timezone.utcnow()
+    Trigger.return_to_worker(task_instance, session)
     session.flush()
 
 

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -20,7 +20,7 @@ import datetime
 import logging
 from collections.abc import Iterable
 from enum import Enum
-from functools import singledispatch
+from functools import cache, singledispatch
 from traceback import format_exception
 from typing import TYPE_CHECKING, Any
 
@@ -311,21 +311,14 @@ class Trigger(Base):
             # Resolve team name for multi-team setups
             team_name: str | None = None
             if conf.getboolean("core", "multi_team"):
-                from airflow.models.dag import DagModel
-                from airflow.models.dagbundle import DagBundleModel
-                from airflow.models.team import Team
+                team_name = task_instance.dag_model.get_team_name(task_instance.dag_id, session=session)
 
-                result = session.execute(
-                    select(Team.name)
-                    .join(DagBundleModel.teams)
-                    .join(DagModel, DagModel.bundle_name == DagBundleModel.name)
-                    .where(DagModel.dag_id == task_instance.dag_id)
-                ).first()
-                team_name = result[0] if result else None
+            # Load configured executors (cached) and find the one responsible for this task instance
+            @cache
+            def get_executors():
+                return ExecutorLoader.init_executors()
 
-            # Load configured executors and find the one responsible for this task instance
-            executors = ExecutorLoader.init_executors()
-            executor = ExecutorLoader.find_executor(executors, task_instance.executor, team_name)
+            executor = ExecutorLoader.find_executor(get_executors(), task_instance.executor, team_name)
 
             # Only directly enqueue if the executor is in the configured allowlist
             if executor is not None and executor.name is not None:
@@ -338,7 +331,7 @@ class Trigger(Base):
                     task_instance.state = TaskInstanceState.QUEUED
                     workload = workloads.ExecuteTask.make(ti=task_instance, generator=executor.jwt_generator)
                     executor.queue_workload(workload, session=session)
-                    executor.trigger_tasks(1)  # Flush all == 1 tasks
+                    executor.trigger_tasks(1)  # Flush all == 1 task to the worker immediately
                     return
 
         # Fall back to SCHEDULED so the scheduler picks it up via the normal scheduling loop

--- a/airflow-core/tests/unit/executors/test_executor_loader.py
+++ b/airflow-core/tests/unit/executors/test_executor_loader.py
@@ -854,3 +854,286 @@ class TestExecutorLoader:
             )
             assert executor.team_name is None
             assert executor.supports_multi_team is False
+
+    # ---Tests for ExecutorLoader.find_executor() method.
+
+    @staticmethod
+    def _make_executor(
+        alias: str | None = None,
+        module_path: str = "airflow.executors.local_executor.LocalExecutor",
+        team_name: str | None = None,
+    ) -> mock.MagicMock:
+        """Create a mock executor with the given name and team."""
+        executor = mock.MagicMock(spec=["name", "team_name"])
+        executor.name = ExecutorName(module_path=module_path, alias=alias, team_name=team_name)
+        executor.team_name = team_name
+        return executor
+
+    # --- executor_name is None, no team ---
+
+    def test_find_executor_no_name_no_team_returns_first_executor(self):
+        """When no executor_name and no team, the first (default) executor is returned."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+        exec2 = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([exec1, exec2], None, None)
+        assert result is exec1
+
+    def test_find_executor_no_name_no_team_empty_list_returns_none(self):
+        """When no executor_name, no team, and empty executor list, None is returned."""
+        result = executor_loader.ExecutorLoader.find_executor([], None, None)
+        assert result is None
+
+    def test_find_executor_no_name_no_team_single_executor(self):
+        """With a single executor, no name, no team returns that executor."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+        result = executor_loader.ExecutorLoader.find_executor([exec1], None, None)
+        assert result is exec1
+
+    # --- executor_name is None, with team ---
+
+    def test_find_executor_no_name_with_team_finds_team_executor(self):
+        """When no executor_name but a team is specified, Returns the team's executor."""
+        global_exec = self._make_executor(alias="LocalExecutor")
+        team_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([global_exec, team_exec], None, "team_a")
+        assert result is team_exec
+
+    def test_find_executor_no_name_with_team_falls_back_to_global_default(self):
+        """When a team has no dedicated executor, falls back to the global default (first)."""
+        global_exec = self._make_executor(alias="LocalExecutor")
+        team_a_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([global_exec, team_a_exec], None, "team_b")
+        assert result is global_exec
+
+    def test_find_executor_no_name_with_team_empty_list_returns_none(self):
+        """When a team is requested but no executors exist, returns None."""
+        result = executor_loader.ExecutorLoader.find_executor([], None, "team_a")
+        assert result is None
+
+    def test_find_executor_no_name_with_team_returns_first_matching_team_executor(self):
+        """When a team has multiple executors, returns the first match."""
+        global_exec = self._make_executor(alias="LocalExecutor")
+        team_exec1 = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+        team_exec2 = self._make_executor(
+            alias="K8sExecutor",
+            module_path="airflow.providers.cncf.kubernetes.executors.KubernetesExecutor",
+            team_name="team_a",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor(
+            [global_exec, team_exec1, team_exec2], None, "team_a"
+        )
+        assert result is team_exec1
+
+    # --- executor_name specified, search by alias ---
+
+    def test_find_executor_by_alias_global(self):
+        """Find an executor by its alias when no team is specified."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+        exec2 = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([exec1, exec2], "CeleryExecutor", None)
+        assert result is exec2
+
+    def test_find_executor_by_alias_with_team_returns_global_executor(self):
+        """When a team is specified but only a global executor matches, returns the global one."""
+        global_exec = self._make_executor(alias="LocalExecutor")
+
+        result = executor_loader.ExecutorLoader.find_executor([global_exec], "LocalExecutor", "team_a")
+        assert result is global_exec
+
+    def test_find_executor_by_alias_with_team_prefers_team_executor(self):
+        """When both global and team executors match by alias, the team executor is returned
+        if it appears first in the list, otherwise the global one is returned first."""
+        global_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+        team_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+
+        # Global comes first in list — find_executor returns the first match
+        result = executor_loader.ExecutorLoader.find_executor(
+            [global_exec, team_exec], "CeleryExecutor", "team_a"
+        )
+        assert result is global_exec
+
+        # Team comes first in list
+        result = executor_loader.ExecutorLoader.find_executor(
+            [team_exec, global_exec], "CeleryExecutor", "team_a"
+        )
+        assert result is team_exec
+
+    # --- executor_name specified, search by module path ---
+
+    def test_find_executor_by_module_path(self):
+        """Find an executor by its full module path."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+
+        result = executor_loader.ExecutorLoader.find_executor(
+            [exec1], "airflow.executors.local_executor.LocalExecutor", None
+        )
+        assert result is exec1
+
+    # --- executor_name specified, search by class name ---
+
+    def test_find_executor_by_class_name(self):
+        """Find an executor by the last component of its module path (class name)."""
+        exec1 = self._make_executor(
+            alias="my_celery",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([exec1], "CeleryExecutor", None)
+        assert result is exec1
+
+    # --- executor_name specified, no match ---
+
+    def test_find_executor_no_match_returns_none(self):
+        """When the requested executor name does not match any executor, returns None."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+
+        result = executor_loader.ExecutorLoader.find_executor([exec1], "NonExistentExecutor", None)
+        assert result is None
+
+    def test_find_executor_no_match_with_team_returns_none(self):
+        """When a team executor is requested but no executor matches the name, returns None."""
+        exec1 = self._make_executor(alias="LocalExecutor")
+        team_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([exec1, team_exec], "NonExistent", "team_a")
+        assert result is None
+
+    def test_find_executor_name_matches_but_wrong_team_returns_none(self):
+        """An executor matching by name but assigned to a different team is not returned
+        when a specific team is queried."""
+        team_b_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_b",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([team_b_exec], "CeleryExecutor", "team_a")
+        assert result is None
+
+    # --- executor with name=None is skipped ---
+
+    def test_find_executor_with_no_name_attribute_is_skipped(self):
+        """An executor whose name attribute is None is skipped during search by name."""
+        nameless_exec = mock.MagicMock(spec=["name", "team_name"])
+        nameless_exec.name = None
+        nameless_exec.team_name = None
+
+        named_exec = self._make_executor(alias="LocalExecutor")
+
+        result = executor_loader.ExecutorLoader.find_executor(
+            [nameless_exec, named_exec], "LocalExecutor", None
+        )
+        assert result is named_exec
+
+    # --- multi-team scenarios with multiple executors ---
+
+    def test_find_executor_multi_team_find_global_default_among_many(self):
+        """In a multi-team setup with global + team executors, no name/no team returns global default."""
+        global_celery = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+        global_local = self._make_executor(alias="LocalExecutor")
+        team_a_exec = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+        team_b_exec = self._make_executor(
+            alias="LocalExecutor",
+            team_name="team_b",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor(
+            [global_celery, global_local, team_a_exec, team_b_exec], None, None
+        )
+        assert result is global_celery
+
+    def test_find_executor_multi_team_find_by_name_for_specific_team(self):
+        """In a multi-team setup, find a named executor for a specific team."""
+        global_exec = self._make_executor(alias="LocalExecutor")
+        team_a_celery = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+            team_name="team_a",
+        )
+        team_b_local = self._make_executor(
+            alias="LocalExecutor",
+            team_name="team_b",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor(
+            [global_exec, team_a_celery, team_b_local], "CeleryExecutor", "team_a"
+        )
+        assert result is team_a_celery
+
+    def test_find_executor_multi_team_find_by_name_falls_back_to_global(self):
+        """Search by name with a team that has no dedicated match falls back to global executor."""
+        global_celery = self._make_executor(
+            alias="CeleryExecutor",
+            module_path="airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+        )
+        team_a_local = self._make_executor(
+            alias="LocalExecutor",
+            team_name="team_a",
+        )
+
+        # team_a has LocalExecutor, but we ask for CeleryExecutor — global match
+        result = executor_loader.ExecutorLoader.find_executor(
+            [global_celery, team_a_local], "CeleryExecutor", "team_a"
+        )
+        assert result is global_celery
+
+    def test_find_executor_custom_module_path_by_alias(self):
+        """Find a custom executor (non-core) by its custom alias."""
+        custom_exec = self._make_executor(
+            alias="my_custom",
+            module_path="my.custom.executor.MyExecutor",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([custom_exec], "my_custom", None)
+        assert result is custom_exec
+
+    def test_find_executor_custom_module_path_by_class_name(self):
+        """Find a custom executor by its class name (last segment of module path)."""
+        custom_exec = self._make_executor(
+            alias="my_custom",
+            module_path="my.custom.executor.MyExecutor",
+        )
+
+        result = executor_loader.ExecutorLoader.find_executor([custom_exec], "MyExecutor", None)
+        assert result is custom_exec

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -20,6 +20,7 @@ import datetime
 import json
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
+from unittest import mock
 from unittest.mock import patch
 
 import pendulum
@@ -46,7 +47,7 @@ from airflow.triggers.base import (
     TriggerEvent,
 )
 from airflow.utils.session import create_session
-from airflow.utils.state import State
+from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
 
@@ -904,6 +905,175 @@ def test_serialize_sensitive_kwargs():
     assert isinstance(trigger_row.encrypted_kwargs, str)
     assert "value1" not in trigger_row.encrypted_kwargs
     assert "value2" not in trigger_row.encrypted_kwargs
+
+
+# ---Tests for Trigger.return_to_worker() method.
+
+
+@staticmethod
+def _make_task_instance(executor=None, dag_id="test_dag"):
+    """Create a mock TaskInstance for return_to_worker tests."""
+    ti = mock.MagicMock(spec=["trigger_id", "scheduled_dttm", "state", "executor", "dag_id", "dag_model"])
+    ti.trigger_id = 42
+    ti.executor = executor
+    ti.dag_id = dag_id
+    ti.dag_model = mock.MagicMock()
+    return ti
+
+
+@staticmethod
+def _make_executor(alias="LocalExecutor", module_path="airflow.executors.local_executor.LocalExecutor"):
+    """Create a mock executor with name, queue_workload, trigger_tasks, and jwt_generator."""
+    from airflow.executors.executor_loader import ExecutorName
+
+    executor = mock.MagicMock()
+    executor.name = ExecutorName(module_path=module_path, alias=alias)
+    return executor
+
+
+def test_return_to_worker_no_direct_queueing_configured(self):
+    """Without direct_queueing_executors configured, task is set to SCHEDULED."""
+    ti = self._make_task_instance()
+    mock_session = mock.MagicMock()
+
+    with conf_vars({("triggerer", "direct_queueing_executors"): "", ("core", "multi_team"): "False"}):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    assert ti.trigger_id is None
+    assert ti.state == State.SCHEDULED
+
+
+def test_return_to_worker_direct_queueing_executor_matches_by_alias(self):
+    """When the executor alias is in the allowlist, task is directly QUEUED."""
+    ti = self._make_task_instance()
+    mock_session = mock.MagicMock()
+    executor = self._make_executor(alias="LocalExecutor")
+    mock_workload = mock.MagicMock()
+
+    with (
+        conf_vars(
+            {("triggerer", "direct_queueing_executors"): "LocalExecutor", ("core", "multi_team"): "False"}
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.init_executors",
+            return_value=[executor],
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.find_executor",
+            return_value=executor,
+        ),
+        patch("airflow.executors.workloads.ExecuteTask.make", return_value=mock_workload),
+    ):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    assert ti.trigger_id is None
+    assert ti.state == TaskInstanceState.QUEUED
+    executor.queue_workload.assert_called_once_with(mock_workload, session=mock_session)
+    executor.trigger_tasks.assert_called_once_with(1)
+
+
+def test_return_to_worker_direct_queueing_executor_not_in_allowlist(self):
+    """When the found executor is not in the allowlist, task falls back to SCHEDULED."""
+    ti = self._make_task_instance()
+    mock_session = mock.MagicMock()
+    executor = self._make_executor(
+        alias="LocalExecutor",
+        module_path="airflow.executors.local_executor.LocalExecutor",
+    )
+
+    with (
+        conf_vars(
+            {
+                ("triggerer", "direct_queueing_executors"): "CeleryExecutor",
+                ("core", "multi_team"): "False",
+            }
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.init_executors",
+            return_value=[executor],
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.find_executor",
+            return_value=executor,
+        ),
+    ):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    assert ti.state == State.SCHEDULED
+    executor.queue_workload.assert_not_called()
+
+
+def test_return_to_worker_direct_queueing_find_executor_returns_none(self):
+    """When find_executor returns None, task falls back to SCHEDULED."""
+    ti = self._make_task_instance(executor="NonExistent")
+    mock_session = mock.MagicMock()
+
+    with (
+        conf_vars(
+            {
+                ("triggerer", "direct_queueing_executors"): "LocalExecutor",
+                ("core", "multi_team"): "False",
+            }
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.init_executors",
+            return_value=[],
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.find_executor",
+            return_value=None,
+        ),
+    ):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    assert ti.state == State.SCHEDULED
+
+
+def test_return_to_worker_direct_queueing_with_multi_team_resolves_team(self):
+    """With multi_team enabled, team_name is resolved from the dag model."""
+    ti = self._make_task_instance(dag_id="team_dag")
+    ti.dag_model.get_team_name.return_value = "team_a"
+    mock_session = mock.MagicMock()
+    executor = self._make_executor(alias="LocalExecutor")
+    mock_workload = mock.MagicMock()
+
+    with (
+        conf_vars(
+            {("triggerer", "direct_queueing_executors"): "LocalExecutor", ("core", "multi_team"): "True"}
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.init_executors",
+            return_value=[executor],
+        ),
+        patch(
+            "airflow.executors.executor_loader.ExecutorLoader.find_executor",
+            return_value=executor,
+        ) as mock_find,
+        patch("airflow.executors.workloads.ExecuteTask.make", return_value=mock_workload),
+    ):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    # Verify team_name was resolved and passed to find_executor
+    ti.dag_model.get_team_name.assert_called_once_with("team_dag", session=mock_session)
+    mock_find.assert_called_once()
+    _, call_kwargs = mock_find.call_args
+    # find_executor is called positionally, so check args
+    call_args = mock_find.call_args[0]
+    assert call_args[2] == "team_a"  # third positional arg is team_name
+    assert ti.state == TaskInstanceState.QUEUED
+
+
+def test_return_to_worker_trigger_id_and_scheduled_dttm_always_set(self):
+    """trigger_id is cleared and scheduled_dttm is set regardless of direct queueing path."""
+    ti = self._make_task_instance()
+    ti.trigger_id = 99
+    mock_session = mock.MagicMock()
+
+    with conf_vars({("triggerer", "direct_queueing_executors"): "", ("core", "multi_team"): "False"}):
+        Trigger.return_to_worker(ti, session=mock_session)
+
+    assert ti.trigger_id is None
+    assert ti.scheduled_dttm is not None
 
 
 def test_kwargs_not_encrypted():

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -935,6 +935,8 @@ def test_return_to_worker_no_direct_queueing_configured():
     mock_session = mock.MagicMock()
 
     with conf_vars({("triggerer", "direct_queueing_executors"): "", ("core", "multi_team"): "False"}):
+        Trigger.direct_queueing_allowlist = []
+        Trigger.multi_team = False
         Trigger.return_to_worker(ti, session=mock_session)
 
     assert ti.trigger_id is None
@@ -962,6 +964,8 @@ def test_return_to_worker_direct_queueing_executor_matches_by_alias():
         ),
         patch("airflow.executors.workloads.ExecuteTask.make", return_value=mock_workload),
     ):
+        Trigger.direct_queueing_allowlist = ["LocalExecutor"]
+        Trigger.multi_team = False
         Trigger.return_to_worker(ti, session=mock_session)
 
     assert ti.trigger_id is None
@@ -995,6 +999,8 @@ def test_return_to_worker_direct_queueing_executor_not_in_allowlist():
             return_value=executor,
         ),
     ):
+        Trigger.direct_queueing_allowlist = ["CeleryExecutor"]
+        Trigger.multi_team = False
         Trigger.return_to_worker(ti, session=mock_session)
 
     assert ti.state == State.SCHEDULED
@@ -1022,6 +1028,8 @@ def test_return_to_worker_direct_queueing_find_executor_returns_none():
             return_value=None,
         ),
     ):
+        Trigger.direct_queueing_allowlist = ["LocalExecutor"]
+        Trigger.multi_team = False
         Trigger.return_to_worker(ti, session=mock_session)
 
     assert ti.state == State.SCHEDULED
@@ -1049,6 +1057,8 @@ def test_return_to_worker_direct_queueing_with_multi_team_resolves_team():
         ) as mock_find,
         patch("airflow.executors.workloads.ExecuteTask.make", return_value=mock_workload),
     ):
+        Trigger.direct_queueing_allowlist = ["LocalExecutor"]
+        Trigger.multi_team = True
         Trigger.return_to_worker(ti, session=mock_session)
 
     # Verify team_name was resolved and passed to find_executor
@@ -1068,6 +1078,8 @@ def test_return_to_worker_trigger_id_and_scheduled_dttm_always_set():
     mock_session = mock.MagicMock()
 
     with conf_vars({("triggerer", "direct_queueing_executors"): "", ("core", "multi_team"): "False"}):
+        Trigger.direct_queueing_allowlist = []
+        Trigger.multi_team = False
         Trigger.return_to_worker(ti, session=mock_session)
 
     assert ti.trigger_id is None

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -910,7 +910,6 @@ def test_serialize_sensitive_kwargs():
 # ---Tests for Trigger.return_to_worker() method.
 
 
-@staticmethod
 def _make_task_instance(executor=None, dag_id="test_dag"):
     """Create a mock TaskInstance for return_to_worker tests."""
     ti = mock.MagicMock(spec=["trigger_id", "scheduled_dttm", "state", "executor", "dag_id", "dag_model"])
@@ -921,7 +920,6 @@ def _make_task_instance(executor=None, dag_id="test_dag"):
     return ti
 
 
-@staticmethod
 def _make_executor(alias="LocalExecutor", module_path="airflow.executors.local_executor.LocalExecutor"):
     """Create a mock executor with name, queue_workload, trigger_tasks, and jwt_generator."""
     from airflow.executors.executor_loader import ExecutorName
@@ -933,7 +931,7 @@ def _make_executor(alias="LocalExecutor", module_path="airflow.executors.local_e
 
 def test_return_to_worker_no_direct_queueing_configured(self):
     """Without direct_queueing_executors configured, task is set to SCHEDULED."""
-    ti = self._make_task_instance()
+    ti = _make_task_instance()
     mock_session = mock.MagicMock()
 
     with conf_vars({("triggerer", "direct_queueing_executors"): "", ("core", "multi_team"): "False"}):
@@ -945,9 +943,9 @@ def test_return_to_worker_no_direct_queueing_configured(self):
 
 def test_return_to_worker_direct_queueing_executor_matches_by_alias(self):
     """When the executor alias is in the allowlist, task is directly QUEUED."""
-    ti = self._make_task_instance()
+    ti = _make_task_instance()
     mock_session = mock.MagicMock()
-    executor = self._make_executor(alias="LocalExecutor")
+    executor = _make_executor(alias="LocalExecutor")
     mock_workload = mock.MagicMock()
 
     with (
@@ -974,9 +972,9 @@ def test_return_to_worker_direct_queueing_executor_matches_by_alias(self):
 
 def test_return_to_worker_direct_queueing_executor_not_in_allowlist(self):
     """When the found executor is not in the allowlist, task falls back to SCHEDULED."""
-    ti = self._make_task_instance()
+    ti = _make_task_instance()
     mock_session = mock.MagicMock()
-    executor = self._make_executor(
+    executor = _make_executor(
         alias="LocalExecutor",
         module_path="airflow.executors.local_executor.LocalExecutor",
     )
@@ -1005,7 +1003,7 @@ def test_return_to_worker_direct_queueing_executor_not_in_allowlist(self):
 
 def test_return_to_worker_direct_queueing_find_executor_returns_none(self):
     """When find_executor returns None, task falls back to SCHEDULED."""
-    ti = self._make_task_instance(executor="NonExistent")
+    ti = _make_task_instance(executor="NonExistent")
     mock_session = mock.MagicMock()
 
     with (
@@ -1031,10 +1029,10 @@ def test_return_to_worker_direct_queueing_find_executor_returns_none(self):
 
 def test_return_to_worker_direct_queueing_with_multi_team_resolves_team(self):
     """With multi_team enabled, team_name is resolved from the dag model."""
-    ti = self._make_task_instance(dag_id="team_dag")
+    ti = _make_task_instance(dag_id="team_dag")
     ti.dag_model.get_team_name.return_value = "team_a"
     mock_session = mock.MagicMock()
-    executor = self._make_executor(alias="LocalExecutor")
+    executor = _make_executor(alias="LocalExecutor")
     mock_workload = mock.MagicMock()
 
     with (
@@ -1065,7 +1063,7 @@ def test_return_to_worker_direct_queueing_with_multi_team_resolves_team(self):
 
 def test_return_to_worker_trigger_id_and_scheduled_dttm_always_set(self):
     """trigger_id is cleared and scheduled_dttm is set regardless of direct queueing path."""
-    ti = self._make_task_instance()
+    ti = _make_task_instance()
     ti.trigger_id = 99
     mock_session = mock.MagicMock()
 

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -929,7 +929,7 @@ def _make_executor(alias="LocalExecutor", module_path="airflow.executors.local_e
     return executor
 
 
-def test_return_to_worker_no_direct_queueing_configured(self):
+def test_return_to_worker_no_direct_queueing_configured():
     """Without direct_queueing_executors configured, task is set to SCHEDULED."""
     ti = _make_task_instance()
     mock_session = mock.MagicMock()
@@ -941,7 +941,7 @@ def test_return_to_worker_no_direct_queueing_configured(self):
     assert ti.state == State.SCHEDULED
 
 
-def test_return_to_worker_direct_queueing_executor_matches_by_alias(self):
+def test_return_to_worker_direct_queueing_executor_matches_by_alias():
     """When the executor alias is in the allowlist, task is directly QUEUED."""
     ti = _make_task_instance()
     mock_session = mock.MagicMock()
@@ -970,7 +970,7 @@ def test_return_to_worker_direct_queueing_executor_matches_by_alias(self):
     executor.trigger_tasks.assert_called_once_with(1)
 
 
-def test_return_to_worker_direct_queueing_executor_not_in_allowlist(self):
+def test_return_to_worker_direct_queueing_executor_not_in_allowlist():
     """When the found executor is not in the allowlist, task falls back to SCHEDULED."""
     ti = _make_task_instance()
     mock_session = mock.MagicMock()
@@ -1001,7 +1001,7 @@ def test_return_to_worker_direct_queueing_executor_not_in_allowlist(self):
     executor.queue_workload.assert_not_called()
 
 
-def test_return_to_worker_direct_queueing_find_executor_returns_none(self):
+def test_return_to_worker_direct_queueing_find_executor_returns_none():
     """When find_executor returns None, task falls back to SCHEDULED."""
     ti = _make_task_instance(executor="NonExistent")
     mock_session = mock.MagicMock()
@@ -1027,7 +1027,7 @@ def test_return_to_worker_direct_queueing_find_executor_returns_none(self):
     assert ti.state == State.SCHEDULED
 
 
-def test_return_to_worker_direct_queueing_with_multi_team_resolves_team(self):
+def test_return_to_worker_direct_queueing_with_multi_team_resolves_team():
     """With multi_team enabled, team_name is resolved from the dag model."""
     ti = _make_task_instance(dag_id="team_dag")
     ti.dag_model.get_team_name.return_value = "team_a"
@@ -1061,7 +1061,7 @@ def test_return_to_worker_direct_queueing_with_multi_team_resolves_team(self):
     assert ti.state == TaskInstanceState.QUEUED
 
 
-def test_return_to_worker_trigger_id_and_scheduled_dttm_always_set(self):
+def test_return_to_worker_trigger_id_and_scheduled_dttm_always_set():
     """trigger_id is cleared and scheduled_dttm is set regardless of direct queueing path."""
     ti = _make_task_instance()
     ti.trigger_id = 99


### PR DESCRIPTION
As we have many Dags with different priorities and use a log of Deferred Tasks we noticed that sometimes tasks returning from triggerer back to worker are stuck for a long time. This can happen if a Dag with higher priority is started after a task has been deferred. Then on return other tasks are scheduled prior a returning task.

This is bad for example in our case where we use KPO as the Pods are completed but still allocate disk space, might get lost if Autoscaler decides to turn down a node. Then the Xcom information gets lost as the XCom side-car is still active waiting to have the task active again on the worker to fetch Xcom and delete the Pod.

We considered the following options:
- Accept the situation... no, this is bothering since a long time and we lose a lot of Xcom results and users sometimes wait long on results. Also we had situations where newer high priority workload could be scheduled as nodes were still allocated with Pod leftovers waiting on deletion but deletion was not happening because lower priority.
- Implement a "hack" and increase priority of tasks returning from Triggerer. But then if the task actually failed the priority would need to be reset again.
- Ensure that tasks that return from Triggerer are not scheduled again (risk of being delayed) but pushing directly to executor queue --> this PR!

I'd like to propose to add this as a new feature into 3.2.0. We have patched this locally into 3.1.7 and results show that (1) latency for cleanup in Deferred KPO is very much improved as well as (2) efforts on scheduling are reduced.

Trade-off might be that there might be situations where more tasks than allowed are "running" if deferred tasks are not counted into pools. Therefore the config is not enabled per default and is therefore an opt-in.

FYI @AutomationDev85 @dabla 

closes: https://github.com/apache/airflow/issues/57210

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
Claude 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
