### PR TITLE
Add v3-2-test branch to remaining .github/ configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,19 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    target-branch: v3-2-test
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 4
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
     target-branch: v3-1-test
     groups:
       github-actions-updates:
@@ -199,6 +212,66 @@ updates:
         applies-to: security-updates
         update-types:
           - "major"
+
+  # Repeat dependency updates on v3-2-test branch as well
+  - package-ecosystem: pip
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core
+      - /airflow-ctl
+      - /clients/python
+      - /dev/breeze
+      - /docker-tests
+      - /kubernetes-tests
+      - /helm-tests
+      - /task-sdk
+      - /
+    schedule:
+      interval: daily
+    target-branch: v3-2-test
+    groups:
+      pip-dependency-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core/src/airflow/ui
+    schedule:
+      interval: "weekly"
+    target-branch: v3-2-test
+    groups:
+      3-2-core-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
+    schedule:
+      interval: "weekly"
+    target-branch: v3-2-test
+    groups:
+      3-2-auth-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Repeat dependency updates on v3-1-test branch as well
   - package-ecosystem: pip

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -414,14 +414,14 @@ jobs:
       - name: Install twine
         run: pip install twine
       - name: "Check Airflow create minor branch command"
-        run: breeze release-management create-minor-branch --version-branch 3-1 --answer yes --dry-run
+        run: breeze release-management create-minor-branch --version-branch 3-2 --answer yes --dry-run
       - name: "Check Airflow RC process command"
         run: >
-          breeze release-management start-rc-process --version 3.1.0rc1 --previous-version 3.0.0
-          --task-sdk-version 1.0.0rc1 --sync-branch v3-1-test --answer yes --dry-run
+          breeze release-management start-rc-process --version 3.2.0rc1 --previous-version 3.1.0
+          --task-sdk-version 1.1.0rc1 --sync-branch v3-2-test --answer yes --dry-run
       - name: "Check Airflow release process command"
         run: >
-          breeze release-management start-release --version 3.1.7
+          breeze release-management start-release --version 3.2.7
           --answer yes --dry-run
       - name: "Test providers metadata generation"
         run: |

--- a/.github/workflows/milestone-tag-assistant.yml
+++ b/.github/workflows/milestone-tag-assistant.yml
@@ -21,6 +21,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - v3-2-test
       - v3-1-test
 
 permissions:

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -282,7 +282,7 @@ explanations added to the documentation. Usually you can see the list of such ch
 
 ```shell
 git fetch apache
-git log --oneline apache/v3-1-test | sed -n 's/.*\((#[0-9]*)\)$/\1/p' > /tmp/merged
+git log --oneline apache/v3-2-test | sed -n 's/.*\((#[0-9]*)\)$/\1/p' > /tmp/merged
 git log --oneline --decorate apache/v2-2-stable..apache/main -- docs/apache-airflow docs/docker-stack/ | grep -vf /tmp/merged
 ```
 
@@ -370,13 +370,13 @@ git show --format=tformat:"" --stat --name-only $(cat /tmp/doc-only-changes.txt)
 Then if you see suspicious file (example airflow/sensors/base.py) you can find details on where they came from:
 
 ```shell
-git log apache/v3-1-test --format="%H" -- airflow/sensors/base.py | grep -f /tmp/doc-only-changes.txt | xargs git show
+git log apache/v3-2-test --format="%H" -- airflow/sensors/base.py | grep -f /tmp/doc-only-changes.txt | xargs git show
 ```
 
 And the URL to the PR it comes from:
 
 ```shell
-git log apache/v3-1-test --format="%H" -- airflow/sensors/base.py | grep -f /tmp/doc-only-changes.txt | \
+git log apache/v3-2-test --format="%H" -- airflow/sensors/base.py | grep -f /tmp/doc-only-changes.txt | \
     xargs -n 1 git log --oneline --max-count=1 | \
     sed s'/.*(#\([0-9]*\))$/https:\/\/github.com\/apache\/airflow\/pull\/\1/'
 ```
