### PR TITLE
Cleanup: Enforce keyword-only session in cli_action_loggers

### DIFF
--- a/airflow-core/newsfragments/63780.improvement.rst
+++ b/airflow-core/newsfragments/63780.improvement.rst
@@ -1,0 +1,1 @@
+Enforce keyword-only session parameter in ``default_action_log`` and fix legacy logical date usage in tests.

--- a/airflow-core/src/airflow/utils/cli_action_loggers.py
+++ b/airflow-core/src/airflow/utils/cli_action_loggers.py
@@ -112,6 +112,7 @@ def default_action_log(
     logical_date,
     host_name,
     full_command,
+    *,
     session: Session = NEW_SESSION,
     **_,
 ):

--- a/airflow-core/tests/unit/utils/test_cli_util.py
+++ b/airflow-core/tests/unit/utils/test_cli_util.py
@@ -223,7 +223,7 @@ class TestCliUtil:
         expected_command = expected_masked_command.split()
 
         exec_date = timezone.utcnow()
-        namespace = Namespace(dag_id="foo", task_id="bar", subcommand="test", execution_date=exec_date)
+        namespace = Namespace(dag_id="foo", task_id="bar", subcommand="test", logical_date=exec_date)
         with (
             mock.patch.object(sys, "argv", args),
             mock.patch("airflow.utils.session.create_session") as mock_create_session,
@@ -243,6 +243,13 @@ class TestCliUtil:
         # Replace single quotes to double quotes to avoid json decode error
         command = ast.literal_eval(command)
         assert command == expected_command
+
+    def test_default_action_log_positional_session_fails(self):
+        with pytest.raises(TypeError) as exc:
+            cli_action_loggers.default_action_log(
+                "sub", "user", "task", "dag", timezone.utcnow(), "host", "cmd", None
+            )
+        assert "takes 7 positional arguments but 8 were given" in str(exc.value)
 
 
 @contextmanager


### PR DESCRIPTION
Enforce keyword-only session parameter in default_action_log and fix legacy logical date usage in tests.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes


---
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

