### PR TITLE
Support Elasticsearch 9 in Elasticsearch Provider

### DIFF
--- a/providers/elasticsearch/docs/index.rst
+++ b/providers/elasticsearch/docs/index.rst
@@ -105,7 +105,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``elasticsearch``                           ``>=8.10,<9``
+``elasticsearch``                           ``<10,>=8.10``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    "elasticsearch>=8.10,<9",
+    "elasticsearch>=8.10,<10",
 ]
 
 [dependency-groups]

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    "elasticsearch>=8.10,<10",
+    "elasticsearch>=9,<10",
 ]
 
 [dependency-groups]

--- a/providers/elasticsearch/pyproject.toml
+++ b/providers/elasticsearch/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    "elasticsearch>=9,<10",
+    "elasticsearch>=8.10,<10",
 ]
 
 [dependency-groups]

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -86,7 +86,7 @@ class ElasticsearchSQLCursor:
         self.body["query"] = statement
         if params:
             self.body["params"] = params
-        self.response = self.es.sql.query(body=self.body)
+        self.response = self.es.sql.query(**self.body)
         if self.cursor:
             self.body["cursor"] = self.cursor
         else:
@@ -135,7 +135,7 @@ class ESConnection:
         netloc = f"{host}:{port}"
         self.url = parse.urlunparse((scheme, netloc, "/", None, None, None))
         if user and password:
-            self.es = Elasticsearch(self.url, http_auth=(user, password), **kwargs)
+            self.es = Elasticsearch(self.url, basic_auth=(user, password), **kwargs)
         else:
             self.es = Elasticsearch(self.url, **kwargs)
 
