### PR TITLE
Allow accessing a TaskGroup's members via `[]`

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -141,6 +141,10 @@ class TaskGroup(DAGNode):
         if not dag:
             raise RuntimeError("TaskGroup can only be used inside a dag")
 
+    def __getitem__(self, key: str) -> DAGNode:
+        """Return a child node by label via ``tg[label]`` syntax. See `get_child_by_label`."""
+        return self.get_child_by_label(key)
+
     def __attrs_post_init__(self):
         # TODO: If attrs supported init only args we could use that here
         # https://github.com/python-attrs/attrs/issues/342

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -223,6 +223,31 @@ def test_build_task_group_with_prefix():
     assert group4.get_child_by_label("task4") == task4
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        pytest.param(True, id="prefix_on"),
+        pytest.param(False, id="prefix_off"),
+    ],
+)
+def test_taskgroup_getitem_returns_child_by_label(prefix: bool):
+    """Tests that TaskGroup[label] returns the correct child task or subgroup."""
+    logical_date = pendulum.datetime(2020, 1, 1)
+    with DAG("test_getitem", start_date=logical_date):
+        with TaskGroup("group1", prefix_group_id=prefix) as group1:
+            task1 = EmptyOperator(task_id="task1")
+            with TaskGroup("subgroup", prefix_group_id=prefix) as subgroup:
+                task2 = EmptyOperator(task_id="task2")
+
+    assert group1["task1"] == task1
+    assert group1["subgroup"] == subgroup
+    assert group1["subgroup"]["task2"] == task2
+
+    # Missing label raises KeyError
+    with pytest.raises(KeyError):
+        group1["nonexistent"]
+
+
 def test_build_task_group_with_prefix_functionality():
     """
     Tests TaskGroup prefix_group_id functionality - additional test for comprehensive coverage.


### PR DESCRIPTION
Minor feature (syntactic sugar): we can now do e.g. `some_group["some_task"]` to access the children of a task group regardless of the `prefix_group_id` setting.

**Motivation**: Discussion in [AIR201](https://github.com/astral-sh/ruff/pull/23583#issuecomment-4151013119)'s PR that made me aware that the shortest way to access child references is not that short - so I made it shorter and more natural (at least to me).

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
