### PR TITLE
Cleanup: Enforce keyword-only session in RenderedTaskInstanceFields

### DIFF
--- a/airflow-core/newsfragments/63782.improvement.rst
+++ b/airflow-core/newsfragments/63782.improvement.rst
@@ -1,0 +1,1 @@
+Enforce keyword-only session parameters in ``RenderedTaskInstanceFields`` methods.

--- a/airflow-core/src/airflow/models/renderedtifields.py
+++ b/airflow-core/src/airflow/models/renderedtifields.py
@@ -194,6 +194,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
     def get_templated_fields(
         cls,
         ti: TaskInstance | TaskInstanceKey,
+        *,
         session: Session = NEW_SESSION,
     ) -> dict | None:
         """
@@ -219,7 +220,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
 
     @classmethod
     @provide_session
-    def get_k8s_pod_yaml(cls, ti: TaskInstance, session: Session = NEW_SESSION) -> dict | None:
+    def get_k8s_pod_yaml(cls, ti: TaskInstance, *, session: Session = NEW_SESSION) -> dict | None:
         """
         Get rendered Kubernetes Pod Yaml for a TaskInstance from the RenderedTaskInstanceFields table.
 
@@ -239,7 +240,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
 
     @provide_session
     @retry_db_transaction
-    def write(self, session: Session):
+    def write(self, *, session: Session = NEW_SESSION):
         """
         Write instance to database.
 
@@ -253,6 +254,7 @@ class RenderedTaskInstanceFields(TaskInstanceDependencies):
         cls,
         task_id: str,
         dag_id: str,
+        *,
         num_to_keep: int = conf.getint("core", "num_dag_runs_to_retain_rendered_fields", fallback=0),
         session: Session = NEW_SESSION,
     ) -> None:

--- a/airflow-core/tests/unit/models/test_renderedtifields.py
+++ b/airflow-core/tests/unit/models/test_renderedtifields.py
@@ -435,3 +435,28 @@ class TestRenderedTaskInstanceFields:
         ti.state = None
         # rerun the old run. this shouldn't fail
         dag_maker.run_ti(task.task_id, dr)
+
+    def test_get_templated_fields_positional_fails(self):
+        ti = mock.MagicMock()
+        with pytest.raises(TypeError) as exc:
+            RTIF.get_templated_fields(ti, None)
+        assert "takes 2 positional arguments but 3" in str(exc.value)
+
+    def test_get_k8s_pod_yaml_positional_fails(self):
+        ti = mock.MagicMock()
+        with pytest.raises(TypeError) as exc:
+            RTIF.get_k8s_pod_yaml(ti, None)
+        assert "takes 2 positional arguments but 3" in str(exc.value)
+
+    def test_write_positional_fails(self):
+        ti = mock.MagicMock()
+        ti.task.template_fields = []
+        rtif = RTIF(ti=ti, render_templates=False)
+        with pytest.raises(TypeError) as exc:
+            rtif.write(None)
+        assert "takes 1 positional argument but 2" in str(exc.value)
+
+    def test_delete_old_records_positional_fails(self):
+        with pytest.raises(TypeError) as exc:
+            RTIF.delete_old_records("task", "dag", 5, None)
+        assert "takes 3 positional arguments but 5" in str(exc.value)


### PR DESCRIPTION
Enforce keyword-only session parameters in RenderedTaskInstanceFields methods to align with Airflow 3 coding standards.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

