### PR TITLE
Fix: Removed the stray 's' and added a unit test to lock the formatting.

### DIFF
--- a/airflow-core/newsfragments/63712.bugfix.rst
+++ b/airflow-core/newsfragments/63712.bugfix.rst
@@ -1,1 +1,0 @@
-Fix FileSyntaxError line number formatting in file parse errors.

--- a/airflow-core/newsfragments/63712.bugfix.rst
+++ b/airflow-core/newsfragments/63712.bugfix.rst
@@ -1,0 +1,1 @@
+Fix FileSyntaxError line number formatting in file parse errors.

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -179,7 +179,7 @@ class FileSyntaxError(NamedTuple):
     message: str
 
     def __str__(self):
-        return f"{self.message}. Line number: s{str(self.line_no)},"
+        return f"{self.message}. Line number: {str(self.line_no)},"
 
 
 class AirflowFileParseException(AirflowException):

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -29,6 +29,7 @@ from airflow.exceptions import (
     AirflowException,
     AirflowFileParseException,
     ConnectionNotUnique,
+    FileSyntaxError,
     VariableNotUnique,
 )
 from airflow.models import Variable
@@ -85,6 +86,12 @@ class TestFileParsers:
         with mock_local_file(content):
             with pytest.raises(AirflowFileParseException, match=re.escape(expected_message)):
                 local_filesystem.load_variables("a.yaml")
+
+
+class TestFileSyntaxError:
+    def test_str(self):
+        error = FileSyntaxError(line_no=10, message="Invalid line format")
+        assert str(error) == "Invalid line format. Line number: 10,"
 
 
 class TestLoadVariables:


### PR DESCRIPTION
This PR fixes a typo in `FileSyntaxError.__str__` that caused user-facing error messages to show an incorrect line number prefix, and adds a unit test to lock the correct formatting. It also includes a newsfragment for the bugfix.

Was generative AI tooling used to co-author this PR?

 Yes

Read the Pull Request Guidelines for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
For fundamental code changes, an Airflow Improvement Proposal (AIP) is needed.
When adding dependency, check compliance with the ASF 3rd Party License Policy.

For significant user-facing changes create newsfragment: {pr_number}.significant.rst, in airflow-core/newsfragments. You can add this file in a follow-up commit after the PR is created so you know the PR number.
