### PR TITLE
Split CI into separate AMD and ARM test workflows

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -18,20 +18,22 @@
 ---
 name: Tests
 on:  # yamllint disable-line rule:truthy
-  schedule:
-    - cron: '28 1,3,7,9,13,15,19,21 * * *'
-  push:
-    branches:
-      - v[0-9]+-[0-9]+-test
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
-  pull_request:
-    branches:
-      - main
-      - v[0-9]+-[0-9]+-test
-      - v[0-9]+-[0-9]+-stable
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
-    types: [opened, reopened, synchronize, ready_for_review]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      platform:
+        description: "Target platform: linux/amd64 or linux/arm64"
+        required: true
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        description: "Slack bot token for CI notifications"
+        required: false
+      DOCS_AWS_ACCESS_KEY_ID:
+        description: "AWS access key for docs publishing"
+        required: false
+      DOCS_AWS_SECRET_ACCESS_KEY:
+        description: "AWS secret key for docs publishing"
+        required: false
 permissions:
   # All other permissions are set to none by default
   contents: read
@@ -42,10 +44,6 @@ env:
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
   UV_VERSION: "0.10.12"  # Keep this comment to allow automatic replacement of uv version
   VERBOSE: "true"
-
-concurrency:
-  group: ci-amd-arm-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   build-info:
@@ -94,7 +92,7 @@ jobs:
       mypy-checks: ${{ steps.selective-checks.outputs.mypy-checks }}
       mysql-exclude: ${{ steps.selective-checks.outputs.mysql-exclude }}
       mysql-versions: ${{ steps.selective-checks.outputs.mysql-versions }}
-      platform: ${{ steps.selective-checks.outputs.platform }}
+      platform: ${{ inputs.platform }}
       postgres-exclude: ${{ steps.selective-checks.outputs.postgres-exclude }}
       postgres-versions: ${{ steps.selective-checks.outputs.postgres-versions }}
       prod-image-build: ${{ steps.selective-checks.outputs.prod-image-build }}
@@ -123,7 +121,8 @@ jobs:
       run-task-sdk-integration-tests: ${{ steps.selective-checks.outputs.run-task-sdk-integration-tests }}
       run-breeze-integration-tests: ${{ steps.selective-checks.outputs.run-breeze-integration-tests }}
       run-scripts-tests: ${{ steps.selective-checks.outputs.run-scripts-tests }}
-      runner-type: ${{ steps.selective-checks.outputs.runner-type }}
+      runner-type: >-
+        ${{ inputs.platform == 'linux/arm64' && '["ubuntu-22.04-arm"]' || steps.selective-checks.outputs.runner-type }}
       run-ui-tests: ${{ steps.selective-checks.outputs.run-ui-tests }}
       run-ui-e2e-tests: ${{ steps.selective-checks.outputs.run-ui-e2e-tests }}
       run-unit-tests: ${{ steps.selective-checks.outputs.run-unit-tests }}
@@ -937,7 +936,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      github.event_name == 'schedule' &&
+      needs.build-info.outputs.canary-run == 'true' &&
       github.run_attempt == 1
     runs-on: ["ubuntu-22.04"]
     steps:
@@ -968,13 +967,13 @@ jobs:
         shell: bash
         run: python3 scripts/ci/slack_notification_state.py
         env:
