### PR TITLE
Fix webserver configurations

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -694,7 +694,7 @@ Here is the full list of secrets that can be disabled and replaced by ``_CMD`` a
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-jwt-secret``                         | ``.Values.jwtSecretName``                | ``AIRFLOW__API_AUTH__JWT_SECRET``                |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
-| ``<RELEASE_NAME>-webserver-secret-key`` | ``.Values.webserverSecretKeySecretName`` (Deprecated) | ``AIRFLOW__WEBSERVER__SECRET_KEY``
+| ``<RELEASE_NAME>-webserver-secret-key`` | ``.Values.webserverSecretKeySecretName`` (Deprecated) | ``AIRFLOW__WEBSERVER__SECRET_KEY``|
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-airflow-result-backend``             | ``.Values.data.resultBackendSecretName`` | ``AIRFLOW__CELERY__RESULT_BACKEND``              |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+

--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -694,7 +694,7 @@ Here is the full list of secrets that can be disabled and replaced by ``_CMD`` a
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-jwt-secret``                         | ``.Values.jwtSecretName``                | ``AIRFLOW__API_AUTH__JWT_SECRET``                |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
-| ``<RELEASE_NAME>-webserver-secret-key``               | ``.Values.webserverSecretKeySecretName`` | ``AIRFLOW__WEBSERVER__SECRET_KEY``               |
+| ``<RELEASE_NAME>-webserver-secret-key`` | ``.Values.webserverSecretKeySecretName`` (Deprecated) | ``AIRFLOW__WEBSERVER__SECRET_KEY``
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-airflow-result-backend``             | ``.Values.data.resultBackendSecretName`` | ``AIRFLOW__CELERY__RESULT_BACKEND``              |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+

--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -694,7 +694,8 @@ Here is the full list of secrets that can be disabled and replaced by ``_CMD`` a
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-jwt-secret``                         | ``.Values.jwtSecretName``                | ``AIRFLOW__API_AUTH__JWT_SECRET``                |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
-| ``<RELEASE_NAME>-webserver-secret-key`` | ``.Values.webserverSecretKeySecretName`` (Deprecated) | ``AIRFLOW__WEBSERVER__SECRET_KEY``|
+| ``<RELEASE_NAME>-webserver-secret-key``               | ``.Values.webserverSecretKeySecretName`` | ``AIRFLOW__WEBSERVER__SECRET_KEY``               |
+|                                                       | (Deprecated)                             |                                                  |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+
 | ``<RELEASE_NAME>-airflow-result-backend``             | ``.Values.data.resultBackendSecretName`` | ``AIRFLOW__CELERY__RESULT_BACKEND``              |
 +-------------------------------------------------------+------------------------------------------+--------------------------------------------------+

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -644,7 +644,13 @@ DEPRECATION WARNING:
     Please change your values as support for the old name will be dropped in a future release.
 
 {{- end }}
-
+{{- if .Values.webserverSecretKeySecretName }}
+#################################################################################
+# WARNING: `webserverSecretKeySecretName` is deprecated and will be removed.    #
+# The Webserver is replaced by the API server in Airflow 3.0.                   #
+# Please use `apiSecretKeySecretName` instead.                                  #
+#################################################################################
+{{- end }}
 {{- if not (or .Values.webserverSecretKey .Values.webserverSecretKeySecretName .Values.apiSecretKey .Values.apiSecretKeySecretName) }}
 {{ if (semverCompare ">=3.0.0" .Values.airflowVersion) }}
 #####################################################

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1663,6 +1663,7 @@
         },
         "webserverSecretKeySecretName": {
             "description": "The Secret name containing Flask secret_key for the Webserver.",
+            "deprecated": true,
             "type": [
                 "string",
                 "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -565,6 +565,8 @@ jwtSecretName: ~
 webserverSecretKey: ~
 # Add custom annotations to the webserver secret
 webserverSecretAnnotations: {}
+# (DEPRECATED) `webserverSecretKeySecretName` is deprecated.
+# Webserver is removed in Airflow 3.0. Please use `apiSecretKeySecretName` instead.
 webserverSecretKeySecretName: ~
 
 # In order to use kerberos you need to create secret containing the keytab file


### PR DESCRIPTION
### What changes are included in this PR?
This PR deprecates the `webserverSecretKeySecretName` configuration in the Helm Chart, as the Webserver is being removed/replaced by the API server in Airflow 3.0. 

Specifically, this includes:
- Adding a `(DEPRECATED)` note in `chart/values.yaml`.
- Setting `"deprecated": true` in `chart/values.schema.json`.
- Adding a deprecation warning block in `chart/templates/NOTES.txt` to alert users during `helm install`/`upgrade`.
- Updating the table in `chart/docs/production-guide.rst` to mark the parameter as `(Deprecated)` with proper line wrapping to keep the rst table formatted.

* closes: #64043
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
