### PR TITLE
Improve deadline callback migration performance for large datasets

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
+++ b/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
@@ -27,14 +27,16 @@ Create Date: 2025-10-24 00:34:57.111239
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import json
+from datetime import date, datetime, timedelta, timezone
 from textwrap import dedent
 
 import sqlalchemy as sa
 from alembic import context, op
 from sqlalchemy import column, select, table
 
-from airflow.serialization.serde import deserialize
+from airflow._shared.timezones.timezone import parse_timezone
+from airflow.configuration import conf
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -44,18 +46,143 @@ branch_labels = None
 depends_on = None
 airflow_version = "3.2.0"
 
-BATCH_SIZE = 1000
+_DEADLINE_BATCH_TABLE = "_migration_deadline_batch_0094"
+_CALLBACK_TYPE_TRIGGERER = "triggerer"
+_CALLBACK_FETCH_METHOD_IMPORT_PATH = "import_path"
+_CALLBACK_STATE_FAILED = "failed"
+_CALLBACK_STATE_PENDING = "pending"
+_CALLBACK_STATE_SUCCESS = "success"
+_CALLBACK_TERMINAL_STATES = frozenset({_CALLBACK_STATE_FAILED, _CALLBACK_STATE_SUCCESS})
+_CALLBACK_METRICS_PREFIX = "deadline_alerts"
+
+# Task SDK serde keys
+_SERDE_CLASSNAME = "__classname__"
+_SERDE_VERSION = "__version__"
+_SERDE_DATA = "__data__"
+_SERDE_DATETIME_TIMESTAMP = "timestamp"
+_SERDE_DATETIME_TIMEZONE = "tz"
+_SERDE_COLLECTION_TYPES = {
+    "builtins.frozenset": frozenset,
+    "builtins.set": set,
+    "builtins.tuple": tuple,
+}
+_SERDE_DATETIME_TYPES = {
+    "datetime.datetime",
+    "pendulum.datetime.DateTime",
+}
+_SERDE_DATE_TYPES = {
+    "datetime.date",
+    "pendulum.date.Date",
+}
+_SERDE_TIMEDELTA_TYPES = {
+    "datetime.timedelta",
+}
+_SERDE_TIMEZONE_TYPES = {
+    "pendulum.tz.timezone.FixedTimezone",
+    "pendulum.tz.timezone.Timezone",
+    "zoneinfo.ZoneInfo",
+}
+
+
+def _deserialize_task_sdk_timezone(value):
+    """Deserialize timezone values produced by Task SDK serde."""
+    if value is None:
+        return None
+
+    if isinstance(value, tuple | list):
+        if len(value) < 3:
+            raise ValueError(f"Unsupported timezone serde payload: {value!r}")
+
+        data, classname, _version = value[:3]
+        if classname not in _SERDE_TIMEZONE_TYPES:
+            raise ValueError(f"Unsupported timezone serde payload: {value!r}")
+        return _deserialize_task_sdk_timezone(data)
+
+    if isinstance(value, int | str):
+        return parse_timezone(value)
+
+    raise ValueError(f"Unsupported timezone serde payload: {value!r}")
+
+
+def _deserialize_task_sdk_value(value):
+    """Deserialize a minimal subset of Task SDK serde values used in callback kwargs."""
+    if value is None or isinstance(value, bool | float | int | str):
+        return value
+
+    if isinstance(value, list):
+        return [_deserialize_task_sdk_value(item) for item in value]
+
+    if not isinstance(value, dict):
+        return value
+
+    if _SERDE_CLASSNAME not in value or _SERDE_VERSION not in value:
+        return {key: _deserialize_task_sdk_value(item) for key, item in value.items()}
+
+    classname = value[_SERDE_CLASSNAME]
+    data = _deserialize_task_sdk_value(value.get(_SERDE_DATA))
+
+    if classname in _SERDE_COLLECTION_TYPES:
+        return _SERDE_COLLECTION_TYPES[classname](data)
+
+    if classname in _SERDE_TIMEZONE_TYPES:
+        return _deserialize_task_sdk_timezone(data)
+
+    if classname in _SERDE_DATETIME_TYPES:
+        if not isinstance(data, dict) or _SERDE_DATETIME_TIMESTAMP not in data:
+            raise ValueError(f"Unsupported datetime serde payload: {value!r}")
+
+        tz = None
+        if _SERDE_DATETIME_TIMEZONE in data:
+            tz = _deserialize_task_sdk_timezone(data[_SERDE_DATETIME_TIMEZONE])
+        return datetime.fromtimestamp(float(data[_SERDE_DATETIME_TIMESTAMP]), tz=tz)
+
+    if classname in _SERDE_DATE_TYPES:
+        if not isinstance(data, str):
+            raise ValueError(f"Unsupported date serde payload: {value!r}")
+        return date.fromisoformat(data)
+
+    if classname in _SERDE_TIMEDELTA_TYPES:
+        return timedelta(seconds=float(data))
+
+    raise ValueError(f"Unsupported Task SDK serde value in callback kwargs: {classname}")
+
+
+def _extract_callback_data(deadline_callback, dag_id):
+    """Convert the stored deadline callback payload into the new callback.data structure."""
+    callback = deadline_callback if isinstance(deadline_callback, dict) else json.loads(deadline_callback)
+    callback_data = callback.get(_SERDE_DATA)
+    if not isinstance(callback_data, dict):
+        raise ValueError(f"Deadline callback is missing {_SERDE_DATA}: {callback!r}")
+
+    callback_path = callback_data.get("path")
+    if not callback_path:
+        raise ValueError(f"Deadline callback is missing path: {callback!r}")
+
+    return {
+        "path": callback_path,
+        "kwargs": _deserialize_task_sdk_value(callback_data.get("kwargs", {})),
+        "prefix": _CALLBACK_METRICS_PREFIX,
+        "dag_id": dag_id,
+    }
+
+
+def _get_migrated_callback_state(callback_state):
+    """Return callback state and missed flag for the migrated callback row."""
+    if callback_state in _CALLBACK_TERMINAL_STATES:
+        return callback_state, True
+    return _CALLBACK_STATE_PENDING, False
+
+
+def _get_batch_size():
+    return conf.getint("database", "migration_batch_size", fallback=1000)
 
 
 def upgrade():
     """Replace Deadline table's inline callback fields with callback_id foreign key."""
     import uuid6
 
