### PR TITLE
Fix Celery worker health check to detect lost queues (#63580)

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
@@ -143,8 +143,9 @@ For details about installation, see: :doc:`apache-airflow-providers-celery:celer
 CLI Check for Celery Workers
 ----------------------------
 
-To verify that the Celery workers are working correctly, you can use the ``celery inspect ping`` command. On failure, the command will exit
-with a non-zero error code.
+To verify that a Celery worker is working correctly, you can use the ``airflow celery health-check`` command. On failure, the command will
+exit with a non-zero error code. It checks both that the worker responds to ``ping`` and that it still reports active queues, so it can
+catch workers that are alive but no longer consuming tasks.
 
 .. note::
 
@@ -155,12 +156,6 @@ To check if the worker running on the local host is working correctly, run:
 
 .. code-block:: bash
 
-    celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
-
-To check if the all workers in the cluster running is working correctly, run:
-
-.. code-block:: bash
-
-    celery --app airflow.providers.celery.executors.celery_executor.app inspect ping
+    airflow celery health-check --celery-hostname celery@${HOSTNAME}
 
 For more information, see: `Management Command-line Utilities (inspect/control) <https://docs.celeryproject.org/en/stable/userguide/monitoring.html#monitoring-control>`__ and `Workers Guide <https://docs.celeryproject.org/en/stable/userguide/workers.html>`__ in the Celery documentation.

--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -171,7 +171,7 @@ services:
     command: celery worker
     healthcheck:
       # yamllint disable rule:line-length
-      test: ["CMD-SHELL", 'celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}" || celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"']
+      test: ["CMD-SHELL", 'airflow celery health-check --celery-hostname "celery@$${HOSTNAME}"']
       interval: 30s
       timeout: 10s
       retries: 5

--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -46,6 +46,13 @@ WORKER_PROCESS_NAME = "worker"
 log = logging.getLogger(__name__)
 
 
+def _get_celery_app():
+    """Import the Celery app lazily to avoid provider initialization during CLI startup."""
+    from airflow.providers.celery.executors.celery_executor import app as celery_app
+
+    return celery_app
+
+
 def _run_command_with_daemon_option(*args, **kwargs):
     try:
         from airflow.cli.commands.daemon_utils import run_command_with_daemon_option
@@ -214,7 +221,7 @@ def worker(args):
         celery_app = create_celery_app(team_config)
     else:
         # Backward compatible: use module-level app with global config
-        from airflow.providers.celery.executors.celery_executor import app as celery_app
+        celery_app = _get_celery_app()
 
     # Use team_config for config reads in multi-team mode, otherwise use global conf
     config = team_config if team_config else conf
@@ -350,15 +357,29 @@ def stop_worker(args):
 @_providers_configuration_loaded
 def _check_if_active_celery_worker(hostname: str):
     """Check if celery worker is active before executing dependent cli commands."""
-    # This needs to be imported locally to not trigger Providers Manager initialization
-    from airflow.providers.celery.executors.celery_executor import app as celery_app
-
+    celery_app = _get_celery_app()
     inspect = celery_app.control.inspect()
     active_workers = inspect.active_queues()
     if not active_workers:
         raise SystemExit("Error: No active Celery workers found!")
     if hostname not in active_workers:
         raise SystemExit(f"Error: {hostname} is unknown!")
+
+
+@cli_utils.action_cli(check_db=False)
+@_providers_configuration_loaded
+def health_check(args):
+    """Check that a celery worker is alive and still consuming queues."""
+    celery_app = _get_celery_app()
+    inspect = celery_app.control.inspect(destination=[args.celery_hostname])
+
+    ping_result = inspect.ping()
+    if not ping_result or args.celery_hostname not in ping_result:
+        raise SystemExit(f"Error: Celery worker '{args.celery_hostname}' is not responding to ping.")
+
+    active_workers = inspect.active_queues()
+    if not active_workers or not active_workers.get(args.celery_hostname):
+        raise SystemExit(f"Error: Celery worker '{args.celery_hostname}' is not consuming any queues.")
 
 
 @cli_utils.action_cli(check_db=False)

--- a/providers/celery/src/airflow/providers/celery/cli/definition.py
+++ b/providers/celery/src/airflow/providers/celery/cli/definition.py
@@ -158,6 +158,12 @@ CELERY_COMMANDS = (
         ),
     ),
     ActionCommand(
+        name="health-check",
+        help="Check whether a Celery worker is alive and still consuming queues",
+        func=lazy_load_command(f"{CELERY_CLI_COMMAND_PATH}.health_check"),
+        args=(ARG_FULL_CELERY_HOSTNAME,),
+    ),
+    ActionCommand(
         name="flower",
         help="Start a Celery Flower",
         func=lazy_load_command(f"{CELERY_CLI_COMMAND_PATH}.flower"),

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -626,6 +626,51 @@ class TestRemoteCeleryControlCommands:
             assert mock_cancel_consumer.call_count == 2
 
 
+class TestCeleryWorkerHealthCheck:
+    @classmethod
+    def setup_class(cls):
+        with conf_vars({("core", "executor"): "CeleryExecutor"}):
+            importlib.reload(executor_loader)
+            importlib.reload(cli_parser)
+            cls.parser = cli_parser.get_parser()
+
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
+    def test_health_check_passes_when_worker_pings_and_has_queues(self, mock_inspect):
+        args = self.parser.parse_args(["celery", "health-check", "--celery-hostname", "celery@host_1"])
+        mock_instance = MagicMock()
+        mock_instance.ping.return_value = {"celery@host_1": {"ok": "pong"}}
+        mock_instance.active_queues.return_value = {"celery@host_1": [{"name": "queue1"}]}
+        mock_inspect.return_value = mock_instance
+
+        celery_command.health_check(args)
+
+        mock_inspect.assert_called_once_with(destination=["celery@host_1"])
+        mock_instance.ping.assert_called_once_with()
+        mock_instance.active_queues.assert_called_once_with()
+
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
+    def test_health_check_fails_when_worker_lost_queues(self, mock_inspect):
+        args = self.parser.parse_args(["celery", "health-check", "--celery-hostname", "celery@host_1"])
+        mock_instance = MagicMock()
+        mock_instance.ping.return_value = {"celery@host_1": {"ok": "pong"}}
+        mock_instance.active_queues.return_value = None
+        mock_inspect.return_value = mock_instance
+
+        with pytest.raises(SystemExit, match="is not consuming any queues"):
+            celery_command.health_check(args)
+
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
+    def test_health_check_fails_when_worker_no_longer_pings(self, mock_inspect):
+        args = self.parser.parse_args(["celery", "health-check", "--celery-hostname", "celery@host_1"])
+        mock_instance = MagicMock()
+        mock_instance.ping.return_value = None
+        mock_instance.active_queues.return_value = {"celery@host_1": [{"name": "queue1"}]}
+        mock_inspect.return_value = mock_instance
+
+        with pytest.raises(SystemExit, match="is not responding to ping"):
+            celery_command.health_check(args)
+
+
 @patch("airflow.providers.celery.cli.celery_command.Process")
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Doesn't apply to pre-3.0")
 def test_stale_bundle_cleanup(mock_process):

--- a/providers/celery/tests/unit/celery/cli/test_definition.py
+++ b/providers/celery/tests/unit/celery/cli/test_definition.py
@@ -52,13 +52,14 @@ class TestCeleryCliDefinition:
         assert len(CELERY_CLI_COMMANDS) == 1
 
     def test_celery_commands_count(self):
-        """Test that CELERY_COMMANDS contains all 9 subcommands."""
-        assert len(CELERY_COMMANDS) == 9
+        """Test that CELERY_COMMANDS contains all 10 subcommands."""
+        assert len(CELERY_COMMANDS) == 10
 
     @pytest.mark.parametrize(
         "command",
         [
             "worker",
+            "health-check",
             "flower",
             "stop",
             "list-workers",
@@ -93,6 +94,12 @@ class TestCeleryCliDefinition:
         assert args.queues == "queue1,queue2"
         assert args.concurrency == 4
         assert args.celery_hostname == "worker1"
+
+    def test_health_check_command_args(self):
+        """Test health-check command with celery hostname."""
+        params = ["celery", "health-check", "--celery-hostname", "celery@worker1"]
+        args = self.arg_parser.parse_args(params)
+        assert args.celery_hostname == "celery@worker1"
 
     def test_flower_command_args(self):
         """Test flower command with various arguments."""


### PR DESCRIPTION


## Summary
The Celery worker health check only verified that a worker responded to `ping`, which let a broker-restarted worker look healthy even after it lost all queue subscriptions. This change adds a dedicated health-check command that also verifies the worker still reports active queues, so the Docker Compose worker probe now fails in the catatonic state described in the issue.

## Changes
- **`providers/celery/src/airflow/providers/celery/cli/celery_command.py`** -- added a `health_check` CLI command that checks both worker ping and active queues.
- **`providers/celery/src/airflow/providers/celery/cli/definition.py`** -- registered the new `celery health-check` subcommand.
- **`providers/celery/tests/unit/celery/cli/test_celery_command.py`** -- added unit tests for the healthy case and both failure modes.
- **`providers/celery/tests/unit/celery/cli/test_definition.py`** -- updated CLI coverage for the new subcommand and its arguments.
- **`airflow-core/docs/howto/docker-compose/docker-compose.yaml`** -- switched the worker healthcheck to the new CLI command.
- **`airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst`** -- updated the docs to describe the stronger worker health check.

## Test plan
- [x] `ruff check providers/celery/src/airflow/providers/celery/cli/celery_command.py providers/celery/src/airflow/providers/celery/cli/definition.py providers/celery/tests/unit/celery/cli/test_celery_command.py providers/celery/tests/unit/celery/cli/test_definition.py`
- [x] `ruff format --check providers/celery/src/airflow/providers/celery/cli/celery_command.py providers/celery/src/airflow/providers/celery/cli/definition.py providers/celery/tests/unit/celery/cli/test_celery_command.py providers/celery/tests/unit/celery/cli/test_definition.py`
- [x] `uv run --project providers/celery pytest providers/celery/tests/unit/celery/cli/test_definition.py providers/celery/tests/unit/celery/cli/test_celery_command.py -xvs`
- [x] `prek run --stage pre-commit --files airflow-core/docs/howto/docker-compose/docker-compose.yaml airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst`

Fixes #63580
