### PR TITLE
Update pools slot input

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -349,6 +349,9 @@
   "triggered": "Triggered",
   "tryNumber": "Try Number",
   "user": "User",
+  "validation": {
+    "mustBeValidNumber": "Must be a valid number."
+  },
   "wrap": {
     "hotkey": "w",
     "tooltip": "Press {{hotkey}} to toggle wrap",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -350,6 +350,7 @@
   "tryNumber": "Try Number",
   "user": "User",
   "validation": {
+    "mustBeAtLeast": "Must be at least {{min}}.",
     "mustBeValidNumber": "Must be a valid number."
   },
   "wrap": {

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -111,9 +111,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
           </Field.Root>
         )}
         rules={{
-          validate: (value: number) =>
-            (typeof value === "number" && Number.isFinite(value)) ||
-            translate("common:validation.mustBeValidNumber"),
+          validate: (value) => Number.isFinite(value) || translate("common:validation.mustBeValidNumber"),
         }}
       />
 

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -87,23 +87,34 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
       <Controller
         control={control}
         name="slots"
-        render={({ field }) => (
-          <Field.Root mt={4}>
+        render={({ field, fieldState }) => (
+          <Field.Root invalid={Boolean(fieldState.error)} mt={4}>
             <Field.Label fontSize="md">{translate("pools.form.slots")}</Field.Label>
             <Input
               min={-1}
+              onBlur={field.onBlur}
               onChange={(event) => {
-                const value = event.target.valueAsNumber;
+                const { value: raw, valueAsNumber } = event.target;
 
-                field.onChange(isNaN(value) ? field.value : value);
+                field.onChange(raw === "" ? Number.NaN : valueAsNumber);
               }}
+              ref={field.ref}
               size="sm"
               type="number"
-              value={field.value}
+              value={Number.isFinite(field.value) ? field.value : ""}
             />
-            <Field.HelperText>{translate("pools.form.slotsHelperText")}</Field.HelperText>
+            {fieldState.error ? (
+              <Field.ErrorText>{fieldState.error.message}</Field.ErrorText>
+            ) : (
+              <Field.HelperText>{translate("pools.form.slotsHelperText")}</Field.HelperText>
+            )}
           </Field.Root>
         )}
+        rules={{
+          validate: (value: number) =>
+            (typeof value === "number" && Number.isFinite(value)) ||
+            translate("common:validation.mustBeValidNumber"),
+        }}
       />
 
       <Controller

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -42,6 +42,8 @@ type PoolFormProps = {
   readonly setError: (error: unknown) => void;
 };
 
+const POOL_SLOTS_MIN = -1;
+
 const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: PoolFormProps) => {
   const { t: translate } = useTranslation(["admin", "common"]);
   const {
@@ -91,7 +93,7 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
           <Field.Root invalid={Boolean(fieldState.error)} mt={4}>
             <Field.Label fontSize="md">{translate("pools.form.slots")}</Field.Label>
             <Input
-              min={-1}
+              min={POOL_SLOTS_MIN}
               onBlur={field.onBlur}
               onChange={(event) => {
                 const { value: raw, valueAsNumber } = event.target;
@@ -111,7 +113,16 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
           </Field.Root>
         )}
         rules={{
-          validate: (value) => Number.isFinite(value) || translate("common:validation.mustBeValidNumber"),
+          validate: (value: number) => {
+            if (!Number.isFinite(value)) {
+              return translate("common:validation.mustBeValidNumber");
+            }
+            if (value < POOL_SLOTS_MIN) {
+              return translate("common:validation.mustBeAtLeast", { min: POOL_SLOTS_MIN });
+            }
+
+            return true;
+          },
         }}
       />
 


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/63846

<img width="940" height="579" alt="Screenshot 2026-03-18 at 3 39 21 PM" src="https://github.com/user-attachments/assets/139bcf0f-6ccd-4da3-a2f5-46d0a15ff8b9" />


Add validators to the slot pools input instead of falling back to using the previous valid form value which caused confusing behavior.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
