### PR TITLE
Fix stats page showing 0 for per-type module counts

### DIFF
--- a/registry/src/_data/statsData.js
+++ b/registry/src/_data/statsData.js
@@ -98,6 +98,7 @@ module.exports = function() {
   // Enriched provider list with totals
   const enrichedProviders = [...providers].map(p => ({
     ...p,
+    module_counts: countsByProvider[p.id] || {},
     totalModules: countsByProvider[p.id]
       ? Object.values(countsByProvider[p.id]).reduce((a, b) => a + b, 0)
       : 0,


### PR DESCRIPTION
The stats page "Top 10 by Module Count" table showed 0 for all per-type columns (Operators, Hooks, Sensors, etc.) while the Total column was correct. This was caused by incremental builds: the `...p` spread copied stale `module_counts` zeros from providers.json, but `totalModules` was correctly computed from modules.json.

Override `module_counts` with the actual per-type counts from modules.json (the source of truth), matching how `totalModules` is already computed.


**Now**:

<img width="1255" height="707" alt="image" src="https://github.com/user-attachments/assets/c96144ca-398f-4f49-bf6b-359547a984b5" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
