### PR TITLE
Fix race condition in process_utils force-kill test

### DIFF
--- a/airflow-core/tests/unit/utils/test_process_utils.py
+++ b/airflow-core/tests/unit/utils/test_process_utils.py
@@ -137,9 +137,10 @@ def my_sleep_subprocess():
     sleep(100)
 
 
-def my_sleep_subprocess_with_signals():
+def my_sleep_subprocess_with_signals(ready_event):
     signal.signal(signal.SIGINT, lambda signum, frame: None)
     signal.signal(signal.SIGTERM, lambda signum, frame: None)
+    ready_event.set()
     sleep(100)
 
 
@@ -161,9 +162,14 @@ class TestKillChildProcessesByPids:
         assert before_num_process == num_process
 
     def test_should_force_kill_process(self, caplog):
-        process = multiprocessing.Process(target=my_sleep_subprocess_with_signals, args=())
+        ready_event = multiprocessing.Event()
+        process = multiprocessing.Process(target=my_sleep_subprocess_with_signals, args=(ready_event,))
         process.start()
-        sleep(0)
+        # Wait until the child has installed its signal handlers, so that SIGTERM will be
+        # ignored and we actually exercise the SIGKILL path.  Without this, on non-fork
+        # start methods (forkserver/spawn) the child may still have the default SIGTERM
+        # handler when we send the signal.
+        ready_event.wait(timeout=10)
 
         all_processes = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().splitlines()
         assert str(process.pid) in (x.strip() for x in all_processes)


### PR DESCRIPTION
## Summary

- Replace `sleep(0)` with `multiprocessing.Event` synchronization in `test_should_force_kill_process` to ensure the child process has installed its signal handlers before SIGTERM is sent.

## Details

The test spawns a child process that ignores SIGTERM (to exercise the SIGKILL fallback path). With the `forkserver` start method (default on Linux in Python 3.14), the child starts from a clean slate and needs time to import modules and install signal handlers. The old `sleep(0)` provided no real synchronization — SIGTERM could arrive before the handlers were in place, killing the process before the test reached the SIGKILL code path.

The fix uses a `multiprocessing.Event`: the child calls `ready_event.set()` only after its signal handlers are installed, and the parent waits on this event before proceeding.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: #63520 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
