### PR TITLE
Fix KubernetesJobOperator failing when pods are deleted after job completion

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -286,7 +286,17 @@ class KubernetesJobOperator(KubernetesPodOperator):
         if self.get_logs:
             for pod_name in event["pod_names"]:
                 pod_namespace = event["pod_namespace"]
-                pod = self.hook.get_pod(pod_name, pod_namespace)
+                try:
+                    pod = self.hook.get_pod(pod_name, pod_namespace)
+                except ApiException as e:
+                    if e.status == 404:
+                        self.log.warning(
+                            "Pod %s in namespace %s not found (possibly deleted). Skipping log retrieval.",
+                            pod_name,
+                            pod_namespace,
+                        )
+                        continue
+                    raise
                 if not pod:
                     raise PodNotFoundException("Could not find pod after resuming from deferral")
                 self._write_logs(pod)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -856,6 +856,58 @@ class TestKubernetesJobOperator:
         mock_ti.xcom_push.assert_called_once_with(key="job", value=mock_job)
 
     @pytest.mark.non_db_test_override
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator._write_logs"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.hook"))
+    def test_execute_complete_pod_not_found_skips_logs(self, mock_hook, mocked_write_logs):
+        """When a pod is deleted before log retrieval, the task should succeed instead of failing."""
+        from kubernetes.client.rest import ApiException
+
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        event = {
+            "job": mock_job,
+            "status": "success",
+            "pod_names": [POD_NAME],
+            "pod_namespace": POD_NAMESPACE,
+            "xcom_result": None,
+        }
+
+        mock_hook.get_pod.side_effect = ApiException(status=404, reason="Not Found")
+
+        KubernetesJobOperator(task_id="test_task_id", get_logs=True, do_xcom_push=False).execute_complete(
+            context=context, event=event
+        )
+
+        mock_hook.get_pod.assert_called_once_with(POD_NAME, POD_NAMESPACE)
+        mocked_write_logs.assert_not_called()
+
+    @pytest.mark.non_db_test_override
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator._write_logs"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.hook"))
+    def test_execute_complete_pod_api_error_reraises(self, mock_hook, mocked_write_logs):
+        """Non-404 ApiExceptions should still be raised."""
+        from kubernetes.client.rest import ApiException
+
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        event = {
+            "job": mock_job,
+            "status": "success",
+            "pod_names": [POD_NAME],
+            "pod_namespace": POD_NAMESPACE,
+            "xcom_result": None,
+        }
+
+        mock_hook.get_pod.side_effect = ApiException(status=403, reason="Forbidden")
+
+        with pytest.raises(ApiException):
+            KubernetesJobOperator(task_id="test_task_id", get_logs=True, do_xcom_push=False).execute_complete(
+                context=context, event=event
+            )
+
+    @pytest.mark.non_db_test_override
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.job_client"))
     def test_on_kill(self, mock_client):
         mock_job = mock.MagicMock()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -908,6 +908,40 @@ class TestKubernetesJobOperator:
             )
 
     @pytest.mark.non_db_test_override
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator._write_logs"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.hook"))
+    def test_execute_complete_multi_pod_partial_not_found(self, mock_hook, mocked_write_logs):
+        """With multiple pods, deleted pods are skipped while surviving pods still get logs written."""
+        from kubernetes.client.rest import ApiException
+
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        surviving_pod = mock.MagicMock()
+
+        event = {
+            "job": mock_job,
+            "status": "success",
+            "pod_names": ["deleted-pod", "surviving-pod"],
+            "pod_namespace": POD_NAMESPACE,
+            "xcom_result": None,
+        }
+
+        def get_pod_side_effect(name, namespace):
+            if name == "deleted-pod":
+                raise ApiException(status=404, reason="Not Found")
+            return surviving_pod
+
+        mock_hook.get_pod.side_effect = get_pod_side_effect
+
+        KubernetesJobOperator(task_id="test_task_id", get_logs=True, do_xcom_push=False).execute_complete(
+            context=context, event=event
+        )
+
+        assert mock_hook.get_pod.call_count == 2
+        mocked_write_logs.assert_called_once_with(surviving_pod)
+
+    @pytest.mark.non_db_test_override
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.job_client"))
     def test_on_kill(self, mock_client):
         mock_job = mock.MagicMock()


### PR DESCRIPTION
 When a Kubernetes Job completes but the pod is deleted before Airflow fetches logs (e.g., by cluster autoscaler), `execute_complete` fails with an unhandled `ApiException(404)`. Task retries also fail repeatedly since they re-enter `execute_complete` and hit the same error.

This fix catches the 404 and skips log retrieval for deleted pods, resolving both the initial failure and the retry loop.

Note: whether retries of deferred tasks should re-run `execute` instead of `execute_complete` is a broader SDK-level concern and out of scope here.

closes: #56693
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code 

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)