### PR TITLE
Fix circular import between connection and configuration modules

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -32,7 +32,6 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, reconstructor, 
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_masker import mask_secret
-from airflow.configuration import conf, ensure_secrets_loaded
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
@@ -527,6 +526,8 @@ class Connection(Base, LoggingMixin):
                 if e.error.error == ErrorType.CONNECTION_NOT_FOUND:
                     raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined") from None
                 raise
+
+        from airflow.configuration import conf, ensure_secrets_loaded
 
         if team_name and not conf.getboolean("core", "multi_team"):
             raise ValueError(


### PR DESCRIPTION
## Summary

- Defer `from airflow.configuration import conf, ensure_secrets_loaded` from module-level to inside `get_connection_from_secrets()`, breaking a circular import cycle where `airflow.models.Connection` → `airflow.configuration` → secrets backend init → `airflow.models.Connection`.

## Details

`connection.py` imports `airflow.configuration` at module level. During startup, `airflow.configuration` initializes secrets backends, which in turn import `airflow.models.Connection`. This creates a circular import that can cause `ImportError: Module "airflow.models.connection" does not define a "Connection"` when the import is re-entered before the `Connection` class is fully defined. The fix moves the import to the only method that uses it (`get_connection_from_secrets`), keeping runtime behavior identical while eliminating the import-time recursion.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
related: #63520

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
