### PR TITLE
Fix dagStats API error when dag_display_name is NULL in database

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_stats.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_stats.py
@@ -84,7 +84,7 @@ def get_dag_stats(
     for dag_id, state, dag_display_name, count in query_result:
         dag_state_data[(dag_id, state)] = count
         if dag_id not in result_dag_ids:
-            dag_display_names[dag_id] = dag_display_name
+            dag_display_names[dag_id] = dag_display_name or dag_id
             result_dag_ids.append(dag_id)
 
     dags = [


### PR DESCRIPTION
## Why
The `/api/v2/dagStats` endpoint was returning HTTP 500 with a Pydantic `ValidationError` (`dag_display_name`: Input should be a valid `string`) for any existing DAG that had a DagRun.

closes: #64247 

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
