### PR TITLE
Scheduler: prevent stale upstream_failed after task recovery

### DIFF
--- a/airflow-core/newsfragments/64025.bugfix.rst
+++ b/airflow-core/newsfragments/64025.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a scheduler race where dependency checks could use stale finished task instance state after task recovery and write incorrect downstream terminal states.

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -800,6 +800,8 @@ class DagRun(Base, LoggingMixin):
         task_ids: list[str] | None = None,
         state: Iterable[TaskInstanceState | None] | None = None,
         session: Session = NEW_SESSION,
+        *,
+        refresh_from_db: bool = False,
     ) -> list[TI]:
         """Return the task instances for this dag run."""
         tis = (
@@ -811,6 +813,8 @@ class DagRun(Base, LoggingMixin):
             )
             .order_by(TI.task_id, TI.map_index)
         )
+        if refresh_from_db:
+            tis = tis.execution_options(populate_existing=True)
 
         if state:
             if isinstance(state, str):
@@ -880,6 +884,8 @@ class DagRun(Base, LoggingMixin):
         self,
         state: Iterable[TaskInstanceState | None] | None = None,
         session: Session = NEW_SESSION,
+        *,
+        refresh_from_db: bool = False,
     ) -> list[TI]:
         """
         Return the task instances for this dag run.
@@ -889,7 +895,12 @@ class DagRun(Base, LoggingMixin):
         """
         task_ids = DagRun._get_partial_task_ids(self.dag)
         return DagRun.fetch_task_instances(
-            dag_id=self.dag_id, run_id=self.run_id, task_ids=task_ids, state=state, session=session
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            task_ids=task_ids,
+            state=state,
+            session=session,
+            refresh_from_db=refresh_from_db,
         )
 
     @provide_session
@@ -1102,9 +1113,7 @@ class DagRun(Base, LoggingMixin):
                 are_runnable_tasks = schedulable_tis or changed_tis
                 # small speed up
                 if not are_runnable_tasks:
-                    are_runnable_tasks, changed_by_upstream = self._are_premature_tis(
-                        unfinished.tis, finished_tis, session
-                    )
+                    are_runnable_tasks, changed_by_upstream = self._are_premature_tis(unfinished.tis, session)
                     if changed_by_upstream:  # Something changed, we need to recalculate!
                         unfinished = unfinished.recalculate()
 
@@ -1238,7 +1247,7 @@ class DagRun(Base, LoggingMixin):
 
     @provide_session
     def task_instance_scheduling_decisions(self, session: Session = NEW_SESSION) -> TISchedulingDecision:
-        tis = self.get_task_instances(session=session, state=State.task_states)
+        tis = self.get_task_instances(session=session, state=State.task_states, refresh_from_db=True)
         self.log.debug("number of tis tasks for %s: %s task(s)", self, len(tis))
 
         def _filter_tis_and_exclude_removed(dag: SerializedDAG, tis: list[TI]) -> Iterable[TI]:
@@ -1263,7 +1272,6 @@ class DagRun(Base, LoggingMixin):
             self.log.debug("number of scheduleable tasks for %s: %s task(s)", self, len(schedulable_tis))
             schedulable_tis, changed_tis, expansion_happened = self._get_ready_tis(
                 schedulable_tis,
-                finished_tis,
                 session=session,
             )
 
@@ -1404,7 +1412,6 @@ class DagRun(Base, LoggingMixin):
     def _get_ready_tis(
         self,
         schedulable_tis: list[TI],
-        finished_tis: list[TI],
         session: Session,
     ) -> tuple[list[TI], bool, bool]:
         old_states: dict[TaskInstanceKey, Any] = {}
@@ -1420,7 +1427,6 @@ class DagRun(Base, LoggingMixin):
         dep_context = DepContext(
             flag_upstream_failed=True,
             ignore_unmapped_tasks=True,  # Ignore this Dep, as we will expand it if we can.
-            finished_tis=finished_tis,
         )
 
         def _expand_mapped_task_if_needed(ti: TI) -> Iterable[TI] | None:
@@ -1507,14 +1513,12 @@ class DagRun(Base, LoggingMixin):
     def _are_premature_tis(
         self,
         unfinished_tis: Sequence[TI],
-        finished_tis: list[TI],
         session: Session,
     ) -> tuple[bool, bool]:
         dep_context = DepContext(
             flag_upstream_failed=True,
             ignore_in_retry_period=True,
             ignore_in_reschedule_period=True,
-            finished_tis=finished_tis,
         )
         # there might be runnable tasks that are up for retry and for some reason(retry delay, etc.) are
         # not ready yet, so we set the flags to count them in

