### PR TITLE
Fix update-uv-lock hook to use `uv lock` instead of `uv sync`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -985,7 +985,7 @@ repos:
         # Unless there is a conflict and uv will determine that the lock needs to be updated to resolve it
       - id: update-uv-lock
         name: Update uv.lock
-        entry: uv sync
+        entry: uv lock
         language: system
         files: >
           (?x)


### PR DESCRIPTION
The `update-uv-lock` pre-commit hook was using `uv sync` which installs
packages in addition to updating the lockfile. Changed to `uv lock` which
only regenerates the lockfile — matching the hook's intended purpose.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)