### PR TITLE
Standardize response schemas for variables and xcoms in Execution API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/common.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/common.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.core_api.base import BaseModel
+
+
+class MessageResponse(BaseModel):
+    """Message response schema."""
+
+    message: str

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/common.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/common.py
@@ -17,9 +17,10 @@
 from __future__ import annotations
 
 from airflow.api_fastapi.core_api.base import BaseModel
+from pydantic import Field
 
 
 class MessageResponse(BaseModel):
     """Message response schema."""
 
-    message: str
+    message: str = Field(title="Message")

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/variables.py
@@ -22,6 +22,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 
+from airflow.api_fastapi.execution_api.datamodels.common import MessageResponse
 from airflow.api_fastapi.execution_api.datamodels.variable import (
     VariablePostBody,
     VariableResponse,
@@ -93,15 +94,14 @@ def put_variable(
     variable_key: Annotated[str, Path(min_length=1)],
     body: VariablePostBody,
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
-):
+) -> MessageResponse:
     """Set an Airflow Variable."""
     Variable.set(key=variable_key, value=body.value, description=body.description, team_name=team_name)
-    return {"message": "Variable successfully set"}
+    return MessageResponse(message="Variable successfully set")
 
 
 @router.delete(
     "/{variable_key:path}",
-    status_code=status.HTTP_204_NO_CONTENT,
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the variable"},
@@ -110,6 +110,7 @@ def put_variable(
 def delete_variable(
     variable_key: Annotated[str, Path(min_length=1)],
     team_name: Annotated[str | None, Depends(get_team_name_dep)],
-):
+) -> MessageResponse:
     """Delete an Airflow Variable."""
     Variable.delete(key=variable_key, team_name=team_name)
+    return MessageResponse(message=f"Variable with key {variable_key} successfully deleted.")

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -27,6 +27,7 @@ from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.base import BaseModel
+from airflow.api_fastapi.execution_api.datamodels.common import MessageResponse
 from airflow.api_fastapi.execution_api.datamodels.xcom import (
     XComResponse,
     XComSequenceIndexResponse,
@@ -348,7 +349,7 @@ def set_xcom(
     mapped_length: Annotated[
         int | None, Query(description="Number of mapped tasks this value expands into")
     ] = None,
-):
+) -> MessageResponse:
     """Set an Airflow XCom."""
     from airflow.configuration import conf
 
@@ -410,7 +411,7 @@ def set_xcom(
             },
         )
 
-    return {"message": "XCom successfully set"}
+    return MessageResponse(message="XCom successfully set")
 
 
 @router.delete(
@@ -425,7 +426,7 @@ def delete_xcom(
     task_id: str,
     key: Annotated[str, Path(min_length=1)],
     map_index: Annotated[int, Query()] = -1,
-):
+) -> MessageResponse:
     """Delete a single XCom Value."""
     query = delete(XComModel).where(
         XComModel.key == key,
@@ -436,4 +437,4 @@ def delete_xcom(
     )
     session.execute(query)
     session.commit()
-    return {"message": f"XCom with key: {key} successfully deleted."}
+    return MessageResponse(message=f"XCom with key: {key} successfully deleted.")

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_03_31.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_03_31.py
@@ -95,3 +95,11 @@ class MakeDagRunStartDateNullable(VersionChange):
         """Ensure start_date is never None in direct DagRun responses for previous API versions."""
         if response.body.get("start_date") is None:
             response.body["start_date"] = response.body.get("run_after")
+
+
+class AddMessageResponseModel(VersionChange):
+    """Add MessageResponse schema to common datamodels."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = ()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_variables.py
@@ -261,7 +261,7 @@ class TestDeleteVariable:
 
         response = client.delete(f"/execution/variables/{key_to_delete}")
 
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         vars = session.scalars(select(Variable)).all()
         assert len(vars) == len(keys_to_create) - 1
@@ -274,7 +274,7 @@ class TestDeleteVariable:
 
         response = client.delete("/execution/variables/non_existent_key")
 
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         vars = session.scalars(select(Variable)).all()
         assert len(vars) == 1

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -177,6 +177,14 @@ class IntermediateTIState(str, Enum):
     DEFERRED = "deferred"
 
 
+class MessageResponse(BaseModel):
+    """
+    Message response schema.
+    """
+
+    message: Annotated[str, Field(title="Message")]
+
+
 class PrevSuccessfulDagRunResponse(BaseModel):
     """
     Schema for response with previous successful DagRun information for Task Template Context.

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -177,14 +177,6 @@ class IntermediateTIState(str, Enum):
     DEFERRED = "deferred"
 
 
-class MessageResponse(BaseModel):
-    """
-    Message response schema.
-    """
-
-    message: Annotated[str, Field(title="Message")]
-
-
 class PrevSuccessfulDagRunResponse(BaseModel):
     """
     Schema for response with previous successful DagRun information for Task Template Context.


### PR DESCRIPTION
### Description

Currently, the Execution API has inconsistent response formats for success messages. While endpoints like `connections.py` return well-defined Pydantic schemas (e.g., `ConnectionResponse`), others like `variables.py` and `xcoms.py` return raw Python dictionaries (e.g., `{"message": "..."}`). 

Returning raw dictionaries causes the OpenAPI specification to default to `Any` or `object`, which makes it difficult to generate strongly-typed SDKs and Clients.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
