### PR TITLE
Fix API server memory leak: bound DBDagBag version cache with LRU eviction

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Annotated
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
+from airflow.configuration import conf
 from airflow.models.dagbag import DBDagBag
 
 if TYPE_CHECKING:
@@ -30,7 +31,8 @@ if TYPE_CHECKING:
 
 def create_dag_bag() -> DBDagBag:
     """Create DagBag to retrieve DAGs from the database."""
-    return DBDagBag()
+    max_cache_size = conf.getint("api", "dag_version_cache_size", fallback=4096)
+    return DBDagBag(max_cache_size=max_cache_size)
 
 
 def dag_bag_from_app(request: Request) -> DBDagBag:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1841,7 +1841,7 @@ api:
         versions. When the limit is reached the least-recently-used version is evicted.
         The scheduler does not use this setting — its cache is naturally bounded by the
         number of active DAGs.
-      version_added: 3.2.0
+      version_added: 3.2.1
       type: integer
       example: ~
       default: "4096"

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -517,6 +517,17 @@ core:
       type: boolean
       example: ~
       default: "False"
+    max_dag_version_cache_size:
+      description: |
+        Maximum number of DAG versions to keep in the in-memory cache used by DBDagBag.
+        When the limit is reached the least-recently-used version is evicted. Increase this
+        value if you have many concurrently active DAG versions and can afford the memory;
+        decrease it to reduce the memory footprint of long-running API server or scheduler
+        processes.
+      version_added: 3.1.0
+      type: integer
+      example: ~
+      default: "512"
 database:
   description: ~
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -517,17 +517,6 @@ core:
       type: boolean
       example: ~
       default: "False"
-    max_dag_version_cache_size:
-      description: |
-        Maximum number of DAG versions to keep in the in-memory cache used by DBDagBag.
-        When the limit is reached the least-recently-used version is evicted. Increase this
-        value if you have many concurrently active DAG versions and can afford the memory;
-        decrease it to reduce the memory footprint of long-running API server or scheduler
-        processes.
-      version_added: 3.2.0
-      type: integer
-      example: ~
-      default: "4096"
 database:
   description: ~
   options:
@@ -1845,6 +1834,17 @@ api:
       type: string
       example: "/etc/airflow/certs/client.key"
       default: ~
+    dag_version_cache_size:
+      description: |
+        Maximum number of DAG versions to keep in the API server's in-memory LRU cache.
+        The API server may serve historical run views so it benefits from retaining older
+        versions. When the limit is reached the least-recently-used version is evicted.
+        The scheduler does not use this setting — its cache is naturally bounded by the
+        number of active DAGs.
+      version_added: 3.2.0
+      type: integer
+      example: ~
+      default: "4096"
 workers:
   description: Configuration related to workers that run Airflow tasks.
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -527,7 +527,7 @@ core:
       version_added: 3.2.0
       type: integer
       example: ~
-      default: "512"
+      default: "4096"
 database:
   description: ~
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -524,7 +524,7 @@ core:
         value if you have many concurrently active DAG versions and can afford the memory;
         decrease it to reduce the memory footprint of long-running API server or scheduler
         processes.
-      version_added: 3.1.0
+      version_added: 3.2.0
       type: integer
       example: ~
       default: "512"

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -305,7 +305,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if log:
             self._log = log
 
-        self.scheduler_dag_bag = DBDagBag(load_op_links=False)
+        self.scheduler_dag_bag = DBDagBag(load_op_links=False, max_cache_size=None)
 
     @provide_session
     def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -25,9 +25,9 @@ from uuid import UUID
 from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, joinedload, mapped_column
 
-from airflow.configuration import conf
 from airflow.models.base import Base, StringID
 from airflow.models.dag_version import DagVersion
