### PR TITLE
Show deactivated DAG state in the UI (#63800)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -52,6 +52,9 @@
     "buttons": {
       "advanced": "Advanced",
       "dagDocs": "Dag Docs"
+    },
+    "status": {
+      "deactivated": "Deactivated"
     }
   },
   "logs": {

--- a/airflow-core/src/airflow/ui/src/components/DagDeactivatedBadge.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagDeactivatedBadge.tsx
@@ -1,0 +1,26 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Badge } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+export const DagDeactivatedBadge = () => {
+  const { t: translate } = useTranslation("dag");
+
+  return <Badge colorPalette="orange">{translate("header.status.deactivated")}</Badge>;
+};

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -66,17 +66,15 @@ export const DagBreadcrumb = () => {
     [
       {
         label: dag?.dag_display_name ?? dagId,
-        labelExtra: (
-          dag?.is_stale ? (
-            <DagDeactivatedBadge />
-          ) : (
-            <TogglePause
-              dagDisplayName={dag?.dag_display_name}
-              dagId={dagId}
-              isPaused={Boolean(dag?.is_paused)}
-              skipConfirm
-            />
-          )
+        labelExtra: dag?.is_stale ? (
+          <DagDeactivatedBadge />
+        ) : (
+          <TogglePause
+            dagDisplayName={dag?.dag_display_name}
+            dagId={dagId}
+            isPaused={Boolean(dag?.is_paused)}
+            skipConfirm
+          />
         ),
         title: translate("dag_one"),
         value: `/dags/${dagId}`,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx
@@ -27,6 +27,7 @@ import {
   useTaskServiceGetTask,
 } from "openapi/queries";
 import { BreadcrumbStats } from "src/components/BreadcrumbStats";
+import { DagDeactivatedBadge } from "src/components/DagDeactivatedBadge";
 import { StateBadge } from "src/components/StateBadge";
 import { TogglePause } from "src/components/TogglePause";
 import { isStatePending, useAutoRefresh } from "src/utils";
@@ -66,12 +67,16 @@ export const DagBreadcrumb = () => {
       {
         label: dag?.dag_display_name ?? dagId,
         labelExtra: (
-          <TogglePause
-            dagDisplayName={dag?.dag_display_name}
-            dagId={dagId}
-            isPaused={Boolean(dag?.is_paused)}
-            skipConfirm
-          />
+          dag?.is_stale ? (
+            <DagDeactivatedBadge />
+          ) : (
+            <TogglePause
+              dagDisplayName={dag?.dag_display_name}
+              dagId={dagId}
+              isPaused={Boolean(dag?.is_paused)}
+              skipConfirm
+            />
+          )
         ),
         title: translate("dag_one"),
         value: `/dags/${dagId}`,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -114,7 +114,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
           <DagBreadcrumb />
           <Flex gap={1}>
             <SearchDagsButton />
-            {dag === undefined || dag.is_stale ? undefined : (
+            {dag === undefined ? undefined : (
               <TriggerDAGButton
                 allowedRunTypes={dag.allowed_run_types}
                 dagDisplayName={dag.dag_display_name}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -48,6 +48,8 @@ import {
   dagRunStateFilterKey,
   dagViewKey,
   DEFAULT_DAG_VIEW_KEY,
+  runAfterGteKey,
+  runAfterLteKey,
   runTypeFilterKey,
   showGanttKey,
   triggeringUserFilterKey,
@@ -77,6 +79,8 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
   const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">(dagViewKey(dagId), defaultDagView);
   const [limit, setLimit] = useLocalStorage(dagRunsLimitKey(dagId), 10);
+  const [runAfterGte, setRunAfterGte] = useLocalStorage<string | undefined>(runAfterGteKey(dagId), undefined);
+  const [runAfterLte, setRunAfterLte] = useLocalStorage<string | undefined>(runAfterLteKey(dagId), undefined);
   const [runTypeFilter, setRunTypeFilter] = useLocalStorage<DagRunType | undefined>(
     runTypeFilterKey(dagId),
     undefined,
@@ -163,10 +167,14 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                   dagView={dagView}
                   limit={limit}
                   panelGroupRef={panelGroupRef}
+                  runAfterGte={runAfterGte}
+                  runAfterLte={runAfterLte}
                   runTypeFilter={runTypeFilter}
                   setDagRunStateFilter={setDagRunStateFilter}
                   setDagView={setDagView}
                   setLimit={setLimit}
+                  setRunAfterGte={setRunAfterGte}
+                  setRunAfterLte={setRunAfterLte}
                   setRunTypeFilter={setRunTypeFilter}
                   setShowGantt={setShowGantt}
                   setShowVersionIndicatorMode={setShowVersionIndicatorMode}
@@ -182,6 +190,8 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                     <Grid
                       dagRunState={dagRunStateFilter}
                       limit={limit}
+                      runAfterGte={runAfterGte}
+                      runAfterLte={runAfterLte}
                       runType={runTypeFilter}
                       showGantt={Boolean(runId) && showGantt}
                       showVersionIndicatorMode={showVersionIndicatorMode}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -78,7 +78,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
   const [defaultDagView] = useLocalStorage<"graph" | "grid">(DEFAULT_DAG_VIEW_KEY, "grid");
   const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">(dagViewKey(dagId), defaultDagView);
-  const [limit, setLimit] = useLocalStorage<number>(dagRunsLimitKey(dagId), 10);
+  const [limit, setLimit] = useLocalStorage(dagRunsLimitKey(dagId), 10);
   const [runAfterGte, setRunAfterGte] = useLocalStorage<string | undefined>(runAfterGteKey(dagId), undefined);
   const [runAfterLte, setRunAfterLte] = useLocalStorage<string | undefined>(runAfterLteKey(dagId), undefined);
   const [runTypeFilter, setRunTypeFilter] = useLocalStorage<DagRunType | undefined>(
@@ -94,9 +94,9 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
     undefined,
   );
 
-  const [showGantt, setShowGantt] = useLocalStorage<boolean>(showGanttKey(dagId), false);
+  const [showGantt, setShowGantt] = useLocalStorage(showGanttKey(dagId), false);
   // Global setting: applies to all Dags (intentionally not scoped to dagId)
-  const [showVersionIndicatorMode, setShowVersionIndicatorMode] = useLocalStorage<VersionIndicatorOptions>(
+  const [showVersionIndicatorMode, setShowVersionIndicatorMode] = useLocalStorage(
     `version_indicator_display_mode`,
     VersionIndicatorOptions.ALL,
   );
@@ -114,7 +114,7 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
           <DagBreadcrumb />
           <Flex gap={1}>
             <SearchDagsButton />
-            {dag === undefined ? undefined : (
+            {dag === undefined || dag.is_stale ? undefined : (
               <TriggerDAGButton
                 allowedRunTypes={dag.allowed_run_types}
                 dagDisplayName={dag.dag_display_name}

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -48,8 +48,6 @@ import {
   dagRunStateFilterKey,
   dagViewKey,
   DEFAULT_DAG_VIEW_KEY,
-  runAfterGteKey,
-  runAfterLteKey,
   runTypeFilterKey,
   showGanttKey,
   triggeringUserFilterKey,
@@ -79,8 +77,6 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
   const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
   const [dagView, setDagView] = useLocalStorage<"graph" | "grid">(dagViewKey(dagId), defaultDagView);
   const [limit, setLimit] = useLocalStorage(dagRunsLimitKey(dagId), 10);
-  const [runAfterGte, setRunAfterGte] = useLocalStorage<string | undefined>(runAfterGteKey(dagId), undefined);
-  const [runAfterLte, setRunAfterLte] = useLocalStorage<string | undefined>(runAfterLteKey(dagId), undefined);
   const [runTypeFilter, setRunTypeFilter] = useLocalStorage<DagRunType | undefined>(
     runTypeFilterKey(dagId),
     undefined,
@@ -167,14 +163,10 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                   dagView={dagView}
                   limit={limit}
                   panelGroupRef={panelGroupRef}
-                  runAfterGte={runAfterGte}
-                  runAfterLte={runAfterLte}
                   runTypeFilter={runTypeFilter}
                   setDagRunStateFilter={setDagRunStateFilter}
                   setDagView={setDagView}
                   setLimit={setLimit}
-                  setRunAfterGte={setRunAfterGte}
-                  setRunAfterLte={setRunAfterLte}
                   setRunTypeFilter={setRunTypeFilter}
                   setShowGantt={setShowGantt}
                   setShowVersionIndicatorMode={setShowVersionIndicatorMode}
@@ -190,8 +182,6 @@ export const DetailsLayout = ({ children, error, isLoading, tabs }: Props) => {
                     <Grid
                       dagRunState={dagRunStateFilter}
                       limit={limit}
-                      runAfterGte={runAfterGte}
-                      runAfterLte={runAfterLte}
                       runType={runTypeFilter}
                       showGantt={Boolean(runId) && showGantt}
                       showVersionIndicatorMode={showVersionIndicatorMode}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -1,0 +1,62 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import type { DAGDetailsResponse } from "openapi-gen/requests/types.gen";
+import { describe, expect, it } from "vitest";
+
+import "src/i18n/config";
+import { MOCK_DAG } from "src/mocks/handlers/dag";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { Header } from "./Header";
+
+const mockDag = {
+  ...MOCK_DAG,
+  active_runs_count: 0,
+  allowed_run_types: [],
+  bundle_name: "dags-folder",
+  bundle_version: "1",
+  default_args: {},
+  fileloc: "/files/dags/stale_dag.py",
+  is_favorite: false,
+  is_stale: true,
+  last_parse_duration: 0.23,
+  latest_dag_version: undefined,
+  next_dagrun_logical_date: "2024-08-22T00:00:00+00:00",
+  next_dagrun_run_after: "2024-08-22T19:00:00+00:00",
+  owner_links: {},
+  relative_fileloc: "stale_dag.py",
+  tags: [],
+  timetable_partitioned: false,
+  timetable_summary: "* * * * *",
+} satisfies DAGDetailsResponse;
+
+describe("Header", () => {
+  it("shows a deactivated badge and hides the next run stat for stale dags", () => {
+    render(
+      <Wrapper>
+        <Header dag={mockDag} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("header.status.deactivated")).toBeInTheDocument();
+    expect(screen.queryByText("dagDetails.nextRun")).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -51,7 +51,7 @@ const mockDag = {
 } as unknown as DAGDetailsResponse;
 
 describe("Header", () => {
-  it("shows a deactivated badge and hides the next run stat for stale dags", () => {
+  it("shows a deactivated badge and hides stale-only next actions for stale dags", () => {
     render(
       <Wrapper>
         <Header dag={mockDag} />
@@ -60,5 +60,6 @@ describe("Header", () => {
 
     expect(screen.getByText("header.status.deactivated")).toBeInTheDocument();
     expect(screen.queryByText("dagDetails.nextRun")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reparse Dag" })).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -21,7 +21,7 @@ import { render, screen } from "@testing-library/react";
 import type { DAGDetailsResponse } from "openapi-gen/requests/types.gen";
 import { describe, expect, it } from "vitest";
 
-import "src/i18n/config";
+import i18n from "src/i18n/config";
 import { MOCK_DAG } from "src/mocks/handlers/dag";
 import { Wrapper } from "src/utils/Wrapper";
 
@@ -58,8 +58,8 @@ describe("Header", () => {
       </Wrapper>,
     );
 
-    expect(screen.getByText("header.status.deactivated")).toBeInTheDocument();
-    expect(screen.queryByText("dagDetails.nextRun")).not.toBeInTheDocument();
+    expect(screen.getByText(i18n.t("dag:header.status.deactivated"))).toBeInTheDocument();
+    expect(screen.queryByText(i18n.t("dag:dagDetails.nextRun"))).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Reparse Dag" })).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -38,7 +38,9 @@ const mockDag = {
   is_favorite: false,
   is_stale: true,
   last_parse_duration: 0.23,
-  latest_dag_version: undefined,
+  // `null` matches the API response shape for DAGs without version metadata.
+  // eslint-disable-next-line unicorn/no-null
+  latest_dag_version: null,
   next_dagrun_logical_date: "2024-08-22T00:00:00+00:00",
   next_dagrun_run_after: "2024-08-22T19:00:00+00:00",
   owner_links: {},
@@ -46,7 +48,7 @@ const mockDag = {
   tags: [],
   timetable_partitioned: false,
   timetable_summary: "* * * * *",
-} satisfies DAGDetailsResponse;
+} as unknown as DAGDetailsResponse;
 
 describe("Header", () => {
   it("shows a deactivated badge and hides the next run stat for stale dags", () => {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -24,6 +24,7 @@ import { useParams, Link as RouterLink } from "react-router-dom";
 import type { DAGDetailsResponse, DagRunState } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
 import { DeleteDagButton } from "src/components/DagActions/DeleteDagButton";
+import { DagDeactivatedBadge } from "src/components/DagDeactivatedBadge";
 import { FavoriteDagButton } from "src/components/DagActions/FavoriteDagButton";
 import { ParseDagButton } from "src/components/DagActions/ParseDagButton";
 import DagRunInfo from "src/components/DagRunInfo";
@@ -89,15 +90,6 @@ export const Header = ({
         ) : undefined,
     },
     {
-      label: translate("dagDetails.nextRun"),
-      value: Boolean(dag?.next_dagrun_run_after) ? (
-        <DagRunInfo
-          logicalDate={dag?.next_dagrun_logical_date}
-          runAfter={dag?.next_dagrun_run_after as string}
-        />
-      ) : undefined,
-    },
-    {
       label: translate("dagDetails.maxActiveRuns"),
       value:
         dag?.max_active_runs === undefined
@@ -117,6 +109,18 @@ export const Header = ({
       value: <DagVersion version={dag?.latest_dag_version} />,
     },
   ];
+
+  if (!dag?.is_stale) {
+    stats.splice(2, 0, {
+      label: translate("dagDetails.nextRun"),
+      value: Boolean(dag?.next_dagrun_run_after) ? (
+        <DagRunInfo
+          logicalDate={dag?.next_dagrun_logical_date}
+          runAfter={dag?.next_dagrun_run_after as string}
+        />
+      ) : undefined,
+    });
+  }
 
   return (
     <HeaderCard
@@ -140,8 +144,12 @@ export const Header = ({
       icon={<DagIcon />}
       stats={stats}
       subTitle={
-        dag !== undefined && (
+        dag?.is_stale ? (
+          <DagDeactivatedBadge />
+        ) : (
+          dag !== undefined && (
           <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
+          )
         )
       }
       title={dag?.dag_display_name ?? dagId}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -57,9 +57,10 @@ export const Header = ({
   const { t: translate } = useTranslation(["common", "dag"]);
   // We would still like to show the dagId even if the dag object hasn't loaded yet
   const { dagId } = useParams();
+  const isStale = dag?.is_stale;
 
   const nextRunStat =
-    dag?.is_stale === true
+    isStale
       ? []
       : [
           {
@@ -140,7 +141,7 @@ export const Header = ({
               />
             )}
             <FavoriteDagButton dagId={dag.dag_id} isFavorite={dag.is_favorite} />
-            {dag.is_stale ? undefined : <ParseDagButton dagId={dag.dag_id} fileToken={dag.file_token} />}
+            {isStale ? undefined : <ParseDagButton dagId={dag.dag_id} fileToken={dag.file_token} />}
             <DeleteDagButton dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} />
           </>
         )
@@ -148,7 +149,7 @@ export const Header = ({
       icon={<DagIcon />}
       stats={stats}
       subTitle={
-        dag?.is_stale ? (
+        isStale ? (
           <DagDeactivatedBadge />
         ) : (
           dag !== undefined && (

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -58,6 +58,21 @@ export const Header = ({
   // We would still like to show the dagId even if the dag object hasn't loaded yet
   const { dagId } = useParams();
 
+  const nextRunStat =
+    dag?.is_stale === true
+      ? []
+      : [
+          {
+            label: translate("dagDetails.nextRun"),
+            value: Boolean(dag?.next_dagrun_run_after) ? (
+              <DagRunInfo
+                logicalDate={dag?.next_dagrun_logical_date}
+                runAfter={dag?.next_dagrun_run_after as string}
+              />
+            ) : undefined,
+          },
+        ];
+
   const stats = [
     {
       label: translate("dagDetails.schedule"),
@@ -89,6 +104,7 @@ export const Header = ({
           </Link>
         ) : undefined,
     },
+    ...nextRunStat,
     {
       label: translate("dagDetails.maxActiveRuns"),
       value:
@@ -110,18 +126,6 @@ export const Header = ({
     },
   ];
 
-  if (!dag?.is_stale) {
-    stats.splice(2, 0, {
-      label: translate("dagDetails.nextRun"),
-      value: Boolean(dag?.next_dagrun_run_after) ? (
-        <DagRunInfo
-          logicalDate={dag?.next_dagrun_logical_date}
-          runAfter={dag?.next_dagrun_run_after as string}
-        />
-      ) : undefined,
-    });
-  }
-
   return (
     <HeaderCard
       actions={
@@ -136,7 +140,7 @@ export const Header = ({
               />
             )}
             <FavoriteDagButton dagId={dag.dag_id} isFavorite={dag.is_favorite} />
-            <ParseDagButton dagId={dag.dag_id} fileToken={dag.file_token} />
+            {dag.is_stale ? undefined : <ParseDagButton dagId={dag.dag_id} fileToken={dag.file_token} />}
             <DeleteDagButton dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} />
           </>
         )

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -24,9 +24,9 @@ import { useParams, Link as RouterLink } from "react-router-dom";
 import type { DAGDetailsResponse, DagRunState } from "openapi/requests/types.gen";
 import { DagIcon } from "src/assets/DagIcon";
 import { DeleteDagButton } from "src/components/DagActions/DeleteDagButton";
-import { DagDeactivatedBadge } from "src/components/DagDeactivatedBadge";
 import { FavoriteDagButton } from "src/components/DagActions/FavoriteDagButton";
 import { ParseDagButton } from "src/components/DagActions/ParseDagButton";
+import { DagDeactivatedBadge } from "src/components/DagDeactivatedBadge";
 import DagRunInfo from "src/components/DagRunInfo";
 import { DagVersion } from "src/components/DagVersion";
 import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
@@ -148,7 +148,7 @@ export const Header = ({
           <DagDeactivatedBadge />
         ) : (
           dag !== undefined && (
-          <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
+            <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
           )
         )
       }


### PR DESCRIPTION
## Summary
When a DAG becomes stale or deactivated, the UI still shows active-oriented controls like the pause toggle, parse action, and next-run information. This change makes the deactivated state explicit by showing a badge and hiding controls or stats that imply the DAG is still schedulable.

## Changes
- **`airflow-core/src/airflow/ui/src/components/DagDeactivatedBadge.tsx`** -- added a reusable badge component for stale/deactivated DAGs.
- **`airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx`** -- shows the deactivated badge for stale DAGs, hides the misleading next-run stat, and removes the parse action for stale DAGs.
- **`airflow-core/src/airflow/ui/src/layouts/Details/DagBreadcrumb.tsx`** -- shows the deactivated badge in the breadcrumb instead of the pause toggle for stale DAGs.
- **`airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json`** -- adds the deactivated badge label.
- **`airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx`** -- adds a regression test covering the stale DAG header behavior, including hiding the stale-only parse action.

## Test plan
- [x] `npm run test -- Header.test.tsx`
- [x] `npx eslint src/components/DagDeactivatedBadge.tsx src/pages/Dag/Header.tsx src/layouts/Details/DagBreadcrumb.tsx src/layouts/Details/DetailsLayout.tsx src/pages/Dag/Header.test.tsx`
- [ ] CI passes

## Evidence it works
- The focused Vitest run passed locally with `2 passed` test files and `3 passed` tests, including the stale-DAG regression that now verifies the parse action is hidden.
- The changed UI files pass focused eslint checks.

Fixes #63800
