### PR TITLE
Adjust release guides after Helm 1.20.0 release

### DIFF
--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -360,7 +360,11 @@ EOF
 ```
 
 ```shell
-export VOTE_END_TIME=$(date --utc -d "now + 72 hours + 10 minutes" +'%Y-%m-%d %H:%M')
+if [ "$OS" = "Darwin" ]; then  # MacOS (BSD date)
+  export VOTE_END_TIME=$(date -u -v "+${VOTE_DURATION_IN_HOURS}H" -v "+10M" +'%Y-%m-%d %H:%M')
+else  # Linux
+  export VOTE_END_TIME=$(date --utc -d "now + $VOTE_DURATION_IN_HOURS hours + 10 minutes" +'%Y-%m-%d %H:%M')
+fi
 export TIME_DATE_URL="to?iso=$(date --utc -d "now + 72 hours + 10 minutes" +'%Y%m%dT%H%M')&p0=136&font=cursive"
 ```
 
@@ -860,7 +864,7 @@ workflow in `airflow-site` is triggered automatically by the push to `main` and 
 You can check the latest chart version that is in the `index.yaml` with:
 
 ```shell
-curl -s https://airflow.apache.org/index.yaml | yq -e '.entries.airflow[0].version' -
+curl -s https://airflow.apache.org/index.yaml | yq '.entries.airflow[0].version' -
 ```
 
 You can see when ArtifactHUB will next check for a new version by logging in and going to the [ArtifactHUB control panel](https://artifacthub.io/control-panel/repositories).
@@ -935,9 +939,7 @@ Update "Announcements" page at the [Official Airflow website](https://airflow.ap
 
 Create a new release on GitHub with the release notes and assets from the release svn.
 
-For this to make use the following:
-
-- Draft a new release in https://github.com/apache/airflow/releases/new
+- Create a new release in https://github.com/apache/airflow/releases/new ("Draft new release" button)
 - Select the tag, e.g. `helm-chart/1.20.0`
 - Use title: Apache Airflow Helm Chart 1.20.0
 - Copy the release notes RST from the release. Need to convert all headings with `^^^^^` as underline to H1 in markdown with a `#` as prefix and all headings with `"""""` as underline to H2 in markdown with a `##` prefix.
@@ -960,7 +962,7 @@ Don't forget to thank the folks who tested and close the issue tracking the test
 ```
 Thank you everyone. New Helm-Chart is released.
 
-I invite everyone to help improve providers for the next release, a list of open issues can be found [here](https://github.com/apache/airflow/issues?q=is%3Aissue%20state%3Aopen%20label%3Aarea%3Ahelm-chart).
+I invite everyone to help improve the chart for the next release, a list of open issues can be found [here](https://github.com/apache/airflow/issues?q=is%3Aissue%20state%3Aopen%20label%3Aarea%3Ahelm-chart).
 ```
 
 ## Update issue template with the new release
@@ -1026,7 +1028,7 @@ It is probably ok if we leave last 2 versions on release svn repo too.
 
 ```shell
 # http://www.apache.org/legal/release-policy.html#when-to-archive
-cd airflow-release/helm-chart
+cd cd ${AIRFLOW_REPO_ROOT}/asf-dist/release/airflow/helm-chart
 export PREVIOUS_VERSION=1.0.0
 svn rm ${PREVIOUS_VERSION}
 svn commit -m "Remove old Helm Chart release: ${PREVIOUS_VERSION}"

--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -258,10 +258,12 @@ popd
 
   ```shell
   # First clone the repo
-  svn checkout https://dist.apache.org/repos/dist/dev/airflow airflow-dev
+  cd ${AIRFLOW_REPO_ROOT}/..
+  [ -d asf-dist ] || svn checkout --depth=immediates https://dist.apache.org/repos/dist asf-dist
+  svn update --set-depth=infinity asf-dist/dev/airflow
 
   # Create new folder for the release
-  cd airflow-dev/helm-chart
+  cd asf-dist/dev/airflow/helm-chart
   svn mkdir ${VERSION}${VERSION_SUFFIX}
 
   # Move the artifacts to svn folder
