### PR TITLE
Execution API: Normalize error response formats

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -21,7 +21,7 @@ import logging
 import traceback
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
@@ -120,6 +120,37 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"An error occurred while trying to deserialize Dag: {exc}",
         )
+
+
+class ExecutionHTTPException(HTTPException):
+    """
+    HTTPException subclass used by Execution API.
+
+    Enforces consistent error response format containing `reason` and `message` keys.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        detail: dict[str, Any] | str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize with enforced dict format."""
+        if isinstance(detail, str) or detail is None:
+            detail = {
+                "reason": "error",
+                "message": detail or "An error occurred",
+            }
+        elif isinstance(detail, dict):
+            detail = dict(detail)  # copy
+            if "reason" not in detail:
+                detail["reason"] = "error"
+            if "message" not in detail:
+                detail["message"] = "An error occurred"
+        else:
+            detail = {"reason": "error", "message": str(detail)}
+
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
 
 
 ERROR_HANDLERS: list[BaseErrorHandler] = [_UniqueConstraintErrorHandler(), DagErrorHandler()]

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -89,16 +89,13 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
                 statement = "hidden"
                 orig_error = "hidden"
 
-            # Return JSONResponse directly to avoid extra wrapping by global HTTPException handler
-            return JSONResponse(
+            raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                content={
-                    "detail": {
-                        "reason": "Unique constraint violation",
-                        "statement": statement,
-                        "orig_error": orig_error,
-                        "message": message,
-                    }
+                detail={
+                    "reason": "Unique constraint violation",
+                    "statement": statement,
+                    "orig_error": orig_error,
+                    "message": message,
                 },
             )
 
@@ -120,15 +117,9 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
 
     def exception_handler(self, request: Request, exc: DeserializationError):
         """Handle Dag deserialization exceptions."""
-        # Return JSONResponse directly to avoid extra wrapping by global HTTPException handler
-        return JSONResponse(
+        raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={
-                "detail": {
-                    "reason": "dag_deserialization_error",
-                    "message": f"An error occurred while trying to deserialize Dag: {exc}",
-                }
-            },
+            detail=f"An error occurred while trying to deserialize Dag: {exc}",
         )
 
 
@@ -175,6 +166,17 @@ def _ensure_detail_dict(detail: dict[str, Any] | str | None) -> dict[str, Any]:
     if isinstance(detail, str) or detail is None:
         return {"reason": "error", "message": detail or "An error occurred"}
     if isinstance(detail, dict):
+        # Flatten legacy/nested payloads: {"detail": "..."} -> {"reason": "error", "message": "..."}
+        if set(detail.keys()) == {"detail"}:
+            nested_detail = detail["detail"]
+            if isinstance(nested_detail, dict):
+                normalized = dict(nested_detail)
+                normalized.setdefault("reason", "error")
+                normalized.setdefault("message", "An error occurred")
+                return normalized
+            return {"reason": "error", "message": str(nested_detail)}
+
+        # Idempotent path: keep already structured details intact.
         normalized = dict(detail)
         normalized.setdefault("reason", "error")
         normalized.setdefault("message", "An error occurred")

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -23,7 +23,8 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Generic, TypeVar
 
-from fastapi import HTTPException, Request, status
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.exc import IntegrityError
 
 from airflow.configuration import conf
@@ -88,13 +89,16 @@ class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
                 statement = "hidden"
                 orig_error = "hidden"
 
-            raise HTTPException(
+            # Return JSONResponse directly to avoid extra wrapping by global HTTPException handler
+            return JSONResponse(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "reason": "Unique constraint violation",
-                    "statement": statement,
-                    "orig_error": orig_error,
-                    "message": message,
+                content={
+                    "detail": {
+                        "reason": "Unique constraint violation",
+                        "statement": statement,
+                        "orig_error": orig_error,
+                        "message": message,
+                    }
                 },
             )
 
@@ -116,9 +120,15 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
 
     def exception_handler(self, request: Request, exc: DeserializationError):
         """Handle Dag deserialization exceptions."""
-        raise HTTPException(
+        # Return JSONResponse directly to avoid extra wrapping by global HTTPException handler
+        return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An error occurred while trying to deserialize Dag: {exc}",
+            content={
+                "detail": {
+                    "reason": "dag_deserialization_error",
+                    "message": f"An error occurred while trying to deserialize Dag: {exc}",
+                }
+            },
         )
 
 
@@ -132,25 +142,80 @@ class ExecutionHTTPException(HTTPException):
     def __init__(
         self,
         status_code: int,
-        detail: dict[str, Any] | str | None = None,
+        *,
+        reason: str,
+        message: str,
+        extra: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        """Initialize with enforced dict format."""
-        if isinstance(detail, str) or detail is None:
-            detail = {
-                "reason": "error",
-                "message": detail or "An error occurred",
-            }
-        elif isinstance(detail, dict):
-            detail = dict(detail)  # copy
-            if "reason" not in detail:
-                detail["reason"] = "error"
-            if "message" not in detail:
-                detail["message"] = "An error occurred"
-        else:
-            detail = {"reason": "error", "message": str(detail)}
+        """
+        Initialize with explicit reason/message and optional extra fields.
 
+        detail will be constructed as a dict: {"reason": reason, "message": message, **extra}
+        """
+        detail: dict[str, Any] = {"reason": reason, "message": message}
+        if extra:
+            # Do not allow overriding reason/message through extra accidentally.
+            for k, v in extra.items():
+                if k not in ("reason", "message"):
+                    detail[k] = v
         super().__init__(status_code=status_code, detail=detail, headers=headers)
 
 
 ERROR_HANDLERS: list[BaseErrorHandler] = [_UniqueConstraintErrorHandler(), DagErrorHandler()]
+
+
+# --------------------
+# Global exception normalization utilities and registration
+# --------------------
+
+
+def _ensure_detail_dict(detail: dict[str, Any] | str | None) -> dict[str, Any]:
+    """Normalize detail into a dict with at least reason/message keys."""
+    if isinstance(detail, str) or detail is None:
+        return {"reason": "error", "message": detail or "An error occurred"}
+    if isinstance(detail, dict):
+        normalized = dict(detail)
+        normalized.setdefault("reason", "error")
+        normalized.setdefault("message", "An error occurred")
+        return normalized
+    return {"reason": "error", "message": str(detail)}
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """
+    Register global and specific exception handlers on the FastAPI app.
+
+    Guarantees JSON error responses carry a `detail` object with `reason` and `message`.
+    """
+    # Specific handlers remain in place (e.g., DB unique constraint, Dag errors)
+    for handler in ERROR_HANDLERS:
+        app.add_exception_handler(handler.exception_cls, handler.exception_handler)  # type: ignore[arg-type]
+
+    # Normalize any HTTPException to have dict detail with reason/message
+    @app.exception_handler(HTTPException)
+    async def _http_exception_handler(request: Request, exc: HTTPException):
+        detail = _ensure_detail_dict(getattr(exc, "detail", None))
+        headers = getattr(exc, "headers", None)
+        return JSONResponse(status_code=exc.status_code, content={"detail": detail}, headers=headers)
+
+    # Catch-all for unhandled Exceptions
+    @app.exception_handler(Exception)
+    async def _unhandled_exception_handler(request: Request, exc: Exception):
+        exception_id = get_random_string()
+        log.exception("Unhandled error id %s while handling request %s", exception_id, request.url.path)
+
+        if conf.get("api", "expose_stacktrace") == "True":
+            message = f"Unhandled error id {exception_id}: {exc}"
+        else:
+            message = (
+                "Serious error when handling your request. Check logs for more details - "
+                f"you will find it in api server when you look for ID {exception_id}"
+            )
+
+        detail = {
+            "reason": "unhandled_error",
+            "message": message,
+            "error_id": exception_id,
+        }
+        return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content={"detail": detail})

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -158,10 +158,9 @@ def init_config(app: FastAPI) -> None:
 
 
 def init_error_handlers(app: FastAPI) -> None:
-    from airflow.api_fastapi.common.exceptions import ERROR_HANDLERS
+    from airflow.api_fastapi.common.exceptions import register_exception_handlers
 
-    for handler in ERROR_HANDLERS:
-        app.add_exception_handler(handler.exception_cls, handler.exception_handler)
+    register_exception_handlers(app)
 
 
 def init_middlewares(app: FastAPI) -> None:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import and_, select
 
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.execution_api.datamodels.asset import AssetResponse
 from airflow.api_fastapi.execution_api.datamodels.asset_event import (
@@ -90,7 +91,7 @@ def get_asset_event_by_asset_name_uri(
     elif name:
         where_clause = and_(AssetModel.name == name, AssetModel.active.has())
     else:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "Missing parameter",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_events.py
@@ -93,10 +93,8 @@ def get_asset_event_by_asset_name_uri(
     else:
         raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "Missing parameter",
-                "message": "name and uri cannot both be None",
-            },
+            reason="Missing parameter",
+            message="name and uri cannot both be None",
         )
 
     if after:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/assets.py
@@ -63,8 +63,6 @@ def _raise_if_not_found(asset, msg):
     if asset is None:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": msg,
-            },
+            reason="not_found",
+            message=msg,
         )

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/assets.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Query, status
 from sqlalchemy import select
 
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.execution_api.datamodels.asset import AssetResponse
 from airflow.models.asset import AssetModel
 
@@ -60,7 +61,7 @@ def get_asset_by_uri(
 
 def _raise_if_not_found(asset, msg):
     if asset is None:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Depends, Path, status
 
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.execution_api.datamodels.connection import ConnectionResponse
 from airflow.api_fastapi.execution_api.security import CurrentTIToken, get_team_name_dep
 from airflow.exceptions import AirflowNotFoundException
@@ -66,7 +67,7 @@ def get_connection(
     try:
         connection = Connection.get_connection_from_secrets(connection_id, team_name=team_name)
     except AirflowNotFoundException:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -69,9 +69,7 @@ def get_connection(
     except AirflowNotFoundException:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"Connection with ID {connection_id} not found",
-            },
+            reason="not_found",
+            message=f"Connection with ID {connection_id} not found",
         )
     return ConnectionResponse.model_validate(connection)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -72,10 +72,8 @@ def get_dag_run(dag_id: str, run_id: str, session: SessionDep) -> DagRun:
     if dr is None:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"Dag run with dag_id '{dag_id}' and run_id '{run_id}' was not found",
-            },
+            reason="not_found",
+            message=f"Dag run with dag_id '{dag_id}' and run_id '{run_id}' was not found",
         )
     return DagRun.model_validate(dr)
 
@@ -101,16 +99,15 @@ def trigger_dag_run(
     if not dm:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": f"Dag with dag_id: '{dag_id}' not found"},
+            reason="not_found",
+            message=f"Dag with dag_id: '{dag_id}' not found",
         )
 
     if dm.has_import_errors:
         raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "import_errors",
