### PR TITLE
Fix newsfragment check being cancelled on rapid PR events

### DIFF
--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -32,7 +32,7 @@ permissions:
 
 concurrency:
   group: check-newsfragment-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   check-newsfragment-pr-number:


### PR DESCRIPTION
Change `cancel-in-progress` from `true` to `false` in the
check-newsfragment-pr-number workflow's concurrency group.

With `cancel-in-progress: true`, when a PR receives multiple events
in quick succession (e.g. a push followed by a label change, or
rapid consecutive pushes), the earlier run gets cancelled by the
newer one, leaving a spurious "Cancelled" status on the PR.

This check is extremely lightweight (a single `gh api` call that
runs in seconds), so queueing concurrent runs has no downside
and avoids the cancelled status issue.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)