+from airflow.observability.stats import Stats
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -46,10 +46,8 @@ class DBDagBag:
     :meta private:
     """
 
-    def __init__(self, load_op_links: bool = True) -> None:
-        self._max_dag_version_cache_size: int = conf.getint(
-            "core", "max_dag_version_cache_size", fallback=4096
-        )
+    def __init__(self, load_op_links: bool = True, max_cache_size: int | None = None) -> None:
+        self._max_dag_version_cache_size = max_cache_size  # None = unbounded
         self._dags: OrderedDict[UUID, SerializedDagModel] = OrderedDict()
         self.load_op_links = load_op_links
 
@@ -59,8 +57,13 @@ class DBDagBag:
             version_id = serialized_dag_model.dag_version_id
             self._dags[version_id] = serialized_dag_model
             self._dags.move_to_end(version_id)
-            if len(self._dags) > self._max_dag_version_cache_size:
-                self._dags.popitem(last=False)  # evict LRU entry
+            if (
+                self._max_dag_version_cache_size is not None
+                and len(self._dags) > self._max_dag_version_cache_size
+            ):
+                self._dags.popitem(last=False)
+                Stats.incr("dag_bag.cache.evictions")
+            Stats.gauge("dag_bag.cache.size", len(self._dags), rate=0.1)
         return dag
 
     def get_serialized_dag_model(self, version_id: UUID, session: Session) -> SerializedDagModel | None:
@@ -82,11 +85,13 @@ class DBDagBag:
         internal cache (``self._dags``) before being returned.
         """
         if not (serialized_dag_model := self._dags.get(version_id)):
+            Stats.incr("dag_bag.cache.misses")
             dag_version = session.get(DagVersion, version_id, options=[joinedload(DagVersion.serialized_dag)])
             if not dag_version or not (serialized_dag_model := dag_version.serialized_dag):
                 return None
             self._read_dag(serialized_dag_model)
         else:
+            Stats.incr("dag_bag.cache.hits")
             self._dags.move_to_end(version_id)  # promote to MRU on cache hit
         return serialized_dag_model
 

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -48,7 +48,7 @@ class DBDagBag:
 
     def __init__(self, load_op_links: bool = True) -> None:
         self._max_dag_version_cache_size: int = conf.getint(
-            "core", "max_dag_version_cache_size", fallback=512
+            "core", "max_dag_version_cache_size", fallback=4096
         )
         self._dags: OrderedDict[UUID, SerializedDagModel] = OrderedDict()
         self.load_op_links = load_op_links

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -18,12 +18,14 @@
 from __future__ import annotations
 
 import hashlib
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, joinedload, mapped_column
 
+from airflow.configuration import conf
 from airflow.models.base import Base, StringID
 from airflow.models.dag_version import DagVersion
 
@@ -45,13 +47,20 @@ class DBDagBag:
     """
 
     def __init__(self, load_op_links: bool = True) -> None:
-        self._dags: dict[UUID, SerializedDagModel] = {}  # dag_version_id to dag
+        self._max_dag_version_cache_size: int = conf.getint(
+            "core", "max_dag_version_cache_size", fallback=512
+        )
+        self._dags: OrderedDict[UUID, SerializedDagModel] = OrderedDict()
         self.load_op_links = load_op_links
 
     def _read_dag(self, serialized_dag_model: SerializedDagModel) -> SerializedDAG | None:
         serialized_dag_model.load_op_links = self.load_op_links
         if dag := serialized_dag_model.dag:
-            self._dags[serialized_dag_model.dag_version_id] = serialized_dag_model
+            version_id = serialized_dag_model.dag_version_id
+            self._dags[version_id] = serialized_dag_model
+            self._dags.move_to_end(version_id)
+            if len(self._dags) > self._max_dag_version_cache_size:
+                self._dags.popitem(last=False)  # evict LRU entry
         return dag
 
     def get_serialized_dag_model(self, version_id: UUID, session: Session) -> SerializedDagModel | None:
@@ -77,6 +86,8 @@ class DBDagBag:
             if not dag_version or not (serialized_dag_model := dag_version.serialized_dag):
                 return None
             self._read_dag(serialized_dag_model)
+        else:
+            self._dags.move_to_end(version_id)  # promote to MRU on cache hit
         return serialized_dag_model
 
     def get_dag(self, version_id: UUID, session: Session) -> SerializedDAG | None:

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -55,7 +55,7 @@ class DBDagBag:
         # Use a real lock only when bounded caching is enabled (API server mode).
         # The scheduler uses max_cache_size=None (unbounded, single-threaded) and
         # gets a no-op context manager to avoid any locking overhead.
-        self._lock: contextlib.AbstractContextManager[None] = (
+        self._lock: threading.Lock | contextlib.nullcontext[None] = (
             threading.Lock() if max_cache_size is not None else contextlib.nullcontext()
         )
 

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -17,7 +17,9 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import threading
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -47,23 +49,30 @@ class DBDagBag:
     """
 
     def __init__(self, load_op_links: bool = True, max_cache_size: int | None = None) -> None:
