### PR TITLE
Fix `uv export` missing `--no-emit-workspace` in CI entrypoint

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1345,7 +1345,7 @@ function determine_airflow_to_use() {
         # via the Python script. --no-cache is needed - otherwise there is possibility of
         # overriding temporary environments by multiple parallel processes
         local constraint_file="/tmp/constraints-from-lock.txt"
-        uv export --frozen --no-hashes --no-emit-project --no-editable --no-header \
+        uv export --frozen --no-hashes --no-emit-project --no-emit-workspace --no-editable --no-header \
             --no-annotate > "${constraint_file}" 2>/dev/null || true
         uv run --no-cache /opt/airflow/scripts/in_container/install_development_dependencies.py \
            --constraint "${constraint_file}"

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -279,7 +279,7 @@ function determine_airflow_to_use() {
         # via the Python script. --no-cache is needed - otherwise there is possibility of
         # overriding temporary environments by multiple parallel processes
         local constraint_file="/tmp/constraints-from-lock.txt"
-        uv export --frozen --no-hashes --no-emit-project --no-editable --no-header \
+        uv export --frozen --no-hashes --no-emit-project --no-emit-workspace --no-editable --no-header \
             --no-annotate > "${constraint_file}" 2>/dev/null || true
         uv run --no-cache /opt/airflow/scripts/in_container/install_development_dependencies.py \
            --constraint "${constraint_file}"


### PR DESCRIPTION
## Summary

- Add `--no-emit-workspace` flag to `uv export` in `entrypoint_ci.sh`

Without `--no-emit-workspace`, the constraint file generated by `uv export`
included workspace packages, which forced installation of newer versions of
dependencies (e.g. pyiceberg) into the shared UV cache. When multiple parallel
CI tasks ran simultaneously, this caused installation lock contention in the
distributed UV cache, leading to intermittent failures.

Adding `--no-emit-workspace` ensures only external dependencies are emitted
in the constraint file, avoiding unnecessary package resolution that
interferes with parallel task execution.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)