### PR TITLE
Fix SAM login showing cryptic error on failed authentication

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/alert/ErrorAlert.tsx
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/alert/ErrorAlert.tsx
@@ -17,47 +17,40 @@
  * under the License.
  */
 import { HStack } from "@chakra-ui/react";
-import type { ApiError } from "openapi-gen/requests/core/ApiError";
-import type { HTTPExceptionResponse, HTTPValidationError } from "openapi-gen/requests/types.gen";
+import type { AxiosError } from "axios";
+import type { HttpExceptionResponse, HttpValidationError } from "openapi/requests/types.gen";
 
 import { Alert } from "./Alert";
-
-type ExpandedApiError = {
-  body: HTTPExceptionResponse | HTTPValidationError | undefined;
-} & ApiError;
 
 type Props = {
   readonly error?: unknown;
 };
 
 export const ErrorAlert = ({ error: err }: Props) => {
-  const error = err as ExpandedApiError;
-
-  if (!Boolean(error)) {
+  if (err === undefined || err === null) {
     return undefined;
   }
 
-  const details = error.body?.detail;
-  let detailMessage;
+  const error = err as AxiosError<HttpExceptionResponse | HttpValidationError>;
+  const { message, response } = error;
+  const statusCode = response?.status;
+  const statusText = response?.statusText ?? message;
+  const detail = response?.data.detail;
+  let detailMessage: React.ReactNode;
 
-  if (details !== undefined) {
-    if (typeof details === "string") {
-      detailMessage = details;
-    } else if (Array.isArray(details)) {
-      detailMessage = details.map(
-        (detail) => `
-          ${detail.loc.join(".")} ${detail.msg}`,
-      );
-    } else {
-      detailMessage = Object.keys(details).map((key) => `${key}: ${details[key] as string}`);
-    }
+  if (typeof detail === "string") {
+    detailMessage = detail;
+  } else if (Array.isArray(detail)) {
+    detailMessage = detail.map((entry) => `${entry.loc.join(".")} ${entry.msg}`).join(", ");
   }
 
   return (
     <Alert status="error">
       <HStack align="start" flexDirection="column" gap={2} mt={-1}>
-        {error.status} {error.message}
-        {detailMessage === error.message ? undefined : <span>{detailMessage}</span>}
+        {statusCode} {statusText}
+        {detailMessage !== undefined && detailMessage !== statusText ? (
+          <span>{detailMessage}</span>
+        ) : undefined}
       </HStack>
     </Alert>
   );

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queries/useCreateToken.ts
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queries/useCreateToken.ts
@@ -32,8 +32,8 @@ export const useCreateToken = ({ onSuccess }: { onSuccess: (data: LoginResponse)
   const { isPending, mutate } = useCreateTokenMutation(undefined, {
     onError,
     onSuccess: (response) => {
-      onSuccess(response.data);
-  },
+      onSuccess(response.data as LoginResponse);
+    },
   });
 
   const createToken = (variableRequestBody: LoginBody) => {

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/src/queryClient.ts
@@ -29,7 +29,7 @@ if (base.endsWith("/")) {
 
 // Configure the generated API client so requests include the subpath prefix
 // when Airflow runs behind a reverse proxy (e.g. /team-a/auth/token instead of /auth/token).
-client.setConfig({ baseURL: base });
+client.setConfig({ baseURL: base, throwOnError: true });
 
 export const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/64280

`openapi code generator` was upgraded to a new major version, this breaks a few things because the interface was updated

The generated openapi client defaults to throwOnError: false, so HTTP errors (e.g. 401) resolve the promise instead of rejecting it. React Query then calls onSuccess with the error response, where response.data is undefined, causing a TypeError when accessing access_token.

Add throwOnError: true to the mutate call so errors are properly thrown and routed to onError. Also fix ErrorAlert stale imports from the old code generator and update it to extract error details from the AxiosError resp
onse shape.
<img width="780" height="826" alt="Screenshot 2026-03-27 at 16 08 57" src="https://github.com/user-attachments/assets/cf45cfca-4f7a-4cb3-bcbb-f4ae57e7fb1e" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Cursor] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
