### PR TITLE
Fix LLMApprovalMixin to enforce allow_modifications in execute_complete

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
@@ -133,7 +133,9 @@ class LLMApprovalMixin:
             timeout=self.approval_timeout,
         )
 
-    def execute_complete(self, context: Context, generated_output: str, event: dict[str, Any]) -> str:
+    def execute_complete(
+        self: DeferForApprovalProtocol, context: Context, generated_output: str, event: dict[str, Any]
+    ) -> str:
         """
         Resume after human review.
 

--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
@@ -133,9 +133,7 @@ class LLMApprovalMixin:
             timeout=self.approval_timeout,
         )
 
-    def execute_complete(
-        self: DeferForApprovalProtocol, context: Context, generated_output: str, event: dict[str, Any]
-    ) -> str:
+    def execute_complete(self, context: Context, generated_output: str, event: dict[str, Any]) -> str:
         """
         Resume after human review.
 
@@ -173,7 +171,7 @@ class LLMApprovalMixin:
         # Only accept modified output when the operator explicitly allows modifications.
         # Without this guard a reviewer could craft a request with params_input even
         # when allow_modifications=False, bypassing the read-only approval flow.
-        if self.allow_modifications and params_input:
+        if getattr(self, "allow_modifications", False) and params_input:
             modified = params_input.get("output")
             if modified is not None and modified != generated_output:
                 log.info("output=%s modified by the reviewer=%s ", modified, responded_by_user)

--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
@@ -168,8 +168,10 @@ class LLMApprovalMixin:
         output = generated_output
         params_input: dict[str, Any] = event.get("params_input") or {}
 
-        # If the reviewer provided modified output, return their version
-        if params_input:
+        # Only accept modified output when the operator explicitly allows modifications.
+        # Without this guard a reviewer could craft a request with params_input even
+        # when allow_modifications=False, bypassing the read-only approval flow.
+        if self.allow_modifications and params_input:
             modified = params_input.get("output")
             if modified is not None and modified != generated_output:
                 log.info("output=%s modified by the reviewer=%s ", modified, responded_by_user)

--- a/providers/common/ai/tests/unit/common/ai/mixins/test_approval.py
+++ b/providers/common/ai/tests/unit/common/ai/mixins/test_approval.py
@@ -295,6 +295,18 @@ class TestDeferForApproval:
 
         assert result == "original"
 
+    def test_approved_no_modifications_rejects_tampered_params_input(self, approval_op):
+        """When allow_modifications=False, tampered params_input with output must be ignored."""
+        event = {
+            "chosen_options": ["Approve"],
+            "responded_by_user": "reviewer",
+            "params_input": {"output": "tampered output"},
+        }
+
+        result = approval_op.execute_complete({}, generated_output="original", event=event)
+
+        assert result == "original"
+
     def test_event_missing_responded_by_user(self, approval_op):
         event = {"chosen_options": ["Approve"]}
 


### PR DESCRIPTION
`LLMApprovalMixin.execute_complete` accepted modified output from
`params_input` regardless of the `allow_modifications` setting.
When modifications were disabled, a reviewer could still submit
edited output via the API and the mixin would return it, bypassing
the read-only approval flow.

Added an `allow_modifications` check so `params_input` is only
honored when the operator permits edits. Added a dedicated test
for this scenario.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kiro (Claude Opus 4.6)

Generated-by: Kiro (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
