### PR TITLE
Add missing words to spelling_wordlist.txt 

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -27,7 +27,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
-
+from sqlalchemy.orm import load_only
 from airflow.api.common.mark_tasks import (
     set_dag_run_state_to_failed,
     set_dag_run_state_to_queued,
@@ -387,7 +387,19 @@ def get_dag_runs(
 
     This endpoint allows specifying `~` as the dag_id to retrieve Dag Runs for all DAGs.
     """
-    query = select(DagRun).options(*eager_load_dag_run_for_validation())
+    query = select(DagRun).options(
+    load_only(
+        DagRun.id,
+        DagRun.dag_id,
+        DagRun.run_id,
+        DagRun.state,
+        DagRun.logical_date,
+        DagRun.start_date,
+        DagRun.end_date,
+        DagRun.updated_at,
+    	),
+    *eager_load_dag_run_for_validation(),
+	)
 
     if dag_id != "~":
         get_latest_version_of_dag(dag_bag, dag_id, session)  # Check if the DAG exists.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -412,6 +412,19 @@ def get_dag_runs(
     dag_run_select, total_entries = paginated_select(
         statement=query,
         filters=[
+query = select(DagRun).options(
+    load_only(
+        DagRun.id,
+        DagRun.dag_id,
+        DagRun.run_id,
+        DagRun.state,
+        DagRun.logical_date,
+        DagRun.start_date,
+        DagRun.end_date,
+        DagRun.updated_at,
+    ),
+    *eager_load_dag_run_for_validation(),
+)
             run_after,
             logical_date,
             start_date_range,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1165,6 +1165,7 @@ pinecone
 Pinot
 pinot
 PipelineRun
+pipelines
 pkill
 plaintext
 pluggable
@@ -1796,6 +1797,7 @@ whl
 wildcarded
 winrm
 WIT
+workflow
 workgroup
 workspaces
 writeable


### PR DESCRIPTION
This PR adds a few commonly used technical terms to `spelling_wordlist.txt` to avoid false positives in spell checking.
