### PR TITLE
Add optional auto-backfill for missing TIs on DAG version updates

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2925,6 +2925,17 @@ dag_processor:
       type: string
       example: ~
       default: "warning"
+    auto_backfill_missing_task_instances:
+      description: |
+        When enabled, creating a new DAG version during parsing will also verify existing DagRuns and
+        add missing TaskInstance rows for tasks introduced in the new version.
+
+        This improves Grid/Graph consistency for historical runs after adding new tasks, but can increase
+        DAG parsing database workload for DAGs with many existing DagRuns.
+      version_added: 3.2.0
+      type: boolean
+      example: ~
+      default: "False"
 
 profiling:
   description: |

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -505,6 +505,31 @@ class SerializedDagModel(Base):
             serialized_dag.deadline_alerts.append(alert)
 
     @classmethod
+    def _backfill_missing_task_instances_for_new_version(
+        cls, dag_id: str, dag_version_id: UUID, current_dag: SerializedDAG, *, session: Session
+    ) -> None:
+        if not conf.getboolean("dag_processor", "auto_backfill_missing_task_instances", fallback=False):
+            return
+
+        dag_runs = session.scalars(
+            select(DagRun).where(
+                DagRun.dag_id == dag_id,
+                ~exists().where(
+                    TaskInstance.dag_id == dag_id,
+                    TaskInstance.run_id == DagRun.run_id,
+                    TaskInstance.dag_version_id == dag_version_id,
+                ),
+            )
+        ).all()
+
+        if not dag_runs:
+            return
+
+        for dag_run in dag_runs:
+            dag_run.dag = current_dag
+            dag_run.verify_integrity(dag_version_id=dag_version_id, session=session)
+
+    @classmethod
     @provide_session
     def write_dag(
         cls,
@@ -660,6 +685,9 @@ class SerializedDagModel(Base):
         new_serialized_dag.dag_version = dagv
         session.add(new_serialized_dag)
         cls._create_deadline_alert_records(new_serialized_dag, deadline_uuid_mapping)
+        cls._backfill_missing_task_instances_for_new_version(
+            dag.dag_id, dagv.id, new_serialized_dag.dag, session=session
+        )
         log.debug("DAG: %s written to the DB", dag.dag_id)
         DagCode.write_code(dagv, dag.fileloc, session=session)
         return True

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -34,6 +34,7 @@ from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.deadline_alert import DeadlineAlert as DAM
 from airflow.models.serialized_dag import SerializedDagModel as SDM
+from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -200,6 +201,59 @@ class TestSerializedDagModel:
         assert s_dag.dag_hash != s_dag_2.dag_hash
         assert s_dag_2.data["dag"]["tags"] == ["example", "example2", "new_tag"]
         assert dag_updated is True
+
+    @pytest.mark.parametrize(
+        ("auto_backfill_missing_task_instances", "expected_backfilled_task_instances"),
+        [(True, 1), (False, 0)],
+    )
+    def test_write_dag_can_backfill_missing_task_instances_for_existing_dagruns(
+        self, auto_backfill_missing_task_instances, expected_backfilled_task_instances, dag_maker, session
+    ):
+        logical_date = pendulum.datetime(2026, 3, 1, tz="UTC")
+        dag_id = f"backfill_missing_ti_{auto_backfill_missing_task_instances}"
+
+        with dag_maker(
+            dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily", bundle_name="testing"
+        ) as dag_v1:
+            EmptyOperator(task_id="existing_task")
+
+        dag_maker.create_dagrun(
+            run_id=f"manual__{logical_date.to_date_string()}",
+            logical_date=logical_date,
+            state=DagRunState.SUCCESS,
+            run_type=DagRunType.MANUAL,
+        )
+
+        with DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule="@daily") as dag_v2:
+            EmptyOperator(task_id="existing_task")
+            EmptyOperator(task_id="test1")
+        dag_v2.fileloc = dag_v1.fileloc
+        dag_v2.relative_fileloc = dag_v1.relative_fileloc
+
+        with conf_vars(
+            {
+                (
+                    "dag_processor",
+                    "auto_backfill_missing_task_instances",
+                ): str(auto_backfill_missing_task_instances)
+            }
+        ):
+            SDM.write_dag(
+                dag=LazyDeserializedDAG.from_dag(dag_v2),
+                bundle_name="testing",
+                session=session,
+            )
+
+        backfilled_ti_count = session.scalar(
+            select(func.count())
+            .select_from(TaskInstance)
+            .where(
+                TaskInstance.dag_id == dag_id,
+                TaskInstance.run_id == f"manual__{logical_date.to_date_string()}",
+                TaskInstance.task_id == "test1",
+            )
+        )
+        assert backfilled_ti_count == expected_backfilled_task_instances
 
     def test_read_dags(self):
         """DAGs can be read from database."""


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
This PR introduces an optional config to improve historical run visibility when DAG structure changes.

related: #61344

## Background

When a new task is added to an existing DAG, Airflow creates a new `DagVersion`, but historical `DagRun`s may not have `TaskInstance` rows for the new task.
In Grid/Graph, those historical cells can appear blank and non-actionable.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=a075b81 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @MonsterChenzhuo** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
