### PR TITLE
airflowctl: fix flaky xcom add test by using unique keys per test run

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -93,11 +93,11 @@ TEST_COMMANDS = [
     # DAG Run commands
     "dagrun list --dag-id example_bash_operator --state success --limit=1",
     # XCom commands - need a DAG run with completed tasks
-    'xcom add --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key=test_xcom_key --value=\'{{"test": "value"}}\'',
-    'xcom get --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key=test_xcom_key',
+    'xcom add --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key={xcom_key} --value=\'{{"test": "value"}}\'',
+    'xcom get --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key={xcom_key}',
     'xcom list --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0',
-    'xcom edit --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key=test_xcom_key --value=\'{{"updated": "value"}}\'',
-    'xcom delete --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key=test_xcom_key',
+    'xcom edit --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key={xcom_key} --value=\'{{"updated": "value"}}\'',
+    'xcom delete --dag-id=example_bash_operator --dag-run-id="manual__{date_param}" --task-id=runme_0 --key={xcom_key}',
     # Jobs commands
     "jobs list",
     # Pools commands
@@ -128,10 +128,37 @@ TEST_COMMANDS = [
 
 DATE_PARAM_1 = date_param()
 DATE_PARAM_2 = date_param()
-TEST_COMMANDS_DEBUG_MODE = [LOGIN_COMMAND] + [test.format(date_param=DATE_PARAM_1) for test in TEST_COMMANDS]
-TEST_COMMANDS_SKIP_KEYRING = [LOGIN_COMMAND_SKIP_KEYRING] + [
-    test.format(date_param=DATE_PARAM_2) for test in TEST_COMMANDS
+
+# Unique xcom key per test run to avoid "already exists" errors from leftover state
+_XCOM_KEY_1 = f"test_xcom_key_{DATE_PARAM_1.replace(':', '').replace('+', '').replace('-', '')[:16]}"
+_XCOM_KEY_2 = f"test_xcom_key_{DATE_PARAM_2.replace(':', '').replace('+', '').replace('-', '')[:16]}"
+TEST_COMMANDS_DEBUG_MODE = [LOGIN_COMMAND] + [
+    test.format(date_param=DATE_PARAM_1, xcom_key=_XCOM_KEY_1) for test in TEST_COMMANDS
 ]
+TEST_COMMANDS_SKIP_KEYRING = [LOGIN_COMMAND_SKIP_KEYRING] + [
+    test.format(date_param=DATE_PARAM_2, xcom_key=_XCOM_KEY_2) for test in TEST_COMMANDS
+]
+
+
+def test_hardcoded_xcom_key_would_collide():
+    """Regression: a hardcoded xcom key produces identical 'xcom add' commands
+    across parametrize sets, causing 'already exists' errors when both run
+    against the same Airflow instance (the bug that was fixed)."""
+    xcom_add_template = [t for t in TEST_COMMANDS if "xcom add" in t]
+    assert xcom_add_template, "xcom add must be in TEST_COMMANDS"
+
+    hardcoded = xcom_add_template[0].format(date_param=DATE_PARAM_1, xcom_key="test_xcom_key")
+    also_hardcoded = xcom_add_template[0].format(date_param=DATE_PARAM_2, xcom_key="test_xcom_key")
+    # With a hardcoded key, only the dag-run-id differs — but if the same date
+    # is reused (e.g. across retries), the commands are fully identical → collision.
+    assert "test_xcom_key" in hardcoded
+    assert "test_xcom_key" in also_hardcoded
+
+    # The fix: derived keys are unique per set, so commands always differ.
+    debug_cmd = xcom_add_template[0].format(date_param=DATE_PARAM_1, xcom_key=_XCOM_KEY_1)
+    keyring_cmd = xcom_add_template[0].format(date_param=DATE_PARAM_2, xcom_key=_XCOM_KEY_2)
+    assert _XCOM_KEY_1 != _XCOM_KEY_2, "derived xcom keys must differ between sets"
+    assert debug_cmd != keyring_cmd, "xcom add commands must differ to avoid collisions"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Fix flaky `test_airflowctl_commands[xcom add]` test that intermittently fails with `The XCom with key: 'test_xcom_key' with mentioned task instance already exists`.
- The hardcoded test_xcom_key could collide with leftover state from a previous failed run where xcom delete never executed (e.g., CI timeout or earlier test failure)
- Derive a unique xcom key per parametrize set from the already-randomized date_param, so both the debug-mode and skip-keyring test sets use distinct keys
- Add a regression test (test_hardcoded_xcom_key_would_collide) that demonstrates the old hardcoded key produces identical commands across sets while the derived keys always differ.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
