### PR TITLE
Add 4-day cooldown for pnpm dependency resolution

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/package.json
@@ -64,6 +64,7 @@
     "vitest": "^4.1.0"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [
       "@swc/core",
       "esbuild"

--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -115,6 +115,7 @@
     "web-worker": "^1.5.0"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [
       "@swc/core",
       "esbuild",

--- a/dev/react-plugin-tools/react_plugin_template/package.json
+++ b/dev/react-plugin-tools/react_plugin_template/package.json
@@ -73,6 +73,7 @@
     "vitest": "^3.2.4"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [
       "@swc/core",
       "esbuild"

--- a/providers/common/ai/src/airflow/providers/common/ai/plugins/www/package.json
+++ b/providers/common/ai/src/airflow/providers/common/ai/plugins/www/package.json
@@ -45,6 +45,7 @@
     "vite-plugin-dts": "^4.5.4"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "overrides": {
       "minimatch@>=10.0.0 <10.2.3": ">=10.2.3"
     }

--- a/providers/edge3/src/airflow/providers/edge3/plugins/www/package.json
+++ b/providers/edge3/src/airflow/providers/edge3/plugins/www/package.json
@@ -83,6 +83,7 @@
     "vitest": "^4.0.18"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [
       "@swc/core",
       "esbuild"

--- a/providers/fab/src/airflow/providers/fab/www/package.json
+++ b/providers/fab/src/airflow/providers/fab/www/package.json
@@ -66,6 +66,7 @@
     "moment-timezone": "^0.6.1"
   },
   "pnpm": {
+    "minimumReleaseAge": 5760,
     "onlyBuiltDependencies": [],
     "overrides": {
       "minimatch@>=10.0.0 <10.2.3": ">=10.2.3",


### PR DESCRIPTION
Add `minimumReleaseAge: 5760` (4 days in minutes) to all pnpm configurations, matching the uv cooldown added in #64249. This prevents pnpm from resolving to very recently published packages, reducing supply chain risk.

Affected package.json files:
- `airflow-core/src/airflow/ui/`
- `airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui/`
- `providers/fab/src/airflow/providers/fab/www/`
- `providers/edge3/src/airflow/providers/edge3/plugins/www/`
- `providers/common/ai/src/airflow/providers/common/ai/plugins/www/`
- `dev/react-plugin-tools/react_plugin_template/`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)