### PR TITLE
Add Python 3.14 Support for the Amazon Provider

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1383,7 +1383,6 @@ def test_excluded_providers():
             "excluded-providers-as-string": json.dumps(
                 {
                     "3.14": [
-                        "amazon",  # Depends on lxml<6
                         "apache.cassandra",  # Enable when the next release after 3.29.3 is available
                     ],
                 }

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -119,9 +119,6 @@ versions:
   - 1.1.0
   - 1.0.0
 
-excluded-python-versions:
-  - "3.14"
-
 integrations:
   - integration-name: Amazon Athena
     external-doc-url: https://aws.amazon.com/athena/

--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -49,9 +49,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Monitoring",
 ]
-requires-python = ">=3.10,!=3.14.*"
+requires-python = ">=3.10"
 
 # The dependencies should be modified in place in the generated file.
 # Any change in the dependencies is preserved when the file is regenerated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ packages = []
     "apache-airflow-providers-alibaba>=3.0.0"
 ]
 "amazon" = [
-    "apache-airflow-providers-amazon>=9.0.0; python_version !=\"3.14\""
+    "apache-airflow-providers-amazon>=9.0.0"
 ]
 "apache.cassandra" = [
     "apache-airflow-providers-apache-cassandra>=3.7.0; python_version !=\"3.14\""
@@ -393,7 +393,7 @@ packages = []
     "apache-airflow-core[all]",
     "apache-airflow-providers-airbyte>=5.0.0",
     "apache-airflow-providers-alibaba>=3.0.0",
-    "apache-airflow-providers-amazon>=9.0.0; python_version !=\"3.14\"",
+    "apache-airflow-providers-amazon>=9.0.0",
     "apache-airflow-providers-apache-cassandra>=3.7.0; python_version !=\"3.14\"",
     "apache-airflow-providers-apache-drill>=2.8.1",
     "apache-airflow-providers-apache-druid>=3.12.0",
@@ -496,7 +496,7 @@ packages = []
 # TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
 # boto3 have native aync support and we move away from aio aiobotocore
 "aiobotocore" =  [
-    "apache-airflow-providers-amazon[aiobotocore]>=9.6.0; python_version !=\"3.14\"",
+    "apache-airflow-providers-amazon[aiobotocore]>=9.6.0",
 ]
 "apache-atlas" = [
     "atlasclient>=0.1.2",
@@ -505,7 +505,7 @@ packages = []
     "apache-airflow-providers-apache-hdfs",
 ]
 "amazon-aws-auth" = [
-   "apache-airflow-providers-amazon[python3-saml]; python_version !=\"3.14\"",
+   "apache-airflow-providers-amazon[python3-saml]",
 ]
 "cloudpickle" = [
     "cloudpickle>=2.2.1",
@@ -536,7 +536,7 @@ packages = []
 "s3fs" = [
     # This is required for support of S3 file system which uses aiobotocore
     # which can have a conflict with boto3 as mentioned in aiobotocore extra
-    "apache-airflow-providers-amazon[s3fs]; python_version !=\"3.14\"",
+    "apache-airflow-providers-amazon[s3fs]",
 ]
 "uv" = [
     "uv>=0.10.12",
@@ -1340,7 +1340,7 @@ leveldb = [
 [tool.uv]
 required-version = ">=0.6.3"
 no-build-isolation-package = ["sphinx-redoc"]
-constraint-dependencies = ["lxml==6.0.2"]
+constraint-dependencies = ["lxml==6.0.2"]  # Remove after https://github.com/aws/amazon-redshift-python-driver/pull/272
 
 [tool.uv.sources]
 # These names must match the names as defined in the pyproject.toml of the workspace items,

--- a/scripts/tests/ci/prek/test_check_excluded_provider_markers.py
+++ b/scripts/tests/ci/prek/test_check_excluded_provider_markers.py
@@ -19,41 +19,42 @@ from __future__ import annotations
 import pytest
 from check_excluded_provider_markers import _check_dependency
 
-EXCLUDED = {
-    "apache-airflow-providers-amazon": ["3.14"],
-}
-
 
 class TestCheckDependency:
+    EXCLUDED = {
+        "apache-airflow-providers-amazon": ["3.14"],
+        "apache-airflow-providers-google": ["3.14"],
+    }
+
     def test_no_error_when_marker_present(self):
         dep = 'apache-airflow-providers-amazon>=9.0.0; python_version !="3.14"'
-        assert _check_dependency(dep, EXCLUDED) == []
+        assert _check_dependency(dep, self.EXCLUDED) == []
 
     def test_error_when_marker_missing(self):
         dep = "apache-airflow-providers-amazon>=9.0.0"
-        errors = _check_dependency(dep, EXCLUDED)
+        errors = _check_dependency(dep, self.EXCLUDED)
         assert len(errors) == 1
         assert '!="3.14"' in errors[0]
 
     def test_error_when_no_marker_with_extras(self):
         dep = "apache-airflow-providers-amazon[aiobotocore]>=9.6.0"
-        errors = _check_dependency(dep, EXCLUDED)
+        errors = _check_dependency(dep, self.EXCLUDED)
         assert len(errors) == 1
 
     def test_no_error_with_extras_and_marker(self):
         dep = 'apache-airflow-providers-amazon[aiobotocore]>=9.6.0; python_version !="3.14"'
-        assert _check_dependency(dep, EXCLUDED) == []
+        assert _check_dependency(dep, self.EXCLUDED) == []
 
     def test_no_error_for_non_excluded_provider(self):
         dep = "apache-airflow-providers-celery>=1.0.0"
-        assert _check_dependency(dep, EXCLUDED) == []
+        assert _check_dependency(dep, self.EXCLUDED) == []
 
     def test_no_error_for_non_provider_dependency(self):
         dep = "requests>=2.28"
-        assert _check_dependency(dep, EXCLUDED) == []
+        assert _check_dependency(dep, self.EXCLUDED) == []
 
     def test_invalid_requirement_ignored(self):
-        assert _check_dependency("not a valid requirement!!!", EXCLUDED) == []
+        assert _check_dependency("not a valid requirement!!!", self.EXCLUDED) == []
 
     @pytest.mark.parametrize(
         "excluded_versions",

--- a/uv.lock
+++ b/uv.lock
@@ -827,7 +827,7 @@ dependencies = [
 
 [package.optional-dependencies]
 aiobotocore = [
-    { name = "apache-airflow-providers-amazon", extra = ["aiobotocore"], marker = "python_full_version != '3.14.*'" },
+    { name = "apache-airflow-providers-amazon", extra = ["aiobotocore"] },
 ]
 airbyte = [
     { name = "apache-airflow-providers-airbyte" },
@@ -840,7 +840,7 @@ all = [
     { name = "apache-airflow-core", extra = ["all", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd"] },
     { name = "apache-airflow-providers-airbyte" },
     { name = "apache-airflow-providers-alibaba" },
-    { name = "apache-airflow-providers-amazon", extra = ["aiobotocore", "python3-saml", "s3fs"], marker = "python_full_version != '3.14.*'" },
+    { name = "apache-airflow-providers-amazon", extra = ["aiobotocore", "python3-saml", "s3fs"] },
     { name = "apache-airflow-providers-apache-cassandra", marker = "python_full_version != '3.14.*'" },
     { name = "apache-airflow-providers-apache-drill" },
     { name = "apache-airflow-providers-apache-druid" },
@@ -951,10 +951,10 @@ all-task-sdk = [
     { name = "apache-airflow-task-sdk", extra = ["all"] },
 ]
 amazon = [
-    { name = "apache-airflow-providers-amazon", marker = "python_full_version != '3.14.*'" },
+    { name = "apache-airflow-providers-amazon" },
 ]
 amazon-aws-auth = [
-    { name = "apache-airflow-providers-amazon", extra = ["python3-saml"], marker = "python_full_version != '3.14.*'" },
+    { name = "apache-airflow-providers-amazon", extra = ["python3-saml"] },
 ]
 apache-atlas = [
     { name = "atlasclient" },
@@ -1227,7 +1227,7 @@ redis = [
     { name = "apache-airflow-providers-redis" },
 ]
 s3fs = [
-    { name = "apache-airflow-providers-amazon", extra = ["s3fs"], marker = "python_full_version != '3.14.*'" },
+    { name = "apache-airflow-providers-amazon", extra = ["s3fs"] },
 ]
 salesforce = [
     { name = "apache-airflow-providers-salesforce" },
@@ -1357,11 +1357,11 @@ requires-dist = [
     { name = "apache-airflow-providers-airbyte", marker = "extra == 'all'", editable = "providers/airbyte" },
     { name = "apache-airflow-providers-alibaba", marker = "extra == 'alibaba'", editable = "providers/alibaba" },
     { name = "apache-airflow-providers-alibaba", marker = "extra == 'all'", editable = "providers/alibaba" },
-    { name = "apache-airflow-providers-amazon", marker = "python_full_version != '3.14.*' and extra == 'all'", editable = "providers/amazon" },
-    { name = "apache-airflow-providers-amazon", marker = "python_full_version != '3.14.*' and extra == 'amazon'", editable = "providers/amazon" },
-    { name = "apache-airflow-providers-amazon", extras = ["aiobotocore"], marker = "python_full_version != '3.14.*' and extra == 'aiobotocore'", editable = "providers/amazon" },
-    { name = "apache-airflow-providers-amazon", extras = ["python3-saml"], marker = "python_full_version != '3.14.*' and extra == 'amazon-aws-auth'", editable = "providers/amazon" },
-    { name = "apache-airflow-providers-amazon", extras = ["s3fs"], marker = "python_full_version != '3.14.*' and extra == 's3fs'", editable = "providers/amazon" },
+    { name = "apache-airflow-providers-amazon", marker = "extra == 'all'", editable = "providers/amazon" },
+    { name = "apache-airflow-providers-amazon", marker = "extra == 'amazon'", editable = "providers/amazon" },
+    { name = "apache-airflow-providers-amazon", extras = ["aiobotocore"], marker = "extra == 'aiobotocore'", editable = "providers/amazon" },
+    { name = "apache-airflow-providers-amazon", extras = ["python3-saml"], marker = "extra == 'amazon-aws-auth'", editable = "providers/amazon" },
+    { name = "apache-airflow-providers-amazon", extras = ["s3fs"], marker = "extra == 's3fs'", editable = "providers/amazon" },
     { name = "apache-airflow-providers-apache-cassandra", marker = "python_full_version != '3.14.*' and extra == 'all'", editable = "providers/apache/cassandra" },
     { name = "apache-airflow-providers-apache-cassandra", marker = "python_full_version != '3.14.*' and extra == 'apache-cassandra'", editable = "providers/apache/cassandra" },
     { name = "apache-airflow-providers-apache-drill", marker = "extra == 'all'", editable = "providers/apache/drill" },


### PR DESCRIPTION
Un-exclude the amazon provider from py3.14. This relies on the lxml version constraint workaround currently in `main`:

```toml
[tool.uv]
...
constraint-dependencies = ["lxml==6.0.2"]
```

related: #63520, #64061, https://github.com/aws/amazon-redshift-python-driver/pull/272

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
