### PR TITLE
CI: Disable Slack notifications in CI workflows

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -978,54 +978,56 @@ jobs:
           path: ./slack-state/
           retention-days: 7
           overwrite: true
-      - name: "Notify Slack (new/changed failures)"
-        if: steps.notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
-          # yamllint enable rule:line-length
-      - name: "Notify Slack (still not fixed)"
-        if: steps.notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
-          # yamllint enable rule:line-length
-      - name: "Notify Slack (all tests passing)"
-        if: steps.notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "✅ All tests passing: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the run log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "✅ All tests passing: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the run log>"
-          # yamllint enable rule:line-length
+      # yamllint disable rule:line-length rule:comments-indentation
+      #      - name: "Notify Slack (new/changed failures)"
+      #        if: steps.notification.outputs.action == 'notify_new'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+      #          # yamllint enable rule:line-length
+      #      - name: "Notify Slack (still not fixed)"
+      #        if: steps.notification.outputs.action == 'notify_reminder'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+      #          # yamllint enable rule:line-length
+      #      - name: "Notify Slack (all tests passing)"
+      #        if: steps.notification.outputs.action == 'notify_recovery'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "✅ All tests passing: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the run log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "✅ All tests passing: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the run log>"
+      #          # yamllint enable rule:line-length
+      # yamllint enable rule:line-length rule:comments-indentation
 
   summarize-warnings:
     timeout-minutes: 15

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -316,54 +316,56 @@ jobs:
           path: ./slack-state/
           retention-days: 7
           overwrite: true
-      - name: "Notify Slack about missing inventories (new/changed)"
-        if: >-
-          inputs.canary-run == 'true' &&
-          matrix.flag == '--docs-only' &&
-          steps.inventory-notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "⚠️ Missing 3rd-party doc inventories in canary build on *${{ github.ref_name }}*: ${{ steps.check-missing-inventories.outputs.packages }}\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
-          # yamllint enable rule:line-length
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      - name: "Notify Slack about missing inventories (still not fixed)"
-        if: >-
-          inputs.canary-run == 'true' &&
-          matrix.flag == '--docs-only' &&
-          steps.inventory-notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "⚠️🔁 Still not fixed: Missing 3rd-party doc inventories in canary build on *${{ github.ref_name }}*: ${{ steps.check-missing-inventories.outputs.packages }}\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
-          # yamllint enable rule:line-length
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      - name: "Notify Slack about inventory recovery"
-        if: >-
-          inputs.canary-run == 'true' &&
-          matrix.flag == '--docs-only' &&
-          steps.inventory-notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "✅ All 3rd-party doc inventories are now available in canary build on *${{ github.ref_name }}*\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
-          # yamllint enable rule:line-length
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      # yamllint disable rule:line-length rule:comments-indentation
+      #      - name: "Notify Slack about missing inventories (new/changed)"
+      #        if: >-
+      #          inputs.canary-run == 'true' &&
+      #          matrix.flag == '--docs-only' &&
+      #          steps.inventory-notification.outputs.action == 'notify_new'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "⚠️ Missing 3rd-party doc inventories in canary build on *${{ github.ref_name }}*: ${{ steps.check-missing-inventories.outputs.packages }}\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      #      - name: "Notify Slack about missing inventories (still not fixed)"
+      #        if: >-
+      #          inputs.canary-run == 'true' &&
+      #          matrix.flag == '--docs-only' &&
+      #          steps.inventory-notification.outputs.action == 'notify_reminder'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "⚠️🔁 Still not fixed: Missing 3rd-party doc inventories in canary build on *${{ github.ref_name }}*: ${{ steps.check-missing-inventories.outputs.packages }}\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      #      - name: "Notify Slack about inventory recovery"
+      #        if: >-
+      #          inputs.canary-run == 'true' &&
+      #          matrix.flag == '--docs-only' &&
+      #          steps.inventory-notification.outputs.action == 'notify_recovery'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "✅ All 3rd-party doc inventories are now available in canary build on *${{ github.ref_name }}*\n\n<${{ steps.get-job-url.outputs.url }}|View job log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      # yamllint enable rule:line-length rule:comments-indentation
       - name: "Save docs inventory cache"
         uses: apache/infrastructure-actions/stash/save@1c35b5ccf8fba5d4c3fdf25a045ca91aa0cbc468
         with:

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -71,66 +71,68 @@ jobs:
           path: ./slack-state/
           retention-days: 7
           overwrite: true
