### PR TITLE
Fix unclear error when pyspark is not installed for JDBC script

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
@@ -26,7 +26,12 @@ if TYPE_CHECKING:
 try:
     from pyspark.sql import SparkSession
 except ImportError:
-    pass
+    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+    raise AirflowOptionalProviderFeatureException(
+        "pyspark is required to run spark_jdbc_script. "
+        "Install it with: pip install 'apache-airflow-providers-apache-spark[pyspark]'"
+    )
 
 SPARK_WRITE_TO_JDBC: str = "spark_to_jdbc"
 SPARK_READ_FROM_JDBC: str = "jdbc_to_spark"


### PR DESCRIPTION
The spark_jdbc_script.py silently swallowed ImportError when pyspark
was missing, causing a confusing NameError later at runtime. Now raises a clear ImportError with install instructions at import time. cc @raphaelauv following https://github.com/apache/airflow/pull/60031


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Kiro (Claude Opus 4.6)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
