### PR TITLE
Speed up migrations 0094 and 0108 by removing ORM imports and batching large updates

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
+++ b/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
@@ -27,14 +27,15 @@ Create Date: 2025-10-24 00:34:57.111239
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import json
+from datetime import date, datetime, timedelta, timezone
 from textwrap import dedent
+from zoneinfo import ZoneInfo
 
 import sqlalchemy as sa
 from alembic import context, op
 from sqlalchemy import column, select, table
 
-from airflow.serialization.serde import deserialize
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -45,15 +46,131 @@ depends_on = None
 airflow_version = "3.2.0"
 
 BATCH_SIZE = 1000
+_CALLBACK_TYPE_TRIGGERER = "triggerer"
+_CALLBACK_FETCH_METHOD_IMPORT_PATH = "import_path"
+_CALLBACK_STATE_FAILED = "failed"
+_CALLBACK_STATE_PENDING = "pending"
+_CALLBACK_STATE_SUCCESS = "success"
+_CALLBACK_TERMINAL_STATES = frozenset({_CALLBACK_STATE_FAILED, _CALLBACK_STATE_SUCCESS})
+_CALLBACK_METRICS_PREFIX = "deadline_alerts"
+_SERDE_CLASSNAME = "__classname__"
+_SERDE_VERSION = "__version__"
+_SERDE_DATA = "__data__"
+_SERDE_DATETIME_TIMESTAMP = "timestamp"
+_SERDE_DATETIME_TIMEZONE = "tz"
+_SERDE_TUPLE_TYPES = {
+    "builtins.frozenset": frozenset,
+    "builtins.set": set,
+    "builtins.tuple": tuple,
+}
+_SERDE_DATETIME_TYPES = {
+    "datetime.datetime",
+    "pendulum.datetime.DateTime",
+}
+_SERDE_DATE_TYPES = {
+    "datetime.date",
+    "pendulum.date.Date",
+}
+_SERDE_TIMEDELTA_TYPES = {
+    "datetime.timedelta",
+}
+_SERDE_TIMEZONE_TYPES = {
+    "pendulum.tz.timezone.FixedTimezone",
+    "pendulum.tz.timezone.Timezone",
+    "zoneinfo.ZoneInfo",
+}
+
+
+def _deserialize_task_sdk_value(value):
+    """Deserialize a minimal subset of Task SDK serde values used in callback kwargs."""
+    if value is None or isinstance(value, bool | float | int | str):
+        return value
+
+    if isinstance(value, list):
+        return [_deserialize_task_sdk_value(item) for item in value]
+
+    if not isinstance(value, dict):
+        return value
+
+    if _SERDE_CLASSNAME not in value or _SERDE_VERSION not in value:
+        return {key: _deserialize_task_sdk_value(item) for key, item in value.items()}
+
+    classname = value[_SERDE_CLASSNAME]
+    data = _deserialize_task_sdk_value(value.get(_SERDE_DATA))
+
+    if classname in _SERDE_TUPLE_TYPES:
+        return _SERDE_TUPLE_TYPES[classname](data)
+
+    if classname in _SERDE_TIMEZONE_TYPES:
+        return _deserialize_task_sdk_timezone(data)
+
+    if classname in _SERDE_DATETIME_TYPES:
+        if not isinstance(data, dict) or _SERDE_DATETIME_TIMESTAMP not in data:
+            raise ValueError(f"Unsupported datetime serde payload: {value!r}")
+        tz = None
+        if _SERDE_DATETIME_TIMEZONE in data:
+            tz = _deserialize_task_sdk_timezone(data[_SERDE_DATETIME_TIMEZONE])
+        return datetime.fromtimestamp(float(data[_SERDE_DATETIME_TIMESTAMP]), tz=tz)
+
+    if classname in _SERDE_DATE_TYPES:
+        if not isinstance(data, str):
+            raise ValueError(f"Unsupported date serde payload: {value!r}")
+        return date.fromisoformat(data)
+
+    if classname in _SERDE_TIMEDELTA_TYPES:
+        return timedelta(seconds=float(data))
+
+    raise ValueError(f"Unsupported Task SDK serde value in callback kwargs: {classname}")
+
+
+def _deserialize_task_sdk_timezone(value):
+    """Deserialize timezone values produced by Task SDK serde."""
+    if value in (None, "UTC"):
+        return timezone.utc if value == "UTC" else None
+
+    if isinstance(value, int):
+        return timezone(timedelta(seconds=value))
+
+    if isinstance(value, str):
+        return ZoneInfo(value)
+
+    if isinstance(value, list) and len(value) == 3:
+        data, classname, _version = value
+        if classname in _SERDE_TIMEZONE_TYPES:
+            return _deserialize_task_sdk_timezone(data)
+
+    raise ValueError(f"Unsupported timezone serde payload: {value!r}")
+
+
+def _extract_callback_data(deadline_callback, dag_id):
+    """Convert the stored deadline callback payload into the new callback.data structure."""
+    callback = deadline_callback if isinstance(deadline_callback, dict) else json.loads(deadline_callback)
+    callback_data = callback.get(_SERDE_DATA)
+    if not isinstance(callback_data, dict):
+        raise ValueError(f"Deadline callback is missing {_SERDE_DATA}: {callback!r}")
+
+    callback_path = callback_data.get("path")
+    if not callback_path:
+        raise ValueError(f"Deadline callback is missing path: {callback!r}")
+
+    return {
+        "path": callback_path,
+        "kwargs": _deserialize_task_sdk_value(callback_data.get("kwargs", {})),
+        "prefix": _CALLBACK_METRICS_PREFIX,
+        "dag_id": dag_id,
+    }
+
+
+def _get_migrated_callback_state(callback_state):
+    """Return callback state and missed flag for the migrated callback row."""
+    if callback_state in _CALLBACK_TERMINAL_STATES:
+        return callback_state, True
+    return _CALLBACK_STATE_PENDING, False
 
 
 def upgrade():
     """Replace Deadline table's inline callback fields with callback_id foreign key."""
     import uuid6