-        self._max_dag_version_cache_size = max_cache_size  # None = unbounded
+        self._max_dag_version_cache_size = max_cache_size
         self._dags: OrderedDict[UUID, SerializedDagModel] = OrderedDict()
         self.load_op_links = load_op_links
+        # Use a real lock only when bounded caching is enabled (API server mode).
+        # The scheduler uses max_cache_size=None (unbounded, single-threaded) and
+        # gets a no-op context manager to avoid any locking overhead.
+        self._lock: contextlib.AbstractContextManager[None] = (
+            threading.Lock() if max_cache_size is not None else contextlib.nullcontext()
+        )
 
     def _read_dag(self, serialized_dag_model: SerializedDagModel) -> SerializedDAG | None:
         serialized_dag_model.load_op_links = self.load_op_links
         if dag := serialized_dag_model.dag:
             version_id = serialized_dag_model.dag_version_id
-            self._dags[version_id] = serialized_dag_model
-            self._dags.move_to_end(version_id)
-            if (
-                self._max_dag_version_cache_size is not None
-                and len(self._dags) > self._max_dag_version_cache_size
-            ):
-                self._dags.popitem(last=False)
-                Stats.incr("dag_bag.cache.evictions")
-            Stats.gauge("dag_bag.cache.size", len(self._dags), rate=0.1)
+            with self._lock:
+                self._dags[version_id] = serialized_dag_model
+                self._dags.move_to_end(version_id)
+                if (
+                    self._max_dag_version_cache_size is not None
+                    and len(self._dags) > self._max_dag_version_cache_size
+                ):
+                    self._dags.popitem(last=False)
+                    Stats.incr("dag_bag.cache.evictions")
+                Stats.gauge("dag_bag.cache.size", len(self._dags), rate=0.1)
         return dag
 
     def get_serialized_dag_model(self, version_id: UUID, session: Session) -> SerializedDagModel | None:
