### PR TITLE
fix(scheduler): refresh finished_tis in _are_premature_tis to prevent stale upstream_failed

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1537,12 +1537,11 @@ class DagRun(Base, LoggingMixin):
     ) -> tuple[bool, bool]:
         # Do not pass the cached finished_tis to DepContext. The list was built
         # at the start of the scheduling loop and may be stale when a concurrent
-        # API call (e.g. "mark task as success") clears downstream task states
-        # between the snapshot and this evaluation.  Leaving finished_tis=None
-        # makes DepContext.ensure_finished_tis() re-query the database so the
+        # API call clears downstream task states between the snapshot and this
+        # evaluation. Leaving finished_tis=None makes
+        # DepContext.ensure_finished_tis() re-query the database so the
         # trigger-rule evaluation sees the latest committed states instead of
         # incorrectly marking tasks as upstream_failed based on outdated data.
-        # See: https://github.com/apache/airflow/issues/63697
         dep_context = DepContext(
             flag_upstream_failed=True,
             ignore_in_retry_period=True,

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1535,11 +1535,19 @@ class DagRun(Base, LoggingMixin):
         finished_tis: list[TI],
         session: Session,
     ) -> tuple[bool, bool]:
+        # Do not pass the cached finished_tis to DepContext. The list was built
+        # at the start of the scheduling loop and may be stale when a concurrent
+        # API call (e.g. "mark task as success") clears downstream task states
+        # between the snapshot and this evaluation.  Leaving finished_tis=None
+        # makes DepContext.ensure_finished_tis() re-query the database so the
+        # trigger-rule evaluation sees the latest committed states instead of
+        # incorrectly marking tasks as upstream_failed based on outdated data.
+        # See: https://github.com/apache/airflow/issues/63697
         dep_context = DepContext(
             flag_upstream_failed=True,
             ignore_in_retry_period=True,
             ignore_in_reschedule_period=True,
-            finished_tis=finished_tis,
+            finished_tis=None,
         )
         # there might be runnable tasks that are up for retry and for some reason(retry delay, etc.) are
         # not ready yet, so we set the flags to count them in

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -3562,3 +3562,81 @@ class TestDagRunTracing:
             assert spans[0].name == f"dag_run.{dr.dag_id}"
         else:
             assert len(spans) == 0
+
+
+@pytest.mark.db_test
+@pytest.mark.skip_if_database_isolation_mode
+def test_are_premature_tis_refreshes_finished_states(dag_maker, session):
+    """
+    Verify that _are_premature_tis does not use stale finished_tis cache.
+
+    Reproduces the race condition from https://github.com/apache/airflow/issues/63697
+    where the scheduler's cached finished_tis snapshot causes downstream tasks to be
+    permanently stuck in upstream_failed after a concurrent API call clears them.
+    """
+    from sqlalchemy.orm import Session as SASession
+
+    with dag_maker("test_upstream_failed_race", session=session):
+        fail_task = EmptyOperator(task_id="fail_task")
+        t0 = EmptyOperator(task_id="t0")
+        t1 = EmptyOperator(task_id="t1")
+        t2 = EmptyOperator(task_id="t2")
+        fail_task >> t0 >> t1 >> t2
+
+    dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+    tis = {ti.task_id: ti for ti in dr.task_instances}
+
+    # Step 1: fail_task fails, scheduler propagates upstream_failed to t0
+    tis["fail_task"].state = TaskInstanceState.FAILED
+    tis["t0"].state = TaskInstanceState.UPSTREAM_FAILED
+    session.flush()
+    session.commit()
+
+    # Step 2: Scheduler takes snapshot (simulated by building finished_tis list)
+    bind = session.get_bind()
+    scheduler_session: SASession = SASession(bind=bind)
+    try:
+        sched_dr = scheduler_session.get(DagRun, dr.id)
+        sched_dr.dag = dr.dag
+
+        stale_finished_tis = sched_dr.get_task_instances(state=State.finished, session=scheduler_session)
+        dag = sched_dr.get_dag()
+        for ti in stale_finished_tis:
+            ti.task = dag.get_task(ti.task_id)
+
+        # Step 3: API clears tasks in the primary session (concurrent connection)
+        session.expire_all()
+        api_tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session)}
+        api_tis["fail_task"].state = TaskInstanceState.SUCCESS
+        api_tis["t0"].state = None  # cleared
+        session.flush()
+        session.commit()
+
+        # Step 4: Scheduler evaluates with stale cache
+        unfinished_tis = sched_dr.get_task_instances(state=State.unfinished, session=scheduler_session)
+        for ti in unfinished_tis:
+            ti.task = dag.get_task(ti.task_id)
+
+        # Call _are_premature_tis — the fix makes it ignore the stale finished_tis
+        # and re-query from DB, seeing the updated states
+        sched_dr._are_premature_tis(
+            unfinished_tis=unfinished_tis,
+            finished_tis=stale_finished_tis,
+            session=scheduler_session,
+        )
+        scheduler_session.flush()
+        scheduler_session.commit()
+
+        # Step 5: Verify t1 was NOT incorrectly marked upstream_failed
+        session.expire_all()
+        final_states = {ti.task_id: ti.state for ti in dr.get_task_instances(session=session)}
+        assert final_states["fail_task"] == TaskInstanceState.SUCCESS
+        assert final_states["t0"] is None  # cleared by API
+        # With the fix, t1 should NOT be upstream_failed because the scheduler
+        # re-reads finished_tis from DB and sees fail_task=SUCCESS, t0=None
+        assert final_states["t1"] != TaskInstanceState.UPSTREAM_FAILED, (
+            "t1 should not be upstream_failed — the scheduler should have re-read "
+            "finished states from DB instead of using stale cache"
+        )
+    finally:
+        scheduler_session.close()

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -38,7 +38,7 @@ from sqlalchemy import (
     select,
     update,
 )
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import Session, joinedload
 
 from airflow import settings
 from airflow._shared.observability.metrics.stats import Stats
