### PR TITLE
Fix db clean DagVersion cleanup to keep referenced versions (#63703)

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -165,6 +165,7 @@ config_list: list[_TableConfig] = [
     _TableConfig(
         table_name="dag_version",
         recency_column_name="created_at",
+        extra_columns=["id"],
         dependent_tables=["task_instance", "dag_run"],
         dag_id_column_name="dag_id",
         keep_last=True,
@@ -372,6 +373,17 @@ def _build_query(
             ),
         )
         conditions.append(column(max_date_col_name).is_(None))
+
+    if orm_model.name == "dag_version":
+        # Keep any DAG version that is still referenced by surviving task instances.
+        # The task_instance cleanup runs first, so this only protects active references.
+        task_instance = table("task_instance", column("dag_version_id"))
+        conditions.append(
+            ~select(1)
+            .select_from(task_instance)
+            .where(task_instance.c.dag_version_id == base_table.c.id)
+            .exists()
+        )
     query = query.where(and_(*conditions))
     return query
 

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -422,6 +422,68 @@ class TestDBCleanup:
                 f"Expected {expected_remaining_dag_ids} to remain, but got {remaining_dag_ids}"
             )
 
+    def test_run_cleanup_keeps_referenced_dag_versions(self):
+        """
+        Verify that db cleanup skips old DagVersion rows that are still referenced by surviving task instances.
+        """
+        base_date = pendulum.datetime(2022, 1, 1, tz="UTC")
+        dag_id = f"test-dag_{uuid4()}"
+
+        with create_session() as session:
+            bundle_name = "testing"
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+
+            dag = DAG(dag_id=dag_id)
+            session.add(DagModel(dag_id=dag_id, bundle_name=bundle_name))
+
+            dag_version_1 = DagVersion.write_dag(dag_id=dag_id, bundle_name=bundle_name, session=session)
+            dag_version_1.created_at = base_date
+            dag_version_1.last_updated = base_date
+            session.flush()
+
+            dag_version_2 = DagVersion.write_dag(dag_id=dag_id, bundle_name=bundle_name, session=session)
+            dag_version_2.created_at = base_date.add(days=1)
+            dag_version_2.last_updated = dag_version_2.created_at
+            session.flush()
+
+            dag_version_3 = DagVersion.write_dag(dag_id=dag_id, bundle_name=bundle_name, session=session)
+            dag_version_3.created_at = base_date.add(days=2)
+            dag_version_3.last_updated = dag_version_3.created_at
+            session.flush()
+
+            dag_run = DagRun(
+                dag_id,
+                run_id="run_1",
+                run_type=DagRunType.MANUAL,
+                start_date=base_date.add(days=10),
+            )
+            task = PythonOperator(task_id="dummy-task", python_callable=print, dag=dag)
+            ti = create_task_instance(
+                task,
+                run_id=dag_run.run_id,
+                dag_version_id=dag_version_1.id,
+            )
+            ti.dag_id = dag_id
+            ti.start_date = base_date.add(days=10)
+            session.add_all([dag_run, ti])
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=5),
+                table_names=["dag_version"],
+                dry_run=False,
+                confirm=False,
+                skip_archive=True,
+                session=session,
+            )
+
+            remaining_version_ids = set(
+                session.scalars(select(DagVersion.id).where(DagVersion.dag_id == dag_id)).all()
+            )
+            assert remaining_version_ids == {dag_version_1.id, dag_version_3.id}
+            assert session.scalar(select(func.count()).select_from(TaskInstance)) == 1
+
     @pytest.mark.parametrize(
         ("skip_archive", "expected_archives"),
         [pytest.param(True, 0, id="skip_archive"), pytest.param(False, 1, id="do_archive")],


### PR DESCRIPTION

## Summary
`airflow db clean` could delete `dag_version` rows that were still referenced by surviving `task_instance` rows, which caused a `ForeignKeyViolation` during cleanup. This fix makes `dag_version` cleanup skip versions that are still referenced after the `task_instance` pass runs.

## Changes
- **`airflow-core/src/airflow/utils/db_cleanup.py`** -- added a reference check for `dag_version` cleanup so rows still referenced by surviving task instances are not deleted, and included the `id` column in the cleanup table shape.
- **`airflow-core/tests/unit/utils/test_db_cleanup.py`** -- added a regression test that creates multiple DAG versions and verifies `db clean` retains the referenced version while still deleting unreferenced older versions.

## Test plan
- [x] `uv run --project airflow-core pytest airflow-core/tests/unit/utils/test_db_cleanup.py::TestDBCleanup::test_run_cleanup_keeps_referenced_dag_versions -xvs`
- [x] `ruff check airflow-core/src/airflow/utils/db_cleanup.py airflow-core/tests/unit/utils/test_db_cleanup.py`
- [x] `ruff format --check airflow-core/src/airflow/utils/db_cleanup.py airflow-core/tests/unit/utils/test_db_cleanup.py`
- [ ] CI passes (ruff, mypy, pytest)

Fixes #63703
