### PR TITLE
Rediscover succeeded pods in GKEJobTrigger to handle Kubernetes Job retries with XCom

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1156,6 +1156,7 @@ class AsyncKubernetesHook(KubernetesHook):
                 if resource_version is not None:
                     kwargs["resource_version"] = resource_version
                     kwargs["resource_version_match"] = "NotOlderThan"
+
                 events: CoreV1EventList = await v1_api.list_namespaced_event(**kwargs)
                 return events
             except HTTPError as e:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1156,7 +1156,6 @@ class AsyncKubernetesHook(KubernetesHook):
                 if resource_version is not None:
                     kwargs["resource_version"] = resource_version
                     kwargs["resource_version_match"] = "NotOlderThan"
-
                 events: CoreV1EventList = await v1_api.list_namespaced_event(**kwargs)
                 return events
             except HTTPError as e:

--- a/providers/google/src/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -507,6 +507,26 @@ class GKEKubernetesAsyncHook(GoogleBaseAsyncHook, AsyncKubernetesHook):
             if kube_client is not None:
                 await kube_client.close()
 
+    async def list_pods(
+        self,
+        namespace: str,
+        label_selector: str,
+    ) -> list:
+        """
+        List pods in the given namespace matching the label selector.
+
+        :param namespace: Kubernetes namespace.
+        :param label_selector: Label selector to filter pods (e.g. ``job-name=my-job``).
+        :return: List of V1Pod objects.
+        """
+        async with self.get_conn() as connection:
+            v1_api = async_client.CoreV1Api(connection)
+            response = await v1_api.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=label_selector,
+            )
+            return list(response.items) if response.items else []
+
     async def _load_config(self) -> async_client.ApiClient:
         configuration = self._get_config()
         token = await self.get_token()

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -333,9 +333,30 @@ class GKEJobTrigger(BaseTrigger):
                     f"package {kubernetes_provider_name}=={kubernetes_provider_version} which doesn't "
                     f"support this feature. Please upgrade it to version higher than or equal to {min_version}."
                 )
+            # Re-discover pods for this job to handle retry scenarios
+            # where the original pod failed and a new pod was created
+            label_selector = f"job-name={self.job_name}"
+            current_pods = await self.hook.list_pods(
+                namespace=self.pod_namespace,
+                label_selector=label_selector,
+            )
+            succeeded_pods = [
+                p for p in current_pods
+                if p.status and p.status.phase == "Succeeded"
+            ]
+            if not succeeded_pods:
+                self.log.warning(
+                    "No succeeded pods found for job %s, falling back to original pod list",
+                    self.job_name,
+                )
+                succeeded_pods = [
+                    await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
+                    for pod_name in self.pod_names
+                ]
+
             xcom_results = []
-            for pod_name in self.pod_names:
-                pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
+            for pod in succeeded_pods:
+                pod_name = pod.metadata.name
                 await self.hook.wait_until_container_complete(
                     name=pod_name,
                     namespace=self.pod_namespace,

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -340,10 +340,7 @@ class GKEJobTrigger(BaseTrigger):
                 namespace=self.pod_namespace,
                 label_selector=label_selector,
             )
-            succeeded_pods = [
-                p for p in current_pods
-                if p.status and p.status.phase == "Succeeded"
-            ]
+            succeeded_pods = [p for p in current_pods if p.status and p.status.phase == "Succeeded"]
             if not succeeded_pods:
                 self.log.warning(
                     "No succeeded pods found for job %s, falling back to original pod list",

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -346,10 +346,7 @@ class GKEJobTrigger(BaseTrigger):
                     "No succeeded pods found for job %s, falling back to original pod list",
                     self.job_name,
                 )
-                succeeded_pods = [
-                    await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
-                    for pod_name in self.pod_names
-                ]
+                succeeded_pods = [p for p in current_pods if p.metadata.name in self.pod_names]
 
             xcom_results = []
             for pod in succeeded_pods:

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import warnings
 from collections.abc import AsyncIterator, Sequence
 from functools import cached_property
@@ -336,14 +337,26 @@ class GKEJobTrigger(BaseTrigger):
             # Re-discover pods for this job to handle retry scenarios
             # where the original pod failed and a new pod was created
             label_selector = f"job-name={self.job_name}"
