### PR TITLE
Relax note about rebase/merge

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/pr_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/pr_commands.py
@@ -2096,7 +2096,7 @@ def _build_comment(
     what_to_do = _load_what_to_do_next()
 
     rebase_note = ""
-    if commits_behind > 0:
+    if commits_behind > 50:
         rebase_note = (
             f"\n\n> **Note:** Your branch is **{commits_behind} "
             f"commit{'s' if commits_behind != 1 else ''} behind `{base_ref}`**. "


### PR DESCRIPTION
We have a very high pace in development at the moment, with the automated PR triage we made a note so far if the PR is not on laest main... but with ~20 PRs/day I think it is hard to keep-up and we do not want to enforce every contributor to always rebase for a few commits of diff.

I think it is reasonable to relax the note to rebase a bit to ~2 days, therefore proposing a threshold of 50 commits behind main before not is presented. Any other number is also fine but we should keep in mind there are "normal" people contributing who are not rebasing 24/7.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
