### PR TITLE
Fix SSH provider imports when sshtunnel is broken on Python 3.14 (#64258)

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
@@ -26,16 +26,22 @@ from collections.abc import Sequence
 from functools import cached_property
 from io import StringIO
 from select import select
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import paramiko
 from paramiko.config import SSH_PORT
-from sshtunnel import SSHTunnelForwarder
 from tenacity import Retrying, stop_after_attempt, wait_fixed, wait_random
 
 from airflow.providers.common.compat.connection import get_async_connection
-from airflow.providers.common.compat.sdk import AirflowException, BaseHook
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowOptionalProviderFeatureException,
+    BaseHook,
+)
 from airflow.utils.platform import getuser
+
+if TYPE_CHECKING:
+    from sshtunnel import SSHTunnelForwarder
 
 try:
     from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet
@@ -50,6 +56,18 @@ except ImportError:
 
 
 CMD_TIMEOUT = 10
+
+
+def SSHTunnelForwarder(*args, **kwargs):
+    """Import ``sshtunnel`` only when tunnel support is actually used."""
+    try:
+        from sshtunnel import SSHTunnelForwarder as forwarder_cls
+    except (ImportError, SyntaxError) as e:
+        raise AirflowOptionalProviderFeatureException(
+            "The SSH tunnel feature requires a working `sshtunnel` installation. "
+            "Upgrade `sshtunnel` or use a Python version supported by that dependency."
+        ) from e
+    return forwarder_cls(*args, **kwargs)
 
 
 class SSHHook(BaseHook):

--- a/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
+++ b/providers/ssh/src/airflow/providers/ssh/hooks/ssh.py
@@ -58,7 +58,7 @@ except ImportError:
 CMD_TIMEOUT = 10
 
 
-def SSHTunnelForwarder(*args, **kwargs):
+def _create_tunnel_forwarder(*args: Any, **kwargs: Any) -> SSHTunnelForwarder:
     """Import ``sshtunnel`` only when tunnel support is actually used."""
     try:
         from sshtunnel import SSHTunnelForwarder as forwarder_cls
@@ -426,7 +426,7 @@ class SSHHook(BaseHook):
             paramkio_log = logging.getLogger("paramiko.transport")
             paramkio_log.addHandler(logging.NullHandler())
             paramkio_log.propagate = True
-        client = SSHTunnelForwarder(self.remote_host, **tunnel_kwargs)
+        client = _create_tunnel_forwarder(self.remote_host, **tunnel_kwargs)
 
         return client
 

--- a/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import json
 import random
 import string
+import sys
 import textwrap
+from importlib import import_module, reload
 from io import StringIO
 from unittest import mock
 
@@ -28,7 +30,7 @@ import paramiko
 import pytest
 
 from airflow.models import Connection
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.providers.ssh.hooks.ssh import SSHHook
 
 pytestmark = pytest.mark.db_test
@@ -476,6 +478,41 @@ class TestSSHHook:
                 host_pkey_directories=None,
                 logger=hook.log,
             )
+
+    def test_can_import_ssh_hook_when_sshtunnel_is_broken(self, monkeypatch):
+        ssh_module_name = "airflow.providers.ssh.hooks.ssh"
+        original_import = __import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "sshtunnel":
+                raise SyntaxError("return in finally")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.delitem(sys.modules, ssh_module_name, raising=False)
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        try:
+            module = import_module(ssh_module_name)
+            assert module.SSHHook is not None
+        finally:
+            monkeypatch.setattr("builtins.__import__", original_import)
+            monkeypatch.delitem(sys.modules, ssh_module_name, raising=False)
+            reload(import_module("airflow.providers.ssh.hooks.ssh"))
+
+    def test_tunnel_requires_working_sshtunnel(self, monkeypatch):
+        hook = SSHHook(remote_host="remote_host", port="port", username="username", key_file="fake.file")
+
+        original_import = __import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "sshtunnel":
+                raise SyntaxError("return in finally")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr("builtins.__import__", fake_import)
+
+        with pytest.raises(AirflowOptionalProviderFeatureException, match="working `sshtunnel` installation"):
+            hook.get_tunnel(1234)
 
     def test_ssh_connection(self):
         hook = SSHHook(ssh_conn_id="ssh_default")

