### PR TITLE
UI Fix for date input 'year' unmodifiable

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -22,7 +22,6 @@ import tz from "dayjs/plugin/timezone";
 import { forwardRef } from "react";
 
 import { useTimezone } from "src/context/timezone";
-import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
 
 dayjs.extend(tz);
 
@@ -32,12 +31,6 @@ type Props = {
 
 export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
   const { selectedTimezone } = useTimezone();
-
-  // Convert UTC value to local time for display
-  const displayValue =
-    Boolean(value) && dayjs(value).isValid()
-      ? dayjs(value).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT)
-      : "";
 
   return (
     <Input
@@ -55,7 +48,6 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
       }
       ref={ref}
       type="datetime-local"
-      value={displayValue}
       {...rest}
     />
   );


### PR DESCRIPTION
Follow-up to https://github.com/apache/airflow/pull/57880

## Problem
When the date input is full, the year field can't be modified

## Why
The value is converted to a dayjs object, which parses a year with 2 digits from 00xx (which occurs while typing) to 19xx 
For example, dayjs(0002-03-17T15:33) = Mon, 17 Mar 1902 15:13:30
https://github.com/iamkun/dayjs/issues/1237


https://github.com/user-attachments/assets/209f8d62-e5a6-4ad9-bde5-da6fdb89d06e



## Possible solution
Avoid passing back the parsed date value to the component
The displayed value will remain the same, but the actual value (which is 'watched' by other forms) will be in UTC

Possible problems with this approach:
When typing from 2026 to 2025, the actual value will be:
2026 -> 1902 -> 1920 -> 0202 -> 2025
But the year being displayed to the user will be:
2026 -> 0002 -> 0020 -> 0202 -> 2025
Lmk what you think, or is display discrepancy is too unexpected