### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,9 @@ ENV/
 .idea/
 *.iml
 
+# Claude Code
+.claude/
+
 # Cursor
 .cursor/
 


### PR DESCRIPTION
Add `.claude/` directory to `.gitignore` alongside the existing `.cursor/` entry.

The `.dockerignore` already excludes it by default (uses allowlist pattern).
The `.prettierignore` files are scoped to UI subdirectories where `.claude` wouldn't exist.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)