### PR TITLE
document missing secret name keys

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -498,19 +498,14 @@ extraEnvFrom: ~
 
 # Airflow database & redis config
 data:
-  # If secret names are provided, use those secrets
-  # These secrets must be created manually, eg:
-  #
-  # kind: Secret
-  # apiVersion: v1
-  # metadata:
-  #   name: custom-airflow-metadata-secret
-  # type: Opaque
-  # data:
-  #   connection: base64_encoded_connection_string
-
+  # Must contain a 'connection' key (e.g., postgresql://user:pass@host:5432/db).
+  # Optional: 'kedaConnection'. Note: URL-encode special characters in passwords.
   metadataSecretName: ~
+
+  # Must contain a 'connection' key. If not provided, it falls back to 'metadataSecretName'.
   resultBackendSecretName: ~
+
+  # Must contain a 'connection' key (e.g., redis://:pass@host:6379/0).
   brokerUrlSecretName: ~
 
   # Otherwise pass connection values in
@@ -545,6 +540,10 @@ data:
 # Fernet key settings
 # Note: fernetKey can only be set during install, not upgrade
 fernetKey: ~
+# The Secret MUST contain a 'fernet-key' key.
+#
+# To handle rotation, provide multiple comma-separated keys in the Secret.
+# New values are encrypted with the first key; decryption is attempted with all keys.
 fernetKeySecretName: ~
 # Add custom annotations to the fernet key secret
 fernetKeySecretAnnotations: {}
@@ -553,18 +552,24 @@ fernetKeySecretAnnotations: {}
 apiSecretKey: ~
 # Add custom annotations to the api secret
 apiSecretAnnotations: {}
+# Must contain an 'api-secret-key' key (suggested: random 32-char string).
+# Note: Values in K8s Secrets must be Base64 encoded.
 apiSecretKeySecretName: ~
 
 # Secret key used to encode and decode JWTs: `[api_auth] jwt_secret` in airflow.cfg
 jwtSecret: ~
 # Add custom annotations to the JWT secret
 jwtSecretAnnotations: {}
+# Must contain a 'jwt-secret' key (suggested: random 32-char string).
+# Note: Values in K8s Secrets must be Base64 encoded.
 jwtSecretName: ~
 
 # Flask secret key for Airflow <3 Webserver: `[webserver] secret_key` in airflow.cfg
 webserverSecretKey: ~
 # Add custom annotations to the webserver secret
 webserverSecretAnnotations: {}
+# Must contain a 'webserver-secret-key' key (suggested: random 32-char string).
+# Note: Values in K8s Secrets must be Base64 encoded.
 webserverSecretKeySecretName: ~
 
 # In order to use kerberos you need to create secret containing the keytab file
@@ -2777,6 +2782,8 @@ flower:
     annotations: {}
 
   # A secret containing the connection
+  # The Secret MUST contain a 'basicAuth' key (formatted as 'username:password').
+  # Note: Values in K8s Secrets must be Base64 encoded.
   secretName: ~
   # Add custom annotations to the flower secret
   secretAnnotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -553,7 +553,6 @@ apiSecretKey: ~
 # Add custom annotations to the api secret
 apiSecretAnnotations: {}
 # Must contain an 'api-secret-key' key (suggested: random 32-char string).
-# Note: Values in K8s Secrets must be Base64 encoded.
 apiSecretKeySecretName: ~
 
 # Secret key used to encode and decode JWTs: `[api_auth] jwt_secret` in airflow.cfg
@@ -561,7 +560,6 @@ jwtSecret: ~
 # Add custom annotations to the JWT secret
 jwtSecretAnnotations: {}
 # Must contain a 'jwt-secret' key (suggested: random 32-char string).
-# Note: Values in K8s Secrets must be Base64 encoded.
 jwtSecretName: ~
 
 # Flask secret key for Airflow <3 Webserver: `[webserver] secret_key` in airflow.cfg
@@ -569,7 +567,6 @@ webserverSecretKey: ~
 # Add custom annotations to the webserver secret
 webserverSecretAnnotations: {}
 # Must contain a 'webserver-secret-key' key (suggested: random 32-char string).
-# Note: Values in K8s Secrets must be Base64 encoded.
 webserverSecretKeySecretName: ~
 
 # In order to use kerberos you need to create secret containing the keytab file
@@ -2782,8 +2779,7 @@ flower:
     annotations: {}
 
   # A secret containing the connection
-  # The Secret MUST contain a 'basicAuth' key (formatted as 'username:password').
-  # Note: Values in K8s Secrets must be Base64 encoded.
+  # The Secret MUST contain a 'basicAuth' key (formatted as 'username:password')
   secretName: ~
   # Add custom annotations to the flower secret
   secretAnnotations: {}


### PR DESCRIPTION
### Summary

This PR adds missing documentation for several secret name parameters in values.yaml. These parameters were previously undocumented or lacked specific details regarding their required internal Kubernetes Secret keys and fallback behaviors.
* closes: #64106

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