-                "message": f"Dag with dag_id '{dag_id}' has import errors and cannot be triggered",
-            },
+            reason="import_errors",
+            message=f"Dag with dag_id '{dag_id}' has import errors and cannot be triggered",
         )
 
     # TODO: TriggerDagRunOperator also calls this route but creates OPERATOR_TRIGGERED runs.
@@ -118,10 +115,8 @@ def trigger_dag_run(
     if dm.allowed_run_types is not None and DagRunType.OPERATOR_TRIGGERED not in dm.allowed_run_types:
         raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "denied_run_type",
-                "message": f"Dag with dag_id '{dag_id}' does not allow operator-triggered runs",
-            },
+            reason="denied_run_type",
+            message=f"Dag with dag_id '{dag_id}' does not allow operator-triggered runs",
         )
 
     try:
@@ -140,10 +135,8 @@ def trigger_dag_run(
     except DagRunAlreadyExists:
         raise ExecutionHTTPException(
             status.HTTP_409_CONFLICT,
-            detail={
-                "reason": "already_exists",
-                "message": f"A run already exists for Dag '{dag_id}' with run_id '{run_id}'",
-            },
+            reason="already_exists",
+            message=f"A run already exists for Dag '{dag_id}' with run_id '{run_id}'",
         )
 
 
@@ -167,16 +160,15 @@ def clear_dag_run(
     if not dm:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": f"Dag with dag_id: '{dag_id}' not found"},
+            reason="not_found",
+            message=f"Dag with dag_id: '{dag_id}' not found",
         )
 
     if dm.has_import_errors:
         raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "import_errors",
-                "message": f"Dag with dag_id '{dag_id}' has import errors and cannot be triggered",
-            },
+            reason="import_errors",
+            message=f"Dag with dag_id '{dag_id}' has import errors and cannot be triggered",
         )
 
     dag_run = session.scalar(
@@ -185,7 +177,8 @@ def clear_dag_run(
     if dag_run is None:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": f"Dag run with run_id: '{run_id}' not found"},
+            reason="not_found",
+            message=f"Dag run with run_id: '{run_id}' not found",
         )
     dag = get_dag_for_run(dag_bag, dag_run=dag_run, session=session)
 
@@ -209,10 +202,8 @@ def get_dagrun_state(
     except NoResultFound:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"Dag run with dag_id '{dag_id}' and run_id '{run_id}' was not found",
-            },
+            reason="not_found",
+            message=f"Dag run with dag_id '{dag_id}' and run_id '{run_id}' was not found",
         )
     return DagRunStateResponse(state=state)
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -21,13 +21,14 @@ import logging
 from typing import Annotated
 
 from cadwyn import VersionedAPIRouter
-from fastapi import HTTPException, Query, status
+from fastapi import Query, status
 from sqlalchemy import func, select
 from sqlalchemy.exc import NoResultFound
 
 from airflow.api.common.trigger_dag import trigger_dag
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.execution_api.datamodels.dagrun import DagRunStateResponse, TriggerDAGRunPayload
@@ -69,7 +70,7 @@ def get_dag_run(dag_id: str, run_id: str, session: SessionDep) -> DagRun:
     """Get detail of a Dag run."""
     dr = session.scalar(select(DagRunModel).where(DagRunModel.dag_id == dag_id, DagRunModel.run_id == run_id))
     if dr is None:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -98,13 +99,13 @@ def trigger_dag_run(
     """Trigger a Dag run."""
     dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
     if not dm:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": f"Dag with dag_id: '{dag_id}' not found"},
         )
 
     if dm.has_import_errors:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "import_errors",
@@ -112,8 +113,10 @@ def trigger_dag_run(
             },
         )
 
+    # TODO: TriggerDagRunOperator also calls this route but creates OPERATOR_TRIGGERED runs.
+    #  Consider a dedicated run type for operator-triggered runs.
     if dm.allowed_run_types is not None and DagRunType.OPERATOR_TRIGGERED not in dm.allowed_run_types:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "denied_run_type",
@@ -135,7 +138,7 @@ def trigger_dag_run(
             session=session,
         )
     except DagRunAlreadyExists:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_409_CONFLICT,
             detail={
                 "reason": "already_exists",
@@ -162,13 +165,13 @@ def clear_dag_run(
     """Clear a Dag run."""
     dm = session.scalar(select(DagModel).where(~DagModel.is_stale, DagModel.dag_id == dag_id).limit(1))
     if not dm:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": f"Dag with dag_id: '{dag_id}' not found"},
         )
 
     if dm.has_import_errors:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "import_errors",
@@ -180,7 +183,7 @@ def clear_dag_run(
         select(DagRunModel).where(DagRunModel.dag_id == dag_id, DagRunModel.run_id == run_id)
     )
     if dag_run is None:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": f"Dag run with run_id: '{run_id}' not found"},
         )
@@ -204,7 +207,7 @@ def get_dagrun_state(
             select(DagRunModel.state).where(DagRunModel.dag_id == dag_id, DagRunModel.run_id == run_id)
         ).one()
     except NoResultFound:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dags.py
@@ -17,9 +17,10 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, status
 
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.execution_api.datamodels.dags import DagResponse
 from airflow.models.dag import DagModel
 
@@ -39,7 +40,7 @@ def get_dag(
     """Get a DAG."""
     dag_model: DagModel | None = session.get(DagModel, dag_id)
     if not dag_model:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dags.py
@@ -42,10 +42,8 @@ def get_dag(
     if not dag_model:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"The Dag with dag_id: `{dag_id}` was not found",
-            },
+            reason="not_found",
+            message=f"The Dag with dag_id: `{dag_id}` was not found",
         )
 
     return DagResponse(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -98,13 +98,10 @@ def _check_hitl_detail_exists(hitl_detail_model: HITLDetail | None) -> HITLDetai
     if not hitl_detail_model:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": (
-                    "HITLDetail not found. "
-                    "This happens most likely due to clearing task instance before receiving response."
-                ),
-            },
+            reason="not_found",
+            message=(
+                "HITLDetail not found. This happens most likely due to clearing task instance before receiving response."
+            ),
         )
 
     return hitl_detail_model
@@ -124,7 +121,8 @@ def update_hitl_detail(
     if hitl_detail_model.response_received:
         raise ExecutionHTTPException(
             status.HTTP_409_CONFLICT,
-            f"Human-in-the-loop detail for Task Instance with id {task_instance_id} already exists.",
+            reason="already_exists",
+            message=f"Human-in-the-loop detail for Task Instance with id {task_instance_id} already exists.",
         )
 
     hitl_detail_model.responded_by = None

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -20,11 +20,12 @@ from uuid import UUID
 
 import structlog
 from cadwyn import VersionedAPIRouter
-from fastapi import HTTPException, Security, status
+from fastapi import Security, status
 from sqlalchemy import select
 
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.execution_api.datamodels.hitl import (
     HITLDetailRequest,
     HITLDetailResponse,
@@ -95,7 +96,7 @@ def upsert_hitl_detail(
 
 def _check_hitl_detail_exists(hitl_detail_model: HITLDetail | None) -> HITLDetail:
     if not hitl_detail_model:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -121,7 +122,7 @@ def update_hitl_detail(
     ).scalar()
     hitl_detail_model = _check_hitl_detail_exists(hitl_detail_model_result)
     if hitl_detail_model.response_received:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_409_CONFLICT,
             f"Human-in-the-loop detail for Task Instance with id {task_instance_id} already exists.",
         )

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -160,10 +160,8 @@ def ti_run(
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
 
     # We exclude_unset to avoid updating fields that are not set in the payload
@@ -199,11 +197,9 @@ def ti_run(
         # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
         raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": "invalid_state",
-                "message": "TI was not in a state where it could be marked as running",
-                "previous_state": previous_state,
-            },
+            reason="invalid_state",
+            message="TI was not in a state where it could be marked as running",
+            extra={"previous_state": previous_state},
         )
     else:
         log.info("Task started", previous_state=previous_state, hostname=ti_run_payload.hostname)
@@ -294,10 +290,8 @@ def ti_run(
         log.exception("Error marking Task Instance state as running")
         raise ExecutionHTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "reason": "database_error",
-                "message": "Database error occurred",
-            },
+            reason="database_error",
+            message="Database error occurred",
         )
 
 
@@ -367,10 +361,8 @@ def ti_update_state(
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
 
     if previous_state != TaskInstanceState.RUNNING:
@@ -380,11 +372,9 @@ def ti_update_state(
         )
         raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": "invalid_state",
-                "message": "TI was not in the running state so it cannot be updated",
-                "previous_state": previous_state,
-            },
+            reason="invalid_state",
+            message="TI was not in the running state so it cannot be updated",
+            extra={"previous_state": previous_state},
         )
 
     # We exclude_unset to avoid updating fields that are not set in the payload
@@ -439,10 +429,8 @@ def ti_update_state(
         log.error("Error updating Task Instance state", error=str(e))
         raise ExecutionHTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "reason": "database_error",
-                "message": "Database error occurred",
-            },
+            reason="database_error",
+            message="Database error occurred",
         )
 
 
@@ -644,7 +632,8 @@ def ti_skip_downstream(
     if row_result is None:
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": "Task Instance not found"},
+            reason="not_found",
+            message="Task Instance not found",
         )
     dag_id, run_id = row_result
     log.debug("Retrieved DAG and run info", dag_id=dag_id, run_id=run_id)
@@ -726,20 +715,16 @@ def ti_heartbeat(
                 "TaskInstance was previously cleared and archived in history, heartbeat skipped",
                 ti_id=str(task_instance_id),
             )
-            raise HTTPException(
+            raise ExecutionHTTPException(
                 status_code=status.HTTP_410_GONE,
-                detail={
-                    "reason": "not_found",
-                    "message": "Task Instance not found, it may have been moved to the Task Instance History table",
-                },
+                reason="not_found",
+                message="Task Instance not found, it may have been moved to the Task Instance History table",
             )
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
 
     if hostname != ti_payload.hostname or pid != ti_payload.pid:
@@ -752,23 +737,18 @@ def ti_heartbeat(
         )
         raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": "running_elsewhere",
-                "message": "TI is already running elsewhere",
-                "current_hostname": hostname,
-                "current_pid": pid,
-            },
+            reason="running_elsewhere",
+            message="TI is already running elsewhere",
+            extra={"current_hostname": hostname, "current_pid": pid},
         )
 
     if previous_state != TaskInstanceState.RUNNING:
         log.warning("Task not in running state", current_state=previous_state)
         raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": "not_running",
-                "message": "TI is no longer in the running state and task should terminate",
-                "current_state": previous_state,
-            },
+            reason="not_running",
+            message="TI is no longer in the running state and task should terminate",
+            extra={"current_state": previous_state},
         )
 
     # Update the last heartbeat time!
