### PR TITLE
Fix registry build failure when logos directory is empty

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -195,13 +195,17 @@ jobs:
           cp \
             "${REGISTRY_DATA_DIR}/${REGISTRY_MODULES_JSON}" \
             "${REGISTRY_SITE_DATA_DIR}/${REGISTRY_MODULES_JSON}"
-          if [ -d "${REGISTRY_DATA_DIR}/output/versions" ]; then
-            cp -r "${REGISTRY_DATA_DIR}/output/versions/"* "${REGISTRY_SITE_VERSIONS_DIR}/"
+          VERSIONS_SRC="${REGISTRY_DATA_DIR}/output/versions"
+          if [ -d "${VERSIONS_SRC}" ] && ls "${VERSIONS_SRC}/"* &>/dev/null; then
+            cp -r "${VERSIONS_SRC}/"* "${REGISTRY_SITE_VERSIONS_DIR}/"
           fi
-          # Copy provider logos extracted from providers/*/docs/integration-logos/
-          if [ -d "${REGISTRY_DATA_DIR}/logos" ]; then
+          # Copy provider logos extracted by extract_metadata.py.
+          # The directory may exist but be empty (incremental build for
+          # a provider without logos), so check for files before copying.
+          LOGOS_SRC="${REGISTRY_DATA_DIR}/logos"
+          if [ -d "${LOGOS_SRC}" ] && ls "${LOGOS_SRC}/"* &>/dev/null; then
             mkdir -p "${REGISTRY_SITE_LOGOS_DIR}"
-            cp -r "${REGISTRY_DATA_DIR}/logos/"* "${REGISTRY_SITE_LOGOS_DIR}/"
+            cp -r "${LOGOS_SRC}/"* "${REGISTRY_SITE_LOGOS_DIR}/"
           fi
 
       - name: "Setup pnpm"

--- a/dev/registry/extract_metadata.py
+++ b/dev/registry/extract_metadata.py
@@ -484,12 +484,14 @@ def main():
         # Write logos to dev/registry/logos/ — this directory is mounted in
         # breeze (unlike registry/public/) so copies survive the container.
         # Also copy to registry/public/logos/ for local dev convenience.
+        # Directories are created lazily (only when a logo is found) to avoid
+        # empty dirs that trip up glob-based cp in the CI workflow.
         logos_dest_dir = SCRIPT_DIR / "logos"
-        logos_dest_dir.mkdir(parents=True, exist_ok=True)
         registry_logos_dir = SCRIPT_DIR.parent.parent / "registry" / "public" / "logos"
-        registry_logos_dir.mkdir(parents=True, exist_ok=True)
 
         if integration_logos_dir.exists():
+            logos_dest_dir.mkdir(parents=True, exist_ok=True)
+
             # First, check for priority logos for known providers
             if provider_id in logo_priority_map:
                 for priority_logo in logo_priority_map[provider_id]:
@@ -538,6 +540,7 @@ def main():
             logo_filename = logo.split("/")[-1]
             src = logos_dest_dir / logo_filename
             if src.exists():
+                registry_logos_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, registry_logos_dir / logo_filename)
 
         # Extract connection types from provider.yaml


### PR DESCRIPTION
Fixes the CI failure: `cp: cannot stat 'dev/registry/logos/*': No such file or directory`.

Failure: https://github.com/apache/airflow/actions/runs/23171286589/job/67323487080

`extract_metadata.py` unconditionally creates `dev/registry/logos/` even when no logos are found (e.g. incremental build for a provider without logos). The workflow's `if [ -d ... ]` check passes for the empty directory, then `cp -r logos/*` fails because the shell glob doesn't expand when the directory is empty.

**Workflow**: Changed both glob-based copy guards to also verify the directory is non-empty before attempting `cp`.

**extract_metadata.py**: Made directory creation lazy — `logos_dest_dir` is only created when `integration_logos_dir` exists, and `registry_logos_dir` is only created when a logo was actually found and needs copying.