### PR TITLE
Refactor 0102_3_2_0_make_external_executor_id_text migration to support batch processing downgrade

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
+++ b/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.configuration import conf
+
 if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
@@ -48,7 +50,7 @@ _TABLE_KEY_COLUMNS = {
 }
 _COLUMN = "external_executor_id"
 _NEW_COL = "external_executor_id_new"
-_BATCH_SIZE = 1000
+_BATCH_SIZE = conf.getint("database", "migration_batch_size", fallback=1000)
 
 
 def upgrade():

--- a/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
+++ b/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
@@ -42,7 +42,10 @@ branch_labels = None
 depends_on = None
 airflow_version = "3.2.0"
 
-_TABLES = {"task_instance", "task_instance_history"}
+_TABLE_KEY_COLUMNS = {
+    "task_instance": "id",
+    "task_instance_history": "task_instance_id",
+}
 _COLUMN = "external_executor_id"
 _NEW_COL = "external_executor_id_new"
 _BATCH_SIZE = 1000
@@ -55,7 +58,7 @@ def upgrade():
     On PostgreSQL this is a metadata-only change (no table rewrite), the ACCESS EXCLUSIVE lock is held for only milliseconds.
     On MySQL, TEXT is also a superset of VARCHAR(250), so no rewrite is needed.
     """
-    for table in _TABLES:
+    for table in _TABLE_KEY_COLUMNS:
         with op.batch_alter_table(table, schema=None) as batch_op:
             batch_op.alter_column(
                 _COLUMN,
@@ -84,17 +87,18 @@ def downgrade():
     dialect_name = conn.dialect.name
 
     if dialect_name == "sqlite":
-        for table in _TABLES:
+        for table in _TABLE_KEY_COLUMNS:
             _downgrade_sqlite(table)
     else:
         # Generic path works for both PostgreSQL and MySQL 8.0+
-        for table in _TABLES:
+        for table in _TABLE_KEY_COLUMNS:
             _downgrade_expand_contract(conn, table)
 
 
 def _downgrade_expand_contract(conn: Connection, table: str):
     """Expand-contract downgrade for PostgreSQL and MySQL."""
     engine = conn.engine
+    key_column = _TABLE_KEY_COLUMNS[table]
 
     print(f"starting expand-contract downgrade for {table}.{_COLUMN}")
 
@@ -114,17 +118,19 @@ def _downgrade_expand_contract(conn: Connection, table: str):
             if last_id is None:
                 rows = batch_conn.execute(
                     sa.text(
-                        f"SELECT id FROM {table} WHERE {_COLUMN} IS NOT NULL ORDER BY id LIMIT :batch_size"
+                        f"SELECT {key_column} FROM {table} "
+                        f"WHERE {_COLUMN} IS NOT NULL "
+                        f"ORDER BY {key_column} LIMIT :batch_size"
                     ),
                     {"batch_size": _BATCH_SIZE},
                 ).fetchall()
             else:
                 rows = batch_conn.execute(
                     sa.text(
-                        f"SELECT id FROM {table} "
+                        f"SELECT {key_column} FROM {table} "
                         f"WHERE {_COLUMN} IS NOT NULL "
-                        f"AND id > :last_id "
-                        f"ORDER BY id "
+                        f"AND {key_column} > :last_id "
+                        f"ORDER BY {key_column} "
                         f"LIMIT :batch_size"
                     ),
                     {"last_id": last_id, "batch_size": _BATCH_SIZE},
@@ -143,7 +149,7 @@ def _downgrade_expand_contract(conn: Connection, table: str):
                     f"CASE WHEN LENGTH({_COLUMN}) > 250 "
                     f"THEN LEFT({_COLUMN}, 250) "
                     f"ELSE {_COLUMN} END "
-                    f"WHERE id >= :min_id AND id <= :max_id "
+                    f"WHERE {key_column} >= :min_id AND {key_column} <= :max_id "
                     f"AND {_COLUMN} IS NOT NULL"
                 ),
                 {"min_id": min_id, "max_id": max_id},

--- a/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
+++ b/airflow-core/src/airflow/migrations/versions/0102_3_2_0_make_external_executor_id_text.py
@@ -27,8 +27,13 @@ Create Date: 2026-01-28 16:35:00.000000
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import sqlalchemy as sa
 from alembic import op
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
 
 # revision identifiers, used by Alembic.
 revision = "a5a3e5eb9b8d"
@@ -37,39 +42,129 @@ branch_labels = None
 depends_on = None
 airflow_version = "3.2.0"
 
+_TABLES = {"task_instance", "task_instance_history"}
+_COLUMN = "external_executor_id"
+_NEW_COL = "external_executor_id_new"
+_BATCH_SIZE = 1000
+
 
 def upgrade():
-    """Change external_executor_id column from VARCHAR(250) to TEXT."""
-    with op.batch_alter_table("task_instance", schema=None) as batch_op:
-        batch_op.alter_column(
-            "external_executor_id",
-            existing_type=sa.VARCHAR(length=250),
-            type_=sa.Text(),
-            existing_nullable=True,
-        )
+    """
+    Change external_executor_id column from VARCHAR(250) to TEXT.
 
