### PR TITLE
AGENTS: Add instruction to format and check Python files with ruff after editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ UV workspace monorepo. Key paths:
 
 ## Coding Standards
 
-- **Always format Python files with ruff immediately after writing or editing them:** `uv run ruff format <file_path>` and `uv run ruff check --fix <file_path>`. Do this for every Python file you create or modify, before moving on to the next step.
+- **Always format and check Python files with ruff immediately after writing or editing them:** `uv run ruff format <file_path>` and `uv run ruff check --fix <file_path>`. Do this for every Python file you create or modify, before moving on to the next step.
 - No `assert` in production code.
 - `time.monotonic()` for durations, not `time.time()`.
 - In `airflow-core`, functions with a `session` parameter must not call `session.commit()`. Use keyword-only `session` parameters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ UV workspace monorepo. Key paths:
 
 ## Coding Standards
 
+- **Always format Python files with ruff immediately after writing or editing them:** `uv run ruff format <file_path>` and `uv run ruff check --fix <file_path>`. Do this for every Python file you create or modify, before moving on to the next step.
 - No `assert` in production code.
 - `time.monotonic()` for durations, not `time.time()`.
 - In `airflow-core`, functions with a `session` parameter must not call `session.commit()`. Use keyword-only `session` parameters.


### PR DESCRIPTION
Add instruction to AGENTS.md Coding Standards to always run `ruff format` and `ruff check --fix` on Python files immediately after writing or editing them.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)