### PR TITLE
Fix @task decorator to use identity check instead of truthiness

### DIFF
--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -922,7 +922,11 @@ def dag_maker(request) -> Generator[DagMaker, None, None]:
                 class DAGProxy(lazy_object_proxy.Proxy):
                     """Wrapper to make test patterns work with serialized dag."""
 
-                    task = factory.dag.task  # Expose the @dag.task decorator.
+                    @property
+                    def task(self):
+                        # Forward explicitly so Proxy binding does not leak the proxy
+                        # instance into the decorator callable on Python 3.14.
+                        return factory.dag.task
 
                     # When adding a task to the dag, automatically re-serialize.
                     def add_task(self, task):

--- a/providers/standard/tests/unit/standard/decorators/test_python.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python.py
@@ -104,6 +104,24 @@ class TestAirflowTaskDecorator(BasePythonTest):
         with pytest.raises(TypeError):
             task_decorator(not_callable)
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="FalseyCallable fix only applies to Airflow 3.2+")
+    def test_python_operator_python_callable_can_be_falsey(self):
+        """Tests that @task accepts callable objects without evaluating their truthiness."""
+
+        class FalseyCallable:
+            __annotations__ = {}
+            __name__ = "falsey_callable"
+
+            def __bool__(self):
+                return False
+
+            def __call__(self):
+                return None
+
+        decorated = task_decorator(FalseyCallable())
+
+        assert isinstance(decorated, _TaskDecorator)
+
     @pytest.mark.parametrize(
         "resolve",
         [
@@ -167,9 +185,6 @@ class TestAirflowTaskDecorator(BasePythonTest):
 
         assert t1().operator.multiple_outputs is False
 
-    @pytest.mark.xfail(
-        reason="TODO AIP72: All @task calls now go to __getattr__ in decorators/__init__.py and this test expects user code to throw the error. Needs to be handled better, likely by changing `fixup_decorator_warning_stack`"
-    )
     def test_infer_multiple_outputs_forward_annotation(self):
         if typing.TYPE_CHECKING:
 

--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -768,7 +768,9 @@ def task_decorator_factory(
     """
     if multiple_outputs is None:
         multiple_outputs = cast("bool", attr.NOTHING)
-    if python_callable:
+    if python_callable is not None:
+        if not callable(python_callable):
+            raise TypeError("No args allowed while using @task, use kwargs instead")
         decorator = _TaskDecorator(
             function=python_callable,
             multiple_outputs=multiple_outputs,
@@ -776,8 +778,6 @@ def task_decorator_factory(
             kwargs=kwargs,
         )
         return cast("TaskDecorator", decorator)
-    if python_callable is not None:
-        raise TypeError("No args allowed while using @task, use kwargs instead")
 
     def decorator_factory(python_callable):
         return _TaskDecorator(

--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -770,7 +770,7 @@ def task_decorator_factory(
         multiple_outputs = cast("bool", attr.NOTHING)
     if python_callable is not None:
         if not callable(python_callable):
-            raise TypeError("No args allowed while using @task, use kwargs instead")
+            raise TypeError("No positional arguments allowed while using @task, use named arguments instead")
         decorator = _TaskDecorator(
             function=python_callable,
             multiple_outputs=multiple_outputs,


### PR DESCRIPTION
## Summary

- Change `if python_callable:` to `if python_callable is not None:` in `task_decorator_factory()` to avoid triggering `__bool__` on callable objects.
- Convert the `task` attribute on the serialized DAG test proxy from a class-level binding to a `@property`, preventing proxy leakage into the decorator callable.
- Add test for callable objects with falsey `__bool__`.
- Remove `xfail` marker from `test_infer_multiple_outputs_forward_annotation` (now passes).

## Details

`task_decorator_factory()` used `if python_callable:` which invokes `__bool__` on the argument. This is incorrect — a callable that happens to be falsey (e.g., `__bool__` returns `False`) would incorrectly take the "no callable provided" path. The fix uses `is not None` for a proper identity check and consolidates the error handling.

The test proxy in `dag_maker` bound `task = factory.dag.task` as a class attribute, which caused proxy binding behavior to leak into the decorator when accessed via `@dag.task`. Converting to a `@property` ensures the real `task` decorator is returned without proxy interference.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: #63520 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
