### PR TITLE
Handle None values when sorting tasks by order_by field

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -54,7 +54,7 @@ def get_tasks(
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
     try:
         tasks = sorted(dag.tasks, key=attrgetter(order_by.lstrip("-")), reverse=(order_by[0:1] == "-"))
-    except AttributeError as err:
+    except (AttributeError, TypeError) as err:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, str(err))
     return TaskCollectionResponse(
         tasks=cast("list[TaskResponse]", tasks),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -547,6 +547,13 @@ class TestGetTasks(TestTaskEndpoint):
             response.json()["detail"] == "'EmptyOperator' object has no attribute 'invalid_task_colume_name'"
         )
 
+    def test_should_raise_400_for_order_by_with_none_values(self, test_client):
+        """Test that ordering by a field with None values returns 400."""
+        response = test_client.get(
+            f"{self.api_prefix}/{self.unscheduled_dag_id}/tasks?order_by=start_date",
+        )
+        assert response.status_code == 400
+
     def test_should_respond_404(self, test_client):
         dag_id = "xxxx_not_existing"
         response = test_client.get(f"{self.api_prefix}/{dag_id}/tasks")


### PR DESCRIPTION
When ordering tasks by a field like 'start_date' that contains None values, Python's sorted() raises a TypeError because None cannot be compared with datetime objects. This change catches TypeError in addition to AttributeError and returns a 400 Bad Request.

Fixes #63927

## Before
```
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

## After
Returns HTTP 400 with the error message when sorting by a field with None values.