### PR TITLE
Add Redis list-based queue support with async hook

### DIFF
--- a/providers/redis/provider.yaml
+++ b/providers/redis/provider.yaml
@@ -77,9 +77,11 @@ operators:
   - integration-name: Redis
     python-modules:
       - airflow.providers.redis.operators.redis_publish
+      - airflow.providers.redis.operators.redis_lpush
 
 queues:
   - airflow.providers.redis.queues.redis.RedisPubSubMessageQueueProvider
+  - airflow.providers.redis.queues.redis_list.RedisListMessageQueueProvider
 
 sensors:
   - integration-name: Redis
@@ -91,6 +93,7 @@ triggers:
   - integration-name: Redis
     python-modules:
       - airflow.providers.redis.triggers.redis_await_message
+      - airflow.providers.redis.triggers.redis_list_await_message
 
 hooks:
   - integration-name: Redis

--- a/providers/redis/src/airflow/providers/redis/get_provider_info.py
+++ b/providers/redis/src/airflow/providers/redis/get_provider_info.py
@@ -37,10 +37,16 @@ def get_provider_info():
         "operators": [
             {
                 "integration-name": "Redis",
-                "python-modules": ["airflow.providers.redis.operators.redis_publish"],
+                "python-modules": [
+                    "airflow.providers.redis.operators.redis_publish",
+                    "airflow.providers.redis.operators.redis_lpush",
+                ],
             }
         ],