--- a/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
@@ -356,7 +356,7 @@ class TestSSHHook:
                 auth_timeout=None,
             )
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
+    @mock.patch("airflow.providers.ssh.hooks.ssh._create_tunnel_forwarder")
     def test_tunnel_with_password(self, ssh_mock):
         hook = SSHHook(
             remote_host="remote_host",
@@ -380,7 +380,7 @@ class TestSSHHook:
                 logger=hook.log,
             )
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
+    @mock.patch("airflow.providers.ssh.hooks.ssh._create_tunnel_forwarder")
     def test_tunnel_without_password(self, ssh_mock):
         hook = SSHHook(
             remote_host="remote_host", port="port", username="username", conn_timeout=10, key_file="fake.file"
@@ -410,7 +410,7 @@ class TestSSHHook:
         ssh_hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS)
         assert ssh_hook.look_for_keys is False
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
+    @mock.patch("airflow.providers.ssh.hooks.ssh._create_tunnel_forwarder")
     def test_tunnel_with_private_key(self, ssh_mock):
         hook = SSHHook(
             ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_EXTRA,
@@ -433,7 +433,7 @@ class TestSSHHook:
                 logger=hook.log,
             )
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
+    @mock.patch("airflow.providers.ssh.hooks.ssh._create_tunnel_forwarder")
     def test_tunnel_with_private_key_passphrase(self, ssh_mock):
         hook = SSHHook(
             ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_PASSPHRASE_EXTRA,
@@ -456,7 +456,7 @@ class TestSSHHook:
                 logger=hook.log,
             )
 
-    @mock.patch("airflow.providers.ssh.hooks.ssh.SSHTunnelForwarder")
+    @mock.patch("airflow.providers.ssh.hooks.ssh._create_tunnel_forwarder")
     def test_tunnel_with_private_key_ecdsa(self, ssh_mock):
         hook = SSHHook(
             ssh_conn_id=self.CONN_SSH_WITH_PRIVATE_KEY_ECDSA_EXTRA,


### PR DESCRIPTION
## Summary
The SSH provider imported `sshtunnel` at module import time, so Python 3.14 environments with the current incompatible `sshtunnel` release could fail on plain imports like `SFTPHook` before any tunnel functionality was used. This change defers the `sshtunnel` import until `get_tunnel()` is called and raises a clear optional-feature error if the dependency is unavailable or syntactically incompatible.

## Changes
- **`providers/ssh/src/airflow/providers/ssh/hooks/ssh.py`** -- lazy-load `sshtunnel` only when tunnel creation is requested and raise `AirflowOptionalProviderFeatureException` on import/runtime incompatibility.
- **`providers/ssh/tests/unit/ssh/hooks/test_ssh.py`** -- add regression coverage for importing `SSHHook` when `sshtunnel` is broken and for the runtime error path when tunnel support is used.

## Test plan
- [x] `uv run --project providers/sftp python - <<'PY'` smoke import of `from airflow.providers.sftp.hooks.sftp import SFTPHook`
- [x] `uv run --project providers/sftp pytest providers/ssh/tests/unit/ssh/hooks/test_ssh.py -k 'test_tunnel_with_password or test_tunnel_without_password or test_tunnel_with_private_key or test_tunnel_with_private_key_passphrase or test_tunnel_with_private_key_ecdsa or test_can_import_ssh_hook_when_sshtunnel_is_broken or test_tunnel_requires_working_sshtunnel' -xvs`
- [ ] CI passes (ruff, mypy, pytest)

Fixes #64258