@@ -461,8 +461,19 @@ uv tool install -e ./dev/breeze
   with minimum version for the next version of Airflow will be added in the future.
 - Check `Apache Airflow is tested with` (stable version) in `README.md` has the same tested versions as in the tip of
   the stable branch in `dev/breeze/src/airflow_breeze/global_constants.py`
-- Create `backport-to-vX-Y-test` branch in https://github.com/apache/airflow/labels
-- Update .github/boring-cyborg.yml and change the previous `backport-...` branch auto assignment to the new one.
+- Create `backport-to-vX-Y-test` label:
+
+    ```shell script
+    gh label create 'backport-to-vX-Y-test' --repo apache/airflow --description 'Backport to vX-Y-test' --color 0e8a16
+    ```
+
+- Update `.github/boring-cyborg.yml` and add `backport-to-vX-Y-test` auto-assignment for the new branch.
+- Update `.github/` configuration on `main` to add the new `vX-Y-test` branch (you can use the
+  `uv run dev/update_github_branch_config.py X Y` helper script for this). The following files need updating:
+  - `.github/dependabot.yml` — add `target-branch: vX-Y-test` entries for github-actions, pip, and npm ecosystems.
+  - `.github/workflows/milestone-tag-assistant.yml` — add `vX-Y-test` to the push branches list.
+  - `.github/workflows/basic-tests.yml` — update the release-management dry-run commands to test the new version.
+  - `.github/workflows/ci-notification.yml` — switch the `workflow-status` matrix branch to the new branch.
 - Commit the above changes with the message `Update version to ${VERSION}`.
 - Build the release notes:
 