-          ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}"
+          ARTIFACT_NAME: "slack-state-tests-${{ inputs.platform == 'linux/arm64' && 'arm' || 'amd' }}-${{ github.ref_name }}"
           CURRENT_FAILURES: "${{ steps.get-failures.outputs.failed-jobs }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Upload notification state"
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: "slack-state-tests-${{ github.ref_name }}"
+          name: "slack-state-tests-${{ inputs.platform == 'linux/arm64' && 'arm' || 'amd' }}-${{ github.ref_name }}"
           path: ./slack-state/
           retention-days: 7
           overwrite: true

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         branch: ["v3-1-test"]
-        workflow-id: ["ci-amd-arm.yml"]
+        workflow-id: ["ci-tests.yml", "ci-tests-arm.yml"]
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/ci-tests-arm.yml
+++ b/.github/workflows/ci-tests-arm.yml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Test ARM
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '28 1,3,7,9,13,15,19,21 * * *'
+  push:
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+  pull_request:
+    branches:
+      - main
+      - v[0-9]+-[0-9]+-test
+      - v[0-9]+-[0-9]+-stable
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+concurrency:
+  group: ci-tests-arm-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  tests:
+    uses: ./.github/workflows/ci-amd-arm.yml
+    with:
+      platform: "linux/arm64"
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      DOCS_AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
+      DOCS_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Tests
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '28 1,3,7,9,13,15,19,21 * * *'
+  push:
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+  pull_request:
+    branches:
+      - main
+      - v[0-9]+-[0-9]+-test
+      - v[0-9]+-[0-9]+-stable
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+concurrency:
+  group: ci-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  tests:
+    uses: ./.github/workflows/ci-amd-arm.yml
+    with:
+      platform: "linux/amd64"
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      DOCS_AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
+      DOCS_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
+| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
+| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-tests.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
 | 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
 
 

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1524,7 +1524,7 @@ class SelectiveChecks:
         import requests  # type: ignore[import-untyped]
 
         job_name = "Basic tests"
-        workflow_name = "ci-amd-arm.yml"
+        workflow_name = "ci-tests.yml"
         headers = {"Accept": "application/vnd.github.v3+json"}
         if os.environ.get("GITHUB_TOKEN"):
             headers["Authorization"] = f"token {os.environ.get('GITHUB_TOKEN')}"

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -32,8 +32,8 @@ PROJECT BY THE `generate-pypi-readme` PREK HOOK. YOUR CHANGES HERE WILL BE AUTOM
 
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
+| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
+| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-tests.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
 | 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
 
 

--- a/scripts/ci/prek/upgrade_important_versions.py
+++ b/scripts/ci/prek/upgrade_important_versions.py
@@ -78,6 +78,8 @@ FILES_TO_UPDATE: list[tuple[Path, bool]] = [
     (AIRFLOW_ROOT_PATH / ".github" / "actions" / "breeze" / "action.yml", False),
     (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "basic-tests.yml", False),
     (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "ci-amd-arm.yml", False),
+    (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "ci-tests.yml", False),
+    (AIRFLOW_ROOT_PATH / ".github" / "workflows" / "ci-tests-arm.yml", False),
     (AIRFLOW_ROOT_PATH / "dev" / "breeze" / "doc" / "ci" / "02_images.md", True),
     (AIRFLOW_ROOT_PATH / "docker-stack-docs" / "build-arg-ref.rst", True),
     (AIRFLOW_ROOT_PATH / "devel-common" / "pyproject.toml", True),


### PR DESCRIPTION
## Summary

- Convert `ci-amd-arm.yml` into a reusable `workflow_call` workflow accepting a `platform` input
- Create `ci-tests.yml` ("Tests") caller for AMD (`linux/amd64`)
- Create `ci-tests-arm.yml` ("Test ARM") caller for ARM (`linux/arm64`)
- Each workflow has independent concurrency groups and platform-specific notification state
- Fix canary run notifications skipped on success after failure (changed condition from `github.event_name == 'schedule'` to `canary-run == 'true'`)
- Update all references: `ci-notification.yml`, `selective_checks.py`, badge URLs, `upgrade_important_versions.py`

## Test plan

- [ ] Verify AMD workflow triggers correctly on PR/push/schedule
- [ ] Verify ARM workflow triggers correctly on push/schedule
- [ ] Verify notification state artifacts are separate per platform (`slack-state-tests-amd-*` / `slack-state-tests-arm-*`)
- [ ] Verify recovery notifications fire on canary push runs after failures

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)