### PR TITLE
Add rebase instruction to AGENTS.md before pushing PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,17 @@ code review checklist in [`.github/instructions/code-review.instructions.md`](.g
 7. Find which tests to run for the changes with selective-checks and run those tests in parallel to confirm they pass and check for CI-specific issues.
 8. Check for security issues — no secrets, no injection vulnerabilities, no unsafe patterns.
 
+Before pushing, always rebase your branch onto the latest target branch (usually `main`)
+to avoid merge conflicts and ensure CI runs against up-to-date code:
+
+```bash
+git fetch <upstream-remote> <target_branch>
+git rebase <upstream-remote>/<target_branch>
+```
+
+If there are conflicts, resolve them and continue the rebase. If the rebase is too complex,
+ask the user for guidance.
+
 Then push the branch to the fork remote and open the PR creation page in the browser
 with the body pre-filled (including the generative AI disclosure already checked):
 


### PR DESCRIPTION
Adds instruction for AI agents to always rebase onto the latest target branch
before pushing changes to a PR. This avoids merge conflicts and ensures CI
runs against up-to-date code.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)