### PR TITLE
[v3-1-test] Fix `TypeError` crashes on `/users/list` and `/roles/list` in FAB UI caused by concurrent API schema requests

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -183,7 +183,7 @@ class HookMetaService:
                 mock.patch("wtforms.validators.Optional", HookMetaService.MockOptional),
                 mock.patch("wtforms.validators.any_of", mock_any_of),
                 # Prevent poisoning the global ProvidersManager singleton with mocks
-                mock.patch("airflow.providers_manager.ProvidersManager._instance", None),
+                mock.patch.dict("airflow.utils.singleton.Singleton._instances", clear=True),
                 mock.patch("airflow.providers_manager.ProvidersManager.initialized", return_value=False),
             ):
                 pm = ProvidersManager()
@@ -223,7 +223,11 @@ class HookMetaService:
         result: dict[str, MutableMapping] = {}
         for key, form_widget in form_widgets.items():
             hook_key = key.split("__")[1]
-            if isinstance(form_widget.field, HookMetaService.MockBaseField):
+            if isinstance(form_widget.field, dict):
+                hook_widgets = result.get(hook_key, {})
+                hook_widgets[form_widget.field_name] = form_widget.field
+                result[hook_key] = hook_widgets
+            elif isinstance(form_widget.field, HookMetaService.MockBaseField):
                 hook_widgets = result.get(hook_key, {})
                 hook_widgets[form_widget.field_name] = form_widget.field.param.dump()
                 result[hook_key] = hook_widgets
@@ -247,6 +251,11 @@ class HookMetaService:
                 validators = form_widget.field.kwargs.get("validators", [])
                 description = form_widget.field.kwargs.get("description", "")
                 default = form_widget.field.kwargs.get("default", None)
+                if callable(default):
+                    try:
+                        default = default()
+                    except Exception:
+                        default = None
 
                 enum = {}
                 for v in validators:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -49,10 +49,11 @@ class HookMetaService:
             pass
 
         def __call__(self, form, field):
-            pass
+            """No-op call to satisfy WTForms validator protocol."""
+            return None
 
     class MockEnum:
-        """Mock for wtforms.validators.Optional."""
+        """Mock for wtforms.validators.AnyOf."""
 
         def __init__(self, allowed_values):
             self.allowed_values = allowed_values
@@ -154,23 +155,40 @@ class HookMetaService:
                     raise ModuleNotFoundError
             except ModuleNotFoundError:
                 sys.modules[mod_name] = MagicMock()
-        with (
-            mock.patch("wtforms.StringField", HookMetaService.MockStringField),
-            mock.patch("wtforms.fields.StringField", HookMetaService.MockStringField),
-            mock.patch("wtforms.fields.simple.StringField", HookMetaService.MockStringField),
-            mock.patch("wtforms.IntegerField", HookMetaService.MockIntegerField),
-            mock.patch("wtforms.fields.IntegerField", HookMetaService.MockIntegerField),
-            mock.patch("wtforms.PasswordField", HookMetaService.MockPasswordField),
-            mock.patch("wtforms.BooleanField", HookMetaService.MockBooleanField),
-            mock.patch("wtforms.fields.BooleanField", HookMetaService.MockBooleanField),
-            mock.patch("wtforms.fields.simple.BooleanField", HookMetaService.MockBooleanField),
-            mock.patch("flask_babel.lazy_gettext", mock_lazy_gettext),
-            mock.patch("flask_appbuilder.fieldwidgets.BS3TextFieldWidget", HookMetaService.MockAnyWidget),
-            mock.patch("flask_appbuilder.fieldwidgets.BS3TextAreaFieldWidget", HookMetaService.MockAnyWidget),
-            mock.patch("flask_appbuilder.fieldwidgets.BS3PasswordFieldWidget", HookMetaService.MockAnyWidget),
-            mock.patch("wtforms.validators.Optional", HookMetaService.MockOptional),
-            mock.patch("wtforms.validators.any_of", mock_any_of),
-        ):
+
+        # We conditionally inject mock classes for missing dependencies
+        # to ensure `ProvidersManager` can initialize hook connection widgets
+        # without crashing when FAB/WTForms are not installed.
+        if "wtforms.StringField" not in sys.modules:
+            # Only apply mocks if the actual module wasn't loaded beforehand.
+            # This avoids thread-safety issues caused by `unittest.mock.patch` mutating global states.
+            with (
+                mock.patch("wtforms.StringField", HookMetaService.MockStringField),
+                mock.patch("wtforms.fields.StringField", HookMetaService.MockStringField),
+                mock.patch("wtforms.fields.simple.StringField", HookMetaService.MockStringField),
+                mock.patch("wtforms.IntegerField", HookMetaService.MockIntegerField),
+                mock.patch("wtforms.fields.IntegerField", HookMetaService.MockIntegerField),
+                mock.patch("wtforms.PasswordField", HookMetaService.MockPasswordField),
+                mock.patch("wtforms.BooleanField", HookMetaService.MockBooleanField),
+                mock.patch("wtforms.fields.BooleanField", HookMetaService.MockBooleanField),
+                mock.patch("wtforms.fields.simple.BooleanField", HookMetaService.MockBooleanField),
+                mock.patch("flask_babel.lazy_gettext", mock_lazy_gettext),
+                mock.patch("flask_appbuilder.fieldwidgets.BS3TextFieldWidget", HookMetaService.MockAnyWidget),
+                mock.patch(
+                    "flask_appbuilder.fieldwidgets.BS3TextAreaFieldWidget", HookMetaService.MockAnyWidget
+                ),
+                mock.patch(
+                    "flask_appbuilder.fieldwidgets.BS3PasswordFieldWidget", HookMetaService.MockAnyWidget
+                ),
+                mock.patch("wtforms.validators.Optional", HookMetaService.MockOptional),
+                mock.patch("wtforms.validators.any_of", mock_any_of),
+                # Prevent poisoning the global ProvidersManager singleton with mocks
+                mock.patch("airflow.providers_manager.ProvidersManager._instance", None),
+                mock.patch("airflow.providers_manager.ProvidersManager.initialized", return_value=False),
+            ):
+                pm = ProvidersManager()
+                return pm.hooks, pm.connection_form_widgets, pm.field_behaviours  # Will init providers hooks
+        else:
             pm = ProvidersManager()
             return pm.hooks, pm.connection_form_widgets, pm.field_behaviours  # Will init providers hooks
 
