### PR TITLE
Remove various upper version bounds in the FAB provider

### DIFF
--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -110,7 +110,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=3.0.2``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
-``flask``                                   ``>=2.2.1,<2.3``
+``flask``                                   ``>=2.2.1``
 ``flask-appbuilder``                        ``==5.2.0``
 ``flask-login``                             ``>=0.6.2``
 ``flask-session``                           ``>=0.8.0``
@@ -118,11 +118,11 @@ PIP package                                 Version required
 ``flask-sqlalchemy``                        ``>=3.0.5``
 ``flask-wtf``                               ``>=1.1.0``
 ``jmespath``                                ``>=0.7.0``
-``werkzeug``                                ``>=2.2,<4``
-``wtforms``                                 ``>=3.0,<4``
+``werkzeug``                                ``>=2.2``
+``wtforms``                                 ``>=3.0``
 ``cachetools``                              ``>=6.0``
 ``marshmallow``                             ``>=3``
-``flask_limiter``                           ``>3,!=3.13,<4``
+``flask_limiter``                           ``>3,!=3.13``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -70,10 +70,7 @@ dependencies = [
     # Blinker use for signals in Flask, this is an optional dependency in Flask 2.2 and lower.
     # In Flask 2.3 it becomes a mandatory dependency, and flask signals are always available.
     "blinker>=1.6.2",
-    # Flask 2.3 is scheduled to introduce a number of deprecation removals - some of them might be breaking
-    # for our dependencies - notably `_app_ctx_stack` and `_request_ctx_stack` removals.
-    # We should remove the limitation after 2.3 is released and our dependencies are updated to handle it
-    "flask>=2.2.1,<2.3",
+    "flask>=2.2.1",
     # We are tightly coupled with FAB version as we vendored-in part of FAB code related to security manager
     # This is done as part of preparation to removing FAB as dependency, but we are not ready for it yet
     # Every time we update FAB version here, please make sure that you review the classes and models in
@@ -86,14 +83,14 @@ dependencies = [
     "flask-sqlalchemy>=3.0.5",
     "flask-wtf>=1.1.0",
     "jmespath>=0.7.0",
-    "werkzeug>=2.2,<4",
-    "wtforms>=3.0,<4",
+    "werkzeug>=2.2",
+    "wtforms>=3.0",
     "cachetools>=6.0",
     "marshmallow>=3",
 
     # https://github.com/dpgaspar/Flask-AppBuilder/blob/release/4.6.3/setup.py#L54C8-L54C26
     # with an exclusion to account for https://github.com/alisaifee/flask-limiter/issues/479
-    "flask_limiter>3,<4,!=3.13",
+    "flask_limiter>3,!=3.13",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/uv.lock
+++ b/uv.lock
@@ -4575,9 +4575,9 @@ requires-dist = [
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "blinker", specifier = ">=1.6.2" },
     { name = "cachetools", specifier = ">=6.0" },
-    { name = "flask", specifier = ">=2.2.1,<2.3" },
+    { name = "flask", specifier = ">=2.2.1" },
     { name = "flask-appbuilder", specifier = "==5.2.0" },
-    { name = "flask-limiter", specifier = ">3,!=3.13,<4" },
+    { name = "flask-limiter", specifier = ">3,!=3.13" },
     { name = "flask-login", specifier = ">=0.6.2" },
     { name = "flask-session", specifier = ">=0.8.0" },
     { name = "flask-sqlalchemy", specifier = ">=3.0.5" },
@@ -4586,8 +4586,8 @@ requires-dist = [
     { name = "kerberos", marker = "extra == 'kerberos'", specifier = ">=1.3.0" },
     { name = "marshmallow", specifier = ">=3" },
     { name = "msgpack", specifier = ">=1.0.0" },
-    { name = "werkzeug", specifier = ">=2.2,<4" },
-    { name = "wtforms", specifier = ">=3.0,<4" },
+    { name = "werkzeug", specifier = ">=2.2" },
+    { name = "wtforms", specifier = ">=3.0" },
 ]
 provides-extras = ["kerberos"]
 


### PR DESCRIPTION
With uv dependency resolution, upstream limits are automatically enforced. I'm attempting to remove our local limits in case they are outdated (e.g. pre-FAB5) and unnecessary.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
