### PR TITLE
Bump Node.js to 24 and upgrade actions to Node.js 24 runtimes

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -33,7 +33,7 @@ runs:
   using: "composite"
   steps:
     - name: "Setup python"
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
     - name: "Install uv"

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -189,7 +189,7 @@ jobs:
       - name: "Setup node"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 21
+          node-version: 24
           cache: 'pnpm'
           cache-dependency-path: 'airflow-core/src/airflow/**/pnpm-lock.yaml'
       - name: "Restore eslint cache (ui)"

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -193,7 +193,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
           cache-dependency-path: 'registry/pnpm-lock.yaml'
 

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -224,7 +224,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
           cache-dependency-path: 'registry/pnpm-lock.yaml'
 

--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -128,7 +128,7 @@ jobs:
       - name: "Setup node"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 21
+          node-version: 24
       - name: "Compile UI assets (for image build fallback)"
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -192,7 +192,7 @@ def get_latest_lts_node_version() -> str:
     response = requests.get("https://nodejs.org/dist/index.json")
     response.raise_for_status()  # Ensure we got a successful response
     versions = response.json()
-    lts_prefix = "v22"
+    lts_prefix = "v24"
     lts_versions = [version["version"] for version in versions if version["version"].startswith(lts_prefix)]
     # The json array is sorted from newest to oldest, so the first element is the latest LTS version
     # Skip leading v in version


### PR DESCRIPTION
Bump Node.js from 20/21 to 24 across all CI workflows and upgrade actions that were still running on the Node.js 20 runtime. GitHub will force Node.js 24 starting June 2026.

**Workflow `node-version` changes:**
- `basic-tests.yml`: 21 → 24
- `ui-e2e-tests.yml`: 21 → 24
- `registry-build.yml`: 20 → 24
- `registry-backfill.yml`: 20 → 24

**Action runtime upgrades (Node.js 20 → 24):**
- `actions/setup-python`: v5.6.0 → v6.2.0 (in `.github/actions/breeze/action.yml`)
- `pnpm/action-setup`: already at v5.0.0 on main

**Automated upgrade script:**
- `upgrade_important_versions.py`: LTS prefix `v22` → `v24`

All `package.json` engine fields already require `>=22`, so Node 24 satisfies them.