### PR TITLE
Make prek cache restoration resilient to corrupted tarballs

### DIFF
--- a/.github/actions/install-prek/action.yml
+++ b/.github/actions/install-prek/action.yml
@@ -67,26 +67,27 @@ runs:
         key: cache-prek-v9-${{ inputs.platform }}-python${{ inputs.python-version }}-uv${{ inputs.uv-version }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
         path: /tmp/
       id: restore-prek-cache
-    - name: "Check if prek cache tarball exists"
-      shell: bash
-      run: |
-        if [ -f /tmp/cache-prek.tar.gz ]; then
-          echo "✅ Cache tarball found: /tmp/cache-prek.tar.gz"
-        else
-          echo "❌ Cache tarball missing. Expected /tmp/cache-prek.tar.gz"
-          exit 1
-        fi
-      if: steps.restore-prek-cache.outputs.stash-hit == 'true'
     - name: "Restore .cache from the tar file"
-      run: tar -C ~ -xzf /tmp/cache-prek.tar.gz
+      id: restore-prek-tar
       shell: bash
-      if: steps.restore-prek-cache.outputs.stash-hit == 'true'
-    - name: "Show restored files"
       run: |
-        echo "Restored files"
-        du ~/ --max-depth=2
-        echo
-      shell: bash
+        if [ ! -f /tmp/cache-prek.tar.gz ]; then
+          echo "❌ Cache tarball missing. Expected /tmp/cache-prek.tar.gz"
+          echo "tar-restored=false" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+        echo "✅ Cache tarball found: /tmp/cache-prek.tar.gz"
+        if tar -C ~ -xzf /tmp/cache-prek.tar.gz; then
+          echo "✅ Cache tarball extracted successfully"
+          echo "tar-restored=true" >> "${GITHUB_OUTPUT}"
+          echo "Restored files"
+          du ~/ --max-depth=2
+          echo
+        else
+          echo "⚠️ Cache tarball extraction failed — treating as cache miss"
+          echo "tar-restored=false" >> "${GITHUB_OUTPUT}"
+          rm -rf ~/.cache/prek
+        fi
       if: steps.restore-prek-cache.outputs.stash-hit == 'true'
     - name: "Make sure cache is cleared on cache miss"
       run: |
@@ -94,7 +95,7 @@ runs:
         ls -la ~/.cache/prek || true
         rm -rf ~/.cache/prek
       shell: bash
-      if: steps.restore-prek-cache.outputs.stash-hit != 'true'
+      if: steps.restore-prek-cache.outputs.stash-hit != 'true' || steps.restore-prek-tar.outputs.tar-restored != 'true'
     - name: Install prek hooks
       shell: bash
       run: prek install-hooks


### PR DESCRIPTION
Previously, a missing or corrupted cache tarball would hard-fail the
entire static checks job even when `stash-hit` reported `true`. This
merges the check/extract/show steps into a single resilient step that
gracefully falls through to a clean `prek install-hooks` on failure.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)