-    from airflow.models.base import StringID
-    from airflow.models.callback import CallbackFetchMethod, CallbackState, CallbackType
-    from airflow.models.deadline import CALLBACK_METRICS_PREFIX
-
     timestamp = datetime.now(timezone.utc)
+    batch_size = _get_batch_size()
 
     def migrate_batch(conn, deadline_table, callback_table, batch):
         callback_inserts = []
@@ -64,36 +191,20 @@ def upgrade():
         for deadline in batch:
             try:
                 callback_id = uuid6.uuid7()
-
-                # Transform serialized callback to the new representation
-                callback_data = deserialize(deadline.callback).serialize() | {
-                    "prefix": CALLBACK_METRICS_PREFIX,
-                    "dag_id": deadline.dag_id,
-                }
-
-                if deadline.callback_state and deadline.callback_state in {
-                    CallbackState.FAILED,
-                    CallbackState.SUCCESS,
-                }:
-                    deadline_missed = True
-                    callback_state = deadline.callback_state
-                else:
-                    # Mark the deadlines in non-terminal states as not missed so the scheduler handles them
-                    deadline_missed = False
-                    callback_state = CallbackState.PENDING
+                callback_data = _extract_callback_data(deadline.callback, deadline.dag_id)
+                callback_state, deadline_missed = _get_migrated_callback_state(deadline.callback_state)
 
                 callback_inserts.append(
                     {
                         "id": callback_id,
-                        "type": CallbackType.TRIGGERER,  # Past versions only support triggerer callbacks
-                        "fetch_method": CallbackFetchMethod.IMPORT_PATH,  # Past versions only support import_path
+                        "type": _CALLBACK_TYPE_TRIGGERER,
+                        "fetch_method": _CALLBACK_FETCH_METHOD_IMPORT_PATH,
                         "data": callback_data,
                         "state": callback_state,
-                        "priority_weight": 1,  # Default priority weight
+                        "priority_weight": 1,
                         "created_at": timestamp,
                     }
                 )
-
                 deadline_updates.append(
                     {"deadline_id": deadline.id, "callback_id": callback_id, "missed": deadline_missed}
                 )
@@ -126,19 +237,16 @@ def upgrade():
             "deadline",
             column("id", sa.Uuid()),
             column("dagrun_id", sa.Integer()),
-            column("deadline_time", UtcDateTime(timezone=True)),
             column("callback", sa.JSON()),
             column("callback_state", sa.String(20)),
             column("missed", sa.Boolean()),
             column("callback_id", sa.Uuid()),
         )
-
         dag_run_table = table(
             "dag_run",
             column("id", sa.Integer()),
-            column("dag_id", StringID()),
+            column("dag_id", sa.String()),
         )
-
         callback_table = table(
             "callback",
             column("id", sa.Uuid()),
@@ -149,30 +257,48 @@ def upgrade():
             column("priority_weight", sa.Integer()),
             column("created_at", UtcDateTime(timezone=True)),
         )
