### PR TITLE
PoC: Add executable-doc based agent skills with context-aware command/guidance responses

### DIFF
--- a/scripts/ci/agent_skills/breeze_context.py
+++ b/scripts/ci/agent_skills/breeze_context.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Context detection helpers for the agent-skills PoC."""
+
+from __future__ import annotations
+
+import os
+
+
+def get_context() -> str:
+    """Return the current execution context.
+
+    For the first PoC, we keep detection intentionally simple:
+    - if AIRFLOW_BREEZE_CONTAINER=1, treat it as Breeze
+    - otherwise treat it as host
+
+    :return: "breeze" if inside Breeze, otherwise "host"
+    """
+    if os.environ.get("AIRFLOW_BREEZE_CONTAINER") == "1":
+        return "breeze"
+    return "host"

--- a/scripts/ci/agent_skills/decision_engine.py
+++ b/scripts/ci/agent_skills/decision_engine.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Decision engine for choosing workflow commands in the agent-skills PoC."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.ci.agent_skills.breeze_context import get_context
+
+
+def load_skills() -> dict[str, dict[str, Any]]:
+    """Load extracted skills from skills.json and index them by workflow ID."""
+    base_dir = Path(__file__).resolve().parent
+    skills_path = base_dir / "skills.json"
+
+    data = json.loads(skills_path.read_text(encoding="utf-8"))
+    return {skill["id"]: skill for skill in data}
+
+
+def get_workflow_definition(workflow_id: str) -> dict[str, Any]:
+    """Return the extracted workflow definition for a given workflow ID."""
+    skills = load_skills()
+
+    if workflow_id not in skills:
+        raise ValueError(f"Unknown workflow_id: {workflow_id}")
+
+    return skills[workflow_id]
+
+
+def get_recommended_command(
+    workflow_id: str,
+    test_path: str,
+    distribution_folder: str = "distribution_folder",
+    force_breeze_fallback: bool = False,
+    context: str | None = None,
+) -> dict[str, Any]:
+    """Return the recommended command or guidance for a workflow.
+
+    The decision logic for the first PoC is:
+
+    - If context is "breeze", run the inside-Breeze command directly.
+    - If context is "host" and fallback is forced, return Breeze command.
+    - If context is "host" and fallback is not forced, return local command.
+    """
+    workflow = get_workflow_definition(workflow_id)
+    current_context = context or get_context()
+
+    if current_context not in workflow["allowed_contexts"]:
+        return {
+            "mode": "guidance",
+            "message": (f"Unsupported context '{current_context}' for workflow '{workflow_id}'."),
+        }
+
+    if current_context == "breeze":
+        return {
+            "mode": "command",
+            "command": workflow["inside_breeze_command"].format(test_path=test_path),
+            "reason": "Already inside Breeze, so run pytest directly.",
+        }
+
+    if current_context == "host":
+        if force_breeze_fallback:
+            return {
+                "mode": "command",
+                "command": workflow["breeze_command"].format(test_path=test_path),
+                "reason": (
+                    "Host context requested Breeze fallback due to environment or dependency concerns."
+                ),
+            }
+
+        return {
+            "mode": "command",
+            "command": workflow["local_command"].format(
+                distribution_folder=distribution_folder,
+                test_path=test_path,
+            ),
+            "reason": "Host context prefers local-first execution.",
+        }
+
+    return {
+        "mode": "guidance",
+        "message": "Could not determine a valid command for the workflow.",
+    }

--- a/scripts/ci/agent_skills/decision_engine.py
+++ b/scripts/ci/agent_skills/decision_engine.py
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 """Decision engine for choosing workflow commands in the agent-skills PoC."""
 
 from __future__ import annotations
@@ -47,33 +30,41 @@ def get_workflow_definition(workflow_id: str) -> dict[str, Any]:
 
 def get_recommended_command(
     workflow_id: str,
-    test_path: str,
+    test_path: str = "",
     distribution_folder: str = "distribution_folder",
     force_breeze_fallback: bool = False,
     context: str | None = None,
 ) -> dict[str, Any]:
-    """Return the recommended command or guidance for a workflow.
-
-    The decision logic for the first PoC is:
-
-    - If context is "breeze", run the inside-Breeze command directly.
-    - If context is "host" and fallback is forced, return Breeze command.
-    - If context is "host" and fallback is not forced, return local command.
-    """
+    """Return the recommended command or guidance for a workflow."""
     workflow = get_workflow_definition(workflow_id)
     current_context = context or get_context()
 
     if current_context not in workflow["allowed_contexts"]:
         return {
             "mode": "guidance",
-            "message": (f"Unsupported context '{current_context}' for workflow '{workflow_id}'."),
+            "message": (
+                f"Unsupported context '{current_context}' "
+                f"for workflow '{workflow_id}'."
+            ),
         }
 
     if current_context == "breeze":
+        inside_command = workflow["inside_breeze_command"]
+
+        if inside_command == "NONE":
+            return {
+                "mode": "guidance",
+                "message": (
+                    "You are already inside Breeze. "
+                    "Do not start a new Breeze shell from here."
+                ),
+                "next_action": "stay_in_current_context",
+            }
+
         return {
             "mode": "command",
-            "command": workflow["inside_breeze_command"].format(test_path=test_path),
-            "reason": "Already inside Breeze, so run pytest directly.",
+            "command": inside_command.format(test_path=test_path),
+            "reason": "Already inside Breeze, so run the container command directly.",
         }
 
     if current_context == "host":
@@ -82,7 +73,8 @@ def get_recommended_command(
                 "mode": "command",
                 "command": workflow["breeze_command"].format(test_path=test_path),
                 "reason": (
-                    "Host context requested Breeze fallback due to environment or dependency concerns."
+                    "Host context requested Breeze fallback due to "
+                    "environment or dependency concerns."
                 ),
             }
 

--- a/scripts/ci/agent_skills/decision_engine.py
+++ b/scripts/ci/agent_skills/decision_engine.py
@@ -1,4 +1,26 @@
-"""Decision engine for choosing workflow commands in the agent-skills PoC."""
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Return a workflow-aware response for the given workflow and context.
+
+The response can be either:
+- a runnable command
+- structured guidance when command execution is not appropriate
+"""
 
 from __future__ import annotations
 
