### PR TITLE
CI: Skip newsfragment check when label is set

### DIFF
--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -24,7 +24,7 @@ on:  # yamllint disable-line rule:truthy
       - v[0-9]+-[0-9]+-test
       - v[0-9]+-[0-9]+-stable
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -36,6 +36,7 @@ concurrency:
 
 jobs:
   check-newsfragment-pr-number:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip newsfragment check') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -53,6 +53,11 @@ jobs:
             | grep -v "/newsfragments/${PR_NUMBER}\." || true)
 
           if [ -n "$bad" ]; then
-            echo "::error::Newsfragment PR number mismatch. Expected ${PR_NUMBER} but found: ${bad}"
+            msg="Newsfragment PR number mismatch."
+            msg+=" Expected ${PR_NUMBER} but found: ${bad}."
+            msg+=" Rename the newsfragment to use the correct"
+            msg+=" PR number, or add the 'skip newsfragment"
+            msg+=" check' label to the PR to skip this check."
+            echo "::error::${msg}"
             exit 1
           fi

--- a/contributing-docs/18_contribution_workflow.rst
+++ b/contributing-docs/18_contribution_workflow.rst
@@ -201,6 +201,10 @@ Step 4: Prepare PR
      In general newsfragments must be one line.  For newsfragment type ``significant``, you may include summary and body separated by a blank line, similar to ``git`` commit messages.
      One thing to note here is that a ``significant`` newsfragment doesn't have to be a breaking change, it can be something that is notable but not breaking.
 
+     A CI check validates that newsfragment filenames use the correct PR number. If you need to skip
+     this check (e.g. when cherry-picking a newsfragment from another PR), add the
+     ``skip newsfragment check`` label to your PR.
+
 2. Rebase your fork, squash commits, and resolve all conflicts. See `How to rebase PR <10_working_with_git.rst#how-to-rebase-pr>`_
    if you need help with rebasing your change. Remember to rebase often if your PR takes a lot of time to
    review/fix. This will make rebase process much easier and less painful and the more often you do it,


### PR DESCRIPTION
Skip the newsfragment PR number check when the `skip newsfragment check` label is applied to a PR.

Changes:
- Add `if` condition to skip the job when the label is present
- Add `labeled`/`unlabeled` event triggers so the workflow re-evaluates on label changes

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)