### PR TITLE
fix: handle NULL values in `/dags/{dag_id}/tasks` `order_by` parameter

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import cast
+from typing import Any, cast
 
 from fastapi import Depends, HTTPException, status
 
@@ -53,7 +53,15 @@ def get_tasks(
     """Get tasks for DAG."""
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     try:
-        tasks = sorted(dag.tasks, key=attrgetter(order_by.lstrip("-")), reverse=(order_by[0:1] == "-"))
+        sort_key = order_by.lstrip("-")
+        reverse = order_by[0:1] == "-"
+
+        def nullslast_key(task: Any) -> tuple[bool, Any]:
+            """Sort key that places NULL values last regardless of sort direction."""
+            value = attrgetter(sort_key)(task)
+            return (value is None, value)
+
+        tasks = sorted(dag.tasks, key=nullslast_key, reverse=reverse)
     except AttributeError as err:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(err))
     return TaskCollectionResponse(


### PR DESCRIPTION
Closes #63927

Adds `nullslast()` handling to the SQLAlchemy `order_by` clause in the tasks listing endpoint to correctly handle NULL values and prevent incorrect sort ordering.