### PR TITLE
Fix `RayJobBaseOperator` polling to recognize STOPPED as terminal status

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/ray.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
 
 
-TERMINAL_STATUSES = {JobStatus.SUCCEEDED.value, JobStatus.FAILED.value}
+TERMINAL_STATUSES = {JobStatus.SUCCEEDED.value, JobStatus.FAILED.value, JobStatus.STOPPED.value}
 
 
 class OperationFailedException(Exception):

--- a/providers/google/tests/unit/google/cloud/operators/test_ray.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_ray.py
@@ -165,9 +165,13 @@ class TestRaySubmitJobOperator:
             },
         )
 
+    @pytest.mark.parametrize(
+        "terminal_status",
+        [JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.STOPPED],
+    )
     @mock.patch(RAY_OP_PATH.format("time.sleep"))
     @mock.patch(RAY_OP_PATH.format("RayJobHook"))
-    def test_check_job_status_reaches_terminal(self, mock_hook_cls, mock_sleep):
+    def test_check_job_status_reaches_terminal(self, mock_hook_cls, mock_sleep, terminal_status):
         mock_hook = mock_hook_cls.return_value
         mock_hook.stop_job.return_value = True
 
@@ -181,11 +185,11 @@ class TestRaySubmitJobOperator:
             get_job_logs=True,
         )
         operator.hook.get_job_status = mock.MagicMock(
-            side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, JobStatus.SUCCEEDED]
+            side_effect=[JobStatus.RUNNING, JobStatus.RUNNING, terminal_status]
         )
         status = operator._check_job_status("addr", "job", polling_interval=1, timeout=100)
 
-        assert status == JobStatus.SUCCEEDED
+        assert status == terminal_status
         assert mock_sleep.call_count == 2
 
     @mock.patch(RAY_OP_PATH.format("time.sleep"))


### PR DESCRIPTION
`TERMINAL_STATUSES` only included SUCCEEDED and FAILED, missing
STOPPED. When a Ray job was manually stopped, the polling loop
would spin until timeout and raise AirflowTaskTimeout instead of
exiting cleanly. Added STOPPED to match Ray's own `is_terminal()`
definition.

See list of states:
https://docs.ray.io/en/latest/cluster/running-applications/job-submission/doc/ray.job_submission.JobStatus.html

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kiro (Claude Opus 4.6)

Generated-by: Kiro (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
