### PR TITLE
Fix cursor not showing pointer on task nodes in graph view (#63714)   

### DIFF
--- a/airflow-core/newsfragments/63714.bugfix.rst
+++ b/airflow-core/newsfragments/63714.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cursor not changing to pointer when hovering over task node box in Graph view.

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -83,7 +83,7 @@ export const TaskNode = ({
 
   return (
     <NodeWrapper>
-      <Flex alignItems="center" cursor="default" flexDirection="column">
+      <Flex alignItems="center" cursor="pointer" flexDirection="column">
         <TaskInstanceTooltip
           openDelay={500}
           positioning={{


### PR DESCRIPTION
Fixes a regression where the cursor no longer changed to a pointer when hovering over task nodes in the Graph view.
Changes
 - TaskNode.tsx: Changed cursor="default" back to cursor="pointer" on the task node Flex wrapper       
Why ?
The pointer cursor is an important UX signal that the task nodes are clickable. This had been set to default in a previous change.

