### PR TITLE
Add import shim for opentelemetry.trace

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/traces.rst
@@ -62,6 +62,31 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
     See the OpenTelemetry `exporter protocol specification <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options>`_  and
     `SDK environment variable documentation <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader>`_ for more information.
 
+Adding Custom Spans in Tasks
+-----------------------------
+
+DAG authors can instrument their tasks with custom spans using the ``trace`` object from
+``airflow.sdk.observability``. This is a thin shim over the standard OpenTelemetry
+``opentelemetry.trace`` module, so all standard OpenTelemetry tracing APIs are available.
+
+.. code-block:: python
+
+    from airflow.sdk import task
+    from airflow.sdk.observability import trace
+
+    tracer = trace.get_tracer(__name__)
+
+
+    @task
+    def my_task():
+        with tracer.start_as_current_span("my_span") as span:
+            span.set_attribute("key", "value")
+            # ... task logic ...
+
+Custom spans created this way are automatically nested as children of the Airflow-managed
+task span when tracing is enabled. When tracing is disabled, the no-op tracer provided by
+the OpenTelemetry API is used, so tasks run without any overhead.
+
 Enable Https
 -----------------
 

--- a/airflow-core/tests/integration/otel/dags/otel_test_dag.py
+++ b/airflow-core/tests/integration/otel/dags/otel_test_dag.py
@@ -19,10 +19,9 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 
-from opentelemetry import trace
-
 from airflow import DAG
 from airflow.sdk import task
+from airflow.sdk.observability import trace
 
 logger = logging.getLogger("airflow.otel_test_dag")
 

--- a/task-sdk/src/airflow/sdk/observability/__init__.py
+++ b/task-sdk/src/airflow/sdk/observability/__init__.py
@@ -14,3 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
+from opentelemetry import trace
+
+__all__ = ["trace"]


### PR DESCRIPTION
Users should import opentelemetry.trace via airflow.sdk.observability.trace.  This way it preserves our ability to make some modifications to all user spans.

@xBis7 @nickstenning 