@@ -31,7 +53,7 @@ def get_workflow_definition(workflow_id: str) -> dict[str, Any]:
 def get_recommended_command(
     workflow_id: str,
     test_path: str = "",
-    distribution_folder: str = "distribution_folder",
+    project: str = "airflow-core",
     force_breeze_fallback: bool = False,
     context: str | None = None,
 ) -> dict[str, Any]:
@@ -42,10 +64,7 @@ def get_recommended_command(
     if current_context not in workflow["allowed_contexts"]:
         return {
             "mode": "guidance",
-            "message": (
-                f"Unsupported context '{current_context}' "
-                f"for workflow '{workflow_id}'."
-            ),
+            "message": (f"Unsupported context '{current_context}' for workflow '{workflow_id}'."),
         }
 
     if current_context == "breeze":
@@ -54,10 +73,7 @@ def get_recommended_command(
         if inside_command == "NONE":
             return {
                 "mode": "guidance",
-                "message": (
-                    "You are already inside Breeze. "
-                    "Do not start a new Breeze shell from here."
-                ),
+                "message": ("You are already inside Breeze. Do not start a new Breeze shell from here."),
                 "next_action": "stay_in_current_context",
             }
 
@@ -73,15 +89,14 @@ def get_recommended_command(
                 "mode": "command",
                 "command": workflow["breeze_command"].format(test_path=test_path),
                 "reason": (
-                    "Host context requested Breeze fallback due to "
-                    "environment or dependency concerns."
+                    "Host context requested Breeze fallback due to environment or dependency concerns."
                 ),
             }
 
         return {
             "mode": "command",
             "command": workflow["local_command"].format(
-                distribution_folder=distribution_folder,
+                project=project,
                 test_path=test_path,
             ),
             "reason": "Host context prefers local-first execution.",

--- a/scripts/ci/agent_skills/extract_agent_skills.py
+++ b/scripts/ci/agent_skills/extract_agent_skills.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Extract structured agent-skill blocks from a markdown PoC file."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+START_MARKER = "<!-- agent-skill:start -->"
+END_MARKER = "<!-- agent-skill:end -->"
+
+
+def parse_skill_block(block_text: str) -> dict[str, object]:
+    """Parse one agent-skill block into a dictionary."""
+    parsed: dict[str, object] = {}
+
+    for raw_line in block_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if ":" not in line:
+            raise ValueError(f"Invalid line in skill block: {line}")
+
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+
+        if key == "allowed_contexts":
+            parsed[key] = [item.strip() for item in value.split(",") if item.strip()]
+        elif key == "fallback_when":
+            parsed[key] = [item.strip() for item in value.split("|") if item.strip()]
+        else:
+            parsed[key] = value
+
+    required_keys = {
+        "id",
+        "title",
+        "preferred_context",
+        "allowed_contexts",
+        "local_command",
+        "breeze_command",
+        "inside_breeze_command",
+        "fallback_when",
+    }
+
+    missing = required_keys - parsed.keys()
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"Missing required keys: {missing_list}")
+
+    return parsed
+
+
+def extract_skills_from_text(text: str) -> list[dict[str, object]]:
+    """Extract all agent-skill blocks from markdown text."""
+    skills: list[dict[str, object]] = []
+    cursor = 0
+
+    while True:
+        start = text.find(START_MARKER, cursor)
+        if start == -1:
+            break
+
+        end = text.find(END_MARKER, start)
+        if end == -1:
+            raise ValueError("Found start marker without matching end marker.")
+
+        block_start = start + len(START_MARKER)
+        block_text = text[block_start:end].strip()
+        skills.append(parse_skill_block(block_text))
+
+        cursor = end + len(END_MARKER)
+
+    return skills
+
+
+def extract_skills_from_file(input_path: Path) -> list[dict[str, object]]:
+    """Read a markdown file and extract all skill blocks."""
+    text = input_path.read_text(encoding="utf-8")
+    return extract_skills_from_text(text)
+
+
+def write_skills_json(skills: list[dict[str, object]], output_path: Path) -> None:
+    """Write extracted skills to a JSON file."""
+    output_path.write_text(
+        json.dumps(skills, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    """Extract skills from the PoC markdown file and write skills.json."""
+    base_dir = Path(__file__).resolve().parent
+    input_path = base_dir / "poc_agent_skills.md"
+    output_path = base_dir / "skills.json"
+
+    skills = extract_skills_from_file(input_path)
+    write_skills_json(skills, output_path)
+
+    print(f"Wrote {len(skills)} skill(s) to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/agent_skills/poc_agent_skills.md
+++ b/scripts/ci/agent_skills/poc_agent_skills.md
@@ -1,0 +1,31 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# PoC Agent Skills
+
+<!-- agent-skill:start -->
+id: run_targeted_tests
+title: Run targeted tests
+preferred_context: host
+allowed_contexts: host,breeze
+local_command: uv run --project {distribution_folder} pytest {test_path}
+breeze_command: breeze exec pytest {test_path} -xvs
+inside_breeze_command: pytest {test_path} -xvs
+fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
+<!-- agent-skill:end -->

--- a/scripts/ci/agent_skills/poc_agent_skills.md
+++ b/scripts/ci/agent_skills/poc_agent_skills.md
@@ -22,10 +22,11 @@
 <!-- agent-skill:start -->
 id: run_targeted_tests
 title: Run targeted tests
+description: Run targeted tests using uv locally, falling back to Breeze when system dependencies are missing or results differ from CI
 preferred_context: host
 allowed_contexts: host,breeze
-local_command: uv run --project {distribution_folder} pytest {test_path}
-breeze_command: breeze exec pytest {test_path} -xvs
+local_command: uv run --project {project} pytest {test_path} -xvs
+breeze_command: breeze run pytest {test_path} -xvs
 inside_breeze_command: pytest {test_path} -xvs
 fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
 <!-- agent-skill:end -->
@@ -33,10 +34,11 @@ fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_d
 <!-- agent-skill:start -->
 id: setup_breeze_environment
 title: Set up Breeze environment
+description: Set up Breeze environment from host; should not be executed inside Breeze container
 preferred_context: host
 allowed_contexts: host,breeze
 local_command: breeze shell
 breeze_command: breeze shell
 inside_breeze_command: NONE
-fallback_when: not_applicable
+fallback_when: none
 <!-- agent-skill:end -->

--- a/scripts/ci/agent_skills/poc_agent_skills.md
+++ b/scripts/ci/agent_skills/poc_agent_skills.md
@@ -29,3 +29,14 @@ breeze_command: breeze exec pytest {test_path} -xvs
 inside_breeze_command: pytest {test_path} -xvs
 fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
 <!-- agent-skill:end -->
+
+<!-- agent-skill:start -->
+id: setup_breeze_environment
+title: Set up Breeze environment
+preferred_context: host
+allowed_contexts: host,breeze
+local_command: breeze shell
+breeze_command: breeze shell
+inside_breeze_command: NONE
+fallback_when: not_applicable
+<!-- agent-skill:end -->

--- a/scripts/ci/agent_skills/skills.json
+++ b/scripts/ci/agent_skills/skills.json
@@ -4,7 +4,8 @@
       "host",
       "breeze"
     ],
-    "breeze_command": "breeze exec pytest {test_path} -xvs",
+    "breeze_command": "breeze run pytest {test_path} -xvs",
+    "description": "Run targeted tests using uv locally, falling back to Breeze when system dependencies are missing or results differ from CI",
     "fallback_when": [
       "missing_system_dependencies",
       "local_environment_mismatch",
@@ -12,7 +13,7 @@
     ],
     "id": "run_targeted_tests",
     "inside_breeze_command": "pytest {test_path} -xvs",
-    "local_command": "uv run --project {distribution_folder} pytest {test_path}",
+    "local_command": "uv run --project {project} pytest {test_path} -xvs",
     "preferred_context": "host",
     "title": "Run targeted tests"
   },
@@ -22,8 +23,9 @@
       "breeze"
     ],
     "breeze_command": "breeze shell",
+    "description": "Set up Breeze environment from host; should not be executed inside Breeze container",
     "fallback_when": [
-      "not_applicable"
+      "none"
     ],
     "id": "setup_breeze_environment",
     "inside_breeze_command": "NONE",

--- a/scripts/ci/agent_skills/skills.json
+++ b/scripts/ci/agent_skills/skills.json
@@ -15,5 +15,20 @@
     "local_command": "uv run --project {distribution_folder} pytest {test_path}",
     "preferred_context": "host",
     "title": "Run targeted tests"
+  },
+  {
+    "allowed_contexts": [
+      "host",
+      "breeze"
+    ],
+    "breeze_command": "breeze shell",
+    "fallback_when": [
+      "not_applicable"
+    ],
+    "id": "setup_breeze_environment",
+    "inside_breeze_command": "NONE",
+    "local_command": "breeze shell",
+    "preferred_context": "host",
+    "title": "Set up Breeze environment"
   }
 ]

