### PR TITLE
Add .claude to IntelliJ IDEA excluded directories

### DIFF
--- a/dev/ide_setup/setup_idea.py
+++ b/dev/ide_setup/setup_idea.py
@@ -101,6 +101,7 @@ EXCLUDE_PATTERNS: list[str] = [
     ".ruff-cache",
     ".hypothesis",
     ".cache",
+    ".claude",
     ".tox",
     "htmlcov",
     # Node / frontend
@@ -132,6 +133,7 @@ EXCLUDE_PATTERNS: list[str] = [
 # Derived from root-anchored .gitignore entries (those starting with /).
 ROOT_EXCLUDE_FOLDERS: list[str] = [
     ".build",
+    ".claude",
     ".kube",
     ".venv",
     ".uv-cache",


### PR DESCRIPTION
Add `.claude` directory to IntelliJ IDEA exclude patterns in `setup_idea.py` so that IDEA does not index Claude Code configuration files.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)