### PR TITLE
Hooks: use uv lock instead of sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -985,7 +985,7 @@ repos:
         # Unless there is a conflict and uv will determine that the lock needs to be updated to resolve it
       - id: update-uv-lock
         name: Update uv.lock
-        entry: uv sync
+        entry: uv lock
         language: system
         files: >
           (?x)


### PR DESCRIPTION
## Summary

- Change the `update-uv-lock` pre-commit hook from `uv sync` to `uv lock`

## Motivation

The `update-uv-lock` hook's purpose is to ensure `uv.lock` stays up-to-date when
dependency files change — it does not need to actually install (sync) packages into
the local environment.

`uv sync` resolves dependencies **and** builds/installs them, which is problematic
in several scenarios:

1. **OOM on resource-constrained machines.** Building packages that are unrelated to
   the contributor's current work can exhaust memory on older or smaller laptops,
   forcing them to skip the hook entirely (`--no-verify`).
2. **Python-version mismatch.** `uv sync` builds against the local Python version,
   which may differ from what CI uses. A local pass/fail therefore does not predict
   CI behavior, making the build step pure overhead.
3. **Unnecessary cost for a lockfile check.** This is analogous to why mypy was
   removed as a hook — the compilation/build price should not be paid at commit
   time when the hook's only goal is keeping the lockfile consistent.

`uv lock` performs the same dependency resolution and lockfile update but **skips
building and installing**, so it is both faster and less resource-intensive while
still catching lockfile drift.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:


* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
