### PR TITLE
fix(providers/standard): remove premature param value validation in HITLOperator

### DIFF
--- a/providers/standard/newsfragments/64108.bugfix.rst
+++ b/providers/standard/newsfragments/64108.bugfix.rst
@@ -1,0 +1,1 @@
+Fix HITLOperator ``ParamValidationError`` when params lack default values at DAG import time

--- a/providers/standard/newsfragments/64108.bugfix.rst
+++ b/providers/standard/newsfragments/64108.bugfix.rst
@@ -1,1 +1,0 @@
-Fix HITLOperator ``ParamValidationError`` when params lack default values at DAG import time

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -147,10 +147,15 @@ class HITLOperator(BaseOperator):
         """
         Validate the `params` attribute of the instance.
 
+        Note: Value validation (e.g., required fields, schema) is intentionally skipped here
+        because HITLOperator params represent form fields that are filled by a human at runtime.
+        Values do not exist at DAG parse time, so validating them in ``__init__`` would cause
+        a ``ParamValidationError`` for any param without a default. Value validation happens
+        in ``validate_params_input`` after the human submits the form.
+
         Raises:
-            ValueError: If `"_options"` key is present in `params`, which is not allowed.
+            ValueError: If ``"_options"`` key is present in ``params``, which is not allowed.
         """
-        self.params.validate()
         if "_options" in self.params:
             raise ValueError('"_options" is not allowed in params')
 

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -149,7 +149,7 @@ class HITLOperator(BaseOperator):
 
         Note: Value validation (e.g., required fields, schema) is intentionally skipped here
         because HITLOperator params represent form fields that are filled by a human at runtime.
-        Values do not exist at DAG parse time, so validating them in ``__init__`` would cause
+        Values do not exist at Dag parse time, so validating them in ``__init__`` would cause
         a ``ParamValidationError`` for any param without a default. Value validation happens
         in ``validate_params_input`` after the human submits the form.
 

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -139,27 +139,9 @@ class TestHITLOperator:
                 params=ParamsDict({"input_1": 1}),
             )
 
-    @pytest.mark.parametrize(
-        ("params", "exc", "error_msg"),
-        (
-            (ParamsDict({"_options": 1}), ValueError, '"_options" is not allowed in params'),
-            (
-                ParamsDict({"param": Param("", type="integer")}),
-                ParamValidationError,
-                (
-                    "Invalid input for param param: '' is not of type 'integer'\n\n"
-                    "Failed validating 'type' in schema:\n"
-                    "    {'type': 'integer'}\n\n"
-                    "On instance:\n    ''"
-                ),
-            ),
-        ),
-    )
-    def test_validate_params(
-        self, params: ParamsDict, exc: type[ValueError | ParamValidationError], error_msg: str
-    ) -> None:
-        # validate_params is called during initialization
-        with pytest.raises(exc, match=error_msg):
+    def test_validate_params_rejects_options_key(self) -> None:
+        """_options is a reserved key and must not be allowed in params."""
+        with pytest.raises(ValueError, match='"_options" is not allowed in params'):
             HITLOperator(
                 task_id="hitl_test",
                 subject="This is subject",
@@ -167,8 +149,56 @@ class TestHITLOperator:
                 body="This is body",
                 defaults=["1"],
                 multiple=False,
-                params=params,
+                params=ParamsDict({"_options": 1}),
             )
+
+    def test_param_without_default_does_not_raise_on_init(self) -> None:
+        """Regression test for #59551.
+
+        HITLOperator params are form fields filled by a human at runtime. A param with no
+        default value is valid — the human provides the value when submitting the form.
+        Validating param values in __init__ incorrectly raises ParamValidationError at DAG
+        parse time, before any value exists.
+        """
+        # Must not raise ParamValidationError
+        op = HITLOperator(
+            task_id="hitl_test",
+            subject="This is subject",
+            options=["1", "2"],
+            body="This is body",
+            defaults=["1"],
+            multiple=False,
+            params={"my_param": Param(type="string")},
+        )
+        assert "my_param" in op.params
+
+    def test_param_with_default_does_not_raise_on_init(self) -> None:
+        """Params with explicit defaults continue to work normally."""
+        op = HITLOperator(
+            task_id="hitl_test",
+            subject="This is subject",
+            options=["1", "2"],
+            body="This is body",
+            defaults=["1"],
+            multiple=False,
+            params={"my_param": Param("hello", type="string")},
+        )
+        assert "my_param" in op.params
+
+    def test_param_with_wrong_value_type_does_not_raise_on_init(self) -> None:
+        """Value validation is deferred to validate_params_input at runtime, not __init__."""
+        # Param("", type="integer") has a value that doesn't match the schema, but
+        # this must NOT raise at init time — the human will provide the correct value at runtime.
+        op = HITLOperator(
+            task_id="hitl_test",
+            subject="This is subject",
+            options=["1", "2"],
+            body="This is body",
+            defaults=["1"],
+            multiple=False,
+            params={"param": Param("", type="integer")},
+        )
+        assert "param" in op.params
 
     def test_validate_defaults(self) -> None:
         hitl_op = HITLOperator(

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -152,15 +152,33 @@ class TestHITLOperator:
                 params=ParamsDict({"_options": 1}),
             )
 
