### PR TITLE
Fix asset materialization run type display on the UI

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -172,6 +172,7 @@
   "reset": "Reset",
   "runId": "Run ID",
   "runTypes": {
+    "asset_materialization": "Asset Materialization",
     "asset_triggered": "Asset Triggered",
     "backfill": "Backfill",
     "manual": "Manual",

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/RunTypeLegend.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/RunTypeLegend.tsx
@@ -24,7 +24,13 @@ import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { Tooltip } from "src/components/ui";
 
-const runTypes: Array<DAGRunResponse["run_type"]> = ["scheduled", "manual", "backfill", "asset_triggered"];
+const runTypes: Array<DAGRunResponse["run_type"]> = [
+  "scheduled",
+  "manual",
+  "backfill",
+  "asset_triggered",
+  "asset_materialization",
+];
 
 export const RunTypeLegend = () => {
   const { t: translate } = useTranslation(["dag", "common"]);

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -76,7 +76,7 @@ export const Details = () => {
           <Table.Cell>
             <HStack>
               <RunTypeIcon runType={dagRun.run_type} />
-              <Text>{dagRun.run_type}</Text>
+              <Text>{translate(`runTypes.${dagRun.run_type}`)}</Text>
             </HStack>
           </Table.Cell>
         </Table.Row>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -105,7 +105,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
             value: (
               <HStack>
                 <RunTypeIcon runType={dagRun.run_type} />
-                <Text>{dagRun.run_type}</Text>
+                <Text>{translate(`runTypes.${dagRun.run_type}`)}</Text>
               </HStack>
             ),
           },


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
- [ ] 

<!--
Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

closes: https://github.com/apache/airflow/issues/63818

Display "Asset Materialization" instead of raw "runTypes.asset_materialization" value
in run details and header pages, matching the existing translation pattern used in the DAG runs table.


Earlier:

<img width="1579" height="558" alt="image" src="https://github.com/user-attachments/assets/266c348b-0ad1-4431-bceb-4c2ff2a42ea3" />


Now:
<img width="2491" height="587" alt="image" src="https://github.com/user-attachments/assets/dc170cea-281b-489b-ade1-a73ebfc6a6c3" />



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
