### PR TITLE
Fix `--github-token` logic bug in ci/prod image load

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -597,7 +597,7 @@ def load(
         )
         sys.exit(1)
 
-    if from_run or from_pr and not github_token:
+    if (from_run or from_pr) and not github_token:
         console_print(
             "[error]The parameter `--github-token` must be provided if `--from-run` or `--from-pr` is "
             "provided. Exiting.[/]"

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -759,7 +759,7 @@ def load(
     perform_environment_checks()
     escaped_platform = platform.replace("/", "_")
 
-    if from_run or from_pr and not github_token:
+    if (from_run or from_pr) and not github_token:
         console_print(
             "[error]The parameter `--github-token` must be provided if `--from-run` or `--from-pr` is "
             "provided. Exiting.[/]"


### PR DESCRIPTION
related: #53641

Hi folks, I found a bug while working on the CI issue. I believe a bracket is missing here, otherwise, the `and` statement will execute first.

https://github.com/apache/airflow/blob/e3cd88f80120d186c57bb03edbdba46d0d005062/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py#L600-L605
<br>
e.g. if I set `--from-run` and provided `--github-token`, it will fall into this block and exit.

<br><br>

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
