### PR TITLE
fix(scheduler): lock asset_dag_run_queue rows to prevent duplicate DAG runs with HA schedulers

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -652,9 +652,14 @@ class DagModel(Base):
         # this loads all the ADRQ records.... may need to limit num dags
         adrq_by_dag: dict[str, list[AssetDagRunQueue]] = defaultdict(list)
         for adrq in session.scalars(
-            select(AssetDagRunQueue).options(
-                joinedload(AssetDagRunQueue.dag_model),
-                joinedload(AssetDagRunQueue.asset),
+            with_row_locks(
+                select(AssetDagRunQueue).options(
+                    joinedload(AssetDagRunQueue.dag_model),
+                    joinedload(AssetDagRunQueue.asset),
+                ),
+                of=AssetDagRunQueue,
+                session=session,
+                skip_locked=True,
             )
         ):
             if adrq.dag_model.asset_expression is None:

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -93,6 +93,7 @@ from airflow.timetables.simple import (
 )
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.session import create_session
+from airflow.utils.sqlalchemy import with_row_locks
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
@@ -2074,6 +2075,32 @@ class TestDagModel:
         with assert_queries_count(6):
             query, _ = DagModel.dags_needing_dagruns(session)
             query.all()
+
+    def test_dags_needing_dagruns_asset_queue_uses_row_locks(self, dag_maker, session):
+        """Test that ADRQ rows are locked to prevent duplicate DAG runs with HA schedulers."""
+        asset = Asset(uri="test://locked-asset", group="test-group")
+        with dag_maker(
+            session=session,
+            dag_id="locked_dag",
+            max_active_runs=10,
+            schedule=[asset],
+            start_date=pendulum.now().add(days=-2),
+        ):
+            EmptyOperator(task_id="dummy")
+
+        dag_model = dag_maker.dag_model
+        asset_model = dag_model.schedule_assets[0]
+        session.add(AssetDagRunQueue(asset_id=asset_model.id, target_dag_id=dag_model.dag_id))
+        session.flush()
+
+        with patch("airflow.models.dag.with_row_locks", wraps=with_row_locks) as mock_wrl:
+            DagModel.dags_needing_dagruns(session)
+            # with_row_locks should be called at least twice:
+            # once for the ADRQ query and once for the DagModel query
+            assert mock_wrl.call_count >= 2
+            # Verify ADRQ call uses skip_locked
+            adrq_call = mock_wrl.call_args_list[0]
+            assert adrq_call.kwargs.get("skip_locked") is True
 
     def test_dags_needing_dagruns_asset_aliases(self, dag_maker, session):
         # link asset_alias hello_alias to asset hello


### PR DESCRIPTION
## Problem

Asset-triggered DAGs get duplicate DAG runs when running with multiple schedulers (HA mode). A single asset event creates two runs with identical timestamps but different run ID hashes. Reported consistently within 15-30 minutes of running 2 schedulers.

## Root Cause

`DagModel.dags_needing_dagruns()` reads `AssetDagRunQueue` records without row-level locking. Both schedulers read the same ADRQ rows, both evaluate the DAG as ready, both create a DAG run, and both delete the ADRQ records. The DagModel rows are locked with `FOR UPDATE SKIP LOCKED` but the ADRQ rows that feed into the decision are not.

## Fix

Added `with_row_locks(skip_locked=True, of=AssetDagRunQueue)` to the ADRQ select query. When scheduler A locks an ADRQ row, scheduler B skips it and won't see the DAG as ready — preventing duplicate runs.

Added a test verifying the ADRQ query uses row-level locking.

Closes: #63507

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
