### PR TITLE
fix(fab): add authlib as optional oauth extra in providers/fab/pyproject.toml

### DIFF
--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -103,6 +103,14 @@ dependencies = [
 "kerberos" = [
     "kerberos>=1.3.0",
 ]
+"oauth" = [
+    # authlib is required by the FAB security manager when AUTH_OAUTH is enabled.
+    # It is used for OAuth provider registration (authlib.integrations.flask_client.OAuth)
+    # and JWT validation (authlib.jose.JsonWebKey / authlib.jose.jwt).
+    # flask-appbuilder ships authlib as its own optional [oauth] extra; we expose it
+    # here so that ``pip install apache-airflow-providers-fab[oauth]`` pulls it in.
+    "authlib>=1.0.0",
+]
 
 [dependency-groups]
 dev = [
@@ -113,6 +121,7 @@ dev = [
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "kerberos>=1.3.0",
     "requests_kerberos>=0.14.0",
+    "authlib>=1.0.0",
 ]
 
 # To build docs:


### PR DESCRIPTION
fix: add `authlib` as optional `oauth` extra to FAB provider, so users can install it with `pip install apache-airflow-providers-fab[oauth]`.

`authlib` is imported at runtime inside `FabAuthManager`'s security-manager override whenever OAuth is enabled:

- `authlib.integrations.flask_client.OAuth` – provider registration (`AUTH_OAUTH`)
- `authlib.jose.JsonWebKey` / `authlib.jose.jwt` – JWT validation (Azure, generic OIDC)

`flask-appbuilder 5.x` already exposes authlib under **its own** `[oauth]` extra (`Authlib<2.0.0,>=0.14`), but `apache-airflow-providers-fab` never re-exported it. Users who enable OAuth have to install `authlib` manually, and receive an unhelpful `ModuleNotFoundError` at login time with no hint about which package is missing.

This commit adds an `oauth` optional-dependency group to `providers/fab/pyproject.toml`, mirroring the existing `kerberos` pattern:

```toml
[project.optional-dependencies]
"oauth" = [
    "authlib>=1.0.0",
]
```

Users can now install it explicitly:
```
pip install 'apache-airflow-providers-fab[oauth]'
```

closes: #64456

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