-    def test_param_without_default_does_not_raise_on_init(self) -> None:
+    @pytest.mark.parametrize(
+        ("params", "expected_key"),
+        [
+            pytest.param(
+                {"my_param": Param(type="string")},
+                "my_param",
+                id="no_default",
+            ),
+            pytest.param(
+                {"my_param": Param("hello", type="string")},
+                "my_param",
+                id="with_default",
+            ),
+            pytest.param(
+                {"param": Param("", type="integer")},
+                "param",
+                id="wrong_value_type",
+            ),
+        ],
+    )
+    def test_param_value_validation_deferred_to_runtime(self, params: dict, expected_key: str) -> None:
         """Regression test for #59551.
 
-        HITLOperator params are form fields filled by a human at runtime. A param with no
-        default value is valid — the human provides the value when submitting the form.
-        Validating param values in __init__ incorrectly raises ParamValidationError at DAG
-        parse time, before any value exists.
+        HITLOperator params are form fields filled by a human at runtime.
+        Value validation (required, schema) must NOT happen in __init__ — it is
+        deferred to ``validate_params_input`` after the human submits the form.
         """
-        # Must not raise ParamValidationError
         op = HITLOperator(
             task_id="hitl_test",
             subject="This is subject",
@@ -168,37 +186,9 @@ class TestHITLOperator:
             body="This is body",
             defaults=["1"],
             multiple=False,
-            params={"my_param": Param(type="string")},
+            params=params,
         )
-        assert "my_param" in op.params
-
-    def test_param_with_default_does_not_raise_on_init(self) -> None:
-        """Params with explicit defaults continue to work normally."""
-        op = HITLOperator(
-            task_id="hitl_test",
-            subject="This is subject",
-            options=["1", "2"],
-            body="This is body",
-            defaults=["1"],
-            multiple=False,
-            params={"my_param": Param("hello", type="string")},
-        )
-        assert "my_param" in op.params
-
-    def test_param_with_wrong_value_type_does_not_raise_on_init(self) -> None:
-        """Value validation is deferred to validate_params_input at runtime, not __init__."""
-        # Param("", type="integer") has a value that doesn't match the schema, but
-        # this must NOT raise at init time — the human will provide the correct value at runtime.
-        op = HITLOperator(
-            task_id="hitl_test",
-            subject="This is subject",
-            options=["1", "2"],
-            body="This is body",
-            defaults=["1"],
-            multiple=False,
-            params={"param": Param("", type="integer")},
-        )
-        assert "param" in op.params
+        assert expected_key in op.params
 
     def test_validate_defaults(self) -> None:
         hitl_op = HITLOperator(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of a new feature or fix,
tell us about it, write a summary of changes.

In case of a bug fix, tell us the expected behavior and the error message.

Please also check the Contributing guide:
https://github.com/apache/airflow/blob/main/contributing-docs/README.rst

Read the Pull Request Guidelines for more information.
In case of fundamental code changes, an Airflow Improvement Proposal (AIP) is needed.
In case of a new dependency, check compliance with the ASF 3rd Party License Policy.
In case of backwards incompatible changes please leave a note in a newsfragment file,
named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in
airflow-core/newsfragments
-->

### Summary

Fixes a regression introduced when `HITLOperator.validate_params()` was extended to call `self.params.validate()`. HITL params are **form fields filled by a human at runtime** — validating their values at DAG parse time (`__init__`) causes `ParamValidationError` for any param that lacks an explicit default value, breaking DAG import.

**Root cause**: `HITLOperator.__init__` → `validate_params()` → `self.params.validate()` → `Param.resolve()` raises `ParamValidationError("No value passed and Param has no default value")` if the param has no default. This validation runs at parse time, but no human input exists yet at that point.

**Fix**: Remove `self.params.validate()` from `validate_params()`. Value validation (type, schema, required fields) already happens correctly in `validate_params_input()` after the human submits the form.

The `"_options"` key check is preserved — it is a structural constraint that can and should be validated at init time.

Credit to @henry3260 who identified the same fix in #59653, which closed as stale without a review.

### Before fixing

```python
# DAG import fails with:
# ParamValidationError: Invalid input for param my_param: No value passed and Param has no default value
HITLOperator(
    task_id="ask_user",
    subject="Please provide input",
    options=["OK"],
    params={"my_param": Param(type="string")},  # no default — valid HITL use case
)
```

### After fixing

```python
# DAG imports successfully. Value is validated when the human submits the form.
HITLOperator(
    task_id="ask_user",
    subject="Please provide input",
    options=["OK"],
    params={"my_param": Param(type="string")},
)
```

### Changes

- `providers/standard/src/airflow/providers/standard/operators/hitl.py`: removed `self.params.validate()` from `validate_params()`; added a docstring clarifying why value validation is intentionally deferred
- `providers/standard/tests/unit/standard/operators/test_hitl.py`:
  - Renamed `test_validate_params` parametrize to individual named tests for clarity
  - Removed the `ParamValidationError` case (wrong-type value at init) — this is no longer expected at init
  - Added `test_param_without_default_does_not_raise_on_init` — regression test for #59551
  - Added `test_param_with_default_does_not_raise_on_init` — happy path
  - Added `test_param_with_wrong_value_type_does_not_raise_on_init` — confirms value validation is deferred

Closes #59551

---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).

<!-- Please keep an empty line above the dashes. -->

**Are there any user-facing changes?**

Yes — DAGs using `HITLOperator` (or any subclass) with params that have no explicit default value will now import successfully, as they should.

**Are there any breaking changes?**

No. The removed call `self.params.validate()` was incorrect behavior — it caused `ParamValidationError` at DAG parse time. Removing it restores correct behavior without impacting any valid use case.

**Commit message for squash merge:**

fix(providers/standard): remove premature param value validation in HITLOperator

**Generated with AI assistance**: Implemented with Claude Code. The logic, root cause analysis, and test strategy were reviewed and confirmed correct.