### PR TITLE
Change hebrew wording for Asset Triggered

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -168,7 +168,7 @@
   "reset": "אתחל",
   "runId": "מזהה ריצה",
   "runTypes": {
-    "asset_triggered": "הופעל על-ידי נכס",
+    "asset_triggered": "מופעל על-ידי נכס",
     "backfill": "השלמה למפרע",
     "manual": "הפעלה ידנית",
     "scheduled": "מתוזמן"


### PR DESCRIPTION
English version:
<img width="761" height="150" alt="Screenshot 2026-03-24 at 19 47 15" src="https://github.com/user-attachments/assets/75cbd233-d046-4669-a3a1-ed3950d14e1c" />


Hebrew version:
<img width="783" height="163" alt="Screenshot 2026-03-24 at 19 46 32" src="https://github.com/user-attachments/assets/a6942119-3337-4bfc-853a-ea00eb5cbf02" />

The wording should be passive not past action.