-    with op.batch_alter_table("task_instance_history", schema=None) as batch_op:
-        batch_op.alter_column(
-            "external_executor_id",
-            existing_type=sa.VARCHAR(length=250),
-            type_=sa.Text(),
-            existing_nullable=True,
-        )
+    On PostgreSQL this is a metadata-only change (no table rewrite), the ACCESS EXCLUSIVE lock is held for only milliseconds.
+    On MySQL, TEXT is also a superset of VARCHAR(250), so no rewrite is needed.
+    """
+    for table in _TABLES:
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.alter_column(
+                _COLUMN,
+                existing_type=sa.VARCHAR(length=250),
+                type_=sa.Text(),
+                existing_nullable=True,
+            )
 
 
 def downgrade():
-    """Revert external_executor_id column from TEXT to VARCHAR(250)."""
-    with op.batch_alter_table("task_instance_history", schema=None) as batch_op:
-        batch_op.alter_column(
-            "external_executor_id",
-            existing_type=sa.Text(),
-            type_=sa.VARCHAR(length=250),
-            existing_nullable=True,
-        )
+    """
+    Revert external_executor_id column from TEXT to VARCHAR(250).
 
-    with op.batch_alter_table("task_instance", schema=None) as batch_op:
+    A naive ALTER COLUMN ... TYPE VARCHAR(250) would acquire ACCESS EXCLUSIVE
+    for the full duration of a table rewrite — minutes on large tables,
+    blocking ALL reads and writes to task_instance / task_instance_history.
+
+    Instead we:
+    1. ADD COLUMN (instant, brief ACCESS EXCLUSIVE)
+    2. Backfill in batches (ROW EXCLUSIVE only — concurrent reads/writes OK)
+    3. DROP old + RENAME new (instant, brief ACCESS EXCLUSIVE)
+
+    This keeps the exclusive lock window to milliseconds at each step.
+    """
+    conn = op.get_bind()
+    dialect_name = conn.dialect.name
+
+    if dialect_name == "sqlite":
+        for table in _TABLES:
+            _downgrade_sqlite(table)
+    else:
+        # Generic path works for both PostgreSQL and MySQL 8.0+
+        for table in _TABLES:
+            _downgrade_expand_contract(conn, table)
+
+
+def _downgrade_expand_contract(conn: Connection, table: str):
+    """Expand-contract downgrade for PostgreSQL and MySQL."""
+    engine = conn.engine
+
+    print(f"starting expand-contract downgrade for {table}.{_COLUMN}")
+
+    # Phase 1: ADD the shadow column (instant, ~ms ACCESS EXCLUSIVE)
+    with engine.begin() as ddl_conn:
+        ddl_conn.execute(sa.text(f"ALTER TABLE {table} ADD COLUMN {_NEW_COL} VARCHAR(250)"))
+
+    # Phase 2: Backfill in batches using keyset pagination.
+    # Keyset (WHERE id > last_seen) is O(batch_size) per batch vs
+    # OFFSET which is O(total_rows). UPDATE uses a range on the PK
+    # for a single index scan instead of N point lookups.
+    total_updated = 0
+    last_id = None
+
+    while True:
+        with engine.begin() as batch_conn:
+            if last_id is None:
+                rows = batch_conn.execute(
+                    sa.text(
+                        f"SELECT id FROM {table} WHERE {_COLUMN} IS NOT NULL ORDER BY id LIMIT :batch_size"
+                    ),
+                    {"batch_size": _BATCH_SIZE},
+                ).fetchall()
+            else:
+                rows = batch_conn.execute(
+                    sa.text(
+                        f"SELECT id FROM {table} "
+                        f"WHERE {_COLUMN} IS NOT NULL "
+                        f"AND id > :last_id "
+                        f"ORDER BY id "
+                        f"LIMIT :batch_size"
+                    ),
+                    {"last_id": last_id, "batch_size": _BATCH_SIZE},
+                ).fetchall()
+
+            if not rows:
+                break
+
+            min_id = rows[0][0]
+            max_id = rows[-1][0]
+            last_id = max_id
+
+            batch_conn.execute(
+                sa.text(
+                    f"UPDATE {table} SET {_NEW_COL} = "
+                    f"CASE WHEN LENGTH({_COLUMN}) > 250 "
+                    f"THEN LEFT({_COLUMN}, 250) "
+                    f"ELSE {_COLUMN} END "
+                    f"WHERE id >= :min_id AND id <= :max_id "
+                    f"AND {_COLUMN} IS NOT NULL"
+                ),
+                {"min_id": min_id, "max_id": max_id},
+            )
+
+            total_updated += len(rows)
+            print(f"backfilled {table}.{_NEW_COL}: {total_updated} rows so far")
+
+    print(f"backfill complete for {table}.{_NEW_COL}: {total_updated} rows total")
+
+    # Phase 3: Atomic swap — DROP old + RENAME new (instant, ~ms ACCESS EXCLUSIVE)
+    with engine.begin() as swap_conn:
+        swap_conn.execute(sa.text(f"ALTER TABLE {table} DROP COLUMN {_COLUMN}"))
+        swap_conn.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN {_NEW_COL} TO {_COLUMN}"))
+
+
+def _downgrade_sqlite(table: str):
+    """SQLite uses Alembic's copy-and-swap, which is fine for small dev/test DBs."""
+    with op.batch_alter_table(table) as batch_op:
         batch_op.alter_column(
-            "external_executor_id",
+            _COLUMN,
             existing_type=sa.Text(),
             type_=sa.VARCHAR(length=250),
             existing_nullable=True,


### PR DESCRIPTION

* closes: #63545

## Why

As pointed out in https://github.com/apache/airflow/pull/63625#pullrequestreview-3967954962, the original migration (and also the PR [[migration-0102] Change logic migration data of postgresql](https://github.com/apache/airflow/pull/63625)) will hold the `ACCESS EXCLUSIVE` lock that blocks **ALL the concurrent READ** and **WRITE**, For `TaskInstance` and `TaskInstanceHistory` tables at production scale, even 4 minutes of total blocking is unacceptable. (e.g. downgrade from 3.2.0 to 3.1.8 due to other feature's error but encounter 8mins downtime)


## What

Instead we:

1. ADD `external_executor_id_new` COLUMN (instant, ~ms level, brief ACCESS EXCLUSIVE)
2. Backfill in batches
    - it _might_ take longer than a naive `ALTER TABLE task_instance ALTER COLUMN ... TYPE VARCHAR(250)` DDL
    - but it's only a ROW EXCLUSIVE lock
    - so **with this approach, it still allow all concurrent reads/writes for the rows that are not in the current batch.**
3. DROP `external_executor_id` + RENAME `external_executor_id_new` to `external_executor_id` in same TX (instant, ~ms level, brief ACCESS EXCLUSIVE)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below) Discussing the locking behavior with Claude, Gemini
