### PR TITLE
Fix Variable write conflict loop (#64060)

### DIFF
--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -487,7 +487,7 @@ class Variable(Base, LoggingMixin):
                         "Checking subsequent secrets backend.",
                         type(secrets_backend).__name__,
                     )
-            return None
+        return None
 
     @staticmethod
     def get_variable_from_secrets(key: str, team_name: str | None = None) -> str | None:

--- a/airflow-core/tests/unit/models/test_variable.py
+++ b/airflow-core/tests/unit/models/test_variable.py
@@ -187,6 +187,30 @@ class TestVariable:
         )
         Variable.delete(key="key", session=session)
 
+    @mock.patch("airflow.models.variable.ensure_secrets_loaded")
+    def test_check_for_write_conflict_checks_later_backends(self, mock_ensure_secrets, caplog):
+        caplog.set_level(logging.WARNING, logger=variable.log.name)
+
+        first_backend = mock.Mock()
+        first_backend.get_variable.return_value = None
+        first_backend.__class__.__name__ = "FirstBackend"
+
+        second_backend = mock.Mock()
+        second_backend.get_variable.return_value = "secret_val"
+        second_backend.__class__.__name__ = "SecondBackend"
+
+        mock_ensure_secrets.return_value = [first_backend, second_backend, MetastoreBackend]
+
+        Variable.check_for_write_conflict("key")
+
+        first_backend.get_variable.assert_called_once_with(key="key")
+        second_backend.get_variable.assert_called_once_with(key="key")
+        assert caplog.messages[0] == (
+            "The variable key is defined in the SecondBackend secrets backend, which takes precedence "
+            "over reading from the database. The value in the database will be updated, but to read it "
+            "you have to delete the conflicting variable from SecondBackend"
+        )
+
     def test_variable_set_get_round_trip_json(self):
         value = {"a": 17, "b": 47}
         Variable.set(key="tested_var_set_id", value=value, serialize_json=True)


### PR DESCRIPTION
## Summary
`Variable.check_for_write_conflict` returned from inside its backend loop, so only the first non-metastore secrets backend was ever checked. That could hide write conflicts in later backends and let the database value be updated without the expected warning.

## Changes
- **`airflow-core/src/airflow/models/variable.py`** -- moved the `return None` out of the backend loop so every configured secrets backend is checked before concluding that no conflict exists.
- **`airflow-core/tests/unit/models/test_variable.py`** -- added a regression test that verifies later secrets backends are still consulted and can trigger the conflict warning.

## Test plan
- [x] `ruff check airflow-core/src/airflow/models/variable.py airflow-core/tests/unit/models/test_variable.py`
- [x] `ruff format --check airflow-core/src/airflow/models/variable.py airflow-core/tests/unit/models/test_variable.py`
- [x] `uv run --project /Users/dejain/nvidia/oss/airflow-64060/airflow-core pytest /Users/dejain/nvidia/oss/airflow-64060/airflow-core/tests/unit/models/test_variable.py -xvs`

Fixes #64060
