### PR TITLE
Fix UI dag code firefox overflow

### DIFF
--- a/airflow-core/newsfragments/64343.bugfix.rst
+++ b/airflow-core/newsfragments/64343.bugfix.rst
@@ -1,0 +1,1 @@
+Fix DAG Code view overflow on Firefox by using Flexbox layout

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -246,22 +246,24 @@ export const Code = () => {
       />
 
       {isDiffMode ? (
-        <Box dir="ltr" height="full">
+        <Box dir="ltr" display="flex" flexDirection="column" height="full">
           {dag?.fileloc !== undefined && (
             <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
           )}
-          <CodeDiffViewer
-            modifiedCode={
-              codeError?.status === 404 && !Boolean(code?.content)
-                ? translate("code.noCode")
-                : (code?.content ?? "")
-            }
-            originalCode={
-              compareCodeError?.status === 404 && !Boolean(compareCode?.content)
-                ? translate("code.noCode")
-                : (compareCode?.content ?? "")
-            }
-          />
+          <Box flex={1} minH={0} position="relative">
+            <CodeDiffViewer
+              modifiedCode={
+                codeError?.status === 404 && !Boolean(code?.content)
+                  ? translate("code.noCode")
+                  : (code?.content ?? "")
+              }
+              originalCode={
+                compareCodeError?.status === 404 && !Boolean(compareCode?.content)
+                  ? translate("code.noCode")
+                  : (compareCode?.content ?? "")
+              }
+            />
+          </Box>
         </Box>
       ) : (
         <Box
@@ -271,22 +273,26 @@ export const Code = () => {
             },
           }}
           dir="ltr"
+          display="flex"
+          flexDirection="column"
           fontSize="14px"
           height="full"
         >
           {dag?.fileloc !== undefined && (
             <FileLocation fileloc={dag.fileloc} relativeFileloc={dag.relative_fileloc} />
           )}
-          <Editor
-            language="python"
-            options={editorOptions}
-            theme={theme}
-            value={
-              codeError?.status === 404 && !Boolean(code?.content)
-                ? translate("code.noCode")
-                : (code?.content ?? "")
-            }
-          />
+          <Box flex={1} minH={0} position="relative">
+            <Editor
+              language="python"
+              options={editorOptions}
+              theme={theme}
+              value={
+                codeError?.status === 404 && !Boolean(code?.content)
+                  ? translate("code.noCode")
+                  : (code?.content ?? "")
+              }
+            />
+          </Box>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
Fixes a layout bug where the last ~6 rows of the DAG Code view were hidden in Firefox. 

The issue occurred because the `Editor` component attempts to take 100% height inside a non-flex container alongside the `FileLocation` header, pushing the bottom boundary of the editor to overflow the viewport. Converting the parent container to an explicit Flex column (using `flex={1}` and `minH={0}` on the code wrapper) ensures the editor strictly fills only the remaining vertical space across both Chrome and Firefox.

closes: #64286
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Gemini(for pr description)

