### PR TITLE
Fix shell injection in GitHook SSH passphrase askpass script

### DIFF
--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -21,6 +21,7 @@ import contextlib
 import json
 import logging
 import os
+import shlex
 import stat
 import tempfile
 from typing import Any
@@ -157,7 +158,7 @@ class GitHook(BaseHook):
             return
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=True) as askpass_script:
-            askpass_script.write(f"#!/bin/sh\necho '{self.private_key_passphrase}'\n")
+            askpass_script.write(f"#!/bin/sh\necho {shlex.quote(self.private_key_passphrase)}\n")
             askpass_script.flush()
             os.chmod(askpass_script.name, stat.S_IRWXU)
 


### PR DESCRIPTION
The passphrase was embedded in a generated shell script using bare single quotes,
which would break or allow command injection if the passphrase contained
shell metacharacters (single quotes, `$`, backticks, etc.). Use `shlex.quote()`
to safely escape the value.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)