### PR TITLE
Fix flaky test_run_no_log in DbApiHook

### DIFF
--- a/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_dbapi.py
@@ -539,7 +539,7 @@ class TestDbApiHook:
         statement = "SQL"
         caplog.clear()
         self.db_hook_no_log_sql.run(statement)
-        assert len(caplog.messages) in [1, 2]
+        assert "Rows affected: 0" in caplog.text
 
     def test_run_with_handler(self):
         sql = "SQL"


### PR DESCRIPTION
## Why
The previous implementation tried to work around this by using a fragile assertion: `assert len(caplog.messages) in [1, 2]`. However, this is an anti-pattern for two major reasons:

1. The previous implementation cannot clearly test what we want to test: By asserting the length of the logs rather than their content, the true intent of the test is obscured. It could theoretically pass even if the target message was never logged
2. It is also flaky: It still leads to CI failures if multiple background tasks happen to be garbage-collected simultaneously (making the log length 3 or more).

closes: #45774


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
