### PR TITLE
Fix edge executor UI navigation when behind reverse proxy with subpath

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/plugins/www/src/layouts/NavTabs.tsx
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/www/src/layouts/NavTabs.tsx
@@ -19,6 +19,7 @@
 import { Center, Flex } from "@chakra-ui/react";
 import axios from "axios";
 import { useQuery } from "@tanstack/react-query";
+import { OpenAPI } from "openapi/requests/core/OpenAPI";
 import { useRef, type ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 
@@ -34,7 +35,7 @@ export const NavTabs = ({ tabs }: Props) => {
 
   const { data } = useQuery<{version: string, git_version: string | null}>({
     queryFn: async () => {
-      const res = await axios.get("/api/v2/version");
+      const res = await axios.get(`${OpenAPI.BASE}/api/v2/version`);
       return res.data;
     },
     queryKey: ["appVersion"],

--- a/providers/edge3/src/airflow/providers/edge3/plugins/www/src/pages/JobsPage.tsx
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/www/src/pages/JobsPage.tsx
@@ -240,7 +240,7 @@ export const JobsPage = () => {
                   {job.queued_dttm ? <TimeAgo date={job.queued_dttm} live={false} /> : undefined}
                 </Table.Cell>
                 <Table.Cell>
-                  <Link to={`../worker#${job.edge_worker}`}>{job.edge_worker}</Link>
+                  <Link relative="path" to={`../worker#${job.edge_worker}`}>{job.edge_worker}</Link>
                 </Table.Cell>
                 <Table.Cell>
                   {job.last_update ? <TimeAgo date={job.last_update} live={false} /> : undefined}

--- a/providers/edge3/src/airflow/providers/edge3/plugins/www/src/pages/WorkerPage.tsx
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/www/src/pages/WorkerPage.tsx
@@ -163,7 +163,7 @@ export const WorkerPage = () => {
                       <List.Root>
                         {worker.queues.map((queue) => (
                           <List.Item key={queue}>
-                            <Link to={`../jobs?queue=${encodeURIComponent(queue)}`}>{queue}</Link>
+                            <Link relative="path" to={`../jobs?queue=${encodeURIComponent(queue)}`}>{queue}</Link>
                           </List.Item>
                         ))}
                       </List.Root>
@@ -179,7 +179,7 @@ export const WorkerPage = () => {
                   </Table.Cell>
                   <Table.Cell>
                     {worker.jobs_active !== undefined && worker.jobs_active > 0 ? (
-                      <Link to={`../jobs?worker=${encodeURIComponent(worker.worker_name)}`}>
+                      <Link relative="path" to={`../jobs?worker=${encodeURIComponent(worker.worker_name)}`}>
                         {worker.jobs_active}
                       </Link>
                     ) : (


### PR DESCRIPTION
  The /api/v2/version call in NavTabs used a hardcoded absolute path,
  which 404s when Airflow is served under a subpath (e.g. /airflow/).
  This prevented the nav tabs from rendering, forcing users to navigate
  via inline table links that lacked relative=path, causing URLs to
  append instead of replace (e.g. /worker/jobs/worker/...).