### PR TITLE
Add runtime_class_name to KubernetesPodOperator

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -185,6 +185,7 @@ class KubernetesPodOperator(BaseOperator):
     :param affinity: affinity scheduling rules for the launched pod.
     :param config_file: The path to the Kubernetes config file. (templated)
         If not specified, default value is ``~/.kube/config``
+    :param runtime_class_name: The name of the RuntimeClass to use for all containers in the pod.
     :param node_selector: A dict containing a group of scheduling rules. (templated)
     :param image_pull_secrets: Any image pull secrets to be given to the pod.
         If more than one secret is required, provide a
@@ -324,6 +325,7 @@ class KubernetesPodOperator(BaseOperator):
         container_resources: k8s.V1ResourceRequirements | None = None,
         affinity: k8s.V1Affinity | None = None,
         config_file: str | None = None,
+        runtime_class_name: str | None = None,
         node_selector: dict | None = None,
         image_pull_secrets: list[k8s.V1LocalObjectReference] | None = None,
         service_account_name: str | None = None,
@@ -405,6 +407,7 @@ class KubernetesPodOperator(BaseOperator):
         self.init_container_logs = init_container_logs
         self.container_logs = container_logs or self.base_container_name
         self.image_pull_policy = image_pull_policy
+        self.runtime_class_name = runtime_class_name
         self.node_selector = node_selector or {}
         self.annotations = annotations or {}
         self.affinity = convert_affinity(affinity) if affinity else {}
@@ -1352,6 +1355,7 @@ class KubernetesPodOperator(BaseOperator):
                 annotations=self.annotations,
             ),
             spec=k8s.V1PodSpec(
+                runtime_class_name=self.runtime_class_name,
                 node_selector=self.node_selector,
                 affinity=self.affinity,
                 tolerations=self.tolerations,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -940,6 +940,21 @@ class TestKubernetesPodOperator:
         pod = k.build_pod_request_obj(create_context(k))
         assert pod.spec.containers[0].termination_message_policy == "File"
 
+    def test_runtime_class_name_correctly_set(self):
+        k = KubernetesPodOperator(
+            task_id="task",
+            runtime_class_name="gvisor",
+        )
+        pod = k.build_pod_request_obj(create_context(k))
+        assert pod.spec.runtime_class_name == "gvisor"
+
+    def test_runtime_class_name_default_value_correctly_set(self):
+        k = KubernetesPodOperator(
+            task_id="task",
+        )
+        pod = k.build_pod_request_obj(create_context(k))
+        assert pod.spec.runtime_class_name is None
+
     def test_termination_grace_period_correctly_set(self):
         k = KubernetesPodOperator(
             task_id="task",


### PR DESCRIPTION
Add `runtime_class_name` parameter to `KubernetesPodOperator`, allowing users to specify the RuntimeClass for all containers in the pod via `k8s.V1PodSpec`.

closes: #50983

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6