### PR TITLE
Add bulk delete and mark actions to Task Instances page (#63855)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -298,6 +298,13 @@
         "title": "Bulk Delete {{resourceName}} Request Submitted"
       }
     },
+    "bulkUpdate": {
+      "error": "Bulk Update {{resourceName}} Request Failed",
+      "success": {
+        "description": "{{count}} {{resourceName}} have been successfully updated.",
+        "title": "Bulk Update {{resourceName}} Request Submitted"
+      }
+    },
     "create": {
       "error": "Create {{resourceName}} Request Failed",
       "success": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
@@ -28,6 +28,24 @@
       "noItemsFound": "No tasks found.",
       "title": "Affected Tasks: {{count}}"
     },
+    "bulkDelete": {
+      "button": "Delete",
+      "dialog": {
+        "confirmMessage": "This action is permanent and cannot be undone. Are you sure?",
+        "title_one": "Delete {{count}} Task Instance",
+        "title_other": "Delete {{count}} Task Instances"
+      },
+      "selected": "Selected",
+      "tooltip": "Delete selected task instances"
+    },
+    "bulkMarkAs": {
+      "button": "Mark As...",
+      "dialog": {
+        "title_one": "Mark {{count}} Task Instance As",
+        "title_other": "Mark {{count}} Task Instances As"
+      },
+      "tooltip": "Mark selected task instances as success or failed"
+    },
     "clear": {
       "button": "Clear {{type}}",
       "buttonTooltip": "Press shift+c to clear",

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -28,6 +28,7 @@ import { Tooltip } from "src/components/ui";
 import ClearTaskInstanceDialog from "./ClearTaskInstanceDialog";
 
 type Props = {
+  readonly disabled?: boolean;
   readonly groupTaskInstance?: LightGridTaskInstanceSummary;
   readonly isHotkeyEnabled?: boolean;
   // Optional: allow parent to handle opening a stable, page-level dialog
@@ -36,6 +37,7 @@ type Props = {
 };
 
 const ClearTaskInstanceButton = ({
+  disabled,
   groupTaskInstance,
   isHotkeyEnabled = false,
   onOpen,
@@ -76,6 +78,7 @@ const ClearTaskInstanceButton = ({
             type: translate("taskInstance_one"),
           })}
           colorPalette="brand"
+          disabled={disabled}
           onClick={() => (onOpen && selectedInstance ? onOpen(selectedInstance) : onOpenInternal())}
           size="md"
           variant="ghost"

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -31,11 +31,12 @@ import { allowedStates } from "../utils";
 import MarkTaskInstanceAsDialog from "./MarkTaskInstanceAsDialog";
 
 type Props = {
+  readonly disabled?: boolean;
   readonly isHotkeyEnabled?: boolean;
   readonly taskInstance: TaskInstanceResponse;
 };
 
-const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Props) => {
+const MarkTaskInstanceAsButton = ({ disabled, isHotkeyEnabled = false, taskInstance }: Props) => {
   const { onClose, onOpen, open } = useDisclosure();
   const { t: translate } = useTranslation();
 
@@ -74,6 +75,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
                   type: translate("taskInstance_one"),
                 })}
                 colorPalette="brand"
+                disabled={disabled}
                 size="md"
                 variant="ghost"
               >

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/BulkDeleteTaskInstancesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/BulkDeleteTaskInstancesButton.tsx
@@ -1,0 +1,77 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Flex, Heading, Text, useDisclosure, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { FiTrash2 } from "react-icons/fi";
+
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { Dialog } from "src/components/ui";
+import { useBulkDeleteTaskInstances } from "src/queries/useBulkDeleteTaskInstances";
+
+type Props = {
+  readonly clearSelections: VoidFunction;
+  readonly selectedRows: Map<string, boolean>;
+};
+
+const BulkDeleteTaskInstancesButton = ({ clearSelections, selectedRows }: Props) => {
+  const { t: translate } = useTranslation("dags");
+  const { onClose, onOpen, open } = useDisclosure();
+  const { bulkDelete, error, isPending } = useBulkDeleteTaskInstances({
+    clearSelections,
+    onSuccessConfirm: onClose,
+  });
+
+  return (
+    <>
+      <Button colorPalette="danger" onClick={onOpen} size="sm" variant="outline">
+        <FiTrash2 />
+        {translate("runAndTaskActions.bulkDelete.button")}
+      </Button>
+
+      <Dialog.Root onOpenChange={onClose} open={open} size="xl">
+        <Dialog.Content backdrop>
+          <Dialog.Header>
+            <VStack align="start" gap={4}>
+              <Heading size="xl">
+                {translate("runAndTaskActions.bulkDelete.dialog.title", {
+                  count: selectedRows.size,
+                })}
+              </Heading>
+            </VStack>
+          </Dialog.Header>
+          <Dialog.CloseTrigger />
+          <Dialog.Body width="full">
+            <Text color="fg" fontSize="md" fontWeight="semibold" mb={4}>
+              {translate("runAndTaskActions.bulkDelete.dialog.confirmMessage")}
+            </Text>
+            <ErrorAlert error={error} />
+            <Flex justifyContent="end" mt={3}>
+              <Button colorPalette="danger" loading={isPending} onClick={() => bulkDelete(selectedRows)}>
+                <FiTrash2 />
+                <Text fontWeight="bold">{translate("runAndTaskActions.bulkDelete.button")}</Text>
+              </Button>
+            </Flex>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
+};
+
+export default BulkDeleteTaskInstancesButton;

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/BulkMarkTaskInstancesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/BulkMarkTaskInstancesButton.tsx
@@ -1,0 +1,90 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Flex, Heading, HStack, useDisclosure, VStack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { FiX } from "react-icons/fi";
+import { LuCheck } from "react-icons/lu";
+
+import { ErrorAlert } from "src/components/ErrorAlert";
+import { Dialog } from "src/components/ui";
+import { useBulkMarkTaskInstances } from "src/queries/useBulkMarkTaskInstances";
+
+type Props = {
+  readonly clearSelections: VoidFunction;
+  readonly selectedRows: Map<string, boolean>;
+};
+
+const BulkMarkTaskInstancesButton = ({ clearSelections, selectedRows }: Props) => {
+  const { t: translate } = useTranslation(["common", "dags"]);
+  const { onClose, onOpen, open } = useDisclosure();
+  const { bulkMark, error, isPending } = useBulkMarkTaskInstances({
+    clearSelections,
+    onSuccessConfirm: onClose,
+  });
+
+  return (
+    <>
+      <Button onClick={onOpen} size="sm" variant="outline">
+        {translate("dags:runAndTaskActions.bulkMarkAs.button")}
+      </Button>
+
+      <Dialog.Root onOpenChange={onClose} open={open} size="xl">
+        <Dialog.Content backdrop>
+          <Dialog.Header>
+            <VStack align="start" gap={4}>
+              <Heading size="xl">
+                {translate("dags:runAndTaskActions.bulkMarkAs.dialog.title", {
+                  count: selectedRows.size,
+                })}
+              </Heading>
+            </VStack>
+          </Dialog.Header>
+          <Dialog.CloseTrigger />
+          <Dialog.Body width="full">
+            <ErrorAlert error={error} />
+            <Flex justifyContent="end" mt={3}>
+              <HStack>
+                <Button
+                  colorPalette="success"
+                  loading={isPending}
+                  onClick={() => bulkMark(selectedRows, "success")}
+                  variant="outline"
+                >
+                  <LuCheck />
+                  {translate("common:states.success")}
+                </Button>
+                <Button
+                  colorPalette="danger"
+                  loading={isPending}
+                  onClick={() => bulkMark(selectedRows, "failed")}
+                  variant="outline"
+                >
+                  <FiX />
+                  {translate("common:states.failed")}
+                </Button>
+              </HStack>
+            </Flex>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+    </>
+  );
+};
+
+export default BulkMarkTaskInstancesButton;

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/DeleteTaskInstanceButton.tsx
@@ -26,10 +26,11 @@ import { Tooltip } from "src/components/ui";
 import { useDeleteTaskInstance } from "src/queries/useDeleteTaskInstance";
 
 type DeleteTaskInstanceButtonProps = {
+  readonly disabled?: boolean;
   readonly taskInstance: TaskInstanceResponse;
 };
 
-const DeleteTaskInstanceButton = ({ taskInstance }: DeleteTaskInstanceButtonProps) => {
+const DeleteTaskInstanceButton = ({ disabled, taskInstance }: DeleteTaskInstanceButtonProps) => {
   const { onClose, onOpen, open } = useDisclosure();
   const { t: translate } = useTranslation();
 
@@ -53,6 +54,7 @@ const DeleteTaskInstanceButton = ({ taskInstance }: DeleteTaskInstanceButtonProp
             type: translate("taskInstance_one"),
           })}
           colorPalette="danger"
+          disabled={disabled}
           onClick={onOpen}
           size="md"
           variant="ghost"

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -29,16 +29,22 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
 import { DataTable } from "src/components/DataTable";
+import { useRowSelection } from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
+import { Tooltip } from "src/components/ui";
+import { ActionBar } from "src/components/ui/ActionBar";
+import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAutoRefresh, isStatePending, renderDuration } from "src/utils";
 import { getTaskInstanceLink } from "src/utils/links";
 
+import BulkDeleteTaskInstancesButton from "./BulkDeleteTaskInstancesButton";
+import BulkMarkTaskInstancesButton from "./BulkMarkTaskInstancesButton";
 import DeleteTaskInstanceButton from "./DeleteTaskInstanceButton";
 import { TaskInstancesFilter } from "./TaskInstancesFilter";
 
@@ -63,17 +69,52 @@ const {
   TRY_NUMBER: TRY_NUMBER_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
+const taskKey = (ti: TaskInstanceResponse) =>
+  `${ti.dag_id}||${ti.dag_run_id}||${ti.task_id}||${ti.map_index}`;
+
 const taskInstanceColumns = ({
+  allRowsSelected,
   dagId,
+  onRowSelect,
+  onSelectAll,
   runId,
+  selectedRows,
   taskId,
   translate,
 }: {
+  allRowsSelected: boolean;
   dagId?: string;
+  onRowSelect: (key: string, isChecked: boolean) => void;
+  onSelectAll: (isChecked: boolean) => void;
   runId?: string;
+  selectedRows: Map<string, boolean>;
   taskId?: string;
   translate: TFunction;
 }): Array<ColumnDef<TaskInstanceResponse>> => [
+  {
+    accessorKey: "select",
+    cell: ({ row }) => (
+      <Checkbox
+        borderWidth={1}
+        checked={selectedRows.get(taskKey(row.original))}
+        colorPalette="brand"
+        onCheckedChange={(event) => onRowSelect(taskKey(row.original), Boolean(event.checked))}
+      />
+    ),
+    enableHiding: false,
+    enableSorting: false,
+    header: () => (
+      <Checkbox
+        borderWidth={1}
+        checked={allRowsSelected}
+        colorPalette="brand"
+        onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
+      />
+    ),
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
   ...(Boolean(dagId)
     ? []
     : [
@@ -206,9 +247,9 @@ const taskInstanceColumns = ({
     accessorKey: "actions",
     cell: ({ row }) => (
       <Flex justifyContent="end">
-        <ClearTaskInstanceButton taskInstance={row.original} />
-        <MarkTaskInstanceAsButton taskInstance={row.original} />
-        <DeleteTaskInstanceButton taskInstance={row.original} />
+        <ClearTaskInstanceButton disabled={selectedRows.size > 0} taskInstance={row.original} />
+        <MarkTaskInstanceAsButton disabled={selectedRows.size > 0} taskInstance={row.original} />
+        <DeleteTaskInstanceButton disabled={selectedRows.size > 0} taskInstance={row.original} />
       </Flex>
     ),
     enableSorting: false,
@@ -292,9 +333,19 @@ export const TaskInstances = () => {
     },
   );
 
+  const { allRowsSelected, clearSelections, handleRowSelect, handleSelectAll, selectedRows } =
+    useRowSelection({
+      data: data?.task_instances,
+      getKey: taskKey,
+    });
+
   const columns = taskInstanceColumns({
+    allRowsSelected,
     dagId,
+    onRowSelect: handleRowSelect,
+    onSelectAll: handleSelectAll,
     runId,
+    selectedRows,
     taskId: Boolean(groupId) ? undefined : taskId,
     translate,
   });
@@ -312,6 +363,21 @@ export const TaskInstances = () => {
         onStateChange={setTableURLState}
         total={data?.total_entries}
       />
+      <ActionBar.Root closeOnInteractOutside={false} open={Boolean(selectedRows.size)}>
+        <ActionBar.Content>
+          <ActionBar.SelectionTrigger>
+            {selectedRows.size} {translate("dags:runAndTaskActions.bulkDelete.selected")}
+          </ActionBar.SelectionTrigger>
+          <ActionBar.Separator />
+          <Tooltip content={translate("dags:runAndTaskActions.bulkMarkAs.tooltip")}>
+            <BulkMarkTaskInstancesButton clearSelections={clearSelections} selectedRows={selectedRows} />
+          </Tooltip>
+          <Tooltip content={translate("dags:runAndTaskActions.bulkDelete.tooltip")}>
+            <BulkDeleteTaskInstancesButton clearSelections={clearSelections} selectedRows={selectedRows} />
+          </Tooltip>
+          <ActionBar.CloseTrigger onClick={clearSelections} />
+        </ActionBar.Content>
+      </ActionBar.Root>
     </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/queries/useBulkDeleteTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useBulkDeleteTaskInstances.ts
@@ -1,0 +1,105 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  useTaskInstanceServiceBulkTaskInstances,
+  useTaskInstanceServiceGetTaskInstancesKey,
+} from "openapi/queries";
+import type { BulkResponse } from "openapi/requests/types.gen";
+import { toaster } from "src/components/ui";
+
+type Props = {
+  readonly clearSelections: VoidFunction;
+  readonly onSuccessConfirm: VoidFunction;
+};
+
+const parseTaskInstanceKey = (key: string) => {
+  const [dagId = "", dagRunId = "", taskId = "", mapIndexStr] = key.split("||");
+
+  return {
+    dag_id: dagId,
+    dag_run_id: dagRunId,
+    map_index: mapIndexStr === undefined ? -1 : Number(mapIndexStr),
+    task_id: taskId,
+  };
+};
+
+export const useBulkDeleteTaskInstances = ({ clearSelections, onSuccessConfirm }: Props) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<unknown>(undefined);
+  const { t: translate } = useTranslation(["common", "dags"]);
+
+  const onSuccess = async (responseData: BulkResponse) => {
+    await queryClient.invalidateQueries({
+      queryKey: [useTaskInstanceServiceGetTaskInstancesKey],
+    });
+
+    if (responseData.delete) {
+      const { errors, success } = responseData.delete;
+
+      if (Array.isArray(errors) && errors.length > 0) {
+        const apiError = errors[0] as { error: string };
+
+        setError({ body: { detail: apiError.error } });
+      } else if (Array.isArray(success) && success.length > 0) {
+        toaster.create({
+          description: translate("toaster.bulkDelete.success.description", {
+            count: success.length,
+            keys: success.join(", "),
+            resourceName: translate("common:taskInstance_other"),
+          }),
+          title: translate("toaster.bulkDelete.success.title"),
+          type: "success",
+        });
+        clearSelections();
+        onSuccessConfirm();
+      }
+    }
+  };
+
+  const onError = (_error: unknown) => {
+    setError(_error);
+  };
+
+  const { isPending, mutate } = useTaskInstanceServiceBulkTaskInstances({
+    onError,
+    onSuccess,
+  });
+
+  const bulkDelete = (selectedRows: Map<string, boolean>) => {
+    mutate({
+      dagId: "~",
+      dagRunId: "~",
+      requestBody: {
+        actions: [
+          {
+            action: "delete" as const,
+            action_on_non_existence: "skip",
+            entities: [...selectedRows.keys()].map((key) => parseTaskInstanceKey(key)),
+          },
+        ],
+      },
+    });
+  };
+
+  return { bulkDelete, error, isPending };
+};

--- a/airflow-core/src/airflow/ui/src/queries/useBulkMarkTaskInstances.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useBulkMarkTaskInstances.ts
@@ -1,0 +1,107 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  useTaskInstanceServiceBulkTaskInstances,
+  useTaskInstanceServiceGetTaskInstancesKey,
+} from "openapi/queries";
+import type { BulkResponse } from "openapi/requests/types.gen";
+import { toaster } from "src/components/ui";
+
+type Props = {
+  readonly clearSelections: VoidFunction;
+  readonly onSuccessConfirm: VoidFunction;
+};
+
+const parseTaskInstanceKey = (key: string) => {
+  const [dagId = "", dagRunId = "", taskId = "", mapIndexStr] = key.split("||");
+
+  return {
+    dag_id: dagId,
+    dag_run_id: dagRunId,
+    map_index: mapIndexStr === undefined ? -1 : Number(mapIndexStr),
+    task_id: taskId,
+  };
+};
+
+export const useBulkMarkTaskInstances = ({ clearSelections, onSuccessConfirm }: Props) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<unknown>(undefined);
+  const { t: translate } = useTranslation(["common", "dags"]);
+
+  const onSuccess = async (responseData: BulkResponse) => {
+    await queryClient.invalidateQueries({
+      queryKey: [useTaskInstanceServiceGetTaskInstancesKey],
+    });
+
+    if (responseData.update) {
+      const { errors, success } = responseData.update;
+
+      if (Array.isArray(errors) && errors.length > 0) {
+        const apiError = errors[0] as { error: string };
+
+        setError({ body: { detail: apiError.error } });
+      } else if (Array.isArray(success) && success.length > 0) {
+        toaster.create({
+          description: translate("toaster.bulkUpdate.success.description", {
+            count: success.length,
+            resourceName: translate("common:taskInstance_other"),
+          }),
+          title: translate("toaster.bulkUpdate.success.title"),
+          type: "success",
+        });
+        clearSelections();
+        onSuccessConfirm();
+      }
+    }
+  };
+
+  const onError = (_error: unknown) => {
+    setError(_error);
+  };
+
+  const { isPending, mutate } = useTaskInstanceServiceBulkTaskInstances({
+    onError,
+    onSuccess,
+  });
+
+  const bulkMark = (selectedRows: Map<string, boolean>, newState: "failed" | "success") => {
+    mutate({
+      dagId: "~",
+      dagRunId: "~",
+      requestBody: {
+        actions: [
+          {
+            action: "update" as const,
+            entities: [...selectedRows.keys()].map((key) => ({
+              ...parseTaskInstanceKey(key),
+              new_state: newState,
+            })),
+            update_mask: ["new_state"],
+          },
+        ],
+      },
+    });
+  };
+
+  return { bulkMark, error, isPending };
+};

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancesPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancesPage.ts
@@ -37,7 +37,7 @@ export class TaskInstancesPage extends BasePage {
   public async navigate(): Promise<void> {
     await this.navigateTo(TaskInstancesPage.taskInstancesUrl);
     await this.page.waitForURL(/.*task_instances/, { timeout: 15_000 });
-    await this.taskInstancesTable.waitFor({ state: "visible", timeout: 10_000 });
+    await this.taskInstancesTable.waitFor({ state: "visible", timeout: 30_000 });
 
     const dataLink = this.taskInstancesTable.locator("a[href*='/dags/']").first();
     const noDataMessage = this.page.locator('text="No Task Instances found"');


### PR DESCRIPTION
Closes #63855

  Airflow 2 included multi-select bulk actions on the "Browse -> Task Instances" page. This PR reintroduces
  this feature in Airflow 3.
  It Adds:
 - Checkboxes on each task instance row with select-all header checkbox
  - ActionBar appears at bottom of page with multiple rows selected
  - Bulk Mark As - Dialog to mark selected task instances as Success/Failed
  - Bulk Delete - Dialog to delete selected task instances
  - Row-level action buttons (Clear, Mark As, Delete) are disabled with bulk selections active

  Out of scope:
  - "Bulk Clear" - Requires different context and API

   Test plan
  - [ ] Navigate to "Browse -> Task Instances"
  - [ ] Verify checkboxes are in first column
  - [ ] Select multiple rows - ActionBar appears at bottom
  - [ ] Click "Mark As..." - Dialog appears with Success/Failed buttons
  - [ ] Click Success/Failed - Dialog allows confirmation
  - [ ] Click "Delete" - Confirmation dialog appears - Delete works
  - [ ] Click X in ActionBar - Selections cleared
  - [ ] Individual row-level action buttons are disabled with bulk selections active
