### PR TITLE
Fix 299 blank lines in registry homepage HTML

### DIFF
--- a/registry/src/index.njk
+++ b/registry/src/index.njk
@@ -99,13 +99,13 @@ title: Discover Providers, Operators & Hooks for Apache Airflow
 </section>
 
 <!-- New Providers -->
-{% set allWithDate = [] %}
-{% for provider in providers.providers %}
-  {% if provider.first_released %}
-    {% set allWithDate = (allWithDate.push(provider), allWithDate) %}
-  {% endif %}
-{% endfor %}
-{% set newProviders = allWithDate | sort(false, false, 'first_released') | reverse | slice(0, 4) %}
+{%- set allWithDate = [] -%}
+{%- for provider in providers.providers -%}
+  {%- if provider.first_released -%}
+    {%- set allWithDate = (allWithDate.push(provider), allWithDate) -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- set newProviders = allWithDate | sort(false, false, 'first_released') | reverse | slice(0, 4) -%}
 {% if newProviders.length > 0 %}
 <section id="new-providers">
   <div class="container">


### PR DESCRIPTION
The Nunjucks loop that filters providers with first_released dates emits blank lines for each iteration (~99 providers x 3 lines). Use whitespace-trimming delimiters ({%- -%}) on the data-processing loop to eliminate blank lines from the rendered HTML.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
