### PR TITLE
Fix IDEA setup to skip .claude directory and add scripts module

### DIFF
--- a/dev/ide_setup/setup_idea.py
+++ b/dev/ide_setup/setup_idea.py
@@ -59,6 +59,7 @@ STATIC_MODULES: list[str] = [
     "docker-tests",
     "kubernetes-tests",
     "helm-tests",
+    "scripts",
     "task-sdk-integration-tests",
 ]
 
@@ -756,7 +757,7 @@ def register_sdk(name: str, venv_dir: Path, working_dir: Path, *, idea_path: Pat
 # Module discovery
 # ---------------------------------------------------------------------------
 
-EXCLUDED_PREFIXES = ("out/", ".build/", "dist/", ".venv/", "generated/")
+EXCLUDED_PREFIXES = ("out/", ".build/", ".claude/", "dist/", ".venv/", "generated/")
 
 
 def discover_modules(*, exclude_modules: set[str] | None = None) -> list[str]:
@@ -804,7 +805,7 @@ def get_module_name(module_path: str) -> str:
 # ---------------------------------------------------------------------------
 
 # Directories that are never scanned for leftover .iml files.
-_CLEANUP_SKIP_DIRS = {".idea", "node_modules", ".venv", ".git", ".build", "out", "dist"}
+_CLEANUP_SKIP_DIRS = {".idea", ".claude", "node_modules", ".venv", ".git", ".build", "out", "dist"}
 
 
 def _find_previous_iml_files() -> list[Path]:


### PR DESCRIPTION
Fix IDEA setup script to exclude `.claude` directory from pyproject.toml discovery
and IML cleanup scans, and add `scripts` distribution to the static modules list.

- Add `.claude/` to `EXCLUDED_PREFIXES` — prevents `rglob` from picking up
  `pyproject.toml` files inside `.claude/worktrees/`
- Add `.claude` to `_CLEANUP_SKIP_DIRS` — prevents the IML cleanup scan from
  entering `.claude/`
- Add `scripts` to `STATIC_MODULES` — includes the `scripts` distribution

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)