### PR TITLE
fix: forward task logs to stdout in LocalExecutor

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -149,6 +149,7 @@ def _execute_work(log: Logger, workload: workloads.ExecuteTask, team_conf) -> No
         token=workload.token,
         server=team_conf.get("core", "execution_api_server_url", fallback=default_execution_api_server),
         log_path=workload.log_path,
+        subprocess_logs_to_stdout=True,
     )
 
 

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -277,6 +277,7 @@ class TestLocalExecutor:
                 token=mock.ANY,
                 server=expected_server,
                 log_path=mock.ANY,
+                subprocess_logs_to_stdout=True,
             )
 
     @mock.patch("airflow.sdk.execution_time.supervisor.supervise")


### PR DESCRIPTION
LocalExecutor's `_execute_work()` calls `supervise()` without passing
`subprocess_logs_to_stdout=True`, so task logs are only written to log
files and never reach the container's stdout. This breaks log collection
in deployments that rely on container stdout for log aggregation.

The containerized executor (`execute_workload.py`) already passes this
flag (added in #47731), but LocalExecutor was not updated.

closes: #54501
related: #49863

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Anthropic)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)