### PR TITLE
fix: suppress false error logs for partitioned timetables when next_dagrun fields are None

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1912,19 +1912,28 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     active_runs=active_runs_of_dags.get(dag_model.dag_id),
                 )
                 continue
-            if dag_model.next_dagrun is None and not dag_model.timetable_partitioned:
-                self.log.error(
-                    "dag_model.next_dagrun is None; expected datetime",
-                    dag_id=dag_model.dag_id,
-                )
-                continue
-            if dag_model.next_dagrun_create_after is None:
-                if not dag_model.timetable_partitioned:
+            if dag_model.timetable_partitioned is False:
+                # non partition-aware DAGs
+                if dag_model.next_dagrun is None:
+                    self.log.error(
+                        "dag_model.next_dagrun is None; expected datetime",
+                        dag_id=dag_model.dag_id,
+                    )
+                    continue
+                if dag_model.next_dagrun_create_after is None:
                     self.log.error(
                         "dag_model.next_dagrun_create_after is None; expected datetime",
                         dag_id=dag_model.dag_id,
                     )
-                continue
+                    continue
+            else:
+                # partition-aware DAGs
+                if dag_model.next_dagrun_partition_key is None:
+                    self.log.error(
+                        "dag_model.next_dagrun_partition_key is None; expected str",
+                        dag_id=dag_model.dag_id,
+                    )
+                    continue
 
             serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not serdag:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1913,7 +1913,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 continue
             if dag_model.timetable_partitioned is False:
-                # non partition-aware DAGs
+                # non partition-aware Dags
                 if dag_model.next_dagrun is None:
                     self.log.error(
                         "dag_model.next_dagrun is None; expected datetime",
@@ -1927,7 +1927,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     )
                     continue
             else:
-                # partition-aware DAGs
+                # partition-aware Dags
                 if dag_model.next_dagrun_partition_key is None:
                     self.log.error(
                         "dag_model.next_dagrun_partition_key is None; expected str",

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1912,17 +1912,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     active_runs=active_runs_of_dags.get(dag_model.dag_id),
                 )
                 continue
-            if dag_model.next_dagrun is None and dag_model.timetable_partitioned is False:
+            if dag_model.next_dagrun is None and not dag_model.timetable_partitioned:
                 self.log.error(
                     "dag_model.next_dagrun is None; expected datetime",
                     dag_id=dag_model.dag_id,
                 )
                 continue
             if dag_model.next_dagrun_create_after is None:
-                self.log.error(
-                    "dag_model.next_dagrun_create_after is None; expected datetime",
-                    dag_id=dag_model.dag_id,
-                )
+                if not dag_model.timetable_partitioned:
+                    self.log.error(
+                        "dag_model.next_dagrun_create_after is None; expected datetime",
+                        dag_id=dag_model.dag_id,
+                    )
                 continue
 
             serdag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -9045,6 +9045,33 @@ def test_partitioned_dag_run_with_invalid_mapping(dag_maker: DagMaker, session: 
     )
 
 
