### PR TITLE
Add PolicyExposureReport to AgentOperator

### DIFF
--- a/providers/common/ai/AGENTS.md
+++ b/providers/common/ai/AGENTS.md
@@ -47,6 +47,8 @@ building a wrapper here.
 3. Keep constructors focused — only accept params that apply to the backend. Don't add params that
    are silently ignored in certain modes.
 4. Mark tools `sequential=True` when the backend uses synchronous I/O.
+5. When a toolset can be used with `AgentOperator`, implement `describe_policy_exposure()` so
+   policy reports can describe its configured access surface without executing the backend.
 
 ## Security
 

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -111,6 +111,61 @@ tasks can consume it.
     :end-before: [END howto_agent_chain]
 
 
+Policy Exposure Report
+----------------------
+
+``AgentOperator`` writes a best-effort **policy exposure report** to XCom at
+the start of execution. The report is a configuration-derived snapshot of the
+agent's declared access surface for that task instance.
+
+It is intended for observability and governance questions such as:
+
+- Which LLM connection and model override were configured?
+- Which toolsets were attached?
+- Which tables, hook methods, MCP servers, or DataFusion datasources were
+  exposed to the agent?
+- What high-level risk flags were present in the configuration?
+
+The report is serialized under the reserved XCom key:
+
+.. code-block:: text
+
+    airflow_common_ai_policy_exposure
+
+This key is reserved by the common-ai provider. DAG authors should not write
+unrelated values to it or depend on mutating it during task execution.
+
+**What the report contains**
+
+The payload includes:
+
+- ``captured_at``: timestamp when the snapshot was created
+- ``task``: DAG, run, task, and map-index identity
+- ``llm``: LLM connection id, hook connection type, and explicit ``model_id``
+- ``approval``: HITL review settings relevant to the task
+- ``toolsets``: one exposure summary per attached toolset
+- ``runtime_notes``: operator-level runtime controls such as tool logging or
+  durable replay
+- ``risk``: deterministic high-level risk classification derived from the
+  configured access surface
+
+**Important limits**
+
+- The report is **configuration-derived**, not a runtime execution trace.
+  It describes what the task was configured to expose, not which tools were
+  actually called.
+- The report is **best effort**. If report generation fails for a toolset,
+  the task continues and the failure is logged instead of failing the run.
+- The report is designed to avoid persisting sensitive details where possible.
+
+**For custom toolsets**
+
+Custom toolsets can participate in the report by implementing
+``describe_policy_exposure()`` and returning a structured description of their
+configured access surface. This method should stay configuration-only and
+should not make backend calls.
+
+
 Durable Execution
 -----------------
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -29,6 +29,15 @@ from pydantic import BaseModel
 from airflow.providers.common.ai.hooks.pydantic_ai import PydanticAIHook
 from airflow.providers.common.ai.mixins.hitl_review import HITLReviewMixin
 from airflow.providers.common.ai.utils.logging import log_run_summary, wrap_toolsets_for_logging
