### PR TITLE
Task SDK: Fix nondumpable supervisor tests for Python 3.14

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3167,9 +3167,10 @@ def test_nondumpable_blocks_sibling_proc_read():
     """A sibling process (same non-root UID) cannot read /proc/<pid>/environ or /proc/<pid>/mem of a nondumpable process."""
     import multiprocessing
 
-    ready = multiprocessing.Event()
-    done = multiprocessing.Event()
-    result_queue = multiprocessing.Queue()
+    ctx = multiprocessing.get_context("fork")
+    ready = ctx.Event()
+    done = ctx.Event()
+    result_queue = ctx.Queue()
 
     def target_fn():
         _drop_root_if_needed()
@@ -3187,11 +3188,11 @@ def test_nondumpable_blocks_sibling_proc_read():
                 blocked.append(proc_file)
         result_queue.put(blocked)
 
-    target = multiprocessing.Process(target=target_fn)
+    target = ctx.Process(target=target_fn)
     target.start()
     try:
         assert ready.wait(timeout=5), "target process did not become ready"
-        reader = multiprocessing.Process(target=reader_fn, args=(target.pid,))
+        reader = ctx.Process(target=reader_fn, args=(target.pid,))
         reader.start()
         reader.join(timeout=5)
         blocked = result_queue.get(timeout=5)
@@ -3209,7 +3210,8 @@ def test_nondumpable_blocks_child_memory_read():
     """A forked child (same non-root UID) cannot read its nondumpable parent's /proc/<pid>/mem."""
     import multiprocessing
 
-    result_queue = multiprocessing.Queue()
+    ctx = multiprocessing.get_context("fork")
+    result_queue = ctx.Queue()
 
     def parent_fn():
         _drop_root_if_needed()
@@ -3226,7 +3228,7 @@ def test_nondumpable_blocks_child_memory_read():
         _, status = os.waitpid(child_pid, 0)
         result_queue.put(os.WEXITSTATUS(status) if os.WIFEXITED(status) else -1)
 
-    proc = multiprocessing.Process(target=parent_fn)
+    proc = ctx.Process(target=parent_fn)
     proc.start()
     proc.join(timeout=10)
     exit_code = result_queue.get(timeout=5)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
 Python 3.14 changes the default multiprocessing start method on POSIX to a pickling-based mode, which breaks these Task SDK supervisor tests because they spawn processes from local test functions.

This change makes the two Linux nondumpable-process tests explicitly use the `fork` multiprocessing context, which matches the behavior the tests are verifying and avoids the Python 3.14 pickling failure.

  Tests:
  - `breeze run pytest task-sdk/tests/task_sdk/execution_time/test_supervisor.py::test_nondumpable_blocks_sibling_proc_read task-sdk/tests/task_sdk/execution_time/
  test_supervisor.py::test_nondumpable_blocks_child_memory_read -xvs`


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Codex GPT-5.4 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