+@pytest.mark.db_test
+def test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none(session, caplog):
+    """
+    Partitioned timetables may leave next_dagrun / next_dagrun_create_after unset when no run is due;
+    scheduler should skip without error logs (unlike non-partitioned DAGs).
+    """
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    dag_model = MagicMock()
+    dag_model.dag_id = "partitioned-skip-no-next-fields"
+    dag_model.exceeds_max_non_backfill = False
+    dag_model.next_dagrun = None
+    dag_model.timetable_partitioned = True
+    dag_model.next_dagrun_create_after = None
+    dag_model.max_active_runs = 16
+    dag_model.allowed_run_types = None
+
+    with caplog.at_level(logging.ERROR):
+        with mock.patch.object(runner, "_get_current_dag") as mock_get_dag:
+            runner._create_dag_runs([dag_model], session)
+
+    mock_get_dag.assert_not_called()
+    assert "dag_model.next_dagrun is None" not in caplog.text
+    assert "dag_model.next_dagrun_create_after is None" not in caplog.text
+
+
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
 def test_partitioned_dag_run_with_customized_mapper(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -9060,6 +9060,7 @@ def test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none(sessi
     dag_model.next_dagrun = None
     dag_model.timetable_partitioned = True
     dag_model.next_dagrun_create_after = None
+    dag_model.next_dagrun_partition_key = "partition-a"
     dag_model.max_active_runs = 16
     dag_model.allowed_run_types = None
 
@@ -9070,6 +9071,30 @@ def test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none(sessi
     mock_get_dag.assert_not_called()
     assert "dag_model.next_dagrun is None" not in caplog.text
     assert "dag_model.next_dagrun_create_after is None" not in caplog.text
+    assert "dag_model.next_dagrun_partition_key is None" not in caplog.text
+
+
+@pytest.mark.db_test
+def test_create_dag_runs_partitioned_timetable_logs_when_partition_key_none(session, caplog):
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    dag_model = MagicMock()
+    dag_model.dag_id = "partitioned-skip-no-partition-key"
+    dag_model.exceeds_max_non_backfill = False
+    dag_model.next_dagrun = None
+    dag_model.timetable_partitioned = True
+    dag_model.next_dagrun_create_after = None
+    dag_model.next_dagrun_partition_key = None
+    dag_model.max_active_runs = 16
+    dag_model.allowed_run_types = None
+
+    with caplog.at_level(logging.ERROR):
+        with mock.patch.object(runner, "_get_current_dag") as mock_get_dag:
+            runner._create_dag_runs([dag_model], session)
+
+    mock_get_dag.assert_not_called()
+    assert "dag_model.next_dagrun_partition_key is None; expected str" in caplog.text
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -9048,39 +9048,14 @@ def test_partitioned_dag_run_with_invalid_mapping(dag_maker: DagMaker, session: 
 @pytest.mark.db_test
 def test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none(session, caplog):
     """
-    Partitioned timetables may leave next_dagrun / next_dagrun_create_after unset when no run is due;
-    scheduler should skip without error logs (unlike non-partitioned DAGs).
+    Partitioned timetables may leave next_dagrun / next_dagrun_create_after unset when no run is due.
+    Scheduler should skip and log if partition key is not set.
     """
     runner = SchedulerJobRunner(
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     dag_model = MagicMock()
     dag_model.dag_id = "partitioned-skip-no-next-fields"
-    dag_model.exceeds_max_non_backfill = False
-    dag_model.next_dagrun = None
-    dag_model.timetable_partitioned = True
-    dag_model.next_dagrun_create_after = None
-    dag_model.next_dagrun_partition_key = "partition-a"
-    dag_model.max_active_runs = 16
-    dag_model.allowed_run_types = None
-
-    with caplog.at_level(logging.ERROR):
-        with mock.patch.object(runner, "_get_current_dag") as mock_get_dag:
-            runner._create_dag_runs([dag_model], session)
-
-    mock_get_dag.assert_not_called()
-    assert "dag_model.next_dagrun is None" not in caplog.text
-    assert "dag_model.next_dagrun_create_after is None" not in caplog.text
-    assert "dag_model.next_dagrun_partition_key is None" not in caplog.text
-
-
-@pytest.mark.db_test
-def test_create_dag_runs_partitioned_timetable_logs_when_partition_key_none(session, caplog):
-    runner = SchedulerJobRunner(
-        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
-    )
-    dag_model = MagicMock()
-    dag_model.dag_id = "partitioned-skip-no-partition-key"
     dag_model.exceeds_max_non_backfill = False
     dag_model.next_dagrun = None
     dag_model.timetable_partitioned = True
@@ -9094,7 +9069,28 @@ def test_create_dag_runs_partitioned_timetable_logs_when_partition_key_none(sess
             runner._create_dag_runs([dag_model], session)
 
     mock_get_dag.assert_not_called()
-    assert "dag_model.next_dagrun_partition_key is None; expected str" in caplog.text
+    assert "dag_model.next_dagrun_partition_key is None" in caplog.text
+
+
+@pytest.mark.db_test
+def test_create_dag_runs_partitioned_timetable_proceeds_when_partition_key_set(session):
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    dag_model = MagicMock()
+    dag_model.dag_id = "partitioned-proceed-with-partition-key"
+    dag_model.exceeds_max_non_backfill = False
+    dag_model.next_dagrun = None
+    dag_model.timetable_partitioned = True
+    dag_model.next_dagrun_create_after = None
+    dag_model.next_dagrun_partition_key = "partition-a"
+    dag_model.max_active_runs = 16
+    dag_model.allowed_run_types = None
+
+    with mock.patch.object(runner, "_get_current_dag", return_value=None) as mock_get_dag:
+        runner._create_dag_runs([dag_model], session)
+
+    mock_get_dag.assert_called_once()
 
 
 @pytest.mark.need_serialized_dag


### PR DESCRIPTION
## Problem

When a DAG uses `CronPartitionTimetable` with `catchup=False`, the scheduler logs a spurious error:
```
dag_model.next_dagrun_create_after is None; expected datetime
```

This happens because `next_dagrun_info()` legitimately returns `None` for partitioned timetables when no next run is due, but the scheduler treated `None` as an unexpected error condition for all timetable types.

## Fix

- Changed `next_dagrun is None` check to use `not dag_model.timetable_partitioned` (style cleanup, same behavior)
- Changed `next_dagrun_create_after is None` check to only log the error for non-partitioned timetables — partitioned timetables now skip silently since `None` is a valid/expected return

## Testing

Added unit test `test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none` that verifies a partitioned timetable DAG with both fields `None` skips without error logs.

Fixes #63436