### PR TITLE
Docs: Add RedisTaskHandler configuration example

### DIFF
--- a/providers/redis/docs/logging/index.rst
+++ b/providers/redis/docs/logging/index.rst
@@ -22,3 +22,29 @@ Writing logs to Redis
 
 Airflow can be configured to store log lines in Redis up to a configured maximum log lines, always keeping the most recent, up to a configured TTL. This deviates from other existing task handlers in that it accepts a connection ID.
 This allows it to be used in addition to other handlers, and so allows a graceful/reversible transition from one logging system to another. This is particularly useful in situations that use Redis as a message broker, where additional infrastructure isn't desired.
+
+Configuring logging
+-------------------
+
+To enable this feature, ``airflow.cfg`` must be configured as in this example:
+
+.. code-block:: ini
+
+    [logging]
+    remote_logging = True
+    remote_log_conn_id = redis_default
+
+    [redis]
+    # Optional configurations
+    # max_lines = 10000
+    # ttl_seconds = 2419200
+
+Airflow uses the :ref:`Redis Connection <howto/connection:redis>` to connect to the Redis cluster.
+If you have a connection with ID ``redis_default`` properly set up, Airflow will use it to read and write logs.
+
+Key template
+------------
+
+Logs are stored in Redis using keys generated with a template. The default template is
+``dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log``.
+Each key holds a Redis List containing the log lines.


### PR DESCRIPTION
### Description
Add configuration examples to [RedisTaskHandler](cci:2://file:///Users/subhamsangwan/airflow/providers/redis/src/airflow/providers/redis/log/redis_task_handler.py:36:0-101:49) documentation to resolve ambiguity about how to configure Redis remote logging (Connection ID vs settings).

### Changes
- Added `airflow.cfg` configuration example.
- Linked to Redis Connection documentation.
- Clarified default log key templates in Redis.

closes: #63881

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Gemini(pr description and research)