### PR TITLE
Fix wrong error message displayed when user logs in with incorrect credentials

### DIFF
--- a/airflow-core/newsfragments/64280.significant.rst
+++ b/airflow-core/newsfragments/64280.significant.rst
@@ -1,0 +1,1 @@
+Fix wrong error message displayed when user logs in with incorrect credentials.

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queries/useCreateToken.ts
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queries/useCreateToken.ts
@@ -32,8 +32,12 @@ export const useCreateToken = ({ onSuccess }: { onSuccess: (data: LoginResponse)
   const { isPending, mutate } = useCreateTokenMutation(undefined, {
     onError,
     onSuccess: (response) => {
-      onSuccess(response.data);
-  },
+      if (response.data) {
+        onSuccess(response.data);
+      } else {
+        onError(response.error);
+      }
+    },
   });
 
   const createToken = (variableRequestBody: LoginBody) => {


### PR DESCRIPTION
Closes #64280

What changed
If a user puts in invalid credentials on the login page, the error message they see now is:
Cannot read properties of undefined (reading 'access_token')
This was a raw JavaScript error instead of a human-readable error.
Root cause
The HeyAPI client used by the simple auth manager UI has `ThrowOnError` set to `false` by default, which means a failed request with a 401 status code doesn't throw an error, but instead returns `{ data: undefined, error: ... }`. The `onSuccess` callback was called unconditionally with `response.data`, which was `undefined` on failure. `Login.tsx` then crashed attempting to access `undefined.access_token`.
Fix
In `useCreateToken.ts`, we now check if `response.data` exists before calling `onSuccess`, and if not, call `onError(response.error)` to display the actual error message from the HeyAPI client to the user.