--- a/scripts/ci/agent_skills/skills.json
+++ b/scripts/ci/agent_skills/skills.json
@@ -1,0 +1,19 @@
+[
+  {
+    "allowed_contexts": [
+      "host",
+      "breeze"
+    ],
+    "breeze_command": "breeze exec pytest {test_path} -xvs",
+    "fallback_when": [
+      "missing_system_dependencies",
+      "local_environment_mismatch",
+      "ci_local_discrepancy"
+    ],
+    "id": "run_targeted_tests",
+    "inside_breeze_command": "pytest {test_path} -xvs",
+    "local_command": "uv run --project {distribution_folder} pytest {test_path}",
+    "preferred_context": "host",
+    "title": "Run targeted tests"
+  }
+]

--- a/scripts/ci/agent_skills/workflow_definitions.py
+++ b/scripts/ci/agent_skills/workflow_definitions.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""DEPRECATED: Initial PoC workflow definitions.
+
+This module was used in the first stage of the PoC where workflows were
+hardcoded in Python. It is no longer used after introducing executable
+documentation and skill extraction from markdown.
+
+Kept temporarily for reference and comparison.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+WORKFLOWS: dict[str, dict[str, Any]] = {
+    "run_targeted_tests": {
+        "id": "run_targeted_tests",
+        "title": "Run targeted tests",
+        "goal": (
+            "Run a specific pytest target using the preferred local workflow "
+            "on host, with Breeze fallback when local execution is not suitable."
+        ),
+        "preferred_context": "host",
+        "allowed_contexts": ["host", "breeze"],
+        "local_command": ("uv run --project {distribution_folder} pytest {test_path}"),
+        "breeze_command": ("breeze exec pytest {test_path} -xvs"),
+        "inside_breeze_command": ("pytest {test_path} -xvs"),
+        "fallback_when": [
+            "missing_system_dependencies",
+            "local_environment_mismatch",
+            "ci_local_discrepancy",
+        ],
+        "wrong_context_guidance": {
+            "host_only_step_inside_breeze": (
+                "You are already inside a Breeze container. "
+                "Do not start a new Breeze shell. Run the test command directly."
+            ),
+            "breeze_required_but_unavailable": (
+                "Local execution is not suitable for this case. Use Breeze for reproducible test execution."
+            ),
+        },
+    }
+}
+
+
+def get_workflow_definition(workflow_id: str) -> dict[str, Any]:
+    """Return the workflow definition for a known workflow ID.
+
+    :param workflow_id: Identifier of the workflow.
+    :return: Workflow definition dictionary.
+    :raises ValueError: If the workflow ID is unknown.
+    """
+    if workflow_id not in WORKFLOWS:
+        raise ValueError(f"Unknown workflow_id: {workflow_id}")
+    return WORKFLOWS[workflow_id]

