### PR TITLE
Fix dataset-triggered DAGs firing without all upstream events

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -37,6 +37,7 @@ from airflow.models.dataset import (
     DatasetModel,
 )
 from airflow.stats import Stats
+from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -184,7 +185,7 @@ class DatasetManager(LoggingMixin):
         cls, dataset_id: int, dags_to_queue: set[DagModel], session: Session
     ) -> None:
         def _queue_dagrun_if_needed(dag: DagModel) -> str | None:
-            item = DatasetDagRunQueue(target_dag_id=dag.dag_id, dataset_id=dataset_id)
+            item = DatasetDagRunQueue(target_dag_id=dag.dag_id, dataset_id=dataset_id, created_at=timezone.utcnow())
             # Don't error whole transaction when a single RunQueue item conflicts.
             # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
             try:
@@ -202,8 +203,13 @@ class DatasetManager(LoggingMixin):
     def _postgres_queue_dagruns(cls, dataset_id: int, dags_to_queue: set[DagModel], session: Session) -> None:
         from sqlalchemy.dialects.postgresql import insert
 
-        values = [{"target_dag_id": dag.dag_id} for dag in dags_to_queue]
-        stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset_id).on_conflict_do_nothing()
+        values = [{"target_dag_id": dag.dag_id, "created_at": timezone.utcnow()} for dag in dags_to_queue]
+        stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset_id)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["dataset_id", "target_dag_id"],
+            set_={"created_at": stmt.excluded.created_at},
+            where=(DatasetDagRunQueue.created_at < stmt.excluded.created_at),
+        )
         session.execute(stmt, values)
 
     @classmethod

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -1489,21 +1489,25 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     events=dataset_events,
                 )
 
