### PR TITLE
Fix tasks API crash when order_by field contains None values

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-from operator import attrgetter
 from typing import cast
 
 from fastapi import Depends, HTTPException, status
@@ -32,6 +31,12 @@ from airflow.api_fastapi.core_api.security import requires_access_dag
 from airflow.exceptions import TaskNotFound
 
 tasks_router = AirflowRouter(tags=["Task"], prefix="/dags/{dag_id}/tasks")
+
+_VALID_TASK_ORDER_BY_FIELDS = {
+    field_name
+    for field_name, field_info in TaskResponse.model_fields.items()
+    if field_name not in ("class_ref", "template_fields", "downstream_task_ids", "params")
+}
 
 
 @tasks_router.get(
@@ -51,10 +56,21 @@ def get_tasks(
     order_by: str = "task_id",
 ) -> TaskCollectionResponse:
     """Get tasks for DAG."""
+    sort_key = order_by.lstrip("-")
+    if sort_key not in _VALID_TASK_ORDER_BY_FIELDS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Invalid order_by parameter: '{sort_key}'. "
+            f"Valid fields are: {', '.join(sorted(_VALID_TASK_ORDER_BY_FIELDS))}",
+        )
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     try:
-        tasks = sorted(dag.tasks, key=attrgetter(order_by.lstrip("-")), reverse=(order_by[0:1] == "-"))
-    except AttributeError as err:
+        tasks = sorted(
+            dag.tasks,
+            key=lambda task: (getattr(task, sort_key) is None, getattr(task, sort_key)),
+            reverse=(order_by[0:1] == "-"),
+        )
+    except (AttributeError, TypeError) as err:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(err))
     return TaskCollectionResponse(
         tasks=cast("list[TaskResponse]", tasks),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -543,9 +543,15 @@ class TestGetTasks(TestTaskEndpoint):
             f"{self.api_prefix}/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
         )
         assert response.status_code == 400
-        assert (
-            response.json()["detail"] == "'EmptyOperator' object has no attribute 'invalid_task_colume_name'"
+        assert "Invalid order_by parameter: 'invalid_task_colume_name'" in response.json()["detail"]
+
+    def test_should_respond_200_order_by_start_date_with_none_values(self, test_client):
+        """Test that ordering by start_date works even when some tasks have None start_date."""
+        response = test_client.get(
+            f"{self.api_prefix}/{self.unscheduled_dag_id}/tasks?order_by=start_date",
         )
+        assert response.status_code == 200
+        assert response.json()["total_entries"] == 2
 
     def test_should_respond_404(self, test_client):
         dag_id = "xxxx_not_existing"


### PR DESCRIPTION
## Summary

The `/api/v2/dags/{dag_id}/tasks` endpoint crashes with `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'` when sorting by fields that can be `None` (e.g., `start_date` on unscheduled DAGs).

## Changes

**`airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py`:**
- Added upfront validation of `order_by` against known `TaskResponse` model fields, returning HTTP 400 with a descriptive error listing valid field names for invalid values
- Replaced `attrgetter` with a None-safe sort key `(value is None, value)` that places `None` values last during sorting
- Extended exception handling to catch `TypeError` in addition to `AttributeError`

**`airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py`:**
- Updated existing invalid `order_by` test to match new error message format
- Added test for sorting unscheduled DAG tasks by `start_date` (where values are `None`)

closes: #63927