--- a/scripts/ci/pre_commit/tests/test_breeze_context.py
+++ b/scripts/ci/pre_commit/tests/test_breeze_context.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for breeze context detection."""
+
+from __future__ import annotations
+
+from scripts.ci.agent_skills.breeze_context import get_context
+
+
+def test_get_context_defaults_to_host(monkeypatch):
+    monkeypatch.delenv("AIRFLOW_BREEZE_CONTAINER", raising=False)
+    assert get_context() == "host"
+
+
+def test_get_context_detects_breeze(monkeypatch):
+    monkeypatch.setenv("AIRFLOW_BREEZE_CONTAINER", "1")
+    assert get_context() == "breeze"

--- a/scripts/ci/pre_commit/tests/test_decision_engine.py
+++ b/scripts/ci/pre_commit/tests/test_decision_engine.py
@@ -27,10 +27,11 @@ def test_host_prefers_local_command():
         workflow_id="run_targeted_tests",
         test_path="tests/models/test_example.py",
         context="host",
+        project="airflow-core",
     )
 
     assert result["mode"] == "command"
-    assert result["command"] == "uv run --project distribution_folder pytest tests/models/test_example.py"
+    assert result["command"] == "uv run --project airflow-core pytest tests/models/test_example.py -xvs"
     assert result["reason"] == "Host context prefers local-first execution."
 
 
@@ -43,7 +44,7 @@ def test_host_falls_back_to_breeze():
     )
 
     assert result["mode"] == "command"
-    assert result["command"] == "breeze exec pytest tests/models/test_example.py -xvs"
+    assert result["command"] == "breeze run pytest tests/models/test_example.py -xvs"
 
 
 def test_inside_breeze_runs_direct_pytest():
@@ -55,7 +56,8 @@ def test_inside_breeze_runs_direct_pytest():
 
     assert result["mode"] == "command"
     assert result["command"] == "pytest tests/models/test_example.py -xvs"
-    
+
+
 def test_setup_breeze_environment_inside_breeze_returns_guidance():
     result = get_recommended_command(
         workflow_id="setup_breeze_environment",
@@ -65,7 +67,8 @@ def test_setup_breeze_environment_inside_breeze_returns_guidance():
     assert result["mode"] == "guidance"
     assert "already inside Breeze" in result["message"]
     assert result["next_action"] == "stay_in_current_context"
-    
+
+
 def test_setup_breeze_environment_on_host_returns_command():
     result = get_recommended_command(
         workflow_id="setup_breeze_environment",

--- a/scripts/ci/pre_commit/tests/test_decision_engine.py
+++ b/scripts/ci/pre_commit/tests/test_decision_engine.py
@@ -55,3 +55,22 @@ def test_inside_breeze_runs_direct_pytest():
 
     assert result["mode"] == "command"
     assert result["command"] == "pytest tests/models/test_example.py -xvs"
+    
+def test_setup_breeze_environment_inside_breeze_returns_guidance():
+    result = get_recommended_command(
+        workflow_id="setup_breeze_environment",
+        context="breeze",
+    )
+
+    assert result["mode"] == "guidance"
+    assert "already inside Breeze" in result["message"]
+    assert result["next_action"] == "stay_in_current_context"
+    
+def test_setup_breeze_environment_on_host_returns_command():
+    result = get_recommended_command(
+        workflow_id="setup_breeze_environment",
+        context="host",
+    )
+
+    assert result["mode"] == "command"
+    assert result["command"] == "breeze shell"

--- a/scripts/ci/pre_commit/tests/test_decision_engine.py
+++ b/scripts/ci/pre_commit/tests/test_decision_engine.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the agent-skills decision engine."""
+
+from __future__ import annotations
+
+from scripts.ci.agent_skills.decision_engine import get_recommended_command
+
+
+def test_host_prefers_local_command():
+    result = get_recommended_command(
+        workflow_id="run_targeted_tests",
+        test_path="tests/models/test_example.py",
+        context="host",
+    )
+
+    assert result["mode"] == "command"
+    assert result["command"] == "uv run --project distribution_folder pytest tests/models/test_example.py"
+    assert result["reason"] == "Host context prefers local-first execution."
+
+
+def test_host_falls_back_to_breeze():
+    result = get_recommended_command(
+        workflow_id="run_targeted_tests",
+        test_path="tests/models/test_example.py",
+        context="host",
+        force_breeze_fallback=True,
+    )
+
+    assert result["mode"] == "command"
+    assert result["command"] == "breeze exec pytest tests/models/test_example.py -xvs"
+
+
+def test_inside_breeze_runs_direct_pytest():
+    result = get_recommended_command(
+        workflow_id="run_targeted_tests",
+        test_path="tests/models/test_example.py",
+        context="breeze",
+    )
+
+    assert result["mode"] == "command"
+    assert result["command"] == "pytest tests/models/test_example.py -xvs"