-
-    from airflow.models.base import StringID
-    from airflow.models.callback import CallbackFetchMethod, CallbackState, CallbackType
-    from airflow.models.deadline import CALLBACK_METRICS_PREFIX
 
     timestamp = datetime.now(timezone.utc)
 
@@ -65,31 +182,17 @@ def upgrade():
             try:
                 callback_id = uuid6.uuid7()
 
-                # Transform serialized callback to the new representation
-                callback_data = deserialize(deadline.callback).serialize() | {
-                    "prefix": CALLBACK_METRICS_PREFIX,
-                    "dag_id": deadline.dag_id,
-                }
-
-                if deadline.callback_state and deadline.callback_state in {
-                    CallbackState.FAILED,
-                    CallbackState.SUCCESS,
-                }:
-                    deadline_missed = True
-                    callback_state = deadline.callback_state
-                else:
-                    # Mark the deadlines in non-terminal states as not missed so the scheduler handles them
-                    deadline_missed = False
-                    callback_state = CallbackState.PENDING
+                callback_data = _extract_callback_data(deadline.callback, deadline.dag_id)
+                callback_state, deadline_missed = _get_migrated_callback_state(deadline.callback_state)
 
                 callback_inserts.append(
                     {
                         "id": callback_id,
-                        "type": CallbackType.TRIGGERER,  # Past versions only support triggerer callbacks
-                        "fetch_method": CallbackFetchMethod.IMPORT_PATH,  # Past versions only support import_path
+                        "type": _CALLBACK_TYPE_TRIGGERER,
+                        "fetch_method": _CALLBACK_FETCH_METHOD_IMPORT_PATH,
                         "data": callback_data,
                         "state": callback_state,
-                        "priority_weight": 1,  # Default priority weight
+                        "priority_weight": 1,
                         "created_at": timestamp,
                     }
                 )
