### PR TITLE
Modify breeze cache test to use constant for supported Python versions

### DIFF
--- a/dev/breeze/tests/test_cache.py
+++ b/dev/breeze/tests/test_cache.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 
+from airflow_breeze.global_constants import ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS
 from airflow_breeze.utils.cache import (
     check_if_cache_exists,
     check_if_values_allowed,
@@ -36,7 +37,7 @@ AIRFLOW_SOURCES = Path(__file__).parents[3].resolve()
     [
         ("backend", "mysql", (True, ["sqlite", "mysql", "postgres", "none", "custom"]), None),
         ("backend", "xxx", (False, ["sqlite", "mysql", "postgres", "none", "custom"]), None),
-        ("python_major_minor_version", "3.10", (True, ["3.10", "3.11", "3.12", "3.13"]), None),
+        ("python_major_minor_version", "3.10", (True, ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS), None),
         ("missing", "value", None, AttributeError),
     ],
 )


### PR DESCRIPTION
Fix a Breeze cache test that hard-coded the supported Python versions list.

`check_if_values_allowed()` returns the canonical list from Breeze global constants, but `dev/breeze/tests/test_cache.py` still expected only `3.10` through `3.13`. Once Python 3.14 was added, the test started failing even though the implementation was correct.

This change updates the test to use `ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS`, so it stays aligned with the supported versions defined by Breeze and does not need a manual update on every new Python minor release.

related: https://github.com/apache/airflow/pull/63520

---

#### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Codex GPT-5.4 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
