### PR TITLE
Fix config secrets not masked in task logs after reset_secrets_masker (#63921)

### DIFF
--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -27,8 +27,11 @@ from io import StringIO
 from typing import Any
 
 from airflow.sdk import yaml
+from airflow.sdk._shared.configuration.exceptions import AirflowConfigException
 from airflow.sdk._shared.configuration.parser import (
     AirflowConfigParser as _SharedAirflowConfigParser,
+    _build_kwarg_env_prefix,
+    _collect_kwarg_env_vars,
     configure_parser_from_configuration_description,
 )
 from airflow.sdk.execution_time.secrets import _SERVER_DEFAULT_SECRETS_SEARCH_PATH
@@ -199,6 +202,31 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         self.expand_all_configuration_values()
 
         log.info("Unit test configuration loaded from 'unit_tests.cfg'")
+
+    def mask_secrets(self) -> None:
+        """Register sensitive configuration values with the SDK secrets masker."""
+        from airflow.sdk.log import mask_secret
+
+        for section, key in self.sensitive_config_values:
+            try:
+                with self.suppress_future_warnings():
+                    value = self.get(section, key, suppress_warnings=True)
+            except AirflowConfigException:
+                log.debug(
+                    "Could not retrieve value from section %s, for key %s. Skipping redaction of this conf.",
+                    section,
+                    key,
+                )
+                continue
+            mask_secret(value)
+
+        for _section, _kwargs_key in [
+            ("secrets", "backend_kwargs"),
+            ("workers", "secrets_backend_kwargs"),
+        ]:
+            _prefix = _build_kwarg_env_prefix(_section, _kwargs_key)
+            for _value in _collect_kwarg_env_vars(_prefix).values():
+                mask_secret(_value)
 
     def remove_all_read_configurations(self):
         """Remove all read configurations, leaving only default values in the config."""

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -35,6 +35,7 @@ from airflow.sdk._shared.configuration.parser import (
     configure_parser_from_configuration_description,
 )
 from airflow.sdk.execution_time.secrets import _SERVER_DEFAULT_SECRETS_SEARCH_PATH
+from airflow.sdk.log import mask_secret
 
 log = logging.getLogger(__name__)
 
@@ -205,8 +206,6 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
 
     def mask_secrets(self) -> None:
         """Register sensitive configuration values with the SDK secrets masker."""
-        from airflow.sdk.log import mask_secret
-
         for section, key in self.sensitive_config_values:
             try:
                 with self.suppress_future_warnings():

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2093,6 +2093,16 @@ def supervise(
 
     reset_secrets_masker()
 
+    # Re-mask configuration secrets that were cleared by the reset.
+    # reset_secrets_masker() wipes all patterns from the SDK masker, including
+    # config-level secrets (webserver.secret_key, api.secret_key, etc.) that
+    # were registered at startup by conf.mask_secrets(). Re-register them so
+    # they remain masked in task subprocess logs. See #63921.
+    if "airflow.configuration" in sys.modules:
+        from airflow.configuration import conf
+
+        conf.mask_secrets()
+
     try:
         process = ActivitySubprocess.start(
             dag_rel_path=dag_rel_path,

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2096,12 +2096,9 @@ def supervise(
     # Re-mask configuration secrets that were cleared by the reset.
     # reset_secrets_masker() wipes all patterns from the SDK masker, including
     # config-level secrets (webserver.secret_key, api.secret_key, etc.) that
-    # were registered at startup by conf.mask_secrets(). Re-register them so
+    # were registered at startup by the SDK config parser. Re-register them so
     # they remain masked in task subprocess logs. See #63921.
-    if "airflow.configuration" in sys.modules:
-        from airflow.configuration import conf
-
-        conf.mask_secrets()
+    conf.mask_secrets()
 
     try:
         process = ActivitySubprocess.start(

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -232,6 +232,37 @@ class TestSupervisor:
             with expectation:
                 supervise(**kw)
 
+    @pytest.mark.enable_redact
+    def test_supervise_remasks_config_secrets_after_reset(self):
+        """Config-level secrets survive reset_secrets_masker() inside supervise().
+
+        Regression test for https://github.com/apache/airflow/issues/63921
+        """
+        from airflow.sdk._shared.secrets_masker import _secrets_masker, redact, reset_secrets_masker
+
+        masker = _secrets_masker()
+        masker.add_mask("super-secret-config-value")
+        assert redact("super-secret-config-value") == "***"
+
+        reset_secrets_masker()
+        assert redact("super-secret-config-value") == "super-secret-config-value", (
+            "reset_secrets_masker should clear all patterns"
+        )
+
+        from airflow.configuration import conf
+
+        conf.mask_secrets()
+
+        for section, key in conf.sensitive_config_values:
+            try:
+                val = conf.get(section, key, suppress_warnings=True)
+            except Exception:
+                continue
+            if val:
+                assert redact(val) == "***", (
+                    f"Config secret {section}/{key} should be masked after conf.mask_secrets()"
+                )
+
 
 @pytest.mark.usefixtures("disable_capturing")
 class TestWatchedSubprocess:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -238,28 +238,34 @@ class TestSupervisor:
 
         Regression test for https://github.com/apache/airflow/issues/63921
         """
-        from airflow.sdk._shared.secrets_masker import _secrets_masker, redact, reset_secrets_masker
+        from airflow.sdk._shared.secrets_masker import redact, reset_secrets_masker
+        from airflow.sdk.configuration import conf
 
-        masker = _secrets_masker()
-        masker.add_mask("super-secret-config-value")
-        assert redact("super-secret-config-value") == "***"
+        expected_secrets = {
+            ("api", "secret_key"): "shared-api-secret",
+            ("api_auth", "jwt_secret"): "jwt-super-secret",
+        }
 
-        reset_secrets_masker()
-        assert redact("super-secret-config-value") == "super-secret-config-value", (
-            "reset_secrets_masker should clear all patterns"
-        )
+        with conf_vars(expected_secrets):
+            conf.mask_secrets()
 
-        from airflow.configuration import conf
+            observed_secrets = {
+                ("api", "secret_key"): conf.get("api", "secret_key", suppress_warnings=True),
+                ("webserver", "secret_key"): conf.get("webserver", "secret_key", suppress_warnings=True),
+                ("api_auth", "jwt_secret"): conf.get("api_auth", "jwt_secret", suppress_warnings=True),
+            }
 
-        conf.mask_secrets()
+            for secret in observed_secrets.values():
+                assert redact(secret) == "***"
 
-        for section, key in conf.sensitive_config_values:
-            try:
-                val = conf.get(section, key, suppress_warnings=True)
-            except Exception:
-                continue
-            if val:
-                assert redact(val) == "***", (
+            reset_secrets_masker()
+            for secret in observed_secrets.values():
+                assert redact(secret) == secret, "reset_secrets_masker should clear all patterns"
+
+            conf.mask_secrets()
+
+            for (section, key), secret in observed_secrets.items():
+                assert redact(secret) == "***", (
                     f"Config secret {section}/{key} should be masked after conf.mask_secrets()"
                 )
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -233,8 +233,8 @@ class TestSupervisor:
                 supervise(**kw)
 
     @pytest.mark.enable_redact
-    def test_supervise_remasks_config_secrets_after_reset(self):
-        """Config-level secrets survive reset_secrets_masker() inside supervise().
+    def test_supervise_remasks_config_secrets_after_reset(self, client_with_ti_start):
+        """Config-level secrets are re-registered before supervise() launches the subprocess.
 
         Regression test for https://github.com/apache/airflow/issues/63921
         """
@@ -243,31 +243,78 @@ class TestSupervisor:
 
         expected_secrets = {
             ("api", "secret_key"): "shared-api-secret",
+            ("webserver", "secret_key"): "shared-web-secret",
             ("api_auth", "jwt_secret"): "jwt-super-secret",
         }
 
-        with conf_vars(expected_secrets):
-            conf.mask_secrets()
+        ti = TaskInstance(
+            id=uuid7(),
+            task_id="async",
+            dag_id="super_basic_deferred_run",
+            run_id="d",
+            try_number=1,
+            dag_version_id=uuid7(),
+        )
+        bundle_info = BundleInfo(name="my-bundle", version=None)
+        call_order: list[str] = []
 
+        class FakeProcess:
+            final_state = TaskInstanceState.SUCCESS
+
+            def wait(self):
+                return 0
+
+        original_mask_secrets = conf.mask_secrets
+        original_reset_secrets_masker = reset_secrets_masker
+
+        def tracked_mask_secrets():
+            call_order.append("mask")
+            original_mask_secrets()
+
+        def tracked_reset_secrets_masker():
+            call_order.append("reset")
+            original_reset_secrets_masker()
+
+        def fake_start(**_kwargs):
             observed_secrets = {
                 ("api", "secret_key"): conf.get("api", "secret_key", suppress_warnings=True),
-                ("webserver", "secret_key"): conf.get("webserver", "secret_key", suppress_warnings=True),
                 ("api_auth", "jwt_secret"): conf.get("api_auth", "jwt_secret", suppress_warnings=True),
             }
+            webserver_secret = conf.get("webserver", "secret_key", suppress_warnings=True)
 
-            for secret in observed_secrets.values():
+            assert observed_secrets == {
+                ("api", "secret_key"): expected_secrets[("api", "secret_key")],
+                ("api_auth", "jwt_secret"): expected_secrets[("api_auth", "jwt_secret")],
+            }
+            for secret in (*observed_secrets.values(), webserver_secret):
                 assert redact(secret) == "***"
 
-            reset_secrets_masker()
-            for secret in observed_secrets.values():
-                assert redact(secret) == secret, "reset_secrets_masker should clear all patterns"
+            call_order.append("start")
+            return FakeProcess()
 
-            conf.mask_secrets()
-
-            for (section, key), secret in observed_secrets.items():
-                assert redact(secret) == "***", (
-                    f"Config secret {section}/{key} should be masked after conf.mask_secrets()"
+        with (
+            conf_vars(expected_secrets),
+            patch("airflow.sdk.execution_time.supervisor._make_process_nondumpable"),
+            patch("airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded", return_value=[]),
+            patch("airflow.sdk.execution_time.supervisor.ActivitySubprocess.start", side_effect=fake_start),
+            patch(
+                "airflow.sdk._shared.secrets_masker.reset_secrets_masker",
+                side_effect=tracked_reset_secrets_masker,
+            ),
+            patch.object(conf, "mask_secrets", side_effect=tracked_mask_secrets),
+        ):
+            assert (
+                supervise(
+                    ti=ti,
+                    bundle_info=bundle_info,
+                    dag_rel_path="super_basic_deferred_run.py",
+                    token="",
+                    client=client_with_ti_start,
                 )
+                == 0
+            )
+
+        assert call_order == ["reset", "mask", "start"]
 
 
 @pytest.mark.usefixtures("disable_capturing")


### PR DESCRIPTION
**Title:** Fix config secrets not masked in task logs after reset_secrets_masker (#63921)

## Summary

`reset_secrets_masker()` in `supervise()` clears **all** patterns from the SDK secrets masker — including config-level secrets (`webserver.secret_key`, `api.secret_key`, `api_auth.jwt_secret`) that were registered at startup by the SDK configuration layer. After the reset, these secrets appear in plaintext in task subprocess logs when printed via `print()` or `structlog`.

The fix adds an SDK-native `conf.mask_secrets()` implementation and calls it immediately after `reset_secrets_masker()` so those config-level secrets are re-registered in the SDK masker before the task subprocess is forked. This avoids depending on `airflow-core` masking internals during provider compatibility runs.

## Changes

- **`task-sdk/src/airflow/sdk/configuration.py`** — Add SDK-native `conf.mask_secrets()` support so the task SDK can re-register sensitive config values without relying on `airflow-core`.
- **`task-sdk/src/airflow/sdk/execution_time/supervisor.py`** — Call the SDK config parser’s `conf.mask_secrets()` immediately after `reset_secrets_masker()` to restore config masking in task subprocesses.
- **`task-sdk/tests/task_sdk/execution_time/test_supervisor.py`** — Regression test verifying that `api.secret_key`, `webserver.secret_key`, and `api_auth.jwt_secret` are re-masked after `reset_secrets_masker()` + `conf.mask_secrets()`.

## Test plan

- [x] Added regression test `test_supervise_remasks_config_secrets_after_reset`
- [ ] CI passes (ruff, mypy, pytest)

Fixes #63921