-                dag_run = dag.create_dagrun(
-                    run_id=run_id,
-                    run_type=DagRunType.DATASET_TRIGGERED,
-                    execution_date=exec_date,
-                    data_interval=data_interval,
-                    state=DagRunState.QUEUED,
-                    external_trigger=False,
-                    session=session,
-                    dag_hash=dag_hash,
-                    creating_job_id=self.job.id,
-                )
-                Stats.incr("dataset.triggered_dagruns")
-                dag_run.consumed_dataset_events.extend(dataset_events)
+                if dataset_events:
+                    dag_run = dag.create_dagrun(
+                        run_id=run_id,
+                        run_type=DagRunType.DATASET_TRIGGERED,
+                        execution_date=exec_date,
+                        data_interval=data_interval,
+                        state=DagRunState.QUEUED,
+                        external_trigger=False,
+                        session=session,
+                        dag_hash=dag_hash,
+                        creating_job_id=self.job.id,
+                    )
+                    Stats.incr("dataset.triggered_dagruns")
+                    dag_run.consumed_dataset_events.extend(dataset_events)
                 session.execute(
-                    delete(DatasetDagRunQueue).where(DatasetDagRunQueue.target_dag_id == dag_run.dag_id)
+                    delete(DatasetDagRunQueue).where(
+                        DatasetDagRunQueue.target_dag_id == dag.dag_id,
+                        DatasetDagRunQueue.created_at <= exec_date,
+                    )
                 )
 
     def _should_update_dag_next_dagruns(

--- a/tests/datasets/test_manager.py
+++ b/tests/datasets/test_manager.py
@@ -228,3 +228,97 @@ class TestDatasetManager:
         # Ensure the listener was notified
         assert len(dataset_listener.created) == 1
         assert dataset_listener.created[0].uri == dsm.uri
+
+    @pytest.mark.skip_if_database_isolation_mode
+    def test_slow_path_queue_dagruns_updates_timestamp(self, session):
+        """
+        On non-Postgres backends, _slow_path_queue_dagruns should update created_at
+        when a DatasetDagRunQueue record already exists for the same (dataset_id, target_dag_id).
+        """
+        from datetime import timedelta
+
+        from airflow.utils import timezone
+
+        dsem = DatasetManager()
+        ds = DatasetModel(uri="test_slow_path_update_ts")
+        dag = DagModel(dag_id="test_slow_path_dag", is_active=True)
+        session.add_all([ds, dag])
+        session.flush()
+
+        old_ts = timezone.utcnow() - timedelta(days=1)
+        session.add(DatasetDagRunQueue(dataset_id=ds.id, target_dag_id=dag.dag_id, created_at=old_ts))
+        session.commit()
+
+        before_update = timezone.utcnow()
+        dsem._slow_path_queue_dagruns(dataset_id=ds.id, dags_to_queue={dag}, session=session)
+        session.commit()
+
+        updated = (
+            session.query(DatasetDagRunQueue)
+            .filter_by(dataset_id=ds.id, target_dag_id=dag.dag_id)
+            .one()
+        )
+        assert updated.created_at >= before_update
+
+    @pytest.mark.skip_if_database_isolation_mode
+    @pytest.mark.backend("postgres")
+    def test_postgres_queue_dagruns_updates_timestamp(self, session):
+        """
+        On PostgreSQL, _postgres_queue_dagruns should update created_at via ON CONFLICT DO UPDATE
+        when a DatasetDagRunQueue record already exists for the same (dataset_id, target_dag_id).
+        """
+        from datetime import timedelta
+
+        from airflow.utils import timezone
+
+        dsem = DatasetManager()
+        ds = DatasetModel(uri="test_postgres_update_ts")
+        dag = DagModel(dag_id="test_postgres_dag", is_active=True)
+        session.add_all([ds, dag])
+        session.flush()
+
+        old_ts = timezone.utcnow() - timedelta(days=1)
+        session.add(DatasetDagRunQueue(dataset_id=ds.id, target_dag_id=dag.dag_id, created_at=old_ts))
+        session.commit()
+
+        before_update = timezone.utcnow()
+        dsem._postgres_queue_dagruns(dataset_id=ds.id, dags_to_queue={dag}, session=session)
+        session.commit()
+
+        updated = (
+            session.query(DatasetDagRunQueue)
+            .filter_by(dataset_id=ds.id, target_dag_id=dag.dag_id)
+            .one()
+        )
+        assert updated.created_at >= before_update
+
+    @pytest.mark.skip_if_database_isolation_mode
+    @pytest.mark.backend("postgres")
+    def test_postgres_queue_dagruns_where_guard_prevents_backwards_drift(self, session):
+        """
+        The WHERE guard on the Postgres upsert should prevent a slower transaction
+        from overwriting a newer created_at with an older one.
+        """
+        from datetime import timedelta
+
+        from airflow.utils import timezone
+
+        dsem = DatasetManager()
+        ds = DatasetModel(uri="test_postgres_where_guard")
+        dag = DagModel(dag_id="test_pg_guard_dag", is_active=True)
+        session.add_all([ds, dag])
+        session.flush()
+
+        newer_ts = timezone.utcnow()
+        session.add(DatasetDagRunQueue(dataset_id=ds.id, target_dag_id=dag.dag_id, created_at=newer_ts))
+        session.commit()
+
+        dsem._postgres_queue_dagruns(dataset_id=ds.id, dags_to_queue={dag}, session=session)
+        session.commit()
+
+        updated = (
+            session.query(DatasetDagRunQueue)
+            .filter_by(dataset_id=ds.id, target_dag_id=dag.dag_id)
+            .one()
+        )
+        assert updated.created_at >= newer_ts


### PR DESCRIPTION
* related: #62501 

Backports #62501 to 2.x

Backports three targeted fixes to 2.11.2 to address the race condition reported in #56750, #56541 and #41101, where a dataset-dependent DAG fires with one or more upstream dataset events missing from consumed_dataset_events.

Root cause: stale `created_at` timestamps in DatasetDagRunQueue caused the scheduler's event-window query to exclude valid events, yet the presence-based readiness check still considered the DAG ready to run.

Changes:
- manager.py: replace ON CONFLICT DO NOTHING with ON CONFLICT DO UPDATE (Postgres) and add a WHERE guard to prevent backwards timestamp drift; pass explicit created_at=utcnow() on the non-Postgres merge path so existing rows are always refreshed.
- scheduler_job_runner.py: wrap create_dagrun in `if dataset_events:` to prevent phantom runs when the event window is empty; scope the DDRQ DELETE to `created_at <= exec_date` instead of deleting all rows, so events that arrived during processing are preserved for the next cycle.
- tests/datasets/test_manager.py: add WHERE-guard regression test for the Postgres upsert path.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Cursor with Claude Opus 4.6)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
