### PR TITLE
E2E: Add health-aware navigation to reduce false-positive failures

### DIFF
--- a/airflow-core/src/airflow/ui/playwright.config.ts
+++ b/airflow-core/src/airflow/ui/playwright.config.ts
@@ -120,7 +120,7 @@ export default defineConfig({
     "**/variable.spec.ts",
   ],
 
-  timeout: 30_000,
+  timeout: 60_000,
   use: {
     actionTimeout: 10_000,
     baseURL: process.env.AIRFLOW_UI_BASE_URL ?? "http://localhost:28080",

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
@@ -54,11 +54,11 @@ export class BasePage {
   }
 
   public async navigateTo(path: string): Promise<void> {
-    await this.goto(path, { waitUntil: "domcontentloaded" });
+    await this.safeGoto(path, { waitUntil: "domcontentloaded" });
   }
 
   /** Health-checked navigation. Subclasses should use this instead of `this.page.goto()`. */
-  protected async goto(path: string, options?: Parameters<Page["goto"]>[1]): Promise<void> {
+  protected async safeGoto(path: string, options?: Parameters<Page["goto"]>[1]): Promise<void> {
     await waitForServerReady(this.page);
     await this.page.goto(path, options);
   }

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
@@ -18,6 +18,7 @@
  */
 import { expect } from "@playwright/test";
 import type { Page, Locator } from "@playwright/test";
+import { waitForServerReady } from "tests/e2e/utils/health";
 
 /**
  * Base Page Object
@@ -53,8 +54,12 @@ export class BasePage {
   }
 
   public async navigateTo(path: string): Promise<void> {
-    await this.page.goto(path, {
-      waitUntil: "domcontentloaded",
-    });
+    await this.goto(path, { waitUntil: "domcontentloaded" });
+  }
+
+  /** Health-checked navigation. Subclasses should use this instead of `this.page.goto()`. */
+  protected async goto(path: string, options?: Parameters<Page["goto"]>[1]): Promise<void> {
+    await waitForServerReady(this.page);
+    await this.page.goto(path, options);
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
@@ -215,7 +215,7 @@ export class ConnectionsPage extends BasePage {
 
       await expect(selectCombobox).toBeEnabled({ timeout: 25_000 });
 
-      await selectCombobox.click({ timeout: 3000 });
+      await selectCombobox.click({ timeout: 10_000 });
 
       // Wait for options to appear and click the matching option
       const option = this.page.getByRole("option", { name: new RegExp(details.conn_type, "i") }).first();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
@@ -84,7 +84,7 @@ export class DagCalendarTab extends BasePage {
 
   public async navigateToCalendar(dagId: string) {
     await expect(async () => {
-      await this.page.goto(`/dags/${dagId}/calendar`);
+      await this.goto(`/dags/${dagId}/calendar`);
       await this.page.getByTestId("dag-calendar-root").waitFor({ state: "visible", timeout: 5000 });
     }).toPass({ intervals: [2000], timeout: 60_000 });
     await this.waitForCalendarReady();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
@@ -84,7 +84,7 @@ export class DagCalendarTab extends BasePage {
 
   public async navigateToCalendar(dagId: string) {
     await expect(async () => {
-      await this.goto(`/dags/${dagId}/calendar`);
+      await this.safeGoto(`/dags/${dagId}/calendar`);
       await this.page.getByTestId("dag-calendar-root").waitFor({ state: "visible", timeout: 5000 });
     }).toPass({ intervals: [2000], timeout: 60_000 });
     await this.waitForCalendarReady();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
@@ -69,10 +69,13 @@ export class DagCalendarTab extends BasePage {
     for (let i = 0; i < count; i++) {
       const cell = this.activeCells.nth(i);
 
-      await cell.hover();
-      await expect(this.tooltip).toBeVisible({ timeout: 20_000 });
+      let text = "";
 
-      const text = ((await this.tooltip.textContent()) ?? "").toLowerCase();
+      await expect(async () => {
+        await cell.hover({ force: true });
+        await expect(this.tooltip).toBeVisible({ timeout: 3000 });
+        text = ((await this.tooltip.textContent()) ?? "").toLowerCase();
+      }).toPass({ intervals: [500], timeout: 20_000 });
 
       if (text.includes("success")) states.push("success");
       if (text.includes("failed")) states.push("failed");

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagCodePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagCodePage.ts
@@ -38,7 +38,7 @@ export class DagCodePage extends BasePage {
   public async navigateToCodeTab(dagId: string): Promise<void> {
     await expect(async () => {
       await this.navigateTo(`/dags/${dagId}/code`);
-      await expect(this.editorContainer).toBeVisible({ timeout: 5000 });
+      await expect(this.editorContainer).toBeVisible({ timeout: 10_000 });
     }).toPass({ intervals: [2000], timeout: 60_000 });
     await this.waitForCodeReady();
   }

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -269,7 +269,7 @@ export class DagsPage extends BasePage {
 
   public async navigateToDagTasks(dagId: string): Promise<void> {
     await expect(async () => {
-      await this.goto(`/dags/${dagId}/tasks`);
+      await this.safeGoto(`/dags/${dagId}/tasks`);
       await expect(
         this.page
           .locator("th")
@@ -364,7 +364,7 @@ export class DagsPage extends BasePage {
    */
   public async verifyDagDetails(dagName: string): Promise<void> {
     await expect(async () => {
-      await this.goto(`/dags/${dagName}/details`, { waitUntil: "domcontentloaded" });
+      await this.safeGoto(`/dags/${dagName}/details`, { waitUntil: "domcontentloaded" });
       await expect(this.page.getByRole("heading", { name: dagName })).toBeVisible({ timeout: 30_000 });
     }).toPass({ intervals: [2000], timeout: 60_000 });
   }
@@ -391,7 +391,7 @@ export class DagsPage extends BasePage {
       return;
     }
 
-    await this.goto(DagsPage.getDagRunDetailsUrl(dagName, dagRunId), {
+    await this.safeGoto(DagsPage.getDagRunDetailsUrl(dagName, dagRunId), {
       timeout: 15_000,
       waitUntil: "domcontentloaded",
     });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -269,7 +269,7 @@ export class DagsPage extends BasePage {
 
   public async navigateToDagTasks(dagId: string): Promise<void> {
     await expect(async () => {
-      await this.page.goto(`/dags/${dagId}/tasks`);
+      await this.goto(`/dags/${dagId}/tasks`);
       await expect(
         this.page
           .locator("th")
@@ -364,7 +364,7 @@ export class DagsPage extends BasePage {
    */
   public async verifyDagDetails(dagName: string): Promise<void> {
     await expect(async () => {
-      await this.page.goto(`/dags/${dagName}/details`, { waitUntil: "domcontentloaded" });
+      await this.goto(`/dags/${dagName}/details`, { waitUntil: "domcontentloaded" });
       await expect(this.page.getByRole("heading", { name: dagName })).toBeVisible({ timeout: 30_000 });
     }).toPass({ intervals: [2000], timeout: 60_000 });
   }
@@ -391,7 +391,7 @@ export class DagsPage extends BasePage {
       return;
     }
 
-    await this.page.goto(DagsPage.getDagRunDetailsUrl(dagName, dagRunId), {
+    await this.goto(DagsPage.getDagRunDetailsUrl(dagName, dagRunId), {
       timeout: 15_000,
       waitUntil: "domcontentloaded",
     });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -120,7 +120,7 @@ export class EventsPage extends BasePage {
 
   public async navigateToAuditLog(dagId: string): Promise<void> {
     await expect(async () => {
-      await this.page.goto(EventsPage.getEventsUrl(dagId), {
+      await this.goto(EventsPage.getEventsUrl(dagId), {
         timeout: 10_000,
         waitUntil: "domcontentloaded",
       });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/EventsPage.ts
@@ -120,7 +120,7 @@ export class EventsPage extends BasePage {
 
   public async navigateToAuditLog(dagId: string): Promise<void> {
     await expect(async () => {
-      await this.goto(EventsPage.getEventsUrl(dagId), {
+      await this.safeGoto(EventsPage.getEventsUrl(dagId), {
         timeout: 10_000,
         waitUntil: "domcontentloaded",
       });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
@@ -205,7 +205,7 @@ export class RequiredActionsPage extends BasePage {
     await this.waitForTaskState(dagRunId, {
       expectedState: "Success",
       taskId: "wait_for_default_option",
-      timeout: 30_000,
+      timeout: 60_000,
     });
 
     await this.handleWaitForInputTask(dagId, dagRunId);

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
@@ -93,7 +93,7 @@ export class RequiredActionsPage extends BasePage {
     const buttonName = approve ? "Approve" : "Reject";
     const actionButton = this.page.getByTestId(`hitl-option-${buttonName}`);
 
-    await expect(actionButton).toBeVisible({ timeout: 10_000 });
+    await expect(actionButton).toBeVisible({ timeout: 30_000 });
 
     const informationInput = this.page.getByRole("textbox");
 
@@ -118,7 +118,7 @@ export class RequiredActionsPage extends BasePage {
 
     const branchButton = this.page.getByTestId("hitl-option-task_1");
 
-    await expect(branchButton).toBeVisible({ timeout: 10_000 });
+    await expect(branchButton).toBeVisible({ timeout: 30_000 });
     await this.clickButtonAndWaitForHITLResponse(branchButton);
 
     await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
@@ -135,7 +135,7 @@ export class RequiredActionsPage extends BasePage {
 
     const informationInput = this.page.getByRole("textbox");
 
-    await expect(informationInput).toBeVisible({ timeout: 10_000 });
+    await expect(informationInput).toBeVisible({ timeout: 30_000 });
     await informationInput.fill("test");
 
     const okButton = this.page.getByRole("button", { name: "OK" });
@@ -183,7 +183,7 @@ export class RequiredActionsPage extends BasePage {
 
     const optionButton = this.page.getByTestId("hitl-option-option 1");
 
-    await expect(optionButton).toBeVisible({ timeout: 10_000 });
+    await expect(optionButton).toBeVisible({ timeout: 30_000 });
     await this.clickButtonAndWaitForHITLResponse(optionButton);
 
     await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
@@ -104,7 +104,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(actionButton).toBeEnabled({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(actionButton);
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "valid_input_and_options" });
   }
 
@@ -121,7 +121,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(branchButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(branchButton);
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "choose_a_branch_to_run" });
   }
 
@@ -143,7 +143,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(okButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(okButton);
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_input" });
   }
 
@@ -169,7 +169,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(respondButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(respondButton);
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_multiple_options" });
   }
 
@@ -186,7 +186,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(optionButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(optionButton);
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_option" });
   }
 
@@ -199,7 +199,7 @@ export class RequiredActionsPage extends BasePage {
       throw new Error("Failed to trigger DAG - dagRunId is null");
     }
 
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForDagRunState("Running");
 
     await this.waitForTaskState(dagRunId, {
@@ -224,7 +224,7 @@ export class RequiredActionsPage extends BasePage {
   }
 
   private async verifyFinalTaskStates(dagId: string, dagRunId: string, approved: boolean): Promise<void> {
-    await this.page.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
 
     if (approved) {
       await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "task_1" });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
@@ -104,7 +104,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(actionButton).toBeEnabled({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(actionButton);
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "valid_input_and_options" });
   }
 
@@ -121,7 +121,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(branchButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(branchButton);
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "choose_a_branch_to_run" });
   }
 
@@ -143,7 +143,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(okButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(okButton);
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_input" });
   }
 
@@ -169,7 +169,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(respondButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(respondButton);
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_multiple_options" });
   }
 
@@ -186,7 +186,7 @@ export class RequiredActionsPage extends BasePage {
     await expect(optionButton).toBeVisible({ timeout: 10_000 });
     await this.clickButtonAndWaitForHITLResponse(optionButton);
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "wait_for_option" });
   }
 
@@ -199,7 +199,7 @@ export class RequiredActionsPage extends BasePage {
       throw new Error("Failed to trigger DAG - dagRunId is null");
     }
 
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
     await this.waitForDagRunState("Running");
 
     await this.waitForTaskState(dagRunId, {
@@ -224,7 +224,7 @@ export class RequiredActionsPage extends BasePage {
   }
 
   private async verifyFinalTaskStates(dagId: string, dagRunId: string, approved: boolean): Promise<void> {
-    await this.goto(`/dags/${dagId}/runs/${dagRunId}`);
+    await this.safeGoto(`/dags/${dagId}/runs/${dagRunId}`);
 
     if (approved) {
       await this.waitForTaskState(dagRunId, { expectedState: "Success", taskId: "task_1" });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancesPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/TaskInstancesPage.ts
@@ -37,7 +37,7 @@ export class TaskInstancesPage extends BasePage {
   public async navigate(): Promise<void> {
     await this.navigateTo(TaskInstancesPage.taskInstancesUrl);
     await this.page.waitForURL(/.*task_instances/, { timeout: 15_000 });
-    await this.taskInstancesTable.waitFor({ state: "visible", timeout: 10_000 });
+    await this.taskInstancesTable.waitFor({ state: "visible", timeout: 30_000 });
 
     const dataLink = this.taskInstancesTable.locator("a[href*='/dags/']").first();
     const noDataMessage = this.page.locator('text="No Task Instances found"');

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
@@ -63,7 +63,7 @@ export class XComsPage extends BasePage {
   public async navigate(): Promise<void> {
     await this.navigateTo(XComsPage.xcomsUrl);
     await this.page.waitForURL(/.*xcoms/, { timeout: 15_000 });
-    await this.xcomsTable.waitFor({ state: "visible", timeout: 10_000 });
+    await this.xcomsTable.waitFor({ state: "visible", timeout: 30_000 });
     await this.page.waitForLoadState("networkidle");
   }
 

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/task-instances.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/task-instances.spec.ts
@@ -19,6 +19,7 @@
 import { test, expect } from "@playwright/test";
 import { AUTH_FILE, testConfig } from "playwright.config";
 import { TaskInstancesPage } from "tests/e2e/pages/TaskInstancesPage";
+import { waitForServerReady } from "tests/e2e/utils/health";
 
 test.describe("Task Instances Page", () => {
   test.setTimeout(60_000);
@@ -27,16 +28,22 @@ test.describe("Task Instances Page", () => {
   const testDagId = testConfig.testDag.id;
 
   test.beforeAll(async ({ browser }) => {
+    test.setTimeout(120_000);
     const context = await browser.newContext({ storageState: AUTH_FILE });
     const page = await context.newPage();
     const baseUrl = process.env.AIRFLOW_UI_BASE_URL ?? "http://localhost:8080";
     const timestamp = Date.now();
 
+    // Wait for server to be responsive before making API calls
+    await waitForServerReady(page);
+
     // Wait for Dag to be parsed before making API calls
     await expect
       .poll(
         async () => {
-          const response = await page.request.get(`${baseUrl}/api/v2/dags/${testDagId}`);
+          const response = await page.request.get(`${baseUrl}/api/v2/dags/${testDagId}`, {
+            timeout: 30_000,
+          });
 
           return response.ok();
         },
@@ -55,6 +62,7 @@ test.describe("Task Instances Page", () => {
       headers: {
         "Content-Type": "application/json",
       },
+      timeout: 30_000,
     });
 
     expect(triggerResponse1.ok()).toBeTruthy();
@@ -62,6 +70,7 @@ test.describe("Task Instances Page", () => {
     // Get all task instances for the first run
     const tasksResponse1 = await page.request.get(
       `${baseUrl}/api/v2/dags/${testDagId}/dagRuns/${runId1}/taskInstances`,
+      { timeout: 30_000 },
     );
 
     expect(tasksResponse1.ok()).toBeTruthy();
@@ -77,6 +86,7 @@ test.describe("Task Instances Page", () => {
         {
           data: JSON.stringify({ new_state: "success" }),
           headers: { "Content-Type": "application/json" },
+          timeout: 30_000,
         },
       );
 
@@ -94,6 +104,7 @@ test.describe("Task Instances Page", () => {
       headers: {
         "Content-Type": "application/json",
       },
+      timeout: 30_000,
     });
 
     expect(triggerResponse2.ok()).toBeTruthy();
@@ -101,6 +112,7 @@ test.describe("Task Instances Page", () => {
     // Get all task instances for the second run
     const tasksResponse2 = await page.request.get(
       `${baseUrl}/api/v2/dags/${testDagId}/dagRuns/${runId2}/taskInstances`,
+      { timeout: 30_000 },
     );
 
     expect(tasksResponse2.ok()).toBeTruthy();
@@ -116,6 +128,7 @@ test.describe("Task Instances Page", () => {
         {
           data: JSON.stringify({ new_state: "failed" }),
           headers: { "Content-Type": "application/json" },
+          timeout: 30_000,
         },
       );
 

--- a/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
@@ -20,33 +20,29 @@ import type { Page } from "@playwright/test";
 
 const HEALTH_ENDPOINT = "/api/v2/monitor/health";
 const MAX_WAIT_MS = 60_000;
-const RESPONSE_TIME_THRESHOLD_MS = 2000;
+const REQUEST_TIMEOUT_MS = 10_000;
 const BACKOFF_INTERVALS = [1000, 2000, 4000, 8000];
 
 /**
  * Wait for the Airflow server to be responsive before proceeding.
  *
- * Polls the health endpoint, checking for HTTP 200 with response time below
- * a threshold. Uses backoff intervals between retries.
+ * Polls the health endpoint, checking for HTTP 200. Uses backoff intervals between retries.
+ * We intentionally do not check response time: on Firefox/CI the health endpoint regularly
+ * exceeds 2s, which would cause the check to never succeed and tests to timeout at 60s.
  *
- * When the server responds quickly on the first attempt, this function returns
- * immediately with negligible overhead.
+ * When the server responds on the first attempt, this function returns immediately.
  */
 export async function waitForServerReady(page: Page): Promise<void> {
   const startTime = Date.now();
   let attempt = 0;
 
   while (Date.now() - startTime < MAX_WAIT_MS) {
-    const attemptStart = Date.now();
-
     try {
       const response = await page.request.get(HEALTH_ENDPOINT, {
-        timeout: RESPONSE_TIME_THRESHOLD_MS,
+        timeout: REQUEST_TIMEOUT_MS,
       });
 
-      const elapsed = Date.now() - attemptStart;
-
-      if (response.status() === 200 && elapsed < RESPONSE_TIME_THRESHOLD_MS) {
+      if (response.status() === 200) {
         return;
       }
     } catch {
@@ -66,6 +62,6 @@ export async function waitForServerReady(page: Page): Promise<void> {
   }
 
   throw new Error(
-    `Server not ready after ${MAX_WAIT_MS}ms — health endpoint ${HEALTH_ENDPOINT} did not return 200 within ${RESPONSE_TIME_THRESHOLD_MS}ms threshold`,
+    `Server not ready after ${MAX_WAIT_MS}ms — health endpoint ${HEALTH_ENDPOINT} did not return 200`,
   );
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
@@ -1,0 +1,71 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { Page } from "@playwright/test";
+
+const HEALTH_ENDPOINT = "/api/v2/monitor/health";
+const MAX_WAIT_MS = 60_000;
+const RESPONSE_TIME_THRESHOLD_MS = 2000;
+const BACKOFF_INTERVALS = [1000, 2000, 4000, 8000];
+
+/**
+ * Wait for the Airflow server to be responsive before proceeding.
+ *
+ * Polls the health endpoint, checking for HTTP 200 with response time below
+ * a threshold. Uses backoff intervals between retries.
+ *
+ * When the server responds quickly on the first attempt, this function returns
+ * immediately with negligible overhead.
+ */
+export async function waitForServerReady(page: Page): Promise<void> {
+  const startTime = Date.now();
+  let attempt = 0;
+
+  while (Date.now() - startTime < MAX_WAIT_MS) {
+    const attemptStart = Date.now();
+
+    try {
+      const response = await page.request.get(HEALTH_ENDPOINT, {
+        timeout: RESPONSE_TIME_THRESHOLD_MS,
+      });
+
+      const elapsed = Date.now() - attemptStart;
+
+      if (response.status() === 200 && elapsed < RESPONSE_TIME_THRESHOLD_MS) {
+        return;
+      }
+    } catch {
+      // Request failed or timed out — server not ready yet.
+    }
+
+    const index = Math.min(attempt, BACKOFF_INTERVALS.length - 1);
+    const interval = BACKOFF_INTERVALS[index] as number;
+    const remaining = MAX_WAIT_MS - (Date.now() - startTime);
+
+    if (remaining <= 0) {
+      break;
+    }
+
+    await page.waitForTimeout(Math.min(interval, remaining));
+    attempt++;
+  }
+
+  throw new Error(
+    `Server not ready after ${MAX_WAIT_MS}ms — health endpoint ${HEALTH_ENDPOINT} did not return 200 within ${RESPONSE_TIME_THRESHOLD_MS}ms threshold`,
+  );
+}

--- a/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/utils/health.ts
@@ -19,7 +19,7 @@
 import type { Page } from "@playwright/test";
 
 const HEALTH_ENDPOINT = "/api/v2/monitor/health";
-const MAX_WAIT_MS = 60_000;
+const MAX_WAIT_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const BACKOFF_INTERVALS = [1000, 2000, 4000, 8000];
 
@@ -28,7 +28,7 @@ const BACKOFF_INTERVALS = [1000, 2000, 4000, 8000];
  *
  * Polls the health endpoint, checking for HTTP 200. Uses backoff intervals between retries.
  * We intentionally do not check response time: on Firefox/CI the health endpoint regularly
- * exceeds 2s, which would cause the check to never succeed and tests to timeout at 60s.
+ * exceeds 2s, which would cause the check to never succeed.
  *
  * When the server responds on the first attempt, this function returns immediately.
  */


### PR DESCRIPTION
## Context

E2E tests running with 2 parallel workers produce false-positive failures in CI. The test suite runs 88 tests across chromium, firefox, and webkit, and consistently shows 2-7 failures + 2-6 flaky tests per run -- all caused by server unresponsiveness or browser-specific interaction issues rather than actual bugs.

### Observed Failure Pattern

From CI logs (`2026-03-28` runs):

**Chromium:**

- **7 failed**: `home-dashboard.spec.ts`, `plugins.spec.ts` x2, `requiredAction.spec.ts`, `task-instances.spec.ts`, `xcoms.spec.ts` x2
- **1 flaky**: `plugins.spec.ts`
- Root causes: health check (60s) exceeded test timeout (30s); `toPass` budgets consumed by health check; spec `beforeAll` API calls using 10s `actionTimeout`

**Firefox:**

- **3 failed**: `requiredAction.spec.ts` (server not ready after 60s), `xcoms.spec.ts` x2
- **1 flaky**: `xcoms.spec.ts`
- Root causes: server genuinely down >60s during concurrent heavy tests; `triggerDag` retry budget consumed by health check

**Webkit:**

- **0 failed**, all passed
- Previously: 1 failed + 6 flaky (fixed by webkit-specific changes)

### Failure Analysis

All failures trace back to infrastructure-level root causes, not test logic bugs:

**1. `plugins.spec.ts` -- Health check exceeds test timeout (chromium)**

```text
page.waitForTimeout: Test timeout of 30000ms exceeded
> 60 |     await page.waitForTimeout(Math.min(interval, remaining));
```

The default test timeout (30s) is shorter than the health check timeout (60s). Playwright kills the test while the health check is still polling for recovery. The health check never gets a chance to complete.

**2. `requiredAction.spec.ts` -- Health check consumes toPass budget**

```text
Server not ready after 60000ms — health endpoint did not return 200
Timeout 60000ms exceeded while waiting on the predicate
```

`triggerDag` uses `toPass({timeout: 60_000})`. A single health check attempt (60s) exhausts the entire retry budget, leaving zero room for `toPass` to retry after recovery.

**3. `xcoms.spec.ts` -- Same toPass/health check conflict**

```text
Timeout 60000ms exceeded while waiting on the predicate
```

The `triggerDag` call in `beforeAll` fails because the health check consumes the full `toPass` timeout. Multiple xcoms tests then fail because setup never completed.

**4. `task-instances.spec.ts` -- Unprotected API calls in beforeAll (chromium)**

```text
apiRequestContext.patch: Timeout 10000ms exceeded
apiRequestContext.get: Timeout 10000ms exceeded
```

The `beforeAll` makes direct API calls (POST dagRuns, GET taskInstances, PATCH state) using the global 10s `actionTimeout`. No health check, no extended timeouts, no retry logic. When the server is overloaded by concurrent heavy tests, these API calls time out.

**5. `dag-calendar-tab.spec.ts` -- Tooltip interaction failure**

```text
DagCalendarTab.ts:73 - expect(locator).toBeVisible() failed - getByTestId('calendar-tooltip')
```

Calendar cell hover fails because the tooltip never appears. On webkit, hover events are unreliable and may not trigger on the first attempt.

**6. `connections.spec.ts` -- Combobox click timeout (webkit)**

```text
ConnectionsPage.ts:218 - locator.click: Timeout 3000ms exceeded
```

The combobox is found, visible, enabled, and stable, but the click action can't complete within 3s on webkit. The explicit 3s timeout is far below the global `actionTimeout` of 10s.

**7. `dag-code-tab.spec.ts` -- Monaco editor slow to initialize (webkit)**

```text
DagCodePage.ts:42 - expect(locator).toBeVisible() failed - locator('[role="code"]')
```

The navigation retry loop (2s intervals, 60s total) repeatedly navigates and checks for the editor. With only 5s per inner check, Monaco doesn't have enough time to initialize on webkit before the next retry fires.

## Root Cause Analysis

Eight interconnected root causes identified during investigation:

| # | Root Cause | Impact | Affected Tests |
|---|-----------|--------|----------------|
| 1 | **No server health gating** -- Tests navigate blindly regardless of server state | When server is overwhelmed by heavy tests (HITL, backfill), all concurrent tests fail | ALL failing tests |
| 2 | **BasePage.navigateTo lacks resilience** -- Simple `page.goto()` with no retry or health check | Navigation times out within test timeout if server is slow | XComs, TaskInstances, all `navigateTo` consumers |
| 3 | **No inter-test recovery** -- No mechanism to wait for server to recover between tests | Heavy test on worker 1 overwhelms server, test on worker 2 fails, retries fail too | Cross-worker failures |
| 4 | **Page objects bypass BasePage with fragile `page.goto()` calls** -- 12 direct `page.goto()` calls across 4 page objects bypass any protection in `navigateTo` | Even if `navigateTo` is hardened, these bypass calls remain vulnerable | RequiredActions (7), DagsPage (3), Calendar (1), Events (1) |
| 5 | **Health check response time threshold too strict for Firefox** -- Original health check required HTTP 200 AND response < 2s, but Firefox on CI regularly exceeds 2s | Health check condition is never satisfied, causing 60s timeout even though the server is healthy | ALL Firefox tests |
| 6 | **Element visibility timeouts too tight** -- After navigation (click-based or programmatic), page elements must fetch API data and render. Hardcoded 3-10s timeouts are insufficient on Firefox/webkit under CI load | Server IS responsive, but post-navigation rendering exceeds tight timeouts | RequiredActions, TaskInstances, Connections, XComs, DagCode |
| 7 | **Webkit-specific interaction unreliability** -- Webkit hover events don't reliably trigger tooltips on first attempt; click dispatch is slower than chromium/firefox | Single-attempt interactions fail intermittently on webkit | DagCalendarTab (hover/tooltip), Connections (combobox click) |
| 8 | **Health check / test timeout imbalance** -- Health check MAX_WAIT (60s) ≥ default test timeout (30s) and `toPass` budgets (60s), consuming entire time budgets with no room for retries or actual work | Tests die mid-health-check; `toPass` loops can't retry after health check timeout | plugins, requiredAction, xcoms, home-dashboard (all browsers) |

## Approach

The fix is a six-layer approach across shared infrastructure, page objects, config, and one spec file:

### Layer 1: Health Check Utility (`tests/e2e/utils/health.ts`)

New shared utility that polls `/api/v2/monitor/health` (unauthenticated endpoint already used by Breeze for startup checks). Checks HTTP 200 only -- no response time threshold, since Firefox on CI regularly exceeds 2s for health responses (making time-based checks unsatisfiable). Uses exponential backoff intervals `[1s, 2s, 4s, 8s]` with 30s max wait and 10s per-request timeout. When the server is healthy (the common case), returns immediately with negligible overhead.

### Layer 2: Health-Aware BasePage Navigation (`BasePage.safeGoto()`)

Added a `protected safeGoto()` method to `BasePage` that wraps `waitForServerReady()` + `page.goto()`. All page object subclasses use `this.safeGoto()` instead of `this.page.goto()` directly. The existing `navigateTo()` delegates to `this.safeGoto()`. Named `safeGoto` (not `goto`) to avoid colliding with `AssetDetailPage.goto()`, which would cause infinite recursion via polymorphic dispatch through `navigateTo()`.

### Layer 3: Consistent Element Visibility Timeouts

After click-based navigation (e.g., clicking a "required action" link), the health check does not apply -- the server IS responsive, but React components must still fetch API data and render. On Firefox/webkit under CI load, this regularly exceeds 10s. Increased element visibility timeouts from 10s to 30s across `RequiredActionsPage` (4 `handle*` methods), `TaskInstancesPage.navigate()`, and `XComsPage.navigate()`. Also increased `ConnectionsPage` combobox click timeout from 3s to 10s, `DagCodePage` inner Monaco editor check from 5s to 10s per retry attempt, and `RequiredActionsPage` `wait_for_default_option` task completion timeout from 30s to 60s.

### Layer 4: Webkit Interaction Reliability

Webkit hover events don't reliably trigger tooltips on the first attempt. Wrapped `DagCalendarTab.getManualRunStates()` hover+tooltip check in a `toPass` retry loop (500ms intervals, 20s total) with `force: true` on hover. This retries the hover if the tooltip doesn't appear, without changing the overall timeout budget.

### Layer 5: Health Check / Test Timeout Rebalancing

The 60s health check exceeded the 30s default test timeout -- tests were killed while the health check was still polling. It also consumed the entire `toPass` budget in `triggerDag` (60s), leaving no room for retries.

- Reduced health check `MAX_WAIT_MS` from 60s to 30s
- Increased default test timeout from 30s to 60s in `playwright.config.ts`

This ensures the health check always fits within the test's time budget (30s < 60s), leaving 30s for navigation and assertions. `toPass` loops with 60s budgets can now retry twice after health check failures.

### Layer 6: Spec-Level API Resilience (`task-instances.spec.ts`)

The `beforeAll` setup makes direct API calls (POST dagRuns, GET taskInstances, PATCH state) that bypass the health check. These used the global 10s `actionTimeout` and had no health gating. Under server load, they time out.

- Added `waitForServerReady(page)` before API calls
- Increased `beforeAll` timeout to 120s (was inheriting 60s)
- Added explicit 30s timeout to all 8 API calls (3x the `actionTimeout`)

### Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Health check timeout | 30s (reduced from 60s) | Must fit within default test timeout (60s) and `toPass` budgets (60s), leaving room for actual navigation and retries. |
| Default test timeout | 60s (increased from 30s) | Tests average ~14s; 60s is generous without masking real failures. Prevents test death during health check polling. |
| Health check criteria | HTTP 200 only, no response time threshold | Firefox on CI regularly exceeds 2s for health responses. A time threshold makes the check unsatisfiable. |
| Pattern consolidation | Single `BasePage.safeGoto()` wrapper | Eliminates 12 scattered manual calls. Future page objects inherit protection automatically. |
| Method name | `safeGoto()` not `goto()` | `AssetDetailPage` has a public `goto()` that calls `navigateTo()`. If `navigateTo()` dispatched to `this.goto()`, polymorphism would resolve to the subclass method, creating infinite recursion. |
| Post-click timeouts | 30s for first element after link navigation | Matches existing `handleWaitForMultipleOptionsTask` threshold. 10s is insufficient for Firefox/webkit under CI load. |
| Hover retry pattern | `toPass` loop with `force: true` | Webkit hover events are unreliable. Retrying the hover handles cases where the first hover didn't register. |
| Spec API timeouts | 30s per request (3x actionTimeout) | Enough for a slow but responsive server. The health check gates the start, timeouts handle in-flight slowness. |

## Changes

### New File

- **`tests/e2e/utils/health.ts`** -- `waitForServerReady(page)` function with backoff polling (HTTP 200 check, 10s per-request timeout, 30s overall)

### Modified Files (page objects)

- **`tests/e2e/pages/BasePage.ts`** -- Added `protected safeGoto()` method; `navigateTo()` delegates to it
- **`tests/e2e/pages/DagsPage.ts`** -- 3 direct `page.goto()` calls replaced with `this.safeGoto()`
- **`tests/e2e/pages/RequiredActionsPage.ts`** -- 7 direct `page.goto()` calls replaced with `this.safeGoto()`; first element visibility timeouts after link clicks 10s→30s in 4 `handle*` methods; `wait_for_default_option` task timeout 30s→60s
- **`tests/e2e/pages/DagCalendarTab.ts`** -- 1 direct `page.goto()` call replaced with `this.safeGoto()`; hover+tooltip wrapped in retry loop for webkit reliability
- **`tests/e2e/pages/EventsPage.ts`** -- 1 direct `page.goto()` call replaced with `this.safeGoto()`
- **`tests/e2e/pages/TaskInstancesPage.ts`** -- Table visibility timeout 10s→30s
- **`tests/e2e/pages/ConnectionsPage.ts`** -- Combobox click timeout 3s→10s
- **`tests/e2e/pages/DagCodePage.ts`** -- Inner Monaco editor visibility check 5s→10s per retry attempt
- **`tests/e2e/pages/XComsPage.ts`** -- Table visibility timeout 10s→30s

### Modified Files (config and specs)

- **`playwright.config.ts`** -- Default test timeout 30s→60s
- **`tests/e2e/specs/task-instances.spec.ts`** -- `beforeAll`: added `waitForServerReady`, 120s timeout, 30s per API call

*All paths relative to `airflow-core/src/airflow/ui/`*

### Not Modified

- **BackfillPage.ts** -- Already uses `navigateTo()` exclusively (only `page.request.*` for API calls)
- **LoginPage.ts** -- Runs before health infra; already uses `navigateTo()`

## Known Remaining Issues

Three categories of flakiness remain. All pass on retry (0 hard failures); none are addressable with further timeout tuning.

1. **`requiredAction.spec.ts` (firefox/webkit)** -- The HITL workflow (`verifyFinalTaskStates` → `waitForTaskState`) sometimes exceeds the test timeout under 2-worker parallel load. The Airflow scheduler is overwhelmed when heavy DAG operations overlap across workers. Passes on retry once the server recovers. The only fix is reducing to `workers: 1` (doubling test time) or increasing server capacity.
2. **Webkit click dispatch (xcoms.spec.ts)** -- Buttons are found, visible, enabled, and stable, but `click()` hangs at the 10s `actionTimeout`. Affects `expandAllButton` and `addFilterButton`. Passes on retry, suggesting a transient webkit click interception issue (possibly an overlay or loading state). Increasing the global `actionTimeout` would affect all tests across all browsers.
3. **`dag-calendar-tab.spec.ts` (webkit)** -- "failed filter shows only failed runs" expects both success and failed runs in the calendar, but only sees success. This is a data timing issue: the failed DAG run created in `beforeAll` hasn't been reflected in the calendar data when the test reads tooltip states. Not a timeout issue — the test reads stale data, not missing UI elements.

## How It Works

```text
Test calls this.navigateTo("/dags")
  -> BasePage.navigateTo() calls this.safeGoto("/dags", { waitUntil: "domcontentloaded" })
    -> BasePage.safeGoto() calls waitForServerReady(this.page)
      -> GET /api/v2/monitor/health (10s timeout per request)
        -> 200? Return immediately (fast path, ~0ms overhead)
        -> Non-200 or timeout? Backoff [1s, 2s, 4s, 8s], retry up to 30s
        -> Still failing after 30s? Throw descriptive error
    -> this.page.goto(path, options)

Test calls this.safeGoto("/dags/my_dag/runs/abc123")  (subclass direct call)
  -> Same flow as above -- health check + goto
```

When the server is healthy (the normal case), `waitForServerReady` completes on the first attempt with negligible overhead. When the server is overloaded (the flaky CI case), the health check waits with backoff until the server recovers, then proceeds with navigation. The 30s health check fits within the 60s default test timeout, leaving room for the actual navigation and assertions. For `toPass` loops, the 30s health check leaves budget for at least one retry.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
