### PR TITLE
update check_clie_definition_import to allow using common provider sdk

### DIFF
--- a/scripts/ci/prek/check_cli_definition_imports.py
+++ b/scripts/ci/prek/check_cli_definition_imports.py
@@ -165,7 +165,7 @@ def main() -> int:
             f"[yellow]CLI definition files (*/cli/definition.py) should only import from:[/]\n"
             "  - airflow.configuration\n"
             "  - airflow.cli.cli_config\n"
-            "  - airflow.providers.common.compat.sdk\n"
+            "  - airflow.providers.common.compat.sdk.conf\n"
             "  - Their own provider's version_compat module\n"
             f"  - Standard library modules ({', '.join(STDLIB_PREFIXES)})\n"
         )

--- a/scripts/ci/prek/check_cli_definition_imports.py
+++ b/scripts/ci/prek/check_cli_definition_imports.py
@@ -39,7 +39,11 @@ from pathlib import Path
 from common_prek_utils import console, get_imports_from_file
 
 # Allowed modules that can be imported in CLI definition files
-ALLOWED_MODULES = {"airflow.configuration", "airflow.cli.cli_config", "airflow.providers.common.compat.sdk"}
+ALLOWED_MODULES = {
+    "airflow.configuration",
+    "airflow.cli.cli_config",
+    "airflow.providers.common.compat.sdk.conf",
+}
 
 # Standard library and __future__ modules are also allowed
 STDLIB_PREFIXES = (

--- a/scripts/ci/prek/check_cli_definition_imports.py
+++ b/scripts/ci/prek/check_cli_definition_imports.py
@@ -39,10 +39,7 @@ from pathlib import Path
 from common_prek_utils import console, get_imports_from_file
 
 # Allowed modules that can be imported in CLI definition files
-ALLOWED_MODULES = {
-    "airflow.configuration",
-    "airflow.cli.cli_config",
-}
+ALLOWED_MODULES = {"airflow.configuration", "airflow.cli.cli_config", "airflow.providers.common.compat.sdk"}
 
 # Standard library and __future__ modules are also allowed
 STDLIB_PREFIXES = (
@@ -164,6 +161,7 @@ def main() -> int:
             f"[yellow]CLI definition files (*/cli/definition.py) should only import from:[/]\n"
             "  - airflow.configuration\n"
             "  - airflow.cli.cli_config\n"
+            "  - airflow.providers.common.compat.sdk\n"
             "  - Their own provider's version_compat module\n"
             f"  - Standard library modules ({', '.join(STDLIB_PREFIXES)})\n"
         )


### PR DESCRIPTION
### Body

error occurs when doing task related: https://github.com/apache/airflow/issues/60000

```
Check CLI definition files only import allowed modules....................................................Failed
- hook id: check-cli-definition-imports
- exit code: 1

  Checking 1 CLI definition file(s)...
  [PosixPath('edge3/src/airflow/providers/edge3/cli/definition.py')]

   Some CLI definition files contain forbidden imports!

  CLI definition files (*/cli/definition.py) should only import from:
    - airflow.configuration
    - airflow.cli.cli_config
    - Their own provider's version_compat module
    - Standard library modules (argparse, getpass, textwrap, typing, collections, functools, itertools, pathlib, os, sys, re, json, dataclasses, enum)

  Found forbidden imports in:

  edge3/src/airflow/providers/edge3/cli/definition.py:
    - airflow.providers.common.compat.sdk.conf

  This restriction exists to:
    - Keep CLI definitions lightweight and declarative to avoid slowdowns
    - Ensure clean separation between CLI structure and implementation
```

Resolving it by allowing to use common provider sdk


<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
