### PR TITLE
Add dynamic DAG bundle configuration from file path

### DIFF
--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -122,6 +122,55 @@ Starting Airflow 3.0.2 git is pre installed in the base image. However, if you a
   ENV GIT_PYTHON_REFRESH=quiet
 
 
+Dynamic Dag bundle configuration via config path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an alternative to listing bundles inline in :ref:`config:dag_processor__dag_bundle_config_list`,
+you can point the Dag processor at a directory of per-bundle JSON files via
+:ref:`config:dag_processor__dag_bundle_config_path`. This is useful in environments where bundle
+configurations change frequently — for example, when bundle configs are mounted from
+Kubernetes ConfigMaps — because the Dag processor reloads them in place without a restart.
+
+.. code-block:: ini
+
+    [dag_processor]
+    dag_bundle_config_path = /opt/airflow/dag-bundles-conf
+
+Each ``*.json`` file in the directory must contain a single bundle configuration as a dict with
+``name``, ``classpath``, and ``kwargs`` keys, mirroring one entry of ``dag_bundle_config_list``:
+
+.. code-block:: json
+
+    {
+      "name": "my_git_repo",
+      "classpath": "airflow.providers.git.bundles.git.GitDagBundle",
+      "kwargs": {"tracking_ref": "main", "git_conn_id": "my_git_conn"}
+    }
+
+Files that are not valid JSON, contain a non-dict body, have a non-string ``name``, or duplicate
+a ``name`` already loaded from the directory, are logged and skipped — the rest of the directory
+still loads.
+
+**Hot-reload semantics**
+
+On every Dag processor refresh cycle the directory is rescanned. Change detection compares each
+file's ``st_mtime_ns`` to the previous scan; any addition, removal, or modification triggers a
+reload. On reload the manager re-parses every JSON file, syncs the resulting bundle set to the
+metadata database, and cleans up the processors, file stats, and parsed Dags for any bundle that
+no longer appears. Removing all files (or removing the directory entirely) cleans up every bundle
+that was loaded from the path.
+
+**Precedence**
+
+When ``dag_bundle_config_path`` is set, it takes precedence over ``dag_bundle_config_list`` — the
+list is ignored.
+
+.. note::
+
+    The :ref:`config:core__multi_team` enforcement applies the same way as for the inline list:
+    bundles with a ``team_name`` require ``[core] multi_team = True``.
+
+
 Using DAG Bundles with User Impersonation
 -----------------------------------------
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2826,6 +2826,21 @@ dag_processor:
                 "kwargs": {{}}
               }}
             ]
+    dag_bundle_config_path:
+      description: |
+        Path to a directory containing JSON files, each defining a DAG bundle configuration.
+        Each JSON file should contain a dict with ``name``, ``classpath``, and ``kwargs`` keys.
+
+        When set, this takes precedence over ``dag_bundle_config_list``.
+
+        This is particularly useful in Kubernetes environments where bundle configurations
+        can be managed via ConfigMaps mounted as files. The DAG processor will detect
+        changes to these files (additions, removals, modifications) and hot-reload
+        bundles without requiring a restart.
+      version_added: 3.2.0
+      type: string
+      example: "/opt/airflow/dag-bundles-conf"
+      default: ""
     refresh_interval:
       description: |
         How often (in seconds) to refresh, or look for new files, in a DAG bundle.

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -504,9 +504,9 @@ class DagBundlesManager(LoggingMixin):
             return True
 
         # Check for modified files
