### PR TITLE
Fix layout overflow issue in DAG Details Logs tab

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -201,11 +201,18 @@ const Main = () => {
       flex={1}
       height={`calc(100vh - ${footerHeight + headerHeight}px)`}
       maxHeight={`calc(100vh - ${footerHeight + headerHeight}px)`}
-      minHeight="750px"
+      minH={0}
       overflow="hidden"
       position="relative"
+      display="flex"
+      flexDirection="column"
     >
-      <Accordion allowToggle index={accordionIndexes} borderTopWidth={0}>
+      <Accordion
+        allowToggle
+        index={accordionIndexes}
+        borderTopWidth={0}
+        flexShrink={0}
+      >
         <AccordionItem
           sx={{
             // Override chakra-collapse so our dropdowns still work
@@ -224,7 +231,7 @@ const Main = () => {
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
-      <Flex height="100%">
+      <Flex flex={1} minH={0}>
         {isLoading || isEmpty(groups) ? (
           <Spinner />
         ) : (
@@ -233,6 +240,7 @@ const Main = () => {
               minWidth={isGridCollapsed ? collapsedWidth : minPanelWidth}
               ref={gridRef}
               height="100%"
+              minH={0}
               width={isGridCollapsed ? collapsedWidth : gridWidth}
               position="relative"
             >
@@ -273,6 +281,7 @@ const Main = () => {
               zIndex={1}
               bg="white"
               height="100%"
+              minH={0}
             >
               <Details
                 openGroupIds={openGroupIds}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -309,7 +309,11 @@ const Details = ({
       <Tabs
         size="lg"
         isLazy
-        height="100%"
+        display="flex"
+        flexDirection="column"
+        flex={1}
+        minH={0}
+        overflow="hidden"
         index={tabIndex}
         onChange={onChangeTab}
       >
@@ -425,8 +429,8 @@ const Details = ({
             </Button>
           )}
         </TabList>
-        <TabPanels height="100%">
-          <TabPanel height="100%">
+        <TabPanels flex={1} overflowY="auto">
+          <TabPanel>
             {isDag && <DagContent />}
             {isDagRun && <DagRunContent runId={runId} />}
             {!!runId && !!taskId && (
@@ -460,10 +464,10 @@ const Details = ({
               runId={runId}
             />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel>
             <DagCode />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel>
             <EventLog
               taskId={isGroup || !taskId ? undefined : taskId}
               showMapped={isMapped || !taskId}
@@ -471,12 +475,12 @@ const Details = ({
             />
           </TabPanel>
           {isDag && (
-            <TabPanel height="100%">
+            <TabPanel>
               <RunDuration />
             </TabPanel>
           )}
           {isDag && (
-            <TabPanel height="80%">
+            <TabPanel>
               <Flex justifyContent="right" pr="30px">
                 <Checkbox
                   isChecked={showBar}
@@ -491,15 +495,12 @@ const Details = ({
             </TabPanel>
           )}
           {isDag && (
-            <TabPanel height="100%" width="100%" overflow="auto">
+            <TabPanel p={0}>
               <Calendar />
             </TabPanel>
           )}
           {isTaskInstance && run && (
-            <TabPanel
-              pt={mapIndex !== undefined ? "0px" : undefined}
-              height="100%"
-            >
+            <TabPanel pt={mapIndex !== undefined ? "0px" : undefined}>
               <BackToTaskSummary
                 isMapIndexDefined={mapIndex !== undefined}
                 onClick={() => onSelect({ runId, taskId })}
@@ -520,7 +521,7 @@ const Details = ({
             </TabPanel>
           )}
           {isMappedTaskSummary && (
-            <TabPanel height="100%">
+            <TabPanel>
               <MappedInstances
                 dagId={dagId}
                 runId={runId}
@@ -532,7 +533,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && (
-            <TabPanel height="100%">
+            <TabPanel>
               <XcomCollection
                 dagId={dagId}
                 dagRunId={runId}
@@ -543,7 +544,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && isK8sExecutor && (
-            <TabPanel height="100%">
+            <TabPanel>
               <RenderedK8s />
             </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -260,7 +260,7 @@ const Details = ({
       : group?.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Flex flexDirection="column" height="100%">
+    <Flex flexDirection="column" height="100%" minH={0}>
       <Flex alignItems="center" justifyContent="space-between" flexWrap="wrap">
         <Header
           mapIndex={
@@ -310,7 +310,11 @@ const Details = ({
         size="lg"
         isLazy
         lazyBehavior="keepMounted"
-        height="100%"
+        display="flex"
+        flexDirection="column"
+        flex={1}
+        minH={0}
+        overflow="hidden"
         index={tabIndex}
         onChange={onChangeTab}
       >
@@ -426,8 +430,8 @@ const Details = ({
             </Button>
           )}
         </TabList>
-        <TabPanels height="100%">
-          <TabPanel height="100%">
+        <TabPanels flex={1} overflow="hidden" minH={0}>
+          <TabPanel>
             {isDag && <DagContent />}
             {isDagRun && <DagRunContent runId={runId} />}
             {!!runId && !!taskId && (
@@ -461,10 +465,10 @@ const Details = ({
               runId={runId}
             />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel>
             <DagCode />
           </TabPanel>
-          <TabPanel height="100%">
+          <TabPanel>
             <EventLog
               taskId={isGroup || !taskId ? undefined : taskId}
               showMapped={isMapped || !taskId}
@@ -472,12 +476,12 @@ const Details = ({
             />
           </TabPanel>
           {isDag && (
-            <TabPanel height="100%">
+            <TabPanel>
               <RunDuration />
             </TabPanel>
           )}
           {isDag && (
-            <TabPanel height="80%">
+            <TabPanel>
               <Flex justifyContent="right" pr="30px">
                 <Checkbox
                   isChecked={showBar}
@@ -492,14 +496,18 @@ const Details = ({
             </TabPanel>
           )}
           {isDag && (
-            <TabPanel height="100%" width="100%" overflow="auto">
+            <TabPanel p={0} overflow="auto">
               <Calendar />
             </TabPanel>
           )}
           {isTaskInstance && run && (
             <TabPanel
               pt={mapIndex !== undefined ? "0px" : undefined}
+              display="flex"
+              flexDirection="column"
               height="100%"
+              minH={0}
+              overflow="hidden"
             >
               <BackToTaskSummary
                 isMapIndexDefined={mapIndex !== undefined}
@@ -521,7 +529,7 @@ const Details = ({
             </TabPanel>
           )}
           {isMappedTaskSummary && (
-            <TabPanel height="100%">
+            <TabPanel>
               <MappedInstances
                 dagId={dagId}
                 runId={runId}
@@ -533,7 +541,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && (
-            <TabPanel height="100%">
+            <TabPanel>
               <XcomCollection
                 dagId={dagId}
                 dagRunId={runId}
@@ -544,7 +552,7 @@ const Details = ({
             </TabPanel>
           )}
           {isTaskInstance && isK8sExecutor && (
-            <TabPanel height="100%">
+            <TabPanel>
               <RenderedK8s />
             </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -17,9 +17,14 @@
  * under the License.
  */
 
-import React, { useRef, useEffect, useState } from "react";
-import { Code } from "@chakra-ui/react";
-import { useOffsetTop } from "src/utils";
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useEffect,
+  useState,
+} from "react";
+import { Box, Code } from "@chakra-ui/react";
 
 interface Props {
   parsedLogs: string;
@@ -35,27 +40,63 @@ const LogBlock = ({
   setUnfoldedLogGroup,
 }: Props) => {
   const [autoScroll, setAutoScroll] = useState(true);
+  const [logHeight, setLogHeight] = useState<number>();
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const offsetTop = useOffsetTop(logBoxRef);
+
+  const resizeLogBlock = useCallback(() => {
+    requestAnimationFrame(() => {
+      const logBox = logBoxRef.current;
+      if (!logBox) return;
+
+      const footerHeight =
+        parseInt(getComputedStyle(document.body).paddingBottom, 10) || 0;
+      const viewportHeight =
+        window.visualViewport?.height ?? window.innerHeight;
+      const { top } = logBox.getBoundingClientRect();
+
+      setLogHeight(Math.max(0, viewportHeight - top - footerHeight));
+    });
+  }, []);
 
   const scrollToBottom = () => {
-    if (logBoxRef.current) {
-      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
-    }
+    requestAnimationFrame(() => {
+      if (logBoxRef.current) {
+        logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+      }
+    });
   };
+
+  useLayoutEffect(() => {
+    window.addEventListener("resize", resizeLogBlock);
+    window.visualViewport?.addEventListener("resize", resizeLogBlock);
+
+    return () => {
+      window.removeEventListener("resize", resizeLogBlock);
+      window.visualViewport?.removeEventListener("resize", resizeLogBlock);
+    };
+  }, [resizeLogBlock]);
+
+  useLayoutEffect(() => {
+    resizeLogBlock();
+  }, [resizeLogBlock, wrap]);
 
   useEffect(() => {
     // Always scroll to bottom when wrap or tryNumber change
-    if (offsetTop) scrollToBottom();
-  }, [wrap, tryNumber, offsetTop]);
+    if (logBoxRef.current) scrollToBottom();
+  }, [wrap, tryNumber]);
+
+  useEffect(() => {
+    // Preserve tailing behavior on resize without pulling users away from earlier logs.
+    if (autoScroll && logBoxRef.current) scrollToBottom();
+  }, [autoScroll, logHeight]);
 
   useEffect(() => {
     // When logs change, only scroll if autoScroll is enabled
-    if (autoScroll && offsetTop) scrollToBottom();
-  }, [parsedLogs, autoScroll, offsetTop]);
+    if (autoScroll && logBoxRef.current) scrollToBottom();
+  }, [parsedLogs, autoScroll]);
 
-  const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
+  const onScroll = (e: React.UIEvent<HTMLPreElement>) => {
     if (e.currentTarget) {
       const { scrollTop, offsetHeight, scrollHeight } = e.currentTarget;
       // Enable autoscroll if we've scrolled to the bottom of the logs
@@ -99,22 +140,27 @@ const LogBlock = ({
   };
 
   return (
-    <Code
-      ref={logBoxRef}
-      onScroll={onScroll}
-      onClick={onClick}
-      maxHeight={`calc(100% - ${offsetTop}px)`}
-      overflowY="auto"
-      p={3}
-      display="block"
-      whiteSpace={wrap ? "pre-wrap" : "pre"}
-      border="1px solid"
-      borderRadius={3}
-      borderColor="blue.500"
-    >
-      {/* eslint-disable-next-line react/no-danger */}
-      <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
-    </Code>
+    <Box flex={1} minH={0} overflow="hidden">
+      <Code
+        as="pre"
+        ref={logBoxRef}
+        onScroll={onScroll}
+        onClick={onClick}
+        height={logHeight === undefined ? "100%" : `${logHeight}px`}
+        maxHeight={logHeight === undefined ? "100%" : `${logHeight}px`}
+        overflowY="auto"
+        overflowX={wrap ? "hidden" : "auto"}
+        p={3}
+        display="block"
+        whiteSpace={wrap ? "pre-wrap" : "pre"}
+        border="1px solid"
+        borderRadius={3}
+        borderColor="blue.500"
+      >
+        {/* eslint-disable-next-line react/no-danger */}
+        <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
+      </Code>
+    </Box>
   );
 };
 

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -153,9 +153,9 @@ const Logs = ({
   }, [data, fileSourceFilters, fileSources, selectedTryNumber, finalTryNumber]);
 
   return (
-    <>
+    <Flex flexDirection="column" flex={1} minH={0} overflow="hidden">
       {showExternalLogRedirect && externalLogName && (
-        <Box my={1}>
+        <Box my={1} flexShrink={0}>
           <Text>View Logs in {externalLogName} (by attempts):</Text>
           <Flex flexWrap="wrap">
             {Array.from({ length: finalTryNumber || 1 }, (_, i) => i + 1).map(
@@ -173,7 +173,7 @@ const Logs = ({
           </Flex>
         </Box>
       )}
-      <Box>
+      <Box flexShrink={0}>
         {!!taskInstance && (
           <TrySelector
             taskInstance={taskInstance}
@@ -250,6 +250,7 @@ const Logs = ({
           alignItems="center"
           p={2}
           mb={2}
+          flexShrink={0}
         >
           <Icon as={MdWarning} color="yellow.500" mr={2} />
           <Text fontSize="sm">{warning}</Text>
@@ -263,6 +264,7 @@ const Logs = ({
           alignItems="center"
           p={2}
           mb={2}
+          flexShrink={0}
         >
           <Icon as={MdInfo} color="blue.600" mr={2} />
           <Text fontSize="sm">
@@ -282,7 +284,7 @@ const Logs = ({
           />
         )
       )}
-    </>
+    </Flex>
   );
 };
 


### PR DESCRIPTION

## Description
Fixes the details panel where the header, breadcrumb, and action buttons disappear when task logs (or any tab content) is longer than the viewport.

## Problem
Improper height handling in nested flex containers caused tab content (such as Logs) to expand beyond its intended bounds. When content exceeded the viewport height, the page-level layout scrolled in a way that hid the header and action controls.

## Fix
- Applied correct flex layout rules (`flex={1}`, `minH={0}`)
- Restored explicit `height="100%"` where required for Graph and Gantt rendering
- Ensured contained scroll behavior without affecting page-level scroll

## Testing
- Manual verification in Logs, Graph, and Gantt tabs
- Frontend tests passing
- Static checks passing

## Before
<img width="1501" height="804" alt="before image 1" src="https://github.com/user-attachments/assets/bb436d93-36e4-413a-b6b6-7ff61f7438cc" />
<img width="1505" height="900" alt="before image 2" src="https://github.com/user-attachments/assets/ba91a221-ce59-446f-809f-b8b8f5681c73" />

## After
<img width="1496" height="899" alt="after image1" src="https://github.com/user-attachments/assets/c46c263d-c2b3-43c8-9b07-65c70407c009" />

#### After scrolling the full page

<img width="1500" height="906" alt="after image 2" src="https://github.com/user-attachments/assets/f987f6fb-a95c-4c48-9523-af41434d0b8d" />

Fixes #63934

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=9362e9b action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Revanth14** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Tests** — failing: Lowest direct dependency providers tests / All-core:LowestDeps-Postgres:13:3.10.
> - :x: **Unresolved review comments** — 2 open thread(s) from `@pierrejeambrun`.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->