### PR TITLE
Fix S3ToGCSOperator deferrable mode to return list of copied files

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -278,6 +278,7 @@ class S3ToGCSOperator(S3ListOperator):
                 gcp_conn_id=self.gcp_conn_id,
                 job_names=job_names,
                 poll_interval=self.poll_interval,
+                files=files,
             ),
             method_name="execute_complete",
         )
@@ -334,16 +335,18 @@ class S3ToGCSOperator(S3ListOperator):
 
         return job_names
 
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> list[str] | None:
         """
-        Return immediately and relies on trigger to throw a success event. Callback for the trigger.
+        Handle the trigger callback when transfer jobs complete.
 
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
+        Returns the list of copied file paths when available (deferrable mode with
+        files passed via trigger), so subsequent tasks can consume them via XCom.
+        Returns None when event does not contain files (e.g. legacy triggers).
         """
         if event["status"] == "error":
             raise AirflowException(event["message"])
         self.log.info("%s completed with response %s ", self.task_id, event["message"])
+        return event.get("files")
 
     def get_transfer_hook(self):
         return CloudDataTransferServiceHook(

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_storage_transfer_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_storage_transfer_service.py
@@ -59,7 +59,7 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
         self.gcp_conn_id = gcp_conn_id
         self.job_names = job_names
         self.poll_interval = poll_interval
-        self.files = files or []
+        self.files = files
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize StorageTransferJobsTrigger arguments and classpath."""
@@ -127,7 +127,7 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
                     "status": "success",
                     "message": f"Transfer job{s} {job_names_str} completed successfully",
                 }
-                if self.files:
+                if self.files is not None:
                     event_payload["files"] = self.files
                 yield TriggerEvent(event_payload)
                 return

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_storage_transfer_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_storage_transfer_service.py
@@ -42,6 +42,8 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
     :param project_id: GCP project id.
     :param poll_interval: Interval in seconds between polls.
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
+    :param files: Optional list of file paths being transferred. When provided, included in the
+        success event for the operator to return to subsequent tasks (e.g. for XCom).
     """
 
     def __init__(
@@ -50,12 +52,14 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
         project_id: str = PROVIDE_PROJECT_ID,
         poll_interval: int = 10,
         gcp_conn_id: str = "google_cloud_default",
+        files: list[str] | None = None,
     ) -> None:
         super().__init__()
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.job_names = job_names
         self.poll_interval = poll_interval
+        self.files = files or []
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize StorageTransferJobsTrigger arguments and classpath."""
@@ -66,6 +70,7 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
                 "job_names": self.job_names,
                 "poll_interval": self.poll_interval,
                 "gcp_conn_id": self.gcp_conn_id,
+                "files": self.files,
             },
         )
 
@@ -117,13 +122,14 @@ class CloudStorageTransferServiceCreateJobsTrigger(BaseTrigger):
             self.log.info("Transfer jobs completed: %s of %s", jobs_completed_successfully, jobs_total)
             if jobs_completed_successfully == jobs_total:
                 s = "s" if jobs_total > 1 else ""
-                job_names = ", ".join(j for j in self.job_names)
-                yield TriggerEvent(
-                    {
-                        "status": "success",
-                        "message": f"Transfer job{s} {job_names} completed successfully",
-                    }
-                )
+                job_names_str = ", ".join(j for j in self.job_names)
+                event_payload: dict[str, Any] = {
+                    "status": "success",
+                    "message": f"Transfer job{s} {job_names_str} completed successfully",
+                }
+                if self.files:
+                    event_payload["files"] = self.files
+                yield TriggerEvent(event_payload)
                 return
 
             self.log.info("Sleeping for %s seconds", self.poll_interval)

--- a/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
@@ -344,6 +344,7 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
         assert trigger.project_id == PROJECT_ID
         assert trigger.job_names == [TRANSFER_JOB_ID_0]
         assert trigger.poll_interval == operator.poll_interval
+        assert trigger.files == MOCK_FILES
 
         assert hasattr(exception_info.value, "method_name")
         assert exception_info.value.method_name == "execute_complete"
@@ -386,6 +387,7 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
         assert trigger.project_id == PROJECT_ID
         assert trigger.job_names == expected_job_names
         assert trigger.poll_interval == operator.poll_interval
+        assert trigger.files == MOCK_FILES
 
         assert hasattr(exception_info.value, "method_name")
         assert exception_info.value.method_name == expected_method_name
@@ -486,11 +488,28 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
             "message": expected_event_message,
         }
         operator = S3ToGCSOperator(task_id=TASK_ID, bucket=S3_BUCKET)
-        operator.execute_complete(context=mock.MagicMock(), event=event)
+        result = operator.execute_complete(context=mock.MagicMock(), event=event)
 
         mock_log.return_value.info.assert_called_once_with(
             "%s completed with response %s ", TASK_ID, event["message"]
         )
+        assert result is None
+
+    @mock.patch(
+        "airflow.providers.google.cloud.transfers.s3_to_gcs.S3ToGCSOperator.log", new_callable=PropertyMock
+    )
+    def test_execute_complete_success_returns_copied_files(self, mock_log):
+        """Deferrable mode returns list of copied files for use in subsequent tasks via XCom."""
+        expected_files = [MOCK_FILE_1, MOCK_FILE_2]
+        event = {
+            "status": "success",
+            "message": "Transfer completed",
+            "files": expected_files,
+        }
+        operator = S3ToGCSOperator(task_id=TASK_ID, bucket=S3_BUCKET)
+        result = operator.execute_complete(context=mock.MagicMock(), event=event)
+
+        assert result == expected_files
 
     @mock.patch(
         "airflow.providers.google.cloud.transfers.s3_to_gcs.S3ToGCSOperator.log", new_callable=PropertyMock

--- a/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
@@ -488,7 +488,7 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
             "message": expected_event_message,
         }
         operator = S3ToGCSOperator(task_id=TASK_ID, bucket=S3_BUCKET)
-        result = operator.execute_complete(context=mock.MagicMock(), event=event)
+        result = operator.execute_complete(context={}, event=event)
 
         mock_log.return_value.info.assert_called_once_with(
             "%s completed with response %s ", TASK_ID, event["message"]
@@ -507,7 +507,7 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
             "files": expected_files,
         }
         operator = S3ToGCSOperator(task_id=TASK_ID, bucket=S3_BUCKET)
-        result = operator.execute_complete(context=mock.MagicMock(), event=event)
+        result = operator.execute_complete(context={}, event=event)
 
         assert result == expected_files
 

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_storage_transfer_service.py
@@ -91,7 +91,7 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
             "job_names": JOB_NAMES,
             "poll_interval": POLL_INTERVAL,
             "gcp_conn_id": GCP_CONN_ID,
-            "files": [],
+            "files": None,
         }
 
     def test_get_async_hook(self, trigger):

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_storage_transfer_service.py
@@ -91,6 +91,7 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
             "job_names": JOB_NAMES,
             "poll_interval": POLL_INTERVAL,
             "gcp_conn_id": GCP_CONN_ID,
+            "files": [],
         }
 
     def test_get_async_hook(self, trigger):
@@ -118,6 +119,31 @@ class TestCloudStorageTransferServiceCreateJobsTrigger:
         actual_event = await generator.asend(None)
 
         assert actual_event == expected_event
+
+    @pytest.mark.asyncio
+    @mock.patch(ASYNC_HOOK_CLASS_PATH + ".get_latest_operation")
+    @mock.patch(ASYNC_HOOK_CLASS_PATH + ".get_jobs")
+    async def test_run_includes_files_in_success_event(self, get_jobs, get_latest_operation):
+        """When trigger has files, success event includes them for operator to return via XCom."""
+        TRANSFERRED_FILES = ["path/file1.csv", "path/file2.csv"]
+        trigger_with_files = CloudStorageTransferServiceCreateJobsTrigger(
+            project_id=PROJECT_ID,
+            job_names=JOB_NAMES,
+            poll_interval=POLL_INTERVAL,
+            gcp_conn_id=GCP_CONN_ID,
+            files=TRANSFERRED_FILES,
+        )
+        get_jobs.return_value = mock_jobs(names=JOB_NAMES, latest_operation_names=LATEST_OPERATION_NAMES)
+        get_latest_operation.side_effect = [
+            create_mock_operation(status=TransferOperation.Status.SUCCESS, name="operation_" + job_name)
+            for job_name in JOB_NAMES
+        ]
+
+        generator = trigger_with_files.run()
+        actual_event = await generator.asend(None)
+
+        assert actual_event.payload["status"] == "success"
+        assert actual_event.payload["files"] == TRANSFERRED_FILES
 
     @pytest.mark.parametrize(
         "status",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR addresses functionality originally proposed in #49768. Since that PR has been stalled, and #11323 is effectively blocked by it, I've proceeded with this implementation in the hope of unblocking progress.

If the original author of #49768 returns and continues his work, I can close this PR so that his proceeds instead. If not, would it be acceptable to merge this PR so that deferrable S3→GCS transfers can return the list of copied files and downstream tasks can consume them via XCom?

`S3ToGCSOperator` in deferrable mode now returns the list of copied file paths (same as non-deferrable mode), so downstream tasks can consume them via XCom. This fixes the previous inconsistency where `deferrable=True` did not return any value.

**_Verified in testing: both deferrable=True and deferrable=False return file names, not URIs. Returning URIs instead could be addressed in a separate PR if desired._**

## Screenshots

### Deferrable state
<img width="1349" height="114" alt="image" src="https://github.com/user-attachments/assets/93cb3da8-b079-43a3-9d96-d39ca8aee81c" />

### XCom
<img width="1165" height="260" alt="image" src="https://github.com/user-attachments/assets/7604c02a-72f3-4726-b288-764f8922ef9d" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
