### PR TITLE
Fix airflowctl dagrun list limit handling (#64066)

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -631,9 +631,11 @@ class DagRunOperations(BaseOperations):
         if end_date is not None:
             params["end_date"] = end_date
 
-        return super().execute_list(
-            path=f"/dags/{dag_id}/dagRuns", data_model=DAGRunCollectionResponse, params=params
-        )
+        try:
+            self.response = self.client.get(f"/dags/{dag_id}/dagRuns", params=params)
+            return DAGRunCollectionResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
 
 
 class JobsOperations(BaseOperations):

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1082,6 +1082,32 @@ class TestDagRunOperations:
         )
         assert response == self.dag_run_collection_response
 
+    def test_list_respects_limit_without_paginating(self):
+        """Dag run listing should honor ``limit`` as the total output cap."""
+        limited_response = DAGRunCollectionResponse(
+            dag_runs=[self.dag_run_response],
+            total_entries=2,
+        )
+        call_count = 0
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            assert request.url.path == f"/api/v2/dags/{self.dag_id}/dagRuns"
+            assert dict(request.url.params)["limit"] == "1"
+            return httpx.Response(200, json=json.loads(limited_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.list(
+            dag_id=self.dag_id,
+            start_date=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            end_date=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            state=DagRunState.RUNNING,
+            limit=1,
+        )
+        assert response == limited_response
+        assert call_count == 1
+
     def test_list_with_optional_parameters(self):
         """Test listing dag runs with only some optional parameters."""
 


### PR DESCRIPTION
## Summary
`airflowctl dagrun list` was using the shared list paginator, which kept fetching and appending additional pages until it returned every matching run. That made `--limit` behave like a page size instead of a hard cap. This change makes DAG run listing return exactly the requested page and preserves the limit the user asked for.

## Changes
- **`airflow-ctl/src/airflowctl/api/operations.py`** -- changed `DagRunOperations.list()` to make a single API request and return the server response directly, so `--limit` is honored as the final result cap.
- **`airflow-ctl/tests/airflow_ctl/api/test_operations.py`** -- added a regression test that verifies DAG run listing does not paginate past the first page when `limit=1`.

## Test plan
- [x] `uv run --project /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl ruff check /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl/src/airflowctl/api/operations.py /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl/tests/airflow_ctl/api/test_operations.py`
- [x] `uv run --project /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl ruff format --check /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl/src/airflowctl/api/operations.py /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl/tests/airflow_ctl/api/test_operations.py`
- [x] `uv run --project /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl pytest /Users/dejain/nvidia/oss/airflow-64066/airflow-ctl/tests/airflow_ctl/api/test_operations.py::TestDagRunOperations -xvs`

Fixes #64066
