### PR TITLE
fix(metrics): emit queued_duration metric in execution API ti_run endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -140,6 +140,9 @@ def ti_run(
             TI.hostname,
             TI.unixname,
             TI.pid,
+            TI.queued_dttm,
+            TI.end_date,
+            TI.queue,
             # This selects the raw JSON value, bypassing the deserialization -- we want that to happen on the
             # client
             column("next_kwargs", JSON),
@@ -232,6 +235,19 @@ def ti_run(
     try:
         result = session.execute(query)
         log.info("Task instance state updated", rows_affected=getattr(result, "rowcount", 0))
+
+        # Emit queued_duration metric (time spent in QUEUED state before RUNNING).
+        # Only on the first attempt (no end_date yet) and when queued_dttm is set.
+        if not ti.end_date and ti.queued_dttm:
+            from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
+
+            queued_duration = timezone.utcnow() - ti.queued_dttm
+            DualStatsManager.timing(
+                "task.queued_duration",
+                queued_duration,
+                tags={},
+                extra_tags={"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue or ""},
+            )
 
         dr = (
             session.scalars(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
 from airflow._shared.observability.traces import override_ids
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
@@ -239,8 +240,6 @@ def ti_run(
         # Emit queued_duration metric (time spent in QUEUED state before RUNNING).
         # Only on the first attempt (no end_date yet) and when queued_dttm is set.
         if not ti.end_date and ti.queued_dttm:
-            from airflow._shared.observability.metrics.dual_stats_manager import DualStatsManager
-
             queued_duration = timezone.utcnow() - ti.queued_dttm
             DualStatsManager.timing(
                 "task.queued_duration",

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -278,6 +278,81 @@ class TestTIRunState:
         )
         assert response.status_code == 409
 
+    def test_ti_run_emits_queued_duration_metric(self, client, session, create_task_instance, time_machine):
+        """Test that transitioning a TI to RUNNING emits the queued_duration metric."""
+        queued_time = timezone.parse("2024-09-30T12:00:00Z")
+        run_time = timezone.parse("2024-09-30T12:05:00Z")
+        time_machine.move_to(queued_time, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_emits_queued_duration_metric",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_time,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_time
+        session.commit()
+
+        time_machine.move_to(run_time, tick=False)
+
+        with mock.patch(
+            "airflow.api_fastapi.execution_api.routes.task_instances.DualStatsManager",
+        ) as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_time.to_iso8601_string(),
+                },
+            )
+            assert response.status_code == 200
+            mock_stats.timing.assert_called_once_with(
+                "task.queued_duration",
+                run_time - queued_time,
+                tags={},
+                extra_tags={"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue or ""},
+            )
+
+    def test_ti_run_skips_queued_duration_metric_on_retry(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """Test that queued_duration metric is NOT emitted when end_date is set (retry)."""
+        instant = timezone.parse("2024-09-30T12:00:00Z")
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_skips_metric_on_retry",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = instant
+        ti.end_date = instant  # Simulates a retry (previous attempt had an end_date)
+        session.commit()
+
+        with mock.patch(
+            "airflow.api_fastapi.execution_api.routes.task_instances.DualStatsManager",
+        ) as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": instant.to_iso8601_string(),
+                },
+            )
+            assert response.status_code == 200
+            mock_stats.timing.assert_not_called()
+
     def test_dynamic_task_mapping_with_parse_time_value(self, client, dag_maker):
         """Test that dynamic task mapping works correctly with parse-time values."""
         with dag_maker("test_dynamic_task_mapping_with_parse_time_value", serialized=True):


### PR DESCRIPTION
In Airflow 3, tasks transition from QUEUED to RUNNING via the execution API (`ti_run` endpoint), not the legacy `TaskInstance._run_raw_task` path. The `task.queued_duration` metric (`dag.{dag_id}.{task_id}.queued_duration` in legacy format) is only emitted in the old path via `emit_state_change_metric()`, so it's never recorded for tasks started through the task SDK.

This adds the metric emission to `ti_run()` — selects `queued_dttm`, `end_date`, and `queue` from the TI row and calls `DualStatsManager.timing()` after the state update. Same first-attempt guard as the original (skips when `end_date` is set).

Closes: #63503

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