-            current_pods = await self.hook.list_pods(
-                namespace=self.pod_namespace,
-                label_selector=label_selector,
-            )
-            succeeded_pods = [p for p in current_pods if p.status and p.status.phase == "Succeeded"]
+            deadline = time.monotonic() + self.poll_interval * 10
+            succeeded_pods = []
+            current_pods = []
+            while time.monotonic() < deadline:
+                current_pods = await self.hook.list_pods(
+                    namespace=self.pod_namespace,
+                    label_selector=label_selector,
+                )
+                succeeded_pods = [p for p in current_pods if p.status and p.status.phase == "Succeeded"]
+                if succeeded_pods:
+                    break
+                self.log.info(
+                    "No succeeded pods found yet for job %s, retrying in %s seconds...",
+                    self.job_name,
+                    self.poll_interval,
+                )
+                await asyncio.sleep(self.poll_interval)
             if not succeeded_pods:
                 self.log.warning(
-                    "No succeeded pods found for job %s, falling back to original pod list",
+                    "No succeeded pods found for job %s after timeout, falling back to original pod list",
                     self.job_name,
                 )
                 succeeded_pods = [p for p in current_pods if p.metadata.name in self.pod_names]

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -589,3 +589,74 @@ class TestGKEStartJobTrigger:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         assert hook_actual == hook_expected
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{GKE_TRIGGERS_PATH}.ProvidersManager")
+    @mock.patch(f"{TRIGGER_GKE_JOB_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_GKE_JOB_PATH}.hook")
+    async def test_run_do_xcom_push_uses_succeeded_retry_pod_not_original_failed_pod(
+        self, mock_hook, mock_pod_manager_prop, mock_providers_manager
+    ):
+        """When a job has a failed pod and a succeeded retry pod, use the succeeded pod for XCom."""
+        mock_providers_manager.return_value.providers = {
+            "apache-airflow-providers-cncf-kubernetes": mock.MagicMock(
+                data={"package-name": "apache-airflow-providers-cncf-kubernetes"},
+                version="8.4.1",
+            )
+        }
+
+        failed_pod = mock.MagicMock()
+        failed_pod.metadata.name = "original-failed-pod"
+        failed_pod.status.phase = "Failed"
+
+        succeeded_pod = mock.MagicMock()
+        succeeded_pod.metadata.name = "retry-succeeded-pod"
+        succeeded_pod.status.phase = "Succeeded"
+
+        mock_hook.list_pods = mock.AsyncMock(return_value=[failed_pod, succeeded_pod])
+        mock_hook.wait_until_container_complete = mock.AsyncMock()
+        mock_hook.wait_until_container_started = mock.AsyncMock()
+        mock_hook.wait_until_job_complete = mock.AsyncMock()
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = JOB_NAME
+        mock_job.metadata.namespace = NAMESPACE
+        mock_job.to_dict.return_value = {"job": "dict"}
+        mock_hook.wait_until_job_complete.return_value = mock_job
+        mock_hook.is_job_failed = mock.MagicMock(return_value=False)
+
+        mock_pod_manager = mock.MagicMock()
+        mock_pod_manager.extract_xcom.return_value = {"xcom": "result"}
+        mock_pod_manager_prop.return_value = mock_pod_manager
+
+        def run_in_executor(_executor, func, *args):
+            result = func(*args)
+            loop = asyncio.get_running_loop()
+            f = loop.create_future()
+            f.set_result(result)
+            return f
+
+        with mock.patch.object(asyncio.get_running_loop(), "run_in_executor", side_effect=run_in_executor):
+            trigger = GKEJobTrigger(
+                cluster_url=CLUSTER_URL,
+                ssl_ca_cert=SSL_CA_CERT,
+                job_name=JOB_NAME,
+                job_namespace=NAMESPACE,
+                pod_names=[POD_NAME],
+                pod_namespace=NAMESPACE,
+                base_container_name=BASE_CONTAINER_NAME,
+                gcp_conn_id=GCP_CONN_ID,
+                poll_interval=POLL_INTERVAL,
+                impersonation_chain=IMPERSONATION_CHAIN,
+                get_logs=GET_LOGS,
+                do_xcom_push=True,
+            )
+            event = await trigger.run().asend(None)
+
+        mock_hook.list_pods.assert_called_once_with(
+            namespace=NAMESPACE,
+            label_selector=f"job-name={JOB_NAME}",
+        )
+        assert mock_pod_manager.extract_xcom.call_count == 1
+        assert mock_pod_manager.extract_xcom.call_args[0][0] is succeeded_pod
+        assert mock_pod_manager.extract_xcom.call_args[0][0].metadata.name == "retry-succeeded-pod"
+        assert event.payload["xcom_result"] == [{"xcom": "result"}]

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -34,6 +34,7 @@ except ImportError:
     from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import (  # type: ignore[no-redef]
         ContainerState,
     )
