### PR TITLE
Fix noisy OTel integration test CI output

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -317,7 +317,7 @@ class TestOtelIntegration:
         try:
             # Start the processes here and not as fixtures or in a common setup,
             # so that the test can capture their output.
-            scheduler_process, apiserver_process = self.start_scheduler()
+            scheduler_process, apiserver_process = self.start_scheduler(capture_output=True)
 
             dag_id = "otel_test_dag"
 
@@ -363,10 +363,7 @@ class TestOtelIntegration:
                 "The apiserver process status is None, which means that it hasn't terminated as expected."
             )
 
-        out, err = capfd.readouterr()
-        log.info("out-start --\n%s\n-- out-end", out)
-        log.info("err-start --\n%s\n-- err-end", err)
-
+        out, _err = capfd.readouterr()
         return out, dag
 
     def _get_ti(self, dag_id: str, run_id: str, task_id: str) -> Any | None:
@@ -482,9 +479,7 @@ class TestOtelIntegration:
                 "The apiserver process status is None, which means that it hasn't terminated as expected."
             )
 
-        out, err = capfd.readouterr()
-        log.info("out-start --\n%s\n-- out-end", out)
-        log.info("err-start --\n%s\n-- err-end", err)
+        capfd.readouterr()
 
         host = "jaeger"
         service_name = os.environ.get("OTEL_SERVICE_NAME", "test")
@@ -513,19 +508,22 @@ class TestOtelIntegration:
             "dag_run.otel_test_dag": None,
         }
 
-    def start_scheduler(self):
+    def start_scheduler(self, capture_output: bool = False):
+        stdout = None if capture_output else subprocess.DEVNULL
+        stderr = None if capture_output else subprocess.DEVNULL
+
         scheduler_process = subprocess.Popen(
             self.scheduler_command_args,
             env=os.environ.copy(),
-            stdout=None,
-            stderr=None,
+            stdout=stdout,
+            stderr=stderr,
         )
 
         apiserver_process = subprocess.Popen(
             self.apiserver_command_args,
             env=os.environ.copy(),
-            stdout=None,
-            stderr=None,
+            stdout=stdout,
+            stderr=stderr,
         )
 
         # Wait to ensure both processes have started.


### PR DESCRIPTION
The `Integration core otel` CI job was producing ~50k lines of log output,
making failures nearly impossible to diagnose. Two sources were responsible:

1. **Scheduler/api-server stdout flooding pytest capture.** `start_scheduler()`
   started both subprocesses with `stdout=None, stderr=None`, inheriting the
   parent's file descriptors. This caused all OTel `ConsoleMetricExporter` JSON
   (emitted every 5 seconds) to flow directly into pytest's `capfd` capture buffer.
   On any test failure pytest would then dump the entire buffer — tens of thousands
   of lines of metrics JSON — as "Captured stdout call".

2. **`log.info("out-start...")` re-emitting the captured output.** After
   `capfd.readouterr()`, the test logged the full captured content back to stdout,
   which pytest re-captured and included in the failure output a second time.

**Fix:**
- Add `capture_output: bool = False` to `start_scheduler()`. When `False`
  (the default), redirect subprocess stdout/stderr to `subprocess.DEVNULL`.
  `dag_execution_for_testing_metrics` passes `capture_output=True` since it
  genuinely needs to parse console metrics output via `capfd`.
- Remove the `log.info("out-start...")` / `log.info("err-start...")` debug
  statements that were re-emitting the full captured content unnecessarily.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (claude-4.6-sonnet-medium)

Generated-by: Claude (claude-4.6-sonnet-medium) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Made with [Cursor](https://cursor.com)