-        for file_path, mtime in current_files.items():
-            if file_path in self._config_path_mtime and self._config_path_mtime[file_path] != mtime:
-                self.log.info("DAG bundle config file modified: %s", file_path)
+        for fpath, mtime in current_files.items():
+            if fpath in self._config_path_mtime and self._config_path_mtime[fpath] != mtime:
+                self.log.info("DAG bundle config file modified: %s", fpath)
                 return True
 
         return False

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -169,7 +169,7 @@ class DagBundlesManager(LoggingMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._bundle_config: dict[str, _InternalBundleConfig] = {}
-        self._config_path_mtime: dict[str, float] = {}
+        self._config_path_mtime: dict[str, int] = {}
         self.parse_config()
 
     def parse_config(self) -> None:
@@ -416,26 +416,36 @@ class DagBundlesManager(LoggingMixin):
         path = Path(config_path)
         if not path.exists():
             self.log.warning("DAG bundle config path does not exist: %s", config_path)
+            self._bundle_config.clear()
+            self._config_path_mtime.clear()
             return
 
         if not path.is_dir():
             raise AirflowConfigException(f"dag_bundle_config_path must be a directory, got: {config_path}")
 
-        # Clear old mtime entries before repopulating
+        # Clear old mtime entries before repopulating; track every JSON file we see
+        # (including invalid ones) so check_config_path_changes doesn't fire spuriously.
         self._config_path_mtime.clear()
 
         config_list = []
         seen_bundle_names: set[str] = set()
 
         for file_path in path.glob("*.json"):
+            self._config_path_mtime[str(file_path)] = file_path.stat().st_mtime_ns
             try:
                 config = json.loads(file_path.read_text())
                 if not isinstance(config, dict):
                     self.log.error("Invalid config in %s: Expected dict but got %s", file_path, type(config))
                     continue
 
-                # Check for duplicate bundle names
                 bundle_name = config.get("name")
+                if bundle_name is not None and (not isinstance(bundle_name, str) or not bundle_name):
+                    self.log.warning(
+                        "Invalid 'name' in %s: must be a non-empty string, got %r",
+                        file_path,
+                        bundle_name,
+                    )
+                    continue
                 if bundle_name and bundle_name in seen_bundle_names:
                     self.log.warning(
                         "Duplicate bundle name '%s' found in %s, skipping this file",
@@ -447,8 +457,6 @@ class DagBundlesManager(LoggingMixin):
                     seen_bundle_names.add(bundle_name)
 
                 config_list.append(config)
-                # Track file modification time for change detection
-                self._config_path_mtime[str(file_path)] = file_path.stat().st_mtime
             except json.JSONDecodeError as e:
                 self.log.error("Failed to parse JSON from %s: %s", file_path, e)
             except Exception as e:
@@ -456,6 +464,7 @@ class DagBundlesManager(LoggingMixin):
 
         if not config_list:
             self.log.warning("No valid DAG bundle configs found in %s", config_path)
+            self._bundle_config.clear()
             return
 
         bundle_config_list = _parse_bundle_config(config_list)
@@ -494,9 +503,9 @@ class DagBundlesManager(LoggingMixin):
         if not path.exists() or not path.is_dir():
             return False
 
-        current_files: dict[str, float] = {}
+        current_files: dict[str, int] = {}
         for file_path in path.glob("*.json"):
-            current_files[str(file_path)] = file_path.stat().st_mtime
+            current_files[str(file_path)] = file_path.stat().st_mtime_ns
 
         # Check for added or removed files
         if set(current_files.keys()) != set(self._config_path_mtime.keys()):

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -16,7 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import json
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from itsdangerous import URLSafeSerializer
@@ -167,16 +169,30 @@ class DagBundlesManager(LoggingMixin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._bundle_config: dict[str, _InternalBundleConfig] = {}
+        self._config_path_mtime: dict[str, float] = {}
         self.parse_config()
 
     def parse_config(self) -> None:
         """
         Get all DAG bundle configurations and store in instance variable.
 
+        If ``dag_bundle_config_path`` is set, configurations are loaded from JSON files in that
+        directory and ``dag_bundle_config_list`` is ignored. Otherwise, falls back to the
+        traditional ``dag_bundle_config_list`` setting.
+
         If a bundle class for a given name has already been imported, it will not be imported again.
 
         :meta private:
         """
+        # Check if we should use config path instead of config list
+        config_path = conf.get("dag_processor", "dag_bundle_config_path", fallback="")
+
+        if config_path:
+            # Use config path mode — takes precedence over config list
+            self._parse_config_from_path(config_path)
+            return
+
+        # Use traditional config list mode
         if self._bundle_config:
             return
 
@@ -368,5 +384,129 @@ class DagBundlesManager(LoggingMixin):
             DeprecationWarning,
             stacklevel=2,
         )
-        bundle = self.get_bundle(name, version)
-        return bundle.view_url(version=version)
+        try:
+            bundle = self.get_bundle(name, version)
+            return bundle.view_url(version=version)
+        except ValueError:
+            # Bundle no longer configured, return None
+            self.log.debug("Bundle '%s' is no longer configured, cannot get view URL", name)
+            return None
+
+    def get_bundle_path_safe(self, name: str) -> Path | None:
+        """
+        Safely get a bundle's path without raising errors if bundle doesn't exist.
+
+        :param name: The name of the DAG bundle.
+        :return: The bundle path if configured, None otherwise.
+        """
+        try:
+            bundle = self.get_bundle(name)
+            return bundle.path
+        except ValueError:
+            # Bundle no longer configured
+            self.log.debug("Bundle '%s' is no longer configured, cannot get path", name)
+            return None
+
+    def _parse_config_from_path(self, config_path: str) -> None:
+        """
+        Parse DAG bundle configurations from JSON files in a directory.
+
+        :param config_path: Path to directory containing JSON config files
+        """
+        path = Path(config_path)
+        if not path.exists():
+            self.log.warning("DAG bundle config path does not exist: %s", config_path)
+            return
+
+        if not path.is_dir():
+            raise AirflowConfigException(f"dag_bundle_config_path must be a directory, got: {config_path}")
+
+        # Clear old mtime entries before repopulating
+        self._config_path_mtime.clear()
+
+        config_list = []
+        seen_bundle_names: set[str] = set()
+
+        for file_path in path.glob("*.json"):
+            try:
+                config = json.loads(file_path.read_text())
+                if not isinstance(config, dict):
+                    self.log.error("Invalid config in %s: Expected dict but got %s", file_path, type(config))
+                    continue
+
+                # Check for duplicate bundle names
+                bundle_name = config.get("name")
+                if bundle_name and bundle_name in seen_bundle_names:
+                    self.log.warning(
+                        "Duplicate bundle name '%s' found in %s, skipping this file",
+                        bundle_name,
+                        file_path,
+                    )
+                    continue
+                if bundle_name:
+                    seen_bundle_names.add(bundle_name)
+
+                config_list.append(config)
+                # Track file modification time for change detection
+                self._config_path_mtime[str(file_path)] = file_path.stat().st_mtime
+            except json.JSONDecodeError as e:
+                self.log.error("Failed to parse JSON from %s: %s", file_path, e)
+            except Exception as e:
+                self.log.error("Error reading config file %s: %s", file_path, e)
+
+        if not config_list:
+            self.log.warning("No valid DAG bundle configs found in %s", config_path)
+            return
+
+        bundle_config_list = _parse_bundle_config(config_list)
+        if conf.getboolean("core", "LOAD_EXAMPLES"):
+            _add_example_dag_bundle(bundle_config_list)
+
+        # Clear existing config and reload
+        self._bundle_config.clear()
+        for bundle_config in bundle_config_list:
+            if bundle_config.team_name and not conf.getboolean("core", "multi_team"):
+                raise AirflowConfigException(
+                    "DAG bundle configurations from path "
+                    "cannot have a team name when multi-team mode is disabled. "
+                    "To enable multi-team, you need to update section `core` key `multi_team` in your config."
+                )
+
+            class_ = import_string(bundle_config.classpath)
+            self._bundle_config[bundle_config.name] = _InternalBundleConfig(
+                bundle_class=class_,
+                kwargs=bundle_config.kwargs,
+                team_name=bundle_config.team_name,
+            )
+        self.log.info("DAG bundles loaded from path: %s", ", ".join(self._bundle_config.keys()))
+
+    def check_config_path_changes(self) -> bool:
+        """
+        Check if any configuration files have been added, removed, or modified.
+
+        :return: True if changes detected, False otherwise
+        """
+        config_path = conf.get("dag_processor", "dag_bundle_config_path", fallback="")
+        if not config_path:
+            return False
+
+        path = Path(config_path)
+        if not path.exists() or not path.is_dir():
+            return False
+
+        current_files: dict[str, float] = {}
+        for file_path in path.glob("*.json"):
+            current_files[str(file_path)] = file_path.stat().st_mtime
+
+        # Check for added or removed files
+        if set(current_files.keys()) != set(self._config_path_mtime.keys()):
+            self.log.info("DAG bundle config files added or removed")
+            return True
+
+        # Check for modified files
+        for file_path, mtime in current_files.items():
+            if file_path in self._config_path_mtime and self._config_path_mtime[file_path] != mtime:
+                self.log.info("DAG bundle config file modified: %s", file_path)
+                return True
+
+        return False

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -288,15 +288,11 @@ class DagFileProcessorManager(LoggingMixin):
 
     def sync_bundles(self) -> None:
         """Sync configured DAG bundles to the metadata database."""
-        if self._bundles_manager is None:
-            self._bundles_manager = DagBundlesManager()
-        self._bundles_manager.sync_bundles_to_db()
+        DagBundlesManager().sync_bundles_to_db()
 
     def get_all_bundles(self) -> list[BaseDagBundle]:
         """Return configured DAG bundles filtered by ``bundle_names_to_parse`` if provided."""
-        if self._bundles_manager is None:
-            self._bundles_manager = DagBundlesManager()
-        return list(self._bundles_manager.get_all_dag_bundles())
+        return list(DagBundlesManager().get_all_dag_bundles())
 
     def run(self):
         """
@@ -677,11 +673,12 @@ class DagFileProcessorManager(LoggingMixin):
         """Refresh DAG bundles, if required."""
         now = timezone.utcnow()
 
-        # Check if config path has changed and reload bundles if needed
+        # Check if config path has changed and reload bundles if needed.
+        # Lazily initialize _bundles_manager for config path tracking.
         if self._bundles_manager is None:
             self._bundles_manager = DagBundlesManager()
 
-        if self._bundles_manager.check_config_path_changes():
+        if self._bundles_manager.check_config_path_changes() is True:
             self.log.info("DAG bundle configuration changed, reloading bundles")
 
             # Track old bundles to detect removed ones

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -235,6 +235,7 @@ class DagFileProcessorManager(LoggingMixin):
 
     _dag_bundles: list[BaseDagBundle] = attrs.field(factory=list, init=False)
     _bundle_versions: dict[str, str | None] = attrs.field(factory=dict, init=False)
+    _bundles_manager: DagBundlesManager | None = attrs.field(default=None, init=False)
 
     _processors: dict[DagFileInfo, DagFileProcessorProcess] = attrs.field(factory=dict, init=False)
 
@@ -287,11 +288,15 @@ class DagFileProcessorManager(LoggingMixin):
 
     def sync_bundles(self) -> None:
         """Sync configured DAG bundles to the metadata database."""
-        DagBundlesManager().sync_bundles_to_db()
+        if self._bundles_manager is None:
+            self._bundles_manager = DagBundlesManager()
+        self._bundles_manager.sync_bundles_to_db()
 
     def get_all_bundles(self) -> list[BaseDagBundle]:
         """Return configured DAG bundles filtered by ``bundle_names_to_parse`` if provided."""
-        return list(DagBundlesManager().get_all_dag_bundles())
+        if self._bundles_manager is None:
+            self._bundles_manager = DagBundlesManager()
+        return list(self._bundles_manager.get_all_dag_bundles())
 
     def run(self):
         """
@@ -671,6 +676,46 @@ class DagFileProcessorManager(LoggingMixin):
     def _refresh_dag_bundles(self, known_files: dict[str, set[DagFileInfo]]):
         """Refresh DAG bundles, if required."""
         now = timezone.utcnow()
+
+        # Check if config path has changed and reload bundles if needed
+        if self._bundles_manager is None:
+            self._bundles_manager = DagBundlesManager()
+
+        if self._bundles_manager.check_config_path_changes():
+            self.log.info("DAG bundle configuration changed, reloading bundles")
+
+            # Track old bundles to detect removed ones
+            old_bundle_names = {bundle.name for bundle in self._dag_bundles}
+
+            # Reload configuration
+            self._bundles_manager.parse_config()
+            self._bundles_manager.sync_bundles_to_db()
+            self._dag_bundles = list(self._bundles_manager.get_all_dag_bundles())
+
+            # Identify removed bundles
+            new_bundle_names = {bundle.name for bundle in self._dag_bundles}
+            removed_bundles = old_bundle_names - new_bundle_names
+
+            # Clean up removed bundles
+            for bundle_name in removed_bundles:
+                self.log.info("Removing bundle %s and its files", bundle_name)
+                if bundle_name in known_files:
+                    for file_info in known_files[bundle_name]:
+                        self._file_stats.pop(file_info, None)
+                        if file_info in self._processors:
+                            processor = self._processors.pop(file_info)
+                            processor.kill(signal.SIGTERM)
+                            try:
+                                if hasattr(processor, "logger_filehandle") and processor.logger_filehandle:
+                                    processor.logger_filehandle.close()
+                            except (OSError, AttributeError):
+                                pass
+                    del known_files[bundle_name]
+                self._bundle_versions.pop(bundle_name, None)
+                self.deactivate_deleted_dags(bundle_name=bundle_name, present=set())
+
+            # Force refresh all bundles after config change
+            self._force_refresh_bundles = {bundle.name for bundle in self._dag_bundles}
 
         # we don't need to check if it's time to refresh every loop - that is way too often
         next_check = self._bundles_last_refreshed + self.bundle_refresh_check_interval

--- a/airflow-core/src/airflow/models/errors.py
+++ b/airflow-core/src/airflow/models/errors.py
@@ -41,5 +41,8 @@ class ParseImportError(Base):
         """Return the full file path of the dag."""
         if self.bundle_name is None or self.filename is None:
             raise ValueError("bundle_name and filename must not be None")
-        bundle = DagBundlesManager().get_bundle(self.bundle_name)
-        return "/".join([str(bundle.path), self.filename])
+        bundle_path = DagBundlesManager().get_bundle_path_safe(self.bundle_name)
+        if bundle_path:
+            return "/".join([str(bundle_path), self.filename])
+        # Bundle no longer exists, return a placeholder path
+        return f"[removed bundle: {self.bundle_name}]/{self.filename}"

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
+import time
 from contextlib import nullcontext
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -467,3 +470,259 @@ def test_multiple_bundles_one_fails(clear_db, session):
 
 def test_get_all_bundle_names():
     assert DagBundlesManager().get_all_bundle_names() == ["dags-folder", "example_dags"]
+
+
+class TestDagBundleConfigPath:
+    """Tests for dynamic DAG bundle configuration from path."""
+
+    def test_parse_config_from_path(self):
+        """Test parsing DAG bundle configs from JSON files in a directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle1 = {
+                "name": "test-bundle-1",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle2 = {
+                "name": "test-bundle-2",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 2},
+            }
+
+            Path(tmpdir).joinpath("bundle1.json").write_text(json.dumps(bundle1))
+            Path(tmpdir).joinpath("bundle2.json").write_text(json.dumps(bundle2))
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+                bundle_names = {b.name for b in manager.get_all_dag_bundles()}
+                assert bundle_names == {"test-bundle-1", "test-bundle-2"}
+
+    def test_config_path_takes_precedence_over_list(self):
+        """Test that config path takes precedence over config list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle = {
+                "name": "path-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            Path(tmpdir).joinpath("bundle.json").write_text(json.dumps(bundle))
+
+            list_config = [
+                {
+                    "name": "list-bundle",
+                    "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                    "kwargs": {"refresh_interval": 1},
+                }
+            ]
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_list"): json.dumps(list_config),
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+                bundle_names = {b.name for b in manager.get_all_dag_bundles()}
+                # Should only have bundle from path, not from list
+                assert bundle_names == {"path-bundle"}
+
+    def test_check_config_path_changes(self):
+        """Test detection of config file changes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_file = Path(tmpdir).joinpath("bundle.json")
+            bundle_config = {
+                "name": "test-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle_file.write_text(json.dumps(bundle_config))
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+
+                # No changes initially
+                assert not manager.check_config_path_changes()
+
+                # Modify the file
+                time.sleep(0.01)  # Ensure mtime changes
+                bundle_config["kwargs"]["refresh_interval"] = 99
+                bundle_file.write_text(json.dumps(bundle_config))
+
+                # Should detect the change
+                assert manager.check_config_path_changes()
+
+                # After reloading, no changes
+                manager.parse_config()
+                assert not manager.check_config_path_changes()
+
+    def test_config_path_file_addition_removal(self):
+        """Test detection of config file addition and removal."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle1_file = Path(tmpdir).joinpath("bundle1.json")
+            bundle1_config = {
+                "name": "bundle-1",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle1_file.write_text(json.dumps(bundle1_config))
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+                assert {b.name for b in manager.get_all_dag_bundles()} == {"bundle-1"}
+
+                # Add a new bundle file
+                bundle2_file = Path(tmpdir).joinpath("bundle2.json")
+                bundle2_config = {
+                    "name": "bundle-2",
+                    "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                    "kwargs": {"refresh_interval": 2},
+                }
+                bundle2_file.write_text(json.dumps(bundle2_config))
+
+                # Should detect the new file
+                assert manager.check_config_path_changes()
+                manager.parse_config()
+                assert {b.name for b in manager.get_all_dag_bundles()} == {"bundle-1", "bundle-2"}
+
+                # Remove a file
+                bundle1_file.unlink()
+
+                # Should detect the removal
+                assert manager.check_config_path_changes()
+                manager.parse_config()
+                assert {b.name for b in manager.get_all_dag_bundles()} == {"bundle-2"}
+
+    def test_invalid_json_file_ignored(self):
+        """Test that invalid JSON files are ignored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            valid_file = Path(tmpdir).joinpath("valid.json")
+            valid_config = {
+                "name": "valid-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            valid_file.write_text(json.dumps(valid_config))
+
+            invalid_file = Path(tmpdir).joinpath("invalid.json")
+            invalid_file.write_text("not valid json {")
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+                assert {b.name for b in manager.get_all_dag_bundles()} == {"valid-bundle"}
+
+    def test_non_existent_config_path(self):
+        """Test handling of non-existent config path."""
+        with conf_vars(
+            {
+                ("dag_processor", "dag_bundle_config_path"): "/non/existent/path",
+                ("core", "LOAD_EXAMPLES"): "False",
+            }
+        ):
+            manager = DagBundlesManager()
+            assert list(manager.get_all_dag_bundles()) == []
+
+    def test_config_path_not_directory(self):
+        """Test error when config path is not a directory."""
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpfile.name,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                with pytest.raises(AirflowConfigException, match="must be a directory"):
+                    DagBundlesManager()
+
+    def test_duplicate_bundle_names_ignored(self):
+        """Test that duplicate bundle names are detected and handled."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle1_file = Path(tmpdir).joinpath("bundle1.json")
+            bundle1_config = {
+                "name": "duplicate-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle1_file.write_text(json.dumps(bundle1_config))
+
+            bundle2_file = Path(tmpdir).joinpath("bundle2.json")
+            bundle2_config = {
+                "name": "duplicate-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle2_file.write_text(json.dumps(bundle2_config))
+
+            bundle3_file = Path(tmpdir).joinpath("bundle3.json")
+            bundle3_config = {
+                "name": "unique-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle3_file.write_text(json.dumps(bundle3_config))
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+                bundle_names = {b.name for b in manager.get_all_dag_bundles()}
+                assert "duplicate-bundle" in bundle_names
+                assert "unique-bundle" in bundle_names
+                assert len(bundle_names) == 2
+
+    def test_safe_bundle_access_methods(self):
+        """Test safe methods that don't raise errors for missing bundles."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_file = Path(tmpdir).joinpath("bundle.json")
+            bundle_config = {
+                "name": "test-bundle",
+                "classpath": "unit.dag_processing.bundles.test_dag_bundle_manager.BasicBundle",
+                "kwargs": {"refresh_interval": 1},
+            }
+            bundle_file.write_text(json.dumps(bundle_config))
+
+            with conf_vars(
+                {
+                    ("dag_processor", "dag_bundle_config_path"): tmpdir,
+                    ("core", "LOAD_EXAMPLES"): "False",
+                }
+            ):
+                manager = DagBundlesManager()
+
+                # Test with existing bundle — BasicBundle returns None for view_url
+                with pytest.warns(DeprecationWarning, match="'view_url' method is deprecated"):
+                    assert manager.view_url("test-bundle") is None
+                path = manager.get_bundle_path_safe("test-bundle")
+                assert path is not None
+
+                # Test with non-existent bundle
+                with pytest.warns(DeprecationWarning, match="'view_url' method is deprecated"):
+                    assert manager.view_url("non-existent") is None
+                assert manager.get_bundle_path_safe("non-existent") is None
+
+                # Test that get_bundle still raises error
+                with pytest.raises(ValueError, match="Requested bundle 'non-existent' is not configured"):
+                    manager.get_bundle("non-existent")

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-import time
 from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import patch
@@ -554,10 +553,12 @@ class TestDagBundleConfigPath:
                 # No changes initially
                 assert not manager.check_config_path_changes()
 
-                # Modify the file
-                time.sleep(0.01)  # Ensure mtime changes
+                # Modify the file and bump its mtime deterministically (avoid relying on
+                # filesystem timestamp granularity).
                 bundle_config["kwargs"]["refresh_interval"] = 99
                 bundle_file.write_text(json.dumps(bundle_config))
+                new_mtime_ns = bundle_file.stat().st_mtime_ns + 10_000_000_000
+                os.utime(bundle_file, ns=(new_mtime_ns, new_mtime_ns))
 
                 # Should detect the change
                 assert manager.check_config_path_changes()


### PR DESCRIPTION
Add a new `dag_bundle_config_path` setting that allows loading DAG bundle configurations from JSON files in a directory, enabling hot-reloading without restarting the DAG processor.

**Motivation:** In Kubernetes environments, bundle configurations need to change frequently (e.g., via ConfigMaps). The current `dag_bundle_config_list` requires static config in `airflow.cfg` and a processor restart. This feature allows mounting a directory of JSON files and having the DAG processor automatically detect and apply changes.

**Key changes:**
- `DagBundlesManager`: new `_parse_config_from_path()`, `check_config_path_changes()`, and `get_bundle_path_safe()` methods
- `DagFileProcessorManager`: reuses a single `DagBundlesManager` instance; detects config path changes in the refresh loop, cleaning up removed bundles (processors, file stats, DAGs)
- `ParseImportError.full_file_path()`: graceful handling when bundles are removed
- `config.yml`: new `dag_bundle_config_path` option under `[dag_processor]`

**JSON config format:**
```json
{
  "name": "my-git-repo",
  "classpath": "airflow.providers.git.bundles.git.GitDagBundle",
  "kwargs": {
    "tracking_ref": "main",
    "git_conn_id": "my_git_conn"
  }
}
```

**Behavior:**
- When `dag_bundle_config_path` is set, it takes precedence over `dag_bundle_config_list`
- The DAG processor monitors the directory for JSON file additions, removals, and modifications via mtime tracking
- On change: reloads config, syncs to DB, cleans up removed bundle processors/DAGs, force-refreshes active bundles
- Invalid JSON files are logged and skipped; duplicate bundle names are warned and skipped

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=8abfb21 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @tardunge** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Build documentation (--spellcheck-only)`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - **Failing test jobs**: `provider distributions tests / Compat 2.11.1:P3.10:`, `provider distributions tests / Compat 3.0.6:P3.10:`, `provider distributions tests / Compat 3.1.8:P3.10:`, `provider distributions tests / Compat 3.2.1:P3.10:`. Reproduce and fix locally, then push.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->