@@ -80,8 +80,6 @@ pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm.session import Session
-
     from airflow.serialization.definitions.dag import SerializedDAG
 
 TI = TaskInstance
@@ -3567,14 +3565,7 @@ class TestDagRunTracing:
 @pytest.mark.db_test
 @pytest.mark.skip_if_database_isolation_mode
 def test_are_premature_tis_refreshes_finished_states(dag_maker, session):
-    """
-    Verify that _are_premature_tis does not use stale finished_tis cache.
-
-    Reproduces the race condition from https://github.com/apache/airflow/issues/63697
-    where the scheduler's cached finished_tis snapshot causes downstream tasks to be
-    permanently stuck in upstream_failed after a concurrent API call clears them.
-    """
-    from sqlalchemy.orm import Session as SASession
+    """Verify `_are_premature_tis` re-reads finished task states instead of using a stale snapshot."""
 
     with dag_maker("test_upstream_failed_race", session=session):
         fail_task = EmptyOperator(task_id="fail_task")
@@ -3594,7 +3585,7 @@ def test_are_premature_tis_refreshes_finished_states(dag_maker, session):
 
     # Step 2: Scheduler takes snapshot (simulated by building finished_tis list)
     bind = session.get_bind()
-    scheduler_session: SASession = SASession(bind=bind)
+    scheduler_session = Session(bind=bind)
     try:
         sched_dr = scheduler_session.get(DagRun, dr.id)
         sched_dr.dag = dr.dag
@@ -3612,7 +3603,8 @@ def test_are_premature_tis_refreshes_finished_states(dag_maker, session):
         session.flush()
         session.commit()
 
-        # Step 4: Scheduler evaluates with stale cache
+        # Step 4: Scheduler evaluates with stale finished_tis but a fresh DB view
+        scheduler_session.expire_all()
         unfinished_tis = sched_dr.get_task_instances(state=State.unfinished, session=scheduler_session)
         for ti in unfinished_tis:
             ti.task = dag.get_task(ti.task_id)
@@ -3631,12 +3623,8 @@ def test_are_premature_tis_refreshes_finished_states(dag_maker, session):
         session.expire_all()
         final_states = {ti.task_id: ti.state for ti in dr.get_task_instances(session=session)}
         assert final_states["fail_task"] == TaskInstanceState.SUCCESS
-        assert final_states["t0"] is None  # cleared by API
-        # With the fix, t1 should NOT be upstream_failed because the scheduler
-        # re-reads finished_tis from DB and sees fail_task=SUCCESS, t0=None
-        assert final_states["t1"] != TaskInstanceState.UPSTREAM_FAILED, (
-            "t1 should not be upstream_failed — the scheduler should have re-read "
-            "finished states from DB instead of using stale cache"
-        )
+        assert final_states["t0"] is None
+        assert final_states["t1"] is None
+        assert final_states["t2"] is None
     finally:
         scheduler_session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -963,6 +963,9 @@ filterwarnings = [
     # https://github.com/dpgaspar/Flask-AppBuilder/pull/1903
     "ignore::DeprecationWarning:apispec.utils",
 ]
+markers = [
+    "skip_if_database_isolation_mode: skip tests that require DB state not supported in isolation mode",
+]
 # We cannot add warnings from the airflow package into `filterwarnings`,
 # because it invokes import airflow before we set up test environment which breaks the tests.
 # Instead of that, we use a separate parameter and dynamically add it into `filterwarnings` marker.


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
closes: #63697
-->

`_are_premature_tis` uses a `finished_tis` list built at the start of the scheduling loop. If the API concurrently marks a failed task as success (clearing downstream tasks), the scheduler still sees the old states and incorrectly marks further downstream tasks as `upstream_failed` — permanently, since that's a terminal state.

Fix: don't pass the cached `finished_tis` to `DepContext`. Leaving it as `None` makes `ensure_finished_tis()` re-query the DB, so trigger-rule evaluation sees the latest committed states. `_are_premature_tis` only runs when there are no schedulable/changed TIs, so the extra query has minimal performance impact.

Added a test that simulates the race with two independent SQLAlchemy sessions (scheduler vs API) and verifies `t1` is not stuck in `upstream_failed` after `fail_task` is marked success and `t0` is cleared.

Closes: #63697

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
