### PR TITLE
Fix Airflow dist URL in helm chart release docs

### DIFF
--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -456,7 +456,7 @@ The legal checks include:
 ## SVN check
 
 The files should be present in the sub-folder of
-[Airflow dist](https://dist.apache.org/repos/dist/dev/airflow/)
+[Airflow dist - helm-chart](https://dist.apache.org/repos/dist/dev/airflow/helm-chart/)
 
 The following files should be present (7 files):
 


### PR DESCRIPTION
Fix the Airflow dist link in helm chart release documentation to point to the correct `helm-chart/` subdirectory instead of the top-level dist directory.

related: #64040

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)