### PR TITLE
fix: DAG serialization with timezone-aware datetime objects

### DIFF
--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -106,7 +106,7 @@ def encode_relativedelta(var: relativedelta) -> dict[str, Any]:
     return encoded
 
 
-def encode_timezone(var: str | pendulum.Timezone | pendulum.FixedTimezone) -> str | int:
+def encode_timezone(var: str | pendulum.Timezone | pendulum.FixedTimezone | datetime.timezone) -> str | int:
     """
     Encode a Pendulum Timezone for serialization.
 
@@ -119,6 +119,15 @@ def encode_timezone(var: str | pendulum.Timezone | pendulum.FixedTimezone) -> st
     """
     if isinstance(var, str):
         return var
+    if isinstance(var, datetime.timezone):
+        # Handle standard library timezone objects (e.g., datetime.timezone.utc)
+        offset = var.utcoffset(None)
+        if offset is None:
+            raise ValueError(f"Cannot serialize timezone {var!r} without UTC offset")
+        offset_seconds = offset.total_seconds()
+        if offset_seconds == 0:
+            return "UTC"
+        return int(offset_seconds)
     if isinstance(var, pendulum.FixedTimezone):
         if var.offset == 0:
             return "UTC"

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -524,7 +524,7 @@ class BaseSerialization:
             return cls._encode(var.timestamp(), type_=DAT.DATETIME)
         elif isinstance(var, datetime.timedelta):
             return cls._encode(var.total_seconds(), type_=DAT.TIMEDELTA)
-        elif isinstance(var, (Timezone, FixedTimezone)):
+        elif isinstance(var, (Timezone, FixedTimezone, datetime.timezone)):
             return cls._encode(encode_timezone(var), type_=DAT.TIMEZONE)
         elif isinstance(var, relativedelta.relativedelta):
             return cls._encode(encode_relativedelta(var), type_=DAT.RELATIVEDELTA)


### PR DESCRIPTION
Fixes #48765

Handle standard library datetime.timezone objects in encode_timezone.
Previously, using datetime.timezone.utc or other stdlib timezone objects
in DAGs would cause serialization to fail with ValueError.

The fix converts datetime.timezone to its UTC offset in seconds for
serialization, treating zero offset as 'UTC' for consistency with
Pendulum timezone handling.

Changes:
- Modified encode_timezone() in encoders.py to handle datetime.timezone
- Updated serialize() in serialized_objects.py to include datetime.timezone check

Tested with:
- datetime.timezone.utc
- Positive offsets (e.g., +05:30)
- Negative offsets (e.g., -08:00)  
- Zero offset (returns 'UTC')
- Existing Pendulum timezone objects still work correctly