### PR TITLE
Feat/check multi team enabled when team name provided api

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -203,7 +203,9 @@ class ConnectionBody(StrictBaseModel):
     @model_validator(mode="after")
     def validate_team_name(self) -> ConnectionBody:
         if self.team_name is not None and not conf.getboolean("core", "multi_team"):
-            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+            raise ValueError(
+                "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            )
         return self
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -21,11 +21,12 @@ import json
 from collections.abc import Iterable, Mapping
 from typing import Annotated, Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from airflow._shared.secrets_masker import redact, should_hide_value_for_key
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel, make_partial_model
+from airflow.configuration import conf
 
 
 # Response Models
@@ -198,6 +199,12 @@ class ConnectionBody(StrictBaseModel):
                 "but encountered non-JSON in `extra` field"
             )
         return v
+
+    @model_validator(mode="after")
+    def validate_team_name(self) -> ConnectionBody:
+        if self.team_name is not None and not conf.getboolean("core", "multi_team"):
+            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+        return self
 
 
 ConnectionBodyPartial = make_partial_model(ConnectionBody)

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import Annotated
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, model_validator
 
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+from airflow.configuration import conf
 
 
 def _call_function(function: Callable[[], int]) -> int:
@@ -83,6 +84,12 @@ class PoolPatchBody(StrictBaseModel):
     include_deferred: bool | None = None
     team_name: str | None = Field(max_length=50, default=None)
 
+    @model_validator(mode="after")
+    def validate_team_name(self) -> PoolPatchBody:
+        if self.team_name is not None and not conf.getboolean("core", "multi_team"):
+            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+        return self
+
 
 class PoolBody(BasePool, StrictBaseModel):
     """Pool serializer for post bodies."""
@@ -91,3 +98,9 @@ class PoolBody(BasePool, StrictBaseModel):
     description: str | None = None
     include_deferred: bool = False
     team_name: str | None = Field(max_length=50, default=None)
+
+    @model_validator(mode="after")
+    def validate_team_name(self) -> PoolBody:
+        if self.team_name is not None and not conf.getboolean("core", "multi_team"):
+            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+        return self

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py
@@ -87,7 +87,9 @@ class PoolPatchBody(StrictBaseModel):
     @model_validator(mode="after")
     def validate_team_name(self) -> PoolPatchBody:
         if self.team_name is not None and not conf.getboolean("core", "multi_team"):
