### PR TITLE
Fix ``SSHHookAsync`` defaulting ``no_host_key_check`` to ``False`` unlike ``SSHHook``

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
@@ -598,7 +598,7 @@ class SSHHookAsync(BaseHook):
 
         host_key = extra_options.get("host_key")
         nhkc_raw = extra_options.get("no_host_key_check")
-        no_host_key_check = str(nhkc_raw).lower() == "true" if nhkc_raw is not None else False
+        no_host_key_check = str(nhkc_raw).lower() == "true" if nhkc_raw is not None else True
 
         if host_key is not None and no_host_key_check:
             raise ValueError("Host key check was skipped, but `host_key` value was given")


### PR DESCRIPTION
## Summary

`SSHHook` (sync) defaults `no_host_key_check=True` ([line 154](https://github.com/apache/airflow/blob/main/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py#L154)), but `SSHHookAsync` defaults to `False` when the option is not explicitly set in connection extras ([line 601](https://github.com/apache/airflow/blob/main/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py#L601)). This mismatch causes `SSHRemoteJobOperator` to submit jobs successfully (worker uses the sync hook) while the triggerer fails to poll for completion (uses the async hook), leaving the task stuck in "deferred" state indefinitely.

https://github.com/apache/airflow/blob/10715fb8a810ac66074226c7538934e748a13197/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py#L154

https://github.com/apache/airflow/blob/10715fb8a810ac66074226c7538934e748a13197/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py#L601

The fix aligns `SSHHookAsync` with `SSHHook` by defaulting `no_host_key_check` to `True` when not configured.

## How to reproduce

1. Create an SSH connection without setting `no_host_key_check` in extras
2. Run an `SSHRemoteJobOperator` DAG
3. The job submits and the task defers, but the triggerer logs: `"Host key is not trusted for host <ip>"`
4. The task stays in deferred/running state forever

## What changed

`providers/ssh/src/airflow/providers/ssh/hooks/ssh.py` line 601:

```python
# Before -- async hook defaults to False (differs from sync hook)
no_host_key_check = str(nhkc_raw).lower() == "true" if nhkc_raw is not None else False

# After -- matches sync hook default of True
no_host_key_check = str(nhkc_raw).lower() == "true" if nhkc_raw is not None else True
```