### PR TITLE
Add helper to tie Airflow version to the min supported Python version

### DIFF
--- a/.github/actions/migration_tests/action.yml
+++ b/.github/actions/migration_tests/action.yml
@@ -28,13 +28,20 @@ runs:
     - name: "Test migration file 2 to 3 migration: ${{env.BACKEND}}"
       shell: bash
       run: |
-        breeze shell "${AIRFLOW_2_CMD}" --use-airflow-version 2.11.0  --airflow-extras pydantic --answer y &&
+        MIN_AIRFLOW_VERSION="$(
+          python ./scripts/ci/testing/get_min_airflow_version_for_python.py "${PYTHON_VERSION}"
+        )"
+        breeze shell "${AIRFLOW_2_CMD}" \
+          --use-airflow-version "${MIN_AIRFLOW_VERSION}" \
+          --airflow-extras pydantic \
+          --answer y &&
         breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANGERS}
                     ${AIRFLOW_3_CMD}" --no-db-cleanup
       env:
         COMPOSE_PROJECT_NAME: "docker-compose"
         DB_RESET: "false"
         DB_MANAGERS: "airflow.providers.fab.auth_manager.models.db.FABDBManager"
+        PYTHON_VERSION: "${{ inputs.python-version }}"
         AIRFLOW_2_CMD: >-
           airflow db reset --skip-init -y &&
           airflow db migrate --to-revision heads
@@ -50,14 +57,21 @@ runs:
         COMPOSE_PROJECT_NAME: "docker-compose"
     - name: "Test ORM migration 2 to 3: ${{env.BACKEND}}"
       shell: bash
-      run: >
-        breeze shell "${AIRFLOW_2_CMD}" --use-airflow-version 2.11.0 --airflow-extras pydantic --answer y &&
+      run: |
+        MIN_AIRFLOW_VERSION="$(
+          python ./scripts/ci/testing/get_min_airflow_version_for_python.py "${PYTHON_VERSION}"
+        )"
+        breeze shell "${AIRFLOW_2_CMD}" \
+          --use-airflow-version "${MIN_AIRFLOW_VERSION}" \
+          --airflow-extras pydantic \
+          --answer y &&
         breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANGERS}
              ${AIRFLOW_3_CMD}" --no-db-cleanup
       env:
         COMPOSE_PROJECT_NAME: "docker-compose"
         DB_RESET: "false"
         DB_MANAGERS: "airflow.providers.fab.auth_manager.models.db.FABDBManager"
+        PYTHON_VERSION: "${{ inputs.python-version }}"
         AIRFLOW_2_CMD: >-
           airflow db reset -y
         AIRFLOW_3_CMD: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -785,6 +785,7 @@ testing = ["dev", "providers.tests", "tests_common", "tests", "system", "unit", 
 "providers/**/tests/*" = ["D", "TID253", "S101", "TRY002"]
 "performance/tests/*" = ["S101"]
 "dev/registry/tests/*" = ["S101"]
+"scripts/tests/*" = ["S101"]
 
 # Shared distributions SHOULD use relative imports when referencing each other
 # This one disables 'ban-relative-imports'.

--- a/scripts/ci/testing/get_min_airflow_version_for_python.py
+++ b/scripts/ci/testing/get_min_airflow_version_for_python.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import argparse
+
+MIN_AIRFLOW_VERSION_BY_PYTHON = {
+    "3.10": "2.11.0",
+    "3.13": "3.1.0",
+    # "3.14": "3.2.0",
+}
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def get_min_airflow_version_for_python(python_version: str) -> str:
+    """
+    Return the minimum supported Airflow version for the given Python version.
+
+    Unknown future Python versions inherit the latest known minimum Airflow version so the
+    requirement never decreases when a new Python version is added to the DB test matrix.
+    """
+
+    matching_versions = [
+        version
+        for version in MIN_AIRFLOW_VERSION_BY_PYTHON
+        if _version_key(version) <= _version_key(python_version)
+    ]
+    if not matching_versions:
+        raise ValueError(f"No minimum Airflow version defined for Python {python_version}")
+    return MIN_AIRFLOW_VERSION_BY_PYTHON[max(matching_versions, key=_version_key)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Return the minimum supported Airflow version for a Python version."
+    )
+    parser.add_argument("python_version", help="Python major.minor version, for example 3.14")
+    args = parser.parse_args()
+    print(get_min_airflow_version_for_python(args.python_version))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/ci/__init__.py
+++ b/scripts/tests/ci/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/scripts/tests/ci/testing/__init__.py
+++ b/scripts/tests/ci/testing/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/scripts/tests/ci/testing/test_get_min_airflow_version_for_python.py
+++ b/scripts/tests/ci/testing/test_get_min_airflow_version_for_python.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "scripts"
+    / "ci"
+    / "testing"
+    / "get_min_airflow_version_for_python.py"
+)
+
+
+@pytest.fixture
+def min_airflow_module():
+    module_name = "test_get_min_airflow_version_for_python_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("python_version", "expected_airflow_version"),
+    [
+        ("3.10", "2.11.0"),
+        ("3.12", "2.11.0"),
+        ("3.13", "3.1.0"),
+        ("3.14", "3.2.0"),
+        ("3.15", "3.2.0"),
+    ],
+)
+def test_get_min_airflow_version_for_python_is_monotonic(
+    min_airflow_module, python_version, expected_airflow_version
+):
+    assert min_airflow_module.get_min_airflow_version_for_python(python_version) == expected_airflow_version
+
+
+def test_get_min_airflow_version_for_python_raises_for_older_python(min_airflow_module):
+    with pytest.raises(ValueError, match="No minimum Airflow version defined for Python 3.9"):
+        min_airflow_module.get_min_airflow_version_for_python("3.9")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
  This change stops the migration test workflow from defaulting to Airflow `2.11.0` and instead derives the minimum Airflow version from the Python version used in CI.

###  Why this is needed:

  Today, DB migration tests effectively rely on a hardcoded default. That becomes wrong as soon as a newer Python version is introduced that is not supported by Airflow `2.11.0`. Without this
  helper, we would need to keep adding special-case logic somewhere else to say that DB tests must not use 2.11 constraints on Python 3.13 and newer.

  We already know the minimum supported Airflow version for Python 3.13, so there is no reason for Python 3.14 or later to fall back to an older and unrelated default. A new Python version
  should inherit the constraint from the previous known Python version until a newer minimum is explicitly defined.

###  What this gives us:

  - Removes an irrelevant `2.11.0` fallback from migration tests.
  - Makes new Python versions inherit the latest known minimum Airflow version instead of silently using an incompatible one.
  - Avoids scattering Python-version exceptions for DB tests in CI logic.
  - Centralizes the compatibility mapping in a small helper with unit coverage.
  - Makes the migration workflow more maintainable as Python support evolves.

  This keeps the migration test setup aligned with actual Airflow/Python compatibility and prevents avoidable CI failures when new Python versions are added.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Codex GPT-5.4 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
