### PR TITLE
Allow direct execution from airflow standalone via uvx

### DIFF
--- a/airflow-core/docs/installation/index.rst
+++ b/airflow-core/docs/installation/index.rst
@@ -49,6 +49,19 @@ via extras and providers.
 When you install Airflow, you need to :doc:`setup the database <setting-up-the-database>` which must
 also be kept updated when Airflow is upgraded.
 
+Local start for development and testing
+'''''''''''''''''''''''''''''''''''''''
+
+You just want to try it without all production complexity? If you have Astral ``uv`` installed, you can install Airflow directly from PyPI with the command below:
+
+.. code-block:: bash
+
+    uvx apache-airflow standalone
+
+Which starts a minimal system with an auto-generated admin password and SQLite database, so you can start using Airflow right away. This is a great way to get familiar with Airflow and try it out without the need to set up a complex environment.
+
+Note that the standalone mode is not for production purposes. But it is a simple start for a local development.
+
 Using released sources
 ''''''''''''''''''''''
 

--- a/airflow-core/docs/installation/index.rst
+++ b/airflow-core/docs/installation/index.rst
@@ -52,13 +52,22 @@ also be kept updated when Airflow is upgraded.
 Local start for development and testing
 '''''''''''''''''''''''''''''''''''''''
 
-You just want to try it without all production complexity? If you have Astral ``uv`` installed, you can install Airflow directly from PyPI with the command below:
+You just want to try Apache Airflow without all production complexity? If you have ``pipx`` installed,
+you can install Airflow directly from PyPI with the command below:
+
+.. code-block:: bash
+
+    pipx run apache-airflow standalone
+
+Alternatively similar with Astral ``uv``:
 
 .. code-block:: bash
 
     uvx apache-airflow standalone
 
-Which starts a minimal system with an auto-generated admin password and SQLite database, so you can start using Airflow right away. This is a great way to get familiar with Airflow and try it out without the need to set up a complex environment.
+Which starts a minimal system with an auto-generated admin password and SQLite database, so you can
+start using Airflow right away. This is a great way to get familiar with Airflow and try it out
+without the need to set up a complex environment.
 
 Note that the standalone mode is not for production purposes. But it is a simple start for a local development.
 

--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -29,11 +29,13 @@ For a local development and testing environment, you can install Airflow directl
 Via Astral ``uv`` it is possible to install airflow directly from PyPI using the command below:
 
 .. code-block:: bash
+
     uv tool install "apache-airflow==|version|"
 
 Additionally to jump-start using it you can also use the shortcut via ``uvx`` command and directly run it without installing it first:
 
 .. code-block:: bash
+
     uvx apache-airflow standalone
 
 

--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -21,8 +21,24 @@ Installation from PyPI
 This page describes installations using the ``apache-airflow`` package `published in
 PyPI <https://pypi.org/project/apache-airflow/>`__.
 
-Installation tools
-''''''''''''''''''
+Installation via uv as tool
+'''''''''''''''''''''''''''
+
+For a local development and testing environment, you can install Airflow directly from PyPI with the command below:
+
+Via Astral ``uv`` it is possible to install airflow directly from PyPI using the command below:
+
+.. code-block:: bash
+    uv tool install "apache-airflow==|version|"
+
+Additionally to jump-start using it you can also use the shortcut via ``uvx`` command and directly run it without installing it first:
+
+.. code-block:: bash
+    uvx apache-airflow standalone
+
+
+Installation in your environment
+''''''''''''''''''''''''''''''''
 
 Only ``pip`` and ``uv`` installation is currently officially supported.
 

--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -21,8 +21,8 @@ Installation from PyPI
 This page describes installations using the ``apache-airflow`` package `published in
 PyPI <https://pypi.org/project/apache-airflow/>`__.
 
-Installation via pipx or uv as tool
-'''''''''''''''''''''''''''''''''''
+Installation via ``pipx`` or ``uv`` as tool
+'''''''''''''''''''''''''''''''''''''''''''
 
 For a local development and testing environment, you can install and run Apache Airflow directly from PyPI.
 

--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -21,12 +21,18 @@ Installation from PyPI
 This page describes installations using the ``apache-airflow`` package `published in
 PyPI <https://pypi.org/project/apache-airflow/>`__.
 
-Installation via uv as tool
-'''''''''''''''''''''''''''
+Installation via pipx or uv as tool
+'''''''''''''''''''''''''''''''''''
 
-For a local development and testing environment, you can install Airflow directly from PyPI with the command below:
+For a local development and testing environment, you can install and run Apache Airflow directly from PyPI.
 
-Via Astral ``uv`` it is possible to install airflow directly from PyPI using the command below:
+If you use ``pipx`` you can run directly from PyPI with the command below:
+
+.. code-block:: bash
+
+    pipx run "apache-airflow==|version|" standalone
+
+Via Astral ``uv`` it is possible to install from PyPI using:
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ dependencies = [
 
 packages = []
 
+[project.scripts]
+# Definition allowing direct execution via `uvx apache-airflow ...`
+apache-airflow = "airflow.__main__:main"
+
 [project.optional-dependencies]
 # Automatically generated airflow optional dependencies (update_airflow_pyproject_toml.py)
 "all-core" = [


### PR DESCRIPTION
I was in discussion with a peer who switched to dagster and he told me "I would reconsider checking with Airflow but it is so complex, if it would be possible to `uvx airflow` that would be cool".

So I had a bit of sleep over it and currently you need to use `uvx --from apache-airflow airflow standalone`... so not far away. But actually just another name-matching entry point definition is missing making it directly usable via uvx.

So this PR proposing to add another script alias and some docs for a jump-start for a local development.

If this is merged and we have a new version published with this a user can directly execute: `uvx apache-airflow standalone` and... boom a minute later the web UI is usable (user just need to grab the admin password from logs... but making this better is another story...)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
