### PR TITLE
docs: document secret key names for Helm chart secretName options

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -508,8 +508,18 @@ data:
   # type: Opaque
   # data:
   #   connection: base64_encoded_connection_string
+  #
+  # The secret must contain a key ``connection`` with a base64-encoded
+  # SQLAlchemy connection string, e.g.:
+  #
+  #   postgresql+psycopg2://airflow:password@postgres/airflow
 
   metadataSecretName: ~
+  # If not set, falls back to metadataSecretName. The secret must contain a key
+  # ``connection`` with a base64-encoded connection string, e.g.:
+  #
+  #   postgresql+psycopg2://user:password@host/db
+  #
   resultBackendSecretName: ~
   brokerUrlSecretName: ~
 
@@ -545,6 +555,17 @@ data:
 # Fernet key settings
 # Note: fernetKey can only be set during install, not upgrade
 fernetKey: ~
+# If set, the secret must contain a key ``fernet-key`` with a base64-encoded
+# Fernet key value. Example secret:
+#
+#   kind: Secret
+#   apiVersion: v1
+#   metadata:
+#     name: custom-fernet-key-secret
+#   type: Opaque
+#   data:
+#     fernet-key: <base64_encoded_fernet_key>
+#
 fernetKeySecretName: ~
 # Add custom annotations to the fernet key secret
 fernetKeySecretAnnotations: {}
@@ -553,18 +574,52 @@ fernetKeySecretAnnotations: {}
 apiSecretKey: ~
 # Add custom annotations to the api secret
 apiSecretAnnotations: {}
+# If set, the secret must contain a key ``api-secret-key`` with a base64-encoded
+# API secret key value. Example secret:
+#
+#   kind: Secret
+#   apiVersion: v1
+#   metadata:
+#     name: custom-api-secret
+#   type: Opaque
+#   data:
+#     api-secret-key: <base64_encoded_api_secret_key>
+#
 apiSecretKeySecretName: ~
 
 # Secret key used to encode and decode JWTs: `[api_auth] jwt_secret` in airflow.cfg
 jwtSecret: ~
 # Add custom annotations to the JWT secret
 jwtSecretAnnotations: {}
+# If set, the secret must contain a key ``jwt-secret`` with a base64-encoded
+# JWT secret value. Example secret:
+#
+#   kind: Secret
+#   apiVersion: v1
+#   metadata:
+#     name: custom-jwt-secret
+#   type: Opaque
+#   data:
+#     jwt-secret: <base64_encoded_jwt_secret>
+#
 jwtSecretName: ~
 
 # Flask secret key for Airflow <3 Webserver: `[webserver] secret_key` in airflow.cfg
 webserverSecretKey: ~
 # Add custom annotations to the webserver secret
 webserverSecretAnnotations: {}
+# Deprecated in favor of apiSecretKeySecretName (Airflow 3+).
+# If set, the secret must contain a key ``webserver-secret-key`` with a
+# base64-encoded secret key value. Example secret:
+#
+#   kind: Secret
+#   apiVersion: v1
+#   metadata:
+#     name: custom-webserver-secret
+#   type: Opaque
+#   data:
+#     webserver-secret-key: <base64_encoded_secret_key>
+#
 webserverSecretKeySecretName: ~
 
 # In order to use kerberos you need to create secret containing the keytab file
@@ -2776,7 +2831,17 @@ flower:
     # Annotations to add to worker kubernetes service account.
     annotations: {}
 
-  # A secret containing the connection
+  # If set, the secret must contain a key ``connection`` with a base64-encoded
+  # Flower basic auth connection string (user:password). Example secret:
+  #
+  #   kind: Secret
+  #   apiVersion: v1
+  #   metadata:
+  #     name: custom-flower-secret
+  #   type: Opaque
+  #   data:
+  #     connection: <base64_encoded_user_password>
+  #
   secretName: ~
   # Add custom annotations to the flower secret
   secretAnnotations: {}


### PR DESCRIPTION
## Description

Improves inline documentation in `chart/values.yaml` for various `secretName` options, following the existing style of `pgbouncer.configSecretName`.

Closes #64106

## Changes

- `metadataSecretName` — added a sample SQLAlchemy connection string example
- `resultBackendSecretName` — added a note that it falls back to `metadataSecretName` if not set, plus a connection string example
- `fernetKeySecretName` — documented the expected secret key (`fernet-key`) with an example Secret manifest
- `jwtSecretName` — documented the expected secret key (`jwt-secret`) with an example Secret manifest
- `apiSecretKeySecretName` — documented the expected secret key (`api-secret-key`) with an example Secret manifest
- `webserverSecretKeySecretName` — added deprecation note (use `apiSecretKeySecretName` for Airflow 3+) and example Secret manifest
- `flower.secretName` — documented the expected secret key (`connection`) with an example Secret manifest
