### PR TITLE
Fix task marked as failed despite successful completion

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -363,6 +363,19 @@ def ti_update_state(
         )
 
     if previous_state != TaskInstanceState.RUNNING:
+        # Check for idempotent duplicate: if the TI is already in the exact same
+        # terminal state being requested, treat it as a successful no-op.
+        # This handles network-retry scenarios where the first request succeeded
+        # but the response was lost, causing a retry that sees the TI already
+        # in the target state.
+        requested_state = _get_requested_state(ti_patch_payload)
+        if requested_state is not None and previous_state == requested_state:
+            log.info(
+                "TI is already in the requested terminal state, treating as idempotent success",
+                previous_state=previous_state,
+                requested_state=requested_state,
+            )
+            return
         log.warning(
             "Cannot update Task Instance in invalid state",
             previous_state=previous_state,
@@ -446,6 +459,13 @@ def _handle_fail_fast_for_dag(ti: TI, dag_id: str, session: SessionDep, dag_bag:
         task_dict = getattr(ser_dag, "task_dict")
         task_teardown_map = {k: v.is_teardown for k, v in task_dict.items()}
         _stop_remaining_tasks(task_instance=ti, task_teardown_map=task_teardown_map, session=session)
+
+
+def _get_requested_state(ti_patch_payload: TIStateUpdate) -> TaskInstanceState | None:
+    """Extract the requested terminal state from a TI state update payload."""
+    if isinstance(ti_patch_payload, (TITerminalStatePayload, TISuccessStatePayload, TIRetryStatePayload)):
+        return TaskInstanceState(ti_patch_payload.state.value)
+    return None
 
 
 def _create_ti_state_update_query_and_update_state(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1604,6 +1604,98 @@ class TestTIUpdateState:
         ti1 = session.get(TaskInstance, ti1.id)
         assert ti1.state == State.FAILED
 
+    def test_ti_update_state_idempotent_success(self, client, session, create_task_instance):
+        """Test that a duplicate success request returns 204 when TI is already SUCCESS."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_idempotent_success",
+            state=State.SUCCESS,
+            session=session,
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        payload = {
+            "state": "success",
+            "end_date": DEFAULT_END_DATE.isoformat(),
+        }
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 204
+
+        session.refresh(ti)
+        assert ti.state == State.SUCCESS
+
+    def test_ti_update_state_idempotent_failed(self, client, session, create_task_instance):
+        """Test that a duplicate failed request returns 204 when TI is already FAILED."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_idempotent_failed",
+            state=State.FAILED,
+            session=session,
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        payload = {
+            "state": "failed",
+            "end_date": DEFAULT_END_DATE.isoformat(),
+        }
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 204
+
+        session.refresh(ti)
+        assert ti.state == State.FAILED
+
+    def test_ti_update_state_idempotent_skipped(self, client, session, create_task_instance):
+        """Test that a duplicate skipped request returns 204 when TI is already SKIPPED."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_idempotent_skipped",
+            state=State.SKIPPED,
+            session=session,
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        payload = {
+            "state": "skipped",
+            "end_date": DEFAULT_END_DATE.isoformat(),
+        }
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 204
+
+        session.refresh(ti)
+        assert ti.state == State.SKIPPED
+
+    @pytest.mark.parametrize(
+        ("initial_state", "requested_state"),
+        [
+            (State.SUCCESS, "failed"),
+            (State.FAILED, "success"),
+            (State.SKIPPED, "success"),
+            (State.SUCCESS, "skipped"),
+        ],
+    )
+    def test_ti_update_state_conflict_different_states(
+        self, client, session, create_task_instance, initial_state, requested_state
+    ):
+        """Test that cross-state transitions still return 409."""
+        ti = create_task_instance(
+            task_id="test_ti_update_state_conflict_different_states",
+            state=initial_state,
+            session=session,
+            start_date=DEFAULT_START_DATE,
+        )
+        session.commit()
+
+        payload = {
+            "state": requested_state,
+            "end_date": DEFAULT_END_DATE.isoformat(),
+        }
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "invalid_state"
+
+        session.refresh(ti)
+        assert ti.state == initial_state
+
 
 class TestTISkipDownstream:
     def setup_method(self):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -167,6 +167,16 @@ STATES_SENT_DIRECTLY = [
     SERVER_TERMINATED,
 ]
 
+
+def _is_already_in_target_state(error: ServerResponseError, target_state: str) -> bool:
+    """Check if a 409 error indicates the TI is already in the target state."""
+    try:
+        detail = error.response.json().get("detail", {})
+        return detail.get("previous_state") == target_state
+    except Exception:
+        return False
+
+
 # Setting a fair buffer size here to handle most message sizes. Intention is to enforce a buffer size
 # that is big enough to handle small to medium messages while not enforcing hard latency issues
 BUFFER_SIZE = 4096
@@ -1081,12 +1091,23 @@ class ActivitySubprocess(WatchedSubprocess):
         # For states like `deferred`, `up_for_reschedule`, the process will exit with 0, but the state will be updated
         # by the subprocess in the `handle_requests` method.
         if self.final_state not in STATES_SENT_DIRECTLY:
-            self.client.task_instances.finish(
-                id=self.id,
-                state=self.final_state,
-                when=datetime.now(tz=timezone.utc),
-                rendered_map_index=self._rendered_map_index,
-            )
+            try:
+                self.client.task_instances.finish(
+                    id=self.id,
+                    state=self.final_state,
+                    when=datetime.now(tz=timezone.utc),
+                    rendered_map_index=self._rendered_map_index,
+                )
+            except ServerResponseError as e:
+                if e.response.status_code == HTTPStatus.CONFLICT:
+                    log.warning(
+                        "Failed to update TI state after process exit due to conflict",
+                        ti_id=self.id,
+                        final_state=self.final_state,
+                        detail=getattr(e, "detail", str(e)),
+                    )
+                else:
+                    raise
 
     def _upload_logs(self):
         """
@@ -1262,22 +1283,44 @@ class ActivitySubprocess(WatchedSubprocess):
             self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()
             self._rendered_map_index = msg.rendered_map_index
-            self.client.task_instances.succeed(
-                id=self.id,
-                when=msg.end_date,
-                task_outlets=msg.task_outlets,
-                outlet_events=msg.outlet_events,
-                rendered_map_index=self._rendered_map_index,
-            )
+            try:
+                self.client.task_instances.succeed(
+                    id=self.id,
+                    when=msg.end_date,
+                    task_outlets=msg.task_outlets,
+                    outlet_events=msg.outlet_events,
+                    rendered_map_index=self._rendered_map_index,
+                )
+            except ServerResponseError as e:
+                if e.response.status_code == HTTPStatus.CONFLICT and _is_already_in_target_state(
+                    e, msg.state
+                ):
+                    log.info(
+                        "TI already in success state, treating as idempotent success",
+                        ti_id=self.id,
+                    )
+                else:
+                    raise
         elif isinstance(msg, RetryTask):
             self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()
             self._rendered_map_index = msg.rendered_map_index
-            self.client.task_instances.retry(
-                id=self.id,
-                end_date=msg.end_date,
-                rendered_map_index=self._rendered_map_index,
-            )
+            try:
+                self.client.task_instances.retry(
+                    id=self.id,
+                    end_date=msg.end_date,
+                    rendered_map_index=self._rendered_map_index,
+                )
+            except ServerResponseError as e:
+                if e.response.status_code == HTTPStatus.CONFLICT and _is_already_in_target_state(
+                    e, msg.state
+                ):
+                    log.info(
+                        "TI already in retry state, treating as idempotent success",
+                        ti_id=self.id,
+                    )
+                else:
+                    raise
         elif isinstance(msg, GetConnection):
             conn = self.client.connections.get(msg.conn_id)
             if isinstance(conn, ConnectionResponse):

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -139,6 +139,7 @@ from airflow.sdk.execution_time.supervisor import (
     ActivitySubprocess,
     InProcessSupervisorComms,
     InProcessTestSupervisor,
+    _is_already_in_target_state,
     _make_process_nondumpable,
     _remote_logging_conn,
     process_log_messages_from_subprocess,
@@ -2701,6 +2702,211 @@ class TestHandleRequest:
             "message": str(error),
             "detail": error.response.json(),
         }
+
+    def test_succeed_task_idempotent_on_409_already_success(self, watched_subprocess, mocker):
+        """Test that a 409 with previous_state=success is treated as idempotent success for SucceedTask."""
+        watched_subprocess, read_socket = watched_subprocess
+
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "message": "TI was not in the running state so it cannot be updated",
+                        "previous_state": "success",
+                    }
+                },
+            ),
+        )
+        watched_subprocess.client.task_instances.succeed = mocker.Mock(side_effect=error)
+
+        generator = watched_subprocess.handle_requests(log=mocker.Mock())
+        next(generator)
+
+        msg = SucceedTask(end_date=timezone.parse("2024-10-31T12:00:00Z"))
+        req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=msg.model_dump())
+        generator.send(req_frame)
+
+        # Read response — should be an ack (no error), not an error response
+        read_socket.settimeout(0.1)
+        frame_len = int.from_bytes(read_socket.recv(4), "big")
+        response_bytes = read_socket.recv(frame_len)
+        frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(response_bytes)
+
+        assert frame.id == req_frame.id
+        # No error should be sent back
+        assert frame.error is None
+
+        # Terminal state should still be set
+        assert watched_subprocess._terminal_state == "success"
+
+    def test_succeed_task_propagates_409_when_different_state(self, watched_subprocess, mocker):
+        """Test that a 409 with a different previous_state still propagates as error."""
+        watched_subprocess, read_socket = watched_subprocess
+
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "message": "TI was not in the running state so it cannot be updated",
+                        "previous_state": "failed",
+                    }
+                },
+            ),
+        )
+        watched_subprocess.client.task_instances.succeed = mocker.Mock(side_effect=error)
+
+        generator = watched_subprocess.handle_requests(log=mocker.Mock())
+        next(generator)
+
+        msg = SucceedTask(end_date=timezone.parse("2024-10-31T12:00:00Z"))
+        req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=msg.model_dump())
+        generator.send(req_frame)
+
+        # Read response — should be an error response
+        read_socket.settimeout(0.1)
+        frame_len = int.from_bytes(read_socket.recv(4), "big")
+        response_bytes = read_socket.recv(frame_len)
+        frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(response_bytes)
+
+        assert frame.id == req_frame.id
+        assert frame.error is not None
+        assert frame.error["error"] == "API_SERVER_ERROR"
+
+    def test_retry_task_idempotent_on_409_already_retry(self, watched_subprocess, mocker):
+        """Test that a 409 with previous_state=up_for_retry is treated as idempotent for RetryTask."""
+        watched_subprocess, read_socket = watched_subprocess
+
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "message": "TI was not in the running state so it cannot be updated",
+                        "previous_state": "up_for_retry",
+                    }
+                },
+            ),
+        )
+        watched_subprocess.client.task_instances.retry = mocker.Mock(side_effect=error)
+
+        generator = watched_subprocess.handle_requests(log=mocker.Mock())
+        next(generator)
+
+        msg = RetryTask(end_date=timezone.parse("2024-10-31T12:00:00Z"))
+        req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=msg.model_dump())
+        generator.send(req_frame)
+
+        read_socket.settimeout(0.1)
+        frame_len = int.from_bytes(read_socket.recv(4), "big")
+        response_bytes = read_socket.recv(frame_len)
+        frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(response_bytes)
+
+        assert frame.id == req_frame.id
+        assert frame.error is None
+        assert watched_subprocess._terminal_state == "up_for_retry"
+
+
+class TestUpdateTaskStateIfNeeded:
+    @pytest.fixture
+    def watched_subprocess(self, mocker):
+        proc = ActivitySubprocess(
+            process_log=mocker.MagicMock(),
+            id=TI_ID,
+            pid=12345,
+            stdin=mocker.Mock(),
+            client=mocker.Mock(),
+            process=mocker.Mock(),
+        )
+        proc._exit_code = 1
+        return proc
+
+    def test_update_task_state_if_needed_handles_conflict(self, watched_subprocess, mocker):
+        """Test that 409 Conflict in update_task_state_if_needed is handled gracefully."""
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "message": "TI was not in the running state so it cannot be updated",
+                        "previous_state": "success",
+                    }
+                },
+            ),
+        )
+        watched_subprocess.client.task_instances.finish = mocker.Mock(side_effect=error)
+
+        # Should not raise
+        watched_subprocess.update_task_state_if_needed()
+
+        watched_subprocess.client.task_instances.finish.assert_called_once()
+
+    def test_update_task_state_if_needed_raises_non_conflict(self, watched_subprocess, mocker):
+        """Test that non-409 errors are still raised."""
+        error = ServerResponseError(
+            message="Server Error",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(500, json={"detail": "Internal Server Error"}),
+        )
+        watched_subprocess.client.task_instances.finish = mocker.Mock(side_effect=error)
+
+        with pytest.raises(ServerResponseError):
+            watched_subprocess.update_task_state_if_needed()
+
+
+class TestIsAlreadyInTargetState:
+    def test_matching_state(self):
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "previous_state": "success",
+                    }
+                },
+            ),
+        )
+        assert _is_already_in_target_state(error, "success") is True
+
+    def test_different_state(self):
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(
+                409,
+                json={
+                    "detail": {
+                        "reason": "invalid_state",
+                        "previous_state": "failed",
+                    }
+                },
+            ),
+        )
+        assert _is_already_in_target_state(error, "success") is False
+
+    def test_malformed_response(self):
+        error = ServerResponseError(
+            message="Conflict",
+            request=httpx.Request("PATCH", "http://test"),
+            response=httpx.Response(409, json={"unexpected": "format"}),
+        )
+        assert _is_already_in_target_state(error, "success") is False
 
 
 class TestSetSupervisorComms:


