### PR TITLE
fix(e2e): improve Playwright test patterns in xcoms.spec.ts

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
@@ -57,14 +57,13 @@ export class XComsPage extends BasePage {
     await filterInput.waitFor({ state: "visible", timeout: 5000 });
     await filterInput.fill(value);
     await filterInput.press("Enter");
-    await this.page.waitForLoadState("networkidle");
+    await expect(this.xcomsTable.locator("tbody tr").first()).toBeVisible({ timeout: 10_000 });
   }
 
   public async navigate(): Promise<void> {
     await this.navigateTo(XComsPage.xcomsUrl);
     await this.page.waitForURL(/.*xcoms/, { timeout: 15_000 });
     await this.xcomsTable.waitFor({ state: "visible", timeout: 30_000 });
-    await this.page.waitForLoadState("networkidle");
   }
 
   public async verifyDagDisplayNameFiltering(dagDisplayNamePattern: string): Promise<void> {
@@ -94,11 +93,10 @@ export class XComsPage extends BasePage {
 
     await expect(this.expandAllButton.first()).toBeVisible({ timeout: 5000 });
     await this.expandAllButton.first().click();
-    await this.page.waitForLoadState("networkidle");
 
     await expect(this.collapseAllButton.first()).toBeVisible({ timeout: 5000 });
     await this.collapseAllButton.first().click();
-    await this.page.waitForLoadState("networkidle");
+    await expect(this.expandAllButton.first()).toBeVisible({ timeout: 5000 });
   }
 
   public async verifyKeyPatternFiltering(keyPattern: string): Promise<void> {
@@ -130,12 +128,8 @@ export class XComsPage extends BasePage {
 
     const keyCell = firstRow.locator("td").first();
 
-    await expect(async () => {
-      await expect(keyCell).toBeVisible();
-      const text = await keyCell.textContent();
-
-      expect(text?.trim()).toBeTruthy();
-    }).toPass({ timeout: 10_000 });
+    await expect(keyCell).toBeVisible({ timeout: 10_000 });
+    await expect(keyCell).not.toBeEmpty();
 
     const dagIdLink = firstRow.locator("a[href*='/dags/']").first();
 
@@ -169,12 +163,6 @@ export class XComsPage extends BasePage {
 
     await expect(valueCell).toBeVisible();
 
-    await expect(async () => {
-      const textContent = await valueCell.textContent();
-      const hasTextContent = (textContent?.trim().length ?? 0) > 0;
-      const hasWidgetContent = (await valueCell.locator("button, pre, code").count()) > 0;
-
-      expect(hasTextContent || hasWidgetContent).toBeTruthy();
-    }).toPass({ timeout: 10_000 });
+    await expect(valueCell).not.toBeEmpty({ timeout: 10_000 });
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/xcoms.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/xcoms.spec.ts
@@ -43,20 +43,9 @@ test.describe("XComs Page", () => {
     }
 
     await setupXComsPage.navigate();
-    await page.waitForFunction(
-      (minCount) => {
-        const table = document.querySelector('[data-testid="table-list"]');
-
-        if (!table) {
-          return false;
-        }
-        const rows = table.querySelectorAll("tbody tr");
-
-        return rows.length >= minCount;
-      },
-      triggerCount,
-      { timeout: 120_000 },
-    );
+    await expect(page.locator('[data-testid="table-list"] tbody tr').nth(triggerCount - 1)).toBeVisible({
+      timeout: 120_000,
+    });
 
     await context.close();
   });


### PR DESCRIPTION
Improve Playwright test patterns in `xcoms.spec.ts` and `XComsPage.ts` to align with [Playwright best practices](https://playwright.dev/docs/best-practices).

**Changes:**
- Replace `page.waitForFunction()` with DOM queries with locator-based waiting (`nth().toBeVisible()`)
- Replace `waitForLoadState("networkidle")` with specific UI state assertions
- Replace manual `textContent()` + assertions with web-first assertions (`not.toBeEmpty()`)

No test coverage or behavior changes. Only pattern improvements.

closes: #63966

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

<!--
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->