### PR TITLE
Docs: add missing words to spelling wordlist

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -106,6 +106,7 @@ asyncio
 athena
 Atlassian
 atlassian
+atomicity
 attr
 attrs
 au
@@ -215,6 +216,7 @@ celltags
 centric
 cfg
 cgi
+cgitb
 chakra
 Changelog
 changelog
@@ -285,6 +287,7 @@ conftest
 conn
 connectTimeoutMS
 connexion
+conns
 containerConfiguration
 containerd
 ContainerGroup
@@ -486,6 +489,7 @@ Docstrings
 docstrings
 doesn
 doesnt
+dom
 Dont
 DownloadReportV
 downscaling
@@ -935,6 +939,7 @@ len
 leq
 LevelDB
 leveldb
+lexicographically
 libs
 libz
 Lifecycle
@@ -1145,6 +1150,7 @@ Paramiko
 paramiko
 Params
 params
+parsers
 passwd
 pathlib
 pathType
@@ -1205,6 +1211,7 @@ preemptible
 prefetch
 prefetched
 prefetches
+preflight
 prek
 Preload
 prepend
@@ -1212,6 +1219,7 @@ prepended
 preprocess
 Preprocessed
 preprocessing
+preselected
 presign
 presigned
 prestodb
@@ -1298,6 +1306,7 @@ Realtime
 realtime
 rebase
 Rebasing
+Recency
 recurse
 redelivery
 Redhat
@@ -1331,6 +1340,7 @@ resetdb
 resizable
 ResourceRequirements
 resourceVersion
+responder
 reStructuredText
 resultset
 resumable
@@ -1400,6 +1410,7 @@ seealso
 seedlist
 seekable
 segmentGranularity
+selectable
 selectin
 Sendgrid
 sendgrid


### PR DESCRIPTION
Add 11 missing words to the spelling wordlist: atomicity, cgitb, conns, dom, lexicographically, parsers, preflight, preselected, Recency, responder, selectable.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)