### PR TITLE
Update README.md badge to v3-2-test and automate badge updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
+| 3.x     | [![GitHub Build 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions) |
 | 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
 
 

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -456,6 +456,8 @@ uv tool install -e ./dev/breeze
 - Run `git commit` without a message to update versions in `docs`.
 - Add supported Airflow version to `./scripts/ci/prek/supported_versions.py` and let prek do the job again.
 - Replace the versions in `README.md` about installation and verify that installation instructions work fine.
+- Update the build status badge in `README.md` to point to the new `vX-Y-test` branch (the `3.x` row in the
+  build status table). The `uv run dev/update_github_branch_config.py X Y` script does this automatically.
 - Add entry for default python version to `PROVIDERS_COMPATIBILITY_TESTS_MATRIX` in `src/airflow_breeze/global_constants.py`
   with the new Airflow version, and empty exclusion for providers. This list should be updated later when providers
   with minimum version for the next version of Airflow will be added in the future.

--- a/dev/update_github_branch_config.py
+++ b/dev/update_github_branch_config.py
@@ -23,7 +23,8 @@ Update .github/ configuration files on ``main`` when a new major/minor
 release branch (vX-Y-test) is created.
 
 Adds the new branch to dependabot, milestone-tag-assistant, basic-tests,
-ci-notification workflows and boring-cyborg auto-labelling.
+ci-notification workflows, boring-cyborg auto-labelling, and the
+README.md build status badge.
 
 Usage::
 
@@ -294,6 +295,37 @@ def update_boring_cyborg(new_branch: str, prev_branch: str) -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# README.md — build status badge
+# ──────────────────────────────────────────────────────────────────────────────
+def update_readme_badge(new_branch: str, prev_branch: str, new_version: str, prev_version: str) -> None:
+    path = REPO_ROOT / "README.md"
+    content = _read(path)
+
+    old_badge = (
+        f"[![GitHub Build {prev_version}"
+        f"](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg"
+        f"?branch={prev_branch})](https://github.com/apache/airflow/actions)"
+    )
+    new_badge = (
+        f"[![GitHub Build {new_version}"
+        f"](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg"
+        f"?branch={new_branch})](https://github.com/apache/airflow/actions)"
+    )
+
+    if new_branch in content:
+        print(f"README.md: {new_branch} badge already present, skipping.")
+        return
+
+    if old_badge not in content:
+        print(f"README.md: could not find existing {prev_branch} badge, skipping.")
+        return
+
+    print(f"README.md: updating 3.x build status badge to {new_branch}...")
+    content = content.replace(old_badge, new_badge)
+    _write(path, content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # dev/README_RELEASE_AIRFLOW.md
 # ──────────────────────────────────────────────────────────────────────────────
 def update_release_readme(new_branch: str, prev_branch: str) -> None:
@@ -334,6 +366,7 @@ def main() -> None:
     update_basic_tests(new_branch, prev_branch, new_version, prev_version, new_dash, prev_dash)
     update_ci_notification(new_branch, prev_branch)
     update_boring_cyborg(new_branch, prev_branch)
+    update_readme_badge(new_branch, prev_branch, new_version, prev_version)
     update_release_readme(new_branch, prev_branch)
 
     print()

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -33,7 +33,7 @@ PROJECT BY THE `generate-pypi-readme` PREK HOOK. YOUR CHANGES HERE WILL BE AUTOM
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.1](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-1-test)](https://github.com/apache/airflow/actions) |
+| 3.x     | [![GitHub Build 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions) |
 | 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
 
 


### PR DESCRIPTION
- Update 3.x build status badge in README.md to point to v3-2-test branch
- Add `update_readme_badge()` to `dev/update_github_branch_config.py` so future minor releases update the badge automatically
- Add a note in `dev/README_RELEASE_AIRFLOW.md` about the badge update step in the release checklist

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)