### PR TITLE
Fix LLM model list variability in generated command docs

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -210,9 +210,16 @@ def get_allowed_llm_models() -> list[str]:
 
     Checks .build/llm_models_cache.json for a cached model list (refreshed at most
     every 24 hours). Falls back to the hardcoded _FALLBACK_LLM_MODELS.
+    When generating command images for documentation, always uses the hardcoded
+    fallback list to ensure deterministic output.
     """
     import json
     import time
+
+    from airflow_breeze.utils.recording import generating_command_images
+
+    if generating_command_images():
+        return list(_FALLBACK_LLM_MODELS)
 
     try:
         from airflow_breeze.utils.path_utils import BUILD_CACHE_PATH


### PR DESCRIPTION
Use the hardcoded fallback model list when generating command images
for documentation, following the same pattern used by `--parallelism`,
`--platform`, and `--tmp-dir` parameters. This ensures the generated
SVG help output for `breeze pr auto-triage --help` (and any other command
using `--llm-model`) is deterministic regardless of the local LLM models
cache state.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)