### PR TITLE
fix: add __call__ to MockOptional for WTForms validator compatibility

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -48,6 +48,9 @@ class HookMetaService:
         ):
             pass
 
+        def __call__(self, form, field):
+            pass
+
     class MockEnum:
         """Mock for wtforms.validators.Optional."""
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.core_api.services.ui.connections import HookMetaService
+
+
+class TestMockOptional:
+    def test_mock_optional_is_callable(self):
+        """MockOptional instances must be callable to satisfy WTForms validator checks."""
+        validator = HookMetaService.MockOptional()
+        assert callable(validator)
+
+    def test_mock_optional_call_is_noop(self):
+        """Calling MockOptional should be a no-op (returns None)."""
+        validator = HookMetaService.MockOptional()
+        result = validator(None, None)
+        assert result is None


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

`HookMetaService.MockOptional` lacks a `__call__` method. When FAB initializes WTForms forms during `POST /auth/token`, stored `MockOptional` instances fail `check_validators` because they're not callable — every token request returns 500.

Added `__call__(self, form, field)` as a no-op so `MockOptional` satisfies the WTForms validator protocol. Added unit tests.

Closes: #63803

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4, claude-opus-4-6)

Generated-by: Claude Code (Opus 4, claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
