### PR TITLE
Fix LocalExecutor crash on non-picklable exceptions (e.g. httpx.HTTPStatusError)

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -64,9 +64,14 @@ def _get_executor_process_title_prefix(team_name: str | None) -> str:
     return f"airflow worker -- LocalExecutor{team_suffix}:"
 
 
-def _safe_exception_for_ipc(e: Exception) -> tuple[str, str]:
-    """Return (exc_type, exc_message) safe to send over multiprocessing.Queue."""
-    return (type(e).__name__, str(e))
+def _safe_exception_for_ipc(e: Exception) -> Exception:
+    """
+    Wrap an exception in a pickle-safe Exception for IPC over multiprocessing.Queue.
+
+    Some exceptions (e.g. httpx.HTTPStatusError) are not picklable and will crash
+    the scheduler if sent raw.
+    """
+    return Exception(f"{type(e).__name__}: {e}")
 
 
 def _run_worker(

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -30,6 +30,7 @@ import multiprocessing
 import multiprocessing.sharedctypes
 import os
 import sys
+import traceback
 from multiprocessing import Queue, SimpleQueue
 from typing import TYPE_CHECKING
 
@@ -106,7 +107,8 @@ def _run_worker(
                 output.put((workload.ti.key, TaskInstanceState.SUCCESS, None))
             except Exception as e:
                 log.exception("Task execution failed.")
-                output.put((workload.ti.key, TaskInstanceState.FAILED, e))
+                safe_exc = Exception(f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}")
+                output.put((workload.ti.key, TaskInstanceState.FAILED, safe_exc))
 
         elif isinstance(workload, workloads.ExecuteCallback):
             output.put((workload.callback.id, CallbackState.RUNNING, None))
@@ -115,7 +117,8 @@ def _run_worker(
                 output.put((workload.callback.id, CallbackState.SUCCESS, None))
             except Exception as e:
                 log.exception("Callback execution failed")
-                output.put((workload.callback.id, CallbackState.FAILED, e))
+                safe_exc = Exception(f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}")
+                output.put((workload.callback.id, CallbackState.FAILED, safe_exc))
 
         else:
             raise ValueError(f"LocalExecutor does not know how to handle {type(workload)}")

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -30,7 +30,6 @@ import multiprocessing
 import multiprocessing.sharedctypes
 import os
 import sys
-import traceback
 from multiprocessing import Queue, SimpleQueue
 from typing import TYPE_CHECKING
 
@@ -63,6 +62,11 @@ def _get_executor_process_title_prefix(team_name: str | None) -> str:
     """
     team_suffix = f" [{team_name}]" if team_name else ""
     return f"airflow worker -- LocalExecutor{team_suffix}:"
+
+
+def _safe_exception_for_ipc(e: Exception) -> tuple[str, str]:
+    """Return (exc_type, exc_message) safe to send over multiprocessing.Queue."""
+    return (type(e).__name__, str(e))
 
 
 def _run_worker(
@@ -107,8 +111,8 @@ def _run_worker(
                 output.put((workload.ti.key, TaskInstanceState.SUCCESS, None))
             except Exception as e:
                 log.exception("Task execution failed.")
-                safe_exc = Exception(f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}")
-                output.put((workload.ti.key, TaskInstanceState.FAILED, safe_exc))
+                exc_info = _safe_exception_for_ipc(e)
+                output.put((workload.ti.key, TaskInstanceState.FAILED, exc_info))
 
         elif isinstance(workload, workloads.ExecuteCallback):
             output.put((workload.callback.id, CallbackState.RUNNING, None))
@@ -117,8 +121,8 @@ def _run_worker(
                 output.put((workload.callback.id, CallbackState.SUCCESS, None))
             except Exception as e:
                 log.exception("Callback execution failed")
-                safe_exc = Exception(f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}")
-                output.put((workload.callback.id, CallbackState.FAILED, safe_exc))
+                exc_info = _safe_exception_for_ipc(e)
+                output.put((workload.callback.id, CallbackState.FAILED, exc_info))
 
         else:
             raise ValueError(f"LocalExecutor does not know how to handle {type(workload)}")
@@ -298,9 +302,9 @@ class LocalExecutor(BaseExecutor):
 
     def _read_results(self):
         while not self.result_queue.empty():
-            key, state, exc = self.result_queue.get()
+            key, state, exc_info = self.result_queue.get()
 
-            self.change_state(key, state)
+            self.change_state(key, state, info=exc_info)
 
     def end(self) -> None:
         """End the executor."""

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -237,7 +237,9 @@ class TestLocalExecutor:
             executor.end()
 
         assert executor.event_buffer[ti.key][0] == State.FAILED
-        assert executor.event_buffer[ti.key][1] == ("UnpicklableError", "non-picklable failure")
+        failure_info = executor.event_buffer[ti.key][1]
+        assert isinstance(failure_info, Exception)
+        assert "UnpicklableError" in str(failure_info)
 
     @mock.patch("airflow.executors.local_executor.LocalExecutor.sync")
     @mock.patch("airflow.executors.base_executor.BaseExecutor.trigger_tasks")

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -195,6 +195,50 @@ class TestLocalExecutor:
             assert executor.event_buffer[ti.key][0] == State.SUCCESS
         assert executor.event_buffer[fail_ti.key][0] == State.FAILED
 
+    @skip_non_fork_mp_start
+    @mock.patch("airflow.sdk.execution_time.supervisor.supervise")
+    def test_non_picklable_exception_does_not_crash_executor(self, mock_supervise):
+        class UnpicklableError(Exception):
+            def __reduce__(self):
+                raise TypeError("cannot pickle")
+
+        mock_supervise.side_effect = UnpicklableError("non-picklable failure")
+        executor = LocalExecutor(parallelism=1)
+        ti = TaskInstanceDTO(
+            id=uuid7(),
+            dag_version_id=uuid7(),
+            task_id="non_picklable_error_task",
+            dag_id="mydag",
+            run_id="run1",
+            try_number=1,
+            state="queued",
+            pool_slots=1,
+            queue="default",
+            priority_weight=1,
+            map_index=-1,
+            start_date=timezone.utcnow(),
+        )
+
+        executor.start()
+        try:
+            executor.queue_workload(
+                workloads.ExecuteTask(
+                    token="",
+                    ti=ti,
+                    dag_rel_path="some/path",
+                    log_path=None,
+                    bundle_info=dict(name="hi", version="hi"),
+                ),
+                session=mock.MagicMock(spec=Session),
+            )
+            executor._process_workloads(list(executor.queued_tasks.values()))
+        finally:
+            # This should not raise even when worker hits an unpicklable exception.
+            executor.end()
+
+        assert executor.event_buffer[ti.key][0] == State.FAILED
+        assert executor.event_buffer[ti.key][1] == ("UnpicklableError", "non-picklable failure")
+
     @mock.patch("airflow.executors.local_executor.LocalExecutor.sync")
     @mock.patch("airflow.executors.base_executor.BaseExecutor.trigger_tasks")
     @mock.patch("airflow.executors.base_executor.Stats.gauge")


### PR DESCRIPTION
﻿Closes #64476

When LocalExecutor runs a task in a subprocess, exceptions are passed back via multiprocessing.Queue using pickle. Some exceptions like httpx.HTTPStatusError are not pickle-safe, causing:

    TypeError: HTTPStatusError.__init__() missing 2 required keyword-only arguments: 'request' and 'response'

This crashes the scheduler loop and takes down the entire scheduler pod.

## Root Cause
Raw exception objects were placed directly onto the result queue:

    output.put((key, TaskInstanceState.FAILED, e))

## Fix
Wrap the exception in a plain Exception before queuing:

    safe_exc = Exception(f"{type(e).__name__}: {str(e)}\n{traceback.format_exc()}")
    output.put((key, TaskInstanceState.FAILED, safe_exc))

Applied to both ExecuteTask and ExecuteCallback branches.

## Impact
- Scheduler no longer crashes on non-picklable exceptions
- Full debugging info preserved
- Minimal change, no other executor behaviour affected