@@ -805,10 +785,8 @@ def ti_put_rtif(
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
     task_instance.update_rtif(put_rtif_payload, session)
     log.debug("RenderedTaskInstanceFields updated successfully")
@@ -836,10 +814,8 @@ def ti_patch_rendered_map_index(
         log.error("rendered_map_index cannot be empty")
         raise ExecutionHTTPException(
             status_code=HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "reason": "invalid_request",
-                "message": "rendered_map_index cannot be empty",
-            },
+            reason="invalid_request",
+            message="rendered_map_index cannot be empty",
         )
 
     log.debug("Updating rendered_map_index", length=len(rendered_map_index))
@@ -852,10 +828,8 @@ def ti_patch_rendered_map_index(
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
 
 
@@ -1105,10 +1079,8 @@ def _get_group_tasks(
     if not task_group:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"Task group {task_group_id} not found in DAG {dag_id}",
-            },
+            reason="not_found",
+            message=f"Task group {task_group_id} not found in DAG {dag_id}",
         )
 
     # First get all task instances to get the task_id, map_index pairs
@@ -1145,10 +1117,8 @@ def validate_inlets_and_outlets(
         log.error("Task Instance not found")
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Task Instance not found",
-            },
+            reason="not_found",
+            message="Task Instance not found",
         )
 
     if not ti.task:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -28,7 +28,7 @@ from uuid import UUID
 import attrs
 import structlog
 from cadwyn import VersionedAPIRouter
-from fastapi import Body, HTTPException, Query, Security, status
+from fastapi import Body, Query, Security, status
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -44,6 +44,7 @@ from airflow._shared.observability.traces import override_ids
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
@@ -157,7 +158,7 @@ def ti_run(
         log.debug("Retrieved task instance details", state=ti.state, dag_id=ti.dag_id, task_id=ti.task_id)
     except NoResultFound:
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -196,7 +197,7 @@ def ti_run(
         # to provide more information about the error
         # FastAPI will automatically convert this to a JSON response
         # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": "invalid_state",
@@ -291,7 +292,7 @@ def ti_run(
         return context
     except SQLAlchemyError:
         log.exception("Error marking Task Instance state as running")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
                 "reason": "database_error",
@@ -364,7 +365,7 @@ def ti_update_state(
         )
     except NoResultFound:
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -377,7 +378,7 @@ def ti_update_state(
             "Cannot update Task Instance in invalid state",
             previous_state=previous_state,
         )
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": "invalid_state",
@@ -436,7 +437,7 @@ def ti_update_state(
         )
     except SQLAlchemyError as e:
         log.error("Error updating Task Instance state", error=str(e))
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
                 "reason": "database_error",
@@ -641,7 +642,7 @@ def ti_skip_downstream(
     query_result = session.execute(select(TI.dag_id, TI.run_id).where(TI.id == task_instance_id))
     row_result = query_result.fetchone()
     if row_result is None:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": "Task Instance not found"},
         )
@@ -733,7 +734,7 @@ def ti_heartbeat(
                 },
             )
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -749,7 +750,7 @@ def ti_heartbeat(
             requested_hostname=ti_payload.hostname,
             requested_pid=ti_payload.pid,
         )
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": "running_elsewhere",
@@ -761,7 +762,7 @@ def ti_heartbeat(
 
     if previous_state != TaskInstanceState.RUNNING:
         log.warning("Task not in running state", current_state=previous_state)
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": "not_running",
@@ -802,7 +803,7 @@ def ti_put_rtif(
     task_instance = session.scalar(select(TI).where(TI.id == task_instance_id))
     if not task_instance:
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -833,7 +834,7 @@ def ti_patch_rendered_map_index(
 
     if not rendered_map_index:
         log.error("rendered_map_index cannot be empty")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
                 "reason": "invalid_request",
@@ -849,7 +850,7 @@ def ti_patch_rendered_map_index(
     result = cast("CursorResult[Any]", result)
     if result.rowcount == 0:
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -1102,7 +1103,7 @@ def _get_group_tasks(
     dag = get_latest_version_of_dag(dag_bag, dag_id, session, include_reason=True)
     task_group = dag.task_group_dict.get(task_group_id)
     if not task_group:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -1142,7 +1143,7 @@ def validate_inlets_and_outlets(
     ti = session.scalar(select(TI).where(TI.id == task_instance_id))
     if not ti:
         log.error("Task Instance not found")
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -292,7 +292,11 @@ def ti_run(
     except SQLAlchemyError:
         log.exception("Error marking Task Instance state as running")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "reason": "database_error",
+                "message": "Database error occurred",
+            },
         )
 
 
@@ -433,7 +437,11 @@ def ti_update_state(
     except SQLAlchemyError as e:
         log.error("Error updating Task Instance state", error=str(e))
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "reason": "database_error",
+                "message": "Database error occurred",
+            },
         )
 
 
@@ -796,6 +804,10 @@ def ti_put_rtif(
         log.error("Task Instance not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": "Task Instance not found",
+            },
         )
     task_instance.update_rtif(put_rtif_payload, session)
     log.debug("RenderedTaskInstanceFields updated successfully")
@@ -823,7 +835,10 @@ def ti_patch_rendered_map_index(
         log.error("rendered_map_index cannot be empty")
         raise HTTPException(
             status_code=HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="rendered_map_index cannot be empty",
+            detail={
+                "reason": "invalid_request",
+                "message": "rendered_map_index cannot be empty",
+            },
         )
 
     log.debug("Updating rendered_map_index", length=len(rendered_map_index))
@@ -836,7 +851,10 @@ def ti_patch_rendered_map_index(
         log.error("Task Instance not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task Instance not found",
+            detail={
+                "reason": "not_found",
+                "message": "Task Instance not found",
+            },
         )
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -67,6 +67,18 @@ def get_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ) -> VariableResponse:
     """Get an Airflow Variable."""
+<<<<<<< HEAD
+=======
+    if not variable_key:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": "Not Found",
+            },
+        )
+
+>>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     try:
         variable_value = Variable.get(variable_key, team_name=team_name)
     except KeyError:
@@ -95,6 +107,18 @@ def put_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Set an Airflow Variable."""
+<<<<<<< HEAD
+=======
+    if not variable_key:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": "Not Found",
+            },
+        )
+
+>>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     Variable.set(key=variable_key, value=body.value, description=body.description, team_name=team_name)
     return {"message": "Variable successfully set"}
 
@@ -112,4 +136,16 @@ def delete_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Delete an Airflow Variable."""
+<<<<<<< HEAD
+=======
+    if not variable_key:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": "Not Found",
+            },
+        )
+
+>>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     Variable.delete(key=variable_key, team_name=team_name)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -68,12 +68,6 @@ def get_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ) -> VariableResponse:
     """Get an Airflow Variable."""
-    if not variable_key:
-        raise ExecutionHTTPException(
-            status.HTTP_404_NOT_FOUND,
-            reason="not_found",
-            message="Not Found",
-        )
     try:
         variable_value = Variable.get(variable_key, team_name=team_name)
     except KeyError:
@@ -100,13 +94,6 @@ def put_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Set an Airflow Variable."""
-    if not variable_key:
-        raise ExecutionHTTPException(
-            status.HTTP_404_NOT_FOUND,
-            reason="not_found",
-            message="Not Found",
-        )
-
     Variable.set(key=variable_key, value=body.value, description=body.description, team_name=team_name)
     return {"message": "Variable successfully set"}
 
@@ -124,11 +111,4 @@ def delete_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Delete an Airflow Variable."""
-    if not variable_key:
-        raise ExecutionHTTPException(
-            status.HTTP_404_NOT_FOUND,
-            reason="not_found",
-            message="Not Found",
-        )
-
     Variable.delete(key=variable_key, team_name=team_name)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -68,27 +68,19 @@ def get_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ) -> VariableResponse:
     """Get an Airflow Variable."""
-<<<<<<< HEAD
-=======
     if not variable_key:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Not Found",
-            },
+            reason="not_found",
+            message="Not Found",
         )
-
->>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     try:
         variable_value = Variable.get(variable_key, team_name=team_name)
     except KeyError:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": f"Variable with key '{variable_key}' not found",
-            },
+            reason="not_found",
+            message=f"Variable with key '{variable_key}' not found",
         )
 
     return VariableResponse(key=variable_key, value=variable_value)
@@ -108,18 +100,13 @@ def put_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Set an Airflow Variable."""
-<<<<<<< HEAD
-=======
     if not variable_key:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Not Found",
-            },
+            reason="not_found",
+            message="Not Found",
         )
 
->>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     Variable.set(key=variable_key, value=body.value, description=body.description, team_name=team_name)
     return {"message": "Variable successfully set"}
 
@@ -137,16 +124,11 @@ def delete_variable(
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Delete an Airflow Variable."""
-<<<<<<< HEAD
-=======
     if not variable_key:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": "Not Found",
-            },
+            reason="not_found",
+            message="Not Found",
         )
 
->>>>>>> 74415533b0 (Execution API: Normalize error response formats)
     Variable.delete(key=variable_key, team_name=team_name)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
+from fastapi import APIRouter, Depends, Path, Request, status
 
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.execution_api.datamodels.variable import (
     VariablePostBody,
     VariableResponse,
@@ -82,7 +83,7 @@ def get_variable(
     try:
         variable_value = Variable.get(variable_key, team_name=team_name)
     except KeyError:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -110,7 +111,7 @@ def put_variable(
 <<<<<<< HEAD
 =======
     if not variable_key:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -139,7 +140,7 @@ def delete_variable(
 <<<<<<< HEAD
 =======
     if not variable_key:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -121,7 +121,8 @@ def get_mapped_xcom_by_index(
         )
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": message},
+            reason="not_found",
+            message=message,
         )
     return XComSequenceIndexResponse((result[0] if isinstance(result, tuple) else result).value)
 
@@ -242,7 +243,8 @@ def head_xcom(
     if map_index is not None:
         raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"reason": "invalid_request", "message": "Cannot specify map_index in a HEAD request"},
+            reason="invalid_request",
+            message="Cannot specify map_index in a HEAD request",
         )
 
     count = get_query_count(xcom_query, session=session)
@@ -307,7 +309,8 @@ def get_xcom(
             )
         raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": message},
+            reason="not_found",
+            message=message,
         )
 
     return XComResponse(key=key, value=(result[0] if isinstance(result, tuple) else result).value)
@@ -359,10 +362,8 @@ def set_xcom(
     if not key:
         raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "invalid_key",
-                "message": "XCom key must be a non-empty string.",
-            },
+            reason="invalid_key",
+            message="XCom key must be a non-empty string.",
         )
 
     if mapped_length is not None:
@@ -378,10 +379,8 @@ def set_xcom(
         if task_map.length > max_map_length:
             raise ExecutionHTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail={
-                    "reason": "unmappable_return_value_length",
-                    "message": "pushed value is too large to map as a downstream's dependency",
-                },
+                reason="unmappable_return_value_length",
+                message="pushed value is too large to map as a downstream's dependency",
             )
         session.merge(task_map)
 
@@ -405,18 +404,14 @@ def set_xcom(
     except ValueError as e:
         raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": "not_found",
-                "message": str(e),
-            },
+            reason="not_found",
+            message=str(e),
         )
     except TypeError as e:
         raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": "invalid_format",
