### PR TITLE
Fix mypy errors in kubernetes, fab, google, and amazon providers

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -616,9 +616,9 @@ class AwsEcsExecutor(BaseExecutor):
                     self.active_workers.add_task(
                         task,
                         ti.key,
-                        ti.queue,
+                        ti.queue or "",
                         command,
-                        ti.executor_config,
+                        ti.executor_config or {},
                         ti.try_number,
                     )
                     adopted_tis.append(ti)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -477,7 +477,7 @@ class KubernetesExecutor(BaseExecutor):
         self.event_buffer[key] = state, termination_reason
 
     def _get_pod_namespace(self, ti: TaskInstance):
-        pod_override = ti.executor_config.get("pod_override")
+        pod_override = (ti.executor_config or {}).get("pod_override")
         namespace = None
         with suppress(Exception):
             if pod_override is not None:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -558,7 +558,7 @@ class FabAuthManager(BaseAuthManager[User]):
         :param session: the session
         """
         rows = session.execute(select(Pool.pool)).scalars().all()
-        return set(rows)
+        return {r for r in rows if r is not None}
 
     @provide_session
     def get_authorized_variables(

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -202,7 +202,7 @@ class StackdriverTaskHandler(logging.Handler):
         :param task_instance: Currently executed task
         """
         self.task_instance_labels = self._task_instance_to_labels(task_instance)
-        self.task_instance_hostname = task_instance.hostname
+        self.task_instance_hostname = task_instance.hostname or "default-hostname"
 
     def read(
         self, task_instance: TaskInstance, try_number: int | None = None, metadata: dict | None = None


### PR DESCRIPTION
Fix 5 pre-existing mypy errors across 4 provider files:

- **kubernetes_executor**: handle `None` `executor_config` before calling `.get()`
- **fab_auth_manager**: filter `None` values from `Pool.pool` query results
- **stackdriver_task_handler**: provide fallback for `None` `hostname`
- **ecs_executor**: handle nullable `queue` and `executor_config` in `add_task` call

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)