### PR TITLE
Fix registry providers sort not applied on initial page load

### DIFF
--- a/registry/src/js/provider-filters.js
+++ b/registry/src/js/provider-filters.js
@@ -132,29 +132,32 @@
     });
   }
 
-  if (sortSelect) {
-    sortSelect.addEventListener('change', () => {
-      const sortBy = sortSelect.value;
-      const items = Array.from(providerItems);
+  function sortProviders() {
+    const sortBy = sortSelect.value;
+    const items = Array.from(providerItems);
 
-      items.sort((a, b) => {
-        switch (sortBy) {
-          case 'downloads':
-            return Number(b.dataset.downloads || 0) - Number(a.dataset.downloads || 0);
-          case 'name':
-            return (a.dataset.name || '').localeCompare(b.dataset.name || '');
-          case 'updated':
-            return (b.dataset.updated || '').localeCompare(a.dataset.updated || '');
-          default:
-            return 0;
-        }
-      });
-
-      items.forEach(item => providerGrid.appendChild(item));
+    items.sort((a, b) => {
+      switch (sortBy) {
+        case 'downloads':
+          return Number(b.dataset.downloads || 0) - Number(a.dataset.downloads || 0);
+        case 'name':
+          return (a.dataset.name || '').localeCompare(b.dataset.name || '');
+        case 'updated':
+          return (b.dataset.updated || '').localeCompare(a.dataset.updated || '');
+        default:
+          return 0;
+      }
     });
+
+    items.forEach(item => providerGrid.appendChild(item));
+  }
+
+  if (sortSelect) {
+    sortSelect.addEventListener('change', sortProviders);
   }
 
   readURLParams();
+  sortProviders();
   if (currentCategory !== 'all' || currentLifecycle !== 'all' || currentSearch) {
     filterProviders();
   }


### PR DESCRIPTION
The providers page at `/registry/providers/` shows "Most Downloads" as the default sort option, but on initial load the providers are displayed in alphabetical order (the Nunjucks template render order). The sort only takes effect after manually changing the dropdown.

- Extract the sort logic into a `sortProviders()` function
- Call it on page initialization after `readURLParams()` so the DOM order matches the selected sort option on first render