@@ -136,7 +239,7 @@ def upgrade():
         dag_run_table = table(
             "dag_run",
             column("id", sa.Integer()),
-            column("dag_id", StringID()),
+            column("dag_id", sa.String()),
         )
 
         callback_table = table(
@@ -152,26 +255,31 @@ def upgrade():
 
         conn = op.get_bind()
         batch_num = 0
+        last_seen_id = None
         while True:
             batch_num += 1
-            batch = conn.execute(
+            batch_query = (
                 select(
                     deadline_table.c.id,
-                    deadline_table.c.dagrun_id,
-                    deadline_table.c.deadline_time,
                     deadline_table.c.callback,
                     deadline_table.c.callback_state,
                     dag_run_table.c.dag_id,
                 )
                 .join(dag_run_table, deadline_table.c.dagrun_id == dag_run_table.c.id)
-                .where(deadline_table.c.callback_id.is_(None))  # Only get rows that haven't been migrated yet
+                .where(deadline_table.c.callback_id.is_(None))
+                .order_by(deadline_table.c.id)
                 .limit(BATCH_SIZE)
-            ).fetchall()
+            )
+            if last_seen_id is not None:
+                batch_query = batch_query.where(deadline_table.c.id > last_seen_id)
+
+            batch = conn.execute(batch_query).fetchall()
 
             if not batch:
                 break
 
             migrate_batch(conn, deadline_table, callback_table, batch)
+            last_seen_id = batch[-1].id
             print(f"Migrated {len(batch)} deadline records in batch {batch_num}")
 
     # Add new columns (temporarily nullable until data has been migrated)
@@ -199,7 +307,6 @@ def upgrade():
 
 def downgrade():
     """Restore Deadline table's inline callback fields from callback_id foreign key."""
-    from airflow.models.callback import CallbackState
 
     def migrate_batch(conn, deadline_table, callback_table, batch):
         deadline_updates = []
@@ -215,14 +322,14 @@ def downgrade():
                 # from airflow.sdk.definitions.deadline import AsyncCallback
                 # callback_serialized = serialize(AsyncCallback.deserialize(filtered_data, 0))
                 callback_serialized = {
-                    "__data__": filtered_cb_data,
-                    "__classname__": "airflow.sdk.definitions.deadline.AsyncCallback",
-                    "__version__": 0,
+                    _SERDE_DATA: filtered_cb_data,
+                    _SERDE_CLASSNAME: "airflow.sdk.definitions.deadline.AsyncCallback",
+                    _SERDE_VERSION: 0,
                 }
 
                 # Mark the deadline as not handled if its callback is not in a terminal state so that the
                 # scheduler handles it appropriately
-                if row.callback_state in {CallbackState.SUCCESS, CallbackState.FAILED}:
+                if row.callback_state in {_CALLBACK_STATE_SUCCESS, _CALLBACK_STATE_FAILED}:
                     callback_state = row.callback_state
                 else:
                     callback_state = None

--- a/airflow-core/src/airflow/migrations/versions/0108_3_2_0_fix_migration_file_ORM_inconsistencies.py
+++ b/airflow-core/src/airflow/migrations/versions/0108_3_2_0_fix_migration_file_ORM_inconsistencies.py
@@ -39,6 +39,178 @@ down_revision = "6222ce48e289"
 branch_labels = None
 depends_on = None
 airflow_version = "3.2.0"
+_TASK_INSTANCE_BATCH_SIZE = 10000
+_POOL_FIX_PREFIX = "__airflow_pool_fix_888b59e02a5b_"
+_VARIABLE_FIX_PREFIX = "__airflow_var_fix_888b59e02a5b_"
+_EXECUTOR_CONFIG_PICKLE_HEX = "80047d942e"
+
+
+def _build_connection_update_sql():
+    return """
+    UPDATE connection
+    SET
+        is_encrypted = COALESCE(is_encrypted, FALSE),
+        is_extra_encrypted = COALESCE(is_extra_encrypted, FALSE)
+    WHERE is_encrypted IS NULL OR is_extra_encrypted IS NULL
+    """
+
+
+def _build_dag_update_sql():
+    return """
+    UPDATE dag
+    SET
+        is_paused = COALESCE(is_paused, FALSE),
+        has_import_errors = COALESCE(has_import_errors, FALSE)
+    WHERE is_paused IS NULL OR has_import_errors IS NULL
+    """
+
+
+def _build_dag_run_update_sql():
+    return """
+    UPDATE dag_run
+    SET
+        state = COALESCE(state, 'queued'),
+        log_template_id = COALESCE(log_template_id, (SELECT max(id) FROM log_template)),
+        updated_at = COALESCE(updated_at, end_date, start_date, queued_at, logical_date, CURRENT_TIMESTAMP)
+    WHERE state IS NULL OR log_template_id IS NULL OR updated_at IS NULL
+    """
+
+
+def _build_log_update_sql():
+    return """
+    UPDATE log
+    SET dttm = COALESCE(dttm, logical_date, CURRENT_TIMESTAMP)
+    WHERE dttm IS NULL
+    """
+
+
+def _build_slot_pool_update_sql(dialect_name):
+    pool_fallback = (
+        f"CONCAT('{_POOL_FIX_PREFIX}', id)" if dialect_name == "mysql" else f"'{_POOL_FIX_PREFIX}' || id"
+    )
+    return f"""
+    UPDATE slot_pool
+    SET
+        slots = COALESCE(slots, 0),
+        pool = COALESCE(pool, {pool_fallback})
+    WHERE slots IS NULL OR pool IS NULL
+    """
+
+
+def _build_task_instance_update_sql(dialect_name):
+    executor_config_fallback = (
+        f"decode('{_EXECUTOR_CONFIG_PICKLE_HEX}', 'hex')"
+        if dialect_name == "postgresql"
+        else f"x'{_EXECUTOR_CONFIG_PICKLE_HEX}'"
+    )
+    return f"""
+    UPDATE task_instance
+    SET
+        try_number = COALESCE(try_number, 0),
+        max_tries = COALESCE(max_tries, -1),
+        hostname = COALESCE(hostname, ''),
+        unixname = COALESCE(unixname, ''),
+        queue = COALESCE(queue, 'default'),
+        priority_weight = COALESCE(priority_weight, 1),
+        custom_operator_name = COALESCE(custom_operator_name, COALESCE(operator, '')),
+        executor_config = COALESCE(executor_config, {executor_config_fallback})
+    WHERE
+        try_number IS NULL
+        OR max_tries IS NULL
+        OR hostname IS NULL
+        OR unixname IS NULL
+        OR queue IS NULL
+        OR priority_weight IS NULL
+        OR custom_operator_name IS NULL
+        OR executor_config IS NULL
+    """
+
+
+def _build_variable_update_sql(dialect_name):
+    key_column = "`key`" if dialect_name == "mysql" else "key"
+    key_fallback = (
+        f"CONCAT('{_VARIABLE_FIX_PREFIX}', id)"
+        if dialect_name == "mysql"
+        else f"'{_VARIABLE_FIX_PREFIX}' || id"
+    )
+    return f"""
+    UPDATE variable
+    SET
+        val = COALESCE(val, ''),
+        is_encrypted = COALESCE(is_encrypted, FALSE),
+        {key_column} = COALESCE({key_column}, {key_fallback})
+    WHERE val IS NULL OR is_encrypted IS NULL OR {key_column} IS NULL
+    """
+
+
+def _task_instance_null_filter(task_instance_table):
+    return sa.or_(
+        task_instance_table.c.try_number.is_(None),
+        task_instance_table.c.max_tries.is_(None),
+        task_instance_table.c.hostname.is_(None),
+        task_instance_table.c.unixname.is_(None),
+        task_instance_table.c.queue.is_(None),
+        task_instance_table.c.priority_weight.is_(None),
+        task_instance_table.c.custom_operator_name.is_(None),
+        task_instance_table.c.executor_config.is_(None),
+    )
+
+
+def _batch_update_task_instance():
+    """Backfill task_instance nulls in batches to reduce lock duration on large tables."""
+    conn = op.get_bind()
+    task_instance_table = sa.table(
+        "task_instance",
+        sa.column("id", sa.Uuid()),
+        sa.column("try_number", sa.Integer()),
+        sa.column("max_tries", sa.Integer()),
+        sa.column("hostname", sa.String()),
+        sa.column("unixname", sa.String()),
+        sa.column("queue", sa.String()),
+        sa.column("priority_weight", sa.Integer()),
+        sa.column("custom_operator_name", sa.String()),
+        sa.column("operator", sa.String()),
+        sa.column("executor_config", sa.LargeBinary()),
+    )
+
+    task_instance_null_filter = _task_instance_null_filter(task_instance_table)
+    executor_config_default = bytes.fromhex(_EXECUTOR_CONFIG_PICKLE_HEX)
+    last_seen_id = None
+
+    while True:
+        batch_query = (
+            sa.select(task_instance_table.c.id)
+            .where(task_instance_null_filter)
+            .order_by(task_instance_table.c.id)
+            .limit(_TASK_INSTANCE_BATCH_SIZE)
+        )
+        if last_seen_id is not None:
+            batch_query = batch_query.where(task_instance_table.c.id > last_seen_id)
+
+        batch_ids = conn.execute(batch_query).scalars().all()
+        if not batch_ids:
+            break
+
+        conn.execute(
+            task_instance_table.update()
+            .where(task_instance_table.c.id.in_(batch_ids))
+            .values(
+                try_number=sa.func.coalesce(task_instance_table.c.try_number, 0),
+                max_tries=sa.func.coalesce(task_instance_table.c.max_tries, -1),
+                hostname=sa.func.coalesce(task_instance_table.c.hostname, ""),
+                unixname=sa.func.coalesce(task_instance_table.c.unixname, ""),
+                queue=sa.func.coalesce(task_instance_table.c.queue, "default"),
+                priority_weight=sa.func.coalesce(task_instance_table.c.priority_weight, 1),
+                custom_operator_name=sa.func.coalesce(
+                    task_instance_table.c.custom_operator_name,
+                    sa.func.coalesce(task_instance_table.c.operator, ""),
+                ),
+                executor_config=sa.func.coalesce(
+                    task_instance_table.c.executor_config, executor_config_default
+                ),
+            )
+        )
+        last_seen_id = batch_ids[-1]
 
 
 def upgrade():
@@ -46,11 +218,8 @@ def upgrade():
     dialect_name = context.get_context().dialect.name
 
     # Use raw SQL so this migration remains usable in offline mode (--show-sql-only).
-    op.execute("UPDATE connection SET is_encrypted = FALSE WHERE is_encrypted IS NULL")
-    op.execute("UPDATE connection SET is_extra_encrypted = FALSE WHERE is_extra_encrypted IS NULL")
-
-    op.execute("UPDATE dag SET is_paused = FALSE WHERE is_paused IS NULL")
-    op.execute("UPDATE dag SET has_import_errors = FALSE WHERE has_import_errors IS NULL")
+    op.execute(_build_connection_update_sql())
+    op.execute(_build_dag_update_sql())
 
     op.execute(
         """
@@ -63,56 +232,18 @@ def upgrade():
         """
     )
 
-    op.execute("UPDATE dag_run SET state = 'queued' WHERE state IS NULL")
-    op.execute(
-        """
-        UPDATE dag_run
-        SET log_template_id = (SELECT max(id) FROM log_template)
-        WHERE log_template_id IS NULL
-        """
-    )
-    op.execute(
-        """
-        UPDATE dag_run
-        SET updated_at = COALESCE(end_date, start_date, queued_at, logical_date, CURRENT_TIMESTAMP)
-        WHERE updated_at IS NULL
-        """
-    )
+    op.execute(_build_dag_run_update_sql())
 
-    op.execute("UPDATE log SET dttm = COALESCE(logical_date, CURRENT_TIMESTAMP) WHERE dttm IS NULL")
+    op.execute(_build_log_update_sql())
 
-    op.execute("UPDATE slot_pool SET slots = 0 WHERE slots IS NULL")
-    if dialect_name == "mysql":
-        op.execute(
-            "UPDATE slot_pool SET pool = CONCAT('__airflow_pool_fix_888b59e02a5b_', id) WHERE pool IS NULL"
-        )
+    op.execute(_build_slot_pool_update_sql(dialect_name))
+
+    if context.is_offline_mode():
+        op.execute(_build_task_instance_update_sql(dialect_name))
     else:
-        op.execute("UPDATE slot_pool SET pool = '__airflow_pool_fix_888b59e02a5b_' || id WHERE pool IS NULL")
+        _batch_update_task_instance()
 
-    op.execute("UPDATE task_instance SET try_number = 0 WHERE try_number IS NULL")
-    op.execute("UPDATE task_instance SET max_tries = -1 WHERE max_tries IS NULL")
-    op.execute("UPDATE task_instance SET hostname = '' WHERE hostname IS NULL")
-    op.execute("UPDATE task_instance SET unixname = '' WHERE unixname IS NULL")
-    op.execute("UPDATE task_instance SET queue = 'default' WHERE queue IS NULL")
-    op.execute("UPDATE task_instance SET priority_weight = 1 WHERE priority_weight IS NULL")
-    op.execute(
-        "UPDATE task_instance SET custom_operator_name = COALESCE(operator, '') WHERE custom_operator_name IS NULL"
-    )
-    if dialect_name == "postgresql":
-        op.execute(
-            "UPDATE task_instance SET executor_config = decode('80047d942e', 'hex') WHERE executor_config IS NULL"
-        )
-    else:
-        op.execute("UPDATE task_instance SET executor_config = x'80047d942e' WHERE executor_config IS NULL")
-
-    op.execute("UPDATE variable SET val = '' WHERE val IS NULL")
-    op.execute("UPDATE variable SET is_encrypted = FALSE WHERE is_encrypted IS NULL")
-    if dialect_name == "mysql":
-        op.execute(
-            "UPDATE variable SET `key` = CONCAT('__airflow_var_fix_888b59e02a5b_', id) WHERE `key` IS NULL"
-        )
-    else:
-        op.execute("UPDATE variable SET key = '__airflow_var_fix_888b59e02a5b_' || id WHERE key IS NULL")
+    op.execute(_build_variable_update_sql(dialect_name))
 
     with op.batch_alter_table("connection", schema=None) as batch_op:
         batch_op.alter_column("is_encrypted", existing_type=sa.BOOLEAN(), nullable=False)


### PR DESCRIPTION
- Replace ORM model imports (CallbackState, CallbackType, etc.) with inline constants so migration loading doesn't pull in the full Airflow runtime
- Inline Task SDK serde deserialization in 0094 to eliminate the airflow.sdk.serde import
- Use keyset pagination for batch queries in 0094 instead of re-scanning unmigrated rows
- Batch task_instance NULL backfill in 0108 (10k rows at a time) to reduce lock duration on large tables
- Consolidate per-column UPDATE statements into single per-table UPDATEs to reduce database round-trips

 
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

GPT-5.4

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
