### PR TITLE
Align key/id path validation for variables and connections

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -29,7 +29,7 @@ from airflow.models.connection import Connection
 
 
 async def has_connection_access(
-    connection_id: str = Path(),
+    connection_id: Annotated[str, Path(min_length=1)],
     token=CurrentTIToken,
 ) -> bool:
     """Check if the task has access to the connection."""
@@ -59,7 +59,8 @@ log = logging.getLogger(__name__)
     },
 )
 def get_connection(
-    connection_id: str, team_name: Annotated[str | None, Depends(get_team_name_dep)]
+    connection_id: Annotated[str, Path(min_length=1)],
+    team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ) -> ConnectionResponse:
     """Get an Airflow connection."""
     try:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -32,7 +32,7 @@ from airflow.models.variable import Variable
 
 async def has_variable_access(
     request: Request,
-    variable_key: str = Path(),
+    variable_key: Annotated[str, Path(min_length=1)],
     token=CurrentTIToken,
 ):
     """Check if the task has access to the variable."""
@@ -63,12 +63,10 @@ log = logging.getLogger(__name__)
     },
 )
 def get_variable(
-    variable_key: str, team_name: Annotated[str | None, Depends(get_team_name_dep)]
+    variable_key: Annotated[str, Path(min_length=1)],
+    team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ) -> VariableResponse:
     """Get an Airflow Variable."""
-    if not variable_key:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Not Found")
-
     try:
         variable_value = Variable.get(variable_key, team_name=team_name)
     except KeyError:
@@ -92,12 +90,11 @@ def get_variable(
     },
 )
 def put_variable(
-    variable_key: str, body: VariablePostBody, team_name: Annotated[str | None, Depends(get_team_name_dep)]
+    variable_key: Annotated[str, Path(min_length=1)],
+    body: VariablePostBody,
+    team_name: Annotated[str | None, Depends(get_team_name_dep)],
 ):
     """Set an Airflow Variable."""
-    if not variable_key:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Not Found")
-
     Variable.set(key=variable_key, value=body.value, description=body.description, team_name=team_name)
     return {"message": "Variable successfully set"}
 
@@ -110,9 +107,9 @@ def put_variable(
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the variable"},
     },
 )
-def delete_variable(variable_key: str, team_name: Annotated[str | None, Depends(get_team_name_dep)]):
+def delete_variable(
+    variable_key: Annotated[str, Path(min_length=1)],
+    team_name: Annotated[str | None, Depends(get_team_name_dep)],
+):
     """Delete an Airflow Variable."""
-    if not variable_key:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Not Found")
-
     Variable.delete(key=variable_key, team_name=team_name)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
@@ -159,20 +159,22 @@ class TestPutVariable:
             assert var_from_db.description == payload["description"]
 
     @pytest.mark.parametrize(
-        ("key", "status_code", "payload"),
+        ("key", "payload", "error_type"),
         [
-            pytest.param("", 404, {"value": "{}", "description": "description"}, id="missing-key"),
-            pytest.param("var_create", 422, {"description": "description"}, id="missing-value"),
+            pytest.param(
+                "", {"value": "{}", "description": "description"}, "string_too_short", id="missing-key"
+            ),
+            pytest.param("var_create", {"description": "description"}, "missing", id="missing-value"),
         ],
     )
-    def test_variable_missing_mandatory_fields(self, client, key, status_code, payload, session):
+    def test_variable_missing_mandatory_fields(self, client, key, payload, error_type, session):
         response = client.put(
             f"/execution/variables/{key}",
             json=payload,
         )
-        assert response.status_code == status_code
-        if response.status_code == 422:
-            assert response.json()["detail"][0]["type"] == "missing"
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["type"] == error_type
+        if error_type == "missing":
             assert response.json()["detail"][0]["msg"] == "Field required"
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Why
Before this PR, similar key/id parameters were handled differently:

- `xcoms`.py used `Path(min_length=1)` (request validation layer),
- variables.py used` Path()` plus manual if not variable_key checks (runtime layer),
- connections.py used `Path()` without a minimum-length constraint.

This inconsistency caused uneven behavior and error handling for the same class of inputs.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