+from airflow.providers.common.ai.utils.policy_exposure import (
+    XCOM_POLICY_EXPOSURE,
+    ApprovalExposure,
+    LLMExposure,
+    PolicyExposureReport,
+    TaskIdentity,
+    classify_policy_risk,
+    describe_toolset_exposure,
+)
 from airflow.providers.common.compat.sdk import (
     AirflowOptionalProviderFeatureException,
     BaseOperator,
@@ -215,7 +224,59 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
 
         return [CachingToolset(wrapped=ts, storage=storage, counter=counter) for ts in toolsets]
 
+    def _build_policy_exposure_report(self, context: Context) -> PolicyExposureReport:
+        """Build a configured policy exposure snapshot from rendered operator configuration."""
+        ti = context["task_instance"]
+        llm_exposure = LLMExposure(
+            llm_conn_id=self.llm_conn_id,
+            connection_type=self.llm_hook.conn_type,
+            model_id=self.model_id,
+        )
+        approval = ApprovalExposure(
+            enable_hitl_review=self.enable_hitl_review,
+            max_hitl_iterations=self.max_hitl_iterations if self.enable_hitl_review else None,
+        )
+        runtime_notes: list[str] = []
+        if self.enable_tool_logging:
+            runtime_notes.append("tool logging enabled")
+        if self.durable:
+            runtime_notes.append("durable replay enabled")
+        if self.enable_hitl_review:
+            runtime_notes.append("human-in-the-loop review enabled")
+
+        toolset_exposures = [describe_toolset_exposure(toolset) for toolset in self.toolsets or []]
+        report = PolicyExposureReport(
+            task=TaskIdentity(
+                dag_id=ti.dag_id,
+                run_id=ti.run_id,
+                task_id=ti.task_id,
+                map_index=ti.map_index if ti.map_index is not None else -1,
+                operator_type=type(self).__name__,
+            ),
+            llm=llm_exposure,
+            approval=approval,
+            toolsets=toolset_exposures,
+            runtime_notes=runtime_notes,
+            risk=classify_policy_risk(
+                llm=llm_exposure,
+                toolsets=toolset_exposures,
+                runtime_notes=runtime_notes,
+            ),
+        )
+        return report
+
+    @staticmethod
+    def _push_policy_exposure_report(context: Context, report: PolicyExposureReport) -> None:
+        """Persist the configured policy exposure snapshot to XCom."""
+        context["task_instance"].xcom_push(key=XCOM_POLICY_EXPOSURE, value=report.model_dump(mode="json"))
+
     def execute(self, context: Context) -> Any:
+        try:
+            policy_exposure_report = self._build_policy_exposure_report(context)
+            self._push_policy_exposure_report(context, policy_exposure_report)
+        except Exception:
+            self.log.warning("Failed to build policy exposure report; continuing without it.", exc_info=True)
+
         self._durable_storage = None
         self._durable_counter = None
 

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
@@ -37,6 +37,8 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 from pydantic_core import SchemaValidator, core_schema
 
+from airflow.providers.common.ai.utils.policy_exposure import ResourceExposure, ToolsetExposure
+
 if TYPE_CHECKING:
     from pydantic_ai._run_context import RunContext
 
@@ -118,6 +120,44 @@ class DataFusionToolset(AbstractToolset[Any]):
     def id(self) -> str:
         suffix = "_".join(config.table_name.replace("-", "_") for config in self._datasource_configs)
         return f"sql_datafusion_{suffix}"
+
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        resources: list[ResourceExposure] = []
+        for config in self._datasource_configs:
+            resources.append(
+                ResourceExposure(
+                    category="datasource",
+                    name=config.table_name,
+                    access_mode="read_write" if self._allow_writes else "read",
+                    details={"conn_id": config.conn_id, "format": config.format},
+                )
+            )
+            resources.append(
+                ResourceExposure(
+                    category="uri",
+                    name=config.uri,
+                    access_mode="read_write" if self._allow_writes else "read",
+                    details={"table_name": config.table_name},
+                )
+            )
+
+        risk_flags: list[str] = []
+        if self._allow_writes:
+            risk_flags.append("write-capable DataFusion access configured")
+        if any("*" in config.uri for config in self._datasource_configs):
+            risk_flags.append("broad DataFusion URI exposure configured")
+
+        summary = "DataFusion access to configured datasources."
+        if self._allow_writes:
+            summary = "Write-capable DataFusion access to configured datasources."
+
+        return ToolsetExposure(
+            toolset_type=type(self).__name__,
+            toolset_id=self.id,
+            summary=summary,
+            resources=resources,
+            risk_flags=risk_flags,
+        )
 
     def _get_engine(self) -> DataFusionEngine:
         """Lazily create and configure a DataFusionEngine from *datasource_configs*."""

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/hook.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/hook.py
@@ -28,6 +28,8 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 from pydantic_core import SchemaValidator, core_schema
 
+from airflow.providers.common.ai.utils.policy_exposure import ResourceExposure, ToolsetExposure
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -92,6 +94,36 @@ class HookToolset(AbstractToolset[Any]):
     @property
     def id(self) -> str:
         return self._id
+
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        resources = [
+            ResourceExposure(
+                category="hook_method",
+                name=method_name,
+                access_mode="unknown",
+            )
+            for method_name in self._allowed_methods
+        ]
+        if self._tool_name_prefix:
+            resources.append(
+                ResourceExposure(
+                    category="tool_prefix",
+                    name=self._tool_name_prefix,
+                    access_mode="unknown",
+                )
+            )
+
+        risk_flags = ["hook methods may access broader runtime resources than this report can infer"]
+        if any(_looks_mutating(method_name) for method_name in self._allowed_methods):
+            risk_flags.append("potentially mutating hook methods exposed")
+
+        return ToolsetExposure(
+            toolset_type=type(self).__name__,
+            toolset_id=self.id,
+            summary=f"Selected methods from {type(self._hook).__name__} are exposed as tools.",
+            resources=resources,
+            risk_flags=risk_flags,
+        )
 
     async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
         tools: dict[str, ToolsetTool[Any]] = {}
@@ -265,3 +297,11 @@ def _serialize_for_llm(value: Any) -> str:
         return json.dumps(value, default=str)
     except (TypeError, ValueError):
         return str(value)
+
+
+def _looks_mutating(method_name: str) -> bool:
+    """Return True when a hook method name suggests write-like side effects."""
+    return any(
+        token in method_name.lower()
+        for token in ("create", "delete", "drop", "update", "insert", "write", "post", "put", "patch")
+    )

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/mcp.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/mcp.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Any
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 from typing_extensions import Self
 
+from airflow.providers.common.ai.utils.policy_exposure import ResourceExposure, ToolsetExposure
+
 if TYPE_CHECKING:
     from pydantic_ai._run_context import RunContext
 
@@ -64,6 +66,31 @@ class MCPToolset(AbstractToolset[Any]):
     @property
     def id(self) -> str:
         return f"mcp-{self._mcp_conn_id}"
+
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        resources = [
+            ResourceExposure(
+                category="mcp_server",
+                name=self._mcp_conn_id,
+                access_mode="unknown",
+            )
+        ]
+        if self._tool_prefix:
+            resources.append(
+                ResourceExposure(
+                    category="tool_prefix",
+                    name=self._tool_prefix,
+                    access_mode="unknown",
+                )
+            )
+
+        return ToolsetExposure(
+            toolset_type=type(self).__name__,
+            toolset_id=self.id,
+            summary="Remote MCP server tools are exposed through an Airflow connection.",
+            resources=resources,
+            risk_flags=["remote MCP capabilities may change independently of DAG code"],
+        )
 
     def _get_server(self) -> Any:
         if self._server is None:

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -36,6 +36,7 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 from pydantic_core import SchemaValidator, core_schema
 
+from airflow.providers.common.ai.utils.policy_exposure import ResourceExposure, ToolsetExposure
 from airflow.providers.common.compat.sdk import BaseHook
 
 if TYPE_CHECKING:
@@ -146,6 +147,40 @@ class SQLToolset(AbstractToolset[Any]):
     @property
     def id(self) -> str:
         return f"sql-{self._db_conn_id}"
+
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        resources = [
+            ResourceExposure(
+                category="database",
+                name=self._db_conn_id,
+                access_mode="read_write" if self._allow_writes else "read",
+                details={"schema": self._schema} if self._schema else {},
+            )
+        ]
+        for table_name in sorted(self._allowed_tables or ()):
+            resources.append(ResourceExposure(category="table", name=table_name, access_mode="read"))
+
+        risk_flags: list[str] = []
+        if self._allow_writes:
+            risk_flags.append("write-capable SQL access configured")
+        if self._allowed_tables is None:
+            risk_flags.append("SQL access is not limited to an allowed table list")
+
+        summary = "SQL access to configured database tables."
+        if self._allow_writes:
+            summary = "Write-capable SQL access to configured database tables."
+        elif self._allowed_tables:
+            summary = "Read-only SQL access to selected database tables."
+        else:
+            summary = "Read-only SQL access to database tables discoverable by the connection."
+
+        return ToolsetExposure(
+            toolset_type=type(self).__name__,
+            toolset_id=self.id,
+            summary=summary,
+            resources=resources,
+            risk_flags=risk_flags,
+        )
 
     # ------------------------------------------------------------------
     # Lazy hook resolution

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/policy_exposure.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/policy_exposure.py
@@ -1,0 +1,204 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared models and helpers for configured policy exposure snapshots."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from pydantic_ai.toolsets.wrapper import WrapperToolset
+
+XCOM_POLICY_EXPOSURE = "airflow_common_ai_policy_exposure"
+
+PolicyRiskLevel = Literal["low", "medium", "high"]
+ResourceCategory = Literal[
+    "database",
+    "table",
+    "schema",
+    "datasource",
+    "uri",
+    "hook_method",
+    "mcp_server",
+    "tool_prefix",
+    "unknown",
+]
+AccessMode = Literal["read", "write", "read_write", "unknown"]
+
+
+class TaskIdentity(BaseModel):
+    """Identifying information for the task instance that produced the report."""
+
+    dag_id: str
+    run_id: str
+    task_id: str
+    map_index: int = -1
+    operator_type: str
+
+
+class LLMExposure(BaseModel):
+    """Configuration-derived LLM access surface."""
+
+    llm_conn_id: str
+    connection_type: str | None = None
+    model_id: str | None = None
+
+
+class ApprovalExposure(BaseModel):
+    """Review and approval controls applied to the task."""
+
+    enable_hitl_review: bool = False
+    max_hitl_iterations: int | None = None
+
+
+class ResourceExposure(BaseModel):
+    """A single configured resource or capability exposed to the agent."""
+
+    category: ResourceCategory
+    name: str
+    access_mode: AccessMode = "unknown"
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolsetExposure(BaseModel):
+    """Exposure summary for one configured toolset."""
+
+    toolset_type: str
+    toolset_id: str | None = None
+    summary: str
+    resources: list[ResourceExposure] = Field(default_factory=list)
+    risk_flags: list[str] = Field(default_factory=list)
+
+
+class PolicyRiskSummary(BaseModel):
+    """High-level risk summary for the configured exposure snapshot."""
+
+    level: PolicyRiskLevel
+    reasons: list[str] = Field(default_factory=list)
+
+
+class PolicyExposureReport(BaseModel):
+    """Configured policy exposure snapshot for an AI task instance."""
+
+    captured_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    task: TaskIdentity
+    llm: LLMExposure
+    approval: ApprovalExposure
+    toolsets: list[ToolsetExposure] = Field(default_factory=list)
+    runtime_notes: list[str] = Field(default_factory=list)
+    risk: PolicyRiskSummary
+
+
+def classify_policy_risk(
+    *, llm: LLMExposure, toolsets: list[ToolsetExposure], runtime_notes: list[str]
+) -> PolicyRiskSummary:
+    """Classify overall risk using deterministic rules based on configured access."""
+    reasons: list[str] = []
+    has_write_access = any(
+        resource.access_mode in {"write", "read_write"}
+        for toolset in toolsets
+        for resource in toolset.resources
+    )
+
+    for toolset in toolsets:
+        reasons.extend(toolset.risk_flags)
+
+    if has_write_access and not any(
+        "write-capable" in reason or "write access" in reason for reason in reasons
+    ):
+        reasons.append("write-capable tool access configured")
+
+    deduped_reasons = _dedupe_reasons(reasons)
+
+    if any(
+        reason in deduped_reasons
+        for reason in ("unknown toolset exposure", "potentially mutating hook methods exposed")
+    ):
+        return PolicyRiskSummary(level="high", reasons=deduped_reasons or ["unknown toolset exposure"])
+
+    if has_write_access:
+        return PolicyRiskSummary(level="high", reasons=deduped_reasons)
+
+    if deduped_reasons:
+        return PolicyRiskSummary(level="medium", reasons=deduped_reasons)
+
+    if runtime_notes:
+        return PolicyRiskSummary(level="low", reasons=["configured access includes runtime controls"])
+
+    return PolicyRiskSummary(level="low", reasons=["no external tool access configured"])
+
+
+def unwrap_toolset(toolset: Any) -> Any:
+    """Unwrap known wrapper-style toolsets to the base policy surface."""
+    current = toolset
+    seen: set[int] = set()
+
+    while isinstance(current, WrapperToolset) and current.wrapped is not None:
+        current_id = id(current)
+        if current_id in seen:
+            break
+        seen.add(current_id)
+        current = current.wrapped
+
+    return current
+
+
+def describe_toolset_exposure(toolset: Any) -> ToolsetExposure:
+    """Describe a toolset's configured exposure with a safe fallback for unknown toolsets."""
+    base_toolset = unwrap_toolset(toolset)
+    describe = getattr(base_toolset, "describe_policy_exposure", None)
+    if callable(describe):
+        try:
+            exposure = describe()
+            if isinstance(exposure, ToolsetExposure):
+                return exposure
+            return ToolsetExposure(
+                toolset_type=type(base_toolset).__name__,
+                toolset_id=_get_toolset_id(base_toolset),
+                summary="Toolset returned an invalid policy exposure report.",
+                risk_flags=["invalid toolset exposure report"],
+            )
+        except Exception:
+            return ToolsetExposure(
+                toolset_type=type(base_toolset).__name__,
+                toolset_id=_get_toolset_id(base_toolset),
+                summary="Toolset exposure details are unavailable because report generation failed.",
+                risk_flags=["toolset exposure report failed"],
+            )
+
+    return ToolsetExposure(
+        toolset_type=type(base_toolset).__name__,
+        toolset_id=_get_toolset_id(base_toolset),
+        summary="Unknown toolset type; configured exposure details are unavailable.",
+        risk_flags=["unknown toolset exposure"],
+    )
+
+
+def _get_toolset_id(toolset: Any) -> str | None:
+    toolset_id = getattr(toolset, "id", None)
+    return toolset_id if isinstance(toolset_id, str) else None
+
+
+def _dedupe_reasons(reasons: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for reason in reasons:
+        if reason and reason not in seen:
+            seen.add(reason)
+            ordered.append(reason)
+    return ordered

--- a/providers/common/ai/tests/unit/common/ai/decorators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/decorators/test_agent.py
@@ -37,6 +37,28 @@ def _make_mock_run_result(output):
     return mock_result
 
 
+class _DummyToolset:
+    id = "dummy-toolset"
+
+
+def _configure_mock_hook(mock_hook_cls, *, agent, conn_type: str = "pydanticai", model_id: str | None = None):
+    mock_hook = mock_hook_cls.get_hook.return_value
+    mock_hook.create_agent.return_value = agent
+    mock_hook.conn_type = conn_type
+    mock_hook.model_id = model_id
+    return mock_hook
+
+
+def _make_mock_context():
+    ti = MagicMock(spec=["xcom_push", "dag_id", "run_id", "task_id", "map_index"])
+    ti.dag_id = "example_dag"
+    ti.run_id = "run_1"
+    ti.task_id = "test"
+    ti.map_index = -1
+    ti.xcom_push = MagicMock()
+    return {"task_instance": ti}
+
+
 class TestAgentDecoratedOperator:
     def test_custom_operator_name(self):
         assert _AgentDecoratedOperator.custom_operator_name == "@task.agent"
@@ -46,13 +68,13 @@ class TestAgentDecoratedOperator:
         """The callable's return value becomes the agent prompt."""
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = _make_mock_run_result("The top customer is Acme Corp.")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         def my_prompt():
             return "Who is our top customer?"
 
         op = _AgentDecoratedOperator(task_id="test", python_callable=my_prompt, llm_conn_id="my_llm")
-        result = op.execute(context={})
+        result = op.execute(context=_make_mock_context())
 
         assert result == "The top customer is Acme Corp."
         assert op.prompt == "Who is our top customer?"
@@ -78,7 +100,7 @@ class TestAgentDecoratedOperator:
         """op_kwargs are resolved by the callable to build the prompt."""
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = _make_mock_run_result("done")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         def my_prompt(topic):
             return f"Analyze {topic}"
@@ -89,7 +111,7 @@ class TestAgentDecoratedOperator:
             llm_conn_id="my_llm",
             op_kwargs={"topic": "revenue trends"},
         )
-        op.execute(context={"task_instance": MagicMock()})
+        op.execute(context=_make_mock_context())
 
         assert op.prompt == "Analyze revenue trends"
         mock_agent.run_sync.assert_called_once_with("Analyze revenue trends")
@@ -99,9 +121,9 @@ class TestAgentDecoratedOperator:
         """Toolsets passed to the decorator are forwarded to the agent."""
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = _make_mock_run_result("result")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
-        mock_toolset = MagicMock()
+        mock_toolset = _DummyToolset()
 
         op = _AgentDecoratedOperator(
             task_id="test",
@@ -109,7 +131,7 @@ class TestAgentDecoratedOperator:
             llm_conn_id="my_llm",
             toolsets=[mock_toolset],
         )
-        op.execute(context={})
+        op.execute(context=_make_mock_context())
 
         create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
         passed_toolsets = create_call[1]["toolsets"]
@@ -126,7 +148,7 @@ class TestAgentDecoratedOperator:
 
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = _make_mock_run_result(Summary(text="Great results"))
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         op = _AgentDecoratedOperator(
             task_id="test",
@@ -134,7 +156,7 @@ class TestAgentDecoratedOperator:
             llm_conn_id="my_llm",
             output_type=Summary,
         )
-        result = op.execute(context={})
+        result = op.execute(context=_make_mock_context())
 
         assert result == {"text": "Great results"}
 

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 
 from airflow.providers.common.ai.operators.agent import AgentOperator, HITLReviewLink
 from airflow.providers.common.ai.toolsets.logging import LoggingToolset
+from airflow.providers.common.ai.utils.policy_exposure import XCOM_POLICY_EXPOSURE
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
@@ -42,9 +43,37 @@ def _make_mock_run_result(output):
 
 def _make_mock_agent(output):
     """Create a mock agent that returns the given output."""
-    mock_agent = MagicMock(spec=["run_sync"])
+    mock_agent = MagicMock(spec=["run_sync", "model", "override"])
     mock_agent.run_sync.return_value = _make_mock_run_result(output)
+    mock_agent.model = "test-model"
+    mock_agent.override.return_value.__enter__ = MagicMock(return_value=None)
+    mock_agent.override.return_value.__exit__ = MagicMock(return_value=False)
     return mock_agent
+
+
+class _DummyToolset:
+    id = "dummy-toolset"
+
+
+def _configure_mock_hook(
+    mock_hook_cls, *, agent=None, conn_type: str = "pydanticai", model_id: str | None = None
+):
+    mock_hook = mock_hook_cls.get_hook.return_value
+    mock_hook.conn_type = conn_type
+    mock_hook.model_id = model_id
+    if agent is not None:
+        mock_hook.create_agent.return_value = agent
+    return mock_hook
+
+
+def _make_mock_context(map_index: int = -1):
+    ti = MagicMock(spec=["xcom_push", "dag_id", "run_id", "task_id", "map_index"])
+    ti.dag_id = "example_dag"
+    ti.run_id = "run_1"
+    ti.task_id = "test"
+    ti.map_index = map_index
+    ti.xcom_push = MagicMock()
+    return {"task_instance": ti}, ti
 
 
 class TestAgentOperatorValidation:
@@ -82,7 +111,7 @@ class TestAgentOperatorExecute:
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_creates_agent_from_hook(self, mock_hook_cls):
         mock_agent = _make_mock_agent("The answer is 42.")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook = _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         op = AgentOperator(
             task_id="test",
@@ -90,30 +119,30 @@ class TestAgentOperatorExecute:
             llm_conn_id="my_llm",
             system_prompt="You are helpful.",
         )
-        result = op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        result = op.execute(context=context)
 
         assert result == "The answer is 42."
         mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": None})
-        mock_hook_cls.get_hook.return_value.create_agent.assert_called_once_with(
-            output_type=str, instructions="You are helpful."
-        )
+        mock_hook.create_agent.assert_called_once_with(output_type=str, instructions="You are helpful.")
         mock_agent.run_sync.assert_called_once_with("What is the answer?")
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_passes_toolsets_in_agent_kwargs(self, mock_hook_cls):
         """Toolsets are passed through to the agent constructor."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+        mock_hook = _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("done"))
 
-        mock_toolset = MagicMock()
+        mock_toolset = _DummyToolset()
         op = AgentOperator(
             task_id="test",
             prompt="Do something",
             llm_conn_id="my_llm",
             toolsets=[mock_toolset],
         )
-        op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        op.execute(context=context)
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         passed_toolsets = create_call[1]["toolsets"]
         assert len(passed_toolsets) == 1
         assert isinstance(passed_toolsets[0], LoggingToolset)
@@ -122,9 +151,9 @@ class TestAgentOperatorExecute:
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_enable_tool_logging_false_skips_wrapping(self, mock_hook_cls):
         """enable_tool_logging=False passes toolsets through unwrapped."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+        mock_hook = _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("done"))
 
-        mock_toolset = MagicMock()
+        mock_toolset = _DummyToolset()
         op = AgentOperator(
             task_id="test",
             prompt="Do something",
@@ -132,15 +161,16 @@ class TestAgentOperatorExecute:
             toolsets=[mock_toolset],
             enable_tool_logging=False,
         )
-        op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        op.execute(context=context)
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         assert create_call[1]["toolsets"] == [mock_toolset]
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_passes_agent_params(self, mock_hook_cls):
         """agent_params are unpacked into create_agent."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
+        mock_hook = _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"))
 
         op = AgentOperator(
             task_id="test",
@@ -148,9 +178,10 @@ class TestAgentOperatorExecute:
             llm_conn_id="my_llm",
             agent_params={"retries": 3, "model_settings": {"temperature": 0}},
         )
-        op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        op.execute(context=context)
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         assert create_call[1]["retries"] == 3
         assert create_call[1]["model_settings"] == {"temperature": 0}
 
@@ -162,8 +193,9 @@ class TestAgentOperatorExecute:
             text: str
             score: float
 
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent(
-            Summary(text="Great", score=0.95)
+        _configure_mock_hook(
+            mock_hook_cls,
+            agent=_make_mock_agent(Summary(text="Great", score=0.95)),
         )
 
         op = AgentOperator(
@@ -172,14 +204,15 @@ class TestAgentOperatorExecute:
             llm_conn_id="my_llm",
             output_type=Summary,
         )
-        result = op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        result = op.execute(context=context)
 
         assert result == {"text": "Great", "score": 0.95}
 
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_with_model_id(self, mock_hook_cls):
         """model_id is passed to PydanticAIHook."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
+        _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"), model_id="openai:gpt-5")
 
         op = AgentOperator(
             task_id="test",
@@ -187,7 +220,8 @@ class TestAgentOperatorExecute:
             llm_conn_id="my_llm",
             model_id="openai:gpt-5",
         )
-        op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        op.execute(context=context)
 
         mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": "openai:gpt-5"})
 
@@ -203,7 +237,7 @@ class TestAgentOperatorExecute:
         mock_result.all_messages.return_value = msg_history
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
         mock_run_hitl.return_value = "Approved output"
 
         op = AgentOperator(
@@ -213,7 +247,7 @@ class TestAgentOperatorExecute:
             enable_hitl_review=True,
             hitl_timeout=timedelta(minutes=5),
         )
-        context = MagicMock()
+        context, _ = _make_mock_context()
         result = op.execute(context=context)
 
         assert result == "Approved output"
@@ -234,7 +268,7 @@ class TestAgentOperatorExecute:
         mock_result = _make_mock_run_result(Summary(text="Approved summary", score=0.9))
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
         # run_hitl_review returns JSON string (as stored in session.current_output)
         mock_run_hitl.return_value = '{"text": "Approved summary", "score": 0.9}'
 
@@ -246,7 +280,7 @@ class TestAgentOperatorExecute:
             enable_hitl_review=True,
             hitl_timeout=timedelta(minutes=5),
         )
