### PR TITLE
fix: add temporary index on serialized_dag.dag_id for MySQL in migration 0101

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0101_3_2_0_ui_improvements_for_deadlines.py
+++ b/airflow-core/src/airflow/migrations/versions/0101_3_2_0_ui_improvements_for_deadlines.py
@@ -530,6 +530,12 @@ def _migrate_deadline_alerts() -> None:
             ")"
         )
 
+    # On MySQL, create a temporary index on dag_id to avoid sort buffer overflow
+    # when paginating over large serialized_dag tables (100K+ rows).
+    _tmp_idx = "_tmp_sd_dag_id_idx"
+    if dialect == "mysql":
+        conn.execute(sa.text(f"CREATE INDEX {_tmp_idx} ON serialized_dag (dag_id)"))
+
     total_dags = conn.execute(
         sa.text("SELECT COUNT(*) FROM serialized_dag WHERE data IS NOT NULL OR data_compressed IS NOT NULL")
     ).scalar()
@@ -541,7 +547,7 @@ def _migrate_deadline_alerts() -> None:
         batch_num += 1
 
         if dialect == "mysql":
-            # Avoid selecting large columns during ORDER BY to prevent sort buffer overflow
+            # Use subquery to avoid sorting large blob columns in the ORDER BY
             result = conn.execute(
                 sa.text(f"""
                     SELECT sd.id, sd.dag_id, sd.data, sd.data_compressed, sd.created_at
@@ -766,6 +772,9 @@ def _migrate_deadline_alerts() -> None:
 
         log.info("Batch complete", batch_num=batch_num, total_batches=total_batches)
 
+    if dialect == "mysql":
+        conn.execute(sa.text(f"DROP INDEX {_tmp_idx} ON serialized_dag"))
+
     log.info(
         "Migration complete",
         processed_records=len(processed_dags),
@@ -806,6 +815,12 @@ def migrate_deadline_alert_data_back_to_serialized_dag() -> None:
     conn = op.get_bind()
     dialect = conn.dialect.name
 
+    # On MySQL, create a temporary index on dag_id to avoid sort buffer overflow
+    # when paginating over large serialized_dag tables (100K+ rows).
+    _tmp_idx = "_tmp_sd_dag_id_idx"
+    if dialect == "mysql":
+        conn.execute(sa.text(f"CREATE INDEX {_tmp_idx} ON serialized_dag (dag_id)"))
+
     # Count all dags - we'll filter in the loop for those with deadline data
     total_dags = conn.execute(
         sa.text("SELECT COUNT(*) FROM serialized_dag WHERE data IS NOT NULL OR data_compressed IS NOT NULL")
@@ -819,7 +834,7 @@ def migrate_deadline_alert_data_back_to_serialized_dag() -> None:
         batch_num += 1
 
         if dialect == "mysql":
-            # Avoid selecting large columns during ORDER BY to prevent sort buffer overflow
+            # Use subquery to avoid sorting large blob columns in the ORDER BY
             result = conn.execute(
                 sa.text("""
                     SELECT sd.id, sd.dag_id, sd.data, sd.data_compressed
@@ -918,6 +933,9 @@ def migrate_deadline_alert_data_back_to_serialized_dag() -> None:
                 dags_with_errors[dag_id].append(f"Could not restore deadline: {e}")
 
         log.info("Batch complete", batch_num=batch_num, total_batches=total_batches)
+
+    if dialect == "mysql":
+        conn.execute(sa.text(f"DROP INDEX {_tmp_idx} ON serialized_dag"))
 
     log.info(
         "Downgrade complete",


### PR DESCRIPTION
Migration 0101 paginates over `serialized_dag` using `ORDER BY dag_id`, but `dag_id` has no index. On MySQL with large tables (100K+ rows), the inner subquery's filesort exceeds `sort_buffer_size` and fails with `OperationalError: (1038, 'Out of sort memory')`.

The existing subquery optimization (selecting only `id, dag_id` in the inner query) isn't enough — without an index, MySQL still has to sort the full result set in memory.

Fix: create a temporary index on `serialized_dag(dag_id)` before the pagination loop and drop it after, in both upgrade and downgrade paths. The index lets MySQL use an index scan instead of a filesort, eliminating the sort buffer dependency entirely.

Closes: #63786

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=cf939d5 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @YoannAbriel** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Unaddressed Copilot review** — a Copilot review thread has been open for ≥7 days with no reply; please respond to or resolve it. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->