### PR TITLE
fix: use uuid_suffix in postgres unique constraint test expectations

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -210,7 +210,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_id)s) RETURNING slot_pool.id",
+                            "statement": f"INSERT INTO slot_pool (pool, slots, description, include_deferred, team_id) VALUES (%(pool)s, %(slots)s, %(description)s, %(include_deferred)s, %(team_id)s{uuid_suffix}) RETURNING slot_pool.id",
                             "orig_error": 'duplicate key value violates unique constraint "slot_pool_pool_uq"\nDETAIL:  Key (pool)=(test_pool) already exists.\n',
                         },
                     ),
@@ -236,7 +236,7 @@ class TestUniqueConstraintErrorHandler:
                         status_code=status.HTTP_409_CONFLICT,
                         detail={
                             "reason": "Unique constraint violation",
-                            "statement": "INSERT INTO variable (key, val, description, is_encrypted, team_id) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_id)s) RETURNING variable.id",
+                            "statement": f"INSERT INTO variable (key, val, description, is_encrypted, team_id) VALUES (%(key)s, %(val)s, %(description)s, %(is_encrypted)s, %(team_id)s{uuid_suffix}) RETURNING variable.id",
                             "orig_error": 'duplicate key value violates unique constraint "variable_key_uq"\nDETAIL:  Key (key)=(test_key) already exists.\n',
                         },
                     ),


### PR DESCRIPTION
## Summary
- Fix failing Postgres tests `test_handle_single_column_unique_constraint_error_with_stacktrace` for Pool and Variable
- SQLAlchemy v2 generates `%(team_id)s::UUID` type cast in SQL on Postgres, but test expected `%(team_id)s` without the cast
- The `uuid_suffix` variable was already defined for this purpose (line 107) but was not used in the expected SQL strings

## Test plan
- [x] Verify the fix addresses the CI failures in `Postgres tests: core / DB-core:Postgres:16:3.13:API...Serialization`
- [x] Verify the fix addresses the CI failures in `Special tests / Latest SQLAlchemy test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)