### PR TITLE
Fix dag_display_name property bypass for DagStats query

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
@@ -35,15 +35,18 @@ from airflow.models.taskinstancehistory import TaskInstanceHistory
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+# Use the hybrid_property for dag_display_name so the CASE WHEN fallback to dag_id
+# is applied when dag_display_name is NULL.  Using __table__.c would return raw NULLs
+# and crash DagStatsResponse validation (https://github.com/apache/airflow/issues/64247).
 dagruns_select_with_state_count = (
-    select(
+    select(  # type: ignore[call-overload]
         DagRun.__table__.c.dag_id,
         DagRun.__table__.c.state,
-        DagModel.__table__.c.dag_display_name,
+        DagModel.dag_display_name,
         func.count(DagRun.__table__.c.state).label("count"),
     )
     .join(DagModel, DagRun.__table__.c.dag_id == DagModel.__table__.c.dag_id)
-    .group_by(DagRun.__table__.c.dag_id, DagRun.__table__.c.state, DagModel.__table__.c.dag_display_name)
+    .group_by(DagRun.__table__.c.dag_id, DagRun.__table__.c.state, DagModel.dag_display_name)
     .order_by(DagRun.__table__.c.dag_id)
 )
 


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/64247

Restore using the hybrid property. This will note bypass it anymore. 

Introduced in https://github.com/apache/airflow/pull/58353. Ignoring the original mypy errors it was trying to fix.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
