### PR TITLE
Update mocking connections docs to use task SDK Connection.get (#63996)

### DIFF
--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -853,6 +853,8 @@ For connection, use :envvar:`AIRFLOW_CONN_{CONN_ID}`.
 
 .. code-block:: python
 
+    from airflow.sdk import Connection
+
     conn = Connection(
         conn_type="gcpssh",
         login="cat",
@@ -860,7 +862,7 @@ For connection, use :envvar:`AIRFLOW_CONN_{CONN_ID}`.
     )
     conn_uri = conn.get_uri()
     with mock.patch.dict("os.environ", AIRFLOW_CONN_MY_CONN=conn_uri):
-        assert "cat" == Connection.get_connection_from_secrets("my_conn").login
+        assert "cat" == Connection.get("my_conn").login
 
 Metadata DB maintenance
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

The "Mocking variables and connections" section in `best-practices.rst` used
the deprecated `Connection.get_connection_from_secrets()` from `airflow.models`.
Updated to use `Connection.get()` from `airflow.sdk`, which is the Airflow 3.x
standard (consistent with `Variable.get()` already shown in the same section).

## Changes

- `airflow-core/docs/best-practices.rst`: Added `from airflow.sdk import Connection`
  import and replaced `Connection.get_connection_from_secrets("my_conn")` with
  `Connection.get("my_conn")` in the connection mocking example.

Fixes #63996