### PR TITLE
Add XCom Push Support for Triggerer

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/deferring.rst
+++ b/airflow-core/docs/authoring-and-scheduling/deferring.rst
@@ -445,11 +445,13 @@ Triggers can have two options: they can either send execution back to the worker
         async def run(self) -> AsyncIterator[TriggerEvent]:
             await asyncio.sleep(self.duration.total_seconds())
             if self.end_from_trigger:
-                yield TaskSuccessEvent()
+                yield TaskSuccessEvent(xcoms={"wait_duration_s": self.duration.total_seconds()})
             else:
                 yield TriggerEvent({"duration": self.duration})
 
 In the above example, the trigger will end the task instance directly if ``end_from_trigger`` is set to ``True`` by yielding ``TaskSuccessEvent``. Otherwise, it will resume the task instance with the method specified in the operator.
+
+Note also that in case of direct exit, an XCom can be produced and passed with the ``TaskSuccessEvent`` or ``TaskFailureEvent``. This XCom will be pushed when the task instance is marked as success or failure.
 
 .. note::
     Exiting from the trigger works only when listeners are not integrated for the deferrable operator. Currently, when deferrable operator has the ``end_from_trigger`` attribute set to ``True`` and listeners are integrated it raises an exception during parsing to indicate this limitation. While writing the custom trigger, ensure that the trigger is not set to end the task instance directly if the listeners are added from plugins. If the ``end_from_trigger`` attribute is changed to different attribute by author of trigger, the Dag parsing would not raise any exception and the listeners dependent on this task would not work. This limitation will be addressed in future releases.

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -460,6 +460,9 @@ def handle_event_submit(event: TriggerEvent, *, task_instance: TaskInstance, ses
     as well as its state to scheduled. It also adds the event's payload
     into the kwargs for the task.
 
+    If the event includes XCom values, they are pushed to the task instance
+    before the task is rescheduled.
+
     :param task_instance: The task instance to handle the submit event for.
     :param session: The session to be used for the database callback sink.
     """
@@ -485,6 +488,11 @@ def handle_event_submit(event: TriggerEvent, *, task_instance: TaskInstance, ses
 
     # re-serialize the entire dict using serde to ensure consistent structure
     task_instance.next_kwargs = serialize(next_kwargs)
+
+    # Push XCom values if provided by the trigger
+    if event.xcoms:
+        for key, value in event.xcoms.items():
+            task_instance.xcom_push(key=key, value=value, session=session)
 
     # Remove ourselves as its trigger
     task_instance.trigger_id = None

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -273,6 +273,12 @@ class Trigger(Base):
             handle_event_submit(event, task_instance=task_instance, session=session)
 
         # Send an event to assets
+        if event.xcoms:
+            log.warning(
+                "Trigger event %i contains XCom values, which cannot be sent to assets or callbacks. XCom values: %s",
+                trigger_id,
+                event.xcoms,
+            )
         trigger = session.scalars(select(cls).where(cls.id == trigger_id)).one_or_none()
         if trigger is None:
             # Already deleted for some reason

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -177,6 +177,10 @@ class TriggerEvent(BaseModel):
     directly without requiring the task to resume on a worker first.
 
     Keys are XCom keys and values must be JSON-serializable.
+
+    Note: XCom only applies to task instances, not to assets or callbacks. If a trigger event
+    with XCom values is sent to an asset or callback, the XCom values will be ignored and a
+    warning will be logged.
     """
 
     def __init__(self, payload, *, xcoms: dict[str, JsonValue] | None = None, **kwargs):

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -168,8 +168,19 @@ class TriggerEvent(BaseModel):
     Must be natively JSON-serializable, or registered with the airflow serialization code.
     """
 
-    def __init__(self, payload, **kwargs):
-        super().__init__(payload=payload, **kwargs)
+    xcoms: dict[str, JsonValue] | None = None
+    """
+    Optional XCom values to persist when the event is processed.
+
+    If provided, these XCom key-value pairs will be pushed to the task instance
+    before the task is rescheduled. This allows triggers to write XCom values
+    directly without requiring the task to resume on a worker first.
+
+    Keys are XCom keys and values must be JSON-serializable.
+    """
+
+    def __init__(self, payload, *, xcoms: dict[str, JsonValue] | None = None, **kwargs):
+        super().__init__(payload=payload, xcoms=xcoms, **kwargs)
 
     def __repr__(self) -> str:
         return f"TriggerEvent<{self.payload!r}>"

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -919,3 +919,68 @@ def test_kwargs_not_encrypted():
 
     assert trigger.kwargs["param1"] == "value1"
     assert trigger.kwargs["param2"] == "value2"
+
+
+def test_submit_event_with_xcoms(session, create_task_instance):
+    """
+    Tests that events with xcoms submitted to a trigger push XCom values
+    to the task instance before rescheduling it.
+    """
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+    task_instance.next_kwargs = {}
+    session.commit()
+
+    event = TriggerEvent("payload", xcoms={"return_value": {"key": "value"}, "extra_key": 42})
+    Trigger.submit_event(trigger.id, event, session=session)
+    session.flush()
+
+    session.refresh(task_instance)
+    assert task_instance.state == State.SCHEDULED
+
+    xcoms = session.scalars(
+        XComModel.get_many(
+            dag_ids=[task_instance.dag_id],
+            task_ids=[task_instance.task_id],
+            run_id=task_instance.run_id,
+        )
+    ).all()
+    actual_xcoms = {x.key: x.value for x in xcoms}
+    assert actual_xcoms == {
+        "return_value": json.dumps({"key": "value"}),
+        "extra_key": json.dumps(42),
+    }
+
+
+def test_submit_event_without_xcoms_does_not_push(session, create_task_instance):
+    """
+    Tests that events without xcoms don't push any XCom values.
+    """
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+    task_instance.next_kwargs = {}
+    session.commit()
+
+    event = TriggerEvent("payload")
+    Trigger.submit_event(trigger.id, event, session=session)
+    session.flush()
+
+    session.refresh(task_instance)
+    assert task_instance.state == State.SCHEDULED
+
+    xcoms = session.scalars(
+        XComModel.get_many(
+            dag_ids=[task_instance.dag_id],
+            task_ids=[task_instance.task_id],
+            run_id=task_instance.run_id,
+        )
+    ).all()
+    assert len(xcoms) == 0


### PR DESCRIPTION
In devlist discussion https://lists.apache.org/thread/6znvd5rtqnxt5r4hys7qn64j5mflr9g1 following PR #63489 to propose for directly enqueue tasks it came up that KPO mainly returns to worker to execute callbacks and retrieve XComs.

As callbacks would be hard to be executed in Triggerer but XComs are a blocker for most users when using KPO, this PR enabled returning XCom data from triggerers in Airflow Core. With this it would be possible to close and complete Pods with standard KPO if this is added to Airflow 3.2.0 scope.

* closes: #63489
* related: #57210

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
