### PR TITLE
Fix newline rendering in DAG warning alert UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
@@ -33,7 +33,7 @@ export const WarningAlert = ({ warning }: Props) => {
 
   return (
     <Alert data-testid="warning-alert" status="warning">
-      <Flex align="center" whiteSpace="pre-wrap">
+      <Flex align="center" overflowWrap="break-word" whiteSpace="preserve">
         {warning?.message}
       </Flex>
     </Alert>

--- a/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
@@ -33,7 +33,9 @@ export const WarningAlert = ({ warning }: Props) => {
 
   return (
     <Alert data-testid="warning-alert" status="warning">
-      <Flex align="center">{warning?.message}</Flex>
+      <Flex align="center" whiteSpace="pre-wrap">
+        {warning?.message}
+      </Flex>
     </Alert>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
+++ b/airflow-core/src/airflow/ui/src/components/WarningAlert.tsx
@@ -33,7 +33,7 @@ export const WarningAlert = ({ warning }: Props) => {
 
   return (
     <Alert data-testid="warning-alert" status="warning">
-      <Flex align="center" overflowWrap="break-word" whiteSpace="preserve">
+      <Flex align="center" whiteSpace="preserve" wordBreak="break-all">
         {warning?.message}
       </Flex>
     </Alert>


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/59430

### Description

Fixes an issue where newlines (\n) in the message field of the DAG warning API were not being rendered as line breaks in the UI.

### UI

#### ASIS
<img width="858" height="105" alt="image" src="https://github.com/user-attachments/assets/dfa2c0d2-bb0e-4401-aa29-372c8a7d2d13" />

#### TOBE
<img width="855" height="169" alt="image" src="https://github.com/user-attachments/assets/9621a863-5f01-47a6-9eb0-3caf8b916985" />

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
