### PR TITLE
fix(amazon): remove stale [boto3] extra from aiobotocore dependency

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -86,11 +86,10 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
-# There is conflict between boto3 and aiobotocore dependency botocore.
-# TODO: We can remove it once boto3 and aiobotocore both have compatible botocore version or
-# boto3 have native async support and we move away from aio aiobotocore
+# Note: aiobotocore removed its [boto3] extra in 3.3.0; boto3 is already
+# in the provider's main dependencies so no extra is needed here.
 "aiobotocore" = [
-    "aiobotocore[boto3]>=2.26.0",
+    "aiobotocore>=2.26.0",
 ]
 "cncf.kubernetes" = [
     "apache-airflow-providers-cncf-kubernetes>=7.2.0",


### PR DESCRIPTION
### Jira

_No Jira_

### What does this PR do?

`aiobotocore` 3.3.0 removed its `[boto3]` extra (see [aio-libs/aiobotocore#1424](https://github.com/aio-libs/aiobotocore/issues/1424)).
Users and CI tooling now see the warning:

```
warning: The package `aiobotocore==3.3.0` does not have an extra named `boto3`
```

**Changes:**
- Remove the `[boto3]` extra suffix from the `aiobotocore` optional-dependency entry in `providers/amazon/pyproject.toml`
- Update the comment to reflect the current situation (`boto3` is already in the providers main deps, so the extra was redundant in any case)

### Are there any requirements? Are there breaking changes?

No. `boto3>=1.41.0` is already present in `[project.dependencies]`, so nothing regresses.

Closes #64283

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
