### PR TITLE
Add prek hook to enforce *.iml in distribution .gitignore files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -235,6 +235,18 @@ repos:
           ^pyproject\.toml$
         pass_filenames: false
         require_serial: true
+      - id: check-distribution-gitignore
+        name: Check distribution .gitignore files have *.iml
+        entry: ./scripts/ci/prek/check_distribution_gitignore.py
+        language: python
+        files: >
+          (?x)
+          ^.*/\.gitignore$|
+          ^\.gitignore$|
+          ^.*/pyproject\.toml$|
+          ^pyproject\.toml$
+        pass_filenames: false
+        require_serial: true
       - id: upgrade-important-versions
         name: Upgrade important versions (manual)
         entry: ./scripts/ci/prek/upgrade_important_versions.py

--- a/scripts/ci/prek/check_distribution_gitignore.py
+++ b/scripts/ci/prek/check_distribution_gitignore.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10,<3.11"
+# dependencies = [
+#   "rich>=13.6.0",
+# ]
+# ///
+"""
+Check that all distributions have a .gitignore file containing *.iml.
+
+Every directory with a pyproject.toml (a distribution) must have a .gitignore
+file that includes the ``*.iml`` pattern to prevent IntelliJ IDEA module files
+from being committed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from common_prek_utils import AIRFLOW_ROOT_PATH, console
+
+errors: list[str] = []
+
+for pyproject_path in sorted(AIRFLOW_ROOT_PATH.rglob("pyproject.toml")):
+    relative = pyproject_path.relative_to(AIRFLOW_ROOT_PATH)
+    # Skip directories that are not part of the source tree
+    if any(part.startswith(".") or part in ("out", "node_modules") for part in relative.parts):
+        continue
+    dist_dir = pyproject_path.parent
+    gitignore_path = dist_dir / ".gitignore"
+    if not gitignore_path.exists():
+        errors.append(f"{gitignore_path.relative_to(AIRFLOW_ROOT_PATH)}: .gitignore file missing")
+        continue
+    lines = gitignore_path.read_text().splitlines()
+    if "*.iml" not in lines:
+        errors.append(f"{gitignore_path.relative_to(AIRFLOW_ROOT_PATH)}: missing '*.iml' entry")
+
+if errors:
+    console.print("[red]Errors found in distribution .gitignore files:[/]")
+    for error in errors:
+        console.print(f"  [red]✗[/] {error}")
+    console.print()
+    console.print(
+        "[bright_blue]Each distribution directory (containing pyproject.toml) must have a "
+        ".gitignore file with a '*.iml' entry.[/]"
+    )
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Adds a pre-commit check that verifies every distribution directory
(containing pyproject.toml) has a .gitignore file with a `*.iml` entry,
preventing IntelliJ IDEA module files from being committed.

This complements #63636 which added `*.iml` to all existing distribution
`.gitignore` files — this hook ensures new distributions also include it.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)