### PR TITLE
Fix task sdk only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 - [Publishing changes manually](#publishing-changes-manually)
 - [Fixing historical documentation](#fixing-historical-documentation)
   - [Manually publishing documentation directly to S3](#manually-publishing-documentation-directly-to-s3)
-  - [Manually publishing documentation via `airflow-site-archive` repo](#manually-publishing-documentation-via-airflow-site-archive-repo)
+  - [Manually publishing documentation via `apache-airflow-site-archive` repo](#manually-publishing-documentation-via-apache-airflow-site-archive-repo)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -79,7 +79,7 @@ There are a few repositories under `apache` organization that are used to build 
 We have two S3 buckets where we can publish the documentation generated from the `apache-airflow` repository:
 
 * `s3://live-docs-airflow-apache-org/docs/` - live, [official documentation](https://airflow.apache.org/docs/)
-* `s3://staging-docs-airflow-apache-org/docs/` - staging documentation [official documentation](https://airflow.staged.apache.org/docs/)
+* `s3://staging-docs-airflow-apache-org/docs/` - staging documentation [official documentation](https://staging-airflow.apache.org/docs/)
 
 Note that those S3 buckets are not served directly to Apache Server, but they are served via Cloudfront
 in order to provide caching and automated resolution of folders into index.html files.
@@ -299,18 +299,18 @@ breeze release-management publish-docs-to-s3 --source-dir-path /tmp/airflow-site
  --exclude-docs "<package_id1_to_exclude> <package_id2_to_exclude>" [--dry-run]
 ```
 
-## Manually publishing documentation via `airflow-site-archive` repo
+## Manually publishing documentation via `apache-airflow-site-archive` repo
 
 If you do not have S3 credentials and want to be careful about publishing the documentation, you can also
-use publishing via `airflow-site-archive` repository. This is a little more complex, but it allows
+use publishing via `apache-airflow-site-archive` repository. This is a little more complex, but it allows
 you to publish documentation without having S3 credentials.
 
 The process is as follows:
 
-1. Run `Sync s3 to GitHub` workflow in `airflow-site-archive` repository. This will download the
+1. Run `Sync s3 to GitHub` workflow in `apache-airflow-site-archive` repository. This will download the
    latest version of the documentation from S3 to `airflow-site-archive` repository (this should normally not
    be needed, if automated synchronization works).
-2. Checkout the `airflow-site-archive` repository and create a branch for your changes.
+2. Checkout the `apache-airflow-site-archive` repository and create a branch for your changes.
 3. Build documentation locally in `apache-airflow` repo with any cherry-picks and modifications you need, and
    publish the docs to the checked out `airflow-site-archive` branch.
 
@@ -319,9 +319,9 @@ breeze build-docs "<package_id1>" "<package_id2>" --docs-only
 breeze release-management publish-docs --override-versioned --airflow-site-directory <PATH_TO_THE_ARCHIVE_REPO>
 ```
 
-4. Commit the changes to `airflow-site-archive` repository and push them to `some` branch of the
+4. Commit the changes to `apache-airflow-site-archive` repository and push them to `some` branch of the
    repository.
-5. Run `Sync GitHub to S3` workflow in `airflow-site-archive` repository. This will upload the modified
+5. Run `Sync GitHub to S3` workflow in `apache-airflow-site-archive` repository. This will upload the modified
    documentation to S3 bucket. You can choose whether to sync the changes to `live` or `staging` bucket.
    The default is `live`. You can also specify which folders to sync - by default, all modified folders are synced.
 6. After you synchronize the changes to S3, the Sync `S3 to GitHub` workflow will be triggered

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 - [Publishing changes manually](#publishing-changes-manually)
 - [Fixing historical documentation](#fixing-historical-documentation)
   - [Manually publishing documentation directly to S3](#manually-publishing-documentation-directly-to-s3)
-  - [Manually publishing documentation via `apache-airflow-site-archive` repo](#manually-publishing-documentation-via-apache-airflow-site-archive-repo)
+  - [Manually publishing documentation via `airflow-site-archive` repo](#manually-publishing-documentation-via-airflow-site-archive-repo)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -79,7 +79,7 @@ There are a few repositories under `apache` organization that are used to build 
 We have two S3 buckets where we can publish the documentation generated from the `apache-airflow` repository:
 
 * `s3://live-docs-airflow-apache-org/docs/` - live, [official documentation](https://airflow.apache.org/docs/)
-* `s3://staging-docs-airflow-apache-org/docs/` - staging documentation [official documentation](https://staging-airflow.apache.org/docs/)
+* `s3://staging-docs-airflow-apache-org/docs/` - staging documentation [official documentation](https://airflow.staged.apache.org/docs/)
 
 Note that those S3 buckets are not served directly to Apache Server, but they are served via Cloudfront
 in order to provide caching and automated resolution of folders into index.html files.
@@ -143,7 +143,13 @@ the auto-detection.
 The person who triggers the build (release manager) should specify the tag name of the docs to be published
 and the list of documentation packages to be published. Usually it is:
 
-* Airflow: `apache-airflow docker-stack task-sdk apache-airflow-ctl`
+* Airflow: `apache-airflow docker-stack apache-airflow-ctl`
+
+> [!NOTE]
+> The `task-sdk` documentation (new format not yet published) is excluded from regular releases.
+> Once the `task-sdk` format is finalized and ready for production, it will be included in the standard
+> publishing workflow.
+
 * Helm chart: `helm-chart`
 * Providers: `provider_id1 provider_id2` or `all providers` if all providers should be published.
 
@@ -293,18 +299,18 @@ breeze release-management publish-docs-to-s3 --source-dir-path /tmp/airflow-site
  --exclude-docs "<package_id1_to_exclude> <package_id2_to_exclude>" [--dry-run]
 ```
 
-## Manually publishing documentation via `apache-airflow-site-archive` repo
+## Manually publishing documentation via `airflow-site-archive` repo
 
 If you do not have S3 credentials and want to be careful about publishing the documentation, you can also
-use publishing via `apache-airflow-site-archive` repository. This is a little more complex, but it allows
+use publishing via `airflow-site-archive` repository. This is a little more complex, but it allows
 you to publish documentation without having S3 credentials.
 
 The process is as follows:
 
-1. Run `Sync s3 to GitHub` workflow in `apache-airflow-site-archive` repository. This will download the
+1. Run `Sync s3 to GitHub` workflow in `airflow-site-archive` repository. This will download the
    latest version of the documentation from S3 to `airflow-site-archive` repository (this should normally not
    be needed, if automated synchronization works).
-2. Checkout the `apache-airflow-site-archive` repository and create a branch for your changes.
+2. Checkout the `airflow-site-archive` repository and create a branch for your changes.
 3. Build documentation locally in `apache-airflow` repo with any cherry-picks and modifications you need, and
    publish the docs to the checked out `airflow-site-archive` branch.
 
@@ -313,9 +319,9 @@ breeze build-docs "<package_id1>" "<package_id2>" --docs-only
 breeze release-management publish-docs --override-versioned --airflow-site-directory <PATH_TO_THE_ARCHIVE_REPO>
 ```
 
-4. Commit the changes to `apache-airflow-site-archive` repository and push them to `some` branch of the
+4. Commit the changes to `airflow-site-archive` repository and push them to `some` branch of the
    repository.
-5. Run `Sync GitHub to S3` workflow in `apache-airflow-site-archive` repository. This will upload the modified
+5. Run `Sync GitHub to S3` workflow in `airflow-site-archive` repository. This will upload the modified
    documentation to S3 bucket. You can choose whether to sync the changes to `live` or `staging` bucket.
    The default is `live`. You can also specify which folders to sync - by default, all modified folders are synced.
 6. After you synchronize the changes to S3, the Sync `S3 to GitHub` workflow will be triggered


### PR DESCRIPTION
 **Resolve contradiction in task-sdk publishing instructions.

## Changes

- Removed `task-sdk` from the publishing example to align with its current status
- Added a note clarifying that `task-sdk` documentation is not yet part of the publishing workflow

## Related Issue

Fixes #64350**