-                "message": f"XCom value is not a valid JSON: {e}",
-            },
+            reason="invalid_format",
+            message=f"XCom value is not a valid JSON: {e}",
         )
 
     return {"message": "XCom successfully set"}

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -20,12 +20,13 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
+from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, status
 from pydantic import JsonValue
 from sqlalchemy import delete
 from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.exceptions import ExecutionHTTPException
 from airflow.api_fastapi.core_api.base import BaseModel
 from airflow.api_fastapi.execution_api.datamodels.xcom import (
     XComResponse,
@@ -118,7 +119,7 @@ def get_mapped_xcom_by_index(
         message = (
             f"XCom with {key=} {offset=} not found for task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
         )
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": message},
         )
@@ -239,7 +240,7 @@ def head_xcom(
 ) -> None:
     """Get the count of XComs from database - not other XCom Backends."""
     if map_index is not None:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"reason": "invalid_request", "message": "Cannot specify map_index in a HEAD request"},
         )
@@ -304,7 +305,7 @@ def get_xcom(
                 f"XCom with {key=} offset={params.offset} not found for "
                 f"task {task_id!r} in DAG run {run_id!r} of {dag_id!r}"
             )
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"reason": "not_found", "message": message},
         )
@@ -356,7 +357,7 @@ def set_xcom(
     # Validate that the provided key is not empty
     # XCom keys must be non-empty strings to ensure proper data retrieval and avoid ambiguity.
     if not key:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "invalid_key",
@@ -375,7 +376,7 @@ def set_xcom(
         )
         max_map_length = conf.getint("core", "max_map_length", fallback=1024)
         if task_map.length > max_map_length:
-            raise HTTPException(
+            raise ExecutionHTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={
                     "reason": "unmappable_return_value_length",
@@ -402,7 +403,7 @@ def set_xcom(
             session=session,
         )
     except ValueError as e:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "not_found",
@@ -410,7 +411,7 @@ def set_xcom(
             },
         )
     except TypeError as e:
-        raise HTTPException(
+        raise ExecutionHTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "invalid_format",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -402,7 +402,13 @@ def set_xcom(
             session=session,
         )
     except ValueError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": str(e),
+            },
+        )
     except TypeError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -61,6 +61,18 @@ DEFAULT_DATE = timezone.datetime(2020, 6, 11, 18, 0, 0)
 pytestmark = pytest.mark.db_test
 
 
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 def _create_assets(session, num: int = 2) -> list[AssetModel]:
     assets = [
         AssetModel(
@@ -491,7 +503,7 @@ class TestGetAssets(TestAssets):
 
         assert response.status_code == 400
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
-        assert response.json()["detail"] == msg
+        assert_error_message(response, msg)
 
     @pytest.mark.parametrize(
         ("params", "expected_assets"),
@@ -721,7 +733,7 @@ class TestGetAssetAliases(TestAssetAliases):
 
         assert response.status_code == 400
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
-        assert response.json()["detail"] == msg
+        assert_error_message(response, msg)
 
     @pytest.mark.parametrize(
         ("params", "expected_asset_aliases"),
@@ -944,7 +956,7 @@ class TestGetAssetEvents(TestAssets):
 
         assert response.status_code == 400
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
-        assert response.json()["detail"] == msg
+        assert_error_message(response, msg)
 
     @pytest.mark.parametrize(
         ("params", "expected_asset_ids"),
@@ -1111,7 +1123,7 @@ class TestGetAssetEndpoint(TestAssets):
     def test_should_respond_404(self, test_client):
         response = test_client.get("/assets/1")
         assert response.status_code == 404
-        assert response.json()["detail"] == "The Asset with ID: `1` was not found"
+        assert_error_message(response, "The Asset with ID: `1` was not found")
 
     @pytest.mark.usefixtures("time_freezer")
     @pytest.mark.enable_redact
@@ -1150,7 +1162,7 @@ class TestGetAssetAliasEndpoint(TestAssetAliases):
     def test_should_respond_404(self, test_client):
         response = test_client.get("/assets/aliases/1")
         assert response.status_code == 404
-        assert response.json()["detail"] == "The Asset Alias with ID: `1` was not found"
+        assert_error_message(response, "The Asset Alias with ID: `1` was not found")
 
 
 class TestQueuedEventEndpoint(TestAssets):
@@ -1244,7 +1256,7 @@ class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         )
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Queue event with dag_id: `not_exists` was not found"
+        assert_error_message(response, "Queue event with dag_id: `not_exists` was not found")
 
     def test_should_respond_404_valid_dag_no_adrq(self, test_client, session, create_dummy_dag):
         dag, _ = create_dummy_dag()
@@ -1258,7 +1270,7 @@ class TestDeleteDagDatasetQueuedEvents(TestQueuedEventEndpoint):
         )
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Queue event with dag_id: `dag` was not found"
+        assert_error_message(response, "Queue event with dag_id: `dag` was not found")
 
 
 class TestPostAssetEvents(TestAssets):
@@ -1472,12 +1484,12 @@ class TestPostAssetMaterialize(TestAssets):
     def test_should_respond_409_on_multiple_dags(self, test_client):
         response = test_client.post("/assets/2/materialize")
         assert response.status_code == 409
-        assert response.json()["detail"] == "More than one DAG materializes asset with ID: 2"
+        assert_error_message(response, "More than one DAG materializes asset with ID: 2")
 
     def test_should_respond_404_on_multiple_dags(self, test_client):
         response = test_client.post("/assets/3/materialize")
         assert response.status_code == 404
-        assert response.json()["detail"] == "No DAG materializes asset with ID: 3"
+        assert_error_message(response, "No DAG materializes asset with ID: 3")
 
     def test_should_respond_400_if_materialization_runs_denied(self, test_client, session):
         sdm = session.scalar(
@@ -1493,9 +1505,9 @@ class TestPostAssetMaterialize(TestAssets):
         session.commit()
         response = test_client.post("/assets/1/materialize")
         assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == f"Dag with dag_id: '{self.DAG_ASSET1_ID}' does not allow asset materialization runs"
+        assert_error_message(
+            response,
+            f"Dag with dag_id: '{self.DAG_ASSET1_ID}' does not allow asset materialization runs",
         )
 
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
@@ -1509,8 +1521,9 @@ class TestPostAssetMaterialize(TestAssets):
             response = test_client.post("/assets/1/materialize")
 
             assert response.status_code == 403
-            assert response.json()["detail"] == (
-                f"User is not authorized to trigger a run for DAG: {self.DAG_ASSET1_ID} that materializes this asset"
+            assert_error_message(
+                response,
+                f"User is not authorized to trigger a run for DAG: {self.DAG_ASSET1_ID} that materializes this asset",
             )
             mock_get_auth_manager.return_value.is_authorized_dag.assert_called_once_with(
                 method="POST",
@@ -1583,7 +1596,7 @@ class TestDeleteAssetQueuedEvents(TestQueuedEventEndpoint):
     def test_should_respond_404(self, test_client):
         response = test_client.delete("/assets/1/queuedEvents")
         assert response.status_code == 404
-        assert response.json()["detail"] == "Queue event with asset_id: `1` was not found"
+        assert_error_message(response, "Queue event with asset_id: `1` was not found")
 
 
 class TestDeleteDagAssetQueuedEvent(TestQueuedEventEndpoint):
@@ -1622,7 +1635,6 @@ class TestDeleteDagAssetQueuedEvent(TestQueuedEventEndpoint):
         )
 
         assert response.status_code == 404
-        assert (
-            response.json()["detail"]
-            == "Queued event with dag_id: `not_exists` and asset_id: `1` was not found"
+        assert_error_message(
+            response, "Queued event with dag_id: `not_exists` and asset_id: `1` was not found"
         )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -55,6 +55,17 @@ DAG2_ID = "test_dag2"
 DAG3_ID = "test_dag3"
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    if isinstance(detail, dict):
+        assert detail["message"] == expected_message
+        assert "reason" in detail
+        if expected_reason is not None:
+            assert detail["reason"] == expected_reason
+    else:
+        assert detail == expected_message
+
+
 def _clean_db():
     clear_db_backfills()
     clear_db_runs()
@@ -191,7 +202,7 @@ class TestGetBackfill(TestBackfillEndpoint):
     def test_no_exist(self, session, test_client):
         response = test_client.get(f"/backfills/{231984098}")
         assert response.status_code == 404
-        assert response.json().get("detail") == "Backfill not found"
+        assert_error_message(response, "Backfill not found")
 
     def test_invalid_id(self, test_client):
         response = test_client.get("/backfills/invalid_id")
@@ -277,7 +288,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
             json=data,
         )
         assert response.status_code == 404
-        assert response.json().get("detail") == "Could not find dag DAG_NOT_EXIST"
+        assert_error_message(response, "Could not find dag DAG_NOT_EXIST")
 
     def test_no_schedule_dag(self, session, dag_maker, test_client):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="None") as dag:
@@ -303,7 +314,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
             json=data,
         )
         assert response.status_code == 422
-        assert response.json().get("detail") == f"{dag.dag_id} has no schedule"
+        assert_error_message(response, f"{dag.dag_id} has no schedule")
 
     @pytest.mark.parametrize(
         ("repro_act", "repro_exp", "run_backwards", "status_code"),
@@ -342,14 +353,14 @@ class TestCreateBackfill(TestBackfillEndpoint):
 
         if response.status_code != 200:
             if run_backwards:
-                assert (
-                    response.json().get("detail")
-                    == "Backfill cannot be run in reverse when the Dag has tasks where depends_on_past=True."
+                assert_error_message(
+                    response,
+                    "Backfill cannot be run in reverse when the Dag has tasks where depends_on_past=True.",
                 )
             else:
-                assert (
-                    response.json().get("detail")
-                    == "Dag has tasks for which depends_on_past=True. You must set reprocess behavior to reprocess completed or reprocess failed."
+                assert_error_message(
+                    response,
+                    "Dag has tasks for which depends_on_past=True. You must set reprocess behavior to reprocess completed or reprocess failed.",
                 )
 
     @pytest.mark.parametrize(
@@ -381,7 +392,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
             json=data,
         )
         assert response.status_code == 422
-        assert response.json().get("detail") == "Backfill cannot be executed for future dates."
+        assert_error_message(response, "Backfill cannot be executed for future dates.")
 
     @pytest.mark.parametrize(
         "run_backwards",
@@ -578,7 +589,7 @@ class TestCreateBackfill(TestBackfillEndpoint):
             json=data,
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == f"Dag with dag_id: '{dag.dag_id}' does not allow backfill runs"
+        assert_error_message(response, f"Dag with dag_id: '{dag.dag_id}' does not allow backfill runs")
 
     def test_should_respond_401(self, unauthenticated_test_client, dag_maker, session):
         with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
@@ -794,14 +805,14 @@ class TestCreateBackfillDryRun(TestBackfillEndpoint):
 
         if response.status_code != 200:
             if run_backwards:
-                assert (
-                    response.json().get("detail")
-                    == "Backfill cannot be run in reverse when the Dag has tasks where depends_on_past=True."
+                assert_error_message(
+                    response,
+                    "Backfill cannot be run in reverse when the Dag has tasks where depends_on_past=True.",
                 )
             else:
-                assert (
-                    response.json().get("detail")
-                    == "Dag has tasks for which depends_on_past=True. You must set reprocess behavior to reprocess completed or reprocess failed."
+                assert_error_message(
+                    response,
+                    "Dag has tasks for which depends_on_past=True. You must set reprocess behavior to reprocess completed or reprocess failed.",
                 )
 
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_config.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_config.py
@@ -158,7 +158,17 @@ class TestConfigEndpoint:
         if headers == HEADERS_TEXT:
             assert response.text == expected_response
         else:
-            assert response.json() == expected_response
+            body = response.json()
+            if (
+                isinstance(expected_response, dict)
+                and isinstance(body, dict)
+                and isinstance(expected_response.get("detail"), str)
+            ):
+                assert isinstance(body["detail"], dict)
+                assert body["detail"]["message"] == expected_response["detail"]
+                assert "reason" in body["detail"]
+            else:
+                assert body == expected_response
 
     @pytest.fixture(autouse=True)
     def setup(self) -> Generator[None, None, None]:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -61,6 +61,15 @@ TEST_CONN_ID_3 = "test_connection_id_3"
 TEST_CONN_TYPE_3 = "test_type_3"
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 @provide_session
 def _create_connection(team_name: str | None = None, session: Session = NEW_SESSION) -> None:
     connection_model = Connection(
@@ -128,8 +137,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
     def test_delete_should_respond_404(self, test_client):
         response = test_client.delete(f"/connections/{TEST_CONN_ID}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Connection with connection_id: `{TEST_CONN_ID}` was not found" == body["detail"]
+        assert_error_message(response, f"The Connection with connection_id: `{TEST_CONN_ID}` was not found")
 
 
 class TestGetConnection(TestConnectionEndpoint):
@@ -153,8 +161,7 @@ class TestGetConnection(TestConnectionEndpoint):
     def test_get_should_respond_404(self, test_client):
         response = test_client.get(f"/connections/{TEST_CONN_ID}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Connection with connection_id: `{TEST_CONN_ID}` was not found" == body["detail"]
+        assert_error_message(response, f"The Connection with connection_id: `{TEST_CONN_ID}` was not found")
 
     def test_get_should_respond_200_with_extra(self, test_client, session):
         self.create_connection()
@@ -826,9 +833,9 @@ class TestPatchConnection(TestConnectionEndpoint):
         self.create_connection()
         response = test_client.patch(f"/connections/{TEST_CONN_ID}", json=body)
         assert response.status_code == 400
-        assert response.json() == {
-            "detail": "The connection_id in the request body does not match the URL parameter",
-        }
+        assert_error_message(
+            response, "The connection_id in the request body does not match the URL parameter"
+        )
 
     @pytest.mark.parametrize(
         "body",
@@ -866,9 +873,10 @@ class TestPatchConnection(TestConnectionEndpoint):
     def test_patch_should_respond_404(self, test_client, body):
         response = test_client.patch(f"/connections/{body['connection_id']}", json=body)
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": f"The Connection with connection_id: `{body['connection_id']}` was not found",
-        }
+        assert_error_message(
+            response,
+            f"The Connection with connection_id: `{body['connection_id']}` was not found",
+        )
 
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
@@ -1028,10 +1036,10 @@ class TestConnection(TestConnectionEndpoint):
     def test_should_respond_403_by_default(self, test_client, body):
         response = test_client.post("/connections/test", json=body)
         assert response.status_code == 403
-        assert response.json() == {
-            "detail": "Testing connections is disabled in Airflow configuration. "
-            "Contact your deployment admin to enable it."
-        }
+        assert_error_message(
+            response,
+            "Testing connections is disabled in Airflow configuration. Contact your deployment admin to enable it.",
+        )
 
     @mock.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})
     def test_should_merge_password_with_existing_connection(self, test_client, session):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -57,6 +57,18 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.db_test
 
 
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 class CustomTimetable(CronDataIntervalTimetable):
     """Custom timetable that generates custom run IDs."""
 
@@ -344,8 +356,9 @@ class TestGetDagRun:
     def test_get_dag_run_not_found(self, test_client):
         response = test_client.get(f"/dags/{DAG1_ID}/dagRuns/invalid")
         assert response.status_code == 404
-        body = response.json()
-        assert body["detail"] == "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        assert_error_message(
+            response, "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        )
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(f"/dags/{DAG1_ID}/dagRuns/invalid")
@@ -377,16 +390,14 @@ class TestGetDagRuns:
     def test_get_dag_runs_not_found(self, test_client):
         response = test_client.get("/dags/invalid/dagRuns")
         assert response.status_code == 404
-        body = response.json()
-        assert body["detail"] == "The Dag with ID: `invalid` was not found"
+        assert_error_message(response, "The Dag with ID: `invalid` was not found")
 
     def test_invalid_order_by_raises_400(self, test_client):
         response = test_client.get("/dags/test_dag1/dagRuns?order_by=invalid")
         assert response.status_code == 400
-        body = response.json()
-        assert (
-            body["detail"]
-            == "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
+        assert_error_message(
+            response,
+            "Ordering with 'invalid' is disallowed or the attribute does not exist on the model",
         )
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -858,8 +869,9 @@ class TestGetDagRuns:
     def test_invalid_state(self, test_client):
         response = test_client.get(f"/dags/{DAG1_ID}/dagRuns", params={"state": ["invalid"]})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"] == f"Invalid value for state. Valid values are {', '.join(DagRunState)}"
+        assert_error_message(
+            response,
+            f"Invalid value for state. Valid values are {', '.join(DagRunState)}",
         )
 
     def test_invalid_dag_version(self, test_client):
@@ -923,10 +935,9 @@ class TestListDagRunsBatch:
     def test_invalid_order_by_raises_400(self, test_client):
         response = test_client.post("/dags/~/dagRuns/list", json={"order_by": "invalid"})
         assert response.status_code == 400
-        body = response.json()
-        assert (
-            body["detail"]
-            == "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
+        assert_error_message(
+            response,
+            "Ordering with 'invalid' is disallowed or the attribute does not exist on the model",
         )
 
     @pytest.mark.parametrize(
@@ -1337,8 +1348,9 @@ class TestPatchDagRun:
             json={"state": DagRunState.SUCCESS},
         )
         assert response.status_code == 404
-        body = response.json()
-        assert body["detail"] == "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        assert_error_message(
+            response, "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        )
 
     def test_patch_dag_run_bad_request(self, test_client):
         response = test_client.patch(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}", json={"state": "running"})
@@ -1374,8 +1386,9 @@ class TestDeleteDagRun:
     def test_delete_dag_run_not_found(self, test_client):
         response = test_client.delete(f"/dags/{DAG1_ID}/dagRuns/invalid")
         assert response.status_code == 404
-        body = response.json()
-        assert body["detail"] == "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        assert_error_message(
+            response, "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        )
 
     def test_delete_dag_run_in_running_state(self, test_client, dag_maker, session):
         with dag_maker(dag_id="test_running_dag"):
@@ -1388,10 +1401,10 @@ class TestDeleteDagRun:
         session.commit()
         response = test_client.delete("/dags/test_running_dag/dagRuns/test_running")
         assert response.status_code == 409
-        body = response.json()
-        assert body["detail"] == (
+        assert_error_message(
+            response,
             "The DagRun with dag_id: `test_running_dag` and run_id: `test_running` "
-            "cannot be deleted in running state"
+            "cannot be deleted in running state",
         )
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -1497,9 +1510,9 @@ class TestGetDagRunAssetTriggerEvents:
             "/dags/invalid-id/dagRuns/invalid-run-id/upstreamAssetEvents",
         )
         assert response.status_code == 404
-        assert (
-            response.json()["detail"]
-            == "The DagRun with dag_id: `invalid-id` and run_id: `invalid-run-id` was not found"
+        assert_error_message(
+            response,
+            "The DagRun with dag_id: `invalid-id` and run_id: `invalid-run-id` was not found",
         )
 
 
@@ -1568,8 +1581,9 @@ class TestClearDagRun:
     def test_clear_dag_run_not_found(self, test_client):
         response = test_client.post(f"/dags/{DAG1_ID}/dagRuns/invalid/clear", json={"dry_run": False})
         assert response.status_code == 404
-        body = response.json()
-        assert body["detail"] == "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        assert_error_message(
+            response, "The DagRun with dag_id: `test_dag1` and run_id: `invalid` was not found"
+        )
 
     def test_clear_dag_run_unprocessable_entity(self, test_client):
         response = test_client.post(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}/clear")
@@ -1842,23 +1856,23 @@ class TestTriggerDagRun:
 
         response = test_client.post(f"/dags/{DAG1_ID}/dagRuns", json={"logical_date": now})
         assert response.status_code == 400
-        assert response.json() == {"detail": error_message}
+        assert_error_message(response, error_message)
 
     def test_should_respond_404_if_a_dag_is_inactive(self, test_client, session, testing_dag_bundle):
         now = timezone.utcnow().isoformat()
         self._dags_for_trigger_tests(session)
         response = test_client.post("/dags/inactive/dagRuns", json={"logical_date": now})
         assert response.status_code == 404
-        assert response.json()["detail"] == "DAG with dag_id: 'inactive' not found"
+        assert_error_message(response, "DAG with dag_id: 'inactive' not found")
 
     def test_should_respond_400_if_a_dag_has_import_errors(self, test_client, session, testing_dag_bundle):
         now = timezone.utcnow().isoformat()
         self._dags_for_trigger_tests(session)
         response = test_client.post("/dags/import_errors/dagRuns", json={"logical_date": now})
         assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == "DAG with dag_id: 'import_errors' has import errors and cannot be triggered"
+        assert_error_message(
+            response,
+            "DAG with dag_id: 'import_errors' has import errors and cannot be triggered",
         )
 
     def test_should_respond_400_if_manual_runs_denied(self, test_client, session, testing_dag_bundle):
@@ -1866,7 +1880,7 @@ class TestTriggerDagRun:
         self._dags_for_trigger_tests(session)
         response = test_client.post("/dags/allowed_scheduled/dagRuns", json={"logical_date": now})
         assert response.status_code == 400
-        assert response.json()["detail"] == "Dag with dag_id: 'allowed_scheduled' does not allow manual runs"
+        assert_error_message(response, "Dag with dag_id: 'allowed_scheduled' does not allow manual runs")
 
     @time_machine.travel(timezone.utcnow(), tick=False)
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
@@ -1949,13 +1963,13 @@ class TestTriggerDagRun:
             json={"conf": {"validated_number": 5000}, "logical_date": now},
         )
         assert response.status_code == 400
-        assert "Invalid input for param validated_number" in response.json()["detail"]
+        assert "Invalid input for param validated_number" in response.json()["detail"]["message"]
 
     def test_response_404(self, test_client):
         now = timezone.utcnow().isoformat()
         response = test_client.post("/dags/randoms/dagRuns", json={"logical_date": now})
         assert response.status_code == 404
-        assert response.json()["detail"] == "DAG with dag_id: 'randoms' not found"
+        assert_error_message(response, "DAG with dag_id: 'randoms' not found")
 
     def test_response_409(self, test_client):
         now = timezone.utcnow().isoformat()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -28,6 +28,15 @@ from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clea
 pytestmark = pytest.mark.db_test
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 class TestDagVersionEndpoint:
     @pytest.fixture(autouse=True)
     def setup(request, dag_maker, session):
@@ -196,9 +205,10 @@ class TestGetDagVersion(TestDagVersionEndpoint):
     def test_get_dag_version_404(self, test_client):
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/99")
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": "The DagVersion with dag_id: `dag_with_multiple_versions` and version_number: `99` was not found",
-        }
+        assert_error_message(
+            response,
+            "The DagVersion with dag_id: `dag_with_multiple_versions` and version_number: `99` was not found",
+        )
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(
@@ -521,9 +531,7 @@ class TestGetDagVersions(TestDagVersionEndpoint):
     def test_get_dag_versions_should_return_404_for_missing_dag(self, test_client):
         response = test_client.get("/dags/MISSING_ID/dagVersions")
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": "The Dag with ID: `MISSING_ID` was not found",
-        }
+        assert_error_message(response, "The Dag with ID: `MISSING_ID` was not found")
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/dags/~/dagVersions", params={})

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -34,6 +34,18 @@ from tests_common.test_utils.mock_operators import CustomOperator
 pytestmark = pytest.mark.db_test
 
 
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 class GoogleLink(BaseOperatorLink):
     name = "Google"
 
@@ -115,27 +127,27 @@ class TestGetExtraLinks:
         return dag
 
     @pytest.mark.parametrize(
-        ("url", "expected_status_code", "expected_response"),
+        ("url", "expected_status_code", "expected_message"),
         [
             pytest.param(
                 "/dags/INVALID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_SINGLE_LINK/links",
                 404,
-                {"detail": "The Dag with ID: `INVALID` was not found"},
+                "The Dag with ID: `INVALID` was not found",
                 id="missing_dag",
             ),
             pytest.param(
                 "/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/INVALID/links",
                 404,
-                {"detail": "Task with ID = INVALID not found"},
+                "Task with ID = INVALID not found",
                 id="missing_task",
             ),
         ],
     )
-    def test_should_respond_404(self, test_client, url, expected_status_code, expected_response):
+    def test_should_respond_404(self, test_client, url, expected_status_code, expected_message):
         response = test_client.get(url)
 
         assert response.status_code == expected_status_code
-        assert response.json() == expected_response
+        assert_error_message(response, expected_message)
 
     def test_should_respond_200(self, test_client, session):
         XCom.set(
@@ -304,7 +316,7 @@ class TestGetExtraLinks:
             params={"map_index": 4},
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "TaskInstance not found"}
+        assert_error_message(response, "TaskInstance not found")
 
     def test_should_not_deserialize_ill_formatted_links(self, test_client, session):
         import json

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -47,6 +47,19 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.db_test
 
+
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 DAG_ID = "test_hitl_dag"
 ANOTHER_DAG_ID = "another_hitl_dag"
 TASK_ID = "sample_task_hitl"
@@ -408,7 +421,7 @@ class TestUpdateHITLDetailEndpoint:
             json={"chosen_options": ["Approve"], "params_input": {"input_1": 2}},
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": expected_ti_not_found_error_msg}
+        assert_error_message(response, expected_ti_not_found_error_msg)
 
     def test_should_respond_404_without_hitl_detail(
         self,
@@ -423,7 +436,7 @@ class TestUpdateHITLDetailEndpoint:
         )
 
         assert response.status_code == 404
-        assert response.json() == {"detail": expected_hitl_detail_not_found_error_msg}
+        assert_error_message(response, expected_hitl_detail_not_found_error_msg)
 
     @time_machine.travel(datetime(2025, 7, 3, 0, 0, 0), tick=False)
     @pytest.mark.usefixtures("sample_hitl_detail")
@@ -452,13 +465,12 @@ class TestUpdateHITLDetailEndpoint:
             json={"chosen_options": ["Approve"], "params_input": {"input_1": 3}},
         )
         assert response.status_code == 409
-        assert response.json() == {
-            "detail": (
-                "Human-in-the-loop detail has already been updated for Task Instance "
-                f"with id {sample_ti.id} "
-                "and is not allowed to write again."
-            )
-        }
+        assert_error_message(
+            response,
+            "Human-in-the-loop detail has already been updated for Task Instance "
+            f"with id {sample_ti.id} "
+            "and is not allowed to write again.",
+        )
 
     @pytest.mark.usefixtures("sample_hitl_detail")
     def test_should_respond_422_with_empty_option(
@@ -509,7 +521,7 @@ class TestGetHITLDetailEndpoint:
     ) -> None:
         response = test_client.get(f"{sample_ti_url_identifier}/hitlDetails")
         assert response.status_code == 404
-        assert response.json() == {"detail": expected_ti_not_found_error_msg}
+        assert_error_message(response, expected_ti_not_found_error_msg)
 
     def test_should_respond_404_without_hitl_detail(
         self,
@@ -519,7 +531,7 @@ class TestGetHITLDetailEndpoint:
     ) -> None:
         response = test_client.get(f"{sample_ti_url_identifier}/hitlDetails")
         assert response.status_code == 404
-        assert response.json() == {"detail": expected_hitl_detail_not_found_error_msg}
+        assert_error_message(response, expected_hitl_detail_not_found_error_msg)
 
 
 class TestGetHITLDetailsEndpoint:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.db_test
 
+
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 FILENAME1 = "test_filename1.py"
 FILENAME2 = "test_filename2.py"
 FILENAME3 = "Lorem_ipsum.py"
@@ -249,7 +262,7 @@ class TestGetImportError:
         # Assert
         mock_get_authorized_dag_ids.assert_called_once_with(user=mock.ANY)
         assert response.status_code == 403
-        assert response.json() == {"detail": "You do not have read permission on any of the DAGs in the file"}
+        assert_error_message(response, "You do not have read permission on any of the DAGs in the file")
 
     @mock.patch("airflow.api_fastapi.core_api.routes.public.import_error.get_auth_manager")
     def test_get_import_error__user_dont_have_read_permission_to_read_all_dags_in_file(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -40,6 +40,18 @@ from tests_common.test_utils.file_task_handler import convert_list_to_stream
 pytestmark = [pytest.mark.db_test, pytest.mark.need_serialized_dag]
 
 
+def assert_error_message(
+    response,
+    expected_message: str,
+    expected_reason: str | None = None,
+) -> None:
+    detail = response.json()["detail"]
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 class TestTaskInstancesLog:
     DAG_ID = "dag_for_testing_log_endpoint"
     RUN_ID = "dag_run_id_for_testing_log_endpoint"
@@ -302,7 +314,7 @@ class TestTaskInstancesLog:
             params={"token": token},
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "TaskInstance not found"}
+        assert_error_message(response, "TaskInstance not found")
 
     @pytest.mark.parametrize("try_number", [1, 2])
     def test_get_logs_with_metadata_as_download_large_file(self, try_number):
@@ -362,7 +374,7 @@ class TestTaskInstancesLog:
             headers={"Accept": "application/json"},
         )
         # assert response.status_code == 400
-        assert response.json() == {"detail": "Bad Signature. Please use only the tokens provided by the API."}
+        assert_error_message(response, "Bad Signature. Please use only the tokens provided by the API.")
 
     def test_should_raises_401_unauthenticated(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(
@@ -385,7 +397,7 @@ class TestTaskInstancesLog:
             headers={"Accept": "application/json"},
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "TaskInstance not found"}
+        assert_error_message(response, "TaskInstance not found")
 
     def test_should_raise_404_when_missing_map_index_param_for_mapped_task(self):
         key = self.app.state.secret_key
@@ -398,7 +410,7 @@ class TestTaskInstancesLog:
             headers={"Accept": "application/x-ndjson"},
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == "TaskInstance not found"
+        assert_error_message(response, "TaskInstance not found")
 
     def test_should_raise_404_when_filtering_on_map_index_for_unmapped_task(self):
         key = self.app.state.secret_key
@@ -411,26 +423,35 @@ class TestTaskInstancesLog:
             headers={"Accept": "application/x-ndjson"},
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == "TaskInstance not found"
+        assert_error_message(response, "TaskInstance not found")
 
     @pytest.mark.parametrize(
-        ("supports_external_link", "task_id", "expected_status", "expected_response", "mock_external_url"),
+        (
+            "supports_external_link",
+            "task_id",
+            "expected_status",
+            "expected_response",
+            "expected_error_message",
+            "mock_external_url",
+        ),
         [
             (
                 True,
                 "task_for_testing_log_endpoint",
                 200,
                 {"url": "https://external-logs.example.com/log/123"},
+                None,
                 True,
             ),
             (
                 False,
                 "task_for_testing_log_endpoint",
                 400,
-                {"detail": "Task log handler does not support external logs."},
+                None,
+                "Task log handler does not support external logs.",
                 False,
             ),
-            (True, "INVALID_TASK", 404, {"detail": "TaskInstance not found"}, False),
+            (True, "INVALID_TASK", 404, None, "TaskInstance not found", False),
         ],
         ids=[
             "external_links_supported_task_exists",
@@ -439,7 +460,13 @@ class TestTaskInstancesLog:
         ],
     )
     def test_get_external_log_url(
-        self, supports_external_link, task_id, expected_status, expected_response, mock_external_url
+        self,
+        supports_external_link,
+        task_id,
+        expected_status,
+        expected_response,
+        expected_error_message,
+        mock_external_url,
     ):
         with (
             mock.patch(
@@ -463,4 +490,7 @@ class TestTaskInstancesLog:
                 mock_log_handler.get_external_log_url.assert_not_called()
 
             assert response.status_code == expected_status
-            assert response.json() == expected_response
+            if expected_error_message is None:
+                assert response.json() == expected_response
+            else:
+                assert_error_message(response, expected_error_message)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -47,6 +47,15 @@ POOL3_INCLUDE_DEFERRED = False
 POOL3_DESCRIPTION = "Some Description"
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 @provide_session
 def _create_pools(session) -> None:
     pool1 = Pool(pool=POOL1_NAME, slots=POOL1_SLOT, include_deferred=POOL1_INCLUDE_DEFERRED, team_name="test")
@@ -102,14 +111,12 @@ class TestDeletePool(TestPoolsEndpoint):
     def test_delete_should_respond_400(self, test_client):
         response = test_client.delete("/pools/default_pool")
         assert response.status_code == 400
-        body = response.json()
-        assert body["detail"] == "Default Pool can't be deleted"
+        assert_error_message(response, "Default Pool can't be deleted")
 
     def test_delete_should_respond_404(self, test_client):
         response = test_client.delete(f"/pools/{POOL1_NAME}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Pool with name: `{POOL1_NAME}` was not found" == body["detail"]
+        assert_error_message(response, f"The Pool with name: `{POOL1_NAME}` was not found")
 
     def test_delete_pool3_should_respond_204(self, test_client, session):
         """Test deleting POOL3 with forward slash in name"""
@@ -153,8 +160,7 @@ class TestGetPool(TestPoolsEndpoint):
     def test_get_should_respond_404(self, test_client):
         response = test_client.get(f"/pools/{POOL1_NAME}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Pool with name: `{POOL1_NAME}` was not found" == body["detail"]
+        assert_error_message(response, f"The Pool with name: `{POOL1_NAME}` was not found")
 
     def test_get_pool3_should_respond_200(self, test_client, session):
         """Test getting POOL3 with forward slash in name"""
@@ -377,7 +383,10 @@ class TestPatchPool(TestPoolsEndpoint):
             assert "slots" in str(detail)
             return
 
-        assert body == expected_response
+        if isinstance(expected_response, dict) and isinstance(expected_response.get("detail"), str):
+            assert_error_message(response, expected_response["detail"])
+        else:
+            assert body == expected_response
         if response.status_code == 200:
             check_last_log(session, dag_id=None, event="patch_pool", logical_date=None)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -71,6 +71,19 @@ DEFAULT_DATETIME_1 = dt.datetime.fromisoformat(DEFAULT_DATETIME_STR_1)
 DEFAULT_DATETIME_2 = dt.datetime.fromisoformat(DEFAULT_DATETIME_STR_2)
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    actual_message = detail["message"]
+    normalized_message = actual_message
+    if normalized_message.startswith("('") and normalized_message.endswith("',)"):
+        normalized_message = normalized_message[2:-3]
+    assert normalized_message == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 class TestTaskInstanceEndpoint:
     @staticmethod
     def clear_db():
@@ -522,9 +535,10 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
         )
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID` and task_id: `print_the_context` was not found"
-        }
+        assert_error_message(
+            response,
+            "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID` and task_id: `print_the_context` was not found",
+        )
 
     def test_raises_404_for_mapped_task_instance_with_multiple_indexes(self, test_client, session):
         tis = self.create_task_instances(session)
@@ -545,7 +559,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "Task instance is mapped, add the map_index value to the URL"}
+        assert_error_message(response, "Task instance is mapped, add the map_index value to the URL")
 
     def test_raises_404_for_mapped_task_instance_with_one_index(self, test_client, session):
         tis = self.create_task_instances(session)
@@ -565,7 +579,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "Task instance is mapped, add the map_index value to the URL"}
+        assert_error_message(response, "Task instance is mapped, add the map_index value to the URL")
 
 
 class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
@@ -656,10 +670,10 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context/10",
         )
         assert response.status_code == 404
-
-        assert response.json() == {
-            "detail": "The Mapped Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context`, and map_index: `10` was not found"
-        }
+        assert_error_message(
+            response,
+            "The Mapped Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context`, and map_index: `10` was not found",
+        )
 
 
 class TestGetMappedTaskInstances:
@@ -811,7 +825,7 @@ class TestGetMappedTaskInstances:
             "/dags/mapped_tis/dagRuns/run_mapped_tis/taskInstances/task_2/listMapped",
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "The Dag with ID: `mapped_tis` was not found"}
+        assert_error_message(response, "The Dag with ID: `mapped_tis` was not found")
 
     def test_should_respond_200(self, one_task_with_many_mapped_tis, test_client):
         with assert_queries_count(4):
@@ -988,7 +1002,7 @@ class TestGetMappedTaskInstances:
             "/dags/mapped_tis/dagRuns/run_mapped_tis/taskInstances/nonexistent_task/listMapped",
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == "Task id nonexistent_task not found"
+        assert_error_message(response, "Task id nonexistent_task not found")
 
     def test_no_duplicate_joins_in_get_mapped_task_instances_query(
         self, one_task_with_mapped_tis, test_client
@@ -1533,20 +1547,20 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
     def test_not_found(self, test_client):
         response = test_client.get("/dags/invalid/dagRuns/~/taskInstances")
         assert response.status_code == 404
-        assert response.json() == {"detail": "The Dag with ID: `invalid` was not found"}
+        assert_error_message(response, "The Dag with ID: `invalid` was not found")
 
     def test_dag_id_required_when_dag_run_id_specified(self, test_client):
         # dag_run_id is not unique - it requires dag_id to identify a specific dag_run
         response = test_client.get("/dags/~/dagRuns/some_run_id/taskInstances")
         assert response.status_code == 400
-        assert response.json() == {"detail": "dag_id is required when dag_run_id is specified"}
+        assert_error_message(response, "dag_id is required when dag_run_id is specified")
 
     def test_bad_state(self, test_client):
         response = test_client.get("/dags/~/dagRuns/~/taskInstances", params={"state": "invalid"})
         assert response.status_code == 422
-        assert (
-            response.json()["detail"]
-            == f"Invalid value for state. Valid values are {', '.join(TaskInstanceState)}"
+        assert_error_message(
+            response,
+            f"Invalid value for state. Valid values are {', '.join(TaskInstanceState)}",
         )
 
     def test_no_duplicate_joins_in_get_task_instances_query(self, test_client, session):
@@ -2505,10 +2519,10 @@ class TestGetTaskInstanceTry(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/nonexistent_task/tries/0"
         )
         assert response.status_code == 404
-
-        assert response.json() == {
-            "detail": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `nonexistent_task`, try_number: `0` and map_index: `-1` was not found"
-        }
+        assert_error_message(
+            response,
+            "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `nonexistent_task`, try_number: `0` and map_index: `-1` was not found",
+        )
 
     @pytest.mark.parametrize(
         ("run_id", "expected_version_number"),
@@ -2976,7 +2990,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert response.status_code == 400
         assert (
             "Cannot use include_past or include_future with no logical_date(e.g. manually or asset-triggered)."
-            in response.json()["detail"]
+            in response.json()["detail"]["message"]
         )
 
     @pytest.mark.parametrize(
@@ -4022,10 +4036,10 @@ class TestGetTaskInstanceTries(TestTaskInstanceEndpoint):
             "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/non_existent_task/tries"
         )
         assert response.status_code == 404
-
-        assert response.json() == {
-            "detail": "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found"
-        }
+        assert_error_message(
+            response,
+            "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `non_existent_task` and map_index: `-1` was not found",
+        )
 
     @pytest.mark.parametrize(
         ("run_id", "expected_version_number"),
@@ -4362,9 +4376,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         ("error", "code", "payload"),
         [
             [
-                [
-                    "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `None` was not found",
-                ],
+                "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `None` was not found",
                 404,
                 {
                     "new_state": "failed",
@@ -4378,7 +4390,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             json=payload,
         )
         assert response.status_code == code
-        assert response.json()["detail"] == error
+        assert_error_message(response, error)
 
     def test_should_200_for_unknown_fields(self, test_client, session):
         self.create_task_instances(session)
@@ -4398,7 +4410,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "The Dag with ID: `non-existent-dag` was not found"}
+        assert_error_message(response, "The Dag with ID: `non-existent-dag` was not found")
 
     def test_should_raise_404_for_non_existent_task_in_dag(self, test_client):
         response = test_client.patch(
@@ -4408,9 +4420,7 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": "Task 'non_existent_task' not found in DAG 'example_python_operator'"
-        }
+        assert_error_message(response, "Task 'non_existent_task' not found in DAG 'example_python_operator'")
 
     def test_should_raise_404_not_found_dag(self, test_client):
         response = test_client.patch(
@@ -5121,9 +5131,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
         ("error", "code", "payload"),
         [
             [
-                [
-                    "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found"
-                ],
+                "The Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context` and map_index: `-1` was not found",
                 404,
                 {
                     "new_state": "failed",
@@ -5137,7 +5145,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             json=payload,
         )
         assert response.status_code == code
-        assert response.json()["detail"] == error
+        assert_error_message(response, error)
 
     def test_should_200_for_unknown_fields(self, test_client, session):
         self.create_task_instances(session)
@@ -5157,7 +5165,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {"detail": "The Dag with ID: `non-existent-dag` was not found"}
+        assert_error_message(response, "The Dag with ID: `non-existent-dag` was not found")
 
     def test_should_raise_404_for_non_existent_task_in_dag(self, test_client):
         response = test_client.patch(
@@ -5167,9 +5175,7 @@ class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
             },
         )
         assert response.status_code == 404
-        assert response.json() == {
-            "detail": "Task 'non_existent_task' not found in DAG 'example_python_operator'"
-        }
+        assert_error_message(response, "Task 'non_existent_task' not found in DAG 'example_python_operator'")
 
     def test_should_raise_404_not_found_dag(self, test_client):
         response = test_client.patch(
@@ -5402,7 +5408,7 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
             self.create_task_instances(session)
         response = test_client.delete(test_url)
         assert response.status_code == 404
-        assert response.json()["detail"] == expected_error
+        assert_error_message(response, expected_error)
 
     @pytest.mark.parametrize(
         ("task_instances", "map_index", "expected_status_code", "expected_remaining"),
@@ -5484,9 +5490,9 @@ class TestDeleteTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == expected_status_code
 
         if expected_status_code == 404:
-            assert (
-                response.json()["detail"]
-                == f"The Task Instance with dag_id: `{self.DAG_ID}`, run_id: `{self.RUN_ID}`, task_id: `{self.TASK_ID}` and map_index: `{map_index}` was not found"
+            assert_error_message(
+                response,
+                f"The Task Instance with dag_id: `{self.DAG_ID}`, run_id: `{self.RUN_ID}`, task_id: `{self.TASK_ID}` and map_index: `{map_index}` was not found",
             )
         else:
             if map_index == -1:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -543,10 +543,11 @@ class TestGetTasks(TestTaskEndpoint):
             f"{self.api_prefix}/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == (
+        assert response.json()["detail"]["message"] == (
             "Ordering with 'invalid_task_colume_name' is disallowed or "
             "the attribute does not exist on the model"
         )
+        assert "reason" in response.json()["detail"]
 
     def test_should_respond_200_order_by_start_date_with_none(self, test_client):
         """Sorting by a nullable field should not raise TypeError (issue #63927)."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -63,6 +63,19 @@ TEST_VARIABLE_SEARCH_VALUE = "random search value"
 TEST_VARIABLE_SEARCH_DESCRIPTION = "Some description for the variable"
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    actual_message = detail["message"]
+    normalized_message = actual_message
+    if normalized_message.startswith("('") and normalized_message.endswith("',)"):
+        normalized_message = normalized_message[2:-3]
+    assert normalized_message == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 # Helper function to simulate file upload
 def create_file_upload(content: dict) -> BytesIO:
     return BytesIO(json.dumps(content).encode("utf-8"))
@@ -163,8 +176,7 @@ class TestDeleteVariable(TestVariableEndpoint):
     def test_delete_should_respond_404(self, test_client):
         response = test_client.delete(f"/variables/{TEST_VARIABLE_KEY}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
+        assert_error_message(response, f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found")
 
 
 class TestGetVariable(TestVariableEndpoint):
@@ -251,8 +263,7 @@ class TestGetVariable(TestVariableEndpoint):
     def test_get_should_respond_404(self, test_client):
         response = test_client.get(f"/variables/{TEST_VARIABLE_KEY}")
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
+        assert_error_message(response, f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found")
 
 
 class TestGetVariables(TestVariableEndpoint):
@@ -495,8 +506,7 @@ class TestPatchVariable(TestVariableEndpoint):
             json={"key": "different_key", "value": "some_value", "description": None},
         )
         assert response.status_code == 400
-        body = response.json()
-        assert body["detail"] == "Invalid body, key from request body doesn't match uri parameter"
+        assert_error_message(response, "Invalid body, key from request body doesn't match uri parameter")
 
     def test_patch_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.patch(
@@ -518,8 +528,7 @@ class TestPatchVariable(TestVariableEndpoint):
             json={"key": TEST_VARIABLE_KEY, "value": "some_value", "description": None},
         )
         assert response.status_code == 404
-        body = response.json()
-        assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
+        assert_error_message(response, f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found")
 
     @pytest.mark.enable_redact
     def test_patch_with_update_mask_description_only(self, test_client, session):
@@ -662,8 +671,7 @@ class TestPostVariable(TestVariableEndpoint):
             },
         )
         assert response.status_code == 409
-        body = response.json()
-        assert body["detail"] == f"The Variable with key: `{TEST_VARIABLE_KEY}` already exists"
+        assert_error_message(response, f"The Variable with key: `{TEST_VARIABLE_KEY}` already exists")
 
     def test_post_should_respond_422_when_key_too_large(self, test_client):
         large_key = "a" * 251  # Exceeds the maximum length of 250

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_xcom.py
@@ -69,6 +69,15 @@ run_id = DagRun.generate_run_id(
 )
 
 
+def assert_error_message(response, expected_message: str, expected_reason: str | None = None) -> None:
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["message"] == expected_message
+    assert "reason" in detail
+    if expected_reason is not None:
+        assert detail["reason"] == expected_reason
+
+
 @provide_session
 def _create_xcom(key, value, backend, session=None) -> None:
     XComModel.set(
@@ -162,7 +171,7 @@ class TestGetXComEntry(TestXComEndpoint):
             f"/dags/{TEST_DAG_ID}/dagRuns/{run_id}/taskInstances/{TEST_TASK_ID}/xcomEntries/{TEST_XCOM_KEY_2}"
         )
         assert response.status_code == 404
-        assert response.json()["detail"] == f"XCom entry with key: `{TEST_XCOM_KEY_2}` not found"
+        assert_error_message(response, f"XCom entry with key: `{TEST_XCOM_KEY_2}` not found")
 
     def test_should_respond_200_native_with_slash_key(self, test_client):
         slash_key = "folder/sub/value"
@@ -675,7 +684,7 @@ class TestCreateXComEntry(TestXComEndpoint):
 
         assert response.status_code == expected_status
         if expected_detail:
-            assert response.json()["detail"] == expected_detail
+            assert_error_message(response, expected_detail)
         elif expected_status == 201:
             # Validate the created XCom response
             current_data = response.json()
@@ -835,7 +844,7 @@ class TestPatchXComEntry(TestXComEndpoint):
         if expected_status == 200:
             assert response.json()["value"] == patch_body["value"]
         else:
-            assert response.json()["detail"] == expected_detail
+            assert_error_message(response, expected_detail)
         check_last_log(session, dag_id=TEST_DAG_ID, event="update_xcom_entry", logical_date=None)
 
     def test_should_respond_401(self, unauthenticated_test_client):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_auth.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_auth.py
@@ -51,7 +51,8 @@ class TestGetAuthLinks:
     def test_with_unauthenticated_user(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/auth/menus")
         assert response.status_code == 401
-        assert response.json() == {"detail": "Not authenticated"}
+        assert response.json()["detail"]["message"] == "Not authenticated"
+        assert "reason" in response.json()["detail"]
 
     @mock.patch.object(SimpleAuthManager, "filter_authorized_menu_items", return_value=[])
     def test_with_unauthorized_user(self, _, unauthorized_test_client):
@@ -75,7 +76,8 @@ class TestGetMeResponse:
         """Test /auth/me endpoint with no authentication."""
         response = unauthenticated_test_client.get("/auth/me")
         assert response.status_code == 401
-        assert response.json() == {"detail": "Not authenticated"}
+        assert response.json()["detail"]["message"] == "Not authenticated"
+        assert "reason" in response.json()["detail"]
 
 
 class TestGenerateToken:
@@ -113,4 +115,5 @@ class TestGenerateToken:
         """Test that unauthenticated requests are rejected."""
         response = unauthenticated_test_client.post("/auth/token", json={"token_type": "api"})
         assert response.status_code == 401
-        assert response.json() == {"detail": "Not authenticated"}
+        assert response.json()["detail"]["message"] == "Not authenticated"
+        assert "reason" in response.json()["detail"]

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
@@ -271,9 +271,11 @@ class TestGetDependencies:
         response = test_client.get("/dependencies", params={"node_id": "missing_node_id"})
         assert response.status_code == 404
 
-        assert response.json() == {
-            "detail": "Unique connected component not found, got [] for connected components of node missing_node_id, expected only 1 connected component.",
-        }
+        assert (
+            response.json()["detail"]["message"]
+            == "Unique connected component not found, got [] for connected components of node missing_node_id, expected only 1 connected component."
+        )
+        assert "reason" in response.json()["detail"]
 
     @pytest.mark.parametrize(
         ("dependency_type", "has_dag", "has_task"),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -528,7 +528,8 @@ class TestGetGridDataEndpoint:
     def test_should_response_404(self, test_client, endpoint):
         response = test_client.get(f"/grid/{endpoint}/invalid_dag")
         assert response.status_code == 404
-        assert response.json() == {"detail": "Dag with id invalid_dag was not found"}
+        assert response.json()["detail"]["message"] == "Dag with id invalid_dag was not found"
+        assert "reason" in response.json()["detail"]
 
     def test_structure_should_response_200_without_dag_run(self, test_client):
         with assert_queries_count(5):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -688,7 +688,8 @@ class TestStructureDataEndpoint:
     def test_should_return_404(self, test_client):
         response = test_client.get("/structure/structure_data", params={"dag_id": "not_existing"})
         assert response.status_code == 404
-        assert response.json()["detail"] == "Dag with id not_existing was not found"
+        assert response.json()["detail"]["message"] == "Dag with id not_existing was not found"
+        assert "reason" in response.json()["detail"]
 
     def test_should_return_404_when_dag_version_not_found(self, test_client):
         response = test_client.get(
@@ -696,9 +697,10 @@ class TestStructureDataEndpoint:
         )
         assert response.status_code == 404
         assert (
-            response.json()["detail"]
+            response.json()["detail"]["message"]
             == "Dag with id dag_with_multiple_versions and version number 999 was not found"
         )
+        assert "reason" in response.json()["detail"]
 
     def test_mapped_operator_graph_view(self, dag_maker, test_client, session):
         """

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1226,7 +1226,10 @@ class TestTIUpdateState:
             mock_register_asset_changes_in_db.return_value = None
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
-            assert response.json()["detail"] == "Database error occurred"
+            assert response.json()["detail"] == {
+                "reason": "database_error",
+                "message": "Database error occurred",
+            }
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(
@@ -1992,7 +1995,10 @@ class TestTIPutRTIF:
         random_id = uuid6.uuid7()
         response = client.put(f"/execution/task-instances/{random_id}/rtif", json=payload)
         assert response.status_code == 404
-        assert response.json()["detail"] == "Not Found"
+        assert response.json()["detail"] == {
+            "reason": "not_found",
+            "message": "Task Instance not found",
+        }
 
 
 class TestPreviousDagRun:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -3238,7 +3238,7 @@ class TestTokenTypeValidation:
         payload = {"hostname": "test-host", "pid": 100}
         resp = client.put(f"/execution/task-instances/{ti.id}/heartbeat", json=payload)
         assert resp.status_code == 403
-        assert "Token type 'workload' not allowed" in resp.json()["detail"]
+        assert "Token type 'workload' not allowed" in resp.json()["detail"]["message"]
 
     def test_execution_scope_accepted_on_all_endpoints(self, client, session, create_task_instance):
         """execution scoped tokens should be able to call all endpoints."""
@@ -3282,7 +3282,7 @@ class TestTokenTypeValidation:
 
         resp = client.patch(f"/execution/task-instances/{ti.id}/run", json=payload)
         assert resp.status_code == 403
-        assert "Invalid token scope" in resp.json()["detail"]
+        assert "Invalid token scope" in resp.json()["detail"]["message"]
 
     def test_no_scope_defaults_to_execution(self, client, session, create_task_instance):
         """Tokens without scope claim should default to 'execution'."""

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
@@ -121,11 +121,8 @@ class TestGetVariable:
 
         # Assert response status code and detail for access denied
         assert response.status_code == 403
-        assert response.json() == {
-            "detail": {
-                "reason": "access_denied",
-            }
-        }
+        assert response.json()["detail"]["reason"] == "access_denied"
+        assert "message" in response.json()["detail"]
 
         assert any(msg.startswith("Checking read access for task instance") for msg in caplog.messages)
 
@@ -236,11 +233,8 @@ class TestPutVariable:
 
         # Assert response status code and detail for access denied
         assert response.status_code == 403
-        assert response.json() == {
-            "detail": {
-                "reason": "access_denied",
-            }
-        }
+        assert response.json()["detail"]["reason"] == "access_denied"
+        assert "message" in response.json()["detail"]
         assert any(msg.startswith("Checking write access for task instance") for msg in caplog.messages)
 
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -126,11 +126,8 @@ class TestXComsGetEndpoint:
             response = client.get("/execution/xcoms/dag/runid/task/xcom_perms")
 
         assert response.status_code == 403, response.json()
-        assert response.json() == {
-            "detail": {
-                "reason": "access_denied",
-            }
-        }
+        assert response.json()["detail"]["reason"] == "access_denied"
+        assert "message" in response.json()["detail"]
         assert any(msg.startswith("Checking read XCom access") for msg in caplog.messages)
 
     @pytest.mark.parametrize(
@@ -512,11 +509,8 @@ class TestXComsSetEndpoint:
             )
 
         assert response.status_code == 403
-        assert response.json() == {
-            "detail": {
-                "reason": "access_denied",
-            }
-        }
+        assert response.json()["detail"]["reason"] == "access_denied"
+        assert "message" in response.json()["detail"]
         assert any(msg.startswith("Checking write XCom access") for msg in caplog.messages)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Standardized Execution API error responses to use structured detail payloads (with reason and message) instead of mixed `string/dict` formats.
Updated affected routes in` variables, xcoms, and task_instance`s to return consistent error shapes.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
