### PR TITLE
Add retries for `_write_logs` method in `KubernetesPodOperator`

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -102,6 +102,8 @@ if TYPE_CHECKING:
     from airflow.providers.cncf.kubernetes.secret import Secret
     from airflow.sdk import Context
 
+log = logging.getLogger(__name__)
+
 alphanum_lower = string.ascii_lowercase + string.digits
 
 KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
@@ -972,7 +974,14 @@ class KubernetesPodOperator(BaseOperator):
 
             if event["status"] in ("error", "failed", "timeout", "success"):
                 if self.get_logs:
-                    self._write_logs(self.pod, follow=follow, since_time=last_log_time)
+                    try:
+                        self._write_logs(self.pod, follow=follow, since_time=last_log_time)
+                    except (HTTPError, ApiException) as e:
+                        self.log.warning(
+                            "Reading of logs interrupted with error %r. "
+                            "Set log level to DEBUG for traceback.",
+                            e if not isinstance(e, ApiException) else e.reason,
+                        )
 
                 for callback in self.callbacks:
                     callback.on_pod_completion(
@@ -1035,32 +1044,32 @@ class KubernetesPodOperator(BaseOperator):
                 result=result,
             )
 
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(3),
+        wait=tenacity.wait_exponential(max=15),
+        retry=tenacity.retry_if_exception_type((HTTPError, ApiException)),
+        before_sleep=tenacity.before_sleep_log(log, logging.WARNING),
+        reraise=True,
+    )
     def _write_logs(self, pod: k8s.V1Pod, follow: bool = False, since_time: DateTime | None = None) -> None:
-        try:
-            since_seconds = (
-                math.ceil((datetime.datetime.now(tz=datetime.timezone.utc) - since_time).total_seconds())
-                if since_time
-                else None
-            )
-            logs = self.client.read_namespaced_pod_log(
-                name=pod.metadata.name,
-                namespace=pod.metadata.namespace,
-                container=self.base_container_name,
-                follow=follow,
-                timestamps=False,
-                since_seconds=since_seconds,
-                _preload_content=False,
-            )
-            for raw_line in logs:
-                line = raw_line.decode("utf-8", errors="backslashreplace").rstrip("\n")
-                if line:
-                    self.log.info("[%s] logs: %s", self.base_container_name, line)
-        except (HTTPError, ApiException) as e:
-            self.log.warning(
-                "Reading of logs interrupted with error %r; will retry. "
-                "Set log level to DEBUG for traceback.",
-                e if not isinstance(e, ApiException) else e.reason,
-            )
+        since_seconds = (
+            math.ceil((datetime.datetime.now(tz=datetime.timezone.utc) - since_time).total_seconds())
+            if since_time
+            else None
+        )
+        logs = self.client.read_namespaced_pod_log(
+            name=pod.metadata.name,
+            namespace=pod.metadata.namespace,
+            container=self.base_container_name,
+            follow=follow,
+            timestamps=False,
+            since_seconds=since_seconds,
+            _preload_content=False,
+        )
+        for raw_line in logs:
+            line = raw_line.decode("utf-8", errors="backslashreplace").rstrip("\n")
+            if line:
+                self.log.info("[%s] logs: %s", self.base_container_name, line)
 
     def post_complete_action(
         self, *, pod: k8s.V1Pod, remote_pod: k8s.V1Pod, context: Context, result: dict | None, **kwargs

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pendulum
 import pytest
+import tenacity
 from kubernetes.client import ApiClient, V1Pod, V1PodSecurityContext, V1PodStatus, models as k8s
 from kubernetes.client.exceptions import ApiException
 
@@ -45,7 +46,7 @@ from airflow.providers.common.compat.sdk import (
     AirflowSkipException,
     TaskDeferred,
 )
-from airflow.utils import timezone
+from airflow.sdk import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
@@ -2764,7 +2765,7 @@ class TestKubernetesPodOperatorAsync:
     @patch(HOOK_CLASS)
     @patch(KUB_OP_PATH.format("pod_manager"))
     def test_async_write_logs_handler_api_exception(
-        self, mock_manager, mocked_hook, mock_extract_xcom, post_complete_action, mocked_client
+        self, mock_manager, mocked_hook, mock_extract_xcom, mocked_client, post_complete_action
     ):
         mocked_client.read_namespaced_pod_log.side_effect = ApiException(status=404)
         mock_manager.await_pod_completion.side_effect = ApiException(status=404)
@@ -2777,8 +2778,69 @@ class TestKubernetesPodOperatorAsync:
             get_logs=True,
             deferrable=True,
         )
