### PR TITLE
fix(api): handle concurrent RTIF writes to prevent unique constraint violation

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -35,7 +35,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from pydantic import JsonValue
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
-from sqlalchemy.exc import NoResultFound, SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, NoResultFound, SQLAlchemyError
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
@@ -816,8 +816,19 @@ def ti_put_rtif(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
         )
-    task_instance.update_rtif(put_rtif_payload, session)
-    log.debug("RenderedTaskInstanceFields updated successfully")
+    try:
+        task_instance.update_rtif(put_rtif_payload, session)
+    except IntegrityError:
+        session.rollback()
+        # Re-fetch the task instance after rollback since the previous one is detached
+        task_instance = session.scalar(select(TI).where(TI.id == task_instance_id))
+        if task_instance:
+            # Retry: the record now exists from the concurrent request,
+            # so merge will find it and update rather than insert.
+            task_instance.update_rtif(put_rtif_payload, session)
+        log.info("RenderedTaskInstanceFields updated after concurrent write conflict")
+    else:
+        log.debug("RenderedTaskInstanceFields updated successfully")
 
     return {"message": "Rendered task instance fields successfully set"}
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2156,7 +2156,6 @@ class TestTIPutRTIF:
         assert response.status_code == 404
         assert response.json()["detail"] == "Not Found"
 
-
     def test_ti_put_rtif_concurrent_write(self, client, session, create_task_instance):
         """Test that concurrent RTIF writes don't cause 409 errors.
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -2157,6 +2157,82 @@ class TestTIPutRTIF:
         assert response.json()["detail"] == "Not Found"
 
 
+    def test_ti_put_rtif_concurrent_write(self, client, session, create_task_instance):
+        """Test that concurrent RTIF writes don't cause 409 errors.
+
+        When two workers try to write rendered fields for the same task instance
+        simultaneously, the second write should succeed by updating the existing record
+        rather than failing with a unique constraint violation.
+        """
+        ti = create_task_instance(
+            task_id="test_ti_put_rtif_concurrent",
+            state=State.RUNNING,
+            session=session,
+        )
+        session.commit()
+
+        payload1 = {"field1": "value1"}
+        payload2 = {"field1": "value2"}
+
+        # First write should succeed
+        response1 = client.put(f"/execution/task-instances/{ti.id}/rtif", json=payload1)
+        assert response1.status_code == 201
+
+        # Second write (simulating concurrent update) should also succeed by merging
+        response2 = client.put(f"/execution/task-instances/{ti.id}/rtif", json=payload2)
+        assert response2.status_code == 201
+
+        session.expire_all()
+        rtifs = session.scalars(select(RenderedTaskInstanceFields)).all()
+        assert len(rtifs) == 1
+        assert rtifs[0].rendered_fields == payload2
+
+    def test_ti_put_rtif_integrity_error_handled(self, client, session, create_task_instance):
+        """Test that IntegrityError from a race condition is handled gracefully.
+
+        Simulates the race condition where the first update_rtif call raises
+        IntegrityError (as if another concurrent request already inserted the record),
+        and verifies the endpoint retries successfully.
+        """
+        from unittest.mock import patch
+
+        from sqlalchemy.exc import IntegrityError
+
+        from airflow.models.taskinstance import TaskInstance
+
+        ti = create_task_instance(
+            task_id="test_ti_put_rtif_integrity",
+            state=State.RUNNING,
+            session=session,
+        )
+        session.commit()
+
+        payload = {"field1": "rendered_value1"}
+
+        original_update_rtif = TaskInstance.update_rtif
+        call_count = 0
+
+        def mock_update_rtif(self_ti, rendered_fields, session):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise IntegrityError(
+                    statement="INSERT INTO rendered_task_instance_fields",
+                    params={},
+                    orig=Exception(
+                        'duplicate key value violates unique constraint "rendered_task_instance_fields_pkey"'
+                    ),
+                )
+            return original_update_rtif(self_ti, rendered_fields, session)
+
+        with patch.object(TaskInstance, "update_rtif", mock_update_rtif):
+            response = client.put(f"/execution/task-instances/{ti.id}/rtif", json=payload)
+
+        assert response.status_code == 201
+        assert response.json() == {"message": "Rendered task instance fields successfully set"}
+        assert call_count == 2  # First call raises, second succeeds
+
+
 class TestPreviousDagRun:
     def setup_method(self):
         clear_db_runs()


### PR DESCRIPTION
## Problem

When multiple workers try to write rendered task instance fields (RTIF) for the same task instance simultaneously, the API server returns a `409 Conflict` error due to a unique constraint violation on `rendered_task_instance_fields_pkey`. This causes the task runner to fail with `AirflowRuntimeError`, marking the task as failed even though it completed successfully.

This is particularly common with CeleryExecutor when parallel tasks render fields at the same time, or when task retries overlap.

Closes: #61705

## Root Cause

The `update_rtif` method uses `session.merge()` which performs a SELECT-then-INSERT/UPDATE pattern. When two concurrent requests both SELECT and find no existing record, they both attempt an INSERT, and the second one fails with an IntegrityError.

The global `_UniqueConstraintErrorHandler` catches this IntegrityError and converts it to a `409 Conflict` HTTP response, which the task-sdk treats as a fatal error.

## Fix

Handle `IntegrityError` in the `ti_put_rtif` endpoint with a retry strategy:

1. Catch `IntegrityError` from the first `update_rtif` call
2. Rollback the failed transaction
3. Re-fetch the task instance (since the previous ORM object is detached after rollback)
4. Retry `update_rtif` — this time `session.merge()` will find the existing record and perform an UPDATE instead of INSERT

This is safe because RTIF writes are idempotent — the last writer wins, which is the correct semantic for rendered template fields.

## Testing

- Added `test_ti_put_rtif_concurrent_write`: verifies that two sequential writes to the same RTIF succeed (the second updates rather than conflicts)
- Added `test_ti_put_rtif_integrity_error_handled`: simulates the race condition by mocking `update_rtif` to raise `IntegrityError` on the first call, verifying the retry succeeds

Verified with unit tests. No external service dependencies.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
