### PR TITLE
Fix Python 3.14 ARM failures by removing side-loaded packages

### DIFF
--- a/providers/apache/cassandra/docs/index.rst
+++ b/providers/apache/cassandra/docs/index.rst
@@ -101,7 +101,6 @@ PIP package                                 Version required
 ==========================================  ==================================================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
-``cassandra-driver``                        ``>=3.30.0; python_version >= "3.14"``
 ``cassandra-driver``                        ``>=3.29.3; python_version >= "3.13" and python_version < "3.14"``
 ``cassandra-driver``                        ``>=3.29.2; python_version >= "3.12" and python_version < "3.13"``
 ``cassandra-driver``                        ``>=3.29.1; python_version < "3.12"``

--- a/providers/apache/cassandra/pyproject.toml
+++ b/providers/apache/cassandra/pyproject.toml
@@ -60,7 +60,6 @@ requires-python = ">=3.10,!=3.14.*"
 dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
-    "cassandra-driver>=3.30.0; python_version >= '3.14'",
     "cassandra-driver>=3.29.3; python_version >= '3.13' and python_version < '3.14'",
     "cassandra-driver>=3.29.2; python_version >= '3.12' and python_version < '3.13'",
     "cassandra-driver>=3.29.1; python_version < '3.12'",

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -109,9 +109,9 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.11.0``.
 
-==========================================  =================================================================
+==========================================  ==================================================================
 PIP package                                 Version required
-==========================================  =================================================================
+==========================================  ==================================================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
@@ -130,7 +130,7 @@ PIP package                                 Version required
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-cloud-aiplatform[evaluation]``     ``>=1.98.0``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
-``ray[default]``                            ``>=2.49.0; python_version >= "3.13"``
+``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``google-cloud-bigquery-storage``           ``>=2.31.0; python_version < "3.13"``
 ``google-cloud-bigquery-storage``           ``>=2.33.0; python_version >= "3.13"``
 ``google-cloud-alloydb``                    ``>=0.4.0``
@@ -187,7 +187,7 @@ PIP package                                 Version required
 ``tenacity``                                ``>=8.3.0``
 ``immutabledict``                           ``>=4.2.0``
 ``types-protobuf``                          ``>=5.27.0,!=5.29.1.20250402``
-==========================================  =================================================================
+==========================================  ==================================================================
 
 Cross provider package dependencies
 -----------------------------------

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
     # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
     "google-cloud-aiplatform[evaluation]>=1.98.0",
     "ray[default]>=2.42.0;python_version<'3.13'",
-    "ray[default]>=2.49.0;python_version>='3.13'",
+    "ray[default]>=2.49.0;python_version>='3.13' and python_version <'3.14'",
     "google-cloud-bigquery-storage>=2.31.0;python_version<'3.13'",
     "google-cloud-bigquery-storage>=2.33.0;python_version>='3.13'",
     "google-cloud-alloydb>=0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1474,20 +1474,6 @@ apache-airflow-providers-ydb = { workspace = true }
 apache-airflow-providers-zendesk = { workspace = true }
 # End of automatically generated provider workspace items
 
