### PR TITLE
Revert run test filtering logic not to skip pytest by breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -249,9 +249,10 @@ def _run_test(
     pytest_args.extend(extra_pytest_args)
     # Skip "FOLDER" in case "--ignore=FOLDER" is passed as an argument
     # Which might be the case if we are ignoring some providers during compatibility checks
+    pytest_args_before_skip = pytest_args
     pytest_args = [arg for arg in pytest_args if f"--ignore={arg}" not in pytest_args]
     # If no test directory is left (all positional args were excluded/ignored), skip
-    if pytest_args and pytest_args[0].startswith("--"):
+    if pytest_args_before_skip != pytest_args and pytest_args[0].startswith("--"):
         return 0, f"Skipped test, no tests needed: {shell_params.test_type}"
     run_cmd.extend(pytest_args)
     try:


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/63793

Unit tests in Breeze that were previously passing have stopped running.
```
breeze testing core-tests --backend sqlite airflow-core/tests/unit/serialization/test_helpers.py
```

It was identified that a change to the pytest skip logic in this PR caused these tests to be filtered out. Commands like the one above have a test_type of "None", which means the args start with -- from the beginning, causing them to always be caught by the filtering logic. Reverted the filtering logic to its original implementation.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
