### PR TITLE
[v3-1-test] Updates exception to hide sql statements on constraint fa…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -74,22 +74,26 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
             for tb in traceback.format_tb(exc.__traceback__):
                 stacktrace += tb
 
-            log_message = f"Error with id {exception_id}\n{stacktrace}"
+            log_message = f"Error with id {exception_id}, statement: {exc.statement}\n{stacktrace}"
             log.error(log_message)
             if conf.get("api", "expose_stacktrace") == "True":
                 message = log_message
+                statement = str(exc.statement)
+                orig_error = str(exc.orig)
             else:
                 message = (
                     "Serious error when handling your request. Check logs for more details - "
                     f"you will find it in api server when you look for ID {exception_id}"
                 )
+                statement = "hidden"
+                orig_error = "hidden"
 
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "reason": "Unique constraint violation",
-                    "statement": str(exc.statement),
-                    "orig_error": str(exc.orig),
+                    "statement": statement,
+                    "orig_error": orig_error,
                     "message": message,
                 },
             )

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -124,75 +124,38 @@ class TestUniqueConstraintErrorHandler:
         clear_db_dags()
 
     @pytest.mark.parametrize(
-        "table, expected_exception",
-        generate_test_cases_parametrize(
-            ["Pool", "Variable"],
+        ("table", "expected_exception"),
+        [
             [
-                [  # Pool
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (?, ?, ?, ?, ?)",
-                            "orig_error": "UNIQUE constraint failed: slot_pool.pool",
-                            "message": MESSAGE,
-                        },
-                    ),
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%s, %s, %s, %s, %s)",
-                            "orig_error": "(1062, \"Duplicate entry 'test_pool' for key 'slot_pool.slot_pool_pool_uq'\")",
-                            "message": MESSAGE,
-                        },
-                    ),
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": f"INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_id)s{uuid_suffix}) RETURNING slot_pool.id",
-                            "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
-                            "message": MESSAGE,
-                        },
-                    ),
-                ],
-                [  # Variable
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": 'INSERT INTO variable ("key", val, description, is_encrypted, team_id) VALUES (?, ?, ?, ?, ?)',
-                            "orig_error": "UNIQUE constraint failed: variable.key",
-                            "message": MESSAGE,
-                        },
-                    ),
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO variable (`key`, val, description, is_encrypted, team_id) VALUES (%s, %s, %s, %s, %s)",
-                            "orig_error": "(1062, \"Duplicate entry 'test_key' for key 'variable.variable_key_uq'\")",
-                            "message": MESSAGE,
-                        },
-                    ),
-                    HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail={
-                            "reason": "Unique constraint violation",
-                            "statement": f"INSERT INTO variable (key, val, description, is_encrypted, team_id) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_id)s{uuid_suffix}) RETURNING variable.id",
-                            "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
-                            "message": MESSAGE,
-                        },
-                    ),
-                ],
+                "Pool",
+                HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "reason": "Unique constraint violation",
+                        "statement": "hidden",
+                        "orig_error": "hidden",
+                        "message": MESSAGE,
+                    },
+                ),
             ],
-        ),
+            [
+                "Variable",
+                HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "reason": "Unique constraint violation",
+                        "statement": "hidden",
+                        "orig_error": "hidden",
+                        "message": MESSAGE,
+                    },
+                ),
+            ],
+        ],
     )
     @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
     @conf_vars({("api", "expose_stacktrace"): "False"})
     @provide_session
