### PR TITLE
avoid unnecessary COUNT queries in slice endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -157,58 +157,63 @@ def get_mapped_xcom_by_slice(
 
     step = params.step or 1
 
-    # We want to optimize negative slicing (e.g. seq[-10:]) by not doing an
-    # additional COUNT query if possible. This is possible unless both start and
-    # stop are explicitly given and have different signs.
-    if (start := params.start) is None:
-        if (stop := params.stop) is None:
+    start = params.start
+    stop = params.stop
+
+    if (
+        start is not None
+        and stop is not None
+        and ((start >= 0 and stop >= 0) or (start < 0 and stop < 0))
+        and ((step > 0 and start >= stop) or (step < 0 and start <= stop))
+    ):
+        # When both bounds are on the same side of zero and the requested
+        # direction conflicts with the step, the slice is empty.
+        return XComSequenceSliceResponse([])
+
+    has_negative_bound = (start is not None and start < 0) or (stop is not None and stop < 0)
+
+    if has_negative_bound:
+        # Negative indices depend on the collection size. Normalize them with
+        # Python's slice semantics before translating the slice to SQL.
+        total_count = get_query_count(query, session=session)
+        start, stop, step = slice(start, stop, step).indices(total_count)
+        if step > 0:
+            if start >= stop:
+                return XComSequenceSliceResponse([])
+            query = query.order_by(XComModel.map_index.asc()).slice(start, stop)
+        else:
+            if start <= stop:
+                return XComSequenceSliceResponse([])
+            query = query.order_by(XComModel.map_index.desc()).slice(
+                total_count - 1 - start,
+                total_count - 1 - stop,
+            )
+            step = -step
+    elif start is None:
+        if stop is None:
             if step >= 0:
                 query = query.order_by(XComModel.map_index.asc())
             else:
                 query = query.order_by(XComModel.map_index.desc())
                 step = -step
-        elif stop >= 0:
+        else:
             query = query.order_by(XComModel.map_index.asc())
             if step >= 0:
                 query = query.limit(stop)
             else:
                 query = query.offset(stop + 1)
-        else:
-            query = query.order_by(XComModel.map_index.desc())
-            step = -step
-            if step > 0:
-                query = query.limit(-stop - 1)
-            else:
-                query = query.offset(-stop)
-    elif start >= 0:
+    else:
         query = query.order_by(XComModel.map_index.asc())
-        if (stop := params.stop) is None:
+        if stop is None:
             if step >= 0:
                 query = query.offset(start)
             else:
                 query = query.limit(start + 1)
         else:
-            if stop < 0:
-                stop += get_query_count(query, session=session)
             if step >= 0:
                 query = query.slice(start, stop)
             else:
                 query = query.slice(stop + 1, start + 1)
-    else:
-        query = query.order_by(XComModel.map_index.desc())
-        step = -step
-        if (stop := params.stop) is None:
-            if step > 0:
-                query = query.offset(-start - 1)
-            else:
-                query = query.limit(-start)
-        else:
-            if stop >= 0:
-                stop -= get_query_count(query, session=session)
-            if step > 0:
-                query = query.slice(-1 - start, -1 - stop)
-            else:
-                query = query.slice(-stop, -start)
 
     values = [row.value for row in session.execute(query.with_only_columns(XComModel.value)).all()]
     if step != 1:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import urllib.parse
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -232,6 +233,10 @@ class TestXComsGetEndpoint:
             pytest.param(slice(-1, None, -1), id="-1::-1"),
             pytest.param(slice(-2, -1, None), id="-2:-1"),
             pytest.param(slice(-1, -3, -1), id="-1:-3:-1"),
+            pytest.param(slice(10, -1, None), id="10:-1"),
+            pytest.param(slice(-1, 10, None), id="-1:10"),
+            pytest.param(slice(1, -10, None), id="1:-10"),
+            pytest.param(slice(1, 2, -1), id="1:2:-1"),
         ],
     )
     def test_xcom_get_with_slice(self, client, dag_maker, session, key):
@@ -322,6 +327,46 @@ class TestXComsGetEndpoint:
         assert response.status_code == 200
 
         assert set(response.json()) == set(expected_xcoms)
+
+    @pytest.mark.parametrize(
+        ("start", "stop", "expected_count_calls"),
+        [
+            pytest.param(None, None, 0, id="no_slice"),
+            pytest.param(5, None, 0, id="positive_start_only"),
+            pytest.param(None, -5, 1, id="negative_stop_only"),
+            pytest.param(-5, None, 1, id="negative_start_only"),
+            pytest.param(5, -3, 1, id="positive_start_negative_stop"),
+            pytest.param(-5, 10, 1, id="negative_start_positive_stop"),
+            pytest.param(-5, -10, 0, id="both_negative_same_sign"),
+        ],
+    )
+    def test_xcom_slice_count_query_called_at_most_once(
+        self, client, dag_maker, session, start, stop, expected_count_calls
+    ):
+        """Test that get_query_count is called at most once for slice requests,
+        and exactly once whenever a negative bound needs normalization.
+
+        Empty slices that can be proven without knowing the collection size
+        still skip the COUNT query.
+        """
+        with dag_maker(dag_id="dag"):
+            EmptyOperator(task_id="task")
+        dag_maker.create_dagrun(run_id="runid")
+
+        with patch("airflow.api_fastapi.execution_api.routes.xcoms.get_query_count") as mock_count:
+            mock_count.return_value = 0
+            qs = {}
+            if start is not None:
+                qs["start"] = start
+            if stop is not None:
+                qs["stop"] = stop
+
+            response = client.get(
+                f"/execution/xcoms/dag/runid/task/test_key/slice?{urllib.parse.urlencode(qs)}"
+            )
+            assert response.status_code == 200
+            assert response.json() == []
+            assert mock_count.call_count == expected_count_calls
 
 
 class TestXComsSetEndpoint:


### PR DESCRIPTION
## Why
The `get_mapped_xcom_by_slice `endpoint previously issued multiple `COUNT `queries in several negative slicing scenarios start or stop were negative. Each` get_query_count(`) call performs an extra database query, which is unnecessary and hurts performance for common slice operations.

This change moves the total count calculation to the top of the function and only executes it when both start and stop are explicitly provided and they have different signs (one positive, one negative). In all other cases involving negative indices we can correctly compute the slice bounds without knowing the total length, avoiding the `COUNT `query entirely.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
