### PR TITLE
Add XCom Push Support in Deferred for KPO

### DIFF
--- a/providers/cncf/kubernetes/docs/operators.rst
+++ b/providers/cncf/kubernetes/docs/operators.rst
@@ -353,6 +353,19 @@ to see and describe PODs in Kubernetes. Instead, pass your secrets via native Ku
 use Connections and Variables from Airflow. For the latter, you need to have ``apache-airflow`` package
 installed in your image in the same version as Airflow you run your Kubernetes Pod Operator from).
 
+Deferrable Mode
+^^^^^^^^^^^^^^^
+
+As in the examples above you can see that KubernetesPodOperator supports deferrable mode. This means that
+the operator can be used in a way that it will not occupy a worker slot while the pod is running in
+Kubernetes. This is achieved by using triggers and sensors under the hood. When the operator is used in
+deferrable mode, it will trigger a KubernetesPodTrigger that will wait for the pod to complete and then
+resume the task.
+
+If Airflow > 3.2.0 is used and no callbacks are defined, the operator will finish all the work on the
+triggerer and push the XCom results. Otherwise once the Pod completes the task is re-scheduled to a worker
+to finish the work and push the XCom results.
+
 Reference
 ^^^^^^^^^
 For further information, look at:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1277,3 +1277,36 @@ class AsyncKubernetesHook(KubernetesHook):
                 break
             self.log.info("Waiting for container '%s' state to be running", container_name)
             await asyncio.sleep(poll_interval)
+
+    @generic_api_retry
+    async def exec_pod_command(
+        self,
+        name: str,
+        namespace: str,
+        container: str,
+        command: list[str],
+    ) -> str:
+        """
+        Execute a command in a container and return the stdout output.
+
+        :param name: Name of the pod.
+        :param namespace: Namespace of the pod.
+        :param container: Container name to exec in.
+        :param command: Command to execute as a list of strings.
+        :return: stdout output from the command.
+        """
+        from kubernetes_asyncio.stream import WsApiClient
+
+        async with WsApiClient() as ws_api_client:
+            v1_api = async_client.CoreV1Api(ws_api_client)
+            response = await v1_api.connect_get_namespaced_pod_exec(
+                name=name,
+                namespace=namespace,
+                container=container,
+                command=command,
+                stdin=False,
+                stdout=True,
+                stderr=True,
+                tty=False,
+            )
+            return response

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -923,6 +923,8 @@ class KubernetesPodOperator(BaseOperator):
             termination_grace_period=self.termination_grace_period,
             last_log_time=last_log_time,
             logging_interval=self.logging_interval,
+            do_xcom_push=self.do_xcom_push,
+            callbacks_defined=bool(self.callbacks),
             trigger_kwargs=self.trigger_kwargs,
         )
         container_state = trigger.define_container_state(self.pod) if self.pod else None
@@ -991,7 +993,11 @@ class KubernetesPodOperator(BaseOperator):
                         operator=self,
                     )
 
-                xcom_sidecar_output = self.extract_xcom(pod=self.pod) if self.do_xcom_push else None
+                xcom_sidecar_output = (
+                    self.extract_xcom(pod=self.pod)
+                    if self.do_xcom_push and not event.get("xcom_pushed_by_trigger")
+                    else None
+                )
 
                 if event["status"] != "success":
                     self.log.error(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import json
 import traceback
 from collections.abc import AsyncIterator
 from enum import Enum
@@ -30,16 +31,20 @@ from asgiref.sync import sync_to_async
 from airflow.providers.cncf.kubernetes.exceptions import KubernetesApiPermissionError
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
+    EMPTY_XCOM_RESULT,
     AsyncPodManager,
     OnFinishAction,
     OnKillAction,
     PodLaunchTimeoutException,
     PodPhase,
 )
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.state import TaskInstanceState
+
+if AIRFLOW_V_3_2_PLUS:
+    from airflow.triggers.base import TaskFailedEvent, TaskSuccessEvent
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import V1Pod
@@ -94,6 +99,13 @@ class KubernetesPodTrigger(BaseTrigger):
     :param logging_interval: number of seconds to wait before kicking it back to
         the operator to print latest logs. If ``None`` will wait until container done.
     :param last_log_time: where to resume logs from