-            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+            raise ValueError(
+                "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            )
         return self
 
 
@@ -102,5 +104,7 @@ class PoolBody(BasePool, StrictBaseModel):
     @model_validator(mode="after")
     def validate_team_name(self) -> PoolBody:
         if self.team_name is not None and not conf.getboolean("core", "multi_team"):
-            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+            raise ValueError(
+                "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            )
         return self

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -24,6 +24,7 @@ from pydantic import Field, JsonValue, model_validator
 
 from airflow._shared.secrets_masker import redact
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel, make_partial_model
+from airflow.configuration import conf
 from airflow.models.base import ID_LEN
 from airflow.typing_compat import Self
 
@@ -59,6 +60,12 @@ class VariableBody(StrictBaseModel):
     value: JsonValue = Field(serialization_alias="val")
     description: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)
+
+    @model_validator(mode="after")
+    def validate_team_name(self) -> VariableBody:
+        if self.team_name is not None and not conf.getboolean("core", "multi_team"):
+            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+        return self
 
 
 VariableBodyPartial = make_partial_model(VariableBody)

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -64,7 +64,9 @@ class VariableBody(StrictBaseModel):
     @model_validator(mode="after")
     def validate_team_name(self) -> VariableBody:
         if self.team_name is not None and not conf.getboolean("core", "multi_team"):
-            raise ValueError("team_name cannot be set when multi_team mode is disabled")
+            raise ValueError(
+                "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            )
         return self
 
 

--- a/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
@@ -89,6 +89,11 @@ export const useEditConnection = (
     if (requestBody.schema !== initialConnection.schema) {
       updateMask.push("schema");
     }
+    if (requestBody.team_name !== initialConnection.team_name) {
+      updateMask.push("team_name");
+    }
+
+    const teamName = requestBody.team_name === "" ? undefined : requestBody.team_name;
 
     mutate({
       connectionId: initialConnection.connection_id,
@@ -99,6 +104,7 @@ export const useEditConnection = (
         extra: requestBody.extra === "{}" ? undefined : requestBody.extra,
         // eslint-disable-next-line unicorn/no-null
         port: requestBody.port === "" ? null : Number(requestBody.port),
+        team_name: teamName,
       },
       updateMask,
     });

--- a/airflow-core/src/airflow/ui/src/queries/useEditVariable.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useEditVariable.ts
@@ -78,12 +78,13 @@ export const useEditVariable = (
 
     const parsedDescription =
       editVariableRequestBody.description === "" ? undefined : editVariableRequestBody.description;
+    const teamName = editVariableRequestBody.team_name === "" ? undefined : editVariableRequestBody.team_name;
 
     mutate({
       requestBody: {
         description: parsedDescription,
         key: editVariableRequestBody.key,
-        team_name: editVariableRequestBody.team_name,
+        team_name: teamName,
         value: editVariableRequestBody.value,
       },
       updateMask,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -345,7 +345,7 @@ class TestPostConnection(TestConnectionEndpoint):
             ]
         }
 
-    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, session, testing_team):
+    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
         with mock.patch(
             "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=False
         ):
@@ -994,7 +994,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         )
         assert response.status_code == 422
 
-    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team, session):
+    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
         self.create_connection()
 
         with mock.patch(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -287,10 +287,17 @@ class TestPostConnection(TestConnectionEndpoint):
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
 
     def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
-        response = test_client.post(
-            "/connections",
-            json={"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "team_name": testing_team.name},
-        )
+        with mock.patch(
+            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=True
+        ):
+            response = test_client.post(
+                "/connections",
+                json={
+                    "connection_id": TEST_CONN_ID,
+                    "conn_type": TEST_CONN_TYPE,
+                    "team_name": testing_team.name,
+                },
+            )
         assert response.status_code == 201
         assert response.json() == {
             "connection_id": TEST_CONN_ID,
@@ -337,6 +344,24 @@ class TestPostConnection(TestConnectionEndpoint):
                 }
             ]
         }
+
+    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, session, testing_team):
+        with mock.patch(
+            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=False
+        ):
+            response = test_client.post(
+                "/connections",
+                json={
+                    "connection_id": TEST_CONN_ID_2,
+                    "conn_type": TEST_CONN_TYPE_2,
+                    "team_name": testing_team.name,
+                },
+            )
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
 
     @pytest.mark.parametrize(
         "body",
@@ -605,10 +630,13 @@ class TestPatchConnection(TestConnectionEndpoint):
     def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):
         self.create_connection()
 
-        response = test_client.patch(
-            f"/connections/{TEST_CONN_ID}",
-            json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
-        )
+        with mock.patch(
+            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=True
+        ):
+            response = test_client.patch(
+                f"/connections/{TEST_CONN_ID}",
+                json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
+            )
         assert response.status_code == 200
         _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
 
@@ -965,6 +993,26 @@ class TestPatchConnection(TestConnectionEndpoint):
             params={"update_mask": ["host"]},
         )
         assert response.status_code == 422
