### PR TITLE
Fix dag run accessorkey on clear ti page

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -46,7 +46,7 @@ export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceR
     header: translate("mapIndex"),
   },
   {
-    accessorKey: "run_id",
+    accessorKey: "dag_run_id",
     header: translate("runId"),
   },
 ];


### PR DESCRIPTION
Dag Run Id was not visible

Issue - 
<img width="1437" height="871" alt="image" src="https://github.com/user-attachments/assets/c187f6b3-750d-4da7-b7c9-c073ce2883bd" />


Fix -
<img width="2072" height="938" alt="image" src="https://github.com/user-attachments/assets/4be630e8-c77e-4a48-a63f-d60d5e86bf7c" />
