### PR TITLE
Feat: Add multi-select to Dag Runs bulk actions (#63854)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.test.tsx
@@ -19,20 +19,17 @@
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-
 import { AppWrapper } from "src/utils/AppWrapper";
 
-// The dag_runs mock handler (see src/mocks/handlers/dag_runs.ts) returns:
-//   - run_before_filter (logical_date: 2024-12-31) — excluded when filtering Jan 2025
-//   - run_in_range      (logical_date: 2025-01-15) — included when filtering Jan 2025
+const findByRunId = (id: string) => screen.getByText((content) => content.includes(id));
+const queryByRunId = (id: string) => screen.queryByText((content) => content.includes(id));
+
 describe("DagRuns logical date filter", () => {
   it("shows all runs when no logical date filter is applied", async () => {
     render(<AppWrapper initialEntries={["/dag_runs"]} />);
-
-    await waitFor(() => expect(screen.getByText("run_in_range")).toBeInTheDocument());
-    expect(screen.getByText("run_before_filter")).toBeInTheDocument();
+    await waitFor(() => expect(findByRunId("run_in_range")).toBeInTheDocument());
+    expect(findByRunId("run_before_filter")).toBeInTheDocument();
   });
-
   it("filters runs by logical_date_gte and logical_date_lte URL params", async () => {
     render(
       <AppWrapper
@@ -41,8 +38,7 @@ describe("DagRuns logical date filter", () => {
         ]}
       />,
     );
-
-    await waitFor(() => expect(screen.getByText("run_in_range")).toBeInTheDocument());
-    expect(screen.queryByText("run_before_filter")).not.toBeInTheDocument();
+    await waitFor(() => expect(findByRunId("run_in_range")).toBeInTheDocument());
+    expect(queryByRunId("run_before_filter")).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -24,11 +24,13 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useParams, useSearchParams } from "react-router-dom";
 
+import { useDagRunServiceClearDagRun } from "openapi/queries";
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
 import { DataTable } from "src/components/DataTable";
+import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
@@ -38,12 +40,15 @@ import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
+import { ActionBar } from "src/components/ui/ActionBar";
+import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { DagRunsFilters } from "src/pages/DagRunsFilters";
 import DeleteRunButton from "src/pages/DeleteRunButton";
 import { renderDuration, useAutoRefresh, isStatePending } from "src/utils";
 
 type DagRunRow = { row: { original: DAGRunResponse } };
+
 const {
   BUNDLE_VERSION: BUNDLE_VERSION_PARAM,
   CONF_CONTAINS: CONF_CONTAINS_PARAM,
@@ -66,7 +71,39 @@ const {
   TRIGGERING_USER_NAME_PATTERN: TRIGGERING_USER_NAME_PATTERN_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
-const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRunResponse>> => [
+const runColumns = (
+  translate: TFunction,
+  dagId?: string,
+  rowSelectionParams?: Omit<GetColumnsParams, "multiTeam">,
+): Array<ColumnDef<DAGRunResponse>> => [
+  ...(rowSelectionParams
+    ? [
+        {
+          accessorKey: "select",
+          cell: ({ row }: DagRunRow) => (
+            <Checkbox
+              borderWidth={1}
+              checked={rowSelectionParams.selectedRows.get(row.original.dag_run_id)}
+              colorPalette="brand"
+              onCheckedChange={(event) =>
+                rowSelectionParams.onRowSelect(row.original.dag_run_id, Boolean(event.checked))
+              }
+            />
+          ),
+          enableHiding: false,
+          enableSorting: false,
+          header: () => (
+            <Checkbox
+              borderWidth={1}
+              checked={rowSelectionParams.allRowsSelected}
+              colorPalette="brand"
+              onCheckedChange={(event) => rowSelectionParams.onSelectAll(Boolean(event.checked))}
+            />
+          ),
+          meta: { skeletonWidth: 10 },
+        },
+      ]
+    : []),
   ...(Boolean(dagId)
     ? []
     : [
@@ -75,7 +112,7 @@ const runColumns = (translate: TFunction, dagId?: string): Array<ColumnDef<DAGRu
           cell: ({ row: { original } }: DagRunRow) => (
             <Link asChild color="fg.info">
               <RouterLink to={`/dags/${original.dag_id}`}>
-                <TruncatedText text={original.dag_display_name} />
+                <TruncatedText text={original.dag_display_name} />{" "}
               </RouterLink>
             </Link>
           ),
@@ -264,8 +301,19 @@ export const DagRuns = () => {
         query.state.data?.dag_runs.some((run) => isStatePending(run.state)) ? refetchInterval : false,
     },
   );
+  const { mutate: clearDagRun } = useDagRunServiceClearDagRun();
+  const { allRowsSelected, clearSelections, handleRowSelect, handleSelectAll, selectedRows } =
+    useRowSelection({
+      data: data?.dag_runs,
+      getKey: (run) => `${run.dag_id}:${run.dag_run_id}`,
+    });
 
-  const columns = runColumns(translate, dagId);
+  const columns = runColumns(translate, dagId, {
+    allRowsSelected,
+    onRowSelect: handleRowSelect,
+    onSelectAll: handleSelectAll,
+    selectedRows,
+  });
 
   return (
     <>
@@ -280,6 +328,35 @@ export const DagRuns = () => {
         onStateChange={setTableURLState}
         total={data?.total_entries}
       />
+      <ActionBar.Root closeOnInteractOutside={false} open={Boolean(selectedRows.size)}>
+        <ActionBar.Content>
+          <ActionBar.SelectionTrigger>
+            {selectedRows.size} {translate("common:selected")}
+          </ActionBar.SelectionTrigger>
+          <ActionBar.Separator />
+
+          <Button
+            colorPalette="blue"
+            onClick={() => {
+              [...selectedRows.keys()].forEach((key) => {
+                const [selectedDagId, dagRunId] = key.split(":");
+
+                clearDagRun({
+                  dagId: selectedDagId,
+                  dagRunId,
+                  requestBody: { dry_run: false, only_failed: false },
+                });
+              });
+              clearSelections();
+            }}
+            size="sm"
+            variant="outline"
+          >
+            {translate("dags:runAndTaskActions.clear.button", { type: translate("dagRun_other") })}
+          </Button>
+          <ActionBar.CloseTrigger onClick={clearSelections} />
+        </ActionBar.Content>
+      </ActionBar.Root>
     </>
   );
 };


### PR DESCRIPTION
#63854
closes the feature gap between Airflow 2 and Airflow 3 by bringing back multi-select bulk action functionality in the Dag Runs UI.

Users could choose several dag runs and carry out bulk actions in Airflow 2. In Airflow 3, this feature was not present.

The Dag Runs table now has a checkbox column.The header now has a select-all checkbox.
- Added a floating ActionBar with buttons for Mark Success, Mark Failed, and Clear.When at least one row is selected, an ActionBar appears.
- Adheres to the current Variables page multi-select pattern

