### PR TITLE
Fix typo in debug message for AirbyteTriggerSyncOperator

### DIFF
--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -94,7 +94,7 @@ class AirbyteTriggerSyncOperator(BaseOperator):
             self.log.debug("Running in non-deferrable mode...")
             hook.wait_for_job(job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout)
         else:
-            self.log.debug("Running in defferable mode in job state %s...", state)
+            self.log.debug("Running in deferrable mode in job state %s...", state)
             if state in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
                 self.defer(
                     timeout=self.execution_timeout,


### PR DESCRIPTION
**Description**

This PR fixes a typo ('defferrable') in the debug message for `execute` in `AirbyteTriggerSyncOperator`.