### PR TITLE
Remove redundant Elasticsearch count() call before search() in _es_re…

### DIFF
--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -739,25 +739,25 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
         index_patterns = self._get_index_patterns(ti)
         try:
-            max_log_line = self.client.count(index=index_patterns, query=query)["count"]
-        except NotFoundError as e:
+            res = self.client.search(
+                index=index_patterns,
+                query=query,
+                sort=[self.offset_field],
+                size=self.MAX_LINE_PER_PAGE,
+                from_=self.MAX_LINE_PER_PAGE * self.PAGE,
+            )
+        except NotFoundError:
             self.log.exception("The target index pattern %s does not exist", index_patterns)
-            raise e
+            raise
+        except Exception:
+            self.log.exception("Could not read log with log_id: %s", log_id)
+            return None
 
-        if max_log_line != 0:
-            try:
-                res = self.client.search(
-                    index=index_patterns,
-                    query=query,
-                    sort=[self.offset_field],
-                    size=self.MAX_LINE_PER_PAGE,
-                    from_=self.MAX_LINE_PER_PAGE * self.PAGE,
-                )
-                return ElasticSearchResponse(self, res)
-            except Exception as err:
-                self.log.exception("Could not read log with log_id: %s. Exception: %s", log_id, err)
+        # Short-circuit on empty hits to avoid constructing ElasticSearchResponse unnecessarily.
+        if not res.get("hits", {}).get("hits"):
+            return None
 
-        return None
+        return ElasticSearchResponse(self, res)
 
     def _get_index_patterns(self, ti: RuntimeTI | None) -> str:
         """

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -636,7 +636,6 @@ class TestElasticsearchRemoteLogIO:
 
     def test_es_read_builds_expected_query(self, ti):
         self.elasticsearch_io.client = Mock()
-        self.elasticsearch_io.client.count.return_value = {"count": 1}
         self.elasticsearch_io.client.search.return_value = _build_es_search_response(
             {
                 "event": "hello",
@@ -655,7 +654,7 @@ class TestElasticsearchRemoteLogIO:
 
         response = self.elasticsearch_io._es_read(log_id, 2, ti)
 
-        self.elasticsearch_io.client.count.assert_called_once_with(index="airflow-logs-*", query=query)
+        self.elasticsearch_io.client.count.assert_not_called()
         self.elasticsearch_io.client.search.assert_called_once_with(
             index="airflow-logs-*",
             query=query,
@@ -666,19 +665,18 @@ class TestElasticsearchRemoteLogIO:
         assert response is not None
         assert response.hits[0].event == "hello"
 
-    def test_es_read_returns_none_when_count_is_zero(self, ti):
+    def test_es_read_returns_none_when_search_returns_empty(self, ti):
         self.elasticsearch_io.client = Mock()
-        self.elasticsearch_io.client.count.return_value = {"count": 0}
+        self.elasticsearch_io.client.search.return_value = _build_es_search_response()
 
         log_id = _render_log_id(self.elasticsearch_io.log_id_template, ti, ti.try_number)
         response = self.elasticsearch_io._es_read(log_id, 0, ti)
 
         assert response is None
-        self.elasticsearch_io.client.search.assert_not_called()
 
     def test_es_read_propagates_missing_index(self, ti):
         self.elasticsearch_io.client = Mock()
-        self.elasticsearch_io.client.count.side_effect = elasticsearch.exceptions.NotFoundError(
+        self.elasticsearch_io.client.search.side_effect = elasticsearch.exceptions.NotFoundError(
             404,
             "IndexMissingException[[missing] missing]",
             {},
@@ -690,7 +688,6 @@ class TestElasticsearchRemoteLogIO:
 
     def test_es_read_logs_and_returns_none_on_search_error(self, ti):
         self.elasticsearch_io.client = Mock()
-        self.elasticsearch_io.client.count.return_value = {"count": 1}
         self.elasticsearch_io.client.search.side_effect = RuntimeError("boom")
 
         log_id = _render_log_id(self.elasticsearch_io.log_id_template, ti, ti.try_number)


### PR DESCRIPTION
Replaced the two-call `count()` + `search()` pattern in `_es_read()` with a single `search()` call, halving Elasticsearch round-trips per log read.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---
