### PR TITLE
Fix: handle cross-event-loop RuntimeError in ExecutionAPISecretsBackend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -66,25 +66,26 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
             # Convert ExecutionAPI response to SDK Connection
             return _process_connection_result_conn(msg)
         except RuntimeError as e:
-            # TriggerCommsDecoder.send() uses async_to_sync internally, which raises RuntimeError
-            # when called within an async event loop. In greenback portal contexts (triggerer),
-            # we catch this and use greenback to call the async version instead.
-            if str(e).startswith("You cannot use AsyncToSync in the same thread as an async event loop"):
-                import asyncio
+            import asyncio
+            import greenback
 
-                import greenback
+            msg = str(e)
 
+            if (
+                "You cannot use AsyncToSync in the same thread as an async event loop" in msg
+                or "attached to a different loop" in msg
+            ):
                 task = asyncio.current_task()
-                if greenback.has_portal(task):
+                if task and greenback.has_portal(task):
                     import warnings
 
                     warnings.warn(
-                        "You should not use sync calls here -- use `await aget_connection` instead",
+                        "Sync connection access failed due to event loop mismatch. "
+                        "Falling back to async connection retrieval.",
                         stacklevel=2,
                     )
                     return greenback.await_(self.aget_connection(conn_id))
-            # Fall through to the general exception handler for other RuntimeErrors
-            return None
+            return None 
         except Exception:
             # If SUPERVISOR_COMMS fails for any reason, return None
             # to allow fallback to other backends

--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -81,7 +81,9 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
 
                     warnings.warn(
                         "Sync connection access failed due to event loop mismatch. "
-                        "Falling back to async connection retrieval.",
+                        "If you are running in an async or triggerer context, use "
+                        "`await aget_connection(conn_id)` instead of `get_connection` "
+                        "to avoid this sync call. Falling back to async connection retrieval.",
                         stacklevel=2,
                     )
                     return greenback.await_(self.aget_connection(conn_id))


### PR DESCRIPTION
### What happened

In triggerer context, `ExecutionAPISecretsBackend.get_connection()` may fail when
`TriggerCommsDecoder.send()` raises a RuntimeError with message:

"Future attached to a different loop"

Currently, only the AsyncToSync RuntimeError is handled. Other RuntimeError variants
fall through and return None, causing the connection lookup to silently fail.

This leads to incorrect behavior in deferrable operators (e.g. AWS hooks),
where the connection appears missing and falls back to default credentials.

### What is fixed

Extended RuntimeError handling to also cover the "attached to a different loop"
case and fallback to async connection retrieval using `greenback.await_`.

### Why this is safe

- Maintains existing fallback behavior (`return None`)
- Only extends handling for an additional RuntimeError variant
- No change to behavior outside this edge case

### Reproduction

Deferrable AWS hooks (e.g. S3KeySensor) in triggerer context fail to resolve
connections and log "Unable to find AWS Connection ID" due to this issue.
