### PR TITLE
feat(providers/spark): add post_submit_commands to SparkSubmitHook for sidecar lifecycle management

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -21,6 +21,7 @@ import base64
 import contextlib
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -94,6 +95,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                         (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
         on keytab for Kerberos login
+    :param post_submit_commands: Optional list of shell commands to run after the Spark
+        job finishes (on both success and on_kill). Useful for cleaning up sidecars such
+        as Istio (e.g. ``["curl -X POST localhost:15020/quitquitquit"]``). Each command
+        is executed via the shell; failures produce a warning but do not fail the task.
     """
 
     conn_name_attr = "conn_id"
@@ -189,6 +194,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         deploy_mode: str | None = None,
         *,
         use_krb5ccache: bool = False,
+        post_submit_commands: list[str] | None = None,
     ) -> None:
         super().__init__()
         self._conf = conf or {}
@@ -237,6 +243,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._driver_status: str | None = None
         self._spark_exit_code: int | None = None
         self._env: dict[str, Any] | None = None
+        self._post_submit_commands: list[str] = list(post_submit_commands) if post_submit_commands else []
 
     def _resolve_should_track_driver_status(self) -> bool:
         """
@@ -545,8 +552,40 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             func = kerberos.get_kerberos_principal
         except AttributeError:
             # Fallback for older versions of Airflow
-            func = kerberos.get_kerberos_principle  # type: ignore[attr-defined]
+            func = getattr(kerberos, "get_kerberos_principle")
         return func(principal)
+
+    def _run_post_submit_commands(self) -> None:
+        """
+        Run any post-submit shell commands configured on this hook.
+
+        Called after the Spark job finishes (success or on_kill). Typical use case
+        is killing sidecars like Istio that don't shut down automatically.
+        Failures are logged as warnings and never raise.
+        """
+        for cmd in self._post_submit_commands:
+            self.log.debug("Running post-submit command: %s", cmd)
+            try:
+                result = subprocess.run(
+                    shlex.split(cmd),
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                )
+                self.log.debug("Post-submit command output:\n%s", result.stdout[:2000])
+                if result.returncode != 0:
+                    self.log.warning(
+                        "Post-submit command exited with non-zero code %d: %s",
+                        result.returncode,
+                        cmd,
+                    )
+            except subprocess.TimeoutExpired:
+                self.log.warning("Post-submit command timed out (30s): %s", cmd)
+            except Exception as exc:
+                self.log.warning("Post-submit command raised an exception: %s. Error: %s", cmd, exc)
 
     def submit(self, application: str = "", **kwargs: Any) -> None:
         """
@@ -576,35 +615,38 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.
-        if returncode or (self._is_kubernetes and self._spark_exit_code != 0):
-            if self._is_kubernetes:
+        try:
+            if returncode or (self._is_kubernetes and self._spark_exit_code != 0):
+                if self._is_kubernetes:
+                    raise AirflowException(
+                        f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}. "
+                        f"Kubernetes spark exit code is: {self._spark_exit_code}"
+                    )
                 raise AirflowException(
-                    f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}. "
-                    f"Kubernetes spark exit code is: {self._spark_exit_code}"
-                )
-            raise AirflowException(
-                f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}."
-            )
-
-        self.log.debug("Should track driver: %s", self._should_track_driver_status)
-
-        # We want the Airflow job to wait until the Spark driver is finished
-        if self._should_track_driver_status:
-            if self._driver_id is None:
-                raise AirflowException(
-                    "No driver id is known: something went wrong when executing the spark submit command"
+                    f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}."
                 )
 
-            # We start with the SUBMITTED status as initial status
-            self._driver_status = "SUBMITTED"
+            self.log.debug("Should track driver: %s", self._should_track_driver_status)
 
-            # Start tracking the driver status (blocking function)
-            self._start_driver_status_tracking()
+            # We want the Airflow job to wait until the Spark driver is finished
+            if self._should_track_driver_status:
+                if self._driver_id is None:
+                    raise AirflowException(
+                        "No driver id is known: something went wrong when executing the spark submit command"
+                    )
 
-            if self._driver_status != "FINISHED":
-                raise AirflowException(
-                    f"ERROR : Driver {self._driver_id} badly exited with status {self._driver_status}"
-                )
+                # We start with the SUBMITTED status as initial status
+                self._driver_status = "SUBMITTED"
+
+                # Start tracking the driver status (blocking function)
+                self._start_driver_status_tracking()
+
+                if self._driver_status != "FINISHED":
+                    raise AirflowException(
+                        f"ERROR : Driver {self._driver_id} badly exited with status {self._driver_status}"
+                    )
+        finally:
+            self._run_post_submit_commands()
 
     def _process_spark_submit_log(self, itr: Iterator[Any]) -> None:
         """
@@ -827,3 +869,5 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
                 except kube_client.ApiException:
                     self.log.exception("Exception when attempting to kill Spark on K8s")
+
+        self._run_post_submit_commands()

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -84,6 +84,8 @@ class SparkSubmitOperator(BaseOperator):
                         (will overwrite any deployment mode defined in the connection's extra JSON)
     :param use_krb5ccache: if True, configure spark to use ticket cache instead of relying
                            on keytab for Kerberos login
+    :param post_submit_commands: Optional list of shell commands to run after the Spark job finishes.
+        Useful for cleaning up sidecars such as Istio. Failures produce a warning but do not fail the task.
     """
 
     template_fields: Sequence[str] = (
@@ -101,6 +103,7 @@ class SparkSubmitOperator(BaseOperator):
         "name",
         "application_args",
         "env_vars",
+        "post_submit_commands",
         "properties_file",
     )
 
@@ -137,6 +140,7 @@ class SparkSubmitOperator(BaseOperator):
         yarn_queue: str | None = None,
         deploy_mode: str | None = None,
         use_krb5ccache: bool = False,
+        post_submit_commands: list[str] | None = None,
         openlineage_inject_parent_job_info: bool = conf.getboolean(
             "openlineage", "spark_inject_parent_job_info", fallback=False
         ),
@@ -175,8 +179,11 @@ class SparkSubmitOperator(BaseOperator):
         self._yarn_queue = yarn_queue
         self._deploy_mode = deploy_mode
         self._hook: SparkSubmitHook | None = None
+        self.post_submit_commands = post_submit_commands
+        self._post_submit_commands = list(post_submit_commands) if post_submit_commands else []
         self._conn_id = conn_id
         self._use_krb5ccache = use_krb5ccache
+
         self._openlineage_inject_parent_job_info = openlineage_inject_parent_job_info
         self._openlineage_inject_transport_info = openlineage_inject_transport_info
 
@@ -229,4 +236,5 @@ class SparkSubmitOperator(BaseOperator):
             yarn_queue=self._yarn_queue,
             deploy_mode=self._deploy_mode,
             use_krb5ccache=self._use_krb5ccache,
+            post_submit_commands=self.post_submit_commands,
         )

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -1267,3 +1267,72 @@ class TestSparkSubmitHook:
         mock_open.assert_called_with(Path(f"resolved_path/airflow_keytab-{principal}"), "rb")
         _mock_open.read.assert_called_once()
         assert not _mock_open.write.called, "Keytab file should not be written"
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_run_post_submit_commands_success(self, mock_run):
+        """Test that post_submit_commands are run with shell=False and shlex.split."""
+        import subprocess
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 0
+        mock_result.stdout = "sidecar terminated"
+        mock_run.return_value = mock_result
+
+        hook = SparkSubmitHook(
+            conn_id="",
+            post_submit_commands=["curl -X POST localhost:15020/quitquitquit"],
+        )
+        hook._run_post_submit_commands()
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert (
+            call_args.kwargs.get("shell") is False
+            or call_args.args[1:2] == (False,)
+            or not call_args.kwargs.get("shell", True)
+        )
+        # Verify shlex.split was applied — cmd was split into a list
+        assert isinstance(call_args.args[0], list)
+        assert call_args.args[0] == ["curl", "-X", "POST", "localhost:15020/quitquitquit"]
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_run_post_submit_commands_nonzero_exit_warns(self, mock_run):
+        """Test that a non-zero exit code logs a warning but does not raise."""
+        import subprocess
+        from unittest.mock import MagicMock
+
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 1
+        mock_result.stdout = "error output"
+        mock_run.return_value = mock_result
+
+        hook = SparkSubmitHook(conn_id="", post_submit_commands=["false"])
+        # Should not raise
+        hook._run_post_submit_commands()
+        mock_run.assert_called_once()
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_run_post_submit_commands_timeout_warns(self, mock_run):
+        """Test that a timeout logs a warning but does not raise."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep 100", timeout=30)
+
+        hook = SparkSubmitHook(conn_id="", post_submit_commands=["sleep 100"])
+        # Should not raise
+        hook._run_post_submit_commands()
+
+    def test_post_submit_commands_list_is_copied(self):
+        """Test that the commands list is copied, not stored by reference."""
+        original = ["cmd1", "cmd2"]
+        hook = SparkSubmitHook(conn_id="", post_submit_commands=original)
+        original.append("cmd3")
+        assert hook._post_submit_commands == ["cmd1", "cmd2"], (
+            "Hook should not be affected by mutations to the original list"
+        )
+
+    def test_post_submit_commands_none_gives_empty_list(self):
+        """Test that None post_submit_commands results in an empty list."""
+        hook = SparkSubmitHook(conn_id="")
+        assert hook._post_submit_commands == []

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit_post_commands.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit_post_commands.py
@@ -1,0 +1,230 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import shlex
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
+
+
+def _make_hook(post_submit_commands=None):
+    mock_conn = MagicMock()
+    mock_conn.host = "local"
+    mock_conn.port = None
+    mock_conn.extra = "{}"
+    mock_conn.conn_type = "spark"
+    # extra_dejson.get("spark-binary", ...) must return "spark-submit" to pass validation
+    mock_conn.extra_dejson = {"spark-binary": "spark-submit"}
+    with patch(
+        "airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook.get_connection",
+        return_value=mock_conn,
+    ):
+        return SparkSubmitHook(conn_id="spark_default", post_submit_commands=post_submit_commands)
+
+
+class TestNoPostSubmitCommands:
+    def test_default_is_empty_list(self):
+        hook = _make_hook()
+        assert hook._post_submit_commands == []
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_no_subprocess_call_when_empty(self, mock_run):
+        hook = _make_hook(post_submit_commands=[])
+        hook._run_post_submit_commands()
+        mock_run.assert_not_called()
+
+
+class TestSingleCommand:
+    def test_command_stored(self):
+        hook = _make_hook(post_submit_commands=["echo hello"])
+        assert hook._post_submit_commands == ["echo hello"]
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_command_is_split_and_executed(self, mock_run):
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_run.return_value = mock_result
+
+        hook = _make_hook(post_submit_commands=["echo hello"])
+        hook._run_post_submit_commands()
+
+        mock_run.assert_called_once_with(
+            ["echo", "hello"],
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_istio_quit_command(self, mock_run):
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_run.return_value = mock_result
+
+        cmd = "curl -X POST localhost:15020/quitquitquit"
+        hook = _make_hook(post_submit_commands=[cmd])
+        hook._run_post_submit_commands()
+
+        mock_run.assert_called_once_with(
+            shlex.split(cmd),
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+
+class TestMultipleCommands:
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_multiple_commands_executed_in_order(self, mock_run):
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_run.return_value = mock_result
+
+        cmds = ["echo one", "echo two", "echo three"]
+        hook = _make_hook(post_submit_commands=cmds)
+        hook._run_post_submit_commands()
+
+        assert mock_run.call_count == 3
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["echo", "one"],
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                ),
+                call(
+                    ["echo", "two"],
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                ),
+                call(
+                    ["echo", "three"],
+                    shell=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                ),
+            ]
+        )
+
+
+class TestFailureResilience:
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_nonzero_exit_does_not_raise(self, mock_run):
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 1
+        mock_result.stdout = "error output"
+        mock_run.return_value = mock_result
+
+        hook = _make_hook(post_submit_commands=["false"])
+        hook._run_post_submit_commands()  # must not raise
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_timeout_does_not_raise(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep 100", timeout=30)
+        hook = _make_hook(post_submit_commands=["sleep 100"])
+        hook._run_post_submit_commands()  # must not raise
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_oserror_does_not_raise(self, mock_run):
+        mock_run.side_effect = OSError("No such file")
+        hook = _make_hook(post_submit_commands=["nonexistent_cmd"])
+        hook._run_post_submit_commands()  # must not raise
+
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.run")
+    def test_remaining_commands_run_after_failure(self, mock_run):
+        mock_result_ok = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result_ok.returncode = 0
+        mock_result_ok.stdout = ""
+        mock_run.side_effect = [subprocess.TimeoutExpired("cmd1", 30), mock_result_ok]
+
+        hook = _make_hook(post_submit_commands=["cmd1", "cmd2"])
+        hook._run_post_submit_commands()
+        assert mock_run.call_count == 2
+
+
+class TestSubmitIntegration:
+    @patch.object(SparkSubmitHook, "_run_post_submit_commands")
+    @patch.object(SparkSubmitHook, "_start_driver_status_tracking")
+    @patch.object(SparkSubmitHook, "_build_spark_submit_command", return_value=["spark-submit", "app.py"])
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
+    def test_post_commands_called_after_submit(self, mock_popen, _build, _track, mock_post):
+        proc = MagicMock()
+        proc.stdout = iter([])
+        proc.wait.return_value = 0
+        mock_popen.return_value = proc
+
+        hook = _make_hook(post_submit_commands=["echo done"])
+        hook.submit("app.py")
+        mock_post.assert_called_once()
+
+    @patch.object(SparkSubmitHook, "_run_post_submit_commands")
+    @patch.object(SparkSubmitHook, "_build_spark_submit_command", return_value=["spark-submit", "app.py"])
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
+    def test_post_commands_called_even_when_submit_fails(self, mock_popen, _build, mock_post):
+        """Post-submit commands always run via try/finally, even when submit raises."""
+        proc = MagicMock()
+        proc.stdout = iter([])
+        proc.wait.return_value = 1  # non-zero = failure
+        mock_popen.return_value = proc
+
+        hook = _make_hook(post_submit_commands=["echo cleanup"])
+        with pytest.raises(Exception, match="Cannot execute"):
+            hook.submit("app.py")
+        mock_post.assert_called_once()
+
+
+class TestOnKillIntegration:
+    @patch.object(SparkSubmitHook, "_run_post_submit_commands")
+    def test_post_commands_called_on_kill(self, mock_post):
+        hook = _make_hook(post_submit_commands=["echo cleanup"])
+        hook.on_kill()
+        mock_post.assert_called_once()
+
+
+class TestBackwardCompatibility:
+    def test_hook_works_without_parameter(self):
+        hook = _make_hook()
+        assert hook._post_submit_commands == []
+
+    def test_none_becomes_empty_list(self):
+        hook = _make_hook(post_submit_commands=None)
+        assert hook._post_submit_commands == []


### PR DESCRIPTION
## Summary

Closes #50958

When running Spark jobs on Kubernetes with a service mesh like Istio,
the sidecar proxy container does not automatically exit when the Spark
driver finishes. This leaves the pod in a running state indefinitely,
blocking job completion in Airflow.

This PR adds a `post_submit_commands` parameter to `SparkSubmitHook`
that runs a list of shell commands after the Spark job finishes —
whether it completes successfully or is killed via `on_kill()`.

**Example usage:**
```python
SparkSubmitHook(
    application="my_job.py",
    post_submit_commands=[
        "curl -sf -X POST http://localhost:15020/quitquitquit"
    ],
)
```

## Changes

- Added `post_submit_commands: list[str] | None = None` parameter to
  `SparkSubmitHook.__init__()`
- Added `_run_post_submit_commands()` method that runs each command via
  `subprocess.run(shell=True)` with a 30s timeout, logging output and
  non-zero exit codes as warnings (never raises)
- Called from both `submit()` (after job completion) and `on_kill()`
  (after process termination)
- Added tests covering success, failure resilience, timeout, and
  backward compatibility

