### PR TITLE
Fix registry explore page showing wrong provider counts and empty Top Providers

### DIFF
--- a/registry/src/_data/exploreCategoryProviders.js
+++ b/registry/src/_data/exploreCategoryProviders.js
@@ -20,14 +20,11 @@
 const providersData = require("./providers.json");
 const exploreCategories = require("./exploreCategories");
 
-const MAX_PROVIDERS_PER_CATEGORY = 6;
-
 module.exports = function () {
   const map = {};
   for (const category of exploreCategories) {
     const matched = [];
     for (const provider of providersData.providers) {
-      if (matched.length >= MAX_PROVIDERS_PER_CATEGORY) break;
       for (const keyword of category.keywords) {
         if (
           provider.id.includes(keyword) ||

--- a/registry/src/explore.njk
+++ b/registry/src/explore.njk
@@ -24,7 +24,7 @@ mainClass: explore-page
           </div>
           <div>
             <h2>{{ category.name }}</h2>
-            <p class="provider-count">{{ categoryProviders.length }}+ providers</p>
+            <p class="provider-count">{{ categoryProviders.length }} providers</p>
           </div>
         </div>
         <p class="category-description">{{ category.description }}</p>
@@ -59,7 +59,7 @@ mainClass: explore-page
         <div class="provider-list">
           {% set topProviders = [] %}
           {% for provider in providers.providers %}
-            {% set counts = provider.module_counts or {} %}
+            {% set counts = moduleCountsByProvider[provider.id] or {} %}
             {% set totalMods = (counts.operator or 0) + (counts.hook or 0) + (counts.sensor or 0) + (counts.trigger or 0) + (counts.transfer or 0) %}
             {% if totalMods > 0 %}
               {% set topProviders = (topProviders.push({provider: provider, total: totalMods}), topProviders) %}
@@ -99,7 +99,7 @@ mainClass: explore-page
           {% for provider in providers.providers %}
             {% set lc = provider.lifecycle or "production" %}
             {% if lc === 'incubation' %}
-              {% set counts = provider.module_counts or {} %}
+              {% set counts = moduleCountsByProvider[provider.id] or {} %}
               {% set totalMods = (counts.operator or 0) + (counts.hook or 0) + (counts.sensor or 0) + (counts.trigger or 0) + (counts.transfer or 0) %}
               {% set incubatingProviders = (incubatingProviders.push({provider: provider, total: totalMods}), incubatingProviders) %}
             {% endif %}


### PR DESCRIPTION
Two bugs on the `/registry/explore/` page:

1. **All category cards showed "6+ providers"** — `exploreCategoryProviders.js` capped keyword matching at 6 per category, then the template appended "+". Every category with ≥6 matches displayed the same "6+" count, making it look like there aren't many providers. Removed the cap so the real count is shown (6, 12, 7, etc.). The template already uses `slice(0, 6)` to limit displayed badges.

2. **Top Providers section was empty, Incubating showed "0 modules"** — `explore.njk` read `provider.module_counts` from `providers.json`, which are always zeros (extract_metadata.py doesn't populate them). Other templates (provider cards, stats) already use `moduleCountsByProvider` which computes counts from `modules.json`. Switched explore.njk to use the same source.

**Before**
<img width="1128" height="803" alt="image" src="https://github.com/user-attachments/assets/5459317a-9525-4f77-86d3-e0e7f0e8c933" />

**After**
<img width="842" height="744" alt="image" src="https://github.com/user-attachments/assets/aae3bda9-8f00-4a9b-abfc-030483047db1" />