--- a/airflow-core/src/airflow/ti_deps/dep_context.py
+++ b/airflow-core/src/airflow/ti_deps/dep_context.py
@@ -89,11 +89,15 @@ class DepContext:
         """
         Ensure finished_tis is populated if it's currently None, which allows running tasks without dag_run.
 
-         :param dag_run: The DagRun for which to find finished tasks
+        :param dag_run: The DagRun for which to find finished tasks
          :return: A list of all the finished tasks of this DAG and logical_date
         """
         if self.finished_tis is None:
-            finished_tis = dag_run.get_task_instances(state=State.finished, session=session)
+            finished_tis = dag_run.get_task_instances(
+                state=State.finished,
+                session=session,
+                refresh_from_db=True,
+            )
             for ti in finished_tis:
                 if getattr(ti, "task", None) is not None or (dag := dag_run.dag) is None:
                     continue

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -4828,6 +4828,49 @@ class TestPatchTaskInstance(TestTaskInstanceEndpoint):
         assert response.status_code == 409
         assert "Task id print_the_context is already in success state" in response.text
 
+    def test_patch_success_clears_failed_downstream_and_requeues_dagrun(
+        self, test_client, dag_maker, session
+    ):
+        dag_id = "test_patch_success_clears_failed_downstream"
+        run_id = "test_patch_success_clears_failed_downstream"
+        endpoint = f"/dags/{dag_id}/dagRuns/{run_id}/taskInstances/fail_task"
+
+        with dag_maker(dag_id=dag_id, session=session, serialized=True):
+            fail_task = EmptyOperator(task_id="fail_task")
+            cleared_upstream_failed = EmptyOperator(task_id="cleared_upstream_failed")
+            cleared_failed = EmptyOperator(task_id="cleared_failed")
+            preserved_success = EmptyOperator(task_id="preserved_success")
+            fail_task >> [cleared_upstream_failed, cleared_failed, preserved_success]
+
+        dagrun = dag_maker.create_dagrun(run_id=run_id, state=DagRunState.FAILED)
+        tis = {ti.task_id: ti for ti in dagrun.task_instances}
+        tis["fail_task"].state = TaskInstanceState.FAILED
+        tis["cleared_upstream_failed"].state = TaskInstanceState.UPSTREAM_FAILED
+        tis["cleared_failed"].state = TaskInstanceState.FAILED
+        tis["preserved_success"].state = TaskInstanceState.SUCCESS
+        session.commit()
+
+        response = test_client.patch(endpoint, json={"new_state": "success"})
+        assert response.status_code == 200, response.text
+
+        session.expire_all()
+        refreshed_tis = {
+            ti.task_id: ti
+            for ti in session.scalars(
+                select(TaskInstance).where(TaskInstance.dag_id == dag_id, TaskInstance.run_id == run_id)
+            )
+        }
+        assert refreshed_tis["fail_task"].state == TaskInstanceState.SUCCESS
+        assert refreshed_tis["cleared_upstream_failed"].state is None
+        assert refreshed_tis["cleared_failed"].state is None
+        assert refreshed_tis["preserved_success"].state == TaskInstanceState.SUCCESS
+
+        refreshed_dagrun = session.scalar(
+            select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)
+        )
+        assert refreshed_dagrun is not None
+        assert refreshed_dagrun.state == DagRunState.QUEUED
+
 
 class TestPatchTaskInstanceDryRun(TestTaskInstanceEndpoint):
     ENDPOINT_URL = "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2254,6 +2254,68 @@ def test_schedule_tis_only_one_scheduler_update_succeeds_when_competing(dag_make
     assert refreshed_ti.try_number == 1
 
 
