### PR TITLE
feat: Add resource quota awareness to KubernetesPodOperator

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -30,6 +30,7 @@ import shlex
 import string
 from collections.abc import Callable, Container, Iterable, Sequence
 from contextlib import AbstractContextManager
+from datetime import timedelta
 from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
@@ -79,8 +80,18 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodNotFoundException,
     PodPhase,
 )
+from airflow.providers.cncf.kubernetes.utils.resource_quota import (
+    PodResourceQuotaExceededException,
+    check_pod_quota_compliance,
+)
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
 from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY, AirflowSkipException, TaskDeferred
+
+# Import AirflowRescheduleException with version compatibility
+try:
+    from airflow.sdk.exceptions import AirflowRescheduleException
+except ImportError:
+    from airflow.exceptions import AirflowRescheduleException  # type: ignore[no-redef]
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import BaseHook, BaseOperator
@@ -254,6 +265,14 @@ class KubernetesPodOperator(BaseOperator):
     :param log_formatter: custom log formatter function that takes two string arguments:
         the first string is the container_name and the second string is the message_to_log.
         The function should return a formatted string. If None, the default formatting will be used.
+    :param check_resource_quotas: if True, check namespace resource quotas before creating the pod.
+        Default to False.
+    :param on_quota_exceeded: action to take when pod would exceed resource quota. Options:
+        "queue" (default) - reschedule the task to try again later,
+        "fail" - fail the task immediately with an exception,
+        "ignore" - proceed with pod creation anyway (same as check_resource_quotas=False).
+    :param quota_check_interval: when on_quota_exceeded="queue", the interval in seconds to wait
+        before retrying. Default to 60 seconds.
     """
 
     # !!! Changes in KubernetesPodOperator's arguments should be also reflected in !!!
@@ -365,6 +384,9 @@ class KubernetesPodOperator(BaseOperator):
         trigger_kwargs: dict | None = None,
         container_name_log_prefix_enabled: bool = True,
         log_formatter: Callable[[str, str], str] | None = None,
+        check_resource_quotas: bool = False,
+        on_quota_exceeded: Literal["queue", "fail", "ignore"] = "queue",
+        quota_check_interval: int = 60,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -463,6 +485,9 @@ class KubernetesPodOperator(BaseOperator):
         self._killed: bool = False
         self.container_name_log_prefix_enabled = container_name_log_prefix_enabled
         self.log_formatter = log_formatter
+        self.check_resource_quotas = check_resource_quotas
+        self.on_quota_exceeded = on_quota_exceeded
+        self.quota_check_interval = quota_check_interval
 
     @cached_property
     def _incluster_namespace(self):
@@ -629,6 +654,29 @@ class KubernetesPodOperator(BaseOperator):
                 self.log.info("Deleted pod to handle rerun and create new pod!")
 
         self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod_request_obj.to_dict()))
+
+        # Check resource quotas before attempting to create the pod
+        if self.check_resource_quotas and self.on_quota_exceeded != "ignore":
+            try:
+                check_pod_quota_compliance(self.client, pod_request_obj, pod_request_obj.metadata.namespace)
+            except PodResourceQuotaExceededException as e:
+                if self.on_quota_exceeded == "queue":
+                    self.log.warning(
+                        "Pod creation would exceed resource quota. Task will be rescheduled to retry later. %s",
+                        str(e),
+                    )
+                    reschedule_time = datetime.datetime.now(datetime.timezone.utc) + timedelta(
+                        seconds=self.quota_check_interval
+                    )
+                    raise AirflowRescheduleException(reschedule_time)
+                if self.on_quota_exceeded == "fail":
+                    self.log.error(
+                        "Pod creation blocked due to resource quota violation. "
+                        "Set on_quota_exceeded='queue' to retry or 'ignore' to skip this check."
+                    )
+                    raise
+                # If "ignore", just continue and try to create the pod anyway
+
         self.pod_manager.create_pod(pod=pod_request_obj)
         return pod_request_obj
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/resource_quota.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/resource_quota.py
@@ -1,0 +1,250 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utilities for checking Kubernetes resource quotas."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from kubernetes.client.exceptions import ApiException
+
+from airflow.providers.common.compat.sdk import AirflowException
+
+if TYPE_CHECKING:
+    from kubernetes.client import CoreV1Api
+    from kubernetes.client.models import V1Pod
+
+logger = logging.getLogger(__name__)
+
+
+class PodResourceQuotaExceededException(AirflowException):
+    """Raised when creating a pod would exceed the namespace resource quota."""
+
+
+def parse_resource_quantity(quantity: str | None) -> float:
+    """
+    Parse Kubernetes resource quantity string to a numeric value.
+
+    Supports suffixes like Ki, Mi, Gi, Ti, Pi, Ei for binary units
+    and k, M, G, T, P, E for decimal units, as well as millicpu 'm' suffix.
+
+    :param quantity: Kubernetes resource quantity string (e.g., "100m", "1Gi", "500Mi")
+    :return: Numeric value in base units (cores for CPU, bytes for memory)
+    """
+    if not quantity:
+        return 0.0
+
+    quantity = str(quantity).strip()
+    if not quantity:
+        return 0.0
+
+    # Binary suffixes (base 1024)
+    binary_suffixes = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "Pi": 1024**5,
+        "Ei": 1024**6,
+    }
+
+    # Decimal suffixes (base 1000)
+    decimal_suffixes = {
+        "k": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+        "P": 1000**5,
+        "E": 1000**6,
+    }
+
+    # Check for millicpu (m suffix)
+    if quantity.endswith("m"):
+        try:
+            return float(quantity[:-1]) / 1000
+        except ValueError:
+            return 0.0
+
+    # Check for binary suffixes
+    for suffix, multiplier in binary_suffixes.items():
+        if quantity.endswith(suffix):
+            try:
+                return float(quantity[: -len(suffix)]) * multiplier
+            except ValueError:
+                return 0.0
+
+    # Check for decimal suffixes
+    for suffix, multiplier in decimal_suffixes.items():
+        if quantity.endswith(suffix):
+            try:
+                return float(quantity[: -len(suffix)]) * multiplier
+            except ValueError:
+                return 0.0
+
+    # No suffix, just a number
+    try:
+        return float(quantity)
+    except ValueError:
+        return 0.0
+
+
+def get_pod_resource_requests(pod: V1Pod) -> dict[str, float]:
+    """
+    Extract total resource requests from a pod specification.
+
+    :param pod: V1Pod object
+    :return: Dictionary with 'cpu' and 'memory' keys containing total requests
+    """
+    total_cpu = 0.0
+    total_memory = 0.0
+
+    if not pod.spec or not pod.spec.containers:
+        return {"cpu": total_cpu, "memory": total_memory}
+
+    for container in pod.spec.containers:
+        if container.resources and container.resources.requests:
+            cpu_request = container.resources.requests.get("cpu")
+            memory_request = container.resources.requests.get("memory")
+
+            if cpu_request:
+                total_cpu += parse_resource_quantity(cpu_request)
+            if memory_request:
+                total_memory += parse_resource_quantity(memory_request)
+
+    # Also check init containers
+    if pod.spec.init_containers:
+        for container in pod.spec.init_containers:
+            if container.resources and container.resources.requests:
+                cpu_request = container.resources.requests.get("cpu")
+                memory_request = container.resources.requests.get("memory")
+
+                if cpu_request:
+                    total_cpu += parse_resource_quantity(cpu_request)
+                if memory_request:
+                    total_memory += parse_resource_quantity(memory_request)
+
+    return {"cpu": total_cpu, "memory": total_memory}
+
+
+def get_namespace_quota_status(
+    client: CoreV1Api, namespace: str
+) -> tuple[dict[str, float], dict[str, float]] | None:
+    """
+    Get the current quota usage and limits for a namespace.
+
+    :param client: Kubernetes CoreV1Api client
+    :param namespace: Namespace name
+    :return: Tuple of (used_resources, hard_limits) dictionaries or None if no quota
+    """
+    try:
+        quota_list = client.list_namespaced_resource_quota(namespace=namespace)
+    except ApiException as e:
+        if e.status == 403:
+            logger.warning(
+                "Insufficient permissions to check resource quotas in namespace %s. "
+                "Skipping quota validation.",
+                namespace,
+            )
+            return None
+        if e.status == 404:
+            logger.debug("Namespace %s not found for quota check", namespace)
+            return None
+        logger.warning("Error checking resource quotas: %s", e)
+        return None
+
+    if not quota_list.items:
+        # No resource quotas defined for this namespace
+        return None
+
+    # Aggregate all quotas in the namespace
+    total_used = {"cpu": 0.0, "memory": 0.0}
+    total_hard = {"cpu": 0.0, "memory": 0.0}
+
+    for quota in quota_list.items:
+        if quota.status and quota.status.used:
+            cpu_used = quota.status.used.get("requests.cpu") or quota.status.used.get("cpu")
+            memory_used = quota.status.used.get("requests.memory") or quota.status.used.get("memory")
+
+            if cpu_used:
+                total_used["cpu"] += parse_resource_quantity(cpu_used)
+            if memory_used:
+                total_used["memory"] += parse_resource_quantity(memory_used)
+
+        if quota.spec and quota.spec.hard:
+            cpu_hard = quota.spec.hard.get("requests.cpu") or quota.spec.hard.get("cpu")
+            memory_hard = quota.spec.hard.get("requests.memory") or quota.spec.hard.get("memory")
+
+            if cpu_hard:
+                total_hard["cpu"] += parse_resource_quantity(cpu_hard)
+            if memory_hard:
+                total_hard["memory"] += parse_resource_quantity(memory_hard)
+
+    # Only return quota info if limits are actually defined
+    if total_hard["cpu"] > 0 or total_hard["memory"] > 0:
+        return total_used, total_hard
+
+    return None
+
+
+def check_pod_quota_compliance(client: CoreV1Api, pod: V1Pod, namespace: str) -> None:
+    """
+    Check if creating a pod would exceed namespace resource quotas.
+
+    :param client: Kubernetes CoreV1Api client
+    :param pod: V1Pod object to check
+    :param namespace: Namespace where pod will be created
+    :raises PodResourceQuotaExceededException: If pod would exceed quota
+    """
+    quota_info = get_namespace_quota_status(client, namespace)
+
+    if not quota_info:
+        # No quotas defined or couldn't check, allow pod creation
+        return
+
+    used_resources, hard_limits = quota_info
+    pod_requests = get_pod_resource_requests(pod)
+
+    violations = []
+
+    # Check CPU quota
+    if hard_limits["cpu"] > 0:
+        new_cpu_usage = used_resources["cpu"] + pod_requests["cpu"]
+        if new_cpu_usage > hard_limits["cpu"]:
+            violations.append(
+                f"CPU: would use {new_cpu_usage:.3f} cores "
+                f"(current: {used_resources['cpu']:.3f}, limit: {hard_limits['cpu']:.3f}, "
+                f"pod requests: {pod_requests['cpu']:.3f})"
+            )
+
+    # Check memory quota
+    if hard_limits["memory"] > 0:
+        new_memory_usage = used_resources["memory"] + pod_requests["memory"]
+        if new_memory_usage > hard_limits["memory"]:
+            violations.append(
+                f"Memory: would use {new_memory_usage / (1024**3):.3f} GiB "
+                f"(current: {used_resources['memory'] / (1024**3):.3f} GiB, "
+                f"limit: {hard_limits['memory'] / (1024**3):.3f} GiB, "
+                f"pod requests: {pod_requests['memory'] / (1024**3):.3f} GiB)"
+            )
+
+    if violations:
+        error_msg = (
+            f"Cannot create pod '{pod.metadata.name}' in namespace '{namespace}'. "
+            f"Would exceed resource quota:\n" + "\n".join(f"  - {v}" for v in violations)
+        )
+        raise PodResourceQuotaExceededException(error_msg)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_resource_quota.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_resource_quota.py
@@ -1,0 +1,378 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from kubernetes.client import models as k8s
+from kubernetes.client.exceptions import ApiException
+
+from airflow.providers.cncf.kubernetes.utils.resource_quota import (
+    PodResourceQuotaExceededException,
+    check_pod_quota_compliance,
+    get_namespace_quota_status,
+    get_pod_resource_requests,
+    parse_resource_quantity,
+)
+
+
+class TestParseResourceQuantity:
+    """Test resource quantity parsing."""
+
+    def test_parse_cpu_cores(self):
+        """Test parsing CPU in cores."""
+        assert parse_resource_quantity("1") == 1.0
+        assert parse_resource_quantity("2.5") == 2.5
+        assert parse_resource_quantity("0.5") == 0.5
+
+    def test_parse_cpu_millicores(self):
+        """Test parsing CPU in millicores."""
+        assert parse_resource_quantity("100m") == 0.1
+        assert parse_resource_quantity("500m") == 0.5
+        assert parse_resource_quantity("1000m") == 1.0
+
+    def test_parse_memory_binary(self):
+        """Test parsing memory with binary suffixes."""
+        assert parse_resource_quantity("1Ki") == 1024
+        assert parse_resource_quantity("1Mi") == 1024**2
+        assert parse_resource_quantity("1Gi") == 1024**3
+        assert parse_resource_quantity("1Ti") == 1024**4
+        assert parse_resource_quantity("2Gi") == 2 * 1024**3
+
+    def test_parse_memory_decimal(self):
+        """Test parsing memory with decimal suffixes."""
+        assert parse_resource_quantity("1k") == 1000
+        assert parse_resource_quantity("1M") == 1000**2
+        assert parse_resource_quantity("1G") == 1000**3
+        assert parse_resource_quantity("2G") == 2 * 1000**3
+
+    def test_parse_empty_or_none(self):
+        """Test parsing empty or None values."""
+        assert parse_resource_quantity(None) == 0.0
+        assert parse_resource_quantity("") == 0.0
+        assert parse_resource_quantity("   ") == 0.0
+
+    def test_parse_invalid(self):
+        """Test parsing invalid values."""
+        assert parse_resource_quantity("invalid") == 0.0
+        assert parse_resource_quantity("abc123") == 0.0
+
+
+class TestGetPodResourceRequests:
+    """Test extracting resource requests from pods."""
+
+    def test_pod_with_requests(self):
+        """Test pod with resource requests."""
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "100m", "memory": "256Mi"}),
+                    )
+                ]
+            ),
+        )
+
+        requests = get_pod_resource_requests(pod)
+        assert requests["cpu"] == 0.1
+        assert requests["memory"] == 256 * 1024**2
+
+    def test_pod_with_multiple_containers(self):
+        """Test pod with multiple containers."""
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "100m", "memory": "256Mi"}),
+                    ),
+                    k8s.V1Container(
+                        name="sidecar",
+                        image="sidecar:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "50m", "memory": "128Mi"}),
+                    ),
+                ]
+            ),
+        )
+
+        requests = get_pod_resource_requests(pod)
+        assert requests["cpu"] == pytest.approx(0.15)  # 100m + 50m
+        assert requests["memory"] == (256 + 128) * 1024**2
+
+    def test_pod_with_init_containers(self):
+        """Test pod with init containers."""
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "100m", "memory": "256Mi"}),
+                    )
+                ],
+                init_containers=[
+                    k8s.V1Container(
+                        name="init",
+                        image="init:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "50m", "memory": "128Mi"}),
+                    )
+                ],
+            ),
+        )
+
+        requests = get_pod_resource_requests(pod)
+        assert requests["cpu"] == pytest.approx(0.15)  # 100m + 50m
+        assert requests["memory"] == (256 + 128) * 1024**2
+
+    def test_pod_without_requests(self):
+        """Test pod without resource requests."""
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(containers=[k8s.V1Container(name="main", image="test:latest")]),
+        )
+
+        requests = get_pod_resource_requests(pod)
+        assert requests["cpu"] == 0.0
+        assert requests["memory"] == 0.0
+
+    def test_pod_without_spec(self):
+        """Test pod without spec."""
+        pod = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"))
+
+        requests = get_pod_resource_requests(pod)
+        assert requests["cpu"] == 0.0
+        assert requests["memory"] == 0.0
+
+
+class TestGetNamespaceQuotaStatus:
+    """Test getting namespace quota status."""
+
+    def test_namespace_with_quota(self):
+        """Test namespace with resource quota."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={"requests.cpu": "4", "requests.memory": "8Gi"}),
+            status=k8s.V1ResourceQuotaStatus(used={"requests.cpu": "2", "requests.memory": "4Gi"}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is not None
+        used, hard = result
+        assert used["cpu"] == 2.0
+        assert used["memory"] == 4 * 1024**3
+        assert hard["cpu"] == 4.0
+        assert hard["memory"] == 8 * 1024**3
+
+    def test_namespace_without_quota(self):
+        """Test namespace without resource quota."""
+        mock_client = mock.MagicMock()
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[])
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is None
+
+    def test_namespace_quota_no_limits(self):
+        """Test namespace quota with no actual limits defined."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={}),
+            status=k8s.V1ResourceQuotaStatus(used={}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is None
+
+    def test_namespace_forbidden_error(self):
+        """Test handling of 403 Forbidden error."""
+        mock_client = mock.MagicMock()
+        mock_client.list_namespaced_resource_quota.side_effect = ApiException(status=403)
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is None
+
+    def test_namespace_not_found_error(self):
+        """Test handling of 404 Not Found error."""
+        mock_client = mock.MagicMock()
+        mock_client.list_namespaced_resource_quota.side_effect = ApiException(status=404)
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is None
+
+    def test_namespace_other_api_error(self):
+        """Test handling of other API errors."""
+        mock_client = mock.MagicMock()
+        mock_client.list_namespaced_resource_quota.side_effect = ApiException(status=500)
+
+        result = get_namespace_quota_status(mock_client, "default")
+
+        assert result is None
+
+
+class TestCheckPodQuotaCompliance:
+    """Test checking pod quota compliance."""
+
+    def test_pod_within_quota(self):
+        """Test pod that fits within quota."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={"requests.cpu": "4", "requests.memory": "8Gi"}),
+            status=k8s.V1ResourceQuotaStatus(used={"requests.cpu": "2", "requests.memory": "4Gi"}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "1", "memory": "2Gi"}),
+                    )
+                ]
+            ),
+        )
+
+        # Should not raise
+        check_pod_quota_compliance(mock_client, pod, "default")
+
+    def test_pod_exceeds_cpu_quota(self):
+        """Test pod that exceeds CPU quota."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={"requests.cpu": "4", "requests.memory": "8Gi"}),
+            status=k8s.V1ResourceQuotaStatus(used={"requests.cpu": "3", "requests.memory": "2Gi"}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "2", "memory": "1Gi"}),
+                    )
+                ]
+            ),
+        )
+
+        with pytest.raises(PodResourceQuotaExceededException) as exc_info:
+            check_pod_quota_compliance(mock_client, pod, "default")
+
+        assert "CPU" in str(exc_info.value)
+        assert "test-pod" in str(exc_info.value)
+
+    def test_pod_exceeds_memory_quota(self):
+        """Test pod that exceeds memory quota."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={"requests.cpu": "4", "requests.memory": "8Gi"}),
+            status=k8s.V1ResourceQuotaStatus(used={"requests.cpu": "1", "requests.memory": "6Gi"}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "1", "memory": "3Gi"}),
+                    )
+                ]
+            ),
+        )
+
+        with pytest.raises(PodResourceQuotaExceededException) as exc_info:
+            check_pod_quota_compliance(mock_client, pod, "default")
+
+        assert "Memory" in str(exc_info.value)
+        assert "test-pod" in str(exc_info.value)
+
+    def test_pod_exceeds_both_quotas(self):
+        """Test pod that exceeds both CPU and memory quotas."""
+        mock_client = mock.MagicMock()
+        mock_quota = k8s.V1ResourceQuota(
+            metadata=k8s.V1ObjectMeta(name="quota"),
+            spec=k8s.V1ResourceQuotaSpec(hard={"requests.cpu": "4", "requests.memory": "8Gi"}),
+            status=k8s.V1ResourceQuotaStatus(used={"requests.cpu": "3", "requests.memory": "6Gi"}),
+        )
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[mock_quota])
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "2", "memory": "3Gi"}),
+                    )
+                ]
+            ),
+        )
+
+        with pytest.raises(PodResourceQuotaExceededException) as exc_info:
+            check_pod_quota_compliance(mock_client, pod, "default")
+
+        error_message = str(exc_info.value)
+        assert "CPU" in error_message
+        assert "Memory" in error_message
+        assert "test-pod" in error_message
+
+    def test_pod_without_quota(self):
+        """Test pod in namespace without quota."""
+        mock_client = mock.MagicMock()
+        mock_client.list_namespaced_resource_quota.return_value = k8s.V1ResourceQuotaList(items=[])
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="test-pod", namespace="default"),
+            spec=k8s.V1PodSpec(
+                containers=[
+                    k8s.V1Container(
+                        name="main",
+                        image="test:latest",
+                        resources=k8s.V1ResourceRequirements(requests={"cpu": "100", "memory": "100Gi"}),
+                    )
+                ]
+            ),
+        )
+
+        # Should not raise even with large requests
+        check_pod_quota_compliance(mock_client, pod, "default")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
This adds, in a non-breaking way, additional parameters for the KubernesPodOperator which allow the lookup of a resource quota in the namespace that is being deployed to to ensure there is proper resources available for the deployment of the pod.  The user can choose what to do if the quota would be exceeded.  The options if the quota is exceeded are to queue (default), fail, or ignore and try anyways.  The default retry is 60 seconds but is configurable via another param.

I was able to successfully test this in a breeze setup connected to a kind cluster.

I will open the PR to update the decorator after any changes to the params are finalized in this PR.

closes: #63944 
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude Sonnet 4.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
