### PR TITLE
Fix mypy type narrowing in sql_validation

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
@@ -81,7 +81,7 @@ def validate_sql(
         raise SQLSafetyError(f"SQL parse error: {e}") from e
 
     # sqlglot.parse can return [None] for empty input
-    parsed: list[exp.Expression] = [s for s in statements if s is not None]  # type: ignore[misc]
+    parsed: list[exp.Expression] = [s for s in statements if isinstance(s, exp.Expression)]
     if not parsed:
         raise SQLSafetyError("Empty SQL input.")
 


### PR DESCRIPTION
## Summary

- Change `if s is not None` to `if isinstance(s, exp.Expression)` in the sqlglot parse result filter to give mypy a proper type narrowing signal.

## Details

`sqlglot.parse()` returns `list[Expr | None]` where `Expr` is a base class of `Expression`. Filtering with `is not None` produces `list[Expr]`, which is not assignable to `list[Expression]` because lists are invariant in Python's type system. Using `isinstance(s, exp.Expression)` allows mypy to correctly narrow the type to `Expression`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:


* closes: #ISSUE
* related: #ISSUE
-->

related: #63520 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
