### PR TITLE
fix: ExternalTaskSensor check_existence ignored in deferrable mode (Airflow < 3.0)

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -457,11 +457,13 @@ class ExternalTaskSensor(BaseSensorOperator):
                     method_name="execute_complete",
                 )
             else:
+                # TODO: Remove this block when Airflow 2 support is dropped
                 if self.check_existence and not self._has_checked_existence:
                     from airflow.utils.session import create_session
 
                     with create_session() as session:
                         self._check_for_existence(session=session)
+
                 self.defer(
                     timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
                     trigger=WorkflowTrigger(

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -457,6 +457,11 @@ class ExternalTaskSensor(BaseSensorOperator):
                     method_name="execute_complete",
                 )
             else:
+                if self.check_existence and not self._has_checked_existence:
+                    from airflow.utils.session import create_session
+
+                    with create_session() as session:
+                        self._check_for_existence(session=session)
                 self.defer(
                     timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
                     trigger=WorkflowTrigger(

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -1122,7 +1122,7 @@ exit 0
 
     @pytest.mark.execution_timeout(10)
     def test_external_task_sensor_deferrable_check_existence_dag_not_found(self, dag_maker):
-        """Test that deferrable sensor raises ExternalDagNotFoundError when DAG doesn't exist."""
+        """Test that deferrable sensor raises ExternalDagNotFoundError when Dag doesn't exist."""
         context = {"execution_date": DEFAULT_DATE}
         with dag_maker() as dag:
             op = ExternalTaskSensor(

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -1120,6 +1120,28 @@ exit 0
             op.execute(context=context)
         assert exc.value.timeout == timedelta(seconds=90)
 
+    @pytest.mark.execution_timeout(10)
+    def test_external_task_sensor_deferrable_check_existence_dag_not_found(self, dag_maker):
+        """Test that deferrable sensor raises ExternalDagNotFoundError when DAG doesn't exist."""
+        context = {"execution_date": DEFAULT_DATE}
+        with dag_maker() as dag:
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="non_existing_dag",
+                external_task_id=None,
+                deferrable=True,
+                check_existence=True,
+            )
+            dag.create_dagrun(
+                run_id="test_run",
+                run_type=DagRunType.MANUAL,
+                state=None,
+            )
+            context.update(logical_date=DEFAULT_DATE)
+
+        with pytest.raises(ExternalDagNotFoundError):
+            op.execute(context=context)
+
     def test_get_logical_date(self):
         """For AF 2, we check for execution_date in context."""
         context = {"execution_date": DEFAULT_DATE}


### PR DESCRIPTION
## Root cause

In execute(), the deferrable path calls self.defer() directly without first calling _check_for_existence.

## Fix

For Airflow < 3.0, call _check_for_existence inside a scoped create_session block before running self.defer() if check_existence flag is set to True.

This fix only works for versions below 3.0 since there is no direct way to assert DAG existence on higher versions. One possible solution would be creating a new RPC call to try to retrieve a specific DAG, but I'm not sure on creating it just for this reason.

closes: #40745

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---