+def test_task_instance_scheduling_decisions_refresh_finished_tis_before_setting_upstream_failed(
+    dag_maker, session
+):
+    with dag_maker(session=session, dag_id="refresh_finished_tis_before_upstream_failed", serialized=True):
+        fail_task = EmptyOperator(task_id="fail_task")
+        t0 = EmptyOperator(task_id="t0")
+        fail_task >> t0
+
+    dag = dag_maker.serialized_dag
+    dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=DagRunState.RUNNING)
+    dr.dag = dag
+
+    tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session, state=State.task_states)}
+    tis["fail_task"].state = TaskInstanceState.FAILED
+    session.commit()
+
+    with create_session() as other_session:
+        dag.set_task_instance_state(
+            task_id="fail_task",
+            run_id=dr.run_id,
+            state=TaskInstanceState.SUCCESS,
+            session=other_session,
+        )
+
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert [ti.task_id for ti in decision.schedulable_tis] == ["t0"]
+    assert tis["fail_task"].state == TaskInstanceState.SUCCESS
+    assert tis["t0"].state is None
+
+
+def test_task_instance_scheduling_decisions_refresh_finished_tis_after_api_clear(dag_maker, session):
+    with dag_maker(session=session, dag_id="refresh_finished_tis_after_api_clear", serialized=True):
+        fail_task = EmptyOperator(task_id="fail_task")
+        t0 = EmptyOperator(task_id="t0")
+        t1 = EmptyOperator(task_id="t1")
+        t2 = EmptyOperator(task_id="t2")
+        fail_task >> t0 >> t1 >> t2
+
+    dag = dag_maker.serialized_dag
+    dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=DagRunState.RUNNING)
+    dr.dag = dag
+
+    tis = {ti.task_id: ti for ti in dr.get_task_instances(session=session, state=State.task_states)}
+    tis["fail_task"].state = TaskInstanceState.FAILED
+    tis["t0"].state = TaskInstanceState.UPSTREAM_FAILED
+    session.commit()
+
+    with create_session() as other_session:
+        dag.set_task_instance_state(
+            task_id="fail_task",
+            run_id=dr.run_id,
+            state=TaskInstanceState.SUCCESS,
+            session=other_session,
+        )
+
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert [ti.task_id for ti in decision.schedulable_tis] == ["t0"]
+    assert tis["fail_task"].state == TaskInstanceState.SUCCESS
+    assert tis["t0"].state is None
+    assert tis["t1"].state is None
+
+
 @pytest.mark.xfail(reason="We can't keep this behaviour with remote workers where scheduler can't reach xcom")
 @pytest.mark.need_serialized_dag
 def test_schedule_tis_start_trigger(dag_maker, session):

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import pendulum
 import pytest
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 from airflow.models import DagRun, TaskInstance
 from airflow.models.xcom import XComModel
@@ -31,6 +31,7 @@ from airflow.ti_deps.deps.not_previously_skipped_dep import (
     XCOM_SKIPMIXIN_KEY,
     NotPreviouslySkippedDep,
 )
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
@@ -214,3 +215,39 @@ def test_unmapped_parent_skip_mapped_downstream(session, dag_maker):
     assert len(list(dep.get_dep_statuses(tis["op2"], session, DepContext()))) == 1
     assert not dep.is_met(tis["op2"], session)
     assert tis["op2"].state == State.SKIPPED
+
+
+def test_cleared_skipmixin_parent_does_not_skip_with_stale_finished_tis(session, dag_maker):
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        "test_cleared_skipmixin_parent_does_not_skip_with_stale_finished_tis",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+        op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3")
+        op2 = EmptyOperator(task_id="op2")
+        op3 = EmptyOperator(task_id="op3")
+        op1 >> [op2, op3]
+
+    dagrun = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    tis = {ti.task_id: ti for ti in dagrun.task_instances}
+    run_task_instance(tis["op1"], op1)
+    session.commit()
+
+    with create_session() as other_session:
+        other_ti = other_session.scalar(
+            select(TaskInstance).where(
+                TaskInstance.dag_id == dagrun.dag_id,
+                TaskInstance.run_id == dagrun.run_id,
+                TaskInstance.task_id == "op1",
+            )
+        )
+        assert other_ti is not None
+        other_ti.state = State.NONE
+        other_session.flush()
+
+    dep = NotPreviouslySkippedDep()
+    assert len(list(dep.get_dep_statuses(tis["op2"], session, DepContext()))) == 0
+    assert dep.is_met(tis["op2"], session)
+    assert tis["op2"].state == State.NONE


### PR DESCRIPTION
This fixes a scheduler race where a task recovered through the public API could still leave downstream tasks permanently marked with terminal states based on stale scheduler-session data.

Why:
- `PATCH /taskInstances/...` already marks the selected task instance successful and clears downstream failed or upstream_failed task instances.
- The scheduler could keep using a stale finished-task view from its own SQLAlchemy session during dependency evaluation.
- That stale view could still drive downstream writes such as `UPSTREAM_FAILED` or `SKIPPED` after the recovery had already been committed.

Impact:
- A recovered upstream task no longer causes deeper descendants to be permanently written into stale terminal states by the scheduler.
- Scheduler dependency evaluation now refreshes finished task instances from the database before using them for dependency checks.
- The API behavior is unchanged: the fix is in scheduler-side state evaluation and its regression coverage.

Files changed:
- `airflow-core/src/airflow/models/dagrun.py`
- `airflow-core/src/airflow/ti_deps/dep_context.py`
- `airflow-core/tests/unit/models/test_dagrun.py`
- `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py`
- `airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py`
- `airflow-core/newsfragments/64025.bugfix.rst`

Validation:
- `breeze run pytest airflow-core/tests/unit/models/test_dagrun.py -k 'refresh_finished_tis' -xvs`
- `breeze run pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py::TestPatchTaskInstance::test_patch_success_clears_failed_downstream_and_requeues_dagrun -xvs`
- `breeze run pytest airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py::test_cleared_skipmixin_parent_does_not_skip_with_stale_finished_tis -xvs`
- `prek run --from-ref origin/main --stage pre-commit`

related: #63697

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex GPT-5

Generated-by: OpenAI Codex GPT-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)