--- a/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
+++ b/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
@@ -31,7 +31,7 @@ def test_parse_skill_block_success():
     title: Run targeted tests
     preferred_context: host
     allowed_contexts: host,breeze
-    local_command: uv run --project {distribution_folder} pytest {test_path}
+    local_command: uv run --project {project} pytest {test_path}
     breeze_command: breeze exec pytest {test_path} -xvs
     inside_breeze_command: pytest {test_path} -xvs
     fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
@@ -58,7 +58,7 @@ def test_extract_skills_from_text_success():
     title: Run targeted tests
     preferred_context: host
     allowed_contexts: host,breeze
-    local_command: uv run --project {distribution_folder} pytest {test_path}
+    local_command: uv run --project {project} pytest {test_path}
     breeze_command: breeze exec pytest {test_path} -xvs
     inside_breeze_command: pytest {test_path} -xvs
     fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
@@ -96,7 +96,8 @@ def test_parse_skill_block_missing_required_keys_raises():
         assert False, "Expected ValueError for missing required keys"
     except ValueError as error:
         assert "Missing required keys" in str(error)
-        
+
+
 def test_extract_skills_from_text_multiple_blocks():
     text = """
     <!-- agent-skill:start -->
@@ -104,7 +105,7 @@ def test_extract_skills_from_text_multiple_blocks():
     title: Run targeted tests
     preferred_context: host
     allowed_contexts: host,breeze
-    local_command: uv run --project {distribution_folder} pytest {test_path}
+    local_command: uv run --project {project} pytest {test_path}
     breeze_command: breeze exec pytest {test_path} -xvs
     inside_breeze_command: pytest {test_path} -xvs
     fallback_when: missing_system_dependencies|local_environment_mismatch

--- a/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
+++ b/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
@@ -96,3 +96,34 @@ def test_parse_skill_block_missing_required_keys_raises():
         assert False, "Expected ValueError for missing required keys"
     except ValueError as error:
         assert "Missing required keys" in str(error)
+        
+def test_extract_skills_from_text_multiple_blocks():
+    text = """
+    <!-- agent-skill:start -->
+    id: run_targeted_tests
+    title: Run targeted tests
+    preferred_context: host
+    allowed_contexts: host,breeze
+    local_command: uv run --project {distribution_folder} pytest {test_path}
+    breeze_command: breeze exec pytest {test_path} -xvs
+    inside_breeze_command: pytest {test_path} -xvs
+    fallback_when: missing_system_dependencies|local_environment_mismatch
+    <!-- agent-skill:end -->
+
+    <!-- agent-skill:start -->
+    id: setup_breeze_environment
+    title: Set up Breeze environment
+    preferred_context: host
+    allowed_contexts: host,breeze
+    local_command: breeze shell
+    breeze_command: breeze shell
+    inside_breeze_command: NONE
+    fallback_when: not_applicable
+    <!-- agent-skill:end -->
+    """
+
+    skills = extract_skills_from_text(text)
+
+    assert len(skills) == 2
+    assert skills[0]["id"] == "run_targeted_tests"
+    assert skills[1]["id"] == "setup_breeze_environment"

--- a/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
+++ b/scripts/ci/pre_commit/tests/test_extract_agent_skills.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for agent skill extraction."""
+
+from __future__ import annotations
+
+from scripts.ci.agent_skills.extract_agent_skills import (
+    extract_skills_from_text,
+    parse_skill_block,
+)
+
+
+def test_parse_skill_block_success():
+    block = """
+    id: run_targeted_tests
+    title: Run targeted tests
+    preferred_context: host
+    allowed_contexts: host,breeze
+    local_command: uv run --project {distribution_folder} pytest {test_path}
+    breeze_command: breeze exec pytest {test_path} -xvs
+    inside_breeze_command: pytest {test_path} -xvs
+    fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
+    """
+
+    parsed = parse_skill_block(block)
+
+    assert parsed["id"] == "run_targeted_tests"
+    assert parsed["preferred_context"] == "host"
+    assert parsed["allowed_contexts"] == ["host", "breeze"]
+    assert parsed["fallback_when"] == [
+        "missing_system_dependencies",
+        "local_environment_mismatch",
+        "ci_local_discrepancy",
+    ]
+
+
+def test_extract_skills_from_text_success():
+    text = """
+    # PoC Agent Skills
+
+    <!-- agent-skill:start -->
+    id: run_targeted_tests
+    title: Run targeted tests
+    preferred_context: host
+    allowed_contexts: host,breeze
+    local_command: uv run --project {distribution_folder} pytest {test_path}
+    breeze_command: breeze exec pytest {test_path} -xvs
+    inside_breeze_command: pytest {test_path} -xvs
+    fallback_when: missing_system_dependencies|local_environment_mismatch|ci_local_discrepancy
+    <!-- agent-skill:end -->
+    """
+
+    skills = extract_skills_from_text(text)
+
+    assert len(skills) == 1
+    assert skills[0]["id"] == "run_targeted_tests"
+
+
+def test_extract_skills_from_text_missing_end_marker_raises():
+    text = """
+    <!-- agent-skill:start -->
+    id: run_targeted_tests
+    title: Run targeted tests
+    """
+
+    try:
+        extract_skills_from_text(text)
+        assert False, "Expected ValueError for missing end marker"
+    except ValueError as error:
+        assert "matching end marker" in str(error)
+
+
+def test_parse_skill_block_missing_required_keys_raises():
+    block = """
+    id: run_targeted_tests
+    title: Run targeted tests
+    """
+
+    try:
+        parse_skill_block(block)
+        assert False, "Expected ValueError for missing required keys"
+    except ValueError as error:
+        assert "Missing required keys" in str(error)