-        "queues": ["airflow.providers.redis.queues.redis.RedisPubSubMessageQueueProvider"],
+        "queues": [
+            "airflow.providers.redis.queues.redis.RedisPubSubMessageQueueProvider",
+            "airflow.providers.redis.queues.redis_list.RedisListMessageQueueProvider",
+        ],
         "sensors": [
             {
                 "integration-name": "Redis",
@@ -53,7 +59,10 @@ def get_provider_info():
         "triggers": [
             {
                 "integration-name": "Redis",
-                "python-modules": ["airflow.providers.redis.triggers.redis_await_message"],
+                "python-modules": [
+                    "airflow.providers.redis.triggers.redis_await_message",
+                    "airflow.providers.redis.triggers.redis_list_await_message",
+                ],
             }
         ],
         "hooks": [{"integration-name": "Redis", "python-modules": ["airflow.providers.redis.hooks.redis"]}],

--- a/providers/redis/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/redis/src/airflow/providers/redis/hooks/redis.py
@@ -133,18 +133,18 @@ class RedisHook(BaseHook):
         ssl_args = {name: val for name, val in conn.extra_dejson.items() if name in ssl_arg_names}
 
         async_redis = AsyncRedis(
-            host=host,
-            port=port,
+            host=host or "localhost",
+            port=port or 6379,
             username=username,
             password=password,
-            db=db,
+            db=db or 0,
             decode_responses=True,
             **ssl_args,
         )
         try:
             yield async_redis
         finally:
-            await async_redis.aclose()
+            await async_redis.close()
 
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:

--- a/providers/redis/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/redis/src/airflow/providers/redis/hooks/redis.py
@@ -24,6 +24,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
 
 from airflow.providers.common.compat.sdk import BaseHook
 
@@ -113,8 +114,6 @@ class RedisHook(BaseHook):
             async with hook.get_async_conn() as redis_conn:
                 await redis_conn.brpop("my_list", timeout=10)
         """
-        from redis.asyncio import Redis as AsyncRedis
-
         conn = self.get_connection(self.redis_conn_id)
         host = conn.host
         port = conn.port

--- a/providers/redis/src/airflow/providers/redis/hooks/redis.py
+++ b/providers/redis/src/airflow/providers/redis/hooks/redis.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from redis import Redis
@@ -97,6 +99,52 @@ class RedisHook(BaseHook):
             )
 
         return self.redis
+
+    @asynccontextmanager
+    async def get_async_conn(self) -> AsyncIterator[Any]:
+        """
+        Return an async Redis connection using ``redis.asyncio``.
+
+        This is an async context manager that creates and cleans up an async Redis connection.
+        Useful for triggers and other async components that need non-blocking Redis access.
+
+        Usage::
+
+            async with hook.get_async_conn() as redis_conn:
+                await redis_conn.brpop("my_list", timeout=10)
+        """
+        from redis.asyncio import Redis as AsyncRedis
+
+        conn = self.get_connection(self.redis_conn_id)
+        host = conn.host
+        port = conn.port
+        username = conn.login
+        password = None if str(conn.password).lower() in ["none", "false", ""] else conn.password
+        db = conn.extra_dejson.get("db")
+
+        ssl_arg_names = [
+            "ssl",
+            "ssl_cert_reqs",
+            "ssl_ca_certs",
+            "ssl_keyfile",
+            "ssl_certfile",
+            "ssl_check_hostname",
+        ]
+        ssl_args = {name: val for name, val in conn.extra_dejson.items() if name in ssl_arg_names}
+
+        async_redis = AsyncRedis(
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            db=db,
+            decode_responses=True,
+            **ssl_args,
+        )
+        try:
+            yield async_redis
+        finally:
+            await async_redis.aclose()
 
     @classmethod
     def get_ui_field_behaviour(cls) -> dict[str, Any]:

--- a/providers/redis/src/airflow/providers/redis/operators/redis_lpush.py
+++ b/providers/redis/src/airflow/providers/redis/operators/redis_lpush.py
@@ -33,7 +33,10 @@ class RedisLPushOperator(BaseOperator):
 
     This operator pushes a message to the head (left) of a Redis list.
     Combined with BRPOP on the consumer side, this provides a FIFO queue pattern
-    with durable, exactly-once delivery semantics.
+    where messages are durable until consumed and BRPOP removes them atomically.
+    Note that BRPOP gives at-most-once delivery: a consumer crash after pop loses
+    the message. For at-least-once semantics, build an ack pattern on top
+    (e.g. ``BLMOVE`` to a processing list, ``LREM`` after successful handling).
 
     :param list_name: redis list to push the message to (templated)
     :param message: the message to push (templated)

--- a/providers/redis/src/airflow/providers/redis/operators/redis_lpush.py
+++ b/providers/redis/src/airflow/providers/redis/operators/redis_lpush.py
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from airflow.providers.common.compat.sdk import BaseOperator
+from airflow.providers.redis.hooks.redis import RedisHook
+
+if TYPE_CHECKING:
+    from airflow.providers.common.compat.sdk import Context
+
+
+class RedisLPushOperator(BaseOperator):
+    """
+    Push a message to a Redis list using LPUSH.
+
+    This operator pushes a message to the head (left) of a Redis list.
+    Combined with BRPOP on the consumer side, this provides a FIFO queue pattern
+    with durable, exactly-once delivery semantics.
+
+    :param list_name: redis list to push the message to (templated)
+    :param message: the message to push (templated)
+    :param redis_conn_id: redis connection to use
+    """
+
+    template_fields: Sequence[str] = ("list_name", "message")
+
+    def __init__(
+        self, *, list_name: str, message: str, redis_conn_id: str = "redis_default", **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+        self.redis_conn_id = redis_conn_id
+        self.list_name = list_name
+        self.message = message
+
+    def execute(self, context: Context) -> int:
+        """
+        Push the message to Redis list.
+
+        :param context: the context object
+        :return: the length of the list after the push
+        """
+        redis_hook = RedisHook(redis_conn_id=self.redis_conn_id)
+
+        self.log.info("Pushing message to Redis list %s", self.list_name)
+
+        result = redis_hook.get_conn().lpush(self.list_name, self.message)
+
+        self.log.info("List %s now has %s elements", self.list_name, result)
+        return result

--- a/providers/redis/src/airflow/providers/redis/queues/redis_list.py
+++ b/providers/redis/src/airflow/providers/redis/queues/redis_list.py
@@ -36,8 +36,10 @@ class RedisListMessageQueueProvider(BaseMessageQueueProvider):
 
     Unlike ``redis+pubsub``, list-based queues provide:
 
-    * **Durability**: Messages persist in the list until consumed (no message loss).
-    * **Exactly-once delivery**: BRPOP atomically removes and returns the message.
+    * **Durability**: Messages persist in the list until consumed.
+    * **Atomic consumption**: BRPOP atomically removes and returns the message
+      (at-most-once delivery — a consumer crash after pop loses the message; build
+      an ack pattern on top with ``BLMOVE`` and ``LREM`` if you need at-least-once).
     * **Priority queues**: Multiple lists are checked in order.
 
     .. code-block:: python

--- a/providers/redis/src/airflow/providers/redis/queues/redis_list.py
+++ b/providers/redis/src/airflow/providers/redis/queues/redis_list.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.providers.common.messaging.providers.base_provider import BaseMessageQueueProvider
+from airflow.providers.redis.triggers.redis_list_await_message import AwaitMessageFromListTrigger
+
+if TYPE_CHECKING:
+    from airflow.triggers.base import BaseEventTrigger
+
+
+class RedisListMessageQueueProvider(BaseMessageQueueProvider):
+    """
+    Configuration for Redis Lists integration with common-messaging.
+
+    [START redis_list_message_queue_provider_description]
+
+    * It uses ``redis+list`` as scheme for identifying Redis list-based queues.
+    * For parameter definitions take a look at :class:`~airflow.providers.redis.triggers.redis_list_await_message.AwaitMessageFromListTrigger`.
+
+    Unlike ``redis+pubsub``, list-based queues provide:
+
+    * **Durability**: Messages persist in the list until consumed (no message loss).
+    * **Exactly-once delivery**: BRPOP atomically removes and returns the message.
+    * **Priority queues**: Multiple lists are checked in order.
+
+    .. code-block:: python
+
+        from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTrigger
+        from airflow.sdk import Asset, AssetWatcher
+
+        trigger = MessageQueueTrigger(
+            scheme="redis+list",
+            lists=["my_queue"],
+            redis_conn_id="redis_default",
+        )
+
+        asset = Asset("redis_list_asset", watchers=[AssetWatcher(name="redis_watcher", trigger=trigger)])
+
+    [END redis_list_message_queue_provider_description]
+    """
+
+    scheme = "redis+list"
+
+    def trigger_class(self) -> type[BaseEventTrigger]:
+        return AwaitMessageFromListTrigger  # type: ignore[return-value]

--- a/providers/redis/src/airflow/providers/redis/triggers/redis_list_await_message.py
+++ b/providers/redis/src/airflow/providers/redis/triggers/redis_list_await_message.py
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from airflow.providers.redis.hooks.redis import RedisHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class AwaitMessageFromListTrigger(BaseTrigger):
+    """
+    A trigger that waits for a message on Redis lists using BRPOP.
+
+    Unlike pub/sub, list-based messaging provides:
+    - **Durability**: messages persist in the list until consumed
+    - **Exactly-once delivery**: BRPOP atomically removes and returns the message
+    - **Priority queues**: when multiple lists are provided, they are checked in order
+
+    :param lists: The Redis list name(s) to monitor. When multiple lists are provided,
+        they are checked in order (first list has highest priority).
+    :param redis_conn_id: The connection ID to use, defaults to "redis_default"
+    :param timeout: BRPOP timeout in seconds. 0 means block indefinitely (default: 0)
+    """
+
+    def __init__(
+        self,
+        lists: list[str] | str,
+        redis_conn_id: str = "redis_default",
+        timeout: int = 0,
+    ) -> None:
+        self.lists = [lists] if isinstance(lists, str) else lists
+        self.redis_conn_id = redis_conn_id
+        self.timeout = timeout
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.redis.triggers.redis_list_await_message.AwaitMessageFromListTrigger",
+            {
+                "lists": self.lists,
+                "redis_conn_id": self.redis_conn_id,
+                "timeout": self.timeout,
+            },
+        )
+
+    async def run(self):
+        hook = RedisHook(redis_conn_id=self.redis_conn_id)
+
+        async with hook.get_async_conn() as redis_conn:
+            while True:
+                result = await redis_conn.brpop(self.lists, timeout=self.timeout)
+
+                if result is not None:
+                    list_name, message = result
+                    # Ensure string values (redis.asyncio with decode_responses=True
+                    # should already return strings, but handle bytes defensively)
+                    if isinstance(list_name, bytes):
+                        list_name = list_name.decode("utf-8")
+                    if isinstance(message, bytes):
+                        message = message.decode("utf-8")
+
+                    yield TriggerEvent({"list": list_name, "data": message})
+                    break
+
+                if self.timeout > 0:
+                    # BRPOP returned None due to timeout, retry
+                    await asyncio.sleep(0)

--- a/providers/redis/src/airflow/providers/redis/triggers/redis_list_await_message.py
+++ b/providers/redis/src/airflow/providers/redis/triggers/redis_list_await_message.py
@@ -30,7 +30,9 @@ class AwaitMessageFromListTrigger(BaseTrigger):
 
     Unlike pub/sub, list-based messaging provides:
     - **Durability**: messages persist in the list until consumed
-    - **Exactly-once delivery**: BRPOP atomically removes and returns the message
+    - **Atomic consumption**: BRPOP atomically removes and returns the message
+      (at-most-once delivery — a consumer crash after pop loses the message; for
+      at-least-once semantics, build an ack pattern on top using ``BLMOVE`` and ``LREM``)
     - **Priority queues**: when multiple lists are provided, they are checked in order
 
     :param lists: The Redis list name(s) to monitor. When multiple lists are provided,

--- a/providers/redis/tests/unit/redis/hooks/test_redis.py
+++ b/providers/redis/tests/unit/redis/hooks/test_redis.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -82,3 +83,73 @@ class TestRedisHook:
         hook = RedisHook(redis_conn_id="redis_default")
         hook.get_conn()
         assert hook.password is None
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.redis.hooks.redis.AsyncRedis")
+    @mock.patch("airflow.providers.redis.hooks.redis.RedisHook.get_connection")
+    async def test_get_async_conn_with_extra_config(self, mock_get_connection, mock_async_redis):
+        connection = Connection(
+            login="user",
+            password="password",
+            host="remote_host",
+            port=1234,
+        )
+        connection.set_extra(
+            """{
+                "db": 2,
+                "ssl": true,
+                "ssl_cert_reqs": "required",
+                "ssl_ca_certs": "/path/to/custom/ca-cert",
+                "ssl_keyfile": "/path/to/key-file",
+                "ssl_certfile": "/path/to/cert-file",
+                "ssl_check_hostname": true
+            }"""
+        )
+        mock_get_connection.return_value = connection
+        mock_async_redis.return_value.close = AsyncMock()
+        hook = RedisHook()
+
+        async with hook.get_async_conn() as conn:
+            assert conn is mock_async_redis.return_value
+
+        mock_async_redis.assert_called_once_with(
+            host=connection.host,
+            port=connection.port,
+            username=connection.login,
+            password=connection.password,
+            db=connection.extra_dejson["db"],
+            decode_responses=True,
+            ssl=connection.extra_dejson["ssl"],
+            ssl_cert_reqs=connection.extra_dejson["ssl_cert_reqs"],
+            ssl_ca_certs=connection.extra_dejson["ssl_ca_certs"],
+            ssl_keyfile=connection.extra_dejson["ssl_keyfile"],
+            ssl_certfile=connection.extra_dejson["ssl_certfile"],
+            ssl_check_hostname=connection.extra_dejson["ssl_check_hostname"],
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.redis.hooks.redis.AsyncRedis")
+    @mock.patch("airflow.providers.redis.hooks.redis.RedisHook.get_connection")
+    async def test_get_async_conn_closes_on_exit(self, mock_get_connection, mock_async_redis):
+        mock_get_connection.return_value = Connection(host="localhost", port=6379)
+        mock_async_redis.return_value.close = AsyncMock()
+        hook = RedisHook()
+
+        async with hook.get_async_conn():
+            pass
+
+        mock_async_redis.return_value.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.redis.hooks.redis.AsyncRedis")
+    @mock.patch("airflow.providers.redis.hooks.redis.RedisHook.get_connection")
+    async def test_get_async_conn_closes_on_exception(self, mock_get_connection, mock_async_redis):
+        mock_get_connection.return_value = Connection(host="localhost", port=6379)
+        mock_async_redis.return_value.close = AsyncMock()
+        hook = RedisHook()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with hook.get_async_conn():
+                raise RuntimeError("boom")
+
+        mock_async_redis.return_value.close.assert_awaited_once()

--- a/providers/redis/tests/unit/redis/operators/test_redis_lpush.py
+++ b/providers/redis/tests/unit/redis/operators/test_redis_lpush.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from airflow.models.dag import DAG
 from airflow.providers.redis.operators.redis_lpush import RedisLPushOperator
@@ -30,7 +30,7 @@ class TestRedisLPushOperator:
     def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", schedule=None, default_args=args)
-        self.mock_context = MagicMock()
+        self.mock_context: dict = {}
 
     @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
     def test_execute_operator(self, mock_redis_conn):

--- a/providers/redis/tests/unit/redis/operators/test_redis_lpush.py
+++ b/providers/redis/tests/unit/redis/operators/test_redis_lpush.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from airflow.models.dag import DAG
+from airflow.providers.redis.operators.redis_lpush import RedisLPushOperator
+from airflow.utils import timezone
+
+DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestRedisLPushOperator:
+    def setup_method(self):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+        self.dag = DAG("test_dag_id", schedule=None, default_args=args)
+        self.mock_context = MagicMock()
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    def test_execute_operator(self, mock_redis_conn):
+        mock_redis_conn().lpush.return_value = 1
+
+        operator = RedisLPushOperator(
+            task_id="test_task",
+            dag=self.dag,
+            list_name="test_list",
+            message="test_message",
+            redis_conn_id="redis_default",
+        )
+        result = operator.execute(self.mock_context)
+
+        mock_redis_conn.assert_called_with()
+        mock_redis_conn().lpush.assert_called_once_with("test_list", "test_message")
+        assert result == 1
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_conn")
+    def test_execute_operator_multiple_pushes(self, mock_redis_conn):
+        mock_redis_conn().lpush.side_effect = [1, 2, 3]
+
+        for i in range(3):
+            operator = RedisLPushOperator(
+                task_id=f"test_task_{i}",
+                dag=self.dag,
+                list_name="test_list",
+                message=f"message_{i}",
+                redis_conn_id="redis_default",
+            )
+            result = operator.execute(self.mock_context)
+            assert result == i + 1

--- a/providers/redis/tests/unit/redis/queues/test_redis_list.py
+++ b/providers/redis/tests/unit/redis/queues/test_redis_list.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.redis.triggers.redis_list_await_message import AwaitMessageFromListTrigger
+
+from tests_common.test_utils.common_msg_queue import mark_common_msg_queue_test
+
+pytest.importorskip("airflow.providers.common.messaging.providers.base_provider")
+
+
+class TestRedisListMessageQueueProvider:
+    """Tests for RedisListMessageQueueProvider."""
+
+    def setup_method(self):
+        from airflow.providers.redis.queues.redis_list import RedisListMessageQueueProvider
+
+        self.provider = RedisListMessageQueueProvider()
+
+    def test_queue_create(self):
+        from airflow.providers.common.messaging.providers.base_provider import BaseMessageQueueProvider
+
+        assert isinstance(self.provider, BaseMessageQueueProvider)
+
+    @pytest.mark.parametrize(
+        ("scheme", "expected_result"),
+        [
+            pytest.param("redis+list", True, id="redis_list_scheme"),
+            pytest.param("redis+pubsub", False, id="redis_pubsub_scheme"),
+            pytest.param("kafka", False, id="kafka_scheme"),
+            pytest.param("sqs", False, id="sqs_scheme"),
+            pytest.param("unknown", False, id="unknown_scheme"),
+        ],
+    )
+    def test_scheme_matches(self, scheme, expected_result):
+        assert self.provider.scheme_matches(scheme) == expected_result
+
+    def test_trigger_class(self):
+        assert self.provider.trigger_class() == AwaitMessageFromListTrigger
+
+
+@mark_common_msg_queue_test
+class TestMessageQueueTriggerWithList:
+    @pytest.mark.usefixtures("cleanup_providers_manager")
+    def test_provider_integrations_with_scheme_param(self):
+        from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTrigger
+        from airflow.providers.redis.triggers.redis_list_await_message import AwaitMessageFromListTrigger
+
+        trigger = MessageQueueTrigger(scheme="redis+list", lists=["test_queue"])
+        assert isinstance(trigger.trigger, AwaitMessageFromListTrigger)

--- a/providers/redis/tests/unit/redis/triggers/test_redis_list_await_message.py
+++ b/providers/redis/tests/unit/redis/triggers/test_redis_list_await_message.py
@@ -58,8 +58,6 @@ class TestAwaitMessageFromListTrigger:
     async def test_trigger_run_succeed(self, mock_async_conn):
         mock_redis = AsyncMock()
         mock_redis.brpop.return_value = ("test_list", "test_data")
-        mock_redis.aclose = AsyncMock()
-
         mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
         mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -81,8 +79,6 @@ class TestAwaitMessageFromListTrigger:
     async def test_trigger_run_with_bytes(self, mock_async_conn):
         mock_redis = AsyncMock()
         mock_redis.brpop.return_value = (b"test_list", b"test_data")
-        mock_redis.aclose = AsyncMock()
-
         mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
         mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -105,8 +101,6 @@ class TestAwaitMessageFromListTrigger:
         """Test that trigger checks multiple lists (priority queue behavior)."""
         mock_redis = AsyncMock()
         mock_redis.brpop.return_value = ("high_priority", "urgent_message")
-        mock_redis.aclose = AsyncMock()
-
         mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
         mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
 

--- a/providers/redis/tests/unit/redis/triggers/test_redis_list_await_message.py
+++ b/providers/redis/tests/unit/redis/triggers/test_redis_list_await_message.py
@@ -1,0 +1,123 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from airflow.providers.redis.triggers.redis_list_await_message import AwaitMessageFromListTrigger
+
+
+class TestAwaitMessageFromListTrigger:
+    def test_trigger_serialization(self):
+        trigger = AwaitMessageFromListTrigger(
+            lists=["test_list"],
+            redis_conn_id="redis_default",
+            timeout=10,
+        )
+
+        assert isinstance(trigger, AwaitMessageFromListTrigger)
+
+        classpath, kwargs = trigger.serialize()
+
+        assert (
+            classpath
+            == "airflow.providers.redis.triggers.redis_list_await_message.AwaitMessageFromListTrigger"
+        )
+        assert kwargs == {
+            "lists": ["test_list"],
+            "redis_conn_id": "redis_default",
+            "timeout": 10,
+        }
+
+    def test_trigger_serialization_string_list(self):
+        """Test that a single string list name is converted to a list."""
+        trigger = AwaitMessageFromListTrigger(lists="single_list")
+        _, kwargs = trigger.serialize()
+        assert kwargs["lists"] == ["single_list"]
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_async_conn")
+    @pytest.mark.asyncio
+    async def test_trigger_run_succeed(self, mock_async_conn):
+        mock_redis = AsyncMock()
+        mock_redis.brpop.return_value = ("test_list", "test_data")
+        mock_redis.aclose = AsyncMock()
+
+        mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        trigger = AwaitMessageFromListTrigger(
+            lists=["test_list"],
+            redis_conn_id="redis_default",
+            timeout=10,
+        )
+
+        trigger_gen = trigger.run()
+        task = asyncio.create_task(trigger_gen.__anext__())
+        event = await task
+        assert task.done() is True
+        assert event.payload["data"] == "test_data"
+        assert event.payload["list"] == "test_list"
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_async_conn")
+    @pytest.mark.asyncio
+    async def test_trigger_run_with_bytes(self, mock_async_conn):
+        mock_redis = AsyncMock()
+        mock_redis.brpop.return_value = (b"test_list", b"test_data")
+        mock_redis.aclose = AsyncMock()
+
+        mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        trigger = AwaitMessageFromListTrigger(
+            lists=["test_list"],
+            redis_conn_id="redis_default",
+            timeout=10,
+        )
+
+        trigger_gen = trigger.run()
+        task = asyncio.create_task(trigger_gen.__anext__())
+        event = await task
+        assert task.done() is True
+        assert event.payload["data"] == "test_data"
+        assert event.payload["list"] == "test_list"
+
+    @patch("airflow.providers.redis.hooks.redis.RedisHook.get_async_conn")
+    @pytest.mark.asyncio
+    async def test_trigger_run_multiple_lists(self, mock_async_conn):
+        """Test that trigger checks multiple lists (priority queue behavior)."""
+        mock_redis = AsyncMock()
+        mock_redis.brpop.return_value = ("high_priority", "urgent_message")
+        mock_redis.aclose = AsyncMock()
+
+        mock_async_conn.return_value.__aenter__ = AsyncMock(return_value=mock_redis)
+        mock_async_conn.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        trigger = AwaitMessageFromListTrigger(
+            lists=["high_priority", "low_priority"],
+            redis_conn_id="redis_default",
+        )
+
+        trigger_gen = trigger.run()
+        task = asyncio.create_task(trigger_gen.__anext__())
+        event = await task
+        assert event.payload["list"] == "high_priority"
+        assert event.payload["data"] == "urgent_message"
+        mock_redis.brpop.assert_called_once_with(["high_priority", "low_priority"], timeout=0)


### PR DESCRIPTION
Adds durable list-based messaging to the Redis provider using LPUSH/BRPOP, complementing the existing pub/sub support.

**Motivation:** Redis pub/sub is fire-and-forget — messages are lost if no subscriber is listening. List-based queues (LPUSH + BRPOP) provide message persistence in the queue until consumed, atomic consumption via BRPOP (at-most-once delivery — a consumer crash after pop loses the message), and priority queue patterns via ordered multi-list BRPOP. For at-least-once semantics, build an ack pattern on top with `BLMOVE` to a processing list and `LREM` after successful handling.

**New components:**
- `RedisLPushOperator` — push messages to Redis lists (FIFO queue producer)
- `AwaitMessageFromListTrigger` — async trigger using BRPOP with priority queue support (multiple lists checked in order)
- `RedisListMessageQueueProvider` — common-messaging integration with `redis+list://` scheme
- `RedisHook.get_async_conn()` — async context manager using `redis.asyncio` for truly non-blocking trigger operations (the existing hook is sync-only, which requires `sync_to_async` wrapping in triggers)

**No new dependencies** — `redis.asyncio` is part of `redis>=4.2.0`, and the provider already requires `redis>=4.5.2`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)