### PR TITLE
Fix import errors updating DAGs in other bundles

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -407,6 +407,7 @@ def _update_import_errors(
             update(DagModel)
             .where(
                 DagModel.relative_fileloc == relative_fileloc,
+                DagModel.bundle_name == bundle_name_,
             )
             .values(
                 has_import_errors=True,

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -49,6 +49,7 @@ from airflow.models.asset import (
     DagScheduleAssetUriReference,
 )
 from airflow.models.dag import DagTag
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -802,6 +803,41 @@ class TestUpdateDagParsingResults:
 
         import_errors = set(session.execute(select(ParseImportError.filename, ParseImportError.bundle_name)))
         assert import_errors == {("other.py", bundle_name)}, "Import error for parsed file should be cleared"
+
+    @pytest.mark.usefixtures("clean_db")
+    def test_import_error_update_does_not_touch_other_bundle_with_same_relative_fileloc(self, session):
+        relative_fileloc = "example_dag.py"
+        session.add_all([DagBundleModel(name="bundle_a"), DagBundleModel(name="bundle_b")])
+        session.flush()
+        session.add_all(
+            [
+                DagModel(dag_id="dag_in_bundle_a", relative_fileloc=relative_fileloc, bundle_name="bundle_a"),
+                DagModel(dag_id="dag_in_bundle_b", relative_fileloc=relative_fileloc, bundle_name="bundle_b"),
+            ]
+        )
+        session.flush()
+
+        update_dag_parsing_results_in_db(
+            bundle_name="bundle_a",
+            bundle_version=None,
+            dags=[],
+            import_errors={("bundle_a", relative_fileloc): "Import failed in bundle_a"},
+            parse_duration=None,
+            warnings=set(),
+            session=session,
+            files_parsed={("bundle_a", relative_fileloc)},
+        )
+        session.flush()
+
+        dag_in_bundle_a = session.get(DagModel, "dag_in_bundle_a")
+        dag_in_bundle_b = session.get(DagModel, "dag_in_bundle_b")
+
+        assert dag_in_bundle_a is not None
+        assert dag_in_bundle_b is not None
+        assert dag_in_bundle_a.bundle_name == "bundle_a"
+        assert dag_in_bundle_b.bundle_name == "bundle_b"
+        assert dag_in_bundle_a.has_import_errors is True
+        assert dag_in_bundle_b.has_import_errors is False
 
     @pytest.mark.need_serialized_dag(False)
     @pytest.mark.parametrize(


### PR DESCRIPTION

Import error updates in dag processing were matching DagModel rows by relative_fileloc only. When two DAG bundles contained files with the same relative path, an import error in one bundle could incorrectly mark the other bundle’s DAG as having import errors and even overwrite its bundle_name.

This is easily reproducible:

1. Configure two DAG bundles that contain the same relative file name, for example:

files/bundle_a/example_dag.py
files/bundle_b/example_dag.py

2. Set the bundle config:
export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST='[
  {"name":"bundle_a","classpath":"airflow.dag_processing.bundles.local.LocalDagBundle","kwargs":{"path":"/files/bundle_a","refresh_interval":0}},
  {"name":"bundle_b","classpath":"airflow.dag_processing.bundles.local.LocalDagBundle","kwargs":{"path":"/files/bundle_b","refresh_interval":0}}
]'


3. Parse both bundles successfully:
4. Introduce an import error only in files/bundle_a/example_dag.py.
5. Reparse only bundle_a

`airflow dags reserialize --bundle-name bundle_a`

```
select dag_id, bundle_name, relative_fileloc, has_import_errors
from dag
where relative_fileloc = 'example_dag.py'
order by bundle_name, dag_id;
```

Before this fix, you can end up with both records marked as having import errors, even though only the DAG in bundle_a is broken.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
