### PR TITLE
Fix TypeError in tasks endpoint when order_by field has None values

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/tasks.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-from operator import attrgetter
 from typing import cast
 
 from fastapi import Depends, HTTPException, status
@@ -32,6 +31,29 @@ from airflow.api_fastapi.core_api.security import requires_access_dag
 from airflow.exceptions import TaskNotFound
 
 tasks_router = AirflowRouter(tags=["Task"], prefix="/dags/{dag_id}/tasks")
+
+_SORTABLE_TASK_FIELDS = {
+    "task_id",
+    "task_display_name",
+    "owner",
+    "start_date",
+    "end_date",
+    "trigger_rule",
+    "depends_on_past",
+    "wait_for_downstream",
+    "retries",
+    "queue",
+    "pool",
+    "pool_slots",
+    "execution_timeout",
+    "retry_delay",
+    "retry_exponential_backoff",
+    "priority_weight",
+    "weight_rule",
+    "ui_color",
+    "ui_fgcolor",
+    "operator_name",
+}
 
 
 @tasks_router.get(
@@ -52,10 +74,18 @@ def get_tasks(
 ) -> TaskCollectionResponse:
     """Get tasks for DAG."""
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-    try:
-        tasks = sorted(dag.tasks, key=attrgetter(order_by.lstrip("-")), reverse=(order_by[0:1] == "-"))
-    except AttributeError as err:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(err))
+    lstripped_order_by = order_by.lstrip("-")
+    if lstripped_order_by not in _SORTABLE_TASK_FIELDS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Ordering with '{lstripped_order_by}' is disallowed or "
+            f"the attribute does not exist on the model",
+        )
+    tasks = sorted(
+        dag.tasks,
+        key=lambda task: (getattr(task, lstripped_order_by) is None, getattr(task, lstripped_order_by)),
+        reverse=(order_by[0:1] == "-"),
+    )
     return TaskCollectionResponse(
         tasks=cast("list[TaskResponse]", tasks),
         total_entries=len(tasks),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_tasks.py
@@ -543,9 +543,21 @@ class TestGetTasks(TestTaskEndpoint):
             f"{self.api_prefix}/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
         )
         assert response.status_code == 400
-        assert (
-            response.json()["detail"] == "'EmptyOperator' object has no attribute 'invalid_task_colume_name'"
+        assert response.json()["detail"] == (
+            "Ordering with 'invalid_task_colume_name' is disallowed or "
+            "the attribute does not exist on the model"
         )
+
+    def test_should_respond_200_order_by_start_date_with_none(self, test_client):
+        """Sorting by a nullable field should not raise TypeError (issue #63927)."""
+        response = test_client.get(
+            f"{self.api_prefix}/{self.unscheduled_dag_id}/tasks?order_by=start_date",
+        )
+        assert response.status_code == 200
+        tasks = response.json()["tasks"]
+        assert len(tasks) == 2
+        # All start_dates are None for unscheduled tasks; verify they sort without error
+        assert all(t["start_date"] is None for t in tasks)
 
     def test_should_respond_404(self, test_client):
         dag_id = "xxxx_not_existing"


### PR DESCRIPTION
Fix TypeError in `GET /dags/{dag_id}/tasks` when sorting by a field whose values
can be `None` (e.g. `start_date` on unscheduled DAGs). Previously this caused a
500 Internal Server Error because Python 3 cannot compare `None` with `None`.

**Changes:**
- Add `_SORTABLE_TASK_FIELDS` whitelist to validate `order_by` upfront, returning
  400 for invalid fields (consistent with `SortParam` error format used in other endpoints)
- Handle `None` values in the sort key so nullable fields sort correctly
  (tasks with `None` values are placed at the end)

closes: #63927

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (Anthropic)

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.