### PR TITLE
feat(providers): migrate conf imports to SDK for informatica, common-ai + fix missed files

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -65,7 +65,7 @@ class HITLReviewLink(BaseOperatorLink):
             return ""
         from urllib.parse import urlparse
 
-        from airflow.configuration import conf
+        from airflow.providers.common.compat.sdk import conf
 
         base_url = conf.get("api", "base_url", fallback="/")
         if base_url.startswith(("http://", "https://")):

--- a/providers/common/ai/src/airflow/providers/common/ai/plugins/hitl_review.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/plugins/hitl_review.py
@@ -31,7 +31,7 @@ from sqlalchemy.orm import Session
 
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
 from airflow.api_fastapi.core_api.security import requires_access_dag
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.models.xcom import XComModel
 from airflow.plugins_manager import AirflowPlugin

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -41,7 +41,7 @@ from elasticsearch import helpers
 from elasticsearch.exceptions import NotFoundError
 
 import airflow.logging_config as alc
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.models.dagrun import DagRun
 from airflow.providers.elasticsearch.log.es_json_formatter import ElasticsearchJSONFormatter
 from airflow.providers.elasticsearch.log.es_response import ElasticSearchResponse, Hit, resolve_nested

--- a/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 from google.genai.errors import ClientError
 from google.genai.types import BatchJob
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.gen_ai import (
     BatchJobStatus,

--- a/providers/informatica/src/airflow/providers/informatica/hooks/edc.py
+++ b/providers/informatica/src/airflow/providers/informatica/hooks/edc.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from requests.exceptions import RequestException
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.http.hooks.http import HttpHook
 
 if TYPE_CHECKING:

--- a/providers/informatica/src/airflow/providers/informatica/plugins/informatica.py
+++ b/providers/informatica/src/airflow/providers/informatica/plugins/informatica.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.plugins_manager import AirflowPlugin
 
 is_disabled = conf.getboolean("informatica", "listener_disabled", fallback=False)

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py
@@ -47,7 +47,7 @@ from airflow.cli.cli_config import CLICommand
 try:
     from airflow.providers.common.compat.sdk import AirflowException, conf
 except ModuleNotFoundError:
-    from airflow.configuration import conf
+    from airflow.providers.common.compat.sdk import conf
     from airflow.exceptions import AirflowException
 from airflow.providers.keycloak.auth_manager.cache import single_flight
 from airflow.providers.keycloak.auth_manager.constants import (

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/powerbi.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, BaseOperatorLink
 from airflow.providers.microsoft.azure.hooks.powerbi import PowerBIHook
 from airflow.providers.microsoft.azure.triggers.powerbi import (


### PR DESCRIPTION
## What this PR does

Migrates `from airflow.configuration import conf` → `from airflow.providers.common.compat.sdk import conf` for providers not yet tracked or missed in previous PRs.

### New providers (not listed in #60000):
- **informatica** (2 files)
- **common/ai** (2 files)

### Missed files from completed PRs:
- **elasticsearch** (1 file - missed in #60030)
- **google** (1 file - missed in #59986)
- **keycloak** (1 file - missed in #60092)
- **microsoft/azure** (1 file - missed in #60030)

All affected providers already depend on `apache-airflow-providers-common-compat>=1.12.0` or higher, which includes the `conf` export in `sdk.py`. No `pyproject.toml` changes needed.

Part of #60000