### PR TITLE
Align `log_id_template` with current default in Elasticsearch provider

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3567,7 +3567,7 @@ config:
     dag_bundle_config_list: '{{ include "dag_bundle_config_list" . }}'
   elasticsearch:
     json_format: 'True'
-    log_id_template: "{dag_id}_{task_id}_{execution_date}_{try_number}"
+    log_id_template: "{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}"
   elasticsearch_configs:
     max_retries: 3
     timeout: 30


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Align the Helm chart default for `log_id_template` with the current [Elasticsearch provider default](https://airflow.apache.org/docs/apache-airflow-providers-elasticsearch/stable/configurations-ref.html#log-id-template).
The previous default (`{dag_id}_{task_id}_{execution_date}_{try_number}`) does not seem to work correctly.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---