### PR TITLE
Add uv-sync prek hook to keep lockfile updated after dependency changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -259,6 +259,13 @@ repos:
           ^scripts/ci/prek/update_installers_and_prek\.py$
         pass_filenames: false
         require_serial: true
+      - id: uv-sync
+        name: Run uv sync
+        entry: uv sync
+        language: system
+        files: (^|/)pyproject\.toml$
+        pass_filenames: false
+        require_serial: true
       - id: update-uv-lock
         name: Update uv.lock (manual)
         entry: ./scripts/ci/prek/update_uv_lock.py


### PR DESCRIPTION
Add a prek hook that automatically runs `uv sync` whenever any `pyproject.toml` file is modified. This ensures the local `uv.lock` and virtual environment stay in sync with declared dependencies during development.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)