@@ -208,6 +226,46 @@ class HookMetaService:
             if isinstance(form_widget.field, HookMetaService.MockBaseField):
                 hook_widgets = result.get(hook_key, {})
                 hook_widgets[form_widget.field_name] = form_widget.field.param.dump()
+                result[hook_key] = hook_widgets
+            elif type(form_widget.field).__name__ == "UnboundField":
+                # handle real WTForms fields gracefully without needing mock patches
+                field_class_name = getattr(form_widget.field.field_class, "__name__", "")
+                param_type = "string"
+                param_format = None
+                if field_class_name == "BooleanField":
+                    param_type = "boolean"
+                elif field_class_name == "IntegerField":
+                    param_type = "integer"
+                elif field_class_name == "PasswordField":
+                    param_format = "password"
+
+                label = (
+                    form_widget.field.args[0]
+                    if len(form_widget.field.args) > 0
+                    else form_widget.field.kwargs.get("label")
+                )
+                validators = form_widget.field.kwargs.get("validators", [])
+                description = form_widget.field.kwargs.get("description", "")
+                default = form_widget.field.kwargs.get("default", None)
+
+                enum = {}
+                for v in validators:
+                    if type(v).__name__ == "AnyOf":
+                        enum["enum"] = getattr(v, "values", [])
+
+                types = [param_type, "null"]
+                format_dict = {"format": param_format} if param_format else {}
+
+                param = Param(
+                    default=default,
+                    title=str(label) if label is not None else None,
+                    description=str(description) if description else None,
+                    type=types,
+                    **format_dict,
+                    **enum,
+                ).dump()
+                hook_widgets = result.get(hook_key, {})
+                hook_widgets[form_widget.field_name] = param
                 result[hook_key] = hook_widgets
             else:
                 log.error("Unknown form widget in %s: %s", hook_key, form_widget)


### PR DESCRIPTION
This PR provides a manual backport of #63986 to v3-1-test to fix a critical TypeError crash in the FAB UI (/users/list) during concurrent API schema requests. The issue was caused by non-thread-safe global mocks in HookMetaService which corrupted FAB's class hierarchy.

The fix involves:

Localizing Mocks: Moving mocking logic locally within discovery methods to prevent global namespace hijacking.
UnboundField Introspection: Naturally introspecting UnboundField variables when FAB is installed to extract parameters safely.

Compatibility Fixes: Making MockOptional callable and adapting the new introspection logic to use Param from airflow.sdk as required by the v3-1-test environment.Conflict Resolution A merge conflict in connections.py was resolved by adapting the main branch introspection logic to use the Param class instead of SerializedParam.

Related Issues

related: #63986 (Manual backport)
closes: #63982 (Original crash issue)

Was generative AI tooling used to co-author this PR?

 Yes — Gemini (conflict resolution, and PR description)