### PR TITLE
Docs: Fix inconsistency in documents when using `BashOperator` with Jinja templating

### DIFF
--- a/airflow-core/docs/core-concepts/dag-run.rst
+++ b/airflow-core/docs/core-concepts/dag-run.rst
@@ -271,7 +271,8 @@ Example of a parameterized Dag:
 
     parameterized_task = BashOperator(
         task_id="parameterized_task",
-        bash_command="echo value: {{ dag_run.conf['conf1'] }}",
+        bash_command="echo \"here is the message: '$message'\"",
+        env={"message": '{{ dag_run.conf["message"] if dag_run else "" }}'},
         dag=dag,
     )
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Why

The [BashOperator](https://airflow.apache.org/docs/apache-airflow/2.4.3/howto/operator/bash.html#templating) document has a warning about passing `dag_run.conf` directly into the `bash_command`. This usage is not suggested. However, in the [Core Concepts - Dag Run](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dag-run.html#passing-parameters-when-triggering-dags) document, the example use the pattern that is not recommended, which is an inconsistency. This PR fixes this by updating the example in the Core Concepts -Dag Run document.

### BashOperator Document

<img width="1153" height="411" alt="Screenshot from 2026-03-23 22-25-46" src="https://github.com/user-attachments/assets/8e1ade08-9cf9-4c7d-990c-b812dee1529d" />

### Core Concepts - Dag Run Document

<img width="1153" height="411" alt="Screenshot from 2026-03-23 22-26-51" src="https://github.com/user-attachments/assets/a5e53344-8d7d-4a9c-bacb-a4b7f0265433" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