+        batch_table = table(
+            _DEADLINE_BATCH_TABLE,
+            column("deadline_id", sa.Uuid()),
+        )
 
         conn = op.get_bind()
-        batch_num = 0
-        while True:
-            batch_num += 1
-            batch = conn.execute(
-                select(
-                    deadline_table.c.id,
-                    deadline_table.c.dagrun_id,
-                    deadline_table.c.deadline_time,
-                    deadline_table.c.callback,
-                    deadline_table.c.callback_state,
-                    dag_run_table.c.dag_id,
+        op.create_table(
+            _DEADLINE_BATCH_TABLE,
+            sa.Column("deadline_id", sa.Uuid(), nullable=False, primary_key=True),
+        )
+
+        try:
+            conn.execute(
+                batch_table.insert().from_select(
+                    ["deadline_id"],
+                    select(deadline_table.c.id).where(deadline_table.c.callback_id.is_(None)),
                 )
-                .join(dag_run_table, deadline_table.c.dagrun_id == dag_run_table.c.id)
-                .where(deadline_table.c.callback_id.is_(None))  # Only get rows that haven't been migrated yet
-                .limit(BATCH_SIZE)
-            ).fetchall()
+            )
 
-            if not batch:
-                break
+            batch_num = 0
+            while True:
+                batch_ids = conn.execute(select(batch_table.c.deadline_id).limit(batch_size)).scalars().all()
+                if not batch_ids:
+                    break
 
-            migrate_batch(conn, deadline_table, callback_table, batch)
-            print(f"Migrated {len(batch)} deadline records in batch {batch_num}")
+                batch_num += 1
+                batch = conn.execute(
+                    select(
+                        deadline_table.c.id,
+                        deadline_table.c.callback,
+                        deadline_table.c.callback_state,
+                        dag_run_table.c.dag_id,
+                    )
+                    .join(dag_run_table, deadline_table.c.dagrun_id == dag_run_table.c.id)
+                    .where(deadline_table.c.id.in_(batch_ids))
+                ).fetchall()
+
+                migrate_batch(conn, deadline_table, callback_table, batch)
+                conn.execute(batch_table.delete().where(batch_table.c.deadline_id.in_(batch_ids)))
+                print(f"Migrated {len(batch)} deadline records in batch {batch_num}")
+        finally:
+            op.drop_table(_DEADLINE_BATCH_TABLE)
 
     # Add new columns (temporarily nullable until data has been migrated)
     with op.batch_alter_table("deadline") as batch_op:
@@ -200,7 +326,6 @@ def upgrade():
 
 def downgrade():
     """Restore Deadline table's inline callback fields from callback_id foreign key."""
-    from airflow.utils.state import CallbackState
 
     def migrate_batch(conn, deadline_table, callback_table, batch):
         deadline_updates = []
@@ -216,14 +341,14 @@ def downgrade():
                 # from airflow.sdk.definitions.deadline import AsyncCallback
                 # callback_serialized = serialize(AsyncCallback.deserialize(filtered_data, 0))
                 callback_serialized = {
-                    "__data__": filtered_cb_data,
-                    "__classname__": "airflow.sdk.definitions.deadline.AsyncCallback",
-                    "__version__": 0,
+                    _SERDE_DATA: filtered_cb_data,
+                    _SERDE_CLASSNAME: "airflow.sdk.definitions.deadline.AsyncCallback",
+                    _SERDE_VERSION: 0,
                 }
 
                 # Mark the deadline as not handled if its callback is not in a terminal state so that the
                 # scheduler handles it appropriately
-                if row.callback_state in {CallbackState.SUCCESS, CallbackState.FAILED}:
+                if row.callback_state in {_CALLBACK_STATE_SUCCESS, _CALLBACK_STATE_FAILED}:
                     callback_state = row.callback_state
                 else:
                     callback_state = None
@@ -289,6 +414,7 @@ def downgrade():
         )
 
         conn = op.get_bind()
+        batch_size = _get_batch_size()
         batch_num = 0
 
         while True:
@@ -302,7 +428,7 @@ def downgrade():
                 )
                 .join(callback_table, deadline_table.c.callback_id == callback_table.c.id)
                 .where(deadline_table.c.callback.is_(None))  # Only get rows that haven't been downgraded yet
-                .limit(BATCH_SIZE)
+                .limit(batch_size)
             ).fetchall()
 
             if not batch:

--- a/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
+++ b/airflow-core/src/airflow/migrations/versions/0094_3_2_0_replace_deadline_inline_callback_with_fkey.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -37,6 +36,7 @@ from sqlalchemy import column, select, table
 
 from airflow._shared.timezones.timezone import parse_timezone
 from airflow.configuration import conf
