### PR TITLE
fix: create default_pool when upgrading fresh DB with explicit revision

### DIFF
--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1245,7 +1245,16 @@ def upgradedb(
         initdb(session=session)
         return
 
+    is_fresh_db = not _get_current_revision(session=session)
+
     _run_upgradedb(config, to_revision, session)
+
+    if is_fresh_db:
+        # When upgrading a fresh DB with an explicit --to-revision/--to-version,
+        # initdb() is skipped, so we need to create the default pool and sync
+        # the log template here to avoid tasks stuck in "scheduled" state.
+        add_default_pool_if_not_exists(session=session)
+        synchronize_log_template(session=session)
 
 
 def _resetdb_mysql(session: Session) -> None:

--- a/airflow-core/tests/unit/utils/test_db.py
+++ b/airflow-core/tests/unit/utils/test_db.py
@@ -251,6 +251,22 @@ class TestDb:
                 f"upgrade should be called with revision='heads', got calls: {mock_upgrade.call_args_list}"
             )
 
+    def test_upgradedb_fresh_db_with_to_revision_creates_default_pool(self, mocker):
+        """When upgrading a fresh DB with an explicit to_revision, default pool must still be created."""
+        mocker.patch("alembic.command.upgrade")
+        mocker.patch("airflow.utils.db._get_alembic_config")
+        mock_add_pool = mocker.patch("airflow.utils.db.add_default_pool_if_not_exists")
+        mock_sync_log = mocker.patch("airflow.utils.db.synchronize_log_template")
+        # Simulate fresh DB: _get_current_revision returns None
+        mocker.patch("airflow.utils.db._get_current_revision", return_value=None)
+        mocker.patch("airflow.utils.db._check_migration_errors", return_value=[])
+        mocker.patch("airflow.utils.db._run_upgradedb")
+
+        upgradedb(to_revision="abc123")
+
+        mock_add_pool.assert_called_once()
+        mock_sync_log.assert_called_once()
+
     @pytest.mark.parametrize(
         ("from_revision", "to_revision"),
         [("be2bfac3da23", "e959f08ac86c"), ("ccde3e26fe78", "2e42bb497a22")],


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

`upgradedb()` has a fast path for fresh databases: when there's no current revision and no explicit `to_revision`, it delegates to `initdb()` which handles pool creation. But when `to_revision` is set (e.g. `airflow db migrate --to-version 3.1.8`), it skips `initdb()` and goes straight to `_run_upgradedb()` — never calling `add_default_pool_if_not_exists()`.

Result: tasks stuck in "scheduled" forever because the scheduler sees zero pool slots.

Fix: after `_run_upgradedb()` on a fresh DB with explicit revision, call `add_default_pool_if_not_exists()` and `synchronize_log_template()` to match what `initdb()` does.

Closes: #63551

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
