### PR TITLE
Deleting spark job before raising exception "Job took too long to start" in start_spark_job method (#63824)

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -309,9 +309,9 @@ class CustomObjectLauncher(LoggingMixin):
                 delta = dt.now() - curr_time
                 if delta.total_seconds() >= startup_timeout:
                     pod_status = self.pod_manager.read_pod(self.pod_spec).status.container_statuses
-                    pod_name = self.spark_obj_spec["metadata"]["name"]
-                    self.log.warning("Deleting spark job: %s", pod_name)
-                    self.delete_spark_job(pod_name)
+                    spark_job_name = self.spark_obj_spec["metadata"]["name"]
+                    self.log.warning("Deleting spark job: %s", spark_job_name)
+                    self.delete_spark_job(spark_job_name=spark_job_name)
                     raise AirflowException(f"Job took too long to start. pod status: {pod_status}")
                 time.sleep(10)
         except Exception as e:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/custom_object_launcher.py
@@ -309,6 +309,9 @@ class CustomObjectLauncher(LoggingMixin):
                 delta = dt.now() - curr_time
                 if delta.total_seconds() >= startup_timeout:
                     pod_status = self.pod_manager.read_pod(self.pod_spec).status.container_statuses
+                    pod_name = self.spark_obj_spec["metadata"]["name"]
+                    self.log.warning("Deleting spark job: %s", pod_name)
+                    self.delete_spark_job(pod_name)
                     raise AirflowException(f"Job took too long to start. pod status: {pod_status}")
                 time.sleep(10)
         except Exception as e:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_custom_object_launcher.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_custom_object_launcher.py
@@ -238,6 +238,18 @@ class TestCustomObjectLauncher:
     def test_start_spark_job_no_error(self, mock_pod_manager, mock_launcher):
         mock_launcher.start_spark_job()
 
+    @patch(
+        "airflow.providers.cncf.kubernetes.operators.custom_object_launcher.CustomObjectLauncher.delete_spark_job"
+    )
+    def test_start_spark_job_deletes_on_timeout(self, mock_delete_spark_job, mock_launcher):
+        mock_launcher.spark_job_not_running = MagicMock(return_value=True)
+        mock_launcher.check_pod_start_failure = MagicMock()
+
+        with pytest.raises(AirflowException):
+            mock_launcher.start_spark_job(startup_timeout=0)
+
+        mock_delete_spark_job.assert_called_once_with(spark_job_name=mock_launcher.name)
+
     @patch("airflow.providers.cncf.kubernetes.operators.custom_object_launcher.PodManager")
     def test_check_pod_start_failure_no_error(self, mock_pod_manager, mock_launcher):
         mock_pod_manager.return_value.read_pod.return_value.status = self.get_pod_status("ContainerCreating")


### PR DESCRIPTION
Previously, when a SparkKubernetesOperator task failed because the SparkApplication CRD stayed in the SUBMITTED state longer than `startup_timeout_seconds`, the SparkApplication would remain in Kubernetes. This could lead to orphaned applications consuming resources, especially in clusters managed by YuniKorn.

This PR ensures that the SparkApplication is deleted when a task fails due to exceeding `startup_timeout_seconds`. The fix adds a deletion step in the failure path of `start_spark_job`, logging a warning when the job is deleted due to task failure.

**Behavior before:**

- Task fails after timeout
- SparkApplication remains in Kubernetes

**Behavior after:**

- Task fails after timeout
- SparkApplication is deleted from Kubernetes
- Warning logged for failed cleanup

This change addresses the scenario described in issue #63824 and improves reliability and resource cleanup for SparkKubernetesOperator tasks.

**Notes:**

- No behavioral changes occur when tasks succeed — normal cleanup remains unchanged.
- Only applies to cases where the task fails due to startup_timeout_seconds.

* closes: #63824 
