### PR TITLE
Fix registry workflow failures from workspace dependency resolution

### DIFF
--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -159,7 +159,7 @@ jobs:
           for VERSION in ${VERSIONS}; do
             VERSION_ARGS="${VERSION_ARGS} --version ${VERSION}"
           done
-          uv run python dev/registry/extract_versions.py \
+          uv run --project dev/registry python dev/registry/extract_versions.py \
             --provider "${PROVIDER}" ${VERSION_ARGS} || true
 
       - name: "Run breeze registry backfill"

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -179,7 +179,7 @@ jobs:
       - name: "Merge with existing registry data"
         if: inputs.provider != '' && steps.download-existing.outputs.found == 'true'
         run: |
-          uv run dev/registry/merge_registry_data.py \
+          uv run --project dev/registry dev/registry/merge_registry_data.py \
             --existing-providers "${EXISTING_REGISTRY_DIR}/${REGISTRY_PROVIDERS_JSON}" \
             --existing-modules "${EXISTING_REGISTRY_DIR}/${REGISTRY_MODULES_JSON}" \
             --new-providers "${REGISTRY_DATA_DIR}/${REGISTRY_PROVIDERS_JSON}" \


### PR DESCRIPTION
The "Build & Publish Registry" and "Registry Backfill" workflows fail when `uv run` resolves the full workspace environment on the GitHub Actions runner. This pulls in all providers, including samba → smbprotocol → pyspnego[kerberos] → gssapi, which requires `libkrb5-dev` (not installed on the runner).

The affected scripts (`merge_registry_data.py`, `extract_versions.py`) only need `pydantic` and `pyyaml` — deps already declared in `dev/registry/pyproject.toml`.

## Changes

Add `--project dev/registry` to `uv run` commands in both workflows so uv resolves deps from `dev/registry/pyproject.toml` instead of the root workspace.

- `registry-build.yml`: `merge_registry_data.py` step
- `registry-backfill.yml`: `extract_versions.py` step

`registry-tests.yml` already does `cd dev/registry && uv run ...` so it's unaffected.

## Failure log

https://github.com/apache/airflow/actions/runs/23169362254/job/67317388641

```
Failed to build gssapi==1.11.1
/bin/sh: 1: krb5-config: not found

help: gssapi (v1.11.1) was included because apache-airflow[all] (v3.2.0)
      depends on apache-airflow-providers-samba (v4.12.3) which depends
      on smbprotocol (v1.16.0) which depends on pyspnego[kerberos]
      (v0.12.1) which depends on gssapi
```