+
+    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team, session):
+        self.create_connection()
+
+        with mock.patch(
+            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=False
+        ):
+            response = test_client.patch(
+                f"/connections/{TEST_CONN_ID_2}",
+                json={
+                    "connection_id": TEST_CONN_ID_2,
+                    "conn_type": "new_type",
+                    "team_name": testing_team.name,
+                },
+            )
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
 
 
 class TestConnection(TestConnectionEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -34,6 +34,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 
 from tests_common.test_utils.api_fastapi import _check_last_log
 from tests_common.test_utils.asserts import assert_queries_count
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_connections, clear_db_logs, clear_test_connections
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
@@ -287,9 +288,7 @@ class TestPostConnection(TestConnectionEndpoint):
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
 
     def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
-        with mock.patch(
-            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=True
-        ):
+        with conf_vars({("core", "multi_team"): "True"}):
             response = test_client.post(
                 "/connections",
                 json={
@@ -346,9 +345,7 @@ class TestPostConnection(TestConnectionEndpoint):
         }
 
     def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
-        with mock.patch(
-            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=False
-        ):
+        with conf_vars({("core", "multi_team"): "False"}):
             response = test_client.post(
                 "/connections",
                 json={
@@ -630,9 +627,7 @@ class TestPatchConnection(TestConnectionEndpoint):
     def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):
         self.create_connection()
 
-        with mock.patch(
-            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=True
-        ):
+        with conf_vars({("core", "multi_team"): "True"}):
             response = test_client.patch(
                 f"/connections/{TEST_CONN_ID}",
                 json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
@@ -997,9 +992,7 @@ class TestPatchConnection(TestConnectionEndpoint):
     def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
         self.create_connection()
 
-        with mock.patch(
-            "airflow.api_fastapi.core_api.datamodels.connections.conf.getboolean", return_value=False
-        ):
+        with conf_vars({("core", "multi_team"): "False"}):
             response = test_client.patch(
                 f"/connections/{TEST_CONN_ID_2}",
                 json={

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -287,16 +287,16 @@ class TestPostConnection(TestConnectionEndpoint):
         assert len(connection) == 1
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
 
+    @conf_vars({("core", "multi_team"): "True"})
     def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
-        with conf_vars({("core", "multi_team"): "True"}):
-            response = test_client.post(
-                "/connections",
-                json={
-                    "connection_id": TEST_CONN_ID,
-                    "conn_type": TEST_CONN_TYPE,
-                    "team_name": testing_team.name,
-                },
-            )
+        response = test_client.post(
+            "/connections",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "team_name": testing_team.name,
+            },
+        )
         assert response.status_code == 201
         assert response.json() == {
             "connection_id": TEST_CONN_ID,
@@ -344,20 +344,20 @@ class TestPostConnection(TestConnectionEndpoint):
             ]
         }
 
-    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.post(
-                "/connections",
-                json={
-                    "connection_id": TEST_CONN_ID_2,
-                    "conn_type": TEST_CONN_TYPE_2,
-                    "team_name": testing_team.name,
-                },
-            )
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client):
+        response = test_client.post(
+            "/connections",
+            json={
+                "connection_id": TEST_CONN_ID_2,
+                "conn_type": TEST_CONN_TYPE_2,
+                "team_name": "test_team",
+            },
+        )
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
     @pytest.mark.parametrize(
@@ -624,14 +624,14 @@ class TestPatchConnection(TestConnectionEndpoint):
 
         assert response.json() == expected_result
 
+    @conf_vars({("core", "multi_team"): "True"})
     def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):
         self.create_connection()
 
-        with conf_vars({("core", "multi_team"): "True"}):
-            response = test_client.patch(
-                f"/connections/{TEST_CONN_ID}",
-                json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
-            )
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID}",
+            json={"connection_id": TEST_CONN_ID, "conn_type": "new_type", "team_name": testing_team.name},
+        )
         assert response.status_code == 200
         _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
 
@@ -989,22 +989,21 @@ class TestPatchConnection(TestConnectionEndpoint):
         )
         assert response.status_code == 422
 
-    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client):
         self.create_connection()
-
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.patch(
-                f"/connections/{TEST_CONN_ID_2}",
-                json={
-                    "connection_id": TEST_CONN_ID_2,
-                    "conn_type": "new_type",
-                    "team_name": testing_team.name,
-                },
-            )
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID_2}",
+            json={
+                "connection_id": TEST_CONN_ID_2,
+                "conn_type": "new_type",
+                "team_name": "test_team",
+            },
+        )
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
 
