### PR TITLE
Fix UI log fetch crash when ti.hostname is empty

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -721,6 +721,11 @@ class FileTaskHandler(logging.Handler):
             hostname = ti.hostname
             config_key = "worker_log_server_port"
             config_default = 8793
+
+        if not hostname:
+            msg = f"Cannot construct log URL for {log_type.value if log_type else LogType.WORKER.value}: missing hostname."
+            raise ValueError(msg)
+
         return (
             urljoin(
                 f"http://{hostname}:{conf.get('logging', config_key, fallback=config_default)}/log/",

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -708,7 +708,7 @@ class FileTaskHandler(logging.Handler):
         ti: TaskInstance | TaskInstanceHistory,
         log_relative_path: str,
         log_type: LogType | None = None,
-    ) -> tuple[str, str]:
+    ) -> tuple[str | None, str | None]:
         """Given TI, generate URL with which to fetch logs from service log server."""
         if log_type == LogType.TRIGGER:
             if not ti.triggerer_job:
@@ -911,7 +911,8 @@ class FileTaskHandler(logging.Handler):
             if not url or not rel_path:
                 sources.append(
                     f"Could not read served logs: Hostname not available for "
-                    f"{log_type.value if log_type else LogType.WORKER.value}."
+                    f"{log_type.value if log_type else LogType.WORKER.value}. "
+                    f"Please check your `hostname_callable` configuration."
                 )
                 return sources, log_streams
             response = _fetch_logs_from_service(url, rel_path)

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -911,7 +911,7 @@ class FileTaskHandler(logging.Handler):
             if not url or not rel_path:
                 sources.append(
                     f"Could not read served logs: Hostname not available for "
-                    f"{log_type.value if log_type else LogType.WORKER.value}. "
+                    f"{log_type.value}. "
                     f"Please check your `hostname_callable` configuration."
                 )
                 return sources, log_streams

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -723,8 +723,7 @@ class FileTaskHandler(logging.Handler):
             config_default = 8793
 
         if not hostname:
-            msg = f"Cannot construct log URL for {log_type.value if log_type else LogType.WORKER.value}: missing hostname."
-            raise ValueError(msg)
+            return None, None
 
         return (
             urljoin(
@@ -909,6 +908,12 @@ class FileTaskHandler(logging.Handler):
         try:
             log_type = LogType.TRIGGER if getattr(ti, "triggerer_job", False) else LogType.WORKER
             url, rel_path = self._get_log_retrieval_url(ti, worker_log_rel_path, log_type=log_type)
+            if not url or not rel_path:
+                sources.append(
+                    f"Could not read served logs: Hostname not available for "
+                    f"{log_type.value if log_type else LogType.WORKER.value}."
+                )
+                return sources, log_streams
             response = _fetch_logs_from_service(url, rel_path)
             if response.status_code == 403:
                 sources.append(

--- a/airflow-core/tests/unit/utils/log/test_file_task_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_task_handler.py
@@ -91,6 +91,37 @@ class TestFileTaskHandlerLogServer:
         assert "secret_key" in sources[0]
         assert streams == []
 
+    @patch("airflow.utils.log.file_task_handler._fetch_logs_from_service")
+    @patch.object(FileTaskHandler, "_get_log_retrieval_url")
+    def test_read_from_logs_server_no_hostname(self, mock_get_url, mock_fetch):
+        """When hostname is missing, show a clear message instead of attempting log server fetch."""
+        mock_get_url.return_value = (None, None)
+
+        sources, streams = self.handler._read_from_logs_server(self.ti, "dag/run/task/1.log")
+
+        assert len(sources) == 1
+        assert "Hostname not available" in sources[0]
+        assert "worker" in sources[0]
+        assert streams == []
+        mock_fetch.assert_not_called()
+
+    @patch("airflow.utils.log.file_task_handler._fetch_logs_from_service")
+    @patch.object(FileTaskHandler, "_get_log_retrieval_url")
+    def test_read_from_logs_server_no_hostname_triggerer(self, mock_get_url, mock_fetch):
+        """When hostname is missing for triggerer, show a clear message instead of attempting log server fetch."""
+        mock_get_url.return_value = (None, None)
+        self.ti.triggerer_job = MagicMock()
+        self.ti.triggerer_job.hostname = None
+        self.ti.triggerer_job.id = 123
+
+        sources, streams = self.handler._read_from_logs_server(self.ti, "dag/run/task/1.log")
+
+        assert len(sources) == 1
+        assert "Hostname not available" in sources[0]
+        assert "trigger" in sources[0]
+        assert streams == []
+        mock_fetch.assert_not_called()
+
 
 class TestFileTaskHandlerReadFromLocal:
     """Tests for ``FileTaskHandler._read_from_local`` path containment."""


### PR DESCRIPTION
This PR fixes a critical crash in the UI log viewer when a [TaskInstance](cci:2://file:///Users/gouravnss/airflow/task-sdk/src/airflow/sdk/execution_time/task_runner.py:173:0-702:27) has an empty [hostname](cci:1://file:///Users/gouravnss/airflow/task-sdk/src/airflow/sdk/api/client.py:137:0-139:76) field. 

In certain environments (e.g., workers behind corporate proxies), if the worker fails to successfully report its hostname via the internal Execution API, the [hostname](cci:1://file:///Users/gouravnss/airflow/task-sdk/src/airflow/sdk/api/client.py:137:0-139:76) defaults to an empty string in the database. When the webserver attempts to fetch logs, it currently constructs a malformed URL (`http://:8793/...`), causing the [requests](cci:1://file:///Users/gouravnss/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py:631:4-665:17) library to raise an `InvalidURL: No host supplied` exception. This results in a completely broken log viewer page for the user.

**Changes:**
- Modified [_get_log_retrieval_url](cci:1://file:///Users/gouravnss/airflow/airflow-core/src/airflow/utils/log/file_task_handler.py:706:4-735:9) in [file_task_handler.py](cci:7://file:///Users/gouravnss/airflow/airflow-core/src/airflow/utils/log/file_task_handler.py:0:0-0:0) to validate that a [hostname](cci:1://file:///Users/gouravnss/airflow/task-sdk/src/airflow/sdk/api/client.py:137:0-139:76) is present before URL construction.
- Added a descriptive `ValueError` raise if the hostname is missing, which prevents the unhandled malformed-URL crash in the networking layer.

closes: #64263

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Gemini for pr description)