### PR TITLE
Add cooldown period to upgrade-important-versions check

### DIFF
--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -358,6 +358,7 @@ jobs:
           UPGRADE_MPROCS: "false"
           UPGRADE_PROTOC: "false"
           UPGRADE_OPENAPI_GENERATOR: "false"
+          UPGRADE_COOLDOWN_DAYS: "4"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-airflow-release-commands:

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -418,6 +418,7 @@ def get_env_bool(name: str, default: bool = True) -> bool:
 
 VERBOSE: bool = os.environ.get("VERBOSE", "false") == "true"
 UPGRADE_ALL_BY_DEFAULT: bool = os.environ.get("UPGRADE_ALL_BY_DEFAULT", "true") == "true"
+UPGRADE_COOLDOWN_DAYS: int = int(os.environ.get("UPGRADE_COOLDOWN_DAYS", "0"))
 
 if UPGRADE_ALL_BY_DEFAULT and VERBOSE:
     console.print("[bright_blue]Upgrading all important versions")
@@ -850,6 +851,40 @@ def update_pyproject_build_requires(
     return changed
 
 
+def is_within_cooldown(cooldown_days: int) -> bool:
+    """Check if there was a version upgrade commit within the cooldown period.
+
+    Looks for commits matching the 'Upgrade important' pattern in the git log
+    within the last ``cooldown_days`` days. If found, the upgrade check should
+    not fail because someone recently addressed the versions.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                f"--since={cooldown_days} days ago",
+                "--all",
+                "--oneline",
+                "--grep=Upgrade important",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=AIRFLOW_ROOT_PATH,
+        )
+        if result.stdout.strip():
+            if VERBOSE:
+                console.print(
+                    f"[bright_blue]Found recent upgrade commits within {cooldown_days} days:\n"
+                    f"{result.stdout.strip()}"
+                )
+            return True
+        return False
+    except subprocess.CalledProcessError:
+        return False
+
+
 def main() -> None:
     """Main entry point for the version upgrade script."""
     retrieve_gh_token(description="airflow-upgrade-important-versions", scopes="public_repo")
@@ -877,6 +912,12 @@ def main() -> None:
         sync_breeze_lock_file()
         if not os.environ.get("CI"):
             console.print("[bright_blue]Please commit the changes")
+        if UPGRADE_COOLDOWN_DAYS > 0 and is_within_cooldown(UPGRADE_COOLDOWN_DAYS):
+            console.print(
+                f"[bright_yellow]Versions are outdated but within {UPGRADE_COOLDOWN_DAYS}-day "
+                f"cooldown period (recent upgrade commit found). Not failing."
+            )
+            sys.exit(0)
         sys.exit(1)
 
 


### PR DESCRIPTION
Add `UPGRADE_COOLDOWN_DAYS` env var to `upgrade_important_versions.py` so
the CI upgrade check only fails when no "Upgrade important" commit has
been merged within the configured number of days. The CI workflow sets
a 4-day cooldown, matching the existing `prek autoupdate --cooldown-days 4`.

This reduces noisy CI failures right after an upgrade PR is merged while
a new version is released for one of the tracked packages.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)