### PR TITLE
Ensure gh CLI auth in Slack notification workflows

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -966,7 +966,10 @@ jobs:
       - name: "Determine notification action"
         id: notification
         shell: bash
-        run: python3 scripts/ci/slack_notification_state.py
+        run: |
+          command -v gh >/dev/null 2>&1 || { echo "::error::gh CLI is not installed"; exit 1; }
+          gh auth status || gh auth login --with-token <<< "${GITHUB_TOKEN}"
+          python3 scripts/ci/slack_notification_state.py
         env:
           ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}"
           CURRENT_FAILURES: "${{ steps.get-failures.outputs.failed-jobs }}"

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -58,7 +58,10 @@ jobs:
       - name: "Determine notification action"
         id: notification
         shell: bash
-        run: python3 scripts/ci/slack_notification_state.py
+        run: |
+          command -v gh >/dev/null 2>&1 || { echo "::error::gh CLI is not installed"; exit 1; }
+          gh auth status || gh auth login --with-token <<< "${GITHUB_TOKEN}"
+          python3 scripts/ci/slack_notification_state.py
         env:
           ARTIFACT_NAME: "slack-state-ci-${{ matrix.branch }}-${{ matrix.workflow-id }}"
           CURRENT_FAILURES: "${{ steps.find-workflow-run-status.outputs.failed-jobs }}"


### PR DESCRIPTION
Ensure gh CLI is installed and authenticated before running the Slack notification state script in CI workflows. This prevents failures when the gh CLI token isn't set up.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)