### PR TITLE
Fix variable import to correctly handle falsy values

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
@@ -51,7 +51,7 @@ def import_(args, api_client=NEW_API_CLIENT) -> list[str]:
     vars_to_update = []
     for k, v in var_json.items():
         value, description = v, None
-        if isinstance(v, dict) and v.get("value"):
+        if isinstance(v, dict) and "value" in v:
             value, description = v["value"], v.get("description")
 
         vars_to_update.append(

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
@@ -83,6 +83,37 @@ class TestCliVariableCommands:
         )
         assert response == [self.key]
 
+    @pytest.mark.parametrize(
+        "falsy_value",
+        [
+            "",
+            0,
+            False,
+        ],
+        ids=["empty_string", "zero", "false"],
+    )
+    def test_import_falsy_values(self, api_client_maker, tmp_path, monkeypatch, falsy_value):
+        """Test that falsy values (empty string, 0, False) are correctly imported."""
+        api_client = api_client_maker(
+            path="/api/v2/variables",
+            response_json=self.bulk_response_success.model_dump(),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        expected_json_path = tmp_path / self.export_file_name
+        variable_file = {
+            self.key: {"value": falsy_value, "description": "test falsy value"},
+        }
+
+        expected_json_path.write_text(json.dumps(variable_file))
+        response = variable_command.import_(
+            self.parser.parse_args(["variables", "import", expected_json_path.as_posix()]),
+            api_client=api_client,
+        )
+        assert response == [self.key]
+
     def test_import_error(self, api_client_maker, tmp_path, monkeypatch):
         api_client = api_client_maker(
             path="/api/v2/variables",


### PR DESCRIPTION
## Why

When importing variables from a JSON file using the dict format like
(`{"mykey": {"value": ""}}`), falsy values such as empty string (`""`),
`0`, or `False` were incorrectly handled. The code used `v.get("value")`
in a truthy check, causing the entire dict to be treated as the value instead
of extracting the actual (falsy) value. This led to incorrect data being
imported.

This bug affected users who store empty strings, zero values, or boolean
`false `in variables via the CLI import command.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