@@ -1656,6 +1655,57 @@ class TestBulkConnections(TestConnectionEndpoint):
             service.handle_bulk_delete(request.actions[0], results)
 
         assert sorted(results.success) == [TEST_CONN_ID, TEST_CONN_ID_2]
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_bulk_rejects_team_name_when_multi_team_is_disabled(self, test_client):
+        actions = {
+            "actions": [
+                {
+                    "action": "create",
+                    "entities": [
+                        {
+                            "connection_id": "test_conn_id_1",
+                            "conn_type": TEST_CONN_TYPE,
+                            "description": "description",
+                        },
+                        {
+                            "connection_id": "test_conn_id_2",
+                            "conn_type": TEST_CONN_TYPE_2,
+                            "description": "description_2",
+                            "team_name": "test_team",
+                        },
+                    ],
+                },
+                {
+                    "action": "update",
+                    "entities": [
+                        {
+                            "connection_id": "test_conn_id_3",
+                            "conn_type": TEST_CONN_TYPE,
+                            "description": "updated_description",
+                            "team_name": "test_team",
+                        },
+                        {
+                            "connection_id": "test_conn_id_4",
+                            "conn_type": TEST_CONN_TYPE_2,
+                            "description": "updated_description_2",
+                        },
+                    ],
+                },
+            ]
+        }
+        response = test_client.patch("/connections", json=actions)
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+
+        assert all(
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in err["msg"]
+            for err in detail
+        ), f"Unexpected errors in detail: {detail}"
+
+        expected_error_conn_ids = {err["input"]["connection_id"] for err in detail}
+        assert sorted(expected_error_conn_ids) == ["test_conn_id_2", "test_conn_id_3"]
 
 
 class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -25,6 +25,7 @@ from airflow.models.pool import Pool
 from airflow.models.team import Team
 from airflow.utils.session import provide_session
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_pools, clear_db_teams
 from tests_common.test_utils.logs import check_last_log
 
@@ -418,7 +419,7 @@ class TestPatchPool(TestPoolsEndpoint):
 
     def test_patch_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
         self.create_pools()
-        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
+        with conf_vars({("core", "multi_team"): "False"}):
             response = test_client.patch(
                 f"/pools/{POOL2_NAME}",
                 json={
@@ -502,7 +503,7 @@ class TestPostPool(TestPoolsEndpoint):
         self.create_pools()
         n_pools = session.scalar(select(func.count()).select_from(Pool))
 
-        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=True):
+        with conf_vars({("core", "multi_team"): "True"}):
             response = test_client.post("/pools", json=body)
 
         assert response.status_code == expected_status_code
@@ -544,7 +545,7 @@ class TestPostPool(TestPoolsEndpoint):
         assert response.status_code == 422
 
     def test_post_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
-        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
+        with conf_vars({("core", "multi_team"): "False"}):
             response = test_client.post(
                 "/pools",
                 json={
@@ -1082,7 +1083,7 @@ class TestBulkPools(TestPoolsEndpoint):
     def test_bulk_pools(self, test_client, actions, expected_results, session):
         self.create_pools()
 
-        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=True):
+        with conf_vars({("core", "multi_team"): "True"}):
             response = test_client.patch("/pools", json=actions)
 
         response_data = response.json()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -416,6 +416,24 @@ class TestPatchPool(TestPoolsEndpoint):
         assert response.json() == expected_response
         check_last_log(session, dag_id=None, event="patch_pool", logical_date=None)
 
+    def test_patch_pool_rejects_team_name_when_multi_team_disabled(self, test_client, session):
+        self.create_pools()
+        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
+            response = test_client.patch(
+                f"/pools/{POOL2_NAME}",
+                json={
+                    "name": POOL2_NAME,
+                    "slots": POOL2_SLOT,
+                    "include_deferred": POOL2_INCLUDE_DEFERRED,
+                    "team_name": "test",
+                },
+            )
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
+
 
 class TestPostPool(TestPoolsEndpoint):
     @pytest.mark.parametrize(
@@ -483,9 +501,11 @@ class TestPostPool(TestPoolsEndpoint):
     def test_should_respond_200(self, test_client, session, body, expected_status_code, expected_response):
         self.create_pools()
         n_pools = session.scalar(select(func.count()).select_from(Pool))
-        response = test_client.post("/pools", json=body)
-        assert response.status_code == expected_status_code
 
+        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=True):
+            response = test_client.post("/pools", json=body)
+
+        assert response.status_code == expected_status_code
         assert response.json() == expected_response
         assert session.scalar(select(func.count()).select_from(Pool)) == n_pools + 1
         check_last_log(session, dag_id=None, event="post_pool", logical_date=None)
@@ -522,6 +542,22 @@ class TestPostPool(TestPoolsEndpoint):
             },
         )
         assert response.status_code == 422
