### PR TITLE
FIX: Allow override of HTTP method in run_method of LivyAsyncHook

### DIFF
--- a/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/hooks/livy.py
@@ -523,7 +523,7 @@ class LivyAsyncHook(HttpAsyncHook):
         )
 
         try:
-            async with self.session() as session:
+            async with self.session(method=method) as session:
                 response = await session.run(
                     endpoint=endpoint,
                     data=data,

--- a/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
@@ -659,8 +659,7 @@ class TestLivyAsyncHook:
             return_value={"hello": "world"}
         )
         hook = LivyAsyncHook(livy_conn_id=LIVY_CONN_ID)
-        hook.method = "GET"
-        response = await hook.run_method("api/jobs/runs/get")
+        response = await hook.run_method("api/jobs/runs/get", method="GET")
         assert response["status"] == "success"
         assert response["response"] == {"hello": "world"}
 
@@ -682,8 +681,7 @@ class TestLivyAsyncHook:
             return_value={"hello": "world"}
         )
         hook = LivyAsyncHook(livy_conn_id=LIVY_CONN_ID)
-        hook.method = "PATCH"
-        response = await hook.run_method("api/jobs/runs/get")
+        response = await hook.run_method("api/jobs/runs/get", method="PATCH")
         assert response["status"] == "success"
         assert response["response"] == {"hello": "world"}
 

--- a/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/hooks/test_livy.py
@@ -592,27 +592,6 @@ class TestLivyAsyncHook:
         assert log_dump == {"id": 1, "log": ["mock_log_1", "mock_log_2"]}
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.http.hooks.http.aiohttp.ClientSession")
-    @mock.patch(
-        "airflow.providers.common.compat.connection.get_async_connection",
-        return_value=Connection(
-            conn_id=LIVY_CONN_ID,
-            conn_type="http",
-            host="http://host",
-            port=80,
-        ),
-    )
-    async def test_run_method_success(self, mock_get_connection, mock_session):
-        """Asserts the run_method for success response."""
-        mock_session.return_value.__aenter__.return_value.post = AsyncMock()
-        mock_session.return_value.__aenter__.return_value.post.return_value.json = AsyncMock(
-            return_value={"id": 1}
-        )
-        hook = LivyAsyncHook(livy_conn_id=LIVY_CONN_ID)
-        response = await hook.run_method("localhost", "GET")
-        assert response == {"status": "success", "response": {"id": 1}}
-
-    @pytest.mark.asyncio
     async def test_run_method_error(self):
         """Asserts the run_method for error response."""
         hook = LivyAsyncHook(livy_conn_id=LIVY_CONN_ID)

--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -453,8 +453,10 @@ class AsyncHttpSession(LoggingMixin):
         hook: HttpAsyncHook,
         request: Callable[..., Awaitable[ClientResponse]],
         config: SessionConfig,
+        method: str | None = None,
     ) -> None:
         super().__init__()
+        self.method = method or hook.method
         self._hook = hook
         self._request = request
         self.config = config
@@ -466,10 +468,6 @@ class AsyncHttpSession(LoggingMixin):
     @property
     def base_url(self) -> str:
         return self.config.base_url
-
-    @property
-    def method(self) -> str:
-        return self._hook.method
 
     @property
     def retry_limit(self) -> int:
@@ -587,23 +585,23 @@ class HttpAsyncHook(BaseHook):
         self.retry_delay = retry_delay
         self._config: SessionConfig | None = None
 
-    def _get_request_func(self, session: aiohttp.ClientSession) -> Callable[..., Any]:
-        method = self.method
-        if method == "GET":
+    def _get_request_func(self, session: aiohttp.ClientSession, method: str | None = None) -> Callable[..., Any]:
+        http_method = method or self.method
+        if http_method == "GET":
             return session.get
-        if method == "POST":
+        if http_method == "POST":
             return session.post
-        if method == "PATCH":
+        if http_method == "PATCH":
             return session.patch
-        if method == "HEAD":
+        if http_method == "HEAD":
             return session.head
-        if method == "PUT":
+        if http_method == "PUT":
             return session.put
-        if method == "DELETE":
+        if http_method == "DELETE":
             return session.delete
-        if method == "OPTIONS":
+        if http_method == "OPTIONS":
             return session.options
-        raise HttpMethodException(f"Unexpected HTTP Method: {method}")
+        raise HttpMethodException(f"Unexpected HTTP Method: {http_method}")
 
     async def config(self) -> SessionConfig:
         if not self._config:
@@ -644,16 +642,19 @@ class HttpAsyncHook(BaseHook):
         return self._config
 
     @asynccontextmanager
-    async def session(self) -> AsyncGenerator[AsyncHttpSession, None]:
+    async def session(self, method: str | None = None) -> AsyncGenerator[AsyncHttpSession, None]:
         """
         Create an ``AsyncHttpSession`` bound to a single ``aiohttp.ClientSession``.
 
         Airflow connection resolution happens exactly once here.
+
+        :param method: Optional HTTP method to be used for requests made by the returned session.
+            If provided, this value overrides the hook's configured default method.
         """
         async with aiohttp.ClientSession() as session:
-            request = self._get_request_func(session=session)
+            request = self._get_request_func(session=session, method=method)
             config = await self.config()
-            yield AsyncHttpSession(hook=self, request=request, config=config)
+            yield AsyncHttpSession(hook=self, request=request, config=config, method=method)
 
     async def run(
         self,

--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -585,7 +585,9 @@ class HttpAsyncHook(BaseHook):
         self.retry_delay = retry_delay
         self._config: SessionConfig | None = None
 
-    def _get_request_func(self, session: aiohttp.ClientSession, method: str | None = None) -> Callable[..., Any]:
+    def _get_request_func(
+        self, session: aiohttp.ClientSession, method: str | None = None
+    ) -> Callable[..., Any]:
         http_method = method or self.method
         if http_method == "GET":
             return session.get

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -739,6 +739,22 @@ class TestHttpAsyncHook:
                 await hook.run(session=session, endpoint="non_existent_endpoint", data=json)
 
     @pytest.mark.asyncio
+    async def test_async_get_request(self):
+        """Test api call asynchronously for POST request."""
+        hook = HttpAsyncHook()
+
+        with aioresponses() as m:
+            m.get(
+                "http://test:8080/v1/test",
+                status=200,
+                payload='{"status":{"status": 200}}',
+                reason="OK",
+            )
+            async with hook.session(method="GET") as session:
+                resp = await session.run(endpoint="v1/test")
+                assert resp.status == 200
+
+    @pytest.mark.asyncio
     async def test_async_post_request(self):
         """Test api call asynchronously for POST request."""
         hook = HttpAsyncHook()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

LivyAsyncHook ignores run_method HTTP method after refactor	LivyAsyncHook.run_method now accepts a nullable method parameter and validates it, but never applies it to the underlying HttpAsyncHook. The new implementation always uses AsyncHttpSession.run, which selects the HTTP verb from the hook‚Äôs self.method property. Since LivyAsyncHook initializes self.method to POST and run_method no longer overrides it, calls that previously defaulted to GET (or explicitly requested GET/PUT/DELETE) are sent as POST. This is a functional regression that can cause incorrect requests or unintended state changes against the Livy API (e.g., get_batch_state now issues POST).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