### PR DESCRIPTION
## Summary

Fixes a race condition where a successfully completed task gets incorrectly marked as FAILED due to network retry behavior.

**Root cause:** When a task completes and the supervisor sends a SUCCESS state update to the API server, if the HTTP response is lost (network timeout), httpx retries the request. The API server sees the task is already in SUCCESS (not RUNNING) and returns 409 Conflict. This error cascades: supervisor sends an error to the task process, task exits with code 1, supervisor interprets exit code 1 as FAILED, and attempts to overwrite the correct SUCCESS state.

**Fix:** Idempotent terminal state handling at three layers:

- **API Server** (`task_instances.py`): Return 204 no-op when a terminal state update matches the current state (e.g., SUCCESS→SUCCESS). Cross-state conflicts (SUCCESS→FAILED) still return 409.
- **Supervisor `_handle_request`** (`supervisor.py`): Catch 409 on `SucceedTask` and `RetryTask` when the task is already in the target state, preventing error propagation to the task process.
- **Supervisor `update_task_state_if_needed`** (`supervisor.py`): Handle 409 during post-exit state reporting to prevent unhandled exceptions from `wait()`.

## Files Changed

| File | Change |
|------|--------|
| `airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py` | Added `_get_requested_state()` helper + idempotency check in `ti_update_state()` |
| `task-sdk/src/airflow/sdk/execution_time/supervisor.py` | Added `_is_already_in_target_state()` helper + 409 handling in `SucceedTask`/`RetryTask` handlers + 409 handling in `update_task_state_if_needed()` |
| `airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py` | 7 new tests: idempotent success/failed/skipped + 4 parametrized cross-state conflict tests |
| `task-sdk/tests/task_sdk/execution_time/test_supervisor.py` | 8 new tests: idempotent 409 for succeed/retry, different-state 409 propagation, `update_task_state_if_needed` conflict handling, `_is_already_in_target_state` unit tests |

## Impact

- **Low risk**: The API change adds an early-return path only when `previous_state == requested_state` — no existing behavior is altered for valid or genuinely conflicting transitions.
- **Defense-in-depth**: The supervisor-side handling is a secondary safety net. Even if the API fix regresses, the supervisor gracefully handles the idempotent 409 case.

## Test Plan

- [x] 7 new API server tests (idempotent + cross-state conflict)
- [x] 8 new supervisor tests (409 handling + helper unit tests)
- [x] Full `TestTIUpdateState` class: 41 passed, 1 skipped
- [ ] `test_ti_update_state_reschedule_mysql_limit` — skipped because it requires a MySQL backend (`BACKEND` env var not set in local test environment). This test is unrelated to the idempotency changes and will pass in CI with the MySQL backend configured.

closes: #63183

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)