+
+    def test_post_pool_rejects_team_name_when_multi_team_disabled(self, test_client, session):
+        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
+            response = test_client.post(
+                "/pools",
+                json={
+                    "name": "bad_team_pool",
+                    "slots": 1,
+                    "team_name": "test",
+                },
+            )
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
 
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.post("/pools", json={})
@@ -1045,7 +1081,10 @@ class TestBulkPools(TestPoolsEndpoint):
     )
     def test_bulk_pools(self, test_client, actions, expected_results, session):
         self.create_pools()
-        response = test_client.patch("/pools", json=actions)
+
+        with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=True):
+            response = test_client.patch("/pools", json=actions)
+
         response_data = response.json()
         for key, value in expected_results.items():
             assert response_data[key] == value

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -416,7 +416,7 @@ class TestPatchPool(TestPoolsEndpoint):
         assert response.json() == expected_response
         check_last_log(session, dag_id=None, event="patch_pool", logical_date=None)
 
-    def test_patch_pool_rejects_team_name_when_multi_team_disabled(self, test_client, session):
+    def test_patch_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
         self.create_pools()
         with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
             response = test_client.patch(
@@ -543,7 +543,7 @@ class TestPostPool(TestPoolsEndpoint):
         )
         assert response.status_code == 422
 
-    def test_post_pool_rejects_team_name_when_multi_team_disabled(self, test_client, session):
+    def test_post_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
         with mock.patch("airflow.api_fastapi.core_api.datamodels.pools.conf.getboolean", return_value=False):
             response = test_client.post(
                 "/pools",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -417,26 +417,27 @@ class TestPatchPool(TestPoolsEndpoint):
         assert response.json() == expected_response
         check_last_log(session, dag_id=None, event="patch_pool", logical_date=None)
 
+    @conf_vars({("core", "multi_team"): "False"})
     def test_patch_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
         self.create_pools()
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.patch(
-                f"/pools/{POOL2_NAME}",
-                json={
-                    "name": POOL2_NAME,
-                    "slots": POOL2_SLOT,
-                    "include_deferred": POOL2_INCLUDE_DEFERRED,
-                    "team_name": "test",
-                },
-            )
+        response = test_client.patch(
+            f"/pools/{POOL2_NAME}",
+            json={
+                "name": POOL2_NAME,
+                "slots": POOL2_SLOT,
+                "include_deferred": POOL2_INCLUDE_DEFERRED,
+                "team_name": "test_team",
+            },
+        )
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
 
 class TestPostPool(TestPoolsEndpoint):
+    @conf_vars({("core", "multi_team"): "True"})
     @pytest.mark.parametrize(
         ("body", "expected_status_code", "expected_response"),
         [
@@ -503,8 +504,7 @@ class TestPostPool(TestPoolsEndpoint):
         self.create_pools()
         n_pools = session.scalar(select(func.count()).select_from(Pool))
 
-        with conf_vars({("core", "multi_team"): "True"}):
-            response = test_client.post("/pools", json=body)
+        response = test_client.post("/pools", json=body)
 
         assert response.status_code == expected_status_code
         assert response.json() == expected_response
@@ -544,20 +544,20 @@ class TestPostPool(TestPoolsEndpoint):
         )
         assert response.status_code == 422
 
+    @conf_vars({("core", "multi_team"): "False"})
     def test_post_pool_rejects_team_name_when_multi_team_disabled(self, test_client):
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.post(
-                "/pools",
-                json={
-                    "name": "bad_team_pool",
-                    "slots": 1,
-                    "team_name": "test",
-                },
-            )
+        response = test_client.post(
+            "/pools",
+            json={
+                "name": "bad_team_pool",
+                "slots": 1,
+                "team_name": "test_team",
+            },
+        )
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -627,6 +627,7 @@ class TestPostPool(TestPoolsEndpoint):
 
 
 class TestBulkPools(TestPoolsEndpoint):
+    @conf_vars({("core", "multi_team"): "True"})
     @pytest.mark.enable_redact
     @pytest.mark.parametrize(
         ("actions", "expected_results"),
@@ -1083,8 +1084,7 @@ class TestBulkPools(TestPoolsEndpoint):
     def test_bulk_pools(self, test_client, actions, expected_results, session):
         self.create_pools()
 
-        with conf_vars({("core", "multi_team"): "True"}):
-            response = test_client.patch("/pools", json=actions)
+        response = test_client.patch("/pools", json=actions)
 
         response_data = response.json()
         for key, value in expected_results.items():
@@ -1145,3 +1145,54 @@ class TestBulkPools(TestPoolsEndpoint):
             },
         )
         assert response.status_code == 403
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_bulk_rejects_team_name_when_multi_team_is_disabled(self, test_client):
+        actions = {
+            "actions": [
+                {
+                    "action": "create",
+                    "entities": [
+                        {
+                            "name": "pool_1",
+                            "slots": 1,
+                            "description": "description",
+                        },
+                        {
+                            "name": "pool_2",
+                            "slots": 2,
+                            "description": "description_2",
+                            "team_name": "test_team",
+                        },
+                    ],
+                },
+                {
+                    "action": "update",
+                    "entities": [
+                        {
+                            "name": "pool_3",
+                            "slots": 3,
+                            "description": "updated_description",
+                            "team_name": "test_team",
+                        },
+                        {
+                            "name": "pool_4",
+                            "slots": 4,
+                            "description": "updated_description_2",
+                        },
+                    ],
+                },
+            ]
+        }
+        response = test_client.patch("/pools", json=actions)
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+
+        assert all(
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in err["msg"]
+            for err in detail
+        ), f"Unexpected errors in detail: {detail}"
+
+        expected_error_names = {err["input"]["name"] for err in detail}
+        assert sorted(expected_error_names) == ["pool_2", "pool_3"]

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -521,6 +521,22 @@ class TestPatchVariable(TestVariableEndpoint):
         body = response.json()
         assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
 
+    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
+        self.create_variables()
+        body = {
+            "key": TEST_VARIABLE_KEY,
+            "value": "The new value",
+            "description": "The new description",
+            "team_name": str(testing_team.name),
+        }
+        with conf_vars({("core", "multi_team"): "False"}):
+            response = test_client.patch(f"/variables/{TEST_VARIABLE_KEY}", json=body)
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
+
     @pytest.mark.enable_redact
     def test_patch_with_update_mask_description_only(self, test_client, session):
         """PATCH with update_mask=['description'] should only update description, keeping value unchanged."""
@@ -685,6 +701,22 @@ class TestPostVariable(TestVariableEndpoint):
                 }
             ]
         }
