### PR TITLE
Fix worker CLI tests for optional pool argument

### DIFF
--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -185,10 +185,64 @@ class TestWorkerStart:
                 autoscale,
                 "--without-mingle",
                 "--without-gossip",
-                "--pool",
-                "prefork",
             ]
         )
+
+    @mock.patch("airflow.providers.celery.cli.celery_command.maybe_patch_concurrency")
+    @mock.patch("airflow.providers.celery.cli.celery_command.conf")
+    @mock.patch("airflow.providers.celery.cli.celery_command.setup_locations")
+    @mock.patch("airflow.providers.celery.cli.celery_command.Process")
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app")
+    def test_worker_started_with_pool_from_config(
+        self,
+        mock_celery_app,
+        mock_popen,
+        mock_locations,
+        mock_conf,
+        mock_maybe_patch_concurrency,
+    ):
+        pid_file = "pid_file"
+        mock_locations.return_value = (pid_file, None, None, None)
+        concurrency = "1"
+        queues = "queue"
+        pool = "prefork"
+        mock_conf.get.side_effect = lambda section, key, **kwargs: {
+            ("logging", "CELERY_LOGGING_LEVEL"): "INFO",
+            ("celery", "pool"): pool,
+            ("celery", "worker_umask"): "0o077",
+        }.get((section, key), kwargs.get("fallback"))
+        mock_conf.getint.return_value = 0
+        mock_conf.has_option.side_effect = lambda section, key: (section, key) == ("celery", "pool")
+
+        args = self.parser.parse_args(
+            [
+                "celery",
+                "worker",
+                "--concurrency",
+                concurrency,
+                "--queues",
+                queues,
+            ]
+        )
+
+        celery_command.worker(args)
+
+        mock_celery_app.worker_main.assert_called_once_with(
+            [
+                "worker",
+                "-O",
+                "fair",
+                "--queues",
+                queues,
+                "--concurrency",
+                int(concurrency),
+                "--loglevel",
+                "INFO",
+                "--pool",
+                pool,
+            ]
+        )
+        mock_maybe_patch_concurrency.assert_called_once_with(["-P", pool])
 
 
 @pytest.mark.backend("mysql", "postgres")


### PR DESCRIPTION
Adjusted the celery worker CLI unit tests to match the current contract for --pool.

The required-arguments test no longer expects --pool prefork, since that flag is only added when celery.pool is present in config. Added a dedicated test that mocks the config-backed pool path and verifies both the forwarded --pool prefork argument and the corresponding maybe_patch_concurrency() call. 

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