-    def test_handle_single_column_unique_constraint_error(
+    def test_handle_single_column_unique_constraint_error_without_stacktrace(
         self,
         mock_get_random_string,
         session,
@@ -224,6 +187,137 @@ class TestUniqueConstraintErrorHandler:
     @pytest.mark.parametrize(
         "table, expected_exception",
         generate_test_cases_parametrize(
+            ["Pool", "Variable"],
+            [
+                [  # Pool
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (?, ?, ?, ?, ?)",
+                            "orig_error": "UNIQUE constraint failed: slot_pool.pool",
+                        },
+                    ),
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (%s, %s, %s, %s, %s)",
+                            "orig_error": "(1062, \"Duplicate entry 'test_pool' for key 'slot_pool.slot_pool_pool_uq'\")",
+                        },
+                    ),
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_name)s) RETURNING slot_pool.id",
+                            "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
+                        },
+                    ),
+                ],
+                [  # Variable
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": 'INSERT INTO variable ("key", val, description, is_encrypted, team_name) VALUES (?, ?, ?, ?, ?)',
+                            "orig_error": "UNIQUE constraint failed: variable.key",
+                        },
+                    ),
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": "INSERT INTO variable (`key`, val, description, is_encrypted, team_name) VALUES (%s, %s, %s, %s, %s)",
+                            "orig_error": "(1062, \"Duplicate entry 'test_key' for key 'variable.variable_key_uq'\")",
+                        },
+                    ),
+                    HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "reason": "Unique constraint violation",
+                            "statement": "INSERT INTO variable (key, val, description, is_encrypted, team_name) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_name)s) RETURNING variable.id",
+                            "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
+                        },
+                    ),
+                ],
+            ],
+        ),
+    )
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
+    @conf_vars({("api", "expose_stacktrace"): "True"})
+    @provide_session
+    def test_handle_single_column_unique_constraint_error_with_stacktrace(
+        self,
+        mock_get_random_string,
+        session,
+        table,
+        expected_exception,
+    ) -> None:
+        # Take Pool and Variable tables as test cases
+        # Note: SQLA2 uses a more optimized bulk insert strategy when multiple objects are added to the
+        #   session. Instead of individual INSERT statements, a single INSERT with the SELECT FROM VALUES
+        #   pattern is used.
+        if table == "Pool":
+            session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
+            session.flush()  # Avoid SQLA2.0 bulk insert optimization
+            session.add(Pool(pool=TEST_POOL, slots=1, description="test pool", include_deferred=False))
+        elif table == "Variable":
+            session.add(Variable(key=TEST_VARIABLE_KEY, val="test_val"))
+            session.flush()
+            session.add(Variable(key=TEST_VARIABLE_KEY, val="test_val"))
+
+        with pytest.raises(IntegrityError) as exeinfo_integrity_error:
+            session.commit()
+
+        with pytest.raises(HTTPException) as exeinfo_response_error:
+            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+
+        exeinfo_response_error.value.detail.pop("message", None)  # type: ignore[attr-defined]
+        assert exeinfo_response_error.value.status_code == expected_exception.status_code
+        assert exeinfo_response_error.value.detail == expected_exception.detail
+
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
+    @conf_vars({("api", "expose_stacktrace"): "False"})
+    @provide_session
+    def test_handle_multiple_columns_unique_constraint_error_without_stacktrace(
+        self,
+        mock_get_random_string,
+        session,
+    ) -> None:
+        expected_exception = HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "reason": "Unique constraint violation",
+                "statement": "hidden",
+                "orig_error": "hidden",
+                "message": MESSAGE,
+            },
+        )
+        session.add(
+            DagRun(dag_id="test_dag_id", run_id="test_run_id", run_type="manual", state=DagRunState.RUNNING)
+        )
+        session.add(
+            DagRun(dag_id="test_dag_id", run_id="test_run_id", run_type="manual", state=DagRunState.RUNNING)
+        )
+        with pytest.raises(IntegrityError) as exeinfo_integrity_error:
+            session.commit()
+
+        with pytest.raises(HTTPException) as exeinfo_response_error:
+            self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
+
+        assert exeinfo_response_error.value.status_code == expected_exception.status_code
+        # The SQL statement is an implementation detail, so we match on the statement pattern (contains
+        # the table name and is an INSERT) instead of insisting on an exact match.
+        response_detail = exeinfo_response_error.value.detail
+        expected_detail = expected_exception.detail
+
+        assert response_detail == expected_detail
+        assert exeinfo_response_error.value.detail == expected_exception.detail
+
+    @pytest.mark.parametrize(
+        ("table", "expected_exception"),
+        generate_test_cases_parametrize(
             ["DagRun"],
             [
                 [  # DagRun
@@ -233,7 +327,6 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, triggering_user_name, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, (SELECT max(log_template.id) AS max_1 \nFROM log_template), ?, ?, ?, ?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: dag_run.dag_id, dag_run.run_id",
-                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -242,7 +335,6 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, triggering_user_name, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %s, %s, %s, %s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_dag_id-test_run_id' for key 'dag_run.dag_run_dag_id_run_id_key'\")",
-                            "message": MESSAGE,
                         },
                     ),
                     HTTPException(
@@ -251,7 +343,6 @@ class TestUniqueConstraintErrorHandler:
                             "reason": "Unique constraint violation",
                             "statement": "INSERT INTO dag_run (dag_id, queued_at, logical_date, start_date, end_date, state, run_id, creating_job_id, run_type, triggered_by, triggering_user_name, conf, data_interval_start, data_interval_end, run_after, last_scheduling_decision, log_template_id, updated_at, clear_number, backfill_id, bundle_version, scheduled_by_job_id, context_carrier, created_dag_version_id) VALUES (%(dag_id)s, %(queued_at)s, %(logical_date)s, %(start_date)s, %(end_date)s, %(state)s, %(run_id)s, %(creating_job_id)s, %(run_type)s, %(triggered_by)s, %(triggering_user_name)s, %(conf)s, %(data_interval_start)s, %(data_interval_end)s, %(run_after)s, %(last_scheduling_decision)s, (SELECT max(log_template.id) AS max_1 \nFROM log_template), %(updated_at)s, %(clear_number)s, %(backfill_id)s, %(bundle_version)s, %(scheduled_by_job_id)s, %(context_carrier)s, %(created_dag_version_id)s) RETURNING dag_run.id",
                             "orig_error": 'duplicate key value violates unique constraint "dag_run_dag_id_run_id_key"\nDETAIL:  Key (dag_id, run_id)=(test_dag_id, test_run_id) already exists.\n',
-                            "message": MESSAGE,
                         },
                     ),
                 ],