+
+    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
+        self.create_variables()
+        body = {
+            "key": "new variable key",
+            "value": "new variable value",
+            "description": "new variable description",
+            "team_name": str(testing_team.name),
+        }
+        with conf_vars({("core", "multi_team"): "False"}):
+            response = test_client.post("/variables", json=body)
+        assert response.status_code == 422
+        assert (
+            response.json()["detail"][0]["msg"]
+            == "Value error, team_name cannot be set when multi_team mode is disabled"
+        )
 
     @pytest.mark.parametrize(
         "body",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -521,20 +521,19 @@ class TestPatchVariable(TestVariableEndpoint):
         body = response.json()
         assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
 
-    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
-        self.create_variables()
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_patch_rejects_team_name_when_multi_team_disabled(self, test_client):
         body = {
             "key": TEST_VARIABLE_KEY,
             "value": "The new value",
             "description": "The new description",
-            "team_name": str(testing_team.name),
+            "team_name": "test_team",
         }
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.patch(f"/variables/{TEST_VARIABLE_KEY}", json=body)
+        response = test_client.patch(f"/variables/{TEST_VARIABLE_KEY}", json=body)
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
     @pytest.mark.enable_redact
@@ -702,20 +701,19 @@ class TestPostVariable(TestVariableEndpoint):
             ]
         }
 
