### PR TITLE
Fix documentation link

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -67,7 +67,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 Full documentation for Helm Chart (latest **stable** release) lives [on the website](https://airflow.apache.org/docs/helm-chart/).
 
 > Note: If you're looking for documentation for main branch (latest development branch): you can find it on [s.apache.org/airflow-docs/](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/stable/index.html).
-> Source code for documentation is in [../docs/helm-chart](https://github.com/apache/airflow/tree/main/docs/helm-chart)
+> Source code for documentation is in [`chart/docs`](https://github.com/apache/airflow/tree/main/chart/docs)
 >
 
 ## Contributing


### PR DESCRIPTION
Fixes incorrect source code link for Helm chart documentation.

## Changes

- Updated the link to point to the correct `chart/docs` directory instead of the outdated path

## Impact

- Improves accuracy of documentation
- Helps contributors locate the correct documentation source


closes: #64353