@@ -259,9 +350,9 @@ class TestUniqueConstraintErrorHandler:
         ),
     )
     @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
-    @conf_vars({("api", "expose_stacktrace"): "False"})
+    @conf_vars({("api", "expose_stacktrace"): "True"})
     @provide_session
-    def test_handle_multiple_columns_unique_constraint_error(
+    def test_handle_multiple_columns_unique_constraint_error_with_stacktrace(
         self,
         mock_get_random_string,
         session,
@@ -297,8 +388,10 @@ class TestUniqueConstraintErrorHandler:
             actual_statement = response_detail.pop("statement", None)  # type: ignore[attr-defined]
             expected_detail.pop("statement", None)
 
-            assert response_detail == expected_detail
-            assert "INSERT INTO dag_run" in actual_statement
+        # Removes the stacktrace from response to remove during comparison.
+        response_detail.pop("message", None)  # type: ignore[attr-defined]
+        assert response_detail == expected_detail
+        assert "INSERT INTO dag_run" in actual_statement
         assert exeinfo_response_error.value.detail == expected_exception.detail
 
 

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -194,7 +194,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (?, ?, ?, ?, ?)",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (?, ?, ?, ?, ?)",
                             "orig_error": "UNIQUE constraint failed: slot_pool.pool",
                         },
                     ),
@@ -202,7 +202,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (%s, %s, %s, %s, %s)",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%s, %s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_pool' for key 'slot_pool.slot_pool_pool_uq'\")",
                         },
                     ),
@@ -210,7 +210,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_name) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_name)s) RETURNING slot_pool.id",
+                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_id)s) RETURNING slot_pool.id",
                             "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
                         },
                     ),
@@ -220,7 +220,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": 'INSERT INTO variable ("key", val, description, is_encrypted, team_name) VALUES (?, ?, ?, ?, ?)',
+                            "statement": 'INSERT INTO variable ("key", val, description, is_encrypted, team_id) VALUES (?, ?, ?, ?, ?)',
                             "orig_error": "UNIQUE constraint failed: variable.key",
                         },
                     ),
@@ -228,7 +228,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO variable (`key`, val, description, is_encrypted, team_name) VALUES (%s, %s, %s, %s, %s)",
+                            "statement": "INSERT INTO variable (`key`, val, description, is_encrypted, team_id) VALUES (%s, %s, %s, %s, %s)",
                             "orig_error": "(1062, \"Duplicate entry 'test_key' for key 'variable.variable_key_uq'\")",
                         },
                     ),
@@ -236,7 +236,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO variable (key, val, description, is_encrypted, team_name) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_name)s) RETURNING variable.id",
+                            "statement": "INSERT INTO variable (key, val, description, is_encrypted, team_id) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_id)s) RETURNING variable.id",
                             "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
                         },
                     ),
@@ -378,20 +378,20 @@ class TestUniqueConstraintErrorHandler:
             self.unique_constraint_error_handler.exception_handler(None, exeinfo_integrity_error.value)  # type: ignore
 
         assert exeinfo_response_error.value.status_code == expected_exception.status_code
+        response_detail = exeinfo_response_error.value.detail
+        # Removes the stacktrace from response to remove during comparison.
+        response_detail.pop("message", None)  # type: ignore[attr-defined]
         if SQLALCHEMY_V_1_4:
             assert exeinfo_response_error.value.detail == expected_exception.detail
         else:
             # The SQL statement is an implementation detail, so we match on the statement pattern (contains
             # the table name and is an INSERT) instead of insisting on an exact match.
-            response_detail = exeinfo_response_error.value.detail
             expected_detail = expected_exception.detail
             actual_statement = response_detail.pop("statement", None)  # type: ignore[attr-defined]
             expected_detail.pop("statement", None)
+            assert response_detail == expected_detail
+            assert "INSERT INTO dag_run" in actual_statement
 
-        # Removes the stacktrace from response to remove during comparison.
-        response_detail.pop("message", None)  # type: ignore[attr-defined]
-        assert response_detail == expected_detail
-        assert "INSERT INTO dag_run" in actual_statement
         assert exeinfo_response_error.value.detail == expected_exception.detail
 
 


### PR DESCRIPTION
…ilure (#63028)

* Updates exception to hide sql statements on constraint failure

The exception handler now hides the sql statement when the expose stacktrace flag is false.

* Fixes failing UT

* Adds ignore type on pop from dict

Since pytest returns a starlette HTTPException
it annotates details as a string, we make use
of FastApi's HTTPException which returns details
as a dict. Due to this mypy get's confused about
some of the operations we're performing on a dict.

* Cleaned up UTs to remove generate_test_cases_parametrize (cherry picked from commit 60f6efca5b5169ad89eda9993c12687715413d69)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