+        # Patch tenacity wait to avoid real delays from _write_logs retries
+        k._write_logs.retry.wait = tenacity.wait_none()
         self.run_pod_async(k)
         post_complete_action.assert_not_called()
+
+    @patch(KUB_OP_PATH.format("post_complete_action"))
+    @patch(KUB_OP_PATH.format("client"))
+    @patch(HOOK_CLASS)
+    @patch(KUB_OP_PATH.format("pod_manager"))
+    def test_write_logs_retries_on_api_exception(
+        self, mock_manager, mocked_hook, mocked_client, post_complete_action
+    ):
+        """Test that _write_logs retries on ApiException and succeeds on subsequent attempt."""
+        test_logs = b"log line\n"
+        mocked_client.read_namespaced_pod_log.side_effect = [
+            ApiException(status=500),
+            [test_logs],
+        ]
+        mock_manager.await_pod_completion.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name=TEST_NAME, namespace=TEST_NAMESPACE)
+        )
+        mocked_hook.return_value.get_pod.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name=TEST_NAME, namespace=TEST_NAMESPACE)
+        )
+        k = KubernetesPodOperator(
+            task_id="task",
+            get_logs=True,
+            deferrable=True,
+        )
+        # Patch tenacity wait to avoid real delays in tests
+        k._write_logs.retry.wait = tenacity.wait_none()
+        self.run_pod_async(k)
+        assert mocked_client.read_namespaced_pod_log.call_count == 2
+        post_complete_action.assert_called_once()
+
+    @patch(KUB_OP_PATH.format("post_complete_action"))
+    @patch(KUB_OP_PATH.format("client"))
+    @patch(HOOK_CLASS)
+    @patch(KUB_OP_PATH.format("pod_manager"))
+    def test_write_logs_gives_up_after_max_retries(
+        self, mock_manager, mocked_hook, mocked_client, post_complete_action, caplog
+    ):
+        """Test that _write_logs gives up after 3 failed attempts and trigger_reentry catches the error."""
+        mocked_client.read_namespaced_pod_log.side_effect = ApiException(status=500)
+        mock_manager.await_pod_completion.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name=TEST_NAME, namespace=TEST_NAMESPACE)
+        )
+        mocked_hook.return_value.get_pod.return_value = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name=TEST_NAME, namespace=TEST_NAMESPACE)
+        )
+        k = KubernetesPodOperator(
+            task_id="task",
+            get_logs=True,
+            deferrable=True,
+        )
+        # Patch tenacity wait to avoid real delays in tests
+        k._write_logs.retry.wait = tenacity.wait_none()
+        self.run_pod_async(k)
+        # 3 attempts (stop_after_attempt(3))
+        assert mocked_client.read_namespaced_pod_log.call_count > 1
+        # trigger_reentry catches the error and continues; post_complete_action still called via _clean
+        post_complete_action.assert_called_once()
+        assert "Reading of logs interrupted with error" in caplog.text
 
     @pytest.mark.parametrize(
         ("log_pod_spec_on_failure", "expect_match"),

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -46,7 +46,7 @@ from airflow.providers.common.compat.sdk import (
     AirflowSkipException,
     TaskDeferred,
 )
-from airflow.sdk import timezone
+from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Description

This PR adds retries using Tenacity to the `_write_logs` method in `KubernetesPodOperator`.
Previously, this method was logging `Reading of logs interrupted with error ...; will retry.` when it encountered an ApiException or HTTPError - but actually it did not retry (maybe the retry logic went missing during some refactoring?).

Apart from adding retries, the behaviour is kept the same: If all retries fail, `KubernetesPodOperator` will print another warning but then proceed with pod cleanup.

### Other changes

- Replace `from airflow.utils import timezone` with `from airflow.sdk import timezone` - this was consistently failing for me in pre-push hooks otherwise, I assume this is needed now
- Fix order of mocks in `test_async_write_logs_handler_api_exception` test

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  GitHub Copilot - Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
