### PR TITLE
Fix KubernetesExecutor broken by executor validation in worker pods

### DIFF
--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -194,10 +194,12 @@ class DagBag(LoggingMixin):
         known_pools: set[str] | None = None,
         bundle_path: Path | None = None,
         bundle_name: str | None = None,
+        validate_executors: bool = True,
     ):
         super().__init__()
         self.bundle_path = bundle_path
         self.bundle_name = bundle_name
+        self.validate_executors = validate_executors
 
         dag_folder = dag_folder or settings.DAGS_FOLDER
         self.dag_folder = dag_folder
@@ -347,7 +349,8 @@ class DagBag(LoggingMixin):
                     dag.fileloc = filepath
                 # Validate before adding to bag (matches original _process_modules behavior)
                 dag.validate()
-                _validate_executor_fields(dag, self.bundle_name)
+                if self.validate_executors:
+                    _validate_executor_fields(dag, self.bundle_name)
                 self.bag_dag(dag=dag)
                 bagged_dags.append(dag)
             except AirflowClusterPolicySkipDag:

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -325,6 +325,41 @@ def test_validate_executor_field():
         _validate_executor_fields(dag)
 
 
+def test_validate_executors_false_skips_validation(tmp_path):
+    """When validate_executors=False, unknown executors should not cause import errors.
+
+    This is the fix for https://github.com/apache/airflow/issues/56271
+    Worker pods (e.g. KubernetesExecutor) only have LocalExecutor configured,
+    so they should not validate executor fields during DAG parsing.
+    """
+    dag_file = tmp_path / "test_dag.py"
+    dag_file.write_text(
+        textwrap.dedent("""\
+        from airflow.sdk import DAG
+        from airflow.sdk import BaseOperator
+        with DAG("test-dag", schedule=None) as dag:
+            BaseOperator(task_id="t1", executor="KubernetesExecutor")
+        """)
+    )
+    # With validate_executors=True (default), the DAG should fail to load
+    dagbag_strict = DagBag(
+        dag_folder=os.fspath(tmp_path),
+        include_examples=False,
+        validate_executors=True,
+    )
+    assert "test-dag" not in dagbag_strict.dags
+    assert any("UnknownExecutorException" in err for err in dagbag_strict.import_errors.values())
+
+    # With validate_executors=False, the DAG should load successfully
+    dagbag_lenient = DagBag(
+        dag_folder=os.fspath(tmp_path),
+        include_examples=False,
+        validate_executors=False,
+    )
+    assert "test-dag" in dagbag_lenient.dags
+    assert not dagbag_lenient.import_errors
+
+
 class TestDagBag:
     def setup_class(self):
         db_clean_up()

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -766,6 +766,7 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
         load_op_links=False,
         bundle_path=bundle_instance.path,
         bundle_name=bundle_info.name,
+        validate_executors=False,
     )
     if TYPE_CHECKING:
         assert what.ti.dag_id


### PR DESCRIPTION
## Summary

Fixes #56271 — KubernetesExecutor tasks fail with `UnknownExecutorException` in Airflow 3.1.0+.

**Root cause:** `_validate_executor_fields()` in `DagBag.process_file()` runs during DAG parsing in ALL contexts, including inside KubernetesExecutor worker pods. Worker pods are configured with only `LocalExecutor` (via `pod_template_file`), so tasks specifying `executor='KubernetesExecutor'` fail validation even though they are valid.

**Fix:** Add a `validate_executors` parameter to `DagBag` (default `True`) and set it to `False` in the task runner's `parse()` function. Worker pods don't need to validate executor assignments — that's the scheduler/dag-processor's responsibility.

## Changes

| File | Change |
|------|--------|
| `airflow-core/src/airflow/dag_processing/dagbag.py` | Add `validate_executors` param to `DagBag.__init__`, skip `_validate_executor_fields()` when `False` |
| `task-sdk/src/airflow/sdk/execution_time/task_runner.py` | Pass `validate_executors=False` to `BundleDagBag` in `parse()` |
| `airflow-core/tests/unit/dag_processing/test_dagbag.py` | Add test verifying `validate_executors=False` skips validation |

## How it was before vs after

| Context | Before (broken) | After (fixed) |
|---------|-----------------|---------------|
| Scheduler/dag-processor | Validates executors ✅ | Validates executors ✅ |
| K8s worker pod | Validates → **FAILS** ❌ | Skips validation ✅ |
| CLI (`airflow dags list`) | Validates ✅ | Validates ✅ |

## Test plan

- [x] Unit test: `test_validate_executors_false_skips_validation` — DAG with unknown executor loads when `validate_executors=False`, fails when `True`
- [ ] Integration: Deploy on K8s with multi-executor config, trigger task with `executor='KubernetesExecutor'`

closes: #56271