### PR TITLE
Fix auto-triage user_confirm accepting unrecognized keys as default answer

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/confirm.py
+++ b/dev/breeze/src/airflow_breeze/utils/confirm.py
@@ -88,38 +88,37 @@ def user_confirm(
         allowed_answers = allowed_answers.replace(default_answer.value, default_answer.value.upper())
 
     prompt = f"\n{message} \nPress {allowed_answers}: "
-    console_print(prompt, end="")
 
-    try:
-        ch = _read_char()
-    except (KeyboardInterrupt, EOFError):
-        console_print()
-        if quit_allowed:
+    while True:
+        console_print(prompt, end="")
+
+        try:
+            ch = _read_char()
+        except (KeyboardInterrupt, EOFError):
+            console_print()
+            if quit_allowed:
+                return Answer.QUIT
+            sys.exit(1)
+
+        # Ignore multi-byte escape sequences (arrow keys, etc.)
+        if len(ch) > 1:
+            console_print()
+            console_print(f"  [warning]Invalid key. Press one of: {allowed_answers}[/]")
+            continue
+
+        console_print(ch)
+
+        if ch.upper() == "Y":
+            return Answer.YES
+        if ch.upper() == "N":
+            return Answer.NO
+        if ch.upper() == "Q" and quit_allowed:
             return Answer.QUIT
-        sys.exit(1)
-
-    # Ignore multi-byte escape sequences (arrow keys, etc.)
-    if len(ch) > 1:
-        console_print()
-        if default_answer:
+        # Enter/Return selects the default
+        if ch in ("\r", "\n", "") and default_answer:
             return default_answer
-        return Answer.NO
 
-    console_print(ch)
-
-    if ch.upper() == "Y":
-        return Answer.YES
-    if ch.upper() == "N":
-        return Answer.NO
-    if ch.upper() == "Q" and quit_allowed:
-        return Answer.QUIT
-    # Enter/Return selects the default
-    if ch in ("\r", "\n", "") and default_answer:
-        return default_answer
-    # Any other key — treat as default if available
-    if default_answer:
-        return default_answer
-    return Answer.NO
+        console_print(f"  [warning]Invalid key. Press one of: {allowed_answers}[/]")
 
 
 def confirm_action(


### PR DESCRIPTION
During `breeze pr auto-triage`, when approving workflow runs, `user_confirm` silently treats unrecognized keys as the default answer. 

Since the approval prompt defaults to YES (when no sensitive changes are detected), pressing a wrong key unintentionally approves workflow runs.

Change `user_confirm` to re-prompt on unrecognized input instead of falling through to the default.

## Before
<img width="1025" height="495" alt="image" src="https://github.com/user-attachments/assets/62653c06-eaa0-4115-9cb1-8c6e3c0f1105" />



## After

<img width="1033" height="674" alt="Screenshot 2026-03-14 at 3 26 05 PM" src="https://github.com/user-attachments/assets/7f639bd7-0fd7-4b70-a101-214d6320139c" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude opus 4.6
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
