### PR TITLE
Fix tasks endpoint 500 error when order_by field has None values

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-from operator import attrgetter
 from typing import cast
 
 from fastapi import Depends, HTTPException, status
@@ -52,10 +51,27 @@ def get_tasks(
 ) -> TaskCollectionResponse:
     """Get tasks for DAG."""
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
+    field_name = order_by.lstrip("-")
+    allowed_fields = set(TaskResponse.model_fields)
+    if field_name not in allowed_fields:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Invalid order_by: '{field_name}'. Allowed fields: {', '.join(sorted(allowed_fields))}",
+        )
+    reverse = order_by[0:1] == "-"
     try:
-        tasks = sorted(dag.tasks, key=attrgetter(order_by.lstrip("-")), reverse=(order_by[0:1] == "-"))
-    except AttributeError as err:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(err))
+        tasks = sorted(
+            dag.tasks,
+            key=lambda task: (getattr(task, field_name) is None, getattr(task, field_name)),
+            reverse=reverse,
+        )
+    except TypeError:
+        # Fallback for fields with mixed types that can't be compared
+        tasks = sorted(
+            dag.tasks,
+            key=lambda task: (getattr(task, field_name) is None, str(getattr(task, field_name))),
+            reverse=reverse,
+        )
     return TaskCollectionResponse(
         tasks=cast("list[TaskResponse]", tasks),
         total_entries=len(tasks),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -543,9 +543,15 @@ class TestGetTasks(TestTaskEndpoint):
             f"{self.api_prefix}/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
         )
         assert response.status_code == 400
-        assert (
-            response.json()["detail"] == "'EmptyOperator' object has no attribute 'invalid_task_colume_name'"
+        assert "Invalid order_by: 'invalid_task_colume_name'" in response.json()["detail"]
+
+    def test_should_handle_order_by_with_none_values(self, test_client):
+        """Test that order_by works when task attribute values are None (e.g. unscheduled DAGs)."""
+        response = test_client.get(
+            f"{self.api_prefix}/{self.unscheduled_dag_id}/tasks?order_by=start_date",
         )
+        assert response.status_code == 200
+        assert response.json()["total_entries"] == 2
 
     def test_should_respond_404(self, test_client):
         dag_id = "xxxx_not_existing"


### PR DESCRIPTION
## Summary

- Validate `order_by` parameter against allowed `TaskResponse` fields, returning HTTP 400 with a helpful error message listing valid fields for invalid field names
- Handle `None` values in task attribute sorting by placing them at the end, preventing `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'`
- Add test for sorting by `start_date` on unscheduled DAGs (reproduces the bug)

closes: #63927

## Test plan

- [x] Added test `test_should_handle_order_by_with_none_values` — verifies sorting works when task attributes are `None`
- [x] Updated `test_should_raise_400_for_invalid_order_by_name` — verifies improved error message
- [ ] Run full test suite: `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py -xvs`