### PR TITLE
Only render cross-provider dependencies if they're optional

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -73,8 +73,8 @@ The minimum Apache Airflow version supported by this provider distribution is ``
 
 {%- if CROSS_PROVIDERS_DEPENDENCIES %}
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.

--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_README_TEMPLATE.rst.jinja2
@@ -86,8 +86,8 @@ Requirements
 {%- endif %}
 {%- if CROSS_PROVIDERS_DEPENDENCIES %}
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.

--- a/dev/breeze/src/airflow_breeze/utils/packages.py
+++ b/dev/breeze/src/airflow_breeze/utils/packages.py
@@ -700,7 +700,12 @@ def get_provider_jinja_context(
     supported_python_versions = [
         p for p in ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS if p not in provider_details.excluded_python_versions
     ]
-    cross_providers_dependencies = get_cross_provider_dependent_packages(provider_id=provider_id)
+
+    pip_requirements = get_provider_requirements(provider_details.provider_id)
+    cross_deps = get_cross_provider_dependent_packages(provider_id=provider_id)
+    optional_cross_provider_dependencies = [
+        dep for dep in cross_deps if get_pip_package_name(dep) not in "\n".join(pip_requirements)
+    ]
 
     requires_python_version: str = f">={DEFAULT_PYTHON_MAJOR_MINOR_VERSION}"
     # Most providers require the same python versions, but some may have exclusions
@@ -716,7 +721,7 @@ def get_provider_jinja_context(
         "RELEASE": current_release_version,
         "RELEASE_NO_LEADING_ZEROS": release_version_no_leading_zeros,
         "VERSION_SUFFIX": version_suffix,
-        "PIP_REQUIREMENTS": get_provider_requirements(provider_details.provider_id),
+        "PIP_REQUIREMENTS": pip_requirements,
         "PROVIDER_DESCRIPTION": provider_details.provider_description,
         "CHANGELOG_RELATIVE_PATH": os.path.relpath(
             provider_details.root_provider_path,
@@ -729,13 +734,11 @@ def get_provider_jinja_context(
         "MIN_AIRFLOW_VERSION": get_min_airflow_version(provider_id),
         "PROVIDER_REMOVED": provider_details.removed,
         "PROVIDER_INFO": get_provider_info_dict(provider_id),
-        "CROSS_PROVIDERS_DEPENDENCIES": get_cross_provider_dependent_packages(provider_id),
+        "CROSS_PROVIDERS_DEPENDENCIES": optional_cross_provider_dependencies,
         "CROSS_PROVIDERS_DEPENDENCIES_TABLE_RST": convert_cross_package_dependencies_to_table(
-            cross_providers_dependencies, markdown=False
+            optional_cross_provider_dependencies, markdown=False
         ),
-        "PIP_REQUIREMENTS_TABLE_RST": convert_pip_requirements_to_table(
-            get_provider_requirements(provider_id), markdown=False
-        ),
+        "PIP_REQUIREMENTS_TABLE_RST": convert_pip_requirements_to_table(pip_requirements, markdown=False),
         "REQUIRES_PYTHON": requires_python_version,
         "EXTRA_PROJECT_METADATA": provider_details.extra_project_metadata,
         "OPTIONAL_DEPENDENCIES": get_provider_optional_dependencies(provider_id),

--- a/providers/airbyte/README.rst
+++ b/providers/airbyte/README.rst
@@ -59,24 +59,5 @@ PIP package                                 Version required
 ``requests``                                ``>=2.32.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-airbyte[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-airbyte/5.4.0/changelog.html>`_.

--- a/providers/airbyte/docs/index.rst
+++ b/providers/airbyte/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``airbyte-api``                             ``>=0.52.0``
 ``requests``                                ``>=2.32.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-airbyte[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-airbyte 5.4.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-airbyte 5.4.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_airbyte-5.4.0-py3-none-any.whl.sha512>`__)

--- a/providers/alibaba/README.rst
+++ b/providers/alibaba/README.rst
@@ -50,35 +50,17 @@ The package supports the following python versions: 3.10,3.11,3.12,3.13,3.14
 Requirements
 ------------
 
-==========================================  ==================
+==========================================  ========================================
 PIP package                                 Version required
-==========================================  ==================
+==========================================  ========================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``oss2``                                    ``>=2.14.0``
 ``alibabacloud_adb20211201``                ``>=1.0.0``
 ``alibabacloud_tea_openapi``                ``>=0.3.7``
-``pyodps``                                  ``>=0.12.2.2``
-==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-alibaba[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
+``pyodps``                                  ``>=0.12.2.2; python_version < "3.13"``
+``pyodps``                                  ``>=0.12.5.1; python_version >= "3.13"``
+==========================================  ========================================
 
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-alibaba/3.3.6/changelog.html>`_.

--- a/providers/alibaba/docs/index.rst
+++ b/providers/alibaba/docs/index.rst
@@ -108,31 +108,3 @@ PIP package                                 Version required
 ``pyodps``                                  ``>=0.12.2.2; python_version < "3.13"``
 ``pyodps``                                  ``>=0.12.5.1; python_version >= "3.13"``
 ==========================================  ========================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-alibaba[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-alibaba 3.3.6 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6.tar.gz.sha512>`__)
-* `The apache-airflow-providers-alibaba 3.3.6 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_alibaba-3.3.6-py3-none-any.whl.sha512>`__)

--- a/providers/amazon/README.rst
+++ b/providers/amazon/README.rst
@@ -71,8 +71,8 @@ PIP package                                 Version required
 ``marshmallow``                             ``>=3``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -89,13 +89,10 @@ Dependent package                                                               
 ========================================================================================================================  ====================
 `apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_            ``apache.hive``
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_    ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_              ``common.sql``
 `apache-airflow-providers-exasol <https://airflow.apache.org/docs/apache-airflow-providers-exasol>`_                      ``exasol``
 `apache-airflow-providers-ftp <https://airflow.apache.org/docs/apache-airflow-providers-ftp>`_                            ``ftp``
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                      ``google``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                          ``http``
 `apache-airflow-providers-imap <https://airflow.apache.org/docs/apache-airflow-providers-imap>`_                          ``imap``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_    ``microsoft.azure``
 `apache-airflow-providers-mongo <https://airflow.apache.org/docs/apache-airflow-providers-mongo>`_                        ``mongo``

--- a/providers/amazon/docs/index.rst
+++ b/providers/amazon/docs/index.rst
@@ -128,8 +128,8 @@ PIP package                                 Version required
 ``marshmallow``                             ``>=3``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -146,13 +146,10 @@ Dependent package                                                               
 ========================================================================================================================  ====================
 `apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_            ``apache.hive``
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_    ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_              ``common.sql``
 `apache-airflow-providers-exasol <https://airflow.apache.org/docs/apache-airflow-providers-exasol>`_                      ``exasol``
 `apache-airflow-providers-ftp <https://airflow.apache.org/docs/apache-airflow-providers-ftp>`_                            ``ftp``
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                      ``google``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                          ``http``
 `apache-airflow-providers-imap <https://airflow.apache.org/docs/apache-airflow-providers-imap>`_                          ``imap``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_    ``microsoft.azure``
 `apache-airflow-providers-mongo <https://airflow.apache.org/docs/apache-airflow-providers-mongo>`_                        ``mongo``

--- a/providers/apache/cassandra/README.rst
+++ b/providers/apache/cassandra/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``cassandra-driver``                        ``>=3.29.1; python_version < "3.12"``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-cassandra[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-cassandra/3.9.3/changelog.html>`_.

--- a/providers/apache/cassandra/docs/index.rst
+++ b/providers/apache/cassandra/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``cassandra-driver``                        ``>=3.29.2; python_version >= "3.12" and python_version < "3.13"``
 ``cassandra-driver``                        ``>=3.29.1; python_version < "3.12"``
 ==========================================  ==================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-cassandra[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-cassandra 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-cassandra 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_cassandra-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/apache/drill/README.rst
+++ b/providers/apache/drill/README.rst
@@ -59,24 +59,5 @@ PIP package                                 Version required
 ``sqlalchemy-drill``                        ``>=1.1.0,!=1.1.6,!=1.1.7``
 ==========================================  ===========================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-drill[common.sql]
-
-
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-drill/3.3.1/changelog.html>`_.

--- a/providers/apache/drill/docs/index.rst
+++ b/providers/apache/drill/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``sqlalchemy-drill``                        ``>=1.1.0,!=1.1.6,!=1.1.7``
 ==========================================  ===========================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-drill[common.sql]
-
-
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-drill 3.3.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-drill 3.3.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_drill-3.3.1-py3-none-any.whl.sha512>`__)

--- a/providers/apache/druid/README.rst
+++ b/providers/apache/druid/README.rst
@@ -59,8 +59,8 @@ PIP package                                 Version required
 ``pydruid``                                 ``>=0.6.6``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -72,13 +72,11 @@ You can install such cross-provider dependencies when installing from PyPI. For 
     pip install apache-airflow-providers-apache-druid[apache.hive]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_      ``apache.hive``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_  ``apache.hive``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/apache/druid/docs/index.rst
+++ b/providers/apache/druid/docs/index.rst
@@ -105,8 +105,8 @@ PIP package                                 Version required
 ``pydruid``                                 ``>=0.6.6``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -118,13 +118,11 @@ You can install such cross-provider dependencies when installing from PyPI. For 
     pip install apache-airflow-providers-apache-druid[apache.hive]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_      ``apache.hive``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_  ``apache.hive``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/apache/flink/README.rst
+++ b/providers/apache/flink/README.rst
@@ -59,25 +59,5 @@ PIP package                                   Version required
 ``apache-airflow-providers-cncf-kubernetes``  ``>=5.1.0``
 ============================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-flink[cncf.kubernetes]
-
-
-======================================================================================================================  ===================
-Dependent package                                                                                                       Extra
-======================================================================================================================  ===================
-`apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-======================================================================================================================  ===================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-flink/1.8.4/changelog.html>`_.

--- a/providers/apache/flink/docs/index.rst
+++ b/providers/apache/flink/docs/index.rst
@@ -96,32 +96,3 @@ PIP package                                   Version required
 ``cryptography``                              ``>=44.0.3``
 ``apache-airflow-providers-cncf-kubernetes``  ``>=5.1.0``
 ============================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-flink[cncf.kubernetes]
-
-
-======================================================================================================================  ===================
-Dependent package                                                                                                       Extra
-======================================================================================================================  ===================
-`apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-======================================================================================================================  ===================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-flink 1.8.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-flink 1.8.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_flink-1.8.4-py3-none-any.whl.sha512>`__)

--- a/providers/apache/hdfs/README.rst
+++ b/providers/apache/hdfs/README.rst
@@ -65,24 +65,5 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-hdfs[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-hdfs/4.11.4/changelog.html>`_.

--- a/providers/apache/hdfs/docs/index.rst
+++ b/providers/apache/hdfs/docs/index.rst
@@ -98,31 +98,3 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  ==================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-hdfs[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-hdfs 4.11.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-hdfs 4.11.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_hdfs-4.11.4-py3-none-any.whl.sha512>`__)

--- a/providers/apache/hive/README.rst
+++ b/providers/apache/hive/README.rst
@@ -64,8 +64,8 @@ PIP package                                 Version required
 ``jmespath``                                ``>=0.7.0``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -81,8 +81,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-mssql <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-mssql>`_  ``microsoft.mssql``
 `apache-airflow-providers-mysql <https://airflow.apache.org/docs/apache-airflow-providers-mysql>`_                      ``mysql``
 `apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_                    ``presto``

--- a/providers/apache/hive/docs/index.rst
+++ b/providers/apache/hive/docs/index.rst
@@ -113,8 +113,8 @@ PIP package                                 Version required
 ``jmespath``                                ``>=0.7.0``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -130,8 +130,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-mssql <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-mssql>`_  ``microsoft.mssql``
 `apache-airflow-providers-mysql <https://airflow.apache.org/docs/apache-airflow-providers-mysql>`_                      ``mysql``
 `apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_                    ``presto``

--- a/providers/apache/iceberg/README.rst
+++ b/providers/apache/iceberg/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``pyiceberg``                               ``>=0.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-iceberg[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-iceberg/2.0.1/changelog.html>`_.

--- a/providers/apache/iceberg/docs/index.rst
+++ b/providers/apache/iceberg/docs/index.rst
@@ -100,31 +100,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``pyiceberg``                               ``>=0.8.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-iceberg[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-iceberg 2.0.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-iceberg 2.0.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_iceberg-2.0.1-py3-none-any.whl.sha512>`__)

--- a/providers/apache/impala/README.rst
+++ b/providers/apache/impala/README.rst
@@ -59,26 +59,6 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-impala[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/apache/impala/docs/index.rst
+++ b/providers/apache/impala/docs/index.rst
@@ -112,32 +112,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
 ``apache-airflow``                          ``>=2.11.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-impala[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-impala 1.9.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-impala 1.9.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_impala-1.9.1-py3-none-any.whl.sha512>`__)

--- a/providers/apache/kafka/README.rst
+++ b/providers/apache/kafka/README.rst
@@ -61,8 +61,8 @@ PIP package                                 Version required
 ``confluent-kafka``                         ``>=2.13.2; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -71,13 +71,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-apache-kafka[common.compat]
+    pip install apache-airflow-providers-apache-kafka[common.messaging]
 
 
 ========================================================================================================================  ====================
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                      ``google``
 ========================================================================================================================  ====================

--- a/providers/apache/kafka/docs/index.rst
+++ b/providers/apache/kafka/docs/index.rst
@@ -114,8 +114,8 @@ PIP package                                 Version required
 ``confluent-kafka``                         ``>=2.13.2; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -124,13 +124,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-apache-kafka[common.compat]
+    pip install apache-airflow-providers-apache-kafka[common.messaging]
 
 
 ========================================================================================================================  ====================
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                      ``google``
 ========================================================================================================================  ====================

--- a/providers/apache/kylin/README.rst
+++ b/providers/apache/kylin/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``kylinpy``                                 ``>2.7.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-kylin[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-kylin/3.10.3/changelog.html>`_.

--- a/providers/apache/kylin/docs/index.rst
+++ b/providers/apache/kylin/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``kylinpy``                                 ``>2.7.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-kylin[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-kylin 3.10.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-kylin 3.10.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_kylin-3.10.3-py3-none-any.whl.sha512>`__)

--- a/providers/apache/livy/README.rst
+++ b/providers/apache/livy/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``aiohttp``                                 ``>=3.9.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-livy[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-livy/4.5.4/changelog.html>`_.

--- a/providers/apache/livy/docs/index.rst
+++ b/providers/apache/livy/docs/index.rst
@@ -104,32 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``aiohttp``                                 ``>=3.9.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-livy[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-livy 4.5.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-livy 4.5.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_livy-4.5.4-py3-none-any.whl.sha512>`__)

--- a/providers/apache/pig/README.rst
+++ b/providers/apache/pig/README.rst
@@ -57,24 +57,5 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-pig[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-pig/4.8.3/changelog.html>`_.

--- a/providers/apache/pig/docs/index.rst
+++ b/providers/apache/pig/docs/index.rst
@@ -101,31 +101,3 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-pig[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-pig 4.8.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-pig 4.8.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pig-4.8.3-py3-none-any.whl.sha512>`__)

--- a/providers/apache/pinot/README.rst
+++ b/providers/apache/pinot/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``pinotdb``                                 ``>=5.1.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-pinot[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-pinot/4.10.1/changelog.html>`_.

--- a/providers/apache/pinot/docs/index.rst
+++ b/providers/apache/pinot/docs/index.rst
@@ -98,32 +98,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
 ``pinotdb``                                 ``>=5.1.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-pinot[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-pinot 4.10.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-pinot 4.10.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_pinot-4.10.1-py3-none-any.whl.sha512>`__)

--- a/providers/apache/spark/README.rst
+++ b/providers/apache/spark/README.rst
@@ -59,8 +59,8 @@ PIP package                                 Version required
 ``grpcio-status``                           ``>=1.67.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -76,7 +76,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
 ======================================================================================================================  ===================
 
 Optional dependencies

--- a/providers/apache/spark/docs/index.rst
+++ b/providers/apache/spark/docs/index.rst
@@ -106,8 +106,8 @@ PIP package                                 Version required
 ``grpcio-status``                           ``>=1.67.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -123,7 +123,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
 ======================================================================================================================  ===================
 
 Downloading official packages

--- a/providers/apache/tinkerpop/README.rst
+++ b/providers/apache/tinkerpop/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``gremlinpython``                           ``>=3.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-tinkerpop[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apache-tinkerpop/1.1.2/changelog.html>`_.

--- a/providers/apache/tinkerpop/docs/index.rst
+++ b/providers/apache/tinkerpop/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``gremlinpython``                           ``>=3.8.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apache-tinkerpop[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apache-tinkerpop 1.1.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apache-tinkerpop 1.1.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apache_tinkerpop-1.1.2-py3-none-any.whl.sha512>`__)

--- a/providers/apprise/README.rst
+++ b/providers/apprise/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``apprise``                                 ``>=1.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apprise[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-apprise/2.3.2/changelog.html>`_.

--- a/providers/apprise/docs/index.rst
+++ b/providers/apprise/docs/index.rst
@@ -91,31 +91,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.9.0``
 ``apprise``                                 ``>=1.8.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-apprise[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-apprise 2.3.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-apprise 2.3.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_apprise-2.3.2-py3-none-any.whl.sha512>`__)

--- a/providers/arangodb/README.rst
+++ b/providers/arangodb/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``python-arango``                           ``>=7.3.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-arangodb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-arangodb/2.9.3/changelog.html>`_.

--- a/providers/arangodb/docs/index.rst
+++ b/providers/arangodb/docs/index.rst
@@ -97,31 +97,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``python-arango``                           ``>=7.3.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-arangodb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-arangodb 2.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-arangodb 2.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_arangodb-2.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/asana/README.rst
+++ b/providers/asana/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``asana``                                   ``>=5.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-asana[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-asana/2.11.2/changelog.html>`_.

--- a/providers/asana/docs/index.rst
+++ b/providers/asana/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``asana``                                   ``>=5.0.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-asana[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-asana 2.11.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-asana 2.11.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_asana-2.11.2-py3-none-any.whl.sha512>`__)

--- a/providers/atlassian/jira/README.rst
+++ b/providers/atlassian/jira/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``atlassian-python-api``                    ``>3.41.10``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-atlassian-jira[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-atlassian-jira/3.3.2/changelog.html>`_.

--- a/providers/atlassian/jira/docs/index.rst
+++ b/providers/atlassian/jira/docs/index.rst
@@ -97,32 +97,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-http``
 ``atlassian-python-api``                    ``>3.41.10``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-atlassian-jira[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-atlassian-jira 3.3.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-atlassian-jira 3.3.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_atlassian_jira-3.3.2-py3-none-any.whl.sha512>`__)

--- a/providers/celery/README.rst
+++ b/providers/celery/README.rst
@@ -59,8 +59,8 @@ PIP package                                 Version required
 ``flower``                                  ``>=1.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -76,7 +76,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
 ======================================================================================================================  ===================
 
 Optional dependencies

--- a/providers/celery/docs/index.rst
+++ b/providers/celery/docs/index.rst
@@ -96,8 +96,8 @@ PIP package                                 Version required
 ``flower``                                  ``>=1.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -113,7 +113,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
 ======================================================================================================================  ===================
 
 Downloading official packages

--- a/providers/cloudant/README.rst
+++ b/providers/cloudant/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``ibmcloudant``                             ``>=0.10.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cloudant[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-cloudant/4.3.3/changelog.html>`_.

--- a/providers/cloudant/docs/index.rst
+++ b/providers/cloudant/docs/index.rst
@@ -82,31 +82,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``ibmcloudant``                             ``>=0.10.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cloudant[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-cloudant 4.3.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-cloudant 4.3.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cloudant-4.3.3-py3-none-any.whl.sha512>`__)

--- a/providers/cncf/kubernetes/README.rst
+++ b/providers/cncf/kubernetes/README.rst
@@ -64,24 +64,5 @@ PIP package                                 Version required
 ``kubernetes_asyncio``                      ``>=32.0.0,<36.0.0``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cncf-kubernetes[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/10.15.0/changelog.html>`_.

--- a/providers/cncf/kubernetes/docs/index.rst
+++ b/providers/cncf/kubernetes/docs/index.rst
@@ -121,31 +121,3 @@ PIP package                                 Version required
 ``urllib3``                                 ``>=2.1.0,!=2.6.0``
 ``kubernetes_asyncio``                      ``>=32.0.0,<36.0.0``
 ==========================================  ======================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cncf-kubernetes[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-cncf-kubernetes 10.15.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-cncf-kubernetes 10.15.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cncf_kubernetes-10.15.0-py3-none-any.whl.sha512>`__)

--- a/providers/cohere/README.rst
+++ b/providers/cohere/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``fastavro``                                ``>=1.12.1; python_version >= "3.14"``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cohere[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-cohere/1.6.4/changelog.html>`_.

--- a/providers/cohere/docs/index.rst
+++ b/providers/cohere/docs/index.rst
@@ -100,31 +100,3 @@ PIP package                                 Version required
 ``fastavro``                                ``>=1.10.0; python_version >= "3.13" and python_version < "3.14"``
 ``fastavro``                                ``>=1.12.1; python_version >= "3.14"``
 ==========================================  ==================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-cohere[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-cohere 1.6.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-cohere 1.6.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_cohere-1.6.4-py3-none-any.whl.sha512>`__)

--- a/providers/common/compat/README.rst
+++ b/providers/common/compat/README.rst
@@ -58,8 +58,8 @@ PIP package         Version required
 ``asgiref``         ``>=3.11.1; python_version >= "3.14"``
 ==================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.

--- a/providers/common/compat/docs/index.rst
+++ b/providers/common/compat/docs/index.rst
@@ -90,8 +90,8 @@ PIP package         Version required
 ``asgiref``         ``>=3.11.1; python_version >= "3.14"``
 ==================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.

--- a/providers/common/io/README.rst
+++ b/providers/common/io/README.rst
@@ -57,8 +57,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -67,15 +67,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-common-io[common.compat]
+    pip install apache-airflow-providers-common-io[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/common/io/docs/index.rst
+++ b/providers/common/io/docs/index.rst
@@ -106,8 +106,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -116,15 +116,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-common-io[common.compat]
+    pip install apache-airflow-providers-common-io[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/common/sql/README.rst
+++ b/providers/common/sql/README.rst
@@ -60,8 +60,8 @@ PIP package                                 Version required
 ``methodtools``                             ``>=0.4.7``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -78,7 +78,6 @@ Dependent package                                                               
 ====================================================================================================================  ==================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                  ``amazon``
 `apache-airflow-providers-apache-iceberg <https://airflow.apache.org/docs/apache-airflow-providers-apache-iceberg>`_  ``apache.iceberg``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_    ``common.compat``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_        ``openlineage``
 ====================================================================================================================  ==================
 

--- a/providers/common/sql/docs/index.rst
+++ b/providers/common/sql/docs/index.rst
@@ -109,8 +109,8 @@ PIP package                                 Version required
 ``methodtools``                             ``>=0.4.7``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -127,7 +127,6 @@ Dependent package                                                               
 ====================================================================================================================  ==================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                  ``amazon``
 `apache-airflow-providers-apache-iceberg <https://airflow.apache.org/docs/apache-airflow-providers-apache-iceberg>`_  ``apache.iceberg``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_    ``common.compat``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_        ``openlineage``
 ====================================================================================================================  ==================
 

--- a/providers/databricks/README.rst
+++ b/providers/databricks/README.rst
@@ -68,8 +68,8 @@ PIP package                                 Version required
 ``pyarrow``                                 ``>=22.0.0; python_version >= "3.14"``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -78,17 +78,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-databricks[common.compat]
+    pip install apache-airflow-providers-databricks[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_            ``google``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/databricks/docs/index.rst
+++ b/providers/databricks/docs/index.rst
@@ -116,8 +116,8 @@ PIP package                                 Version required
 ``pyarrow``                                 ``>=22.0.0; python_version >= "3.14"``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -126,17 +126,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-databricks[common.compat]
+    pip install apache-airflow-providers-databricks[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_            ``google``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/datadog/README.rst
+++ b/providers/datadog/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``datadog``                                 ``>=0.50.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-datadog[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-datadog/3.10.3/changelog.html>`_.

--- a/providers/datadog/docs/index.rst
+++ b/providers/datadog/docs/index.rst
@@ -95,31 +95,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``datadog``                                 ``>=0.50.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-datadog[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-datadog 3.10.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-datadog 3.10.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_datadog-3.10.3-py3-none-any.whl.sha512>`__)

--- a/providers/dbt/cloud/README.rst
+++ b/providers/dbt/cloud/README.rst
@@ -62,8 +62,8 @@ PIP package                                 Version required
 ``tenacity``                                ``>=8.3.0``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -72,16 +72,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-dbt-cloud[common.compat]
+    pip install apache-airflow-providers-dbt-cloud[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/dbt/cloud/docs/index.rst
+++ b/providers/dbt/cloud/docs/index.rst
@@ -113,8 +113,8 @@ PIP package                                 Version required
 ``tenacity``                                ``>=8.3.0``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -123,16 +123,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-dbt-cloud[common.compat]
+    pip install apache-airflow-providers-dbt-cloud[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/dingding/README.rst
+++ b/providers/dingding/README.rst
@@ -58,25 +58,5 @@ PIP package                                 Version required
 ``apache-airflow-providers-http``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-dingding[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-dingding/3.9.3/changelog.html>`_.

--- a/providers/dingding/docs/index.rst
+++ b/providers/dingding/docs/index.rst
@@ -103,32 +103,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``apache-airflow-providers-http``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-dingding[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-dingding 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-dingding 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_dingding-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/discord/README.rst
+++ b/providers/discord/README.rst
@@ -58,25 +58,5 @@ PIP package                                 Version required
 ``apache-airflow-providers-http``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-discord[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-discord/3.12.1/changelog.html>`_.

--- a/providers/discord/docs/index.rst
+++ b/providers/discord/docs/index.rst
@@ -90,32 +90,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``apache-airflow-providers-http``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-discord[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-discord 3.12.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-discord 3.12.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_discord-3.12.1-py3-none-any.whl.sha512>`__)

--- a/providers/docker/README.rst
+++ b/providers/docker/README.rst
@@ -59,24 +59,5 @@ PIP package                                 Version required
 ``python-dotenv``                           ``>=0.21.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-docker[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-docker/4.5.4/changelog.html>`_.

--- a/providers/docker/docs/index.rst
+++ b/providers/docker/docs/index.rst
@@ -98,31 +98,3 @@ PIP package                                 Version required
 ``docker``                                  ``>=7.1.0``
 ``python-dotenv``                           ``>=0.21.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-docker[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-docker 4.5.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-docker 4.5.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_docker-4.5.4-py3-none-any.whl.sha512>`__)

--- a/providers/edge3/README.rst
+++ b/providers/edge3/README.rst
@@ -73,24 +73,5 @@ PIP package                                 Version required
 ``aiohttp``                                 ``>=3.9.2``
 ==========================================  ===================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-edge3[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-edge3/3.3.0/changelog.html>`_.

--- a/providers/edge3/docs/index.rst
+++ b/providers/edge3/docs/index.rst
@@ -127,31 +127,3 @@ PIP package                                 Version required
 ``aiofiles``                                ``>=23.2.0``
 ``aiohttp``                                 ``>=3.9.2``
 ==========================================  ===================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-edge3[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-edge3 3.3.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-edge3 3.3.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_edge3-3.3.0-py3-none-any.whl.sha512>`__)

--- a/providers/elasticsearch/README.rst
+++ b/providers/elasticsearch/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``elasticsearch``                           ``<10,>=8.10``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-elasticsearch[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-elasticsearch/6.5.1/changelog.html>`_.

--- a/providers/elasticsearch/docs/index.rst
+++ b/providers/elasticsearch/docs/index.rst
@@ -107,32 +107,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
 ``elasticsearch``                           ``<10,>=8.10``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-elasticsearch[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-elasticsearch 6.5.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-elasticsearch 6.5.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_elasticsearch-6.5.1-py3-none-any.whl.sha512>`__)

--- a/providers/exasol/README.rst
+++ b/providers/exasol/README.rst
@@ -62,26 +62,6 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-exasol[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/exasol/docs/index.rst
+++ b/providers/exasol/docs/index.rst
@@ -106,32 +106,3 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-exasol[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-exasol 4.10.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-exasol 4.10.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_exasol-4.10.1-py3-none-any.whl.sha512>`__)

--- a/providers/fab/README.rst
+++ b/providers/fab/README.rst
@@ -74,25 +74,6 @@ PIP package                                 Version required
 ``flask_limiter``                           ``>3,!=3.13``
 ==========================================  =====================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-fab[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -127,31 +127,3 @@ PIP package                                 Version required
 ``marshmallow``                             ``>=3``
 ``flask_limiter``                           ``>3,!=3.13``
 ==========================================  =====================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-fab[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-fab 3.6.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-fab 3.6.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_fab-3.6.0-py3-none-any.whl.sha512>`__)

--- a/providers/facebook/README.rst
+++ b/providers/facebook/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``facebook-business``                       ``>=22.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-facebook[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-facebook/3.9.3/changelog.html>`_.

--- a/providers/facebook/docs/index.rst
+++ b/providers/facebook/docs/index.rst
@@ -88,31 +88,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``facebook-business``                       ``>=22.0.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-facebook[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-facebook 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-facebook 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_facebook-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/ftp/README.rst
+++ b/providers/ftp/README.rst
@@ -57,8 +57,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -67,15 +67,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-ftp[common.compat]
+    pip install apache-airflow-providers-ftp[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/ftp/docs/index.rst
+++ b/providers/ftp/docs/index.rst
@@ -111,8 +111,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -121,15 +121,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-ftp[common.compat]
+    pip install apache-airflow-providers-ftp[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/git/README.rst
+++ b/providers/git/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``GitPython``                               ``>=3.1.44``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-git[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-git/0.3.0/changelog.html>`_.

--- a/providers/git/docs/index.rst
+++ b/providers/git/docs/index.rst
@@ -99,31 +99,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``GitPython``                               ``>=3.1.44``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-git[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-git 0.3.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-git 0.3.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_git-0.3.0-py3-none-any.whl.sha512>`__)

--- a/providers/github/README.rst
+++ b/providers/github/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``PyGithub``                                ``>=2.1.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-github[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-github/2.11.1/changelog.html>`_.

--- a/providers/github/docs/index.rst
+++ b/providers/github/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``PyGithub``                                ``>=2.1.1``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-github[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-github 2.11.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-github 2.11.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_github-2.11.1-py3-none-any.whl.sha512>`__)

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -137,8 +137,8 @@ PIP package                                 Version required
 ``types-protobuf``                          ``>=5.27.0,!=5.29.1.20250402``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -157,9 +157,7 @@ Dependent package                                                               
 `apache-airflow-providers-apache-beam <https://airflow.apache.org/docs/apache-airflow-providers-apache-beam>`_            ``apache.beam``
 `apache-airflow-providers-apache-cassandra <https://airflow.apache.org/docs/apache-airflow-providers-apache-cassandra>`_  ``apache.cassandra``
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_    ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_              ``common.sql``
 `apache-airflow-providers-facebook <https://airflow.apache.org/docs/apache-airflow-providers-facebook>`_                  ``facebook``
 `apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                          ``http``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_    ``microsoft.azure``

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -189,8 +189,8 @@ PIP package                                 Version required
 ``types-protobuf``                          ``>=5.27.0,!=5.29.1.20250402``
 ==========================================  ==================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -209,9 +209,7 @@ Dependent package                                                               
 `apache-airflow-providers-apache-beam <https://airflow.apache.org/docs/apache-airflow-providers-apache-beam>`_            ``apache.beam``
 `apache-airflow-providers-apache-cassandra <https://airflow.apache.org/docs/apache-airflow-providers-apache-cassandra>`_  ``apache.cassandra``
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_    ``cncf.kubernetes``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_              ``common.sql``
 `apache-airflow-providers-facebook <https://airflow.apache.org/docs/apache-airflow-providers-facebook>`_                  ``facebook``
 `apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                          ``http``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_    ``microsoft.azure``

--- a/providers/grpc/README.rst
+++ b/providers/grpc/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``grpcio``                                  ``>=1.59.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-grpc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-grpc/3.9.3/changelog.html>`_.

--- a/providers/grpc/docs/index.rst
+++ b/providers/grpc/docs/index.rst
@@ -97,31 +97,3 @@ PIP package                                 Version required
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``grpcio``                                  ``>=1.59.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-grpc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-grpc 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-grpc 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_grpc-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/hashicorp/README.rst
+++ b/providers/hashicorp/README.rst
@@ -58,8 +58,8 @@ PIP package                                 Version required
 ``hvac``                                    ``>=1.1.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -68,15 +68,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-hashicorp[common.compat]
+    pip install apache-airflow-providers-hashicorp[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Optional dependencies
 ----------------------

--- a/providers/hashicorp/docs/index.rst
+++ b/providers/hashicorp/docs/index.rst
@@ -97,8 +97,8 @@ PIP package                                 Version required
 ``hvac``                                    ``>=1.1.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -107,15 +107,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-hashicorp[common.compat]
+    pip install apache-airflow-providers-hashicorp[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Downloading official packages
 -----------------------------

--- a/providers/http/README.rst
+++ b/providers/http/README.rst
@@ -62,24 +62,5 @@ PIP package                                 Version required
 ``asgiref``                                 ``>=3.11.1; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-http[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-http/6.0.1/changelog.html>`_.

--- a/providers/http/docs/index.rst
+++ b/providers/http/docs/index.rst
@@ -109,31 +109,3 @@ PIP package                                 Version required
 ``asgiref``                                 ``>=2.3.0; python_version < "3.14"``
 ``asgiref``                                 ``>=3.11.1; python_version >= "3.14"``
 ==========================================  ======================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-http[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-http 6.0.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-http 6.0.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_http-6.0.1-py3-none-any.whl.sha512>`__)

--- a/providers/imap/README.rst
+++ b/providers/imap/README.rst
@@ -57,24 +57,5 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-imap[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-imap/3.11.1/changelog.html>`_.

--- a/providers/imap/docs/index.rst
+++ b/providers/imap/docs/index.rst
@@ -89,31 +89,3 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-imap[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-imap 3.11.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-imap 3.11.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_imap-3.11.1-py3-none-any.whl.sha512>`__)

--- a/providers/influxdb/README.rst
+++ b/providers/influxdb/README.rst
@@ -59,24 +59,5 @@ PIP package                                 Version required
 ``requests``                                ``>=2.32.0,<3``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-influxdb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-influxdb/2.10.3/changelog.html>`_.

--- a/providers/influxdb/docs/index.rst
+++ b/providers/influxdb/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``influxdb-client``                         ``>=1.19.0``
 ``requests``                                ``>=2.32.0,<3``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-influxdb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-influxdb 2.10.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-influxdb 2.10.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_influxdb-2.10.3-py3-none-any.whl.sha512>`__)

--- a/providers/informatica/README.rst
+++ b/providers/informatica/README.rst
@@ -58,26 +58,6 @@ PIP package                                 Version required
 ``apache-airflow-providers-http``           ``>=4.13.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-informatica[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/informatica/docs/index.rst
+++ b/providers/informatica/docs/index.rst
@@ -141,32 +141,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-http``           ``>=4.13.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-informatica[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-informatica 0.1.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-informatica 0.1.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_informatica-0.1.2-py3-none-any.whl.sha512>`__)

--- a/providers/jdbc/README.rst
+++ b/providers/jdbc/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``jaydebeapi``                              ``>=1.1.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-jdbc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-jdbc/5.4.2/changelog.html>`_.

--- a/providers/jdbc/docs/index.rst
+++ b/providers/jdbc/docs/index.rst
@@ -106,32 +106,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
 ``jaydebeapi``                              ``>=1.1.1``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-jdbc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-jdbc 5.4.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-jdbc 5.4.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jdbc-5.4.2-py3-none-any.whl.sha512>`__)

--- a/providers/jenkins/README.rst
+++ b/providers/jenkins/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``python-jenkins``                          ``>=1.8.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-jenkins[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-jenkins/4.2.4/changelog.html>`_.

--- a/providers/jenkins/docs/index.rst
+++ b/providers/jenkins/docs/index.rst
@@ -103,31 +103,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``python-jenkins``                          ``>=1.8.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-jenkins[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-jenkins 4.2.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-jenkins 4.2.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_jenkins-4.2.4-py3-none-any.whl.sha512>`__)

--- a/providers/keycloak/README.rst
+++ b/providers/keycloak/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``python-keycloak``                         ``>=5.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-keycloak[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-keycloak/0.7.0/changelog.html>`_.

--- a/providers/keycloak/docs/index.rst
+++ b/providers/keycloak/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``python-keycloak``                         ``>=5.0.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-keycloak[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-keycloak 0.7.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-keycloak 0.7.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_keycloak-0.7.0-py3-none-any.whl.sha512>`__)

--- a/providers/microsoft/azure/README.rst
+++ b/providers/microsoft/azure/README.rst
@@ -86,8 +86,8 @@ PIP package                                 Version required
 ``msal-extensions``                         ``>=1.3.0``
 ==========================================  ===========================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -103,7 +103,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                      ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 `apache-airflow-providers-oracle <https://airflow.apache.org/docs/apache-airflow-providers-oracle>`_                      ``oracle``
 `apache-airflow-providers-sftp <https://airflow.apache.org/docs/apache-airflow-providers-sftp>`_                          ``sftp``

--- a/providers/microsoft/azure/docs/index.rst
+++ b/providers/microsoft/azure/docs/index.rst
@@ -140,8 +140,8 @@ PIP package                                 Version required
 ``msal-extensions``                         ``>=1.3.0``
 ==========================================  ===========================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -157,7 +157,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                      ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 `apache-airflow-providers-oracle <https://airflow.apache.org/docs/apache-airflow-providers-oracle>`_                      ``oracle``
 `apache-airflow-providers-sftp <https://airflow.apache.org/docs/apache-airflow-providers-sftp>`_                          ``sftp``

--- a/providers/microsoft/mssql/README.rst
+++ b/providers/microsoft/mssql/README.rst
@@ -60,8 +60,8 @@ PIP package                              Version required
 ``methodtools``                          ``>=0.4.7``
 =======================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -70,13 +70,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-microsoft-mssql[common.sql]
+    pip install apache-airflow-providers-microsoft-mssql[openlineage]
 
 
 ==============================================================================================================  ===============
 Dependent package                                                                                               Extra
 ==============================================================================================================  ===============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_    ``common.sql``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 

--- a/providers/microsoft/mssql/docs/index.rst
+++ b/providers/microsoft/mssql/docs/index.rst
@@ -108,8 +108,8 @@ PIP package                              Version required
 ``methodtools``                          ``>=0.4.7``
 =======================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -118,13 +118,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-microsoft-mssql[common.sql]
+    pip install apache-airflow-providers-microsoft-mssql[openlineage]
 
 
 ==============================================================================================================  ===============
 Dependent package                                                                                               Extra
 ==============================================================================================================  ===============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_    ``common.sql``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 

--- a/providers/microsoft/psrp/README.rst
+++ b/providers/microsoft/psrp/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``pypsrp``                                  ``>=0.8.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-microsoft-psrp[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-psrp/3.2.4/changelog.html>`_.

--- a/providers/microsoft/psrp/docs/index.rst
+++ b/providers/microsoft/psrp/docs/index.rst
@@ -97,31 +97,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``pypsrp``                                  ``>=0.8.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-microsoft-psrp[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-microsoft-psrp 3.2.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-microsoft-psrp 3.2.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_psrp-3.2.4-py3-none-any.whl.sha512>`__)

--- a/providers/microsoft/winrm/README.rst
+++ b/providers/microsoft/winrm/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``pywinrm``                                 ``>=0.5.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-microsoft-winrm[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-winrm/3.14.1/changelog.html>`_.

--- a/providers/microsoft/winrm/docs/index.rst
+++ b/providers/microsoft/winrm/docs/index.rst
@@ -103,31 +103,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``pywinrm``                                 ``>=0.5.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-microsoft-winrm[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-microsoft-winrm 3.14.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-microsoft-winrm 3.14.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_microsoft_winrm-3.14.1-py3-none-any.whl.sha512>`__)

--- a/providers/mongo/README.rst
+++ b/providers/mongo/README.rst
@@ -59,24 +59,5 @@ PIP package                                 Version required
 ``pymongo``                                 ``>=4.13.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-mongo[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-mongo/5.3.4/changelog.html>`_.

--- a/providers/mongo/docs/index.rst
+++ b/providers/mongo/docs/index.rst
@@ -90,31 +90,3 @@ PIP package                                 Version required
 ``dnspython``                               ``>=1.13.0``
 ``pymongo``                                 ``>=4.13.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-mongo[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-mongo 5.3.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-mongo 5.3.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_mongo-5.3.4-py3-none-any.whl.sha512>`__)

--- a/providers/mysql/README.rst
+++ b/providers/mysql/README.rst
@@ -61,8 +61,8 @@ PIP package                                 Version required
 ``aiomysql``                                ``>=0.2.0``
 ==========================================  =====================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -74,17 +74,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
     pip install apache-airflow-providers-mysql[amazon]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-`apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_                ``presto``
-`apache-airflow-providers-trino <https://airflow.apache.org/docs/apache-airflow-providers-trino>`_                  ``trino``
-`apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_              ``vertica``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_            ``amazon``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+`apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_            ``presto``
+`apache-airflow-providers-trino <https://airflow.apache.org/docs/apache-airflow-providers-trino>`_              ``trino``
+`apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_          ``vertica``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -108,8 +108,8 @@ PIP package                                 Version required
 ``aiomysql``                                ``>=0.2.0``
 ==========================================  =====================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -121,17 +121,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
     pip install apache-airflow-providers-mysql[amazon]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-`apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_                ``presto``
-`apache-airflow-providers-trino <https://airflow.apache.org/docs/apache-airflow-providers-trino>`_                  ``trino``
-`apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_              ``vertica``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_            ``amazon``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+`apache-airflow-providers-presto <https://airflow.apache.org/docs/apache-airflow-providers-presto>`_            ``presto``
+`apache-airflow-providers-trino <https://airflow.apache.org/docs/apache-airflow-providers-trino>`_              ``trino``
+`apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_          ``vertica``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/neo4j/README.rst
+++ b/providers/neo4j/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``neo4j``                                   ``>=5.20.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-neo4j[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-neo4j/3.11.4/changelog.html>`_.

--- a/providers/neo4j/docs/index.rst
+++ b/providers/neo4j/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``neo4j``                                   ``>=5.20.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-neo4j[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-neo4j 3.11.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-neo4j 3.11.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_neo4j-3.11.4-py3-none-any.whl.sha512>`__)

--- a/providers/odbc/README.rst
+++ b/providers/odbc/README.rst
@@ -60,25 +60,5 @@ PIP package                                 Version required
 ``pyodbc``                                  ``>=5.2.0; python_version >= "3.13"``
 ==========================================  =====================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-odbc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-odbc/4.12.1/changelog.html>`_.

--- a/providers/odbc/docs/index.rst
+++ b/providers/odbc/docs/index.rst
@@ -106,32 +106,3 @@ PIP package                                 Version required
 ``pyodbc``                                  ``>=5.0.0; python_version < "3.13"``
 ``pyodbc``                                  ``>=5.2.0; python_version >= "3.13"``
 ==========================================  =====================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-odbc[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-odbc 4.12.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-odbc 4.12.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_odbc-4.12.1-py3-none-any.whl.sha512>`__)

--- a/providers/openai/README.rst
+++ b/providers/openai/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``openai[datalib]``                         ``>=1.66.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openai[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-openai/1.7.3/changelog.html>`_.

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -100,31 +100,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``openai[datalib]``                         ``>=1.66.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openai[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-openai 1.7.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-openai 1.7.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openai-1.7.3-py3-none-any.whl.sha512>`__)

--- a/providers/openfaas/README.rst
+++ b/providers/openfaas/README.rst
@@ -57,24 +57,5 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openfaas[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-openfaas/3.9.3/changelog.html>`_.

--- a/providers/openfaas/docs/index.rst
+++ b/providers/openfaas/docs/index.rst
@@ -94,31 +94,3 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openfaas[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-openfaas 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-openfaas 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openfaas-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/openlineage/README.rst
+++ b/providers/openlineage/README.rst
@@ -62,26 +62,6 @@ PIP package                                 Version required
 ``openlineage-python``                      ``>=1.41.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openlineage[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/openlineage/docs/index.rst
+++ b/providers/openlineage/docs/index.rst
@@ -113,32 +113,3 @@ PIP package                                 Version required
 ``openlineage-integration-common``          ``>=1.41.0``
 ``openlineage-python``                      ``>=1.41.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-openlineage[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-openlineage 2.13.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-openlineage 2.13.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_openlineage-2.13.0-py3-none-any.whl.sha512>`__)

--- a/providers/opensearch/README.rst
+++ b/providers/opensearch/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``opensearch-py``                           ``>=2.2.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-opensearch[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-opensearch/1.8.5/changelog.html>`_.

--- a/providers/opensearch/docs/index.rst
+++ b/providers/opensearch/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``opensearch-py``                           ``>=2.2.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-opensearch[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-opensearch 1.8.5 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5.tar.gz.sha512>`__)
-* `The apache-airflow-providers-opensearch 1.8.5 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opensearch-1.8.5-py3-none-any.whl.sha512>`__)

--- a/providers/opsgenie/README.rst
+++ b/providers/opsgenie/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``opsgenie-sdk``                            ``>=2.1.5``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-opsgenie[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-opsgenie/5.10.2/changelog.html>`_.

--- a/providers/opsgenie/docs/index.rst
+++ b/providers/opsgenie/docs/index.rst
@@ -105,31 +105,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``opsgenie-sdk``                            ``>=2.1.5``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-opsgenie[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-opsgenie 5.10.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-opsgenie 5.10.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_opsgenie-5.10.2-py3-none-any.whl.sha512>`__)

--- a/providers/oracle/README.rst
+++ b/providers/oracle/README.rst
@@ -59,8 +59,8 @@ PIP package                                 Version required
 ``oracledb``                                ``>=2.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -69,16 +69,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-oracle[common.compat]
+    pip install apache-airflow-providers-oracle[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/oracle/docs/index.rst
+++ b/providers/oracle/docs/index.rst
@@ -106,8 +106,8 @@ PIP package                                 Version required
 ``oracledb``                                ``>=2.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -116,16 +116,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-oracle[common.compat]
+    pip install apache-airflow-providers-oracle[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/pagerduty/README.rst
+++ b/providers/pagerduty/README.rst
@@ -59,25 +59,5 @@ PIP package                                 Version required
 ``pagerduty``                               ``>=2.3.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-pagerduty[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-pagerduty/5.2.4/changelog.html>`_.

--- a/providers/pagerduty/docs/index.rst
+++ b/providers/pagerduty/docs/index.rst
@@ -97,32 +97,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-http``
 ``pagerduty``                               ``>=2.3.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-pagerduty[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-http <https://airflow.apache.org/docs/apache-airflow-providers-http>`_                    ``http``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-pagerduty 5.2.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-pagerduty 5.2.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pagerduty-5.2.4-py3-none-any.whl.sha512>`__)

--- a/providers/papermill/README.rst
+++ b/providers/papermill/README.rst
@@ -64,24 +64,5 @@ PIP package                                 Version required
 ``nbconvert``                               ``>=7.16.1``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-papermill[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-papermill/3.12.2/changelog.html>`_.

--- a/providers/papermill/docs/index.rst
+++ b/providers/papermill/docs/index.rst
@@ -110,31 +110,3 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ``nbconvert``                               ``>=7.16.1``
 ==========================================  =================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-papermill[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-papermill 3.12.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-papermill 3.12.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_papermill-3.12.2-py3-none-any.whl.sha512>`__)

--- a/providers/pgvector/README.rst
+++ b/providers/pgvector/README.rst
@@ -59,8 +59,8 @@ PIP package                                 Version required
 ``pgvector``                                ``>=0.3.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -76,7 +76,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                             Extra
 ============================================================================================================  ==============
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-`apache-airflow-providers-postgres <https://airflow.apache.org/docs/apache-airflow-providers-postgres>`_      ``postgres``
 ============================================================================================================  ==============
 
 Optional dependencies

--- a/providers/pgvector/docs/index.rst
+++ b/providers/pgvector/docs/index.rst
@@ -108,8 +108,8 @@ PIP package                                 Version required
 ``pgvector``                                ``>=0.3.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -125,7 +125,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                             Extra
 ============================================================================================================  ==============
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-`apache-airflow-providers-postgres <https://airflow.apache.org/docs/apache-airflow-providers-postgres>`_      ``postgres``
 ============================================================================================================  ==============
 
 Downloading official packages

--- a/providers/pinecone/README.rst
+++ b/providers/pinecone/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``pinecone``                                ``>=7.0.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-pinecone[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-pinecone/2.4.3/changelog.html>`_.

--- a/providers/pinecone/docs/index.rst
+++ b/providers/pinecone/docs/index.rst
@@ -98,31 +98,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``pinecone``                                ``>=7.0.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-pinecone[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-pinecone 2.4.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-pinecone 2.4.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_pinecone-2.4.3-py3-none-any.whl.sha512>`__)

--- a/providers/postgres/README.rst
+++ b/providers/postgres/README.rst
@@ -61,8 +61,8 @@ PIP package                                 Version required
 ``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -78,8 +78,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -109,8 +109,8 @@ PIP package                                 Version required
 ``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -126,8 +126,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================

--- a/providers/presto/README.rst
+++ b/providers/presto/README.rst
@@ -64,8 +64,8 @@ PIP package                                 Version required
 ``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -74,16 +74,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-presto[common.compat]
+    pip install apache-airflow-providers-presto[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Optional dependencies
 ----------------------

--- a/providers/presto/docs/index.rst
+++ b/providers/presto/docs/index.rst
@@ -112,8 +112,8 @@ PIP package                                 Version required
 ``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -122,16 +122,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-presto[common.compat]
+    pip install apache-airflow-providers-presto[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Downloading official packages
 -----------------------------

--- a/providers/qdrant/README.rst
+++ b/providers/qdrant/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``qdrant_client``                           ``>=1.17.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-qdrant[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-qdrant/1.5.4/changelog.html>`_.

--- a/providers/qdrant/docs/index.rst
+++ b/providers/qdrant/docs/index.rst
@@ -97,31 +97,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``qdrant_client``                           ``>=1.17.1``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-qdrant[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-qdrant 1.5.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-qdrant 1.5.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_qdrant-1.5.4-py3-none-any.whl.sha512>`__)

--- a/providers/redis/README.rst
+++ b/providers/redis/README.rst
@@ -58,8 +58,8 @@ PIP package                                 Version required
 ``redis``                                   ``>=4.5.2,!=4.5.5,!=5.0.2``
 ==========================================  ===========================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -68,13 +68,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-redis[common.compat]
+    pip install apache-airflow-providers-redis[common.messaging]
 
 
 ========================================================================================================================  ====================
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 ========================================================================================================================  ====================
 

--- a/providers/redis/docs/index.rst
+++ b/providers/redis/docs/index.rst
@@ -107,8 +107,8 @@ PIP package                                 Version required
 ``redis``                                   ``>=4.5.2,!=4.5.5,!=5.0.2``
 ==========================================  ===========================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -117,13 +117,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-redis[common.compat]
+    pip install apache-airflow-providers-redis[common.messaging]
 
 
 ========================================================================================================================  ====================
 Dependent package                                                                                                         Extra
 ========================================================================================================================  ====================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_        ``common.compat``
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 ========================================================================================================================  ====================
 

--- a/providers/salesforce/README.rst
+++ b/providers/salesforce/README.rst
@@ -61,24 +61,5 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-salesforce[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-salesforce/5.13.0/changelog.html>`_.

--- a/providers/salesforce/docs/index.rst
+++ b/providers/salesforce/docs/index.rst
@@ -107,31 +107,3 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-salesforce[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-salesforce 5.13.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-salesforce 5.13.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_salesforce-5.13.0-py3-none-any.whl.sha512>`__)

--- a/providers/samba/README.rst
+++ b/providers/samba/README.rst
@@ -58,8 +58,8 @@ PIP package                                 Version required
 ``smbprotocol``                             ``>=1.5.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -68,15 +68,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-samba[common.compat]
+    pip install apache-airflow-providers-samba[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Optional dependencies
 ----------------------

--- a/providers/samba/docs/index.rst
+++ b/providers/samba/docs/index.rst
@@ -104,8 +104,8 @@ PIP package                                 Version required
 ``smbprotocol``                             ``>=1.5.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -114,15 +114,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-samba[common.compat]
+    pip install apache-airflow-providers-samba[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-==================================================================================================================  =================
+====================================================================================================  ==========
+Dependent package                                                                                     Extra
+====================================================================================================  ==========
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
+====================================================================================================  ==========
 
 Downloading official packages
 -----------------------------

--- a/providers/segment/README.rst
+++ b/providers/segment/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``segment-analytics-python``                ``>=2.3.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-segment[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-segment/3.9.3/changelog.html>`_.

--- a/providers/segment/docs/index.rst
+++ b/providers/segment/docs/index.rst
@@ -88,31 +88,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``segment-analytics-python``                ``>=2.3.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-segment[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-segment 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-segment 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_segment-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/sendgrid/README.rst
+++ b/providers/sendgrid/README.rst
@@ -61,24 +61,5 @@ PIP package                                 Version required
 ``werkzeug``                                ``>=3.1.6,<4; python_version >= "3.14"``
 ==========================================  ===================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-sendgrid[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-sendgrid/4.2.2/changelog.html>`_.

--- a/providers/sendgrid/docs/index.rst
+++ b/providers/sendgrid/docs/index.rst
@@ -91,31 +91,3 @@ PIP package                                 Version required
 ``werkzeug``                                ``>=2.2,<4; python_version >= "3.12" and python_version <= "3.13"``
 ``werkzeug``                                ``>=3.1.6,<4; python_version >= "3.14"``
 ==========================================  ===================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-sendgrid[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-sendgrid 4.2.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-sendgrid 4.2.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sendgrid-4.2.2-py3-none-any.whl.sha512>`__)

--- a/providers/sftp/README.rst
+++ b/providers/sftp/README.rst
@@ -61,8 +61,8 @@ PIP package                                 Version required
 ``asyncssh``                                ``>=2.22.0; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -71,16 +71,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-sftp[common.compat]
+    pip install apache-airflow-providers-sftp[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-`apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                      ``ssh``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/sftp/docs/index.rst
+++ b/providers/sftp/docs/index.rst
@@ -108,8 +108,8 @@ PIP package                                 Version required
 ``asyncssh``                                ``>=2.22.0; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -118,16 +118,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-sftp[common.compat]
+    pip install apache-airflow-providers-sftp[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-`apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                      ``ssh``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/singularity/README.rst
+++ b/providers/singularity/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``spython``                                 ``>=0.0.56``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-singularity[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-singularity/3.9.3/changelog.html>`_.

--- a/providers/singularity/docs/index.rst
+++ b/providers/singularity/docs/index.rst
@@ -96,31 +96,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``spython``                                 ``>=0.0.56``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-singularity[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-singularity 3.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-singularity 3.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_singularity-3.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/slack/README.rst
+++ b/providers/slack/README.rst
@@ -64,25 +64,5 @@ PIP package                                 Version required
 ``asgiref``                                 ``>=3.11.1; python_version >= "3.14"``
 ==========================================  ======================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-slack[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-slack/9.9.0/changelog.html>`_.

--- a/providers/slack/docs/index.rst
+++ b/providers/slack/docs/index.rst
@@ -111,32 +111,3 @@ PIP package                                 Version required
 ``asgiref``                                 ``>=2.3.0; python_version < "3.14"``
 ``asgiref``                                 ``>=3.11.1; python_version >= "3.14"``
 ==========================================  ======================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-slack[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-slack 9.9.0 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0.tar.gz.sha512>`__)
-* `The apache-airflow-providers-slack 9.9.0 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_slack-9.9.0-py3-none-any.whl.sha512>`__)

--- a/providers/smtp/README.rst
+++ b/providers/smtp/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``aiosmtplib``                              ``>=0.1.6``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-smtp[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-smtp/2.4.4/changelog.html>`_.

--- a/providers/smtp/docs/index.rst
+++ b/providers/smtp/docs/index.rst
@@ -91,31 +91,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``aiosmtplib``                              ``>=0.1.6``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-smtp[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-smtp 2.4.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-smtp 2.4.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_smtp-2.4.4-py3-none-any.whl.sha512>`__)

--- a/providers/snowflake/README.rst
+++ b/providers/snowflake/README.rst
@@ -69,8 +69,8 @@ PIP package                                 Version required
 ``setuptools``                              ``>=80.0.0,<9999``
 ==========================================  ========================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -79,14 +79,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-snowflake[common.compat]
+    pip install apache-airflow-providers-snowflake[microsoft.azure]
 
 
 ======================================================================================================================  ===================
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================

--- a/providers/snowflake/docs/index.rst
+++ b/providers/snowflake/docs/index.rst
@@ -118,8 +118,8 @@ PIP package                                 Version required
 ``setuptools``                              ``>=80.0.0,<9999``
 ==========================================  ========================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -128,14 +128,12 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-snowflake[common.compat]
+    pip install apache-airflow-providers-snowflake[microsoft.azure]
 
 
 ======================================================================================================================  ===================
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================

--- a/providers/sqlite/README.rst
+++ b/providers/sqlite/README.rst
@@ -57,24 +57,5 @@ PIP package                              Version required
 ``apache-airflow-providers-common-sql``  ``>=1.32.0``
 =======================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-sqlite[common.sql]
-
-
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-sqlite/4.3.1/changelog.html>`_.

--- a/providers/sqlite/docs/index.rst
+++ b/providers/sqlite/docs/index.rst
@@ -103,31 +103,3 @@ PIP package                              Version required
 ``apache-airflow``                       ``>=2.11.0``
 ``apache-airflow-providers-common-sql``  ``>=1.32.0``
 =======================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-sqlite[common.sql]
-
-
-============================================================================================================  ==============
-Dependent package                                                                                             Extra
-============================================================================================================  ==============
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
-============================================================================================================  ==============
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-sqlite 4.3.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-sqlite 4.3.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_sqlite-4.3.1-py3-none-any.whl.sha512>`__)

--- a/providers/ssh/README.rst
+++ b/providers/ssh/README.rst
@@ -60,24 +60,5 @@ PIP package                                 Version required
 ``sshtunnel``                               ``>=0.3.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-ssh[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-ssh/4.3.3/changelog.html>`_.

--- a/providers/ssh/docs/index.rst
+++ b/providers/ssh/docs/index.rst
@@ -98,31 +98,3 @@ PIP package                                 Version required
 ``paramiko``                                ``>=3.4.0,<4.0.0``
 ``sshtunnel``                               ``>=0.3.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-ssh[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-ssh 4.3.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-ssh 4.3.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ssh-4.3.3-py3-none-any.whl.sha512>`__)

--- a/providers/standard/README.rst
+++ b/providers/standard/README.rst
@@ -57,8 +57,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.14.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -67,15 +67,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-standard[common.compat]
+    pip install apache-airflow-providers-standard[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/standard/docs/index.rst
+++ b/providers/standard/docs/index.rst
@@ -93,8 +93,8 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.14.1``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -103,15 +103,14 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-standard[common.compat]
+    pip install apache-airflow-providers-standard[openlineage]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/tableau/README.rst
+++ b/providers/tableau/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``tableauserverclient``                     ``>=0.27,!=0.39``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-tableau[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-tableau/5.3.4/changelog.html>`_.

--- a/providers/tableau/docs/index.rst
+++ b/providers/tableau/docs/index.rst
@@ -98,31 +98,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``tableauserverclient``                     ``>=0.27,!=0.39``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-tableau[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-tableau 5.3.4 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4.tar.gz.sha512>`__)
-* `The apache-airflow-providers-tableau 5.3.4 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_tableau-5.3.4-py3-none-any.whl.sha512>`__)

--- a/providers/telegram/README.rst
+++ b/providers/telegram/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``python-telegram-bot``                     ``>=20.2``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-telegram[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-telegram/4.9.3/changelog.html>`_.

--- a/providers/telegram/docs/index.rst
+++ b/providers/telegram/docs/index.rst
@@ -104,31 +104,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.10.1``
 ``python-telegram-bot``                     ``>=20.2``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-telegram[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-telegram 4.9.3 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3.tar.gz.sha512>`__)
-* `The apache-airflow-providers-telegram 4.9.3 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_telegram-4.9.3-py3-none-any.whl.sha512>`__)

--- a/providers/teradata/README.rst
+++ b/providers/teradata/README.rst
@@ -60,8 +60,8 @@ PIP package                                 Version required
 ``teradatasql``                             ``>=17.20.0.28``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -77,8 +77,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                          ``ssh``
 ======================================================================================================================  ===================

--- a/providers/teradata/docs/index.rst
+++ b/providers/teradata/docs/index.rst
@@ -107,8 +107,8 @@ PIP package                                 Version required
 ``teradatasql``                             ``>=17.20.0.28``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -124,8 +124,6 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 Dependent package                                                                                                       Extra
 ======================================================================================================================  ===================
 `apache-airflow-providers-amazon <https://airflow.apache.org/docs/apache-airflow-providers-amazon>`_                    ``amazon``
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_      ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_            ``common.sql``
 `apache-airflow-providers-microsoft-azure <https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure>`_  ``microsoft.azure``
 `apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                          ``ssh``
 ======================================================================================================================  ===================

--- a/providers/trino/README.rst
+++ b/providers/trino/README.rst
@@ -62,8 +62,8 @@ PIP package                                 Version required
 ``trino``                                   ``>=0.319.0``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified providers in order to use them.
@@ -72,17 +72,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-trino[common.compat]
+    pip install apache-airflow-providers-trino[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_            ``google``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Optional dependencies
 ----------------------

--- a/providers/trino/docs/index.rst
+++ b/providers/trino/docs/index.rst
@@ -110,8 +110,8 @@ PIP package                                 Version required
 ``trino``                                   ``>=0.319.0``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
+Optional cross provider package dependencies
+--------------------------------------------
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified provider distributions in order to use them.
@@ -120,17 +120,15 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 .. code-block:: bash
 
-    pip install apache-airflow-providers-trino[common.compat]
+    pip install apache-airflow-providers-trino[google]
 
 
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                ``google``
-`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
-==================================================================================================================  =================
+==============================================================================================================  ===============
+Dependent package                                                                                               Extra
+==============================================================================================================  ===============
+`apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_            ``google``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
+==============================================================================================================  ===============
 
 Downloading official packages
 -----------------------------

--- a/providers/vertica/README.rst
+++ b/providers/vertica/README.rst
@@ -59,26 +59,6 @@ PIP package                                 Version required
 ``vertica-python``                          ``>=1.3.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-vertica[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 Optional dependencies
 ----------------------
 

--- a/providers/vertica/docs/index.rst
+++ b/providers/vertica/docs/index.rst
@@ -106,32 +106,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
 ``vertica-python``                          ``>=1.3.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-vertica[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-vertica 4.3.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-vertica 4.3.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_vertica-4.3.1-py3-none-any.whl.sha512>`__)

--- a/providers/weaviate/README.rst
+++ b/providers/weaviate/README.rst
@@ -62,24 +62,5 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-weaviate[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-weaviate/3.3.2/changelog.html>`_.

--- a/providers/weaviate/docs/index.rst
+++ b/providers/weaviate/docs/index.rst
@@ -110,31 +110,3 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-weaviate[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-weaviate 3.3.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-weaviate 3.3.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_weaviate-3.3.2-py3-none-any.whl.sha512>`__)

--- a/providers/yandex/README.rst
+++ b/providers/yandex/README.rst
@@ -63,24 +63,5 @@ PIP package                                 Version required
 ``grpcio``                                  ``>=1.70.0``
 ==========================================  =======================================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-yandex[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-yandex/4.4.1/changelog.html>`_.

--- a/providers/yandex/docs/index.rst
+++ b/providers/yandex/docs/index.rst
@@ -111,31 +111,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``grpcio``                                  ``>=1.70.0``
 ==========================================  =======================================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-yandex[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-yandex 4.4.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-yandex 4.4.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_yandex-4.4.1-py3-none-any.whl.sha512>`__)

--- a/providers/ydb/README.rst
+++ b/providers/ydb/README.rst
@@ -60,25 +60,5 @@ PIP package                                 Version required
 ``ydb-dbapi``                               ``>=0.1.0``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-ydb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-ydb/2.5.1/changelog.html>`_.

--- a/providers/ydb/docs/index.rst
+++ b/providers/ydb/docs/index.rst
@@ -106,32 +106,3 @@ PIP package                                 Version required
 ``ydb``                                     ``>=3.18.8``
 ``ydb-dbapi``                               ``>=0.1.0``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-ydb[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-`apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-ydb 2.5.1 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1.tar.gz.sha512>`__)
-* `The apache-airflow-providers-ydb 2.5.1 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_ydb-2.5.1-py3-none-any.whl.sha512>`__)

--- a/providers/zendesk/README.rst
+++ b/providers/zendesk/README.rst
@@ -58,24 +58,5 @@ PIP package                                 Version required
 ``zenpy``                                   ``>=2.0.40``
 ==========================================  ==================
 
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified providers in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-zendesk[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 The changelog for the provider package can be found in the
 `changelog <https://airflow.apache.org/docs/apache-airflow-providers-zendesk/4.11.2/changelog.html>`_.

--- a/providers/zendesk/docs/index.rst
+++ b/providers/zendesk/docs/index.rst
@@ -103,31 +103,3 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``zenpy``                                   ``>=2.0.40``
 ==========================================  ==================
-
-Cross provider package dependencies
------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-zendesk[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
-Downloading official packages
------------------------------
-
-You can download officially released packages and verify their checksums and signatures from the
-`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
-
-* `The apache-airflow-providers-zendesk 4.11.2 sdist package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2.tar.gz.sha512>`__)
-* `The apache-airflow-providers-zendesk 4.11.2 wheel package <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/apache_airflow_providers_zendesk-4.11.2-py3-none-any.whl.sha512>`__)


### PR DESCRIPTION
This mirrors what happens when generating `pyproject.toml` - if providers are listed in the package requirements, they are not added as `extras`.

The difference here - and where I'm hoping for some feedback - is that the docs say both "This is a cross provider dependency" and "here's the extra you can use to install it if you want".

Basically, do we want to differentiate between optional and required cross provider dependencies, but still show both? Or perhaps rename the docs section "optional cross provider dependencies"? This PR currently chooses to do neither, and just doesn't show the cross provider dependency if it's also a required dependency.

closes: #63891

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
---

##### Was generative AI tooling used to co-author this PR?
Nope
