### PR TITLE
Add boolean helm chart option dags.gitSync.syncToApiServer

### DIFF
--- a/chart/docs/manage-dag-files.rst
+++ b/chart/docs/manage-dag-files.rst
@@ -103,6 +103,7 @@ Mounting Dags using Git-Sync sidecar without persistence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This option will always use running Git-Sync sidecar on every dag-processor, worker and triggerer pods
+(and optionally on API server pods when ``dags.gitSync.syncToApiServer=true``)
 (In Airflow 2.11, if separate dag-processor is not enabled, the Git-Sync sidecar will run on scheduler for Dag parsing as well).
 
 The Git-Sync sidecar containers will sync Dags from a git repository every configured number of

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -30,6 +30,8 @@
 {{- $containerSecurityContext := include "containerSecurityContext" (list .Values.apiServer .Values) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list .Values.apiServer.waitForMigrations .Values) }}
 {{- $containerLifecycleHooks := or .Values.apiServer.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $syncGitToApiServer := and .Values.dags.gitSync.enabled .Values.dags.gitSync.syncToApiServer (not .Values.dags.persistence.enabled) }}
+{{- $mountDagsToApiServer := and .Values.dags.gitSync.syncToApiServer (or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -152,6 +154,9 @@ spec:
               {{- tpl (toYaml .Values.apiServer.waitForMigrations.env) $ | nindent 12 }}
             {{- end }}
         {{- end }}
+        {{- if $syncGitToApiServer }}
+          {{- include "git_sync_container" (dict "Values" .Values "is_init" "true" "Template" .Template) | nindent 8 }}
+        {{- end }}
         {{- if .Values.apiServer.extraInitContainers }}
           {{- tpl (toYaml .Values.apiServer.extraInitContainers) . | nindent 8 }}
         {{- end }}
@@ -181,6 +186,9 @@ spec:
               {{- if .Values.logs.persistence.subPath }}
               subPath: {{ .Values.logs.persistence.subPath }}
               {{- end }}
+            {{- end }}
+            {{- if $mountDagsToApiServer }}
+              {{- include "airflow_dags_mount" . | nindent 12 }}
             {{- end }}
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}
@@ -223,6 +231,9 @@ spec:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" (merge (dict "IncludeJwtSecret" true) .) | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.apiServer.env) | indent 10 }}
+        {{- if $syncGitToApiServer }}
+          {{- include "git_sync_container" . | indent 8 }}
+        {{- end }}
         {{- if .Values.apiServer.extraContainers }}
           {{- tpl (toYaml .Values.apiServer.extraContainers) . | nindent 8 }}
         {{- end }}
@@ -239,6 +250,17 @@ spec:
         - name: logs
           persistentVolumeClaim:
             claimName: {{ template "airflow_logs_volume_claim" . }}
+        {{- end }}
+        {{- if and .Values.dags.persistence.enabled .Values.dags.gitSync.syncToApiServer }}
+        - name: dags
+          persistentVolumeClaim:
+            claimName: {{ template "airflow_dags_volume_claim" . }}
+        {{- else if and .Values.dags.gitSync.enabled .Values.dags.gitSync.syncToApiServer }}
+        - name: dags
+          emptyDir: {{- toYaml (default (dict) .Values.dags.gitSync.emptyDirConfig) | nindent 12 }}
+        {{- end }}
+        {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.syncToApiServer (or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey) }}
+          {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- if .Values.volumes }}
           {{- toYaml .Values.volumes | nindent 8 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10655,6 +10655,11 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "syncToApiServer": {
+                            "description": "Enable git sync and dags mount for API server pods (Airflow 3+).",
+                            "type": "boolean",
+                            "default": false
+                        },
                         "repo": {
                             "description": "Git repository.",
                             "type": "string",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3589,6 +3589,9 @@ dags:
   gitSync:
     enabled: false
 
+    # enable git sync and dags mount for the api-server pods (Airflow 3+)
+    syncToApiServer: false
+
     # git repo clone url
     # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git

--- a/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_api_server.py
@@ -622,6 +622,70 @@ class TestAPIServerDeployment:
         assert jmespath.search("spec.template.spec.hostAliases[0].ip", docs[0]) == "127.0.0.1"
         assert jmespath.search("spec.template.spec.hostAliases[0].hostnames[0]", docs[0]) == "foo.local"
 
+    def test_dags_gitsync_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+
+        container_names = [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        init_container_names = [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]
+        volume_mount_names = [
+            vm["name"] for vm in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        ]
+        volume_names = [v["name"] for v in jmespath.search("spec.template.spec.volumes", docs[0])]
+
+        assert "git-sync" not in container_names
+        assert "git-sync-init" not in init_container_names
+        assert "dags" not in volume_mount_names
+        assert "dags" not in volume_names
+
+    def test_dags_gitsync_sidecar_and_init_container_when_enabled(self):
+        docs = render_chart(
+            values={"dags": {"gitSync": {"enabled": True, "syncToApiServer": True}}},
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+
+        container_names = [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        init_container_names = [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]
+        volume_mount_names = [
+            vm["name"] for vm in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        ]
+        volume_names = [v["name"] for v in jmespath.search("spec.template.spec.volumes", docs[0])]
+
+        assert "git-sync" in container_names
+        assert "git-sync-init" in init_container_names
+        assert "dags" in volume_mount_names
+        assert "dags" in volume_names
+
+    def test_dags_gitsync_with_persistence_no_sidecar_or_init_container(self):
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {"enabled": True, "syncToApiServer": True},
+                    "persistence": {"enabled": True},
+                }
+            },
+            show_only=["templates/api-server/api-server-deployment.yaml"],
+        )
+
+        container_names = [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        init_container_names = [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]
+        volume_mount_names = [
+            vm["name"] for vm in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        ]
+        volume_names = [v["name"] for v in jmespath.search("spec.template.spec.volumes", docs[0])]
+
+        assert "git-sync" not in container_names
+        assert "git-sync-init" not in init_container_names
+        assert "dags" in volume_mount_names
+        assert "dags" in volume_names
+
     def test_can_be_disabled(self):
         """
         API server can be disabled by configuration.


### PR DESCRIPTION
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

# Add helm chart option `dags.gitSync.syncToApiServer`

## What 

Simply adds a boolean option (Default false) to the helm chart that will allow the gitsync to work with api-server pods as well.

## Why

We want to display the currently deployed githash using https://airflow.apache.org/docs/apache-airflow/stable/howto/customize-ui.html#dynamic-dashboard-alerts. But to do this I need the gitsync /sidecar on the api-server pods hence this pr

## Was generative AI tooling used to co-author this PR?

- [x] Yes

Generated-by: [GPT-5.3-Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Note: I'm not familiar with helm chart stuff at all, AKA maintainers feel free to take over this branch. I've got no desire for this credit I'd just like to slip this feature into 1.20 https://apache-airflow.slack.com/archives/C03G9H97MM2/p1773585210359609