+      # yamllint disable rule:line-length rule:comments-indentation
 
-      - name: "Send Slack notification (new/changed failures)"
-        if: steps.notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "🚨 Failure Alert: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "🚨 Failure Alert: ${{ env.workflow_id }} on *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
-          # yamllint enable rule:line-length
-        env:
-          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
-          branch: ${{ matrix.branch }}
-          workflow_id: ${{ matrix.workflow-id }}
-
-      - name: "Send Slack notification (still not fixed)"
-        if: steps.notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "🚨🔁 Still not fixed: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "🚨🔁 Still not fixed: ${{ env.workflow_id }} on *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
-          # yamllint enable rule:line-length
-        env:
-          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
-          branch: ${{ matrix.branch }}
-          workflow_id: ${{ matrix.workflow-id }}
-
-      - name: "Send Slack notification (all passing)"
-        if: steps.notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ env.SLACK_BOT_TOKEN }}
-          # yamllint disable rule:line-length
-          payload: |
-            channel: "internal-airflow-ci-cd"
-            text: "✅ All passing: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\n*Details:* <${{ env.run_url }}|View the run log>"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: "✅ All passing: ${{ env.workflow_id }} on *${{ env.branch }}*\n\n*Details:* <${{ env.run_url }}|View the run log>"
-          # yamllint enable rule:line-length
-        env:
-          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
-          branch: ${{ matrix.branch }}
-          workflow_id: ${{ matrix.workflow-id }}
+      #      - name: "Send Slack notification (new/changed failures)"
+      #        if: steps.notification.outputs.action == 'notify_new'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "🚨 Failure Alert: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "🚨 Failure Alert: ${{ env.workflow_id }} on *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
+      #          branch: ${{ matrix.branch }}
+      #          workflow_id: ${{ matrix.workflow-id }}
+      #
+      #      - name: "Send Slack notification (still not fixed)"
+      #        if: steps.notification.outputs.action == 'notify_reminder'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "🚨🔁 Still not fixed: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "🚨🔁 Still not fixed: ${{ env.workflow_id }} on *${{ env.branch }}*\n\nFailing jobs:\n${{ steps.find-workflow-run-status.outputs.failed-jobs }}\n\n*Details:* <${{ env.run_url }}|View the failure log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
+      #          branch: ${{ matrix.branch }}
+      #          workflow_id: ${{ matrix.workflow-id }}
+      #
+      #      - name: "Send Slack notification (all passing)"
+      #        if: steps.notification.outputs.action == 'notify_recovery'
+      #        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      #        with:
+      #          method: chat.postMessage
+      #          token: ${{ env.SLACK_BOT_TOKEN }}
+      #          # yamllint disable rule:line-length
+      #          payload: |
+      #            channel: "internal-airflow-ci-cd"
+      #            text: "✅ All passing: ${{ env.workflow_id }} on branch *${{ env.branch }}*\n\n*Details:* <${{ env.run_url }}|View the run log>"
+      #            blocks:
+      #              - type: "section"
+      #                text:
+      #                  type: "mrkdwn"
+      #                  text: "✅ All passing: ${{ env.workflow_id }} on *${{ env.branch }}*\n\n*Details:* <${{ env.run_url }}|View the run log>"
+      #          # yamllint enable rule:line-length
+      #        env:
+      #          run_url: ${{ steps.find-workflow-run-status.outputs.run-url }}
+      #          branch: ${{ matrix.branch }}
+      #          workflow_id: ${{ matrix.workflow-id }}
+      # yamllint enable rule:line-length rule:comments-indentation


### PR DESCRIPTION
Comment out Slack notification steps in CI workflows while keeping the
notification state tracking in place. This disables the actual Slack
messages (failure alerts, reminders, recovery) in ci-amd-arm, ci-image-checks,
and ci-notification workflows.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)