### PR TITLE
Fix OTel timer metrics using Gauge instead of Histogram

### DIFF
--- a/airflow-core/newsfragments/64207.significant.rst
+++ b/airflow-core/newsfragments/64207.significant.rst
@@ -1,0 +1,1 @@
+OTel timer and timing metrics now use Histogram instead of Gauge, preserving count, sum, and bucket distribution across recordings.

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -146,7 +146,8 @@ class _OtelTimer(Timer):
     """
     An implementation of Stats.Timer() which records the result in the OTel Metrics Map.
 
-    OpenTelemetry does not have a native timer, we will store the values as a Gauge.
+    OpenTelemetry does not have a native timer; values are stored as a Histogram so that
+    all observations (count, sum, bucket distribution) are preserved across multiple recordings.
 
     :param name: The name of the timer.
     :param tags: Tags to append to the timer.
@@ -161,8 +162,8 @@ class _OtelTimer(Timer):
     def stop(self, send: bool = True) -> None:
         super().stop(send)
         if self.name and send and self.duration:
-            self.otel_logger.metrics_map.set_gauge_value(
-                full_name(prefix=self.otel_logger.prefix, name=self.name), self.duration, False, self.tags
+            self.otel_logger.metrics_map.record_histogram_value(
+                full_name(prefix=self.otel_logger.prefix, name=self.name), self.duration, self.tags
             )
 
 
@@ -278,11 +279,11 @@ class SafeOtelLogger:
         *,
         tags: Attributes = None,
     ) -> None:
-        """OTel does not have a native timer, stored as a Gauge whose value is elapsed ms."""
+        """Record a timing observation as a Histogram to preserve distribution information."""
         if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
             if isinstance(dt, datetime.timedelta):
                 dt = dt.total_seconds() * 1000.0
-            self.metrics_map.set_gauge_value(full_name(prefix=self.prefix, name=stat), float(dt), False, tags)
+            self.metrics_map.record_histogram_value(full_name(prefix=self.prefix, name=stat), float(dt), tags)
 
     def timer(
         self,
@@ -312,6 +313,18 @@ class InternalGauge:
             new_value += self.value
         self.value = new_value
         self.gauge.set(new_value, attributes=self.attributes)
+
+
+class InternalHistogram:
+    """Stores a histogram instrument for timer/timing metrics."""
+
+    def __init__(self, meter, name: str):
+        otel_safe_name = _get_otel_safe_name(name)
+        self.histogram = meter.create_histogram(name=otel_safe_name, unit="ms")
+        log.debug("Created %s as type: %s", otel_safe_name, _type_as_str(self.histogram))
+
+    def record(self, value: float, tags: Attributes) -> None:
+        self.histogram.record(value, attributes=tags)
 
 
 class MetricsMap:
@@ -375,6 +388,21 @@ class MetricsMap:
             self.map[key] = InternalGauge(meter=self.meter, name=name, tags=tags)
 
         self.map[key].set_value(value, delta)
+
+    def record_histogram_value(self, name: str, value: float, tags: Attributes) -> None:
+        """
+        Record a timing observation in a Histogram instrument.
+
+        Unlike a Gauge, a Histogram accumulates all observations so that count, sum,
+        and bucket distribution are preserved across multiple recordings.
+
+        :param name: The name of the histogram to record.
+        :param value: The timing observation in milliseconds.
+        :param tags: Attributes to attach to the observation.
+        """
+        if name not in self.map:
+            self.map[name] = InternalHistogram(meter=self.meter, name=name)
+        self.map[name].record(value, tags)
 
 
 def flush_otel_metrics():

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -26,10 +26,12 @@ from typing import TYPE_CHECKING
 
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.aggregation import ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.metrics._internal.export import (
     ConsoleMetricExporter,
     PeriodicExportingMetricReader,
 )
+from opentelemetry.sdk.metrics.view import View
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
 from ..common import get_otel_data_exporter
@@ -428,6 +430,15 @@ def get_otel_logger(
     stat_name_handler: Callable[[str], str] | None = None,
     statsd_influxdb_enabled: bool = False,
 ) -> SafeOtelLogger:
+    """
+    Build and return a :class:`SafeOtelLogger` backed by a configured :class:`MeterProvider`.
+
+    Histogram instruments (used for ``timing()`` / ``timer()`` metrics) are aggregated with
+    :class:`~opentelemetry.sdk.metrics._internal.aggregation.ExponentialBucketHistogramAggregation`
+    so that bucket boundaries adapt automatically to the observed data range.  This avoids
+    the need to hand-tune explicit bucket boundaries for metrics that span very different
+    scales (milliseconds to hours).
+    """
     otel_env_config = load_metrics_env_config()
 
     effective_service_name: str = otel_env_config.service_name or service_name or "airflow"
@@ -465,6 +476,12 @@ def get_otel_logger(
         MeterProvider(
             resource=resource,
             metric_readers=readers,
+            views=[
+                View(
+                    instrument_type=metrics.Histogram,
+                    aggregation=ExponentialBucketHistogramAggregation(),
+                )
+            ],
             shutdown_on_exit=False,
         ),
     )

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -26,12 +26,11 @@ from typing import TYPE_CHECKING
 
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics._internal.aggregation import ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.metrics._internal.export import (
     ConsoleMetricExporter,
     PeriodicExportingMetricReader,
 )
-from opentelemetry.sdk.metrics.view import View
+from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
 from ..common import get_otel_data_exporter
@@ -163,7 +162,7 @@ class _OtelTimer(Timer):
 
     def stop(self, send: bool = True) -> None:
         super().stop(send)
-        if self.name and send and self.duration:
+        if self.name and send and self.duration is not None:
             self.otel_logger.metrics_map.record_histogram_value(
                 full_name(prefix=self.otel_logger.prefix, name=self.name), self.duration, self.tags
             )
@@ -335,9 +334,11 @@ class MetricsMap:
     def __init__(self, meter):
         self.meter = meter
         self.map = {}
+        self.histograms: dict[str, InternalHistogram] = {}
 
     def clear(self) -> None:
         self.map.clear()
+        self.histograms.clear()
 
     def _create_counter(self, name):
         """Create a new counter or up_down_counter for the provided name."""
@@ -402,9 +403,9 @@ class MetricsMap:
         :param value: The timing observation in milliseconds.
         :param tags: Attributes to attach to the observation.
         """
