### PR TITLE
Fix excluded provider tests crashing pytest

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -114,6 +114,7 @@ from airflow_breeze.utils.parallel import (
 from airflow_breeze.utils.path_utils import AIRFLOW_CTL_ROOT_PATH, FILES_PATH, cleanup_python_generated_files
 from airflow_breeze.utils.run_tests import (
     TASK_SDK_INTEGRATION_TESTS_ROOT_PATH,
+    are_all_test_paths_excluded,
     file_name_from_test_type,
     generate_args_for_pytest,
     run_docker_compose_tests,
@@ -206,6 +207,15 @@ def _run_test(
             "[error]Only 'Providers' test type can specify actual tests with \\[\\][/]"
         )
         sys.exit(1)
+    if are_all_test_paths_excluded(
+        test_group=shell_params.test_group,
+        test_type=shell_params.test_type,
+        python_version=python_version,
+        skip_db_tests=shell_params.skip_db_tests,
+        parallel_test_types_list=shell_params.parallel_test_types_list,
+        integration=shell_params.integration,
+    ):
+        return 0, f"Skipped test, no tests needed: {shell_params.test_type}"
     compose_project_name, project_name = _get_project_names(shell_params)
     env = shell_params.env_variables_for_docker_commands
     down_cmd = [

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -227,6 +227,44 @@ def get_excluded_test_provider_folders(python_version: str) -> list[str]:
     return get_test_folders(excluded_folders)
 
 
+def are_all_test_paths_excluded(
+    *,
+    test_group: GroupOfTests,
+    test_type: str,
+    python_version: str,
+    skip_db_tests: bool = False,
+    parallel_test_types_list: list[str] | None = None,
+    integration: tuple | None = None,
+) -> bool:
+    """Check if all test paths for the given test type are excluded or suspended.
+
+    Uses the same provider.yaml exclusion data as generate_args_for_pytest to determine
+    whether every test directory that would be generated for this test type is in the
+    excluded or suspended provider set.
+
+    Returns False when test_type is "None" (user provides explicit paths via extra_pytest_args)
+    or when any test path remains after exclusions.
+    """
+    if skip_db_tests and parallel_test_types_list:
+        initial_paths = convert_parallel_types_to_folders(
+            test_group=test_group,
+            parallel_test_types_list=parallel_test_types_list,
+        )
+    else:
+        initial_paths = convert_test_type_to_pytest_args(
+            test_group=test_group,
+            test_type=test_type,
+            integration=integration,
+        )
+    # Filter to only actual test directory paths (not pytest flags like -m, --include-quarantined)
+    test_dir_paths = [p for p in initial_paths if not p.startswith("-")]
+    if not test_dir_paths:
+        return False
+    excluded = set(get_excluded_test_provider_folders(python_version))
+    suspended = set(get_suspended_test_provider_folders())
+    return all(p in excluded | suspended for p in test_dir_paths)
+
+
 TEST_TYPE_CORE_MAP_TO_PYTEST_ARGS: dict[str, list[str]] = {
     "Always": ["airflow-core/tests/unit/always"],
     "API": ["airflow-core/tests/unit/api", "airflow-core/tests/unit/api_fastapi"],

--- a/dev/breeze/tests/test_run_test_args.py
+++ b/dev/breeze/tests/test_run_test_args.py
@@ -107,3 +107,48 @@ def test_test_is_skipped_if_all_are_ignored(mock_run_command):
     )
 
     mock_run_command.assert_called_once()  # called only to compose down
+
+
+def test_test_is_skipped_when_all_providers_excluded_for_python_version(
+    mock_run_command, mock_get_excluded_provider_folders
+):
+    """When all providers in the test type are excluded for the Python version, skip without Docker calls."""
+    mock_get_excluded_provider_folders.return_value = ["http"]
+    return_code, message = _run_test(
+        shell_params=ShellParams(test_group=GroupOfTests.PROVIDERS, test_type="Providers[http]"),
+        extra_pytest_args=(),
+        python_version="3.14",
+        output=None,
+        test_timeout=60,
+        skip_docker_compose_down=True,
+    )
+    assert return_code == 0
+    assert "Skipped" in message
+    mock_run_command.assert_not_called()
+
+
+def test_test_is_not_skipped_when_some_providers_remain(mock_run_command, mock_get_excluded_provider_folders):
+    """When only some providers are excluded, the test should still run."""
+    mock_get_excluded_provider_folders.return_value = ["http"]
+    _run_test(
+        shell_params=ShellParams(test_group=GroupOfTests.PROVIDERS, test_type="Providers[http,standard]"),
+        extra_pytest_args=(),
+        python_version="3.14",
+        output=None,
+        test_timeout=60,
+        skip_docker_compose_down=True,
+    )
+    assert mock_run_command.call_count >= 2  # compose down + compose run
+
+
+def test_none_test_type_with_extra_args_does_not_skip(mock_run_command):
+    """test_type=None with user-provided test paths via extra_pytest_args must not skip."""
+    _run_test(
+        shell_params=ShellParams(test_group=GroupOfTests.CORE, test_type="None"),
+        extra_pytest_args=("airflow-core/tests/unit/serialization/test_helpers.py",),
+        python_version="3.14",
+        output=None,
+        test_timeout=60,
+        skip_docker_compose_down=True,
+    )
+    assert mock_run_command.call_count >= 2  # compose down + compose run


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/63793, https://github.com/apache/airflow/pull/63870

## Summary

- Skip Breeze provider test runs before Docker startup when every selected test path is excluded or suspended for the current Python version.
- Preserve explicit pytest path runs such as `test_type="None"` so the earlier skip regression does not come back.

## Details

`#63793` fixed one failure mode for Python-version-excluded providers by skipping when pytest ended up with no test directories. `#63870` then reverted that broader filtering because it also skipped valid `test_type="None"` runs where users passed explicit test paths.

This change keeps the skip, but moves the decision earlier and makes it specific to provider exclusion data. A new `are_all_test_paths_excluded()` helper checks the test directories implied by the selected provider test type against the excluded and suspended provider sets. When every generated path is excluded for the current Python version, `_run_test` now returns a skip result immediately, before any Docker cleanup or `docker compose run` calls.

Because the new check only applies to generated provider test paths, explicit pytest path invocations still run normally. The added Breeze tests cover the full-exclusion skip path, the partial-exclusion path, and the `test_type="None"` regression case from `#63870`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
