### PR TITLE
fix(ui): restore pointer cursor on task nodes in graph view (#63714)

### DIFF
--- a/airflow/www/static/js/dag/details/graph/DagNode.tsx
+++ b/airflow/www/static/js/dag/details/graph/DagNode.tsx
@@ -115,7 +115,7 @@ const DagNode = ({
         }
         height={`${height}px`}
         width={`${width}px`}
-        cursor={latestDagRunId ? "cursor" : "default"}
+        cursor={latestDagRunId ? "pointer" : "default"}
         opacity={isActive ? 1 : 0.3}
         transition="opacity 0.2s"
         data-testid="node"


### PR DESCRIPTION
Fixes incorrect cursor behavior in the Graph view where task nodes do not display a pointer cursor on hover despite being interactive.

Problem

In the Graph view, task nodes are clickable but the cursor remains the default arrow. This creates inconsistent UI feedback and makes interactivity less obvious.

Root Cause

The cursor style for task nodes was either missing or not explicitly set to "pointer" in the node rendering component.

Solution

Explicitly set the cursor style to "pointer" for task nodes in:

airflow/www/static/js/dag/details/graph/DagNode.tsx

Verification

Ran Airflow locally on v2-11-stable

Opened Graph view for a DAG

Confirmed that hovering over task nodes now shows the pointer cursor

Impact

Improves UX by aligning visual feedback with interactivity, making task nodes clearly identifiable as clickable elements.

Fixes #63714