-        if name not in self.map:
-            self.map[name] = InternalHistogram(meter=self.meter, name=name)
-        self.map[name].record(value, tags)
+        if name not in self.histograms:
+            self.histograms[name] = InternalHistogram(meter=self.meter, name=name)
+        self.histograms[name].record(value, tags)
 
 
 def flush_otel_metrics():
@@ -434,7 +435,7 @@ def get_otel_logger(
     Build and return a :class:`SafeOtelLogger` backed by a configured :class:`MeterProvider`.
 
     Histogram instruments (used for ``timing()`` / ``timer()`` metrics) are aggregated with
-    :class:`~opentelemetry.sdk.metrics._internal.aggregation.ExponentialBucketHistogramAggregation`
+    :class:`~opentelemetry.sdk.metrics.view.ExponentialBucketHistogramAggregation`
     so that bucket boundaries adapt automatically to the observed data range.  This avoids
     the need to hand-tune explicit bucket boundaries for metrics that span very different
     scales (milliseconds to hours).

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -244,25 +244,28 @@ class TestOtelMetrics:
 
         self.stats.timing(name, dt=datetime.timedelta(seconds=123))
 
-        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
-        expected_value = 123000.0
-        assert self.map[full_name(name)].value == expected_value
+        self.meter.get_meter().create_histogram.assert_called_once_with(name=full_name(name), unit="ms")
+        self.meter.get_meter().create_histogram.return_value.record.assert_called_once_with(
+            123000.0, attributes=None
+        )
 
     def test_timing_new_metric_with_tags(self, name):
         tags = {"hello": "world"}
-        key = _generate_key_name(full_name(name), tags)
 
         self.stats.timing(name, dt=1, tags=tags)
 
-        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
-        self.map[key].attributes == tags
+        self.meter.get_meter().create_histogram.assert_called_once_with(name=full_name(name), unit="ms")
+        self.meter.get_meter().create_histogram.return_value.record.assert_called_once_with(
+            1.0, attributes=tags
+        )
 
     def test_timing_existing_metric(self, name):
         self.stats.timing(name, dt=1)
         self.stats.timing(name, dt=2)
 
-        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
-        assert self.map[full_name(name)].value == 2
+        # histogram created only once, but both observations are recorded
+        self.meter.get_meter().create_histogram.assert_called_once_with(name=full_name(name), unit="ms")
+        assert self.meter.get_meter().create_histogram.return_value.record.call_count == 2
 
     # For the four test_timer_foo tests below:
     #   time.perf_count() is called once to get the starting timestamp and again
@@ -277,7 +280,7 @@ class TestOtelMetrics:
         expected_duration = 3140.0
         assert timer.duration == expected_duration
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
+        self.meter.get_meter().create_histogram.assert_called_once_with(name=full_name(name), unit="ms")
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_no_name_returns_float_but_does_not_store_value(self, mock_time, name):
@@ -288,7 +291,7 @@ class TestOtelMetrics:
         expected_duration = 3140.0
         assert timer.duration == expected_duration
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_gauge.assert_not_called()
+        self.meter.get_meter().create_histogram.assert_not_called()
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_start_and_stop_manually_send_false(self, mock_time, name):
@@ -301,7 +304,7 @@ class TestOtelMetrics:
         expected_value = 3140.0
         assert timer.duration == expected_value
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_gauge.assert_not_called()
+        self.meter.get_meter().create_histogram.assert_not_called()
 
     @mock.patch.object(time, "perf_counter", side_effect=[0.0, 3.14])
     def test_timer_start_and_stop_manually_send_true(self, mock_time, name):
@@ -314,7 +317,7 @@ class TestOtelMetrics:
         expected_value = 3140.0
         assert timer.duration == expected_value
         assert mock_time.call_count == 2
-        self.meter.get_meter().create_gauge.assert_called_once_with(name=full_name(name))
+        self.meter.get_meter().create_histogram.assert_called_once_with(name=full_name(name), unit="ms")
 
     @pytest.mark.parametrize(
         (

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -25,6 +25,8 @@ from unittest import mock
 
 import pytest
 from opentelemetry.metrics import MeterProvider
+from opentelemetry.sdk.metrics._internal.aggregation import ExponentialBucketHistogramAggregation
+from opentelemetry.sdk.metrics.view import View
 
 from airflow_shared.observability.common import get_otel_data_exporter
 from airflow_shared.observability.exceptions import InvalidStatsNameException
@@ -418,6 +420,18 @@ class TestOtelMetrics:
                 == f"opentelemetry.exporter.otlp.proto.{expected_exporter_module}.metric_exporter"
             )
 
+    @mock.patch("airflow_shared.observability.metrics.otel_logger.metrics")
+    @mock.patch("airflow_shared.observability.metrics.otel_logger.MeterProvider")
+    def test_get_otel_logger_uses_exponential_histogram_view(self, mock_provider, mock_metrics):
+        get_otel_logger(host="localhost", port=4318)
+
+        call_kwargs = mock_provider.call_args.kwargs
+        views = call_kwargs["views"]
+        assert len(views) == 1
+        view = views[0]
+        assert isinstance(view, View)
+        assert isinstance(view._aggregation, ExponentialBucketHistogramAggregation)
+
     def test_atexit_flush_on_process_exit(self):
         """
         Run a process that initializes a logger, creates a stat and then exits.
@@ -425,8 +439,11 @@ class TestOtelMetrics:
         The logger initialization registers an atexit hook.
         Test that the hook runs and flushes the created stat at shutdown.
         """
-        test_module_name = "tests.observability.metrics.test_otel_logger"
-        function_call_str = f"import {test_module_name} as m; m.mock_service_run()"
+        function_call_str = (
+            "from airflow_shared.observability.metrics.otel_logger import get_otel_logger; "
+            "logger = get_otel_logger(debug=True); "
+            "logger.incr('my_test_stat')"
+        )
 
         proc = subprocess.run(
             [sys.executable, "-c", function_call_str],

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -25,8 +25,7 @@ from unittest import mock
 
 import pytest
 from opentelemetry.metrics import MeterProvider
-from opentelemetry.sdk.metrics._internal.aggregation import ExponentialBucketHistogramAggregation
-from opentelemetry.sdk.metrics.view import View
+from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
 
 from airflow_shared.observability.common import get_otel_data_exporter
 from airflow_shared.observability.exceptions import InvalidStatsNameException


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Timer and timing metrics in the OTel logger were recorded using a `Gauge` instrument, which does not preserve multiple observations within an export interval. In practice, if the scheduler loop runs many times between exports, only a single value is retained, and the distribution of durations is lost.

This PR switches `timing()` and `timer()` to use a `Histogram` instrument, which captures duration distributions via count, sum, and bucketed observations. This enables accurate downstream analysis such as percentiles (p50, p95, p99).

The [OTel supplementary guidelines](https://opentelemetry.io/docs/specs/otel/metrics/supplementary-guidelines/) recommend Histogram for measurements where "the statistics about this thing are likely to be meaningful" and durations are a canonical example.

### Changes

- `_OtelTimer.stop()` and `SafeOtelLogger.timing()` now call `record_histogram_value()` instead of `set_gauge_value()`
- New `InternalHistogram` class wrapping `meter.create_histogram(unit="ms")`
- New `MetricsMap.record_histogram_value()` method
- `get_otel_logger()` configures the `MeterProvider` with a `View` that applies `ExponentialBucketHistogramAggregation` to all Histogram instruments — bucket boundaries adapt automatically to the observed data range without requiring hand-tuned explicit boundaries for metrics that span very different scales (ms to hours)
- Tests updated: `test_timing_existing_metric` now verifies both observations are recorded (`record.call_count == 2`), not just the last value; new test verifies the exponential histogram view is wired into the `MeterProvider`

### Users affected

**Affected metrics:** all timer/timing metrics emitted via the OTel logger (e.g. `scheduler.scheduler_loop_duration`, `dagrun.dependency-check`, `task.duration`, etc.)

**OTel users:** the instrument type for timer/timing metrics changes from `Gauge` to `Histogram`. Dashboards or alerts treating these as Gauges may need to be updated.

**Backend compatibility:** exponential (native) histograms require Prometheus 2.40+ with native histogram scraping enabled and OTel Collector 0.70+. Deployments on older backends will have the collector downconvert to explicit buckets automatically — no data is lost, but the adaptive bucketing benefit is reduced. Both query styles work:

Before (Gauge):
```
airflow_task_duration{dag_id="my_dag", task_id="my_task"}
```

After (Histogram — explicit buckets, works on all backends):
```
# p95
histogram_quantile(0.95,
  rate(airflow_task_duration_bucket{dag_id="my_dag", task_id="my_task"}[5m])
)

# Average duration
rate(airflow_task_duration_sum{dag_id="my_dag", task_id="my_task"}[5m])
/ rate(airflow_task_duration_count{dag_id="my_dag", task_id="my_task"}[5m])
```

After (Histogram — native histogram queries, Prometheus 2.40+):
```
histogram_quantile(0.95, rate(airflow_task_duration[5m]))
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
