### PR TITLE
Fix flaky DagRunTab E2E test for Dag runs state filtering

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagRunsTabPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagRunsTabPage.ts
@@ -59,7 +59,14 @@ export class DagRunsTabPage extends BasePage {
     const currentUrl = new URL(this.page.url());
 
     currentUrl.searchParams.set("state", state.toLowerCase());
+
+    const responsePromise = this.page.waitForResponse(
+      (response) => response.url().includes("dagRuns") && response.request().method() === "GET",
+      { timeout: 15_000 },
+    );
+
     await this.navigateTo(currentUrl.pathname + currentUrl.search);
+    await responsePromise;
     await expect(this.page).toHaveURL(/.*state=.*/, { timeout: 15_000 });
     await this.waitForRunsTableToLoad();
   }
@@ -118,7 +125,14 @@ export class DagRunsTabPage extends BasePage {
     const currentUrl = new URL(this.page.url());
 
     currentUrl.searchParams.set("run_id_pattern", pattern);
+
+    const responsePromise = this.page.waitForResponse(
+      (response) => response.url().includes("dagRuns") && response.request().method() === "GET",
+      { timeout: 15_000 },
+    );
+
     await this.navigateTo(currentUrl.pathname + currentUrl.search);
+    await responsePromise;
     await expect(this.page).toHaveURL(/.*run_id_pattern=.*/, { timeout: 15_000 });
     await this.waitForRunsTableToLoad();
   }
@@ -160,16 +174,13 @@ export class DagRunsTabPage extends BasePage {
 
     const rows = this.tableRows;
 
-    await expect(rows).not.toHaveCount(0);
+    await expect(rows).not.toHaveCount(0, { timeout: 10_000 });
 
-    const rowCount = await rows.count();
+    const nonMatchingRows = rows.filter({
+      hasNot: this.page.getByTestId("state-badge").getByText(new RegExp(expectedState, "i")),
+    });
 
-    for (let i = 0; i < Math.min(rowCount, 5); i++) {
-      const stateBadge = rows.nth(i).getByTestId("state-badge");
-
-      await expect(stateBadge).toBeVisible();
-      await expect(stateBadge).toContainText(expectedState, { ignoreCase: true });
-    }
+    await expect(nonMatchingRows).toHaveCount(0, { timeout: 10_000 });
   }
 
   public async verifyRunDetailsDisplay(): Promise<void> {
@@ -203,15 +214,13 @@ export class DagRunsTabPage extends BasePage {
 
     const rows = this.tableRows;
 
-    await expect(rows).not.toHaveCount(0);
+    await expect(rows).not.toHaveCount(0, { timeout: 10_000 });
 
-    const count = await rows.count();
+    const nonMatchingRows = rows.filter({
+      hasNot: this.page.getByRole("link").getByText(new RegExp(pattern, "i")),
+    });
 
-    for (let i = 0; i < Math.min(count, 5); i++) {
-      const runIdLink = rows.nth(i).getByRole("link").first();
-
-      await expect(runIdLink).toContainText(pattern, { ignoreCase: true });
-    }
+    await expect(nonMatchingRows).toHaveCount(0, { timeout: 10_000 });
   }
 
   public async waitForRunsTableToLoad(): Promise<void> {


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

The "filter runs by success state" E2E test was flaky due to a race condition between URL navigation and table data rendering.

After `filterByState()` navigated to the filtered URL, `verifyFilteredByState()` evaluated `rows.count()` before the API response arrived, resulting in stale (unfiltered) rows being read.
When accessing nth(1), the row had already been removed by the filter, causing an "element(s) not found" error.

## Changes
* Add `waitForResponse` in `filterByState()` and `searchByRunIdPattern()` to synchronize with the dagRuns API response before assertions.

* Replace imperative `count()` based loops with locator filtering and web-first assertions `(filter({ hasNot })` + `toHaveCount(0))`, eliminating snapshot-based race conditions.


related: #63036 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
