### PR TITLE
UI Fix: Date time input 'year' field unmodifiable

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -27,7 +27,7 @@ import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
 
 dayjs.extend(tz);
 
-const debounceDelay = 500;
+const debounceDelay = 1000;
 
 type Props = {
   readonly value: string;
@@ -41,8 +41,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
     const valid = dayjs(event.target.value).isValid();
     // UI Timezone -> Utc -> yyyy-mm-ddThh:mmZ
     const utc = valid ? dayjs.tz(event.target.value, selectedTimezone).toISOString() : "";
-    const local =
-      Boolean(utc) && valid ? dayjs(utc).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT) : "";
+    const local = Boolean(utc) ? dayjs(utc).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT) : "";
 
     // Set display value to be from utc to local to avoid year mismatch
     // As dayjs() parses years before 1000 incorrectly, see dayjs/issues/1237

--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -36,33 +36,35 @@ type Props = {
 export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
   const { selectedTimezone } = useTimezone();
   const [displayDate, setDisplayDate] = useState(value);
-  const deboundedOnDateChange = useDebouncedCallback((e: ChangeEvent<HTMLInputElement>) => onDateChange(e), debounceDelay);
 
   const onDateChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const valid = dayjs(event.target.value).isValid()
+    const valid = dayjs(event.target.value).isValid();
     // UI Timezone -> Utc -> yyyy-mm-ddThh:mmZ
-    const utc = valid? dayjs.tz(event.target.value, selectedTimezone).toISOString() : ""
-    const local = Boolean(utc) && valid? 
-    dayjs(utc).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT)
-      : "";
+    const utc = valid ? dayjs.tz(event.target.value, selectedTimezone).toISOString() : "";
+    const local =
+      Boolean(utc) && valid ? dayjs(utc).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT) : "";
 
     // Set display value to be from utc to local to avoid year mismatch
-    // As dayjs() parses years before 1000 incorrectly, see dayjs/issues/1237 
-    setDisplayDate(local)
-    onChange?.({...event, target:{...event.target, value: utc}})
+    // As dayjs() parses years before 1000 incorrectly, see dayjs/issues/1237
+    setDisplayDate(local);
+    onChange?.({ ...event, target: { ...event.target, value: utc } });
   };
-  
+
+  const debouncedOnDateChange = useDebouncedCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onDateChange(event),
+    debounceDelay,
+  );
+
   return (
     <Input
       data-testid="datetime-input"
-      onChange={(event) =>
-        {
-          const local = dayjs(event.target.value).isValid()? event.target.value : ""
-          setDisplayDate(local)
-          // Parse input to UTC once user finishes typing
-          deboundedOnDateChange(event)
-        }
-      }
+      onChange={(event) => {
+        const local = dayjs(event.target.value).isValid() ? event.target.value : "";
+
+        setDisplayDate(local);
+        // Parse input to UTC once user finishes typing
+        debouncedOnDateChange(event);
+      }}
       ref={ref}
       type="datetime-local"
       value={displayDate}

--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -19,11 +19,15 @@
 import { Input, type InputProps } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import tz from "dayjs/plugin/timezone";
-import { forwardRef } from "react";
+import { forwardRef, type ChangeEvent, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import { useTimezone } from "src/context/timezone";
+import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
 
 dayjs.extend(tz);
+
+const debounceDelay = 500;
 
 type Props = {
   readonly value: string;
@@ -31,23 +35,37 @@ type Props = {
 
 export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
   const { selectedTimezone } = useTimezone();
+  const [displayDate, setDisplayDate] = useState(value);
+  const deboundedOnDateChange = useDebouncedCallback((e: ChangeEvent<HTMLInputElement>) => onDateChange(e), debounceDelay);
 
+  const onDateChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const valid = dayjs(event.target.value).isValid()
+    // UI Timezone -> Utc -> yyyy-mm-ddThh:mmZ
+    const utc = valid? dayjs.tz(event.target.value, selectedTimezone).toISOString() : ""
+    const local = Boolean(utc) && valid? 
+    dayjs(utc).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT)
+      : "";
+
+    // Set display value to be from utc to local to avoid year mismatch
+    // As dayjs() parses years before 1000 incorrectly, see dayjs/issues/1237 
+    setDisplayDate(local)
+    onChange?.({...event, target:{...event.target, value: utc}})
+  };
+  
   return (
     <Input
       data-testid="datetime-input"
       onChange={(event) =>
-        onChange?.({
-          ...event,
-          target: {
-            ...event.target,
-            value: dayjs(event.target.value).isValid()
-              ? dayjs.tz(event.target.value, selectedTimezone).toISOString() // UI Timezone -> Utc -> yyyy-mm-ddThh:mm
-              : "",
-          },
-        })
+        {
+          const local = dayjs(event.target.value).isValid()? event.target.value : ""
+          setDisplayDate(local)
+          // Parse input to UTC once user finishes typing
+          deboundedOnDateChange(event)
+        }
       }
       ref={ref}
       type="datetime-local"
+      value={displayDate}
       {...rest}
     />
   );

--- a/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DateTimeInput.tsx
@@ -22,7 +22,6 @@ import tz from "dayjs/plugin/timezone";
 import { forwardRef } from "react";
 
 import { useTimezone } from "src/context/timezone";
-import { DEFAULT_DATETIME_FORMAT } from "src/utils/datetimeUtils";
 
 dayjs.extend(tz);
 
@@ -32,12 +31,6 @@ type Props = {
 
 export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, value, ...rest }, ref) => {
   const { selectedTimezone } = useTimezone();
-
-  // Convert UTC value to local time for display
-  const displayValue =
-    Boolean(value) && dayjs(value).isValid()
-      ? dayjs(value).tz(selectedTimezone).format(DEFAULT_DATETIME_FORMAT)
-      : "";
 
   return (
     <Input
@@ -55,7 +48,6 @@ export const DateTimeInput = forwardRef<HTMLInputElement, Props>(({ onChange, va
       }
       ref={ref}
       type="datetime-local"
-      value={displayValue}
       {...rest}
     />
   );


### PR DESCRIPTION
Follow-up to https://github.com/apache/airflow/pull/57880

## Problem
When the date input is full, the year field can't be modified

## Why
The value is converted to a dayjs object, which parses a year with 2 digits from 00xx (which occurs while typing) to 19xx 
For example, dayjs(0002-03-17T15:33) = Mon, 17 Mar 1902 15:13:30
https://github.com/iamkun/dayjs/issues/1237


https://github.com/user-attachments/assets/209f8d62-e5a6-4ad9-bde5-da6fdb89d06e



## Possible solution
Avoid passing back the parsed date value to the component
The displayed value will remain the same, but the actual value (which is 'watched' by other forms) will be in UTC

Possible problems with this approach:
When typing from 2026 to 2025, the actual value will be:
2026 -> 1902 -> 1920 -> 0202 -> 2025
But the year being displayed to the user will be:
2026 -> 0002 -> 0020 -> 0202 -> 2025
Lmk what you think, with the display discrepancy in mind