### PR TITLE
Add ASF allowlist check workflow for GitHub Actions

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+name: "ASF Allowlist Check"
+"on":
+  pull_request:
+    paths: [".github/**"]
+  push:
+    branches: [main, v*-test]
+    paths: [".github/**"]
+permissions:
+  contents: read
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@493edcdbd80d9e78a767f256a877b1cc6c9712ba  # main


### PR DESCRIPTION
Add a CI workflow that validates all `uses:` references in workflow files against the
ASF Infrastructure approved allowlist. This catches action refs that are not on the
org-level allowlist early at PR time, instead of causing silent "Startup failure"
errors in CI with no logs or notifications.

The workflow triggers on PRs and pushes to `main`/`v*-test` that modify files under `.github/`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)