### PR TITLE
Remove useless mock_db

### DIFF
--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -534,6 +534,15 @@ class TestFlowerCommand:
 
 
 class TestRemoteCeleryControlCommands:
+    @pytest.fixture(autouse=True)
+    def _disable_cli_action_logging(self):
+        # Keep these tests as true unit tests: action_cli's default callbacks write to DB.
+        with (
+            patch("airflow.utils.cli.cli_action_loggers.on_pre_execution"),
+            patch("airflow.utils.cli.cli_action_loggers.on_post_execution"),
+        ):
+            yield
+
     @classmethod
     def setup_class(cls):
         with conf_vars({("core", "executor"): "CeleryExecutor"}):
@@ -541,7 +550,6 @@ class TestRemoteCeleryControlCommands:
             importlib.reload(cli_parser)
             cls.parser = cli_parser.get_parser()
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
     def test_list_celery_workers(self, mock_inspect):
         args = self.parser.parse_args(["celery", "list-workers", "--output", "json"])
@@ -559,7 +567,6 @@ class TestRemoteCeleryControlCommands:
             assert key in celery_workers[0]
         assert any("celery@host_1" in h["worker_name"] for h in celery_workers)
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.shutdown")
     def test_shutdown_worker(self, mock_shutdown):
         args = self.parser.parse_args(["celery", "shutdown-worker", "-H", "celery@host_1"])
@@ -569,7 +576,6 @@ class TestRemoteCeleryControlCommands:
             celery_command.shutdown_worker(args)
             mock_shutdown.assert_called_once_with(destination=["celery@host_1"])
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.broadcast")
     def test_shutdown_all_workers(self, mock_broadcast):
         args = self.parser.parse_args(["celery", "shutdown-all-workers", "-y"])
@@ -579,7 +585,6 @@ class TestRemoteCeleryControlCommands:
             celery_command.shutdown_all_workers(args)
             mock_broadcast.assert_called_once_with("shutdown")
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.add_consumer")
     def test_add_queue(self, mock_add_consumer):
         args = self.parser.parse_args(["celery", "add-queue", "-q", "test1", "-H", "celery@host_1"])
@@ -589,7 +594,6 @@ class TestRemoteCeleryControlCommands:
             celery_command.add_queue(args)
             mock_add_consumer.assert_called_once_with("test1", destination=["celery@host_1"])
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.cancel_consumer")
     def test_remove_queue(self, mock_cancel_consumer):
         args = self.parser.parse_args(["celery", "remove-queue", "-q", "test1", "-H", "celery@host_1"])
@@ -599,7 +603,6 @@ class TestRemoteCeleryControlCommands:
             celery_command.remove_queue(args)
             mock_cancel_consumer.assert_called_once_with("test1", destination=["celery@host_1"])
 
-    @pytest.mark.db_test
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.cancel_consumer")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
     def test_remove_all_queues(self, mock_inspect, mock_cancel_consumer):


### PR DESCRIPTION
## Why
The tests in `TestRemoteCeleryControlCommands `are decorated with `@pytest.mark.db_test`. During parallel CI execution, this unnecessary database initialization leads to lock contention.

closes: #54266

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
