### PR TITLE
fix(ui/e2e): improve Playwright test patterns in variable.spec.ts

### DIFF
--- a/airflow-core/src/airflow/ui/playwright.config.ts
+++ b/airflow-core/src/airflow/ui/playwright.config.ts
@@ -117,7 +117,6 @@ export default defineConfig({
     "**/dag-grid-view.spec.ts",
     "**/task-logs.spec.ts",
     "**/dag-tasks.spec.ts",
-    "**/variable.spec.ts",
   ],
 
   timeout: 30_000,

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/VariablePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/VariablePage.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { expect } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
 
 import { BasePage } from "./BasePage";
@@ -35,8 +36,8 @@ export class VariablePage extends BasePage {
     this.addButton = page.getByRole("button", { name: /add/i });
     this.importButton = page.getByRole("button", { name: "Import Variables" });
     this.table = page.getByTestId("table-list");
-    this.tableRows = this.table.locator("tbody tr");
-    this.selectAllCheckbox = page.locator("thead input[type='checkbox']");
+    this.tableRows = this.table.locator("tbody").getByRole("row");
+    this.selectAllCheckbox = this.table.locator("thead").getByRole("checkbox");
   }
 
   public async getVariableKeys(): Promise<Array<string>> {
@@ -46,7 +47,7 @@ export class VariablePage extends BasePage {
     if (count === 0) {
       return [];
     }
-    const keys = await this.tableRows.locator("td:nth-child(2)").allTextContents();
+    const keys = await this.tableRows.getByRole("cell").nth(1).allTextContents();
 
     return keys.map((key) => key.trim()).filter(Boolean);
   }
@@ -56,7 +57,7 @@ export class VariablePage extends BasePage {
   }
 
   public rowByKey(key: string): Locator {
-    return this.page.locator(`tr:has-text("${key}")`);
+    return this.tableRows.filter({ hasText: key });
   }
 
   public async search(key: string) {
@@ -65,37 +66,20 @@ export class VariablePage extends BasePage {
 
   public async selectRow(key: string) {
     const row = this.rowByKey(key);
-    const checkbox = row.locator('[id^="checkbox"][id$=":control"]');
 
-    await checkbox.click();
+    await row.getByRole("checkbox").click();
   }
 
   public async waitForLoad(): Promise<void> {
-    await this.table.waitFor({ state: "visible", timeout: 15_000 });
+    await expect(this.table).toBeVisible({ timeout: 15_000 });
     await this.waitForTableData();
   }
 
   private async waitForTableData(): Promise<void> {
-    await this.page.waitForFunction(
-      () => {
-        const table = document.querySelector('[data-testid="table-list"]');
+    // Wait for either "No variables found" message or table rows with content
+    const noVariablesMessage = this.page.getByText("No variables found");
+    const firstRowCell = this.tableRows.first().getByRole("cell").nth(1);
 
-        if (!table) return false;
-
-        if (document.body.textContent.includes("No variables found")) {
-          return true;
-        }
-
-        const rows = table.querySelectorAll("tbody tr");
-
-        if (rows.length === 0) return false;
-
-        const keyCells = table.querySelectorAll("tbody tr td:nth-child(2)");
-
-        return [...keyCells].some((cell) => Boolean(cell.textContent.trim()));
-      },
-      undefined,
-      { timeout: 60_000 },
-    );
+    await expect(noVariablesMessage.or(firstRowCell)).toBeVisible({ timeout: 60_000 });
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/variable.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/variable.spec.ts
@@ -50,7 +50,7 @@ test.describe("Variables Page", () => {
       createdVariables.push(variable);
 
       // Wait for dialog backdrop to fully disappear
-      await expect(page.locator('[data-part="backdrop"]')).toHaveCount(0);
+      await expect(page.getByRole("dialog")).toBeHidden();
 
       await variablesPage.addButton.click();
 


### PR DESCRIPTION
## Problem

`variable.spec.ts` and `VariablePage.ts` use several Playwright anti-patterns that can cause flakiness and reduce maintainability.

## Solution

**Changes in `VariablePage.ts`:**
- Replace `page.waitForFunction()` with DOM queries → locator-based `.or()` pattern using web-first assertions
- Replace `this.table.waitFor()` → `expect().toBeVisible()`
- Replace `locator('tbody tr')` → `locator('tbody').getByRole('row')`
- Replace `locator('thead input[type=checkbox]')` → `locator('thead').getByRole('checkbox')`
- Replace `locator('[id^=checkbox][id$=:control]')` → `getByRole('checkbox')`
- Replace `locator('tr:has-text(...)')` → `tableRows.filter({ hasText })`
- Replace `locator('td:nth-child(2)')` → `getByRole('cell').nth(1)`

**Changes in `variable.spec.ts`:**
- Replace `locator('[data-part="backdrop"]')` → `getByRole('dialog')`

**Changes in `playwright.config.ts`:**
- Remove `variable.spec.ts` from `testIgnore` list

## Checklist
- [x] `page.waitForFunction()` with DOM queries → locator-based waiting ✅
- [x] `page.waitForTimeout()` → N/A (not present)
- [x] `waitForLoadState("networkidle")` → N/A (not present)
- [x] Manual assertions → web-first assertions ✅
- [x] `page.evaluate()` for DOM manipulation → N/A (not present)
- [x] CSS `:has-text()` → user-facing locators ✅
- [x] Remove from ignore spec list ✅

## Files Changed
- `airflow-core/src/airflow/ui/tests/e2e/pages/VariablePage.ts`
- `airflow-core/src/airflow/ui/tests/e2e/specs/variable.spec.ts`
- `airflow-core/src/airflow/ui/playwright.config.ts`

Part of #63036
Closes #63965