### PR TITLE
tests: fix failing integration test after upgrading to elasticsearch 9

### DIFF
--- a/airflow-e2e-tests/docker/elasticsearch.yml
+++ b/airflow-e2e-tests/docker/elasticsearch.yml
@@ -17,7 +17,7 @@
 ---
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/scripts/ci/docker-compose/integration-elasticsearch.yml
+++ b/scripts/ci/docker-compose/integration-elasticsearch.yml
@@ -17,7 +17,7 @@
 ---
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
     labels:
       breeze.description: "Integration required for Elasticsearch hooks."
     environment:


### PR DESCRIPTION
ES Integration test is failing after we upgrade to elasticsearch 9.

https://github.com/apache/airflow/actions/runs/23604018605/job/68743632344#step:5:3926