--- a/dev/update_github_branch_config.py
+++ b/dev/update_github_branch_config.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.9"
+# ///
+"""
+Update .github/ configuration files on ``main`` when a new major/minor
+release branch (vX-Y-test) is created.
+
+Adds the new branch to dependabot, milestone-tag-assistant, basic-tests,
+ci-notification workflows and boring-cyborg auto-labelling.
+
+Usage::
+
+    uv run dev/update_github_branch_config.py <NEW_MAJOR> <NEW_MINOR>
+
+Example — after creating the v3-3-test branch::
+
+    uv run dev/update_github_branch_config.py 3 3
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(path: Path) -> str:
+    return path.read_text()
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# dependabot.yml
+# ──────────────────────────────────────────────────────────────────────────────
+def update_dependabot(new_branch: str, prev_branch: str, new_dash: str) -> None:
+    path = REPO_ROOT / ".github" / "dependabot.yml"
+    content = _read(path)
+
+    if f"target-branch: {new_branch}" in content:
+        print(f"dependabot.yml: {new_branch} already present, skipping.")
+        return
+
+    print(f"dependabot.yml: adding {new_branch} entries...")
+
+    # 1. Add github-actions entry before the existing entry for prev_branch
+    gh_actions_new_entry = f"""\
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 4
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"
+
+"""
+    # Match the full existing block for prev_branch
+    prev_gh_actions = f"""\
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 4
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    target-branch: {prev_branch}
+"""
+    content = content.replace(prev_gh_actions, gh_actions_new_entry + prev_gh_actions, 1)
+
+    # 2. Add pip + npm entries before the previous branch's comment block
+    pip_npm_block = f"""\
+  # Repeat dependency updates on {new_branch} branch as well
+  - package-ecosystem: pip
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core
+      - /airflow-ctl
+      - /clients/python
+      - /dev/breeze
+      - /docker-tests
+      - /kubernetes-tests
+      - /helm-tests
+      - /task-sdk
+      - /
+    schedule:
+      interval: daily
+    target-branch: {new_branch}
+    groups:
+      pip-dependency-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core/src/airflow/ui
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-core-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-auth-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+"""
+    prev_comment = f"  # Repeat dependency updates on {prev_branch} branch as well"
+    content = content.replace(prev_comment, pip_npm_block + prev_comment, 1)
+
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# milestone-tag-assistant.yml
+# ──────────────────────────────────────────────────────────────────────────────
+def update_milestone_tag_assistant(new_branch: str, prev_branch: str) -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "milestone-tag-assistant.yml"
+    content = _read(path)
+
+    if f"- {new_branch}" in content:
+        print(f"milestone-tag-assistant.yml: {new_branch} already present, skipping.")
+        return
+
+    print(f"milestone-tag-assistant.yml: adding {new_branch}...")
+    content = content.replace(
+        f"      - {prev_branch}",
+        f"      - {new_branch}\n      - {prev_branch}",
+        1,
+    )
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# basic-tests.yml
+# ──────────────────────────────────────────────────────────────────────────────
+def update_basic_tests(
+    new_branch: str,
+    prev_branch: str,
+    new_version: str,
+    prev_version: str,
+    new_dash: str,
+    prev_dash: str,
+) -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "basic-tests.yml"
+    content = _read(path)
+
+    print(f"basic-tests.yml: updating release-management dry-run versions to {new_version}...")
+
+    content = content.replace(
+        f"create-minor-branch --version-branch {prev_dash}",
+        f"create-minor-branch --version-branch {new_dash}",
+    )
+    content = content.replace(
+        f"--sync-branch {prev_branch}",
+        f"--sync-branch {new_branch}",
+    )
+
+    # Update start-rc-process version and previous-version
+    content = content.replace(
+        f"start-rc-process --version {prev_version}.0rc1",
+        f"start-rc-process --version {new_version}.0rc1",
+    )
+    content = re.sub(
+        r"--previous-version \d+\.\d+\.0(\s+.*--task-sdk-version)",
+        f"--previous-version {prev_version}.0\\1",
+        content,
+    )
+    # Bump task-sdk version: increment minor
+    content = re.sub(
+        r"--task-sdk-version \d+\.\d+\.0rc1",
+        f"--task-sdk-version 1.{int(new_version.split('.')[1]) - 1}.0rc1",
+        content,
+    )
+
+    # Update start-release version
+    content = re.sub(
+        rf"start-release --version {re.escape(prev_version)}\.\d+",
+        f"start-release --version {new_version}.7",
+        content,
+    )
+
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ci-notification.yml
+# ──────────────────────────────────────────────────────────────────────────────
+def update_ci_notification(new_branch: str, prev_branch: str) -> None:
+    path = REPO_ROOT / ".github" / "workflows" / "ci-notification.yml"
+    content = _read(path)
+
+    print(f"ci-notification.yml: switching branch to {new_branch}...")
+    content = content.replace(
+        f'branch: ["{prev_branch}"]',
+        f'branch: ["{new_branch}"]',
+    )
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# boring-cyborg.yml
+# ──────────────────────────────────────────────────────────────────────────────
+BORING_CYBORG_BACKPORT_BLOCK = """\
+  # This should be copy of the "area:dev-tools" above minus contributing docs and some files that should
+  # only make sense in main - it should be updated when we switch maintenance branch
+  backport-to-{new_branch}:
+    - scripts/**/*
+    - dev/**/*
+    - .github/**/*
+    - Dockerfile.ci
+    - yamllint-config.yml
+    - .dockerignore
+    - .hadolint.yaml
+    - .pre-commit-config.yaml
+    - .rat-excludes
+
+"""
+
+
+def update_boring_cyborg(new_branch: str, prev_branch: str) -> None:
+    path = REPO_ROOT / ".github" / "boring-cyborg.yml"
+    content = _read(path)
+
+    if f"backport-to-{new_branch}:" in content:
+        print(f"boring-cyborg.yml: backport-to-{new_branch} already present, skipping.")
+        return
+
+    print(f"boring-cyborg.yml: adding backport-to-{new_branch}...")
+    new_block = BORING_CYBORG_BACKPORT_BLOCK.format(new_branch=new_branch)
+    anchor = f"  backport-to-{prev_branch}:"
+    # Find the comment block preceding the previous backport entry
+    prev_comment = f"""\
+  # This should be copy of the "area:dev-tools" above minus contributing docs and some files that should
+  # only make sense in main - it should be updated when we switch maintenance branch
+  backport-to-{prev_branch}:"""
+    if prev_comment in content:
+        content = content.replace(prev_comment, new_block + anchor, 1)
+    else:
+        content = content.replace(anchor, new_block + anchor, 1)
+
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# dev/README_RELEASE_AIRFLOW.md
+# ──────────────────────────────────────────────────────────────────────────────
+def update_release_readme(new_branch: str, prev_branch: str) -> None:
+    path = REPO_ROOT / "dev" / "README_RELEASE_AIRFLOW.md"
+    content = _read(path)
+
+    print(f"README_RELEASE_AIRFLOW.md: updating apache/{prev_branch} references to apache/{new_branch}...")
+    content = content.replace(f"apache/{prev_branch}", f"apache/{new_branch}")
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# main
+# ──────────────────────────────────────────────────────────────────────────────
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <NEW_MAJOR> <NEW_MINOR>")
+        print(f"Example: {sys.argv[0]} 3 3   (for v3-3-test branch)")
+        sys.exit(1)
+
+    new_major = int(sys.argv[1])
+    new_minor = int(sys.argv[2])
+    prev_minor = new_minor - 1
+
+    new_branch = f"v{new_major}-{new_minor}-test"
+    prev_branch = f"v{new_major}-{prev_minor}-test"
+    new_version = f"{new_major}.{new_minor}"
+    prev_version = f"{new_major}.{prev_minor}"
+    new_dash = f"{new_major}-{new_minor}"
+    prev_dash = f"{new_major}-{prev_minor}"
+
+    print(f"Updating .github/ configs: adding {new_branch} (previous: {prev_branch})")
+    print(f"Repository root: {REPO_ROOT}")
+    print()
+
+    update_dependabot(new_branch, prev_branch, new_dash)
+    update_milestone_tag_assistant(new_branch, prev_branch)
+    update_basic_tests(new_branch, prev_branch, new_version, prev_version, new_dash, prev_dash)
+    update_ci_notification(new_branch, prev_branch)
+    update_boring_cyborg(new_branch, prev_branch)
+    update_release_readme(new_branch, prev_branch)
+
+    print()
+    print("Done! Please review the changes with 'git diff' before committing.")
+    print()
+    print("Additional manual steps:")
+    print(f"  - Create the 'backport-to-{new_branch}' label:")
+    print(
+        f"      gh label create 'backport-to-{new_branch}' --repo apache/airflow"
+        f" --description 'Backport to {new_branch}' --color 0e8a16"
+    )
+    print("  - Update test references in dev/breeze/tests/test_set_milestone.py if needed")
+    print("  - Update dev/README_AIRFLOW3_DEV.md references if needed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up from #64423 — adds `v3-2-test` to the remaining `.github/` configuration
files that still referenced only `v3-1-test`:

- `.github/dependabot.yml` — new `target-branch: v3-2-test` entries for github-actions, pip, and npm
- `.github/workflows/milestone-tag-assistant.yml` — added `v3-2-test` to push branches
- `.github/workflows/basic-tests.yml` — updated release-management dry-run commands to 3.2

Also updates `dev/README_RELEASE_AIRFLOW.md` with expanded instructions on which
`.github/` files need updating when creating a new minor/major branch (including
`gh label create` command), and adds `dev/update_github_branch_config.py` — a helper
script (`uv run dev/update_github_branch_config.py X Y`) that automates all these
changes for future branches.

related: #64423

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)