-    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client, testing_team):
-        self.create_variables()
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_post_rejects_team_name_when_multi_team_disabled(self, test_client):
         body = {
             "key": "new variable key",
             "value": "new variable value",
             "description": "new variable description",
-            "team_name": str(testing_team.name),
+            "team_name": "test_team",
         }
-        with conf_vars({("core", "multi_team"): "False"}):
-            response = test_client.post("/variables", json=body)
+        response = test_client.post("/variables", json=body)
         assert response.status_code == 422
         assert (
-            response.json()["detail"][0]["msg"]
-            == "Value error, team_name cannot be set when multi_team mode is disabled"
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in response.json()["detail"][0]["msg"]
         )
 
     @pytest.mark.parametrize(
@@ -1398,3 +1396,55 @@ class TestBulkVariables(TestVariableEndpoint):
             },
         )
         assert response.status_code == 403
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_bulk_rejects_team_name_when_multi_team_is_disabled(self, test_client):
+        actions = {
+            "actions": [
+                {
+                    "action": "create",
+                    "entities": [
+                        {
+                            "key": "var_1",
+                            "value": "value_1",
+                            "description": "description",
+                        },
+                        {
+                            "key": "var_2",
+                            "value": "value_2",
+                            "description": "description_2",
+                            "team_name": "test_team",
+                        },
+                    ],
+                },
+                {
+                    "action": "update",
+                    "entities": [
+                        {
+                            "key": "var_3",
+                            "value": "value_3",
+                            "description": "updated_description",
+                            "team_name": "test_team",
+                        },
+                        {
+                            "key": "var_4",
+                            "value": "value_4",
+                            "description": "updated_description_2",
+                        },
+                    ],
+                },
+            ]
+        }
+        response = test_client.patch("/variables", json=actions)
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+
+        assert all(
+            "team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+            in err["msg"]
+            for err in detail
+        ), f"Unexpected errors in detail: {detail}"
+
+        expected_error_keys = {err["input"]["key"] for err in detail}
+        assert sorted(expected_error_keys) == ["var_2", "var_3"]


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Description

This PR adds pydantic validators to the Pools, Connections and Variables APIs to ensure that multi\_team mode is enabled when team\_name is provided. This check is missing from these APIs.

## Motivation

In the case of the Pools API (which should apply to other APIs) without this check as shown in issue #62251 under Test 3 you are able to create a pool when multi-team is disabled if there is a pre-existing team in the database, and if you try to add a pool with a non-existent team you will get a 500 error. With this change you will now get a 422 value error as shown below with a clearer error.

<img width="2097" height="669" alt="image" src="https://github.com/user-attachments/assets/5ed6cb12-4c5e-41df-9e55-1da4f396729f" />

## Tests

- Added tests under airflow-core/tests/unit/api_fastapi/core_api/routes/public for each respective API file to validate the error behaviour when submitting a request with team\-name and multi\-team mode disabled.
- Fixed failing tests under airflow-core/tests/unit/api_fastapi/core_api/routes/public in Connections and Pools test files due to default behaviour of multi\-team mode being disabled in tests.

related: #62251 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Google Antigravity)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
