### PR TITLE
Generate constraints from uv.lock instead of skipping download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -734,12 +734,13 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    # When installing from sources without upgrade, uv sync --frozen uses uv.lock directly
-    # so we don't need to download constraints
+    # When installing from sources without upgrade, generate constraints from uv.lock
     if [[ ${AIRFLOW_INSTALLATION_METHOD=} == "." && -z "${UPGRADE_RANDOM_INDICATOR_STRING=}" ]]; then
         echo
-        echo "${COLOR_BLUE}Installing from sources with uv.lock - skipping constraints download${COLOR_RESET}"
+        echo "${COLOR_BLUE}Installing from sources with uv.lock - generating constraints from uv.lock${COLOR_RESET}"
         echo
+        uv export --frozen --no-hashes --no-emit-project --no-editable --no-header \
+            --no-annotate > "${HOME}/constraints.txt" 2>/dev/null || true
         return
     fi
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -674,12 +674,13 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    # When installing from sources without upgrade, uv sync --frozen uses uv.lock directly
-    # so we don't need to download constraints
+    # When installing from sources without upgrade, generate constraints from uv.lock
     if [[ ${AIRFLOW_INSTALLATION_METHOD=} == "." && -z "${UPGRADE_RANDOM_INDICATOR_STRING=}" ]]; then
         echo
-        echo "${COLOR_BLUE}Installing from sources with uv.lock - skipping constraints download${COLOR_RESET}"
+        echo "${COLOR_BLUE}Installing from sources with uv.lock - generating constraints from uv.lock${COLOR_RESET}"
         echo
+        uv export --frozen --no-hashes --no-emit-project --no-editable --no-header \
+            --no-annotate > "${HOME}/constraints.txt" 2>/dev/null || true
         return
     fi
 

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -87,12 +87,13 @@ function common::get_airflow_version_specification() {
 }
 
 function common::get_constraints_location() {
-    # When installing from sources without upgrade, uv sync --frozen uses uv.lock directly
-    # so we don't need to download constraints
+    # When installing from sources without upgrade, generate constraints from uv.lock
     if [[ ${AIRFLOW_INSTALLATION_METHOD=} == "." && -z "${UPGRADE_RANDOM_INDICATOR_STRING=}" ]]; then
         echo
-        echo "${COLOR_BLUE}Installing from sources with uv.lock - skipping constraints download${COLOR_RESET}"
+        echo "${COLOR_BLUE}Installing from sources with uv.lock - generating constraints from uv.lock${COLOR_RESET}"
         echo
+        uv export --frozen --no-hashes --no-emit-project --no-editable --no-header \
+            --no-annotate > "${HOME}/constraints.txt" 2>/dev/null || true
         return
     fi
 


### PR DESCRIPTION
When installing from sources, `common::get_constraints_location()` was returning early without
creating `constraints.txt`, leaving downstream steps without a constraints file. Now it uses
`uv export --frozen` to generate constraints from `uv.lock`, matching the pattern already used
in `entrypoint_ci.sh`.

Changed in all three copies: `scripts/docker/common.sh`, `Dockerfile`, and `Dockerfile.ci`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)