### PR TITLE
Add DagRunType for operator

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -44,7 +44,7 @@ def _trigger_dag(
     dag_bag: DBDagBag,
     *,
     triggered_by: DagRunTriggeredByType,
-    run_type: DagRunType = DagRunType.MANUAL,
+    run_type: DagRunType,
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,
@@ -60,6 +60,7 @@ def _trigger_dag(
 
     :param dag_id: DAG ID
     :param dag_bag: DAG Bag model
+    :param run_type: DagRun type to create
     :param triggered_by: the entity which triggers the dag_run
     :param run_type: the type of dag run (default: MANUAL)
     :param triggering_user_name: the user name who triggers the dag_run
@@ -136,6 +137,7 @@ def trigger_dag(
     *,
     triggered_by: DagRunTriggeredByType,
     run_type: DagRunType = DagRunType.MANUAL,
+    run_type: DagRunType = DagRunType.MANUAL,
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,
@@ -166,14 +168,14 @@ def trigger_dag(
         raise DagNotFound(f"Dag id {dag_id} not found in DagModel")
 
     if dag_model.allowed_run_types is not None and run_type not in dag_model.allowed_run_types:
-        raise ValueError(f"Dag with dag_id: '{dag_id}' does not allow {run_type} runs")
+        raise ValueError(f"Dag with dag_id: '{dag_id}' does not allow {run_type.value} runs")
 
     dagbag = DBDagBag()
     dr = _trigger_dag(
         dag_id=dag_id,
         dag_bag=dagbag,
-        run_id=run_id,
         run_type=run_type,
+        run_id=run_id,
         run_after=run_after or timezone.utcnow(),
         conf=conf,
         logical_date=logical_date,

--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -137,7 +137,6 @@ def trigger_dag(
     *,
     triggered_by: DagRunTriggeredByType,
     run_type: DagRunType = DagRunType.MANUAL,
-    run_type: DagRunType = DagRunType.MANUAL,
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,

--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -44,7 +44,7 @@ def _trigger_dag(
     dag_bag: DBDagBag,
     *,
     triggered_by: DagRunTriggeredByType,
-    run_type: DagRunType,
+    run_type: DagRunType = DagRunType.MANUAL,
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,
@@ -60,7 +60,6 @@ def _trigger_dag(
 
     :param dag_id: DAG ID
     :param dag_bag: DAG Bag model
-    :param run_type: DagRun type to create
     :param triggered_by: the entity which triggers the dag_run
     :param run_type: the type of dag run (default: MANUAL)
     :param triggering_user_name: the user name who triggers the dag_run
@@ -167,14 +166,14 @@ def trigger_dag(
         raise DagNotFound(f"Dag id {dag_id} not found in DagModel")
 
     if dag_model.allowed_run_types is not None and run_type not in dag_model.allowed_run_types:
-        raise ValueError(f"Dag with dag_id: '{dag_id}' does not allow {run_type.value} runs")
+        raise ValueError(f"Dag with dag_id: '{dag_id}' does not allow {run_type} runs")
 
     dagbag = DBDagBag()
     dr = _trigger_dag(
         dag_id=dag_id,
         dag_bag=dagbag,
-        run_type=run_type,
         run_id=run_id,
+        run_type=run_type,
         run_after=run_after or timezone.utcnow(),
         conf=conf,
         logical_date=logical_date,

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1999,6 +1999,7 @@ components:
       - backfill
       - scheduled
       - manual
+      - operator
       - asset_triggered
       - asset_materialization
       title: DagRunType

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1999,7 +1999,7 @@ components:
       - backfill
       - scheduled
       - manual
-      - operator
+      - operator_triggered
       - asset_triggered
       - asset_materialization
       title: DagRunType

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -11151,6 +11151,7 @@ components:
       - backfill
       - scheduled
       - manual
+      - operator
       - asset_triggered
       - asset_materialization
       title: DagRunType

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -11151,7 +11151,7 @@ components:
       - backfill
       - scheduled
       - manual
-      - operator
+      - operator_triggered
       - asset_triggered
       - asset_materialization
       title: DagRunType

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -112,14 +112,12 @@ def trigger_dag_run(
             },
         )
 
-    # TODO: TriggerDagRunOperator also calls this route but creates MANUAL runs.
-    #  Consider a dedicated run type for operator-triggered runs.
-    if dm.allowed_run_types is not None and DagRunType.MANUAL not in dm.allowed_run_types:
+    if dm.allowed_run_types is not None and DagRunType.OPERATOR not in dm.allowed_run_types:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "denied_run_type",
-                "message": f"Dag with dag_id '{dag_id}' does not allow manual runs",
+                "message": f"Dag with dag_id '{dag_id}' does not allow operator-triggered runs",
             },
         )
 
@@ -127,6 +125,7 @@ def trigger_dag_run(
         trigger_dag(
             dag_id=dag_id,
             run_id=run_id,
+            run_type=DagRunType.OPERATOR,
             conf=payload.conf,
             logical_date=payload.logical_date,
             triggered_by=DagRunTriggeredByType.OPERATOR,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -112,7 +112,7 @@ def trigger_dag_run(
             },
         )
 
-    if dm.allowed_run_types is not None and DagRunType.OPERATOR not in dm.allowed_run_types:
+    if dm.allowed_run_types is not None and DagRunType.OPERATOR_TRIGGERED not in dm.allowed_run_types:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
             detail={
@@ -125,7 +125,7 @@ def trigger_dag_run(
         trigger_dag(
             dag_id=dag_id,
             run_id=run_id,
-            run_type=DagRunType.OPERATOR,
+            run_type=DagRunType.OPERATOR_TRIGGERED,
             conf=payload.conf,
             logical_date=payload.logical_date,
             triggered_by=DagRunTriggeredByType.OPERATOR,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3311,7 +3311,7 @@ export const $DagRunTriggeredByType = {
 
 export const $DagRunType = {
     type: 'string',
-    enum: ['backfill', 'scheduled', 'manual', 'operator', 'asset_triggered', 'asset_materialization'],
+    enum: ['backfill', 'scheduled', 'manual', 'operator_triggered', 'asset_triggered', 'asset_materialization'],
     title: 'DagRunType',
     description: 'Class with DagRun types.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3311,7 +3311,7 @@ export const $DagRunTriggeredByType = {
 
 export const $DagRunType = {
     type: 'string',
-    enum: ['backfill', 'scheduled', 'manual', 'asset_triggered', 'asset_materialization'],
+    enum: ['backfill', 'scheduled', 'manual', 'operator', 'asset_triggered', 'asset_materialization'],
     title: 'DagRunType',
     description: 'Class with DagRun types.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -817,7 +817,7 @@ export type DagRunTriggeredByType = 'cli' | 'operator' | 'rest_api' | 'ui' | 'te
 /**
  * Class with DagRun types.
  */
-export type DagRunType = 'backfill' | 'scheduled' | 'manual' | 'asset_triggered' | 'asset_materialization';
+export type DagRunType = 'backfill' | 'scheduled' | 'manual' | 'operator' | 'asset_triggered' | 'asset_materialization';
 
 /**
  * DAG schedule reference serializer for assets.

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -817,7 +817,7 @@ export type DagRunTriggeredByType = 'cli' | 'operator' | 'rest_api' | 'ui' | 'te
 /**
  * Class with DagRun types.
  */
-export type DagRunType = 'backfill' | 'scheduled' | 'manual' | 'operator' | 'asset_triggered' | 'asset_materialization';
+export type DagRunType = 'backfill' | 'scheduled' | 'manual' | 'operator_triggered' | 'asset_triggered' | 'asset_materialization';
 
 /**
  * DAG schedule reference serializer for assets.

--- a/airflow-core/src/airflow/ui/src/components/RunTypeIcon.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RunTypeIcon.tsx
@@ -36,6 +36,7 @@ export const RunTypeIcon = ({ runType, ...rest }: Props) => {
   switch (runType) {
     case "asset_materialization":
     case "asset_triggered":
+    case "operator":
       return <HiDatabase style={iconStyle} {...rest} />;
     case "backfill":
       return <RiArrowGoBackFill style={iconStyle} {...rest} />;

--- a/airflow-core/src/airflow/ui/src/components/RunTypeIcon.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RunTypeIcon.tsx
@@ -18,6 +18,7 @@
  */
 import type { IconBaseProps } from "react-icons";
 import { HiDatabase } from "react-icons/hi";
+import { HiLightningBolt } from "react-icons/hi";
 import { MdPlayArrow, MdOutlineSchedule } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 
@@ -36,12 +37,13 @@ export const RunTypeIcon = ({ runType, ...rest }: Props) => {
   switch (runType) {
     case "asset_materialization":
     case "asset_triggered":
-    case "operator":
       return <HiDatabase style={iconStyle} {...rest} />;
     case "backfill":
       return <RiArrowGoBackFill style={iconStyle} {...rest} />;
     case "manual":
       return <MdPlayArrow style={iconStyle} {...rest} />;
+    case "operator_triggered":
+      return <HiLightningBolt style={iconStyle} {...rest} />;
     case "scheduled":
       return <MdOutlineSchedule style={iconStyle} {...rest} />;
     default:

--- a/airflow-core/src/airflow/utils/types.py
+++ b/airflow-core/src/airflow/utils/types.py
@@ -28,6 +28,7 @@ class DagRunType(str, enum.Enum):
     BACKFILL_JOB = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
+    OPERATOR = "operator"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 

--- a/airflow-core/src/airflow/utils/types.py
+++ b/airflow-core/src/airflow/utils/types.py
@@ -28,7 +28,7 @@ class DagRunType(str, enum.Enum):
     BACKFILL_JOB = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
-    OPERATOR = "operator"
+    OPERATOR_TRIGGERED = "operator_triggered"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 

--- a/airflow-core/tests/unit/api/common/test_trigger_dag.py
+++ b/airflow-core/tests/unit/api/common/test_trigger_dag.py
@@ -91,10 +91,12 @@ def test_trigger_dag_operator_denied_when_only_manual_allowed(dag_maker, session
     dag_model.allowed_run_types = ["manual"]
     session.commit()
 
-    with pytest.raises(ValueError, match="Dag with dag_id: 'TEST_DAG_1' does not allow operator runs"):
+    with pytest.raises(
+        ValueError, match="Dag with dag_id: 'TEST_DAG_1' does not allow operator_triggered runs"
+    ):
         trigger_dag(
             dag_id="TEST_DAG_1",
-            run_type=DagRunType.OPERATOR,
+            run_type=DagRunType.OPERATOR_TRIGGERED,
             triggered_by=DagRunTriggeredByType.OPERATOR,
             session=session,
         )

--- a/airflow-core/tests/unit/api/common/test_trigger_dag.py
+++ b/airflow-core/tests/unit/api/common/test_trigger_dag.py
@@ -81,3 +81,20 @@ def test_trigger_dag_with_custom_run_type(dag_maker, session):
     )
 
     assert dag_run.run_type == DagRunType.ASSET_MATERIALIZATION
+
+
+def test_trigger_dag_operator_denied_when_only_manual_allowed(dag_maker, session):
+    with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *"):
+        EmptyOperator(task_id="mytask")
+    session.commit()
+    dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == "TEST_DAG_1"))
+    dag_model.allowed_run_types = ["manual"]
+    session.commit()
+
+    with pytest.raises(ValueError, match="Dag with dag_id: 'TEST_DAG_1' does not allow operator runs"):
+        trigger_dag(
+            dag_id="TEST_DAG_1",
+            run_type=DagRunType.OPERATOR,
+            triggered_by=DagRunTriggeredByType.OPERATOR,
+            session=session,
+        )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
@@ -60,7 +60,7 @@ class TestDagRunTrigger:
         dag_run = session.scalars(select(DagRun).where(DagRun.run_id == run_id)).one()
         assert dag_run.conf == {"key1": "value1"}
         assert dag_run.logical_date == logical_date
-        assert dag_run.run_type == DagRunType.OPERATOR
+        assert dag_run.run_type == DagRunType.OPERATOR_TRIGGERED
 
     def test_trigger_dag_run_with_partition_key(self, client, session, dag_maker):
         dag_id = "test_trigger_dag_run_partition_key"

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
@@ -60,6 +60,7 @@ class TestDagRunTrigger:
         dag_run = session.scalars(select(DagRun).where(DagRun.run_id == run_id)).one()
         assert dag_run.conf == {"key1": "value1"}
         assert dag_run.logical_date == logical_date
+        assert dag_run.run_type == DagRunType.OPERATOR
 
     def test_trigger_dag_run_with_partition_key(self, client, session, dag_maker):
         dag_id = "test_trigger_dag_run_partition_key"
@@ -130,7 +131,7 @@ class TestDagRunTrigger:
         }
 
     def test_trigger_dag_run_denied_run_type(self, client, session, dag_maker):
-        """Test that a Dag with allowed_run_types excluding 'manual' cannot be triggered."""
+        """Test that a Dag with denied operator run type cannot be triggered."""
         dag_id = "test_trigger_dag_run_denied"
         run_id = "test_run_id"
         logical_date = timezone.datetime(2025, 2, 20)
@@ -151,7 +152,34 @@ class TestDagRunTrigger:
         assert response.status_code == 400
         assert response.json() == {
             "detail": {
-                "message": f"Dag with dag_id '{dag_id}' does not allow manual runs",
+                "message": f"Dag with dag_id '{dag_id}' does not allow operator-triggered runs",
+                "reason": "denied_run_type",
+            }
+        }
+
+    def test_trigger_dag_run_manual_denied_for_operator(self, client, session, dag_maker):
+        """Test that MANUAL-only allowed_run_types rejects operator-triggered runs."""
+        dag_id = "test_trigger_dag_run_manual_allowed"
+        run_id = "test_run_id"
+        logical_date = timezone.datetime(2025, 2, 20)
+
+        with dag_maker(dag_id=dag_id, session=session, serialized=True):
+            EmptyOperator(task_id="test_task")
+
+        session.execute(
+            update(DagModel).where(DagModel.dag_id == dag_id).values(allowed_run_types=["manual"])
+        )
+        session.commit()
+
+        response = client.post(
+            f"/execution/dag-runs/{dag_id}/{run_id}",
+            json={"logical_date": logical_date.isoformat()},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": {
+                "message": f"Dag with dag_id '{dag_id}' does not allow operator-triggered runs",
                 "reason": "denied_run_type",
             }
         }

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -394,7 +394,7 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
-    OPERATOR = "operator"
+    OPERATOR_TRIGGERED = "operator_triggered"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -394,6 +394,7 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
+    OPERATOR = "operator"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -128,7 +128,7 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
-    OPERATOR = "operator"
+    OPERATOR_TRIGGERED = "operator_triggered"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -128,6 +128,7 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
+    OPERATOR = "operator"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 


### PR DESCRIPTION
## Why

- The Execution API previously used the `MANUAL `run type for operator-triggered DAG runs, which caused ambiguity and made it difficult to distinguish between user-initiated and operator-initiated runs.

## What

- Added `OPERATOR `to the `DagRunType `enum and updated all relevant code paths to use `OPERATOR `for operator-triggered DAG runs.
- Updated the Execution API route to strictly enforce `OPERATOR `as the only allowed run type.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
