### PR TITLE
Bump minimum uv version to 0.9.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1339,7 +1339,7 @@ leveldb = [
 ]
 
 [tool.uv]
-required-version = ">=0.6.3"
+required-version = ">=0.9.17"
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
 exclude-newer = "4 days"
 no-build-isolation-package = ["sphinx-redoc"]


### PR DESCRIPTION
The `exclude-newer = "4 days"` relative duration syntax (added in #64249) requires uv 0.9.17+. Older versions fail with a parse error on this value.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)