### PR TITLE
Support paused DAG checks for TriggerDagRunOperator from Airflow 3.2+

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -43,7 +43,7 @@ from airflow.providers.common.compat.sdk import (
 )
 from airflow.providers.standard.triggers.external_task import DagStateTrigger
 from airflow.providers.standard.utils.openlineage import safe_inject_openlineage_properties_into_dagrun_conf
-from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperator
+from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS, BaseOperator
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
@@ -215,8 +215,10 @@ class TriggerDagRunOperator(BaseOperator):
                 f"Expected str, datetime.datetime, or None for parameter 'logical_date'. Got {type(logical_date).__name__}"
             )
 
-        if fail_when_dag_is_paused and AIRFLOW_V_3_0_PLUS:
-            raise NotImplementedError("Setting `fail_when_dag_is_paused` not yet supported for Airflow 3.x")
+        if fail_when_dag_is_paused and AIRFLOW_V_3_0_PLUS and not AIRFLOW_V_3_2_PLUS:
+            raise NotImplementedError(
+                "Setting `fail_when_dag_is_paused` is only supported for Airflow 3.2 and above"
+            )
 
     def execute(self, context: Context):
         if self.logical_date is NOTSET:
@@ -256,14 +258,7 @@ class TriggerDagRunOperator(BaseOperator):
         self.trigger_run_id = run_id
 
         if self.fail_when_dag_is_paused:
-            dag_model = DagModel.get_current(self.trigger_dag_id)
-            if not dag_model:
-                raise ValueError(f"Dag {self.trigger_dag_id} is not found")
-            if dag_model.is_paused:
-                # TODO: enable this when dag state endpoint available from task sdk
-                # if AIRFLOW_V_3_0_PLUS:
-                #     raise DagIsPaused(dag_id=self.trigger_dag_id)
-                raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
+            self._raise_if_trigger_dag_is_paused(context)
 
         if AIRFLOW_V_3_0_PLUS:
             self._trigger_dag_af_3(
@@ -295,6 +290,19 @@ class TriggerDagRunOperator(BaseOperator):
             kwargs_accepted["note"] = self.note
 
         raise DagRunTriggerException(**kwargs_accepted)
+
+    def _raise_if_trigger_dag_is_paused(self, context: Context) -> None:
+        if AIRFLOW_V_3_0_PLUS:
+            dag = context["ti"].get_dag(dag_id=self.trigger_dag_id)
+            if dag.is_paused:
+                raise DagIsPaused(dag_id=self.trigger_dag_id)
+            return
+
+        dag_model = DagModel.get_current(self.trigger_dag_id)
+        if not dag_model:
+            raise ValueError(f"Dag {self.trigger_dag_id} is not found")
+        if dag_model.is_paused:
+            raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
 
     def _trigger_dag_af_2(self, context, run_id, parsed_logical_date):
         try:

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -38,7 +38,7 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import parse_and_sync_to_db
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_2_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.providers.common.compat.sdk import DagRunTriggerException
@@ -294,10 +294,14 @@ class TestDagRunOperator:
                 {}, {"dag_id": "dag_id", "run_ids": ["run_id_1"], "poll_interval": 15, "run_id_1": "success"}
             )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS or AIRFLOW_V_3_2_PLUS,
+        reason="Test only for Airflow 3.0 and 3.1",
+    )
     def test_trigger_dag_run_with_fail_when_dag_is_paused_should_fail(self):
         with pytest.raises(
-            NotImplementedError, match="Setting `fail_when_dag_is_paused` not yet supported for Airflow 3.x"
+            NotImplementedError,
+            match="Setting `fail_when_dag_is_paused` is only supported for Airflow 3.2 and above",
         ):
             TriggerDagRunOperator(
                 task_id="test_task",
@@ -305,6 +309,24 @@ class TestDagRunOperator:
                 conf={"foo": "bar"},
                 fail_when_dag_is_paused=True,
             )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="Test only for Airflow 3.2+")
+    def test_trigger_dag_run_with_fail_when_dag_is_paused_raises_dag_is_paused(self):
+        from airflow.providers.standard.operators.trigger_dagrun import DagIsPaused
+        from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+        ti = mock.Mock(spec=RuntimeTaskInstanceProtocol)
+        ti.get_dag.return_value = mock.Mock(is_paused=True)
+
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            conf={"foo": "bar"},
+            fail_when_dag_is_paused=True,
+        )
+
+        with pytest.raises(DagIsPaused, match=f"^Dag {TRIGGERED_DAG_ID} is paused$"):
+            task.execute(context={"ti": ti})
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
     def test_trigger_dagrun_with_str_conf(self):
@@ -1042,6 +1064,7 @@ class TestDagRunOperatorAF2:
         # The second DagStateTrigger call should still use the original `logical_date` value.
         assert mock_task_defer.call_args_list[1].kwargs["trigger"].run_ids == [run_id]
 
+    @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow 2")
     def test_trigger_dagrun_with_fail_when_dag_is_paused(self, dag_maker, session):
         """Test TriggerDagRunOperator with fail_when_dag_is_paused set to True."""
         session.execute(


### PR DESCRIPTION
Update `TriggerDagRunOperator` to handle `fail_when_dag_is_paused` from 3.2+



 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