@@ -84,15 +93,21 @@ class DBDagBag:
         Note: If a serialized dag model is found in the database it will be stored in the
         internal cache (``self._dags``) before being returned.
         """
-        if not (serialized_dag_model := self._dags.get(version_id)):
-            Stats.incr("dag_bag.cache.misses")
-            dag_version = session.get(DagVersion, version_id, options=[joinedload(DagVersion.serialized_dag)])
-            if not dag_version or not (serialized_dag_model := dag_version.serialized_dag):
-                return None
-            self._read_dag(serialized_dag_model)
-        else:
+        with self._lock:
+            if serialized_dag_model := self._dags.get(version_id):
+                self._dags.move_to_end(version_id)  # promote to MRU on cache hit
+
+        if serialized_dag_model is not None:
             Stats.incr("dag_bag.cache.hits")
-            self._dags.move_to_end(version_id)  # promote to MRU on cache hit
+            return serialized_dag_model
+
+        # Cache miss — query the DB outside the lock to avoid blocking other threads
+        # during slow I/O. _read_dag re-acquires the lock for the insert.
+        Stats.incr("dag_bag.cache.misses")
+        dag_version = session.get(DagVersion, version_id, options=[joinedload(DagVersion.serialized_dag)])
+        if not dag_version or not (serialized_dag_model := dag_version.serialized_dag):
+            return None
+        self._read_dag(serialized_dag_model)
         return serialized_dag_model
 
     def get_dag(self, version_id: UUID, session: Session) -> SerializedDAG | None:

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -16,11 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+from collections import OrderedDict
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 
 from airflow.api_fastapi.app import purge_cached_app
+from airflow.models.dagbag import DBDagBag
 from airflow.sdk import BaseOperator
 
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
@@ -82,3 +85,61 @@ class TestDagBagSingleton:
         assert resp2.status_code == 200
 
         assert self.dagbag_call_counter["count"] == 1
+
+
+class TestDBDagBagLRUCache:
+    """Tests for the bounded LRU eviction behaviour of DBDagBag._dags."""
+
+    def _make_bag(self, max_size: int) -> DBDagBag:
+        bag = DBDagBag.__new__(DBDagBag)
+        bag.load_op_links = True
+        bag._max_dag_version_cache_size = max_size
+        bag._dags = OrderedDict()
+        return bag
+
+    def _make_model(self, version_id):
+        m = mock.MagicMock()
+        m.dag_version_id = version_id
+        m.dag = mock.MagicMock()  # truthy — deserialization succeeds
+        return m
+
+    def test_cache_bounded_by_max_size(self):
+        """Inserting beyond max_size evicts the least-recently-used entry."""
+        bag = self._make_bag(max_size=3)
+        ids = [uuid4() for _ in range(4)]
+        for uid in ids:
+            bag._read_dag(self._make_model(uid))
+
+        assert len(bag._dags) == 3
+        assert ids[0] not in bag._dags  # first inserted → LRU → evicted
+        assert ids[3] in bag._dags
+
+    def test_cache_hit_promotes_to_mru(self):
+        """A cache hit via get_serialized_dag_model promotes the entry to MRU."""
+        bag = self._make_bag(max_size=3)
+        ids = [uuid4() for _ in range(3)]
+        models = {uid: self._make_model(uid) for uid in ids}
+        for uid in ids:
+            bag._read_dag(models[uid])
+
+        # Re-access ids[0] through get_serialized_dag_model to promote it
+        session = mock.MagicMock()
+        bag.get_serialized_dag_model(ids[0], session=session)
+        session.get.assert_not_called()  # should be a pure cache hit
+
+        # Insert a 4th entry — ids[1] (now LRU) should be evicted, not ids[0]
+        bag._read_dag(self._make_model(uuid4()))
+
+        assert ids[0] in bag._dags  # promoted to MRU, survives
+        assert ids[1] not in bag._dags  # was LRU after ids[0] promoted, evicted
+
+    def test_failed_deserialization_not_cached(self):
+        """Entries whose .dag property is falsy are not inserted into the cache."""
+        bag = self._make_bag(max_size=10)
+        m = mock.MagicMock()
+        m.dag_version_id = uuid4()
+        m.dag = None  # deserialization failure
+
+        bag._read_dag(m)
+
+        assert len(bag._dags) == 0

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from collections import OrderedDict
 from unittest import mock
 from uuid import uuid4
 
@@ -91,11 +90,7 @@ class TestDBDagBagLRUCache:
     """Tests for the bounded LRU eviction behaviour of DBDagBag._dags."""
 
     def _make_bag(self, max_size: int) -> DBDagBag:
-        bag = DBDagBag.__new__(DBDagBag)
-        bag.load_op_links = True
-        bag._max_dag_version_cache_size = max_size
-        bag._dags = OrderedDict()
-        return bag
+        return DBDagBag(max_cache_size=max_size)
 
     def _make_model(self, version_id):
         m = mock.MagicMock()
@@ -143,3 +138,22 @@ class TestDBDagBagLRUCache:
         bag._read_dag(m)
 
         assert len(bag._dags) == 0
+
+    def test_cache_metrics_on_hit(self):
+        """A cache hit emits dag_bag.cache.hits via Stats.incr."""
+        bag = self._make_bag(max_size=10)
+        uid = uuid4()
+        bag._dags[uid] = self._make_model(uid)
+
+        with mock.patch("airflow.models.dagbag.Stats") as mock_stats:
+            bag.get_serialized_dag_model(uid, session=mock.MagicMock())
+            mock_stats.incr.assert_called_with("dag_bag.cache.hits")
+
+    def test_unbounded_cache_never_evicts(self):
+        """max_cache_size=None (scheduler mode) never evicts entries."""
+        bag = DBDagBag(max_cache_size=None)
+        ids = [uuid4() for _ in range(100)]
+        for uid in ids:
+            bag._read_dag(self._make_model(uid))
+
+        assert len(bag._dags) == 100

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -21,6 +21,7 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.orm import Session
 
 from airflow.api_fastapi.app import purge_cached_app
 from airflow.models.dagbag import DBDagBag
@@ -32,9 +33,9 @@ pytestmark = pytest.mark.db_test
 
 
 def _make_serialized_dag_model(version_id):
-    m = mock.MagicMock()
+    m = mock.Mock(spec_set=["dag_version_id", "dag", "load_op_links"])
     m.dag_version_id = version_id
-    m.dag = mock.MagicMock()  # truthy — deserialization succeeds
+    m.dag = mock.Mock()  # truthy — deserialization succeeds
     return m
 
 
@@ -120,7 +121,7 @@ class TestDBDagBagLRUCache:
             bag._read_dag(models[uid])
 
         # Re-access ids[0] through get_serialized_dag_model to promote it
-        session = mock.MagicMock()
+        session = mock.create_autospec(Session, instance=True)
         bag.get_serialized_dag_model(ids[0], session=session)
         session.get.assert_not_called()  # should be a pure cache hit
 
@@ -133,7 +134,7 @@ class TestDBDagBagLRUCache:
     def test_failed_deserialization_not_cached(self):
         """Entries whose .dag property is falsy are not inserted into the cache."""
         bag = self._make_bag(max_size=10)
-        m = mock.MagicMock()
+        m = mock.Mock(spec_set=["dag_version_id", "dag", "load_op_links"])
         m.dag_version_id = uuid4()
         m.dag = None  # deserialization failure
 
@@ -148,7 +149,7 @@ class TestDBDagBagLRUCache:
         bag._dags[uid] = _make_serialized_dag_model(uid)
 
         with mock.patch("airflow.models.dagbag.Stats") as mock_stats:
-            bag.get_serialized_dag_model(uid, session=mock.MagicMock())
+            bag.get_serialized_dag_model(uid, session=mock.create_autospec(Session, instance=True))
             mock_stats.incr.assert_called_with("dag_bag.cache.hits")
 
     def test_unbounded_cache_never_evicts(self):

--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import threading
 from unittest import mock
 from uuid import uuid4
 
@@ -28,6 +29,13 @@ from airflow.sdk import BaseOperator
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
 
 pytestmark = pytest.mark.db_test
+
+
+def _make_serialized_dag_model(version_id):
+    m = mock.MagicMock()
+    m.dag_version_id = version_id
+    m.dag = mock.MagicMock()  # truthy — deserialization succeeds
+    return m
 
 
 class TestDagBagSingleton:
@@ -92,18 +100,12 @@ class TestDBDagBagLRUCache:
     def _make_bag(self, max_size: int) -> DBDagBag:
         return DBDagBag(max_cache_size=max_size)
 
-    def _make_model(self, version_id):
-        m = mock.MagicMock()
-        m.dag_version_id = version_id
-        m.dag = mock.MagicMock()  # truthy — deserialization succeeds
-        return m
-
     def test_cache_bounded_by_max_size(self):
         """Inserting beyond max_size evicts the least-recently-used entry."""
         bag = self._make_bag(max_size=3)
         ids = [uuid4() for _ in range(4)]
         for uid in ids:
-            bag._read_dag(self._make_model(uid))
+            bag._read_dag(_make_serialized_dag_model(uid))
 
         assert len(bag._dags) == 3
         assert ids[0] not in bag._dags  # first inserted → LRU → evicted
@@ -113,7 +115,7 @@ class TestDBDagBagLRUCache:
         """A cache hit via get_serialized_dag_model promotes the entry to MRU."""
         bag = self._make_bag(max_size=3)
         ids = [uuid4() for _ in range(3)]
-        models = {uid: self._make_model(uid) for uid in ids}
+        models = {uid: _make_serialized_dag_model(uid) for uid in ids}
         for uid in ids:
             bag._read_dag(models[uid])
 
@@ -123,7 +125,7 @@ class TestDBDagBagLRUCache:
         session.get.assert_not_called()  # should be a pure cache hit
 
         # Insert a 4th entry — ids[1] (now LRU) should be evicted, not ids[0]
-        bag._read_dag(self._make_model(uuid4()))
+        bag._read_dag(_make_serialized_dag_model(uuid4()))
 
         assert ids[0] in bag._dags  # promoted to MRU, survives
         assert ids[1] not in bag._dags  # was LRU after ids[0] promoted, evicted
@@ -143,7 +145,7 @@ class TestDBDagBagLRUCache:
         """A cache hit emits dag_bag.cache.hits via Stats.incr."""
         bag = self._make_bag(max_size=10)
         uid = uuid4()
-        bag._dags[uid] = self._make_model(uid)
+        bag._dags[uid] = _make_serialized_dag_model(uid)
 
         with mock.patch("airflow.models.dagbag.Stats") as mock_stats:
             bag.get_serialized_dag_model(uid, session=mock.MagicMock())
@@ -154,6 +156,37 @@ class TestDBDagBagLRUCache:
         bag = DBDagBag(max_cache_size=None)
         ids = [uuid4() for _ in range(100)]
         for uid in ids:
-            bag._read_dag(self._make_model(uid))
+            bag._read_dag(_make_serialized_dag_model(uid))
 
         assert len(bag._dags) == 100
+
+
+class TestDBDagBagThreadSafety:
+    """Tests that DBDagBag is safe under concurrent access from multiple threads."""
+
+    def test_concurrent_reads_and_writes_do_not_corrupt_cache(self):
+        """
+        Verify no data corruption or exceptions under concurrent _read_dag calls.
+
+        Simulates the API server scenario: a bounded DBDagBag shared across many
+        threads, each inserting and reading entries simultaneously.
+        """
+        bag = DBDagBag(max_cache_size=10)
+        errors: list[Exception] = []
+
+        def worker():
+            try:
+                for _ in range(50):
+                    bag._read_dag(_make_serialized_dag_model(uuid4()))
+                    assert len(bag._dags) <= 10
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Errors in threads: {errors}"
+        assert len(bag._dags) <= 10

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -292,11 +292,35 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "dag_bag.cache.hits"
+    description: "Number of DBDagBag cache hits (DAG version found in memory)"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "dag_bag.cache.misses"
+    description: "Number of DBDagBag cache misses (DAG version fetched from DB)"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "dag_bag.cache.evictions"
+    description: "Number of DAG versions evicted from the DBDagBag LRU cache"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   # ==========
   # Gauges
   # ==========
   - name: "dagbag_size"
     description: "Number of Dags found when the scheduler ran a scan based on its configuration"
+    type: "gauge"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "dag_bag.cache.size"
+    description: "Current number of DAG versions held in the DBDagBag in-memory LRU cache"
     type: "gauge"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
  DBDagBag._dags is an unbounded in-memory cache causing steady memory
  growth in the API server.

  DBDagBag was designed for the scheduler, which works with a bounded set
  of currently-active DAG versions. As an API server singleton, it is exposed to
  the full history of DAG versions in the database with no bound on how
  many it will cache.

  Replace the plain dict in DBDagBag._dags with an OrderedDict-based LRU
  cache. In long-running API server processes, every unique dag_version_id
  accessed is inserted and never evicted, causing unbounded RSS growth (observed:
  9.4 GiB after 7 days with ~70k DAG versions in DB).

  The scheduler and API server have different access patterns, so the cache
  policy is now split:

  - API server: bounded LRU cache, capped at 4096 entries by default
  (configurable via api.dag_version_cache_size). Cache hits promote the
  entry to MRU so frequently-accessed versions are retained over stale
  historical ones.
  - Scheduler: explicitly unbounded (max_cache_size=None). Its working
  set is naturally capped at one version per active DAG, so a size limit
  would add eviction overhead with no benefit.

  Add Stats metrics to make the cache observable:
  dag_bag.cache.hits, dag_bag.cache.misses, dag_bag.cache.evictions,
  dag_bag.cache.size — emitted to the configured StatsD/OTEL backend,
  no-op if metrics are not configured.

<img width="1408" height="227" alt="image" src="https://github.com/user-attachments/assets/8a235479-7d6d-4b17-b7f1-8c4f58354408" />

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode

