### PR TITLE
Fix silent CI failures on connection import

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/commands/connection_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/connection_command.py
@@ -67,8 +67,8 @@ def import_(args, api_client=NEW_API_CLIENT) -> None:
         response = api_client.connections.bulk(BulkBodyConnectionBody(actions=[connection_create_action]))
         if response.create.errors:
             rich.print(f"[red]Failed to import connections: {response.create.errors}[/red]")
-            raise SystemExit
+            raise SystemExit(1)
         rich.print(f"[green]Successfully imported {response.create.success} connection(s)[/green]")
     except Exception as e:
         rich.print(f"[red]Failed to import connections: {e}[/red]")
-        raise SystemExit
+        raise SystemExit(1)

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_connections_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_connections_command.py
@@ -124,11 +124,12 @@ class TestCliConnectionCommands:
         }
 
         expected_json_path.write_text(json.dumps(connection_file))
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             connection_command.import_(
                 self.parser.parse_args(["connections", "import", expected_json_path.as_posix()]),
                 api_client=api_client,
             )
+        assert exc_info.value.code == 1
 
     def test_import_without_extra_field(self, api_client_maker, tmp_path, monkeypatch):
         """Import succeeds when JSON omits the ``extra`` field (#62653).


### PR DESCRIPTION
## Why
This PR explicitly sets a non-zero exit code` SystemExit(1)` to ensure failures are correctly propagated to the shell.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