+    :param do_xcom_push: whether to extract and push XCom values from the pod's xcom sidecar
+        container. When True, XCom data is extracted from the sidecar before the event is fired
+        and included in the TriggerEvent so it can be persisted without requiring a worker.
+    :param callbacks_defined: whether the operator has callbacks defined. When False and the pod
+        completes, the trigger will handle pod cleanup (deletion based on ``on_finish_action``)
+        and emit a terminal event (``TaskSuccessEvent`` or ``TaskFailedEvent``) so the task
+        goes directly to its final state without using a worker slot.
     :param trigger_kwargs: additional keyword parameters to send in the event
     """
 
@@ -118,6 +130,8 @@ class KubernetesPodTrigger(BaseTrigger):
         termination_grace_period: int | None = None,
         last_log_time: DateTime | None = None,
         logging_interval: int | None = None,
+        do_xcom_push: bool = False,
+        callbacks_defined: bool = True,
         trigger_kwargs: dict | None = None,
     ):
         super().__init__()
@@ -140,6 +154,8 @@ class KubernetesPodTrigger(BaseTrigger):
         self.on_finish_action = OnFinishAction(on_finish_action)
         self.on_kill_action = OnKillAction(on_kill_action)
         self.termination_grace_period = termination_grace_period
+        self.do_xcom_push = do_xcom_push
+        self.callbacks_defined = callbacks_defined
         self.trigger_kwargs = trigger_kwargs or {}
         self._fired_event = False
         self._since_time = None
@@ -168,6 +184,8 @@ class KubernetesPodTrigger(BaseTrigger):
                 "termination_grace_period": self.termination_grace_period,
                 "last_log_time": self.last_log_time,
                 "logging_interval": self.logging_interval,
+                "do_xcom_push": self.do_xcom_push,
+                "callbacks_defined": self.callbacks_defined,
                 "trigger_kwargs": self.trigger_kwargs,
             },
         )
@@ -183,25 +201,61 @@ class KubernetesPodTrigger(BaseTrigger):
         try:
             state = await self._wait_for_pod_start()
             if state == ContainerState.TERMINATED:
-                event = TriggerEvent(
-                    {
-                        "status": "success",
-                        "namespace": self.pod_namespace,
-                        "name": self.pod_name,
-                        "message": "All containers inside pod have started successfully.",
-                        **self.trigger_kwargs,
-                    }
-                )
+                if AIRFLOW_V_3_2_PLUS:
+                    xcom_result = await self._extract_xcom_if_needed()
+                    if not self.callbacks_defined:
+                        await self._cleanup_pod_in_trigger(is_success=True)
+                        event = TaskSuccessEvent(xcoms=xcom_result)
+                    else:
+                        event = TriggerEvent(
+                            {
+                                "status": "success",
+                                "namespace": self.pod_namespace,
+                                "name": self.pod_name,
+                                "message": "All containers inside pod have started successfully.",
+                                "xcom_pushed_by_trigger": self.do_xcom_push,
+                                **self.trigger_kwargs,
+                            },
+                            xcoms=xcom_result,
+                        )
+                else:
+                    event = TriggerEvent(
+                        {
+                            "status": "success",
+                            "namespace": self.pod_namespace,
+                            "name": self.pod_name,
+                            "message": "All containers inside pod have started successfully.",
+                            **self.trigger_kwargs,
+                        }
+                    )
             elif state == ContainerState.FAILED:
-                event = TriggerEvent(
-                    {
-                        "status": "failed",
-                        "namespace": self.pod_namespace,
-                        "name": self.pod_name,
-                        "message": "pod failed",
-                        **self.trigger_kwargs,
-                    }
-                )
+                if AIRFLOW_V_3_2_PLUS:
+                    xcom_result = await self._extract_xcom_if_needed()
+                    if not self.callbacks_defined:
+                        await self._cleanup_pod_in_trigger(is_success=False)
+                        event = TaskFailedEvent(xcoms=xcom_result)
+                    else:
+                        event = TriggerEvent(
+                            {
+                                "status": "failed",
+                                "namespace": self.pod_namespace,
+                                "name": self.pod_name,
+                                "message": "pod failed",
+                                "xcom_pushed_by_trigger": self.do_xcom_push,
+                                **self.trigger_kwargs,
+                            },
+                            xcoms=xcom_result,
+                        )
+                else:
+                    event = TriggerEvent(
+                        {
+                            "status": "failed",
+                            "namespace": self.pod_namespace,
+                            "name": self.pod_name,
+                            "message": "pod failed",
+                            **self.trigger_kwargs,
+                        }
+                    )
             else:
                 event = await self._wait_for_container_completion()
             self._fired_event = True
@@ -307,6 +361,22 @@ class KubernetesPodTrigger(BaseTrigger):
             pod = await self._get_pod()
             container_state = self.define_container_state(pod)
             if container_state == ContainerState.TERMINATED:
+                if AIRFLOW_V_3_2_PLUS:
+                    xcom_result = await self._extract_xcom_if_needed()
+                    if not self.callbacks_defined:
+                        await self._cleanup_pod_in_trigger(is_success=True)
+                        return TaskSuccessEvent(xcoms=xcom_result)
+                    return TriggerEvent(
+                        {
+                            "status": "success",
+                            "namespace": self.pod_namespace,
+                            "name": self.pod_name,
+                            "last_log_time": self.last_log_time,
+                            "xcom_pushed_by_trigger": self.do_xcom_push,
+                            **self.trigger_kwargs,
+                        },
+                        xcoms=xcom_result,
+                    )
                 return TriggerEvent(
                     {
                         "status": "success",
@@ -317,6 +387,23 @@ class KubernetesPodTrigger(BaseTrigger):
                     }
                 )
             if container_state == ContainerState.FAILED:
+                if AIRFLOW_V_3_2_PLUS:
+                    xcom_result = await self._extract_xcom_if_needed()
+                    if not self.callbacks_defined:
+                        await self._cleanup_pod_in_trigger(is_success=False)
+                        return TaskFailedEvent(xcoms=xcom_result)
+                    return TriggerEvent(
+                        {
+                            "status": "failed",
+                            "namespace": self.pod_namespace,
+                            "name": self.pod_name,
+                            "message": "Container state failed",
+                            "last_log_time": self.last_log_time,
+                            "xcom_pushed_by_trigger": self.do_xcom_push,
+                            **self.trigger_kwargs,
+                        },
+                        xcoms=xcom_result,
+                    )
                 return TriggerEvent(
                     {
                         "status": "failed",
@@ -346,6 +433,62 @@ class KubernetesPodTrigger(BaseTrigger):
         # Due to AsyncKubernetesHook overriding get_pod, we need to cast the return
         # value to kubernetes_asyncio.V1Pod, because it's perceived as different type
         return cast("V1Pod", pod)
+
+    async def _extract_xcom_if_needed(self) -> dict[str, Any] | None:
+        """
+        Extract XCom from the pod's sidecar container if ``do_xcom_push`` is enabled.
+
+        :return: A dict mapping the return key to the XCom value, or None if XCom push is disabled
+                 or the XCom result is empty.
+        """
+        if not self.do_xcom_push:
+            return None
+
+        try:
+            result = await self.pod_manager.extract_xcom(await self._get_pod())
+            if isinstance(result, str) and result.rstrip() == EMPTY_XCOM_RESULT:
+                self.log.info("xcom result file is empty.")
+                return None
+            self.log.debug("xcom result: \n%s", result)
+            return {"return_value": json.loads(result)}
+        except Exception:
+            self.log.exception("Failed to extract xcom from pod %s", self.pod_name)
+            return None
+
+    async def _cleanup_pod_in_trigger(self, *, is_success: bool) -> None:
+        """
+        Handle pod cleanup directly in the trigger when no callbacks are defined.
+
+        Fetches any remaining logs and deletes the pod based on ``on_finish_action``.
+        This allows the task to go directly to a terminal state via ``TaskSuccessEvent``
+        or ``TaskFailedEvent`` without needing a worker slot.
+        """
+        # Fetch final logs before deleting the pod
+        if self.get_logs:
+            try:
+                pod = await self._get_pod()
+                await self.pod_manager.fetch_container_logs_before_current_sec(
+                    pod, container_name=self.base_container_name, since_time=self.last_log_time
+                )
+            except Exception:
+                self.log.exception("Failed to fetch final logs for pod %s", self.pod_name)
+
+        # Delete pod based on on_finish_action
+        should_delete = self.on_finish_action == OnFinishAction.DELETE_POD or (
+            self.on_finish_action == OnFinishAction.DELETE_SUCCEEDED_POD and is_success
+        )
+        if should_delete:
+            self.log.info("Deleting pod %s in namespace %s.", self.pod_name, self.pod_namespace)
+            try:
+                await self.hook.delete_pod(
+                    name=self.pod_name,
+                    namespace=self.pod_namespace,
+                    grace_period_seconds=self.termination_grace_period,
+                )
+            except Exception:
+                self.log.exception("Failed to delete pod %s", self.pod_name)
+        else:
+            self.log.info("Skipping pod deletion: on_finish_action=%s", self.on_finish_action.value)
 
     @cached_property
     def hook(self) -> AsyncKubernetesHook:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -1180,3 +1180,70 @@ class AsyncPodManager(LoggingMixin):
                 else:
                     self.log.info("[%s] %s", container_name, message_to_log)
         return now  # Return the current time as the last log time to ensure logs from the current second are read in the next fetch.
+
+    async def extract_xcom(self, pod: V1Pod) -> str:
+        """
+        Retrieve XCom value from the xcom sidecar container asynchronously.
+
+        Reads the content of ``/airflow/xcom/return.json`` from the sidecar container
+        and then kills the sidecar.
+
+        :param pod: The pod to extract XCom from.
+        :return: The XCom JSON string.
+        :raises XComRetrievalError: If the xcom sidecar container is not running or extraction fails.
+        """
+        # Check sidecar is still running
+        refreshed_pod = await self.read_pod(pod)
+        if not container_is_running(refreshed_pod, PodDefaults.SIDECAR_CONTAINER_NAME):
+            raise XComRetrievalError(
+                f"{PodDefaults.SIDECAR_CONTAINER_NAME} container is not running! "
+                f"Not possible to read xcom from pod: {pod.metadata.name}"
+            )
+
+        try:
+            result = await self._extract_xcom_json(pod)
+            return result
+        finally:
+            await self._extract_xcom_kill(pod)
+
+    async def _extract_xcom_json(self, pod: V1Pod) -> str:
+        """Retrieve XCom value and also check if xcom json is valid."""
+        command = [
+            "/bin/sh",
+            "-c",
+            f"if [ -s {PodDefaults.XCOM_MOUNT_PATH}/return.json ]; "
+            f"then cat {PodDefaults.XCOM_MOUNT_PATH}/return.json; "
+            f"else echo {EMPTY_XCOM_RESULT}; fi",
+        ]
+        self.log.info("Extracting xcom from pod %s", pod.metadata.name)
+        result = await self._hook.exec_pod_command(
+            name=pod.metadata.name,
+            namespace=pod.metadata.namespace,
+            container=PodDefaults.SIDECAR_CONTAINER_NAME,
+            command=command,
+        )
+
+        if result is None:
+            raise XComRetrievalError(f"Failed to extract xcom from pod: {pod.metadata.name}")
+
+        if result and result.rstrip() != EMPTY_XCOM_RESULT:
+            json.loads(result)
+
+        return result
+
+    async def _extract_xcom_kill(self, pod: V1Pod) -> None:
+        """Kill the xcom sidecar container."""
+        kill_command = [
+            "/bin/sh",
+            "-c",
+            "kill -s INT 1",
+        ]
+        try:
+            await self._hook.exec_pod_command(
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                container=PodDefaults.SIDECAR_CONTAINER_NAME,
+                command=kill_command,
+            )
+        except Exception:
+            self.log.warning("Failed to kill xcom sidecar container, it may have already terminated")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -31,7 +31,7 @@ from pendulum import DateTime
 
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-from airflow.triggers.base import TriggerEvent
+from airflow.triggers.base import TaskFailedEvent, TaskSuccessEvent, TriggerEvent
 from airflow.utils.state import TaskInstanceState
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
@@ -130,6 +130,8 @@ class TestKubernetesPodTrigger:
             "termination_grace_period": None,
             "last_log_time": None,
             "logging_interval": None,
+            "do_xcom_push": False,
+            "callbacks_defined": True,
             "trigger_kwargs": {},
         }
 
@@ -190,6 +192,7 @@ class TestKubernetesPodTrigger:
                 "namespace": "default",
                 "name": "test-pod-name",
                 "message": "All containers inside pod have started successfully.",
+                "xcom_pushed_by_trigger": False,
             }
         )
         actual_event = await trigger.run().asend(None)
@@ -255,6 +258,7 @@ class TestKubernetesPodTrigger:
                 "name": "test-pod-name",
                 "message": "Container state failed",
                 "last_log_time": None,
+                "xcom_pushed_by_trigger": False,
             }
         )
         actual_event = await trigger.run().asend(None)
@@ -313,6 +317,7 @@ class TestKubernetesPodTrigger:
                     "last_log_time": DateTime(2022, 1, 1),
                     "name": POD_NAME,
                     "namespace": NAMESPACE,
+                    "xcom_pushed_by_trigger": False,
                 },
                 id="short_interval",
             ),
@@ -509,6 +514,7 @@ class TestKubernetesPodTrigger:
                     "namespace": NAMESPACE,
                     "message": "All containers inside pod have started successfully.",
                     "status": "success",
+                    "xcom_pushed_by_trigger": False,
                 }
             )
             == actual
@@ -694,4 +700,264 @@ class TestKubernetesPodTrigger:
             on_finish_action="delete_pod",
         )
         await trigger.cleanup()
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_run_loop_return_success_event_with_xcom(self, mock_get_pod, mock_pm, mock_wait_pod):
+        """When do_xcom_push=True and pod succeeds, XCom should be extracted and included in the event."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pod_manager.extract_xcom.return_value = '{"key": "value"}'
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            do_xcom_push=True,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert actual_event.payload["status"] == "success"
+        assert actual_event.payload["xcom_pushed_by_trigger"] is True
+        assert actual_event.xcoms == {"return_value": {"key": "value"}}
+        mock_pod_manager.extract_xcom.assert_called_once()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_run_loop_xcom_extraction_failure_is_handled(self, mock_get_pod, mock_pm, mock_wait_pod):
+        """When do_xcom_push=True but XCom extraction fails, event should still fire without XCom."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pod_manager.extract_xcom.side_effect = Exception("Sidecar terminated")
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            do_xcom_push=True,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert actual_event.payload["status"] == "success"
+        assert actual_event.payload["xcom_pushed_by_trigger"] is True
+        assert actual_event.xcoms is None
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    async def test_run_loop_no_xcom_when_disabled(self, mock_wait_pod, trigger):
+        """When do_xcom_push=False (default), no XCom extraction should happen."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+
+        actual_event = await trigger.run().asend(None)
+
+        assert actual_event.payload["status"] == "success"
+        assert actual_event.payload["xcom_pushed_by_trigger"] is False
+        assert actual_event.xcoms is None
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_run_loop_return_failed_event_with_xcom(self, mock_get_pod, mock_pm, mock_wait_pod):
+        """When do_xcom_push=True and pod fails, XCom should still be extracted and included in the event."""
+        mock_wait_pod.return_value = ContainerState.FAILED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pod_manager.extract_xcom.return_value = '{"error_details": "out of memory"}'
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            do_xcom_push=True,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert actual_event.payload["status"] == "failed"
+        assert actual_event.payload["xcom_pushed_by_trigger"] is True
+        assert actual_event.xcoms == {"return_value": {"error_details": "out of memory"}}
+        mock_pod_manager.extract_xcom.assert_called_once()
+
+    def test_serialize_with_do_xcom_push(self):
+        """Verify do_xcom_push is included in serialization."""
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            do_xcom_push=True,
+        )
+        _, kwargs_dict = trigger.serialize()
+        assert kwargs_dict["do_xcom_push"] is True
+
+    def test_serialize_with_callbacks_defined(self):
+        """Verify callbacks_defined is included in serialization."""
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            callbacks_defined=False,
+        )
+        _, kwargs_dict = trigger.serialize()
+        assert kwargs_dict["callbacks_defined"] is False
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_no_callbacks_success_emits_task_success_event(
+        self, mock_get_pod, mock_pm, mock_hook, mock_wait_pod
+    ):
+        """When callbacks_defined=False and pod succeeds, trigger should emit TaskSuccessEvent."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pod_manager.extract_xcom.return_value = '{"result": 42}'
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            do_xcom_push=True,
+            callbacks_defined=False,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert isinstance(actual_event, TaskSuccessEvent)
+        assert actual_event.xcoms == {"return_value": {"result": 42}}
+        mock_hook.delete_pod.assert_called_once()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_no_callbacks_failure_emits_task_failed_event(
+        self, mock_get_pod, mock_pm, mock_hook, mock_wait_pod
+    ):
+        """When callbacks_defined=False and pod fails, trigger should emit TaskFailedEvent."""
+        mock_wait_pod.return_value = ContainerState.FAILED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            callbacks_defined=False,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert isinstance(actual_event, TaskFailedEvent)
+        mock_hook.delete_pod.assert_called_once()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_no_callbacks_keep_pod_action_skips_deletion(self, mock_get_pod, mock_hook, mock_wait_pod):
+        """When on_finish_action=keep_pod, pod should not be deleted even with no callbacks."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            callbacks_defined=False,
+            on_finish_action="keep_pod",
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert isinstance(actual_event, TaskSuccessEvent)
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_no_callbacks_delete_succeeded_pod_skips_on_failure(
+        self, mock_get_pod, mock_hook, mock_wait_pod
+    ):
+        """When on_finish_action=delete_succeeded_pod and pod fails, pod should not be deleted."""
+        mock_wait_pod.return_value = ContainerState.FAILED
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            callbacks_defined=False,
+            on_finish_action="delete_succeeded_pod",
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert isinstance(actual_event, TaskFailedEvent)
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}._wait_for_pod_start")
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{TRIGGER_PATH}.pod_manager", new_callable=mock.PropertyMock)
+    @mock.patch(f"{TRIGGER_PATH}._get_pod", new_callable=mock.AsyncMock)
+    async def test_callbacks_defined_emits_regular_trigger_event(
+        self, mock_get_pod, mock_pm, mock_hook, mock_wait_pod
+    ):
+        """When callbacks_defined=True (default), trigger should emit regular TriggerEvent."""
+        mock_wait_pod.return_value = ContainerState.TERMINATED
+        mock_pod_manager = mock.AsyncMock()
+        mock_pm.return_value = mock_pod_manager
+        mock_get_pod.return_value = mock.MagicMock()
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            callbacks_defined=True,
+        )
+
+        actual_event = await trigger.run().asend(None)
+
+        assert isinstance(actual_event, TriggerEvent)
+        assert not isinstance(actual_event, TaskSuccessEvent)
+        assert actual_event.payload["status"] == "success"
         mock_hook.delete_pod.assert_not_called()


### PR DESCRIPTION
With PR #64068 assuming it is possible to make this into Airflow 3.2.0 it is possible to push XCom directly from triggerer.

Except callbacks this would resolve the need to return to a worker to complete a task directly from triggerer. This PR builds on top of #64068 and applies the feature to KPO:

- XComs are retrieved from pushed from triggerer
- Except if Airflow is not 3.2.0 - then the current approach is used
- Except if a callback is defined - then the current approach is used

Note that CI will most probably fail until PR #64068 is not merged.

* closes: #63489
* related: #64068

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
