### PR TITLE
Fix api 500 error

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import logging
 import posixpath
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
@@ -114,9 +113,6 @@ MAP_BULK_ACTION_TO_AUTH_METHOD: dict[BulkAction, ResourceMethod] = {
 }
 
 
-log = logging.getLogger(__name__)
-
-
 async def resolve_user_from_token(token_str: str | None) -> BaseUser:
     if not token_str:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
@@ -127,9 +123,6 @@ async def resolve_user_from_token(token_str: str | None) -> BaseUser:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token Expired")
     except InvalidTokenError:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid JWT token")
-    except Exception:
-        log.exception("Unexpected error during token authentication")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
 
 async def get_user(

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 import posixpath
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
@@ -113,6 +114,9 @@ MAP_BULK_ACTION_TO_AUTH_METHOD: dict[BulkAction, ResourceMethod] = {
 }
 
 
+log = logging.getLogger(__name__)
+
+
 async def resolve_user_from_token(token_str: str | None) -> BaseUser:
     if not token_str:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
@@ -123,6 +127,9 @@ async def resolve_user_from_token(token_str: str | None) -> BaseUser:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token Expired")
     except InvalidTokenError:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid JWT token")
+    except Exception:
+        log.exception("Unexpected error during token authentication")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
 
 async def get_user(
@@ -140,6 +147,13 @@ async def get_user(
         token_str = bearer_credentials.credentials
     elif oauth_token:
         token_str = oauth_token
+    elif request.headers.get("authorization"):
+        # An Authorization header is present but neither security scheme recognized it
+        # (e.g. the token was sent without the "Bearer" prefix).
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Expected: 'Bearer <token>'",
+        )
     else:
         token_str = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -110,20 +110,6 @@ class TestFastApiSecurity:
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)
 
-    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_resolve_user_from_token_unexpected_error(self, mock_get_auth_manager):
-        """Unexpected exceptions (e.g., DB errors, network errors) should return 401, not 500."""
-        token_str = "test-token"
-
-        auth_manager = AsyncMock()
-        auth_manager.get_user_from_token.side_effect = RuntimeError("unexpected failure")
-        mock_get_auth_manager.return_value = auth_manager
-
-        with pytest.raises(HTTPException) as exc_info:
-            await resolve_user_from_token(token_str)
-
-        assert exc_info.value.status_code == 401
-        assert exc_info.value.detail == "Not authenticated"
 
     @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
     async def test_get_user_with_request_state(self, mock_resolve_user_from_token):
@@ -997,42 +983,20 @@ class TestAuthManagerDependency:
 
 
 class TestMalformedAuthorizationHeader:
-    """Malformed Authorization headers must return 401/403, never 500."""
+    """Unrecognized Authorization headers must return 401 with a helpful message."""
 
-    @staticmethod
-    def _get_token(test_client):
-        """Extract the raw JWT from the test_client's default Bearer header."""
-        return test_client.headers.get("Authorization").removeprefix("Bearer ")
-
-    @pytest.mark.db_test
-    def test_token_without_bearer_prefix_returns_401(self, test_client):
-        """Sending a valid JWT without the 'Bearer' prefix must return 401 with a helpful message."""
-        token = self._get_token(test_client)
-        response = test_client.get("/api/v2/dags", headers={"Authorization": token})
-        assert response.status_code == 401
-        assert "Bearer" in response.json()["detail"]
-
-    @pytest.mark.db_test
-    def test_wrong_scheme_with_valid_token_returns_401(self, test_client):
-        """Using a wrong scheme like 'Token' with a valid JWT must return 401 with a helpful message."""
-        token = self._get_token(test_client)
-        response = test_client.get("/api/v2/dags", headers={"Authorization": f"Token {token}"})
-        assert response.status_code == 401
-        assert "Bearer" in response.json()["detail"]
-
-    def test_no_auth_header_returns_401(self, unauthenticated_test_client):
-        response = unauthenticated_test_client.get("/api/v2/dags")
-        assert response.status_code == 401
-
-    def test_bearer_with_invalid_token_returns_error(self, unauthenticated_test_client):
-        """Sending 'Bearer <garbage>' must return 401 or 403, never 500."""
+    @pytest.mark.parametrize(
+        "auth_header",
+        [
+            pytest.param("some.jwt.token", id="bare-token-without-bearer-prefix"),
+            pytest.param("Token some.jwt.token", id="wrong-scheme"),
+        ],
+    )
+    def test_malformed_auth_header_returns_401(self, unauthenticated_test_client, auth_header):
         response = unauthenticated_test_client.get(
-            "/api/v2/dags", headers={"Authorization": "Bearer not.a.jwt"}
+            "/api/v2/dags",
+            headers={"Authorization": auth_header},
         )
-        assert response.status_code in {401, 403}
+        assert response.status_code == 401
+        assert "Bearer" in response.json()["detail"]
 
-    @pytest.mark.db_test
-    def test_valid_bearer_token_returns_200(self, test_client):
-        """Sending 'Bearer <valid_token>' must return 200."""
-        response = test_client.get("/api/v2/dags")
-        assert response.status_code == 200

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -110,6 +110,21 @@ class TestFastApiSecurity:
 
         auth_manager.get_user_from_token.assert_called_once_with(token_str)
 
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_resolve_user_from_token_unexpected_error(self, mock_get_auth_manager):
+        """Unexpected exceptions (e.g., DB errors, network errors) should return 401, not 500."""
+        token_str = "test-token"
+
+        auth_manager = AsyncMock()
+        auth_manager.get_user_from_token.side_effect = RuntimeError("unexpected failure")
+        mock_get_auth_manager.return_value = auth_manager
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_user_from_token(token_str)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Not authenticated"
+
     @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
     async def test_get_user_with_request_state(self, mock_resolve_user_from_token):
         user = Mock()
@@ -139,6 +154,8 @@ class TestFastApiSecurity:
         request = Mock()
         request.state.user = None
         request.cookies = cookies
+        request.headers = Mock()
+        request.headers.get = Mock(return_value=None)
         bearer_credentials = None
         if bearer_credentials_creds:
             bearer_credentials = Mock()
@@ -977,3 +994,45 @@ class TestAuthManagerDependency:
         assert auth_manager is not None
         assert hasattr(auth_manager, "get_url_login")
         assert hasattr(auth_manager, "get_url_logout")
+
+
+class TestMalformedAuthorizationHeader:
+    """Malformed Authorization headers must return 401/403, never 500."""
+
+    @staticmethod
+    def _get_token(test_client):
+        """Extract the raw JWT from the test_client's default Bearer header."""
+        return test_client.headers.get("Authorization").removeprefix("Bearer ")
+
+    @pytest.mark.db_test
+    def test_token_without_bearer_prefix_returns_401(self, test_client):
+        """Sending a valid JWT without the 'Bearer' prefix must return 401 with a helpful message."""
+        token = self._get_token(test_client)
+        response = test_client.get("/api/v2/dags", headers={"Authorization": token})
+        assert response.status_code == 401
+        assert "Bearer" in response.json()["detail"]
+
+    @pytest.mark.db_test
+    def test_wrong_scheme_with_valid_token_returns_401(self, test_client):
+        """Using a wrong scheme like 'Token' with a valid JWT must return 401 with a helpful message."""
+        token = self._get_token(test_client)
+        response = test_client.get("/api/v2/dags", headers={"Authorization": f"Token {token}"})
+        assert response.status_code == 401
+        assert "Bearer" in response.json()["detail"]
+
+    def test_no_auth_header_returns_401(self, unauthenticated_test_client):
+        response = unauthenticated_test_client.get("/api/v2/dags")
+        assert response.status_code == 401
+
+    def test_bearer_with_invalid_token_returns_error(self, unauthenticated_test_client):
+        """Sending 'Bearer <garbage>' must return 401 or 403, never 500."""
+        response = unauthenticated_test_client.get(
+            "/api/v2/dags", headers={"Authorization": "Bearer not.a.jwt"}
+        )
+        assert response.status_code in {401, 403}
+
+    @pytest.mark.db_test
+    def test_valid_bearer_token_returns_200(self, test_client):
+        """Sending 'Bearer <valid_token>' must return 200."""
+        response = test_client.get("/api/v2/dags")
+        assert response.status_code == 200


### PR DESCRIPTION
When an Authorization header is present but uses an invalid format
(e.g. a bare token without the "Bearer" prefix) return a 401 "Not authenticated" error.

Added an explicit check in `get_user` for unrecognized Authorization
headers, returning 401 with a clear message about the expected format.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
GitHub Copilot
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---