### PR TITLE
Fix FAB DB manager discovery in migration-only contexts

### DIFF
--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -196,16 +196,17 @@ class RunDBManager(LoggingMixin):
     """
 
     def __init__(self):
-        from airflow.api_fastapi.app import create_auth_manager
         from airflow.providers_manager import ProvidersManager
 
         super().__init__()
         self._managers: list[BaseDBManager] = []
 
-        # Start with auto-discovered DB managers from installed providers
+        # Start with auto-discovered DB managers from installed providers.
+        # ProvidersManager reads the ``db-managers`` key from each provider's
+        # get_provider_info() and is the primary source of truth.
         managers: list[str] = list(ProvidersManager().db_managers)
 
-        # Add any explicitly configured managers not already discovered
+        # Add any explicitly configured managers not already discovered.
         managers_config = conf.get("database", "external_db_managers", fallback=None)
         if managers_config:
             for m in managers_config.split(","):
@@ -213,10 +214,28 @@ class RunDBManager(LoggingMixin):
                     if stripped not in managers:
                         managers.append(stripped)
 
-        # Add DB manager declared by the configured auth manager (existing behavior, deduplicated)
-        auth_manager_db_manager = create_auth_manager().get_db_manager()
-        if auth_manager_db_manager and auth_manager_db_manager not in managers:
-            managers.append(auth_manager_db_manager)
+        # Add the DB manager declared by the configured auth manager as a
+        # final fallback for backward compatibility.
+        # This is wrapped in a try/except because in migration-only contexts
+        # (e.g. the Helm migrateDatabaseJob) the auth manager may not be fully
+        # initializable — a Flask app context or other runtime state may be
+        # absent.  A failure here must not silently drop the auth manager's DB
+        # manager from the migration list; ProvidersManager discovery above is
+        # the reliable path in those contexts.
+        try:
+            from airflow.api_fastapi.app import create_auth_manager
+
+            auth_manager_db_manager = create_auth_manager().get_db_manager()
+            if auth_manager_db_manager and auth_manager_db_manager not in managers:
+                managers.append(auth_manager_db_manager)
+        except Exception:
+            self.log.debug(
+                "Could not retrieve DB manager from auth manager during RunDBManager "
+                "initialisation. This is expected in migration-only contexts where the "
+                "auth manager cannot be fully initialised. DB managers discovered via "
+                "ProvidersManager will still be used.",
+                exc_info=True,
+            )
 
         for module in managers:
             manager = import_string(module.strip())

--- a/airflow-core/tests/unit/utils/test_db_manager.py
+++ b/airflow-core/tests/unit/utils/test_db_manager.py
@@ -230,10 +230,76 @@ class TestRunDBManager:
     def test_initdb_and_upgradedb_pass_use_migration_files_to_var_kwarg_manager(self, session):
         VarKwargExternalManager.initdb_kwargs = []
         VarKwargExternalManager.upgradedb_kwargs = []
-
         run_db_manager = _create_run_db_manager(VarKwargExternalManager)
         run_db_manager.initdb(session=session, use_migration_files=True)
         run_db_manager.upgradedb(session=session, use_migration_files=False)
 
         assert VarKwargExternalManager.initdb_kwargs == [{"use_migration_files": True}]
         assert VarKwargExternalManager.upgradedb_kwargs == [{"use_migration_files": False}]
+
+    @mock.patch("airflow.utils.db_manager.import_string")
+    def test_run_db_manager_uses_providers_manager_when_auth_manager_fails(self, mock_import):
+        """
+        When create_auth_manager() raises in a migration-only context (e.g. the Helm
+        migrateDatabaseJob), RunDBManager must still load managers discovered via
+        ProvidersManager — the exception must not silently drop all DB managers.
+        """
+        sentinel = object()
+        mock_import.return_value = sentinel
+
+        with (
+            mock.patch(
+                "airflow.providers_manager.ProvidersManager",
+            ) as mock_pm,
+            mock.patch(
+                "airflow.api_fastapi.app.create_auth_manager",
+                side_effect=RuntimeError("No app context"),
+            ),
+        ):
+            mock_pm.return_value.db_managers = ["airflow.providers.fab.auth_manager.models.db.FABDBManager"]
+            with mock.patch("airflow.utils.db_manager.conf") as mock_conf:
+                mock_conf.get.return_value = None
+                rdm = RunDBManager.__new__(RunDBManager)
+                # Manually call __init__ so we control all side-effects
+                RunDBManager.__init__(rdm)
+
+        # The sentinel class returned by import_string must be in _managers
+        assert sentinel in rdm._managers
+
+    @mock.patch("airflow.utils.db_manager.import_string")
+    def test_run_db_manager_includes_auth_manager_db_manager_when_available(self, mock_import):
+        """
+        When create_auth_manager() succeeds and returns a DB manager class name not
+        already in the ProvidersManager list, it must be appended to _managers.
+        """
+        sentinel_pm = object()
+        sentinel_am = object()
+        call_order = []
+
+        def _import(path):
+            if "fab" in path:
+                call_order.append("fab")
+                return sentinel_pm
+            call_order.append("auth_manager_extra")
+            return sentinel_am
+
+        mock_import.side_effect = _import
+
+        mock_am = mock.MagicMock()
+        mock_am.get_db_manager.return_value = "some.extra.AuthManagerDBManager"
+
+        with (
+            mock.patch("airflow.providers_manager.ProvidersManager") as mock_pm,
+            mock.patch(
+                "airflow.api_fastapi.app.create_auth_manager",
+                return_value=mock_am,
+            ),
+        ):
+            mock_pm.return_value.db_managers = ["airflow.providers.fab.auth_manager.models.db.FABDBManager"]
+            with mock.patch("airflow.utils.db_manager.conf") as mock_conf:
+                mock_conf.get.return_value = None
+                rdm = RunDBManager.__new__(RunDBManager)
+                RunDBManager.__init__(rdm)
+
+        assert sentinel_pm in rdm._managers
+        assert sentinel_am in rdm._managers


### PR DESCRIPTION
This PR fixes a bug where the FABDBManager is not automatically discovered during database migrations in lean environments, such as the Helm migrateDatabaseJob.In these contexts (e.g., worker/migration containers), the call to 
create_auth_manager().get_db_manager() in RunDBManager can fail because it may require an application context or runtime state that is not present. Previously, this failure was unhandled, causing the FABDBManager to be skipped and results in missing FAB tables (like ab_user, ab_role) unless manually configured.

This change wraps the fallback auth manager check in a try...except block, ensuring the migration process correctly uses the FABDBManager discovered via ProvidersManager which is the reliable discovery path in these environments.

closes: #63847

Was generative AI tooling used to co-author this PR?

Yes — Gemini (Code Research and PR Description)