### PR TITLE
Fix timeout_with_traceback crashes on Windows and non-main threads

### DIFF
--- a/airflow-core/newsfragments/63664.bugfix.rst
+++ b/airflow-core/newsfragments/63664.bugfix.rst
@@ -1,1 +1,1 @@
-Fix timeout_with_traceback crashes on Windows and non-main threads
+Fix ``timeout_with_traceback`` crashes on Windows and non-main threads

--- a/airflow-core/newsfragments/63664.bugfix.rst
+++ b/airflow-core/newsfragments/63664.bugfix.rst
@@ -1,0 +1,1 @@
+Fix timeout_with_traceback crashes on Windows and non-main threads

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -151,15 +151,24 @@ def timeout_with_traceback(seconds, message="Operation timed out"):
         raise TimeoutException(message)
 
     # Set the signal handler
-    old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-    signal.alarm(seconds)
+    timeout_supported = False
+    try:
+        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(seconds)
+        timeout_supported = True
+    except (AttributeError, ValueError):
+        log.warning(
+            "timeout_with_traceback requires signal.SIGALRM and the main thread. "
+            "Proceeding without a timeout."
+        )
 
     try:
         yield
     finally:
-        # Cancel the alarm and restore the old handler
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, old_handler)
+        if timeout_supported:
+            # Cancel the alarm and restore the old handler
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old_handler)
 
 
 @provide_session

--- a/airflow-core/tests/unit/utils/test_db_timeout.py
+++ b/airflow-core/tests/unit/utils/test_db_timeout.py
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.utils.db import timeout_with_traceback
+
+
+class TestTimeoutWithTraceback:
+    def test_timeout_with_traceback_basic(self):
+        """Test that the context manager works normally on supported systems."""
+        with mock.patch("signal.signal") as mock_signal, mock.patch("signal.alarm") as mock_alarm:
+            mock_signal.return_value = "old_handler"
+
+            with timeout_with_traceback(10):
+                pass
+
+            # Check signal handler was set
+            mock_signal.assert_any_call(mock.ANY, mock.ANY)
+            mock_alarm.assert_any_call(10)
+
+            # Check cleanup happened
+            mock_alarm.assert_any_call(0)
+            mock_signal.assert_any_call(mock.ANY, "old_handler")
+
+    @pytest.mark.parametrize("exception", [AttributeError, ValueError])
+    def test_timeout_with_traceback_unsupported(self, exception, caplog):
+        """
+        Test that it handles missing SIGALRM or non-main thread gracefully.
+        AttributeError happens on Windows (missing SIGALRM).
+        ValueError happens in non-main threads (signal.signal not allowed).
+        """
+        # Patch BOTH signal.signal and signal.SIGALRM to be safe across platforms
+        with mock.patch("signal.signal", side_effect=exception), mock.patch("signal.SIGALRM", create=True):
+            with timeout_with_traceback(10):
+                # Should not raise exception
+                pass
+
+            assert "timeout_with_traceback requires signal.SIGALRM and the main thread" in caplog.text
+            assert "Proceeding without a timeout" in caplog.text

--- a/airflow-core/tests/unit/utils/test_timeout_traceback.py
+++ b/airflow-core/tests/unit/utils/test_timeout_traceback.py
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import signal
+from unittest import mock
+
+import pytest
+
+from airflow.utils.db import timeout_with_traceback
+
+
+class TestTimeoutWithTraceback:
+    def test_timeout_supported_unix(self):
+        """Test that it works normally on Unix-like systems where SIGALRM is supported."""
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM not supported on this platform")
+
+        with mock.patch("signal.signal") as mock_signal, mock.patch("signal.alarm") as mock_alarm:
+            mock_signal.return_value = "old_handler"
+
+            with timeout_with_traceback(seconds=5):
+                pass
+
+            mock_signal.assert_any_call(signal.SIGALRM, mock.ANY)
+            mock_alarm.assert_any_call(5)
+            # Cleanup
+            mock_alarm.assert_any_call(0)
+            mock_signal.assert_any_call(signal.SIGALRM, "old_handler")
+
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(AttributeError("SIGALRM missing"), id="windows_attribute_error"),
+            pytest.param(ValueError("signal only works in main thread"), id="non_main_thread_value_error"),
+        ],
+    )
+    def test_timeout_unsupported_platforms_or_threads(self, exception):
+        """Test that it handles unsupported platforms (Windows) or non-main threads gracefully."""
+        # We need to patch signal.signal to raise the exception
+        # Even if SIGALRM exists, we force it to fail to test the catch block
+
+        with (
+            mock.patch("signal.signal", side_effect=exception),
+            mock.patch("airflow.utils.db.log") as mock_log,
+        ):
+            with timeout_with_traceback(seconds=5):
+                # Should not raise any exception
+                pass
+
+            mock_log.warning.assert_called_once_with(
+                "timeout_with_traceback requires signal.SIGALRM and the main thread. "
+                "Proceeding without a timeout."
+            )
+
+    def test_timeout_happens(self):
+        """Test that it actually raises TimeoutException when time is up."""
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM not supported on this platform")
+
+        # We can't easily test real timeout in unit test without blocking
+        # but we can call the handler directly to see if it raises
+
+        with mock.patch("signal.signal") as mock_signal:
+            with timeout_with_traceback(seconds=1):
+                # The handler is the second argument to the first call of signal.signal
+                handler = mock_signal.call_args_list[0][0][1]
+
+                with pytest.raises(Exception, match="Operation timed out") as excinfo:
+                    handler(signal.SIGALRM, None)
+
+                assert "Operation timed out" in str(excinfo.value)
+                assert excinfo.type.__name__ == "TimeoutException"


### PR DESCRIPTION
The `timeout_with_traceback` context manager in `airflow.utils.db` uses `signal.SIGALRM` to raise a `TimeoutException`.

However, `signal.SIGALRM` does not exist on Windows, causing an `AttributeError`. Furthermore, even on Unix, `signal.signal()` can only be called from the main thread, raising a `ValueError` inside worker threads. This completely breaks logic wrapped in this context in non-standard environments.

I have added safe exception handling around the signal initialization. If `signal.SIGALRM` fails due to OS constraints or thread context, it logs a warning and proceeds gracefully as a no-op timeout, instead of crashing the process.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
