### PR TITLE
remove leftover of `uv.lock` file changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/constraints_version_check.py
@@ -494,7 +494,10 @@ def explain_package_upgrade(
         additional_args.extend(
             ["--group", "dev", "--group", "docs", "--group", "docs-gen", "--group", "leveldb"]
         )
-    with preserve_pyproject_file(AIRFLOW_ROOT_PATH / "pyproject.toml") as airflow_pyproject:
+    with (
+        preserve_pyproject_file(AIRFLOW_ROOT_PATH / "pyproject.toml") as airflow_pyproject,
+        preserve_pyproject_file(AIRFLOW_ROOT_PATH / "uv.lock"),
+    ):
         shell_params = ShellParams(
             github_repository=github_repository,
             python=python_version,


### PR DESCRIPTION
When running
`breeze release-management constraints-version-check --python 3.13 --package google-cloud-storage  --explain-why`
and it results with 
`Package google-cloud-storage can be upgraded from 3.4.1 to 3.10.0 without conflicts..`
The `uv.lock` file changes that were made to test the upgrade are not cleaned as expected.
This PR fix the problem