@@ -266,5 +266,5 @@ class ElasticsearchPythonHook(BaseHook):
         :returns: dict: The response 'hits' object from Elasticsearch
         """
         es_client = self.get_conn
-        result = es_client.search(index=index, body=query)
+        result = es_client.search(index=index, **query)
         return result["hits"]

--- a/providers/elasticsearch/tests/integration/elasticsearch/log/test_es_remote_log_io.py
+++ b/providers/elasticsearch/tests/integration/elasticsearch/log/test_es_remote_log_io.py
@@ -136,7 +136,7 @@ class TestElasticsearchRemoteLogIOIntegration:
             "offset": 1,
             "error_detail": error_detail,
         }
-        self.elasticsearch_io.client.index(index=self.target_index, body=body)
+        self.elasticsearch_io.client.index(index=self.target_index, document=body)
         self.elasticsearch_io.client.indices.refresh(index=self.target_index)
 
         log_source_info, log_messages = self.elasticsearch_io.read("", ti)

--- a/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
@@ -236,11 +236,9 @@ class TestElasticsearchSQLHook:
         es_connection = ESConnection(host="localhost", port=9200)
         response = es_connection.execute_sql("SELECT * FROM hollywood.actors")
         mock_es_sql_client.query.assert_called_once_with(
-            body={
-                "fetch_size": 1000,
-                "field_multi_value_leniency": False,
-                "query": "SELECT * FROM hollywood.actors",
-            }
+            fetch_size=1000,
+            field_multi_value_leniency=False,
+            query="SELECT * FROM hollywood.actors",
         )
 
         assert response == RESPONSE_WITHOUT_CURSOR

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/elasticmock/fake_elasticsearch.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/elasticmock/fake_elasticsearch.py
@@ -316,7 +316,9 @@ class FakeElasticsearch(Elasticsearch):
         "version",
         "version_type",
     )
-    def index(self, index, doc_type, body, id=None, params=None, headers=None):
+    def index(self, index, document=None, doc_type=None, body=None, id=None, params=None, headers=None):
+        if document is None:
+            document = body
         if index not in self.__documents_dict:
             self.__documents_dict[index] = []
 
@@ -329,7 +331,7 @@ class FakeElasticsearch(Elasticsearch):
             {
                 "_type": doc_type,
                 "_id": id,
-                "_source": body,
+                "_source": document,
                 "_index": index,
                 "_version": version,
                 "_headers": headers,

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -139,7 +139,7 @@ class TestElasticsearchTaskHandler:
             "offset": 1,
             "event": self.test_message,
         }
-        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=1)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, document=self.body, id=1)
 
     def teardown_method(self):
         shutil.rmtree(self.local_log_location.split(os.path.sep)[0], ignore_errors=True)
@@ -375,7 +375,7 @@ class TestElasticsearchTaskHandler:
             "log_id": similar_log_id,
             "offset": 1,
         }
-        self.es.index(index=self.index_name, doc_type=self.doc_type, body=another_body, id=1)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, document=another_body, id=1)
 
         ts = pendulum.now()
         logs, metadatas = self.es_task_handler.read(
@@ -624,7 +624,7 @@ class TestElasticsearchTaskHandler:
             "levelname": "INFO",
         }
         self.es_task_handler.set_context(ti)
-        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, document=self.body, id=id)
 
         logs, _ = self.es_task_handler.read(
             ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
@@ -658,7 +658,7 @@ class TestElasticsearchTaskHandler:
             "levelname": "INFO",
         }
         self.es_task_handler.set_context(ti)
-        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, document=self.body, id=id)
 
         logs, _ = self.es_task_handler.read(
             ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
@@ -685,7 +685,7 @@ class TestElasticsearchTaskHandler:
             "log": {"offset": 1},
             "host": {"name": "somehostname"},
         }
-        self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=id)
+        self.es.index(index=self.index_name, doc_type=self.doc_type, document=self.body, id=id)
 
         logs, _ = self.es_task_handler.read(
             ti, 1, {"offset": 0, "last_log_timestamp": str(ts), "end_of_log": False}
@@ -925,14 +925,14 @@ def test_retrieve_config_keys():
     with conf_vars(
         {
             ("elasticsearch_configs", "http_compress"): "False",
-            ("elasticsearch_configs", "timeout"): "10",
+            ("elasticsearch_configs", "request_timeout"): "10",
         }
     ):
         args_from_config = get_es_kwargs_from_config().keys()
         # verify_certs comes from default config value
         assert "verify_certs" in args_from_config
-        # timeout comes from config provided value
-        assert "timeout" in args_from_config
+        # request_timeout comes from config provided value
+        assert "request_timeout" in args_from_config
         # http_compress comes from config value
         assert "http_compress" in args_from_config
         assert "self" not in args_from_config
@@ -1290,7 +1290,7 @@ class TestBuildStructuredLogFields:
                 }
             ],
         }
-        es.index(index="test_index", doc_type="log", body=body, id=1)
+        es.index(index="test_index", doc_type="log", document=body, id=1)
 
         # Patch the IO layer to return our fake document
         mock_hit_dict = body.copy()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -4572,7 +4572,7 @@ requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
-    { name = "elasticsearch", specifier = ">=8.10,<9" },
+    { name = "elasticsearch", specifier = ">=8.10,<10" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
-    { name = "elasticsearch", specifier = ">=9,<10" },
+    { name = "elasticsearch", specifier = ">=8.10,<10" },
 ]
 
 [package.metadata.requires-dev]
@@ -10616,32 +10616,29 @@ wheels = [
 
 [[package]]
 name = "elastic-transport"
-version = "9.2.1"
+version = "8.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
-    { name = "sniffio" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/0a/a92140b666afdcb9862a16e4d80873b3c887c1b7e3f17e945fc3460edf1b/elastic_transport-9.2.1.tar.gz", hash = "sha256:97d9abd638ba8aa90faa4ca1bf1a18bde0fe2088fbc8757f2eb7b299f205773d", size = 77403, upload-time = "2025-12-23T11:54:12.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/54/d498a766ac8fa475f931da85a154666cc81a70f8eb4a780bc8e4e934e9ac/elastic_transport-8.17.1.tar.gz", hash = "sha256:5edef32ac864dca8e2f0a613ef63491ee8d6b8cfb52881fa7313ba9290cac6d2", size = 73425, upload-time = "2025-03-13T07:28:30.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e6/a42b600ae8b808371f740381f6c32050cad93f870d36cc697b8b7006bf7c/elastic_transport-9.2.1-py3-none-any.whl", hash = "sha256:39e1a25e486af34ce7aa1bc9005d1c736f1b6fb04c9b64ea0604ded5a61fc1d4", size = 65327, upload-time = "2025-12-23T11:54:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cd/b71d5bc74cde7fc6fd9b2ff9389890f45d9762cbbbf81dc5e51fd7588c4a/elastic_transport-8.17.1-py3-none-any.whl", hash = "sha256:192718f498f1d10c5e9aa8b9cf32aed405e469a7f0e9d6a8923431dbb2c59fb8", size = 64969, upload-time = "2025-03-13T07:28:29.031Z" },
 ]
 
 [[package]]
 name = "elasticsearch"
-version = "9.3.0"
+version = "8.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
     { name = "elastic-transport" },
     { name = "python-dateutil" },
-    { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/15/283459c9299d412ffa2aaab69b082857631c519233f5491d6c567e3320ca/elasticsearch-9.3.0.tar.gz", hash = "sha256:f76e149c0a22d5ccbba58bdc30c9f51cf894231b359ef4fd7e839b558b59f856", size = 893538, upload-time = "2026-02-03T20:26:38.914Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/79/365e306017a9fcfbbefab1a3b588d2404bea8806b36766ff0f886509a20e/elasticsearch-8.19.3.tar.gz", hash = "sha256:e84dd618a220cac25b962790085045dd27ac72e01c0a5d81bd29a2d47a71f03f", size = 800298, upload-time = "2025-12-23T12:56:00.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/37/3a196f8918743f2104cb66b1f56218079ecac6e128c061de7df7f4faef02/elasticsearch-9.3.0-py3-none-any.whl", hash = "sha256:67bd2bb4f0800f58c2847d29cd57d6e7bf5bc273483b4f17421f93e75ba09f39", size = 979405, upload-time = "2026-02-03T20:26:34.552Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0f/ac126833c385b06166d41c486e4911f58ad7791fd1a53dd6e0b8d16ff214/elasticsearch-8.19.3-py3-none-any.whl", hash = "sha256:fe1db2555811192e8a1be78b01234d0a49d32b185ea7eeeb6f059331dee32838", size = 952820, upload-time = "2025-12-23T12:55:56.796Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
-    { name = "elasticsearch", specifier = ">=8.10,<10" },
+    { name = "elasticsearch", specifier = ">=9,<10" },
 ]
 
 [package.metadata.requires-dev]
@@ -10616,29 +10616,32 @@ wheels = [
 
 [[package]]
 name = "elastic-transport"
-version = "8.17.1"
+version = "9.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
+    { name = "sniffio" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/54/d498a766ac8fa475f931da85a154666cc81a70f8eb4a780bc8e4e934e9ac/elastic_transport-8.17.1.tar.gz", hash = "sha256:5edef32ac864dca8e2f0a613ef63491ee8d6b8cfb52881fa7313ba9290cac6d2", size = 73425, upload-time = "2025-03-13T07:28:30.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/0a/a92140b666afdcb9862a16e4d80873b3c887c1b7e3f17e945fc3460edf1b/elastic_transport-9.2.1.tar.gz", hash = "sha256:97d9abd638ba8aa90faa4ca1bf1a18bde0fe2088fbc8757f2eb7b299f205773d", size = 77403, upload-time = "2025-12-23T11:54:12.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/cd/b71d5bc74cde7fc6fd9b2ff9389890f45d9762cbbbf81dc5e51fd7588c4a/elastic_transport-8.17.1-py3-none-any.whl", hash = "sha256:192718f498f1d10c5e9aa8b9cf32aed405e469a7f0e9d6a8923431dbb2c59fb8", size = 64969, upload-time = "2025-03-13T07:28:29.031Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e6/a42b600ae8b808371f740381f6c32050cad93f870d36cc697b8b7006bf7c/elastic_transport-9.2.1-py3-none-any.whl", hash = "sha256:39e1a25e486af34ce7aa1bc9005d1c736f1b6fb04c9b64ea0604ded5a61fc1d4", size = 65327, upload-time = "2025-12-23T11:54:11.681Z" },
 ]
 
 [[package]]
 name = "elasticsearch"
-version = "8.19.3"
+version = "9.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "elastic-transport" },
     { name = "python-dateutil" },
+    { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/79/365e306017a9fcfbbefab1a3b588d2404bea8806b36766ff0f886509a20e/elasticsearch-8.19.3.tar.gz", hash = "sha256:e84dd618a220cac25b962790085045dd27ac72e01c0a5d81bd29a2d47a71f03f", size = 800298, upload-time = "2025-12-23T12:56:00.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/15/283459c9299d412ffa2aaab69b082857631c519233f5491d6c567e3320ca/elasticsearch-9.3.0.tar.gz", hash = "sha256:f76e149c0a22d5ccbba58bdc30c9f51cf894231b359ef4fd7e839b558b59f856", size = 893538, upload-time = "2026-02-03T20:26:38.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/0f/ac126833c385b06166d41c486e4911f58ad7791fd1a53dd6e0b8d16ff214/elasticsearch-8.19.3-py3-none-any.whl", hash = "sha256:fe1db2555811192e8a1be78b01234d0a49d32b185ea7eeeb6f059331dee32838", size = 952820, upload-time = "2025-12-23T12:55:56.796Z" },
+    { url = "https://files.pythonhosted.org/packages/05/37/3a196f8918743f2104cb66b1f56218079ecac6e128c061de7df7f4faef02/elasticsearch-9.3.0-py3-none-any.whl", hash = "sha256:67bd2bb4f0800f58c2847d29cd57d6e7bf5bc273483b4f17421f93e75ba09f39", size = 979405, upload-time = "2026-02-03T20:26:34.552Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR updates the `elasticsearch-py` library dependency to support version `9.x` while maintaining backward compatibility with version `8.x` (`>=8.10`).

Key changes:
1. Updated [airflow/providers/elasticsearch/pyproject.toml](cci:7://file:///Users/subhamsangwan/airflow/providers/elasticsearch/pyproject.toml:0:0-0:0) dependency range to `"elasticsearch>=8.10,<10"`.
2. Replaced the deprecated `http_auth` with `basic_auth` in hook connections.
3. Removed usage of the deprecated `body` parameter in query and search APIs, replacing it directly with keyword arguments (`**kwargs`) which works for both Elasticsearch 8.x and 9.x.

closes: #64064

---

Was generative AI tooling used to co-author this PR?
Yes — Gemini (Code Research and PR Description)