+from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.providers.google.cloud.triggers.kubernetes_engine import (
     GKEJobTrigger,
     GKEOperationTrigger,
@@ -595,7 +596,7 @@ class TestGKEStartJobTrigger:
     @mock.patch(f"{TRIGGER_GKE_JOB_PATH}.pod_manager", new_callable=mock.PropertyMock)
     @mock.patch(f"{TRIGGER_GKE_JOB_PATH}.hook")
     async def test_run_do_xcom_push_uses_succeeded_retry_pod_not_original_failed_pod(
-        self, mock_hook, mock_pod_manager_prop, mock_providers_manager
+        self, mock_hook, mock_pod_manager_prop, mock_providers_manager, job_trigger
     ):
         """When a job has a failed pod and a succeeded retry pod, use the succeeded pod for XCom."""
         mock_providers_manager.return_value.providers = {
@@ -614,13 +615,16 @@ class TestGKEStartJobTrigger:
         succeeded_pod.status.phase = "Succeeded"
 
         mock_hook.list_pods = mock.AsyncMock(return_value=[failed_pod, succeeded_pod])
+
         mock_hook.wait_until_container_complete = mock.AsyncMock()
         mock_hook.wait_until_container_started = mock.AsyncMock()
         mock_hook.wait_until_job_complete = mock.AsyncMock()
+
         mock_job = mock.MagicMock()
         mock_job.metadata.name = JOB_NAME
         mock_job.metadata.namespace = NAMESPACE
         mock_job.to_dict.return_value = {"job": "dict"}
+
         mock_hook.wait_until_job_complete.return_value = mock_job
         mock_hook.is_job_failed = mock.MagicMock(return_value=False)
 
@@ -628,35 +632,24 @@ class TestGKEStartJobTrigger:
         mock_pod_manager.extract_xcom.return_value = {"xcom": "result"}
         mock_pod_manager_prop.return_value = mock_pod_manager
 
-        def run_in_executor(_executor, func, *args):
-            result = func(*args)
-            loop = asyncio.get_running_loop()
-            f = loop.create_future()
-            f.set_result(result)
-            return f
-
-        with mock.patch.object(asyncio.get_running_loop(), "run_in_executor", side_effect=run_in_executor):
-            trigger = GKEJobTrigger(
-                cluster_url=CLUSTER_URL,
-                ssl_ca_cert=SSL_CA_CERT,
-                job_name=JOB_NAME,
-                job_namespace=NAMESPACE,
-                pod_names=[POD_NAME],
-                pod_namespace=NAMESPACE,
-                base_container_name=BASE_CONTAINER_NAME,
-                gcp_conn_id=GCP_CONN_ID,
-                poll_interval=POLL_INTERVAL,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                get_logs=GET_LOGS,
-                do_xcom_push=True,
-            )
-            event = await trigger.run().asend(None)
+        job_trigger.do_xcom_push = True
+        event = await job_trigger.run().asend(None)
 
         mock_hook.list_pods.assert_called_once_with(
             namespace=NAMESPACE,
             label_selector=f"job-name={JOB_NAME}",
         )
-        assert mock_pod_manager.extract_xcom.call_count == 1
-        assert mock_pod_manager.extract_xcom.call_args[0][0] is succeeded_pod
-        assert mock_pod_manager.extract_xcom.call_args[0][0].metadata.name == "retry-succeeded-pod"
+        mock_pod_manager.extract_xcom.assert_called_once_with(succeeded_pod)
         assert event.payload["xcom_result"] == [{"xcom": "result"}]
+        mock_hook.wait_until_container_complete.assert_called_once_with(
+            name="retry-succeeded-pod",
+            namespace=NAMESPACE,
+            container_name=BASE_CONTAINER_NAME,
+            poll_interval=POLL_INTERVAL,
+        )
+        mock_hook.wait_until_container_started.assert_called_once_with(
+            name="retry-succeeded-pod",
+            namespace=NAMESPACE,
+            container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
+            poll_interval=POLL_INTERVAL,
+        )

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -635,7 +635,7 @@ class TestGKEStartJobTrigger:
         job_trigger.do_xcom_push = True
         event = await job_trigger.run().asend(None)
 
-        mock_hook.list_pods.assert_called_once_with(
+        mock_hook.list_pods.assert_awaited_once_with(
             namespace=NAMESPACE,
             label_selector=f"job-name={JOB_NAME}",
         )


### PR DESCRIPTION
## Problem

When a Kubernetes Job retries (creates a new pod after a pod failure), `GKEJobTrigger` keeps tracking the original pod names set at trigger creation time. It waits for XCom on the failed pod instead of the new retry pod. This causes the XCom sidecar on the retry pod to never receive a termination signal, leaving the pod running until the job's `activeDeadlineSeconds` is exceeded and failing the task.

## Fix

Before XCom extraction, re-discover all current pods for the job using the `job-name=<job_name>` label selector. Filter to only succeeded pods and extract XCom from those. Falls back to original pod list if no succeeded pods are found.

Added `list_pods()` async method to `GKEKubernetesAsyncHook` to support pod discovery by label selector.

## Testing

Added unit test `test_run_do_xcom_push_uses_succeeded_retry_pod_not_original_failed_pod` that verifies the trigger uses the succeeded retry pod for XCom extraction when the original pod failed.

Fixes #63838