### PR DESCRIPTION
### Summary

This PR introduces a small PoC for modeling Airflow contributor workflows as structured, executable agent skills, with context-aware command selection.

The goal is to explore a narrow vertical slice of the problem described in #62500 , focusing on workflow semantics rather than broad coverage.
---

### What is implemented

#### 1. Structured workflow blocks (Executable-doc style)

Two workflows are defined in a markdown file using structured blocks:

- `run_targeted_tests`
  - local-first (`uv run --project ... pytest`)
  - Breeze fallback (`breeze run pytest`) when system dependencies are missing

- `setup_breeze_environment`
  - host-only workflow
  - returns guidance when invoked inside Breeze instead of suggesting incorrect commands
---

#### 2. Extraction pipeline

A lightweight extractor converts structured blocks into machine-readable skill definitions:

```
Markdown → Extractor → skills.json
```

---

#### 3. Context-aware decision engine

A simple decision engine consumes `skills.json` and returns the appropriate response based on execution context:

- detects `host` vs `breeze`
- applies local-first vs fallback logic
- prevents invalid operations across contexts

---

#### 4. Command vs Guidance response model

Instead of returning only commands, the PoC introduces a response contract:

```json
{ "mode": "command", "command": "...", "reason": "..." }

{ "mode": "guidance", "message": "...", "next_action": "..." }
```

This allows modeling workflows where the correct action is not execution, but a context-aware transition.

Example:
- running `setup_breeze_environment` inside Breeze returns guidance instead of suggesting `breeze shell`

---

#### 5. Tests

Unit tests cover:

- skill extraction
- context detection
- decision logic
- command vs guidance behavior

---

### Why this approach

This PoC explores whether:

> agent-facing interfaces should return structured workflow-aware responses (command or guidance), rather than only raw commands.

This may better reflect real contributor workflows where:
- some actions are executable
- others require environment/context adjustments first

---

### Scope

This is intentionally limited to:
- 2 workflows
- basic context detection
- minimal extraction pipeline

It does not yet include:
- full contributor-doc integration
- drift detection / prek hooks
- multiple workflow categories

---
Related: #62500 