-# Ray v3 nightly wheels – direct S3 URLs so uv doesn't need a parseable find-links index.
-ray = [
-    { url = "https://s3-us-west-2.amazonaws.com/ray-wheels/master/671390966dc4081d68c4cd5cdb359b0b5773cb56/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl", marker = "python_version == '3.14' and sys_platform == 'linux'" },
-]
-# cassandra-python-driver from GitHub trunk for Python 3.14 (no PyPI release yet)
-cassandra-driver = [
-    { git = "https://github.com/apache/cassandra-python-driver", branch = "trunk", marker = "python_version >= '3.14'" },
-]
-# Python 3.14 support in pluggy (and by extension, pytest) is expected in the next release after 1.6.0
-pluggy = [
-    { git = "https://github.com/pytest-dev/pluggy", rev = "97355a5a464af9c9eef51328ef43fb67145413dd", marker = "python_version == '3.14'" },
-]
-
-
 [tool.uv.workspace]
 members = [
     ".",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -443,7 +443,7 @@ name = "aiohttp-cors"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403", size = 38626, upload-time = "2025-03-31T14:16:20.048Z" }
 wheels = [
@@ -1715,8 +1715,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pendulum" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pygments" },
@@ -1851,8 +1850,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pathspec", specifier = ">=0.9.0" },
     { name = "pendulum", specifier = ">=3.1.0" },
-    { name = "pluggy", marker = "python_full_version != '3.14.*'", specifier = ">=1.5.0" },
-    { name = "pluggy", marker = "python_full_version == '3.14.*'", git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd" },
+    { name = "pluggy", specifier = ">=1.5.0" },
     { name = "psutil", specifier = ">=5.8.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pygments", specifier = ">=2.0.1,!=2.19.0" },
@@ -2828,8 +2826,7 @@ source = { editable = "providers/apache/cassandra" }
 dependencies = [
     { name = "apache-airflow" },
     { name = "apache-airflow-providers-common-compat" },
-    { name = "cassandra-driver", version = "3.29.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "cassandra-driver", version = "3.30.0", source = { git = "https://github.com/apache/cassandra-python-driver?branch=trunk#141853dc3188c1030e06b1cf44ed8881cf835f17" }, marker = "python_full_version >= '3.14'" },
+    { name = "cassandra-driver", marker = "python_full_version < '3.14'" },
 ]
 
 [package.dev-dependencies]
@@ -2850,7 +2847,6 @@ requires-dist = [
     { name = "cassandra-driver", marker = "python_full_version < '3.12'", specifier = ">=3.29.1" },
     { name = "cassandra-driver", marker = "python_full_version == '3.12.*'", specifier = ">=3.29.2" },
     { name = "cassandra-driver", marker = "python_full_version == '3.13.*'", specifier = ">=3.29.3" },
-    { name = "cassandra-driver", marker = "python_full_version >= '3.14'", git = "https://github.com/apache/cassandra-python-driver?branch=trunk" },
 ]
 
 [package.metadata.requires-dev]
@@ -4945,8 +4941,7 @@ dependencies = [
     { name = "proto-plus" },
     { name = "pyarrow" },
     { name = "python-slugify" },
-    { name = "ray", version = "2.54.0", source = { registry = "https://pypi.org/simple" }, extra = ["default"], marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "ray", version = "3.0.0.dev0", source = { url = "https://s3-us-west-2.amazonaws.com/ray-wheels/master/671390966dc4081d68c4cd5cdb359b0b5773cb56/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl" }, extra = ["default"], marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
+    { name = "ray", extra = ["default"], marker = "python_full_version < '3.14'" },
     { name = "sqlalchemy-bigquery" },
     { name = "sqlalchemy-spanner" },
     { name = "tenacity" },
@@ -5138,8 +5133,7 @@ requires-dist = [
     { name = "pyarrow", marker = "python_full_version >= '3.14'", specifier = ">=22.0.0" },
     { name = "python-slugify", specifier = ">=7.0.0" },
     { name = "ray", extras = ["default"], marker = "python_full_version < '3.13'", specifier = ">=2.42.0" },
-    { name = "ray", extras = ["default"], marker = "python_full_version == '3.14.*' and sys_platform == 'linux'", url = "https://s3-us-west-2.amazonaws.com/ray-wheels/master/671390966dc4081d68c4cd5cdb359b0b5773cb56/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl" },
-    { name = "ray", extras = ["default"], marker = "(python_full_version >= '3.13' and sys_platform != 'linux') or (python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'linux')", specifier = ">=2.49.0" },
+    { name = "ray", extras = ["default"], marker = "python_full_version == '3.13.*'", specifier = ">=2.49.0" },
     { name = "sqlalchemy-bigquery", specifier = ">=1.2.1" },
     { name = "sqlalchemy-spanner", specifier = ">=1.6.2" },
     { name = "tenacity", specifier = ">=8.3.0" },
@@ -7760,8 +7754,7 @@ name = "apache-airflow-shared-listeners"
 version = "0.0"
 source = { editable = "shared/listeners" }
 dependencies = [
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "structlog" },
 ]
 
@@ -7772,8 +7765,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pluggy", marker = "python_full_version != '3.14.*'", specifier = ">=1.5.0" },
-    { name = "pluggy", marker = "python_full_version == '3.14.*'", git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd" },
+    { name = "pluggy", specifier = ">=1.5.0" },
     { name = "structlog", specifier = ">=25.4.0" },
 ]
 
@@ -8056,8 +8048,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "pendulum" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pygtrie" },
@@ -8135,8 +8126,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=25.0" },
     { name = "pathspec", specifier = ">=0.9.0" },
     { name = "pendulum", specifier = ">=3.1.0" },
-    { name = "pluggy", marker = "python_full_version != '3.14.*'", specifier = ">=1.5.0" },
-    { name = "pluggy", marker = "python_full_version == '3.14.*'", git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd" },
+    { name = "pluggy", specifier = ">=1.5.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">2.11.0" },
     { name = "pygtrie", specifier = ">=2.5.0" },
@@ -9384,12 +9374,6 @@ wheels = [
 name = "cassandra-driver"
 version = "3.29.3"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
     { name = "geomet", marker = "python_full_version < '3.14'" },
 ]
@@ -9419,22 +9403,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/42/a4f10ef8274a2bd05e859b7d2141c2c0cc13a8ef4ea6e825a660960b17d7/cassandra_driver-3.29.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51d6a5390e2454b599500049f0a5c72aa701db155c1e542f9a1157c1c45814b1", size = 374432, upload-time = "2025-10-22T15:14:49.44Z" },
     { url = "https://files.pythonhosted.org/packages/ea/55/611982779ddeb4b98658d87ab3b150506b2121d8d16a843459c7aacc7884/cassandra_driver-3.29.3-cp313-cp313-win32.whl", hash = "sha256:638047c1f70fb14c9d8f743931d4f4f42aff6793b47afded3097c002ef8c1165", size = 341529, upload-time = "2025-10-22T15:14:50.896Z" },
     { url = "https://files.pythonhosted.org/packages/b2/13/aaa6c7559bfb11c58a1978dfa46732f4d477230641259f13a14907cb4546/cassandra_driver-3.29.3-cp313-cp313-win_amd64.whl", hash = "sha256:27adf8869937461ad08c5fefb47857532e467b408db496db4dbf8b132a4bd623", size = 349242, upload-time = "2025-10-22T15:14:52.472Z" },
-]
-
-[[package]]
-name = "cassandra-driver"
-version = "3.30.0"
-source = { git = "https://github.com/apache/cassandra-python-driver?branch=trunk#141853dc3188c1030e06b1cf44ed8881cf835f17" }
-resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'linux'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux'",
-]
-dependencies = [
-    { name = "deprecated", marker = "python_full_version >= '3.14'" },
-    { name = "geomet", marker = "python_full_version >= '3.14'" },
 ]
 
 [[package]]
@@ -9875,7 +9843,7 @@ name = "colorful"
 version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/31/109ef4bedeb32b4202e02ddb133162457adc4eb890a9ed9c05c9dd126ed0/colorful-0.5.8.tar.gz", hash = "sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445", size = 209361, upload-time = "2025-10-29T11:53:21.663Z" }
 wheels = [
@@ -11377,7 +11345,7 @@ name = "geomet"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/8c/dde022aa6747b114f6b14a7392871275dea8867e2bd26cddb80cc6d66620/geomet-1.1.0.tar.gz", hash = "sha256:51e92231a0ef6aaa63ac20c443377ba78a303fd2ecd179dc3567de79f3c11605", size = 28732, upload-time = "2023-11-14T15:43:36.764Z" }
 wheels = [
@@ -12826,8 +12794,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "trove-classifiers" },
 ]
@@ -15903,9 +15870,9 @@ name = "opencensus"
 version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "opencensus-context" },
-    { name = "six" },
+    { name = "google-api-core", marker = "python_full_version < '3.14'" },
+    { name = "opencensus-context", marker = "python_full_version < '3.14'" },
+    { name = "six", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966, upload-time = "2024-01-03T18:04:07.085Z" }
 wheels = [
@@ -16776,27 +16743,9 @@ wheels = [
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.1.dev77+g97355a5a4"
-source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }
-resolution-markers = [
-    "python_full_version == '3.14.*' and sys_platform == 'linux'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux'",
 ]
 
 [[package]]
@@ -18317,8 +18266,7 @@ dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -18347,8 +18295,7 @@ version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
-    { name = "pluggy", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
-    { name = "pluggy", version = "1.6.1.dev77+g97355a5a4", source = { git = "https://github.com/pytest-dev/pluggy?rev=97355a5a464af9c9eef51328ef43fb67145413dd#97355a5a464af9c9eef51328ef43fb67145413dd" }, marker = "python_full_version == '3.14.*'" },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
@@ -18903,25 +18850,15 @@ wheels = [
 name = "ray"
 version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "click", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "filelock", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "jsonschema", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "msgpack", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "packaging", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "protobuf", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "pyyaml", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "requests", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "msgpack", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/13/b86d791b41f33220335eba18fc4841f1ebddae41e562c6a216846404c88d/ray-2.54.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:a22937f09ee74a43171df338d84b45ef882c1c05748947ca9d5343a44d4b9379", size = 70097079, upload-time = "2026-02-18T04:04:35.409Z" },
@@ -18943,317 +18880,21 @@ wheels = [
 
 [package.optional-dependencies]
 default = [
-    { name = "aiohttp", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "aiohttp-cors", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "colorful", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "grpcio", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "opencensus", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "opentelemetry-proto", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "prometheus-client", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "py-spy", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "pydantic", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "requests", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "smart-open", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
-    { name = "virtualenv", marker = "python_full_version != '3.14.*' or sys_platform != 'linux'" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp-cors", marker = "python_full_version < '3.14'" },
+    { name = "colorful", marker = "python_full_version < '3.14'" },
+    { name = "grpcio", marker = "python_full_version < '3.14'" },
+    { name = "opencensus", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-proto", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
+    { name = "prometheus-client", marker = "python_full_version < '3.14'" },
+    { name = "py-spy", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "smart-open", marker = "python_full_version < '3.14'" },
+    { name = "virtualenv", marker = "python_full_version < '3.14'" },
 ]
-
-[[package]]
-name = "ray"
-version = "3.0.0.dev0"
-source = { url = "https://s3-us-west-2.amazonaws.com/ray-wheels/master/671390966dc4081d68c4cd5cdb359b0b5773cb56/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl" }
-resolution-markers = [
-    "python_full_version == '3.14.*' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "click", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "jsonschema", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "msgpack", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "packaging", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "protobuf", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "requests", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://s3-us-west-2.amazonaws.com/ray-wheels/master/671390966dc4081d68c4cd5cdb359b0b5773cb56/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:50f710166fac8a3c6ac502795d568050f6a7ca14caa6df44628c145fd9e566fc" },
-]
-
-[package.optional-dependencies]
-default = [
-    { name = "aiohttp", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "aiohttp-cors", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "colorful", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "grpcio", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "opencensus", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "opentelemetry-proto", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "prometheus-client", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "py-spy", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "requests", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "smart-open", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-    { name = "virtualenv", marker = "python_full_version == '3.14.*' and sys_platform == 'linux'" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", marker = "extra == 'air'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'all-cpp'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'default'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'llm'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'serve'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'serve-async-inference'", specifier = ">=3.13.3" },
-    { name = "aiohttp", marker = "extra == 'serve-grpc'", specifier = ">=3.13.3" },
-    { name = "aiohttp-cors", marker = "extra == 'air'" },
-    { name = "aiohttp-cors", marker = "extra == 'all'" },
-    { name = "aiohttp-cors", marker = "extra == 'all-cpp'" },
-    { name = "aiohttp-cors", marker = "extra == 'default'" },
-    { name = "aiohttp-cors", marker = "extra == 'llm'" },
-    { name = "aiohttp-cors", marker = "extra == 'serve'" },
-    { name = "aiohttp-cors", marker = "extra == 'serve-async-inference'" },
-    { name = "aiohttp-cors", marker = "extra == 'serve-grpc'" },
-    { name = "async-timeout", marker = "python_full_version < '3.11' and extra == 'llm'" },
-    { name = "celery", marker = "extra == 'all'" },
-    { name = "celery", marker = "extra == 'all-cpp'" },
-    { name = "celery", marker = "extra == 'serve-async-inference'" },
-    { name = "click", specifier = ">=7.0" },
-    { name = "colorful", marker = "extra == 'air'" },
-    { name = "colorful", marker = "extra == 'all'" },
-    { name = "colorful", marker = "extra == 'all-cpp'" },
-    { name = "colorful", marker = "extra == 'default'" },
-    { name = "colorful", marker = "extra == 'llm'" },
-    { name = "colorful", marker = "extra == 'serve'" },
-    { name = "colorful", marker = "extra == 'serve-async-inference'" },
-    { name = "colorful", marker = "extra == 'serve-grpc'" },
-    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin' and extra == 'adag'" },
-    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin' and extra == 'all'" },
-    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin' and extra == 'all-cpp'" },
-    { name = "cupy-cuda12x", marker = "sys_platform != 'darwin' and extra == 'cgraph'" },
-    { name = "dm-tree", marker = "extra == 'all'" },
-    { name = "dm-tree", marker = "extra == 'all-cpp'" },
-    { name = "dm-tree", marker = "extra == 'rllib'" },
-    { name = "fastapi", marker = "extra == 'air'" },
-    { name = "fastapi", marker = "extra == 'all'" },
-    { name = "fastapi", marker = "extra == 'all-cpp'" },
-    { name = "fastapi", marker = "extra == 'llm'" },
-    { name = "fastapi", marker = "extra == 'serve'" },
-    { name = "fastapi", marker = "extra == 'serve-async-inference'" },
-    { name = "fastapi", marker = "extra == 'serve-grpc'" },
-    { name = "filelock" },
-    { name = "fsspec", marker = "extra == 'air'" },
-    { name = "fsspec", marker = "extra == 'all'" },
-    { name = "fsspec", marker = "extra == 'all-cpp'" },
-    { name = "fsspec", marker = "extra == 'data'" },
-    { name = "fsspec", marker = "extra == 'llm'" },
-    { name = "fsspec", marker = "extra == 'rllib'" },
-    { name = "fsspec", marker = "extra == 'train'" },
-    { name = "fsspec", marker = "extra == 'tune'" },
-    { name = "grpcio", marker = "sys_platform == 'darwin' and extra == 'all'", specifier = "!=1.56.0" },
-    { name = "grpcio", marker = "sys_platform == 'darwin' and extra == 'all-cpp'", specifier = "!=1.56.0" },
-    { name = "grpcio", marker = "sys_platform == 'darwin' and extra == 'client'", specifier = "!=1.56.0" },
-    { name = "grpcio", marker = "extra == 'air'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'all'" },
-    { name = "grpcio", marker = "extra == 'all'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'all-cpp'" },
-    { name = "grpcio", marker = "extra == 'all-cpp'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'client'" },
-    { name = "grpcio", marker = "extra == 'default'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'llm'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'serve'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'serve-async-inference'", specifier = ">=1.42.0" },
-    { name = "grpcio", marker = "extra == 'serve-grpc'", specifier = ">=1.42.0" },
-    { name = "gymnasium", marker = "extra == 'all'", specifier = "==1.2.2" },
-    { name = "gymnasium", marker = "extra == 'all-cpp'", specifier = "==1.2.2" },
-    { name = "gymnasium", marker = "extra == 'rllib'", specifier = "==1.2.2" },
-    { name = "hf-transfer", marker = "extra == 'llm'" },
-    { name = "jsonref", marker = "extra == 'llm'", specifier = ">=1.1.0" },
-    { name = "jsonschema" },
-    { name = "jsonschema", marker = "extra == 'llm'" },
-    { name = "lz4", marker = "extra == 'all'" },
-    { name = "lz4", marker = "extra == 'all-cpp'" },
-    { name = "lz4", marker = "extra == 'rllib'" },
-    { name = "memray", marker = "sys_platform != 'win32' and extra == 'all'" },
-    { name = "memray", marker = "sys_platform != 'win32' and extra == 'all-cpp'" },
-    { name = "memray", marker = "sys_platform != 'win32' and extra == 'observability'" },
-    { name = "meson", marker = "extra == 'llm'" },
-    { name = "msgpack", specifier = ">=1.0.0,<2.0.0" },
-    { name = "ninja", marker = "extra == 'llm'" },
-    { name = "nixl", marker = "extra == 'llm'", specifier = ">=0.6.1" },
-    { name = "numpy", marker = "extra == 'air'", specifier = ">=1.20" },
-    { name = "numpy", marker = "extra == 'all'", specifier = ">=1.20" },
-    { name = "numpy", marker = "extra == 'all-cpp'", specifier = ">=1.20" },
-    { name = "numpy", marker = "extra == 'data'", specifier = ">=1.20" },
-    { name = "numpy", marker = "extra == 'llm'", specifier = ">=1.20" },
-    { name = "opencensus", marker = "extra == 'air'" },
-    { name = "opencensus", marker = "extra == 'all'" },
-    { name = "opencensus", marker = "extra == 'all-cpp'" },
-    { name = "opencensus", marker = "extra == 'default'" },
-    { name = "opencensus", marker = "extra == 'llm'" },
-    { name = "opencensus", marker = "extra == 'serve'" },
-    { name = "opencensus", marker = "extra == 'serve-async-inference'" },
-    { name = "opencensus", marker = "extra == 'serve-grpc'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'air'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'all'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'all-cpp'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'default'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'llm'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'serve'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'serve-async-inference'" },
-    { name = "opentelemetry-exporter-prometheus", marker = "extra == 'serve-grpc'" },
-    { name = "opentelemetry-proto", marker = "extra == 'air'" },
-    { name = "opentelemetry-proto", marker = "extra == 'all'" },
-    { name = "opentelemetry-proto", marker = "extra == 'all-cpp'" },
-    { name = "opentelemetry-proto", marker = "extra == 'default'" },
-    { name = "opentelemetry-proto", marker = "extra == 'llm'" },
-    { name = "opentelemetry-proto", marker = "extra == 'serve'" },
-    { name = "opentelemetry-proto", marker = "extra == 'serve-async-inference'" },
-    { name = "opentelemetry-proto", marker = "extra == 'serve-grpc'" },
-    { name = "opentelemetry-sdk", marker = "extra == 'air'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'all'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'all-cpp'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'default'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'llm'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'serve'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'serve-async-inference'", specifier = ">=1.30.0" },
-    { name = "opentelemetry-sdk", marker = "extra == 'serve-grpc'", specifier = ">=1.30.0" },
-    { name = "ormsgpack", marker = "extra == 'all'", specifier = ">=1.7.0" },
-    { name = "ormsgpack", marker = "extra == 'all-cpp'", specifier = ">=1.7.0" },
-    { name = "ormsgpack", marker = "extra == 'rllib'", specifier = ">=1.7.0" },
-    { name = "packaging", specifier = ">=24.2" },
-    { name = "pandas", marker = "extra == 'air'" },
-    { name = "pandas", marker = "extra == 'air'", specifier = ">=1.3" },
-    { name = "pandas", marker = "extra == 'all'" },
-    { name = "pandas", marker = "extra == 'all'", specifier = ">=1.3" },
-    { name = "pandas", marker = "extra == 'all-cpp'" },
-    { name = "pandas", marker = "extra == 'all-cpp'", specifier = ">=1.3" },
-    { name = "pandas", marker = "extra == 'data'", specifier = ">=1.3" },
-    { name = "pandas", marker = "extra == 'llm'", specifier = ">=1.3" },
-    { name = "pandas", marker = "extra == 'rllib'" },
-    { name = "pandas", marker = "extra == 'train'" },
-    { name = "pandas", marker = "extra == 'tune'" },
-    { name = "prometheus-client", marker = "extra == 'air'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'all'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'all-cpp'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'default'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'llm'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'serve'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'serve-async-inference'", specifier = ">=0.7.1" },
-    { name = "prometheus-client", marker = "extra == 'serve-grpc'", specifier = ">=0.7.1" },
-    { name = "protobuf", specifier = ">=3.20.3" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'air'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'all'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'all-cpp'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'default'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'llm'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'serve'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'serve-async-inference'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version >= '3.12' and extra == 'serve-grpc'", specifier = ">=0.4.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'air'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'all'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'all-cpp'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'default'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'llm'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'serve'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'serve-async-inference'", specifier = ">=0.2.0" },
-    { name = "py-spy", marker = "python_full_version < '3.12' and extra == 'serve-grpc'", specifier = ">=0.2.0" },
-    { name = "pyarrow", marker = "extra == 'air'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'all'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'all-cpp'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'data'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'llm'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'rllib'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'train'", specifier = ">=9.0.0" },
-    { name = "pyarrow", marker = "extra == 'tune'", specifier = ">=9.0.0" },
-    { name = "pybind11", marker = "extra == 'llm'" },
-    { name = "pydantic", marker = "extra == 'air'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'all'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'all-cpp'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'default'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'llm'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'rllib'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'serve'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'serve-async-inference'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'serve-grpc'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'train'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pydantic", marker = "extra == 'tune'", specifier = "!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*,!=2.11.*,<3" },
-    { name = "pyopenssl", marker = "extra == 'all'" },
-    { name = "pyopenssl", marker = "extra == 'all-cpp'" },
-    { name = "pyopenssl", marker = "extra == 'serve-grpc'" },
-    { name = "pyyaml" },
-    { name = "pyyaml", marker = "extra == 'all'" },
-    { name = "pyyaml", marker = "extra == 'all-cpp'" },
-    { name = "pyyaml", marker = "extra == 'rllib'" },
-    { name = "ray-cpp", marker = "extra == 'all-cpp'", specifier = "==3.0.0.dev0" },
-    { name = "ray-cpp", marker = "extra == 'cpp'", specifier = "==3.0.0.dev0" },
-    { name = "requests" },
-    { name = "requests", marker = "extra == 'air'" },
-    { name = "requests", marker = "extra == 'all'" },
-    { name = "requests", marker = "extra == 'all-cpp'" },
-    { name = "requests", marker = "extra == 'default'" },
-    { name = "requests", marker = "extra == 'llm'" },
-    { name = "requests", marker = "extra == 'rllib'" },
-    { name = "requests", marker = "extra == 'serve'" },
-    { name = "requests", marker = "extra == 'serve-async-inference'" },
-    { name = "requests", marker = "extra == 'serve-grpc'" },
-    { name = "requests", marker = "extra == 'train'" },
-    { name = "requests", marker = "extra == 'tune'" },
-    { name = "scipy", marker = "extra == 'all'" },
-    { name = "scipy", marker = "extra == 'all-cpp'" },
-    { name = "scipy", marker = "extra == 'rllib'" },
-    { name = "smart-open", marker = "extra == 'air'" },
-    { name = "smart-open", marker = "extra == 'all'" },
-    { name = "smart-open", marker = "extra == 'all-cpp'" },
-    { name = "smart-open", marker = "extra == 'default'" },
-    { name = "smart-open", marker = "extra == 'llm'" },
-    { name = "smart-open", marker = "extra == 'serve'" },
-    { name = "smart-open", marker = "extra == 'serve-async-inference'" },
-    { name = "smart-open", marker = "extra == 'serve-grpc'" },
-    { name = "starlette", marker = "extra == 'air'" },
-    { name = "starlette", marker = "extra == 'all'" },
-    { name = "starlette", marker = "extra == 'all-cpp'" },
-    { name = "starlette", marker = "extra == 'llm'" },
-    { name = "starlette", marker = "extra == 'serve'" },
-    { name = "starlette", marker = "extra == 'serve-async-inference'" },
-    { name = "starlette", marker = "extra == 'serve-grpc'" },
-    { name = "taskiq", marker = "extra == 'all'" },
-    { name = "taskiq", marker = "extra == 'all-cpp'" },
-    { name = "taskiq", marker = "extra == 'serve-async-inference'" },
-    { name = "tensorboardx", marker = "extra == 'air'", specifier = ">=1.9" },
-    { name = "tensorboardx", marker = "extra == 'all'", specifier = ">=1.9" },
-    { name = "tensorboardx", marker = "extra == 'all-cpp'", specifier = ">=1.9" },
-    { name = "tensorboardx", marker = "extra == 'rllib'", specifier = ">=1.9" },
-    { name = "tensorboardx", marker = "extra == 'train'", specifier = ">=1.9" },
-    { name = "tensorboardx", marker = "extra == 'tune'", specifier = ">=1.9" },
-    { name = "typer", marker = "extra == 'llm'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'air'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'all-cpp'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'llm'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve-async-inference'" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve-grpc'" },
-    { name = "virtualenv", marker = "extra == 'air'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'all'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'all-cpp'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'default'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'llm'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'serve'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'serve-async-inference'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "virtualenv", marker = "extra == 'serve-grpc'", specifier = ">=20.0.24,!=20.21.1" },
-    { name = "vllm", extras = ["audio"], marker = "extra == 'llm'", specifier = ">=0.16.0" },
-    { name = "watchfiles", marker = "extra == 'air'" },
-    { name = "watchfiles", marker = "extra == 'all'" },
-    { name = "watchfiles", marker = "extra == 'all-cpp'" },
-    { name = "watchfiles", marker = "extra == 'llm'" },
-    { name = "watchfiles", marker = "extra == 'serve'" },
-    { name = "watchfiles", marker = "extra == 'serve-async-inference'" },
-    { name = "watchfiles", marker = "extra == 'serve-grpc'" },
-]
-provides-extras = ["cgraph", "client", "data", "default", "observability", "serve", "tune", "adag", "serve-grpc", "serve-async-inference", "cpp", "rllib", "train", "air", "all", "all-cpp", "llm"]
 
 [[package]]
 name = "reactivex"
@@ -20385,7 +20026,7 @@ name = "smart-open"
 version = "7.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/be/a66598b305763861a9ab15ff0f2fbc44e47b1ce7a776797337a4eef37c66/smart_open-7.5.1.tar.gz", hash = "sha256:3f08e16827c4733699e6b2cc40328a3568f900cb12ad9a3ad233ba6c872d9fe7", size = 54034, upload-time = "2026-02-23T11:01:28.979Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Remove side-loaded package overrides from `[tool.uv.sources]`: ray nightly wheels (x86_64-only, broke ARM), cassandra-driver git trunk, and pluggy git rev
- Restrict `ray[default]` to `python_version < '3.14'` in google provider (no ARM wheel available)
- Remove `cassandra-driver>=3.30.0` specifier for Python 3.14 in cassandra provider (no such release exists yet)
- Updated `uv.lock` accordingly

The side-loaded packages were temporary workarounds for Python 3.14 support that are no longer needed (upstream releases now support 3.14) or that broke ARM builds (ray nightly was x86_64-only).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)