### PR TITLE
Fix airflowctl boolean flags on Python 3.14

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -152,7 +152,10 @@ class Arg:
                     return self._is_valid_directory(parser, x)
 
                 self.kwargs["type"] = type
-        parser.add_argument(*self.flags, **self.kwargs)
+        kwargs = self.kwargs.copy()
+        if kwargs.get("action") is argparse.BooleanOptionalAction:
+            kwargs.pop("type", None)
+        parser.add_argument(*self.flags, **kwargs)
 
     def _is_valid_directory(self, parser, arg):
         if not os.path.isdir(arg):

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import argparse
 from argparse import BooleanOptionalAction
 from textwrap import dedent
 
@@ -288,6 +289,22 @@ class TestCommandFactory:
 
 
 class TestCliConfigMethods:
+    def test_add_to_parser_drops_type_for_boolean_optional_action(self):
+        """Test add_to_parser removes type for BooleanOptionalAction."""
+        parser = argparse.ArgumentParser()
+        arg = Arg(
+            flags=("--run-backwards",),
+            action=BooleanOptionalAction,
+            default=False,
+            help="run_backwards for backfill operation",
+            type=bool,
+        )
+
+        arg.add_to_parser(parser)
+
+        assert parser.parse_args(["--run-backwards"]).run_backwards is True
+        assert parser.parse_args(["--no-run-backwards"]).run_backwards is False
+
     def test_merge_commands(self, no_op_method):
         """Test the merge_commands method."""
         # Create two Command objects with different names and help texts


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Summary

`airflowctl` was generating CLI options for boolean fields with both:

- `action=argparse.BooleanOptionalAction`
- `type=bool`

On Python 3.14, `argparse.BooleanOptionalAction` no longer accepts the `type` keyword, which caused parser construction to fail with:

```text
TypeError: BooleanOptionalAction.__init__() got an unexpected keyword argument 'type'
```

This change updates `Arg.add_to_parser()` to drop `type` when the argument uses `BooleanOptionalAction`, while leaving the existing generated argument metadata unchanged.

## Why this approach

The fix is applied at the final parser handoff point rather than changing every code path that creates boolean arguments. That keeps the behavior centralized and preserves the existing test expectations around generated `Arg` objects.

This is backward compatible with older Python versions because `BooleanOptionalAction` is a flag action and does not consume a value that would need type conversion.

## Tests

- Added a regression test that exercises `Arg.add_to_parser()` with `BooleanOptionalAction`
- Verified with:

```bash
pytest airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py -xvs
```

## References

- Python 3.14 `argparse.py`:
  https://raw.githubusercontent.com/python/cpython/3.14/Lib/argparse.py
- Python 3.12 `argparse.py`:
  https://raw.githubusercontent.com/python/cpython/3.12/Lib/argparse.py
- Updated code:
  [`airflow-ctl/src/airflowctl/ctl/cli_config.py`](/home/iliya/repositories/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py)
- Regression test:
  [`airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py`](/home/iliya/repositories/airflow/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py)



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Codex gpt-5.4 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