-        context = MagicMock()
+        context, _ = _make_mock_context()
         result = op.execute(context=context)
 
         assert result == {"text": "Approved summary", "score": 0.9}
@@ -261,7 +295,7 @@ class TestAgentOperatorExecute:
         mock_result = _make_mock_run_result("Initial output")
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
         mock_run_hitl.return_value = "Approved output"
 
         op = AgentOperator(
@@ -272,7 +306,7 @@ class TestAgentOperatorExecute:
             enable_hitl_review=True,
             hitl_timeout=timedelta(minutes=5),
         )
-        context = MagicMock()
+        context, _ = _make_mock_context()
         result = op.execute(context=context)
 
         assert result == "Approved output"
@@ -289,7 +323,7 @@ class TestAgentOperatorExecute:
         mock_result = _make_mock_run_result("Initial output")
         mock_agent = MagicMock(spec=["run_sync"])
         mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
         mock_run_hitl.side_effect = HITLMaxIterationsError("Task exceeded max iterations.")
 
         op = AgentOperator(
@@ -300,10 +334,101 @@ class TestAgentOperatorExecute:
             max_hitl_iterations=5,
             hitl_timeout=timedelta(minutes=5),
         )
-        context = MagicMock()
+        context, _ = _make_mock_context()
 
         with pytest.raises(HITLMaxIterationsError, match="Task exceeded max iterations"):
             op.execute(context=context)
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_pushes_policy_exposure_report_to_xcom(self, mock_hook_cls):
+        _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"))
+        op = AgentOperator(task_id="test", prompt="test", llm_conn_id="my_llm")
+        context, ti = _make_mock_context()
+
+        op.execute(context=context)
+
+        xcom_push_calls = [call.kwargs for call in ti.xcom_push.call_args_list]
+        policy_push = next(call for call in xcom_push_calls if call["key"] == XCOM_POLICY_EXPOSURE)
+        assert policy_push["value"]["task"]["dag_id"] == "example_dag"
+        assert policy_push["value"]["task"]["map_index"] == -1
+        assert policy_push["value"]["llm"]["connection_type"] == "pydanticai"
+        assert policy_push["value"]["llm"]["model_id"] is None
+        assert policy_push["value"]["risk"]["level"] == "low"
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_policy_report_includes_runtime_notes_and_map_index(self, mock_hook_cls):
+        _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"))
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="my_llm",
+            durable=True,
+            enable_tool_logging=True,
+        )
+        context, ti = _make_mock_context(map_index=3)
+
+        with (
+            patch(
+                "airflow.providers.common.ai.operators.agent.AgentOperator._build_durable_toolsets",
+                autospec=True,
+                return_value=[],
+            ),
+            patch("airflow.providers.common.ai.durable.storage._get_base_path"),
+            patch("pydantic_ai.models.infer_model", autospec=True, return_value=MagicMock()),
+            patch("pydantic_ai.models.wrapper.infer_model", side_effect=lambda model: model),
+        ):
+            op.execute(context=context)
+
+        xcom_push_calls = [call.kwargs for call in ti.xcom_push.call_args_list]
+        policy_push = next(call for call in xcom_push_calls if call["key"] == XCOM_POLICY_EXPOSURE)
+        assert policy_push["value"]["task"]["map_index"] == 3
+        assert "tool logging enabled" in policy_push["value"]["runtime_notes"]
+        assert "durable replay enabled" in policy_push["value"]["runtime_notes"]
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_policy_report_uses_fallback_for_unknown_toolset(self, mock_hook_cls):
+        _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"))
+
+        class CustomToolset:
+            id = "custom-toolset"
+
+        unknown_toolset = CustomToolset()
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="my_llm",
+            toolsets=[unknown_toolset],
+        )
+        context, ti = _make_mock_context()
+
+        op.execute(context=context)
+
+        xcom_push_calls = [call.kwargs for call in ti.xcom_push.call_args_list]
+        policy_push = next(call for call in xcom_push_calls if call["key"] == XCOM_POLICY_EXPOSURE)
+        assert policy_push["value"]["toolsets"][0]["toolset_type"] == "CustomToolset"
+        assert policy_push["value"]["risk"]["level"] == "high"
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_continues_when_toolset_exposure_report_fails(self, mock_hook_cls):
+        _configure_mock_hook(mock_hook_cls, agent=_make_mock_agent("ok"))
+
+        class BrokenToolset:
+            id = "broken-toolset"
+
+            def describe_policy_exposure(self):
+                raise RuntimeError("boom")
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="my_llm",
+            toolsets=[BrokenToolset()],
+        )
+        context, _ = _make_mock_context()
+
+        result = op.execute(context=context)
+
+        assert result == "ok"
 
 
 @pytest.mark.skipif(
@@ -434,15 +559,12 @@ class TestAgentOperatorDurable:
         mock_agent.override = MagicMock()
         mock_agent.override.return_value.__enter__ = MagicMock(return_value=None)
         mock_agent.override.return_value.__exit__ = MagicMock(return_value=False)
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         mock_resolved = MagicMock()
         mock_infer.return_value = mock_resolved
 
-        context = MagicMock()
-        context.__getitem__ = MagicMock(
-            return_value=MagicMock(dag_id="d", task_id="t", run_id="r", map_index=-1)
-        )
+        context, _ = _make_mock_context()
 
         op = AgentOperator(task_id="test", prompt="test", llm_conn_id="my_llm", durable=True)
         result = op.execute(context=context)
@@ -456,10 +578,11 @@ class TestAgentOperatorDurable:
     def test_execute_non_durable_does_not_wrap(self, mock_hook_cls):
         """Default (durable=False) does not use override."""
         mock_agent = _make_mock_agent("ok")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        _configure_mock_hook(mock_hook_cls, agent=mock_agent)
 
         op = AgentOperator(task_id="test", prompt="test", llm_conn_id="my_llm")
-        op.execute(context=MagicMock())
+        context, _ = _make_mock_context()
+        op.execute(context=context)
 
         # run_sync called directly, no override
         mock_agent.run_sync.assert_called_once_with("test")

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
@@ -91,6 +91,31 @@ class TestDataFusionToolsetInit:
         with pytest.raises(ValueError, match="datasource_configs must contain at least one DataSourceConfig"):
             DataFusionToolset([])
 
+    def test_describe_policy_exposure_lists_datasources(self):
+        cfg = _make_mock_datasource_config("sales")
+        cfg.conn_id = "aws_default"
+        cfg.format = "parquet"
+        cfg.uri = "s3://bucket/sales/file.parquet"
+        ts = DataFusionToolset([cfg])
+
+        exposure = ts.describe_policy_exposure()
+
+        assert exposure.resources[0].category == "datasource"
+        assert exposure.resources[1].category == "uri"
+        assert exposure.resources[1].name == "s3://bucket/sales/file.parquet"
+        assert exposure.risk_flags == []
+
+    def test_describe_policy_exposure_flags_wildcard_uris(self):
+        cfg = _make_mock_datasource_config("sales")
+        cfg.conn_id = "aws_default"
+        cfg.format = "parquet"
+        cfg.uri = "s3://bucket/sales/*"
+        ts = DataFusionToolset([cfg])
+
+        exposure = ts.describe_policy_exposure()
+
+        assert "broad DataFusion URI exposure configured" in exposure.risk_flags
+
 
 class TestDataFusionToolsetGetTools:
     def test_returns_three_tools(self):

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_hook.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_hook.py
@@ -75,6 +75,26 @@ class TestHookToolsetInit:
         ts = HookToolset(hook, allowed_methods=["list_keys"])
         assert "FakeHook" in ts.id
 
+    def test_describe_policy_exposure_summarizes_hook_methods(self):
+        hook = _FakeHook()
+        ts = HookToolset(hook, allowed_methods=["list_keys"], tool_name_prefix="s3_")
+
+        exposure = ts.describe_policy_exposure()
+
+        assert exposure.toolset_type == "HookToolset"
+        assert exposure.resources[0].category == "hook_method"
+        assert exposure.resources[1].category == "tool_prefix"
+        assert "broader runtime resources" in exposure.risk_flags[0]
+
+    def test_describe_policy_exposure_flags_mutating_methods(self):
+        hook = _FakeHook()
+        hook.create_job = lambda name: name
+        ts = HookToolset(hook, allowed_methods=["create_job"])
+
+        exposure = ts.describe_policy_exposure()
+
+        assert "potentially mutating hook methods exposed" in exposure.risk_flags
+
 
 class TestHookToolsetGetTools:
     def test_returns_tools_for_allowed_methods(self):

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_mcp.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_mcp.py
@@ -33,6 +33,15 @@ class TestMCPToolsetInit:
         ts = MCPToolset("my_mcp_server", tool_prefix="weather")
         assert ts._tool_prefix == "weather"
 
+    def test_describe_policy_exposure_includes_server_and_prefix(self):
+        ts = MCPToolset("my_mcp_server", tool_prefix="weather")
+
+        exposure = ts.describe_policy_exposure()
+
+        assert exposure.resources[0].category == "mcp_server"
+        assert exposure.resources[1].name == "weather"
+        assert "remote MCP capabilities may change" in exposure.risk_flags[0]
+
 
 class TestMCPToolsetGetServer:
     @patch(_HOOK_PATH, autospec=True)

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
@@ -55,6 +55,25 @@ class TestSQLToolsetInit:
         ts = SQLToolset("my_pg")
         assert ts.id == "sql-my_pg"
 
+    def test_describe_policy_exposure_for_read_only_tables(self):
+        ts = SQLToolset("my_pg", allowed_tables=["orders", "users"], schema="public")
+
+        exposure = ts.describe_policy_exposure()
+
+        assert exposure.toolset_id == "sql-my_pg"
+        assert exposure.resources[0].category == "database"
+        assert exposure.resources[0].details == {"schema": "public"}
+        assert {resource.name for resource in exposure.resources[1:]} == {"orders", "users"}
+        assert exposure.risk_flags == []
+
+    def test_describe_policy_exposure_for_write_enabled_access(self):
+        ts = SQLToolset("my_pg", allow_writes=True)
+
+        exposure = ts.describe_policy_exposure()
+
+        assert "write-capable SQL access configured" in exposure.risk_flags
+        assert "allowed table list" in exposure.risk_flags[1]
+
 
 class TestSQLToolsetGetTools:
     def test_returns_four_tools(self):

--- a/providers/common/ai/tests/unit/common/ai/utils/test_policy_exposure.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_policy_exposure.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.common.ai.toolsets.logging import LoggingToolset
+from airflow.providers.common.ai.utils.policy_exposure import (
+    LLMExposure,
+    ResourceExposure,
+    ToolsetExposure,
+    _dedupe_reasons,
+    classify_policy_risk,
+    describe_toolset_exposure,
+    unwrap_toolset,
+)
+
+
+class _UnknownToolset:
+    id = "custom"
+
+
+class _BaseToolset:
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        return ToolsetExposure(
+            toolset_type="BaseToolset",
+            toolset_id="base",
+            summary="base toolset",
+        )
+
+
+class _BrokenToolset:
+    id = "broken"
+
+    def describe_policy_exposure(self) -> ToolsetExposure:
+        raise RuntimeError("boom")
+
+
+def test_unwrap_toolset_returns_base_toolset():
+    wrapped = _BaseToolset()
+    toolset = LoggingToolset(wrapped=wrapped, logger=logging.getLogger(__name__))
+
+    base_toolset = unwrap_toolset(toolset)
+
+    assert base_toolset is wrapped
+
+
+def test_describe_toolset_exposure_uses_base_toolset_for_wrappers():
+    wrapped = MagicMock()
+    wrapped.describe_policy_exposure.return_value = ToolsetExposure(
+        toolset_type="WrappedToolset",
+        toolset_id="wrapped",
+        summary="wrapped toolset",
+    )
+    toolset = LoggingToolset(wrapped=wrapped, logger=logging.getLogger(__name__))
+
+    exposure = describe_toolset_exposure(toolset)
+
+    assert exposure.toolset_type == "WrappedToolset"
+    assert exposure.toolset_id == "wrapped"
+
+
+def test_describe_toolset_exposure_falls_back_for_unknown_toolset():
+    exposure = describe_toolset_exposure(_UnknownToolset())
+
+    assert exposure.toolset_type == "_UnknownToolset"
+    assert "unknown toolset exposure" in exposure.risk_flags
+
+
+def test_describe_toolset_exposure_falls_back_when_report_generation_fails():
+    exposure = describe_toolset_exposure(_BrokenToolset())
+
+    assert exposure.toolset_type == "_BrokenToolset"
+    assert exposure.summary == "Toolset exposure details are unavailable because report generation failed."
+    assert exposure.risk_flags == ["toolset exposure report failed"]
+
+
+@pytest.mark.parametrize(
+    ("llm", "toolsets", "runtime_notes", "expected_level"),
+    [
+        (
+            LLMExposure(llm_conn_id="llm"),
+            [
+                ToolsetExposure(
+                    toolset_type="Unknown", summary="unknown", risk_flags=["unknown toolset exposure"]
+                )
+            ],
+            [],
+            "high",
+        ),
+        (
+            LLMExposure(llm_conn_id="llm"),
+            [
+                ToolsetExposure(
+                    toolset_type="HookToolset",
+                    summary="hook",
+                    risk_flags=["potentially mutating hook methods exposed"],
+                )
+            ],
+            [],
+            "high",
+        ),
+        (
+            LLMExposure(llm_conn_id="llm"),
+            [
+                ToolsetExposure(
+                    toolset_type="WriteToolset",
+                    summary="write",
+                    resources=[ResourceExposure(category="database", name="db", access_mode="read_write")],
+                )
+            ],
+            [],
+            "high",
+        ),
+        (
+            LLMExposure(llm_conn_id="llm"),
+            [],
+            ["tool logging enabled"],
+            "low",
+        ),
+        (
+            LLMExposure(llm_conn_id="llm"),
+            [],
+            [],
+            "low",
+        ),
+    ],
+)
+def test_classify_policy_risk_returns_expected_level(llm, toolsets, runtime_notes, expected_level):
+    risk = classify_policy_risk(llm=llm, toolsets=toolsets, runtime_notes=runtime_notes)
+
+    assert risk.level == expected_level
+
+
+def test_classify_policy_risk_does_not_duplicate_write_reasons():
+    risk = classify_policy_risk(
+        llm=LLMExposure(llm_conn_id="llm"),
+        toolsets=[
+            ToolsetExposure(
+                toolset_type="SQLToolset",
+                summary="write",
+                resources=[ResourceExposure(category="database", name="db", access_mode="read_write")],
+                risk_flags=["write-capable SQL access configured"],
+            )
+        ],
+        runtime_notes=[],
+    )
+
+    assert risk.level == "high"
+    assert risk.reasons == ["write-capable SQL access configured"]
+
+
+def test_dedupe_reasons_preserves_order_and_drops_empty_strings():
+    reasons = _dedupe_reasons(["first", "", "second", "first", "third", "second"])
+
+    assert reasons == ["first", "second", "third"]


### PR DESCRIPTION
### What

Implemented a first pass of policy exposure reporting for common.ai AgentOperator.

This adds a structured, XCom-backed PolicyExposureReport snapshot for each task run so users can inspect the configured AI access surface without reading operator code. The report captures task identity, LLM metadata, attached toolset exposure summaries, runtime notes, and a deterministic risk summary.


For each task the output is stored in the `airflow_common_ai_policy_exposure` xcom key

Ideally this kind of view is very useful in large entierprises if anyone is using llm its easy way to track what exactly the run uses configs instead of in the logs or input from the dag.

eg:
```
{
  "llm": {
    "model_id": "google-gla:gemini-2.5-pro",
    "llm_conn_id": "pydanticai_default",
    "connection_type": "pydanticai"
  },
  "risk": {
    "level": "low",
    "reasons": [
      "configured access includes runtime controls"
    ]
  },
  "task": {
    "dag_id": "example_data_analyst_agent",
    "run_id": "manual__2026-03-29T22:09:00.476052+00:00",
    "task_id": "analyze",
    "map_index": -1,
    "operator_type": "AgentOperator"
  },
  "approval": {
    "enable_hitl_review": true,
    "max_hitl_iterations": 5
  },
  "toolsets": [
    {
      "summary": "Read-only SQL access to selected database tables.",
      "resources": [
        {
          "name": "postgres_default",
          "details": {},
          "category": "database",
          "access_mode": "read"
        },
        {
          "name": "customers",
          "details": {},
          "category": "table",
          "access_mode": "read"
        },
        {
          "name": "orders",
          "details": {},
          "category": "table",
          "access_mode": "read"
        }
      ],
      "risk_flags": [],
      "toolset_id": "sql-postgres_default",
      "toolset_type": "SQLToolset"
    }
  ],
  "captured_at": "2026-03-29T22:09:03.444516Z",
  "runtime_notes": [
    "tool logging enabled",
    "human-in-the-loop review enabled"
  ]
}
```




<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