@@ -508,7 +510,7 @@ VERSION_SUFFIX= breeze release-management prepare-helm-chart-package
 As a PMC member, you should be able to clone the SVN repository:
 
 ```shell script
-cd ..
+cd ${AIRFLOW_REPO_ROOT}/..
 [ -d asf-dist ] || svn checkout --depth=immediates https://dist.apache.org/repos/dist asf-dist
 svn update --set-depth=infinity asf-dist/dev/airflow
 ```
@@ -707,6 +709,20 @@ upgrading the Chart or installing by overriding default of `values.yaml`.
 
 # Publish the final release
 
+Re-establish your shell like when prepared
+
+```shell
+# Set Version
+export VERSION=1.1.0
+export VERSION_SUFFIX=rc1
+
+# Set AIRFLOW_REPO_ROOT to the path of your git repo
+export AIRFLOW_REPO_ROOT=$(pwd -P)
+
+breeze k8s setup-env
+breeze k8s shell
+```
+
 ## Summarize the voting for the release
 
 Once the vote has been passed, you will need to send a result vote to dev@airflow.apache.org:
@@ -760,21 +776,20 @@ the binaries again, and gives a clearer history in the svn commit logs):
 
 ```shell
 # First clone the repo
-export VERSION=1.1.0
-export VERSION_SUFFIX=rc1
-svn checkout https://dist.apache.org/repos/dist/release/airflow airflow-release
+cd ${AIRFLOW_REPO_ROOT}/..
+[ -d asf-dist ] || svn checkout --depth=immediates https://dist.apache.org/repos/dist asf-dist
+svn update --set-depth=infinity asf-dist/release/airflow
 
 # Create new folder for the release
-cd airflow-release/helm-chart
+cd asf-dist/release/airflow/helm-chart
 export AIRFLOW_SVN_RELEASE_HELM=$(pwd -P)
 svn mkdir ${VERSION}
 cd ${VERSION}
 
 # Move the artifacts to svn folder & commit (don't copy or copy & remove - index.yaml)
-for f in ../../../airflow-dev/helm-chart/${VERSION}${VERSION_SUFFIX}/*; do svn cp $f ${$(basename $f)/}; done
+for f in ../../../../dev/airflow/helm-chart/${VERSION}${VERSION_SUFFIX}/*; do svn cp $f $(basename $f); done
 svn rm index.yaml
 svn commit -m "Release Airflow Helm Chart Check ${VERSION} from ${VERSION}${VERSION_SUFFIX}"
-
 ```
 
 Verify that the packages appear in [Airflow Helm Chart](https://dist.apache.org/repos/dist/release/airflow/helm-chart/).
@@ -829,7 +844,11 @@ cp ${AIRFLOW_SVN_RELEASE_HELM}/${VERSION}/airflow-${VERSION}.tgz .
 helm repo index --merge ./index.yaml . --url "https://downloads.apache.org/airflow/helm-chart/${VERSION}"
 rm airflow-${VERSION}.tgz
 mv index.yaml landing-pages/site/static/index.yaml
-git add p . # leave the license at the top
+git checkout -b feature/new-chart-release-${VERSION}
+git add .
+# Note: commit will re-add the license at the top, need to add another time
+git commit -m "Add Apache Airflow Helm Chart Release ${VERSION} to chart index file"
+git add .
 git commit -m "Add Apache Airflow Helm Chart Release ${VERSION} to chart index file"
 git push
 # and finally open a PR
@@ -841,7 +860,7 @@ workflow in `airflow-site` is triggered automatically by the push to `main` and 
 You can check the latest chart version that is in the `index.yaml` with:
 
 ```shell
-curl -s https://airflow.apache.org/index.yaml | yq e '.entries.airflow[0].version' -
+curl -s https://airflow.apache.org/index.yaml | yq -e '.entries.airflow[0].version' -
 ```
 
 You can see when ArtifactHUB will next check for a new version by logging in and going to the [ArtifactHUB control panel](https://artifacthub.io/control-panel/repositories).
@@ -916,7 +935,18 @@ Update "Announcements" page at the [Official Airflow website](https://airflow.ap
 
 Create a new release on GitHub with the release notes and assets from the release svn.
 
+For this to make use the following:
+
+- Draft a new release in https://github.com/apache/airflow/releases/new
+- Select the tag, e.g. `helm-chart/1.20.0`
+- Use title: Apache Airflow Helm Chart 1.20.0
+- Copy the release notes RST from the release. Need to convert all headings with `^^^^^` as underline to H1 in markdown with a `#` as prefix and all headings with `"""""` as underline to H2 in markdown with a `##` prefix.
+- Use binaries (all chart files, signatures and source tar) from the SVN
+- Click on "Publish release"
+
 ## Close the milestone
+
+Use: https://github.com/apache/airflow/milestones
 
 Before closing the milestone on GitHub, make sure that all PR marked for it are either part of the release (was cherry picked) or
 postponed to the next release, then close the milestone. Create the next one if it hasn't been already (it probably has been).
@@ -926,6 +956,12 @@ make sure to update the last updated timestamp as well.
 ## Close the testing status issue
 
 Don't forget to thank the folks who tested and close the issue tracking the testing status.
+
+```
+Thank you everyone. New Helm-Chart is released.
+
+I invite everyone to help improve providers for the next release, a list of open issues can be found [here](https://github.com/apache/airflow/issues?q=is%3Aissue%20state%3Aopen%20label%3Aarea%3Ahelm-chart).
+```
 
 ## Update issue template with the new release
 

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -583,7 +583,11 @@ email.
 export VOTE_DURATION_IN_HOURS=72
 export IS_SHORTEN_VOTE=$([ $VOTE_DURATION_IN_HOURS -ge 72 ] && echo "false" || echo "true")
 export SHORTEN_VOTE_TEXT="This is a shortened ($VOTE_DURATION_IN_HOURS hours vote) as agreed by policy set it https://lists.apache.org/thread/cv194w1fqqykrhswhmm54zy9gnnv6kgm"
-export VOTE_END_TIME=$(date --utc -d "now + $VOTE_DURATION_IN_HOURS hours + 10 minutes" +'%Y-%m-%d %H:%M')
+if [ "$OS" = "Darwin" ]; then  # MacOS (BSD date)
+  export VOTE_END_TIME=$(date -u -v "+${VOTE_DURATION_IN_HOURS}H" -v "+10M" +'%Y-%m-%d %H:%M')
+else  # Linux
+  export VOTE_END_TIME=$(date --utc -d "now + $VOTE_DURATION_IN_HOURS hours + 10 minutes" +'%Y-%m-%d %H:%M')
+fi
 export RELEASE_MANAGER_NAME="RELEASE_MANAGER_NAME_HERE"
 export GITHUB_ISSUE_LINK="LINK_TO_GITHUB_ISSUE"
 ```

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -583,7 +583,7 @@ email.
 export VOTE_DURATION_IN_HOURS=72
 export IS_SHORTEN_VOTE=$([ $VOTE_DURATION_IN_HOURS -ge 72 ] && echo "false" || echo "true")
 export SHORTEN_VOTE_TEXT="This is a shortened ($VOTE_DURATION_IN_HOURS hours vote) as agreed by policy set it https://lists.apache.org/thread/cv194w1fqqykrhswhmm54zy9gnnv6kgm"
-export VOTE_END_TIME=$(LANG=en_US.UTF-8 TZ=UTC date -v+"${VOTE_DURATION_IN_HOURS}"H "+%B %d, %Y %H:%M %p")
+export VOTE_END_TIME=$(date --utc -d "now + $VOTE_DURATION_IN_HOURS hours + 10 minutes" +'%Y-%m-%d %H:%M')
 export RELEASE_MANAGER_NAME="RELEASE_MANAGER_NAME_HERE"
 export GITHUB_ISSUE_LINK="LINK_TO_GITHUB_ISSUE"
 ```


### PR DESCRIPTION
Like usual with each release you find some glitches... with this PR some small updates in the docs for Helm chart release for the next release manager.

Note I also stumbled multiple times over the "date" command for voting period which might be working on mac only, not on Linuix... but the one in Helm release works, so replicating this back to providers guide...

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
