### PR TITLE
Pass parameters to k8s methods conditionally to fix mypy

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -1040,15 +1040,19 @@ class AsyncKubernetesHook(KubernetesHook):
                 # (e.g. binary data, truncated multi-byte sequences).
                 # kubernetes_asyncio's default decoding uses strict UTF-8 which
                 # crashes the task in those cases.
-                raw_resp: ClientResponse = await v1_api.read_namespaced_pod_log(
-                    name=name,
-                    namespace=namespace,
-                    container=container_name,
-                    follow=False,
-                    timestamps=True,
-                    since_seconds=since_seconds,
-                    _preload_content=False,
-                )  # type: ignore  # _preload_content=False makes returning ClientResponse instead of str!
+                kwargs = {
+                    "name": name,
+                    "namespace": namespace,
+                    "follow": False,
+                    "timestamps": True,
+                    "_preload_content": False,
+                }
+                if container_name is not None:
+                    kwargs["container"] = container_name
+                if since_seconds is not None:
+                    kwargs["since_seconds"] = since_seconds
+
+                raw_resp: ClientResponse = await v1_api.read_namespaced_pod_log(**kwargs)  # type: ignore  # _preload_content=False makes returning ClientResponse instead of str!
                 raw_bytes = await raw_resp.read()
                 logs = raw_bytes.decode("utf-8", errors="replace")
                 logs_list: list[str] = logs.splitlines()
@@ -1070,12 +1074,15 @@ class AsyncKubernetesHook(KubernetesHook):
         async with self.get_conn() as connection:
             try:
                 v1_api = async_client.CoreV1Api(connection)
-                events: CoreV1EventList = await v1_api.list_namespaced_event(
-                    field_selector=f"involvedObject.name={name}",
-                    namespace=namespace,
-                    resource_version=resource_version,
-                    resource_version_match="NotOlderThan" if resource_version else None,
-                )
+                kwargs = {
+                    "field_selector": f"involvedObject.name={name}",
+                    "namespace": namespace,
+                }
+                if resource_version is not None:
+                    kwargs["resource_version"] = resource_version
+                    kwargs["resource_version_match"] = "NotOlderThan"
+
+                events: CoreV1EventList = await v1_api.list_namespaced_event(**kwargs)
                 return events
             except HTTPError as e:
                 if hasattr(e, "status") and e.status == 403:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1186,8 +1186,6 @@ class TestAsyncKubernetesHook:
         mock_list_namespaced_event.assert_called_once_with(
             field_selector=f"involvedObject.name={POD_NAME}",
             namespace=NAMESPACE,
-            resource_version=None,
-            resource_version_match=None,
         )
         assert result == mock_events
 

--- a/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
@@ -538,13 +538,11 @@ class TestGKEKubernetesAsyncHook:
 
         get_conn_mock.assert_called_once_with()
         read_namespaced_pod_log.assert_called_with(
-            _preload_content=False,
             name=POD_NAME,
             namespace=POD_NAMESPACE,
             follow=False,
             timestamps=True,
-            container=None,
-            since_seconds=None,
+            _preload_content=False,
         )
         assert "Test string #1" in logs
         assert "Test string #2" in logs


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

As seen in https://github.com/apache/airflow/actions/runs/23577516559/job/68654632264?pr=64239

There were some issues here.

1. `container_name (typed as str | None)` passed to parameter expecting `str`
`since_seconds (typed as int | None)` passed to parameter expecting `int`
Fix is to use conditional parameter passing - only include optional parameters when they have non-None values:

2. `resource_version (typed as str | None)` passed to parameter expecting `str`
Conditional expression "NotOlderThan" if `resource_version` else `None` evaluated to `str | None` but expected `str`
Fix is to only include both resource_version and resource_version_match when resource_version is not None

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
