### PR TITLE
Fix SQLToolset read-only mode bypass via data-modifying CTEs and SELECT INTO

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
@@ -42,6 +42,10 @@ DEFAULT_ALLOWED_TYPES: tuple[type[exp.Expr], ...] = (
 # Denylist: expression types that mutate data or schema when found anywhere in the AST.
 # This catches data-modifying CTEs (e.g. WITH del AS (DELETE …) SELECT …),
 # SELECT INTO, and other constructs that bypass top-level type checks.
+# Note: exp.Command is sqlglot's fallback for any syntax it doesn't recognize.
+# Including it makes the denylist fail-closed (safer), but may block legitimate
+# vendor-specific SQL that sqlglot can't parse. Callers who need such syntax can
+# provide custom allowed_types to bypass the deep scan entirely.
 _DATA_MODIFYING_NODES: tuple[type[exp.Expr], ...] = (
     exp.Insert,
     exp.Update,
@@ -113,7 +117,7 @@ def validate_sql(
     # (e.g. data-modifying CTEs, SELECT INTO). Only applies when using the default
     # read-only allowlist — callers who provide custom allowed_types have explicitly
     # opted into non-read-only operations.
-    if allowed_types is None:
+    if types is DEFAULT_ALLOWED_TYPES:
         _check_for_data_modifying_nodes(parsed)
 
     return parsed

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
@@ -39,6 +39,18 @@ DEFAULT_ALLOWED_TYPES: tuple[type[exp.Expr], ...] = (
     exp.Except,
 )
 
+# Denylist: expression types that mutate data or schema when found anywhere in the AST.
+# This catches data-modifying CTEs (e.g. WITH del AS (DELETE …) SELECT …),
+# SELECT INTO, and other constructs that bypass top-level type checks.
+_DATA_MODIFYING_NODES: tuple[type[exp.Expr], ...] = (
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Merge,
+    exp.Into,
+    exp.Command,
+)
+
 
 class SQLSafetyError(Exception):
     """Generated SQL failed safety validation."""
@@ -97,4 +109,31 @@ def validate_sql(
                 f"Statement type '{type(stmt).__name__}' is not allowed. Allowed types: {allowed_names}"
             )
 
+    # Deep scan: reject data-modifying nodes hidden inside otherwise-allowed statements
+    # (e.g. data-modifying CTEs, SELECT INTO). Only applies when using the default
+    # read-only allowlist — callers who provide custom allowed_types have explicitly
+    # opted into non-read-only operations.
+    if allowed_types is None:
+        _check_for_data_modifying_nodes(parsed)
+
     return parsed
+
+
+def _check_for_data_modifying_nodes(statements: list[exp.Expr]) -> None:
+    """
+    Walk the full AST of each statement and reject data-modifying expressions.
+
+    This catches bypass vectors like:
+    - Data-modifying CTEs: ``WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d``
+    - SELECT INTO: ``SELECT * INTO new_table FROM t``
+    - INSERT/UPDATE/DELETE hidden inside subqueries or CTEs
+
+    :raises SQLSafetyError: If any data-modifying node is found in the AST.
+    """
+    for stmt in statements:
+        for node in stmt.walk():
+            if isinstance(node, _DATA_MODIFYING_NODES):
+                raise SQLSafetyError(
+                    f"Data-modifying operation '{type(node).__name__}' found inside statement. "
+                    f"Only pure read operations are allowed in read-only mode."
+                )

--- a/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
@@ -159,3 +159,46 @@ class TestValidateSQLEdgeCases:
         """Trailing semicolon should not cause multi-statement error."""
         result = validate_sql("SELECT 1;")
         assert len(result) == 1
+
+
+class TestDataModifyingNodeDetection:
+    """Data-modifying operations hidden inside allowed statement types should be blocked."""
+
+    def test_cte_with_delete_blocked(self):
+        """DELETE inside a CTE bypasses top-level type check."""
+        with pytest.raises(SQLSafetyError, match="Data-modifying operation 'Delete'"):
+            validate_sql(
+                "WITH del AS (DELETE FROM users RETURNING *) SELECT * FROM del",
+                dialect="postgres",
+            )
+
+    def test_cte_with_insert_blocked(self):
+        """INSERT inside a CTE bypasses top-level type check."""
+        with pytest.raises(SQLSafetyError, match="Data-modifying operation 'Insert'"):
+            validate_sql(
+                "WITH ins AS (INSERT INTO users(name) VALUES ('x') RETURNING *) SELECT * FROM ins",
+                dialect="postgres",
+            )
+
+    def test_cte_with_update_blocked(self):
+        """UPDATE inside a CTE bypasses top-level type check."""
+        with pytest.raises(SQLSafetyError, match="Data-modifying operation 'Update'"):
+            validate_sql(
+                "WITH upd AS (UPDATE users SET name = 'x' RETURNING *) SELECT * FROM upd",
+                dialect="postgres",
+            )
+
+    def test_select_into_blocked(self):
+        """SELECT INTO creates a new table — should be blocked."""
+        with pytest.raises(SQLSafetyError, match="Data-modifying operation 'Into'"):
+            validate_sql("SELECT * INTO new_table FROM users")
+
+    def test_plain_cte_select_still_allowed(self):
+        """Normal read-only CTEs should not be affected."""
+        result = validate_sql("WITH t AS (SELECT id FROM users) SELECT * FROM t")
+        assert len(result) == 1
+
+    def test_nested_subquery_select_still_allowed(self):
+        """Subqueries that are pure reads should not be affected."""
+        result = validate_sql("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)")
+        assert len(result) == 1

--- a/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
@@ -202,3 +202,14 @@ class TestDataModifyingNodeDetection:
         """Subqueries that are pure reads should not be affected."""
         result = validate_sql("SELECT * FROM users WHERE id IN (SELECT user_id FROM orders)")
         assert len(result) == 1
+
+    def test_deep_scan_runs_with_explicit_default_types(self):
+        """Deep scan should also block when DEFAULT_ALLOWED_TYPES is passed explicitly."""
+        from airflow.providers.common.ai.utils.sql_validation import DEFAULT_ALLOWED_TYPES
+
+        with pytest.raises(SQLSafetyError, match="Data-modifying operation 'Delete'"):
+            validate_sql(
+                "WITH del AS (DELETE FROM users RETURNING *) SELECT * FROM del",
+                allowed_types=DEFAULT_ALLOWED_TYPES,
+                dialect="postgres",
+            )


### PR DESCRIPTION
Not an expert for this provider but I think we should avoid DML statements.
The `validate_sql` function only checked the top-level statement type, so queries like
`WITH d AS (DELETE FROM users RETURNING *) SELECT * FROM d` or `SELECT * INTO new_table FROM users`
passed validation despite mutating data. This adds a deep AST scan that walks the full parse tree
and rejects any `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `INTO`, or `Command` nodes found anywhere
inside an otherwise-allowed SELECT. The scan only applies when using the default read-only allowlist;
callers who provide custom `allowed_types` are unaffected.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [v] Yes (please specify the tool below)
Claude Opus 4.6
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
