### PR TITLE
Fix/fab provider to import conf from sdk

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api/auth/backend/kerberos_auth.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api/auth/backend/kerberos_auth.py
@@ -28,7 +28,7 @@ from flask import Response, current_app, g, make_response, request
 from requests_kerberos import HTTPKerberosAuth
 
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.utils.net import getfqdn
 
 if TYPE_CHECKING:

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/parameters.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/parameters.py
@@ -20,7 +20,7 @@ import logging
 
 from fastapi import Query
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 
 log = logging.getLogger(__name__)
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -24,7 +24,7 @@ from fastapi.responses import RedirectResponse
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
 from airflow.providers.fab.auth_manager.api_fastapi.routes.router import auth_router
 from airflow.providers.fab.auth_manager.api_fastapi.services.login import FABAuthManagerLogin

--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/services/login.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.auth_manager.api_fastapi.datamodels.login import LoginResponse
 from airflow.providers.fab.www.utils import get_fab_auth_manager
 

--- a/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/cli_commands/utils.py
@@ -29,8 +29,8 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.engine import make_url
 
 import airflow
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
 from airflow.providers.fab.www.extensions.init_session import init_airflow_session_interface
 from airflow.providers.fab.www.extensions.init_views import init_plugins

--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -52,10 +52,9 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
     VariableDetails,
 )
 from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, AirflowProviderDeprecationWarning
 from airflow.models import Connection, DagModel, Pool, Variable
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, conf
 from airflow.providers.fab.auth_manager.models import Permission, Role, User
 from airflow.providers.fab.auth_manager.models.anonymous_user import AnonymousUser
 from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_PLUS

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -68,7 +68,7 @@ from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.orm import joinedload
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.auth_manager.models import (
     Action,
     Group,

--- a/providers/fab/src/airflow/providers/fab/auth_manager/views/auth_oauth.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/views/auth_oauth.py
@@ -25,7 +25,7 @@ from flask import session
 from flask_appbuilder import expose
 from flask_appbuilder.security.views import AuthOAuthView
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 
 log = logging.getLogger(__name__)
 

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -28,9 +28,9 @@ from sqlalchemy.engine.url import make_url
 
 from airflow import settings
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
 from airflow.logging_config import configure_logging
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_8_PLUS
 from airflow.providers.fab.www.extensions.init_appbuilder import init_appbuilder
 from airflow.providers.fab.www.extensions.init_jinja_globals import init_jinja_globals

--- a/providers/fab/src/airflow/providers/fab/www/auth.py
+++ b/providers/fab/src/airflow/providers/fab/www/auth.py
@@ -39,7 +39,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
     PoolDetails,
     VariableDetails,
 )
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.utils import get_fab_auth_manager
 from airflow.utils.net import get_hostname
 

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_appbuilder.py
@@ -41,7 +41,7 @@ from flask_appbuilder.views import IndexView, UtilView
 
 from airflow import settings
 from airflow.api_fastapi.app import create_auth_manager, get_auth_manager
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.security_manager import AirflowSecurityManagerV2
 from airflow.providers.fab.www.views import FabIndexView, redirect
 

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_jinja_globals.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_jinja_globals.py
@@ -22,7 +22,7 @@ from pendulum import local_timezone
 
 import airflow
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.utils.net import get_hostname
 from airflow.utils.platform import get_airflow_git_version
 

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_security.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_security.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import logging
 from importlib import import_module
 
-from airflow.configuration import conf
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, conf
 
 log = logging.getLogger(__name__)
 

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_session.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from flask import session as builtin_flask_session
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.session import (
     AirflowDatabaseSessionInterface,
     AirflowSecureCookieSessionInterface,

--- a/providers/fab/src/airflow/providers/fab/www/extensions/init_wsgi_middlewares.py
+++ b/providers/fab/src/airflow/providers/fab/www/extensions/init_wsgi_middlewares.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 
 if TYPE_CHECKING:
     from flask import Flask

--- a/providers/fab/src/airflow/providers/fab/www/utils.py
+++ b/providers/fab/src/airflow/providers/fab/www/utils.py
@@ -21,7 +21,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from airflow.api_fastapi.app import get_auth_manager
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.www.security.permissions import (
     ACTION_CAN_ACCESS_MENU,
     ACTION_CAN_CREATE,

--- a/providers/fab/src/airflow/providers/fab/www/views.py
+++ b/providers/fab/src/airflow/providers/fab/www/views.py
@@ -31,7 +31,7 @@ from flask_appbuilder import IndexView, expose
 
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
-from airflow.configuration import conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.fab.version_compat import AIRFLOW_V_3_1_1_PLUS, AIRFLOW_V_3_1_8_PLUS
 
 if AIRFLOW_V_3_1_8_PLUS:


### PR DESCRIPTION




-->

closes: #60000 

Update fab provider to stop importing `conf from airflow.configuration` and instead use the shared compat 
```import from airflow.providers.common.compat.sdk import conf```

<!--