+from airflow.migrations.utils import disable_sqlite_fkeys, get_dialect_name, mysql_drop_foreignkey_if_exists
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -177,6 +177,26 @@ def _get_batch_size():
     return conf.getint("database", "migration_batch_size", fallback=1000)
 
 
+def _drop_deadline_trigger_fkey_if_exists() -> None:
+    """Drop deadline.trigger_id's foreign key if it still exists."""
+    constraint_name = op.f("deadline_trigger_id_fkey")
+    dialect_name = get_dialect_name(op)
+
+    if dialect_name == "postgresql":
+        op.execute(sa.text(f'ALTER TABLE "deadline" DROP CONSTRAINT IF EXISTS "{constraint_name}"'))
+        return
+
+    if dialect_name == "mysql":
+        mysql_drop_foreignkey_if_exists(constraint_name, "deadline", op)
+        return
+
+    if dialect_name == "sqlite":
+        return
+
+    with op.batch_alter_table("deadline") as batch_op:
+        batch_op.drop_constraint(constraint_name, type_="foreignkey")
+
+
 def upgrade():
     """Replace Deadline table's inline callback fields with callback_id foreign key."""
     import uuid6
@@ -307,21 +327,53 @@ def upgrade():
 
     migrate_all_data()
 
-    with op.batch_alter_table("deadline") as batch_op:
-        # Data for `missed` and `callback_id` has been migrated so make them non-nullable
-        batch_op.alter_column("missed", existing_type=sa.Boolean(), nullable=False)
-        batch_op.alter_column("callback_id", existing_type=sa.Uuid(), nullable=False)
+    if get_dialect_name(op) == "sqlite":
+        with disable_sqlite_fkeys(op), op.batch_alter_table("deadline") as batch_op:
+            # Data for `missed` and `callback_id` has been migrated so make them non-nullable
+            batch_op.alter_column("missed", existing_type=sa.Boolean(), nullable=False)
+            batch_op.alter_column("callback_id", existing_type=sa.Uuid(), nullable=False)
 
-        batch_op.create_index("deadline_missed_deadline_time_idx", ["missed", "deadline_time"], unique=False)
-        batch_op.create_index("deadline_callback_id_idx", ["callback_id"], unique=False)
-        batch_op.drop_index(batch_op.f("deadline_callback_state_time_idx"))
-        batch_op.create_foreign_key(
-            batch_op.f("deadline_callback_id_fkey"), "callback", ["callback_id"], ["id"], ondelete="CASCADE"
+            batch_op.create_index(
+                "deadline_missed_deadline_time_idx", ["missed", "deadline_time"], unique=False
+            )
+            batch_op.create_index("deadline_callback_id_idx", ["callback_id"], unique=False)
+            batch_op.drop_index(batch_op.f("deadline_callback_state_time_idx"))
+            batch_op.create_foreign_key(
+                batch_op.f("deadline_callback_id_fkey"),
+                "callback",
+                ["callback_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+            try:
+                batch_op.drop_constraint(batch_op.f("deadline_trigger_id_fkey"), type_="foreignkey")
+            except ValueError:
+                pass
+            batch_op.drop_column("callback")
+            batch_op.drop_column("trigger_id")
+            batch_op.drop_column("callback_state")
+    else:
+        op.alter_column("deadline", "missed", existing_type=sa.Boolean(), nullable=False)
+        op.alter_column("deadline", "callback_id", existing_type=sa.Uuid(), nullable=False)
+        op.create_index(
+            "deadline_missed_deadline_time_idx", "deadline", ["missed", "deadline_time"], unique=False
         )
-        batch_op.drop_constraint(batch_op.f("deadline_trigger_id_fkey"), type_="foreignkey")
-        batch_op.drop_column("callback")
-        batch_op.drop_column("trigger_id")
-        batch_op.drop_column("callback_state")
+        op.create_index("deadline_callback_id_idx", "deadline", ["callback_id"], unique=False)
+        op.drop_index(op.f("deadline_callback_state_time_idx"), table_name="deadline")
+        op.create_foreign_key(
+            op.f("deadline_callback_id_fkey"),
+            "deadline",
+            "callback",
+            ["callback_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+        _drop_deadline_trigger_fkey_if_exists()
+
+        op.drop_column("deadline", "callback")
+        op.drop_column("deadline", "trigger_id")
+        op.drop_column("deadline", "callback_state")
 
 
 def downgrade():


### PR DESCRIPTION
Speed up migration 0094 (deadline inline callback → foreign key) for installations with millions of deadline rows. Uses a temporary batch table for deterministic batching and a minimal, migration-only serde instead of full deserialization, avoiding Task SDK and user code.

Validated with 10.7M rows migrating in ~24 minutes.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)
composer 1.5 on cursor
