### PR TITLE
Speed up 'Generate the FastAPI API spec' prek hook (~2min → ~25s)

### DIFF
--- a/scripts/ci/prek/generate_openapi_spec.py
+++ b/scripts/ci/prek/generate_openapi_spec.py
@@ -33,7 +33,7 @@ initialize_breeze_prek(__name__, __file__)
 
 cmd_result = run_command_via_breeze_shell(
     ["python3", "/opt/airflow/scripts/in_container/run_generate_openapi_spec.py"],
-    backend="postgres",
+    backend="sqlite",
     skip_environment_initialization=False,
 )
 


### PR DESCRIPTION
The `generate-openapi-spec` prek hook was running with `backend="postgres"`, adding ~90 seconds of Postgres container startup and DB migration overhead on every invocation.

Since OpenAPI spec generation only introspects FastAPI routes and never queries the database, Postgres is unnecessary. Switching to `backend="sqlite"` cuts the hook runtime from ~2 minutes to ~25 seconds (~78% faster).

Benchmarks (wall clock, measured via `time`):

| Backend | `skip_environment_initialization` | Time |
|---|---|---|
| postgres | False (original) | ~2 min |
| postgres | True | ~31 s |
| **sqlite** | **False** | **~25 s** ← new |
| sqlite | True | ~31 s |

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)