### PR TITLE
Add tests for execute_complete success and error handling in AirbyteTriggerSyncOperator

### DIFF
--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -127,7 +127,7 @@ class AirbyteTriggerSyncOperator(BaseOperator):
         """
         if event["status"] == "error":
             self.log.debug("Error occurred with context: %s", context)
-            raise AirflowException(event["message"])
+            raise RuntimeError(event["message"])
 
         self.log.info("%s completed successfully.", self.task_id)
         return None

--- a/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
 from airbyte_api.models import JobCreateRequest, JobResponse, JobStatusEnum, JobTypeEnum
 
 from airflow.models import Connection
@@ -66,6 +67,52 @@ class TestAirbyteTriggerSyncOp:
         mock_wait_for_job.assert_called_once_with(
             job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout
         )
+
+    @pytest.mark.parametrize("status", ["success", "cancelled"])
+    def test_execute_complete_non_error_states(self, status, create_connection_without_db):
+        conn = Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com")
+        create_connection_without_db(conn)
+
+        op = AirbyteTriggerSyncOperator(
+            task_id="test_airbyte_op",
+            airbyte_conn_id=self.airbyte_conn_id,
+            connection_id=self.connection_id,
+            wait_seconds=self.wait_seconds,
+            timeout=self.timeout,
+            deferrable=True,
+        )
+
+        event = {
+            "status": status,
+            "message": "succeeded/cancelled",
+            "job_id": self.job_id,
+        }
+
+        result = op.execute_complete(context={}, event=event)
+
+        assert result is None
+
+    def test_execute_complete_error(self, create_connection_without_db):
+        conn = Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com")
+        create_connection_without_db(conn)
+
+        op = AirbyteTriggerSyncOperator(
+            task_id="test_airbyte_op",
+            airbyte_conn_id=self.airbyte_conn_id,
+            connection_id=self.connection_id,
+            wait_seconds=self.wait_seconds,
+            timeout=self.timeout,
+            deferrable=True,
+        )
+
+        error_event = {
+            "status": "error",
+            "message": "Job failed",
+            "job_id": self.job_id,
+        }
+
+        with pytest.raises(RuntimeError, match="Job failed"):
+            op.execute_complete(context={}, event=error_event)
 
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.get_job_status")
     @mock.patch("airflow.providers.airbyte.hooks.airbyte.AirbyteHook.cancel_job")

--- a/scripts/ci/prek/known_airflow_exceptions.txt
+++ b/scripts/ci/prek/known_airflow_exceptions.txt
@@ -32,7 +32,7 @@ devel-common/src/tests_common/test_utils/salesforce_system_helpers.py::2
 devel-common/src/tests_common/test_utils/sftp_system_helpers.py::1
 devel-common/src/tests_common/test_utils/watcher.py::1
 providers/airbyte/src/airflow/providers/airbyte/hooks/airbyte.py::8
-providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py::4
+providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py::3
 providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py::6
 providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/analyticdb_spark.py::6
 providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/oss.py::11


### PR DESCRIPTION
**Description**

This PR adds unit tests for `AirbyteTriggerSyncOperator.execute_complete`. The tests cover scenarios where the operator completes successfully on non-error events and where an error event triggers an exception.

**Rationale**

`execute_complete` is a key part of the deferrable execution flow but was not previously covered by the test suite. The method contains branching logic based on trigger event status that determines whether execution succeeds or fails. 

**Notes**

* The Airbyte connection has been mocked prematurely to accomodate changes in PR #64051. These 2 PRs are forwards-compatible i.e. the changes will work irrespective of the merge order.
* Opportunistically updated exception type from `AirflowException` to `RuntimeError` to align with agreed consensus and current implementation, as one of the tests asserts that an error is raised.