### PR TITLE
Log RTIF overwrite error with simpler context

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1765,7 +1765,11 @@ def finalize(
             try:
                 SUPERVISOR_COMMS.send(SetRenderedFields(rendered_fields=_serialize_rendered_fields(ti.task)))
             except Exception:
-                log.exception("Failed to set rendered fields during finalization", ti=ti, task=ti.task)
+                log.exception(
+                    "Failed to set rendered fields during finalization",
+                    task_id=ti.task_id,
+                    dag_id=ti.dag_id,
+                )
 
     log.debug("Running finalizers", ti=ti)
     if state == TaskInstanceState.SUCCESS:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2337,8 +2337,8 @@ class TestRuntimeTaskInstance:
 
         mock_log.exception.assert_called_once_with(
             "Failed to set rendered fields during finalization",
-            ti=runtime_ti,
-            task=task,
+            task_id=runtime_ti.task_id,
+            dag_id=runtime_ti.dag_id,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Recently, I made this fix: 

In that fix, I wrapped `SetRenderedFields` call in finalize() with try/except to prevent API errors from masking the original task failure. 


Noticed an issue during that:
```python
Task failed with exception
CosmosDbtRunError: error here
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1112 in run

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1528 in _execute_task

File "/usr/local/astronomer-cosmos/cosmos/operators/base.py", line 342 in execute

File "/usr/local/astronomer-cosmos/cosmos/operators/local.py", line 895 in build_and_run_cmd

File "/usr/local/astronomer-cosmos/cosmos/operators/local.py", line 693 in run_command

File "/usr/local/astronomer-cosmos/cosmos/operators/local.py", line 273 in handle_exception_dbt_runner

File "/usr/local/astronomer-cosmos/cosmos/dbt/runner.py", line 151 in handle_exception_if_needed

[2026-03-12 20:58:50] ERROR - Top level error
RecursionError: maximum recursion depth exceeded
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1699 in main

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1629 in finalize

File "/usr/local/lib/python3.12/site-packages/structlog/_native.py", line 46 in exception

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/_shared/logging/structlog.py", line 95 in meth

File "/usr/local/lib/python3.12/site-packages/structlog/_base.py", line 222 in _proxy_to_logger

File "/usr/local/lib/python3.12/site-packages/structlog/_base.py", line 173 in _process_event

File "/usr/local/lib/python3.12/site-packages/structlog/processors.py", line 353 in __call__

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/_shared/logging/structlog.py", line 316 in json_dumps

File "/usr/local/lib/python3.12/site-packages/structlog/processors.py", line 369 in _json_fallback_handler

File "/usr/local/lib/python3.12/site-packages/pendulum/datetime.py", line 491 in __repr__

AttributeError: 'DateTime' object has no attribute '__structlog__'
File "/usr/local/lib/python3.12/site-packages/structlog/processors.py", line 367 in _json_fallback_handler

AirflowRuntimeError: API_SERVER_ERROR: {'status_code': 404, 'message': 'Not Found', 'detail': {'detail': 'Not Found'}}
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1627 in finalize

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/comms.py", line 206 in send

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/comms.py", line 270 in _get_response

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/comms.py", line 257 in _from_frame

[2026-03-12 20:58:50] WARNING - Process exited abnormally exit_code=1
```
The issue was that while logging the exception, there is some chance that complex operators might cause bloating of log context and cause serialization issues like above. 

I am now logging errors with simpler context to avoid recursion issues from complex object serialization like dag_id and task_id which is good enough to debug the failures in logs like operator links does.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
