### PR TITLE
Improve Playwright test patterns in TaskInstancePage #63963

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -265,6 +265,7 @@ const TriggerDAGForm = ({
           <Spacer />
           <Button
             colorPalette="brand"
+            data-testid="trigger-dag-submit"
             disabled={
               Boolean(errors.conf) ||
               Boolean(errors.date) ||

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancePage.ts
@@ -27,8 +27,8 @@ export class TaskInstancePage extends BasePage {
 
   public constructor(page: Page) {
     super(page);
-    this.triggerButton = page.locator('button[aria-label="Trigger Dag"]:has-text("Trigger")');
-    this.confirmTriggerButton = page.locator('button:has-text("Trigger")').last();
+    this.triggerButton = page.getByTestId("trigger-dag-button");
+    this.confirmTriggerButton = page.getByTestId("trigger-dag-submit");
     this.stateBadge = page.getByTestId("state-badge").first();
   }
 


### PR DESCRIPTION
Replace `:has-text()` CSS pseudo-selectors with `getByTestId()` locators in `TaskInstancePage.ts` to align with Playwright best practices. Added `data-testid="trigger-dag-submit"` to the trigger form submit button in `TriggerDAGForm.tsx`.
                                                                                                                                                       
closes: #63963                                                                                                                                       
                
                                                                                                                                                       