### PR TITLE
Fix BigQueryInsertJobTrigger not propagating CancelledError

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
@@ -215,6 +215,7 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                     self.location,
                     self.job_id,
                 )
+            raise
         except Exception as e:
             self.log.exception("Exception occurred while checking for query completion")
             yield TriggerEvent({"status": "error", "message": str(e)})

--- a/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
@@ -258,11 +258,9 @@ class TestBigQueryInsertJobTrigger:
 
         caplog.set_level(logging.INFO)
 
-        try:
+        with pytest.raises(asyncio.CancelledError):
             async for _ in insert_job_trigger.run():
                 pass
-        except asyncio.CancelledError:
-            pass
 
         assert (
             "Task was killed" in caplog.text
@@ -294,11 +292,9 @@ class TestBigQueryInsertJobTrigger:
 
         caplog.set_level(logging.INFO)
 
-        try:
+        with pytest.raises(asyncio.CancelledError):
             async for _ in insert_job_trigger.run():
                 pass
-        except asyncio.CancelledError:
-            pass
 
         assert "Skipping to cancel job" in caplog.text, (
             "Expected message about skipping cancellation not found in log."


### PR DESCRIPTION
The `except asyncio.CancelledError` block in `BigQueryInsertJobTrigger.run()` catches the exception to perform cleanup (cancelling the BQ job) but never re-raises it. This causes the cancellation to be silently dropped — the triggerer framework never knows the trigger was cancelled and an error gets logged:

> Trigger ... exited without sending an event. Dependent tasks will be failed.

---

- Add `raise` after cleanup to propagate the error.
- Update tests to assert the exception is raised.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)