### PR TITLE
Document using toolsets directly with PydanticAI in any task

### DIFF
--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -49,6 +49,31 @@ passed to any pydantic-ai ``Agent``, including via
     but you are not locked in.
 
 
+Using Toolsets Directly with PydanticAI
+---------------------------------------
+
+Toolsets are standard pydantic-ai ``AbstractToolset`` implementations with no
+dependency on ``AgentOperator`` or ``@task.agent``. You can use them anywhere
+you can run Python within Airflow -- ``@task`` functions, ``PythonOperator``
+callables, or any custom operator's ``execute()`` method -- by creating a
+``pydantic_ai.Agent`` yourself:
+
+.. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_pydantic_ai_hook.py
+    :language: python
+    :start-after: [START howto_task_with_toolsets]
+    :end-before: [END howto_task_with_toolsets]
+
+This works because toolsets resolve Airflow connections lazily via
+``BaseHook.get_connection()``, which is available in any task execution
+context.
+
+This approach gives you full control over the agent lifecycle -- you can call
+``agent.run_sync()`` multiple times, swap models at runtime, or combine
+results from several agents in a single task. The tradeoff is that you lose
+the durable execution (step-level caching with retry replay), HITL review
+integration, and automatic tool call logging that ``AgentOperator`` provides.
+
+
 ``HookToolset``
 ---------------
 

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_pydantic_ai_hook.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_pydantic_ai_hook.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example DAG demonstrating PydanticAIHook usage."""
+"""Example DAGs demonstrating PydanticAIHook and direct pydantic-ai Agent usage."""
 
 from __future__ import annotations
 
@@ -65,3 +65,38 @@ def example_pydantic_ai_structured_output():
 # [END howto_hook_pydantic_ai_structured_output]
 
 example_pydantic_ai_structured_output()
+
+
+# [START howto_task_with_toolsets]
+@dag(schedule=None)
+def example_task_with_toolsets():
+    """Use toolsets directly in a @task function without AgentOperator."""
+
+    @task
+    def analyze_revenue() -> str:
+        from airflow.providers.common.ai.toolsets.sql import SQLToolset
+
+        hook = PydanticAIHook(llm_conn_id="pydanticai_default")
+        agent = hook.create_agent(
+            output_type=str,
+            instructions=(
+                "You are a sales analytics assistant. "
+                "Use the SQL tools to explore the database schema and answer questions."
+            ),
+            toolsets=[
+                SQLToolset(
+                    db_conn_id="my_database",
+                    allowed_tables=["customers", "orders"],
+                    max_rows=20,
+                ),
+            ],
+        )
+        result = agent.run_sync("Which customers have spent the most? Show the top 5.")
+        return result.output
+
+    analyze_revenue()
+
+
+# [END howto_task_with_toolsets]
+
+example_task_with_toolsets()


### PR DESCRIPTION
- Add a "Using Toolsets Directly with PydanticAI" section to `toolsets.rst` documenting that toolsets work anywhere you can run Python within Airflow (`@task`, `PythonOperator`, custom operator `execute()`), not just via `AgentOperator` or `@task.agent`.
- Add an example DAG showing `@task` + `PydanticAIHook.create_agent()` + `SQLToolset`.
- Explain the tradeoffs: full agent lifecycle control vs losing durable execution, HITL review, and automatic tool logging.


<img width="1706" height="820" alt="image" src="https://github.com/user-attachments/assets/87ec1268-e6ef-4f97-b448-527360a8d820" />


```py

@task
def analyze():
    import pydantic_ai

    agent = pydantic_ai.Agent(
        "anthropic:claude-sonnet-4-6",
        system_prompt=(
            "You are a sales analytics assistant. "
            "Use the available SQL tools to query the database and answer questions. "
            "Always start by listing tables and checking their schema before writing queries."
        ),
        toolsets=[SQLToolset(db_conn_id="sqlite_default")]
    )
    result = agent.run_sync(
        user_prompt=(
            "Which customers have spent the most in total? "
            "Show the top 5 with their total spend and number of orders. "
            "Also tell me which product category generates the most revenue."
        )
    )
    return result

```