### PR TITLE
Fix e2e tests failing on release branches due to docker compose pull

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
@@ -158,9 +158,9 @@ def spin_up_airflow_environment(tmp_path_factory: pytest.TempPathFactory):
     #
     os.environ["FERNET_KEY"] = generate_fernet_key_string()
 
-    # If we are using the image from ghcr.io/apache/airflow/main we do not pull
+    # If we are using the image from ghcr.io/apache/airflow we do not pull
     # as it is already available and loaded using prepare_breeze_and_image step in workflow
-    pull = False if DOCKER_IMAGE.startswith("ghcr.io/apache/airflow/main/") else True
+    pull = False if DOCKER_IMAGE.startswith("ghcr.io/apache/airflow/") else True
 
     try:
         console.print(f"[blue]Spinning up airflow environment using {DOCKER_IMAGE}")


### PR DESCRIPTION
## Summary
- The e2e test `conftest.py` hardcoded `ghcr.io/apache/airflow/main/` as the only prefix
  to skip `docker compose pull`. On release branches (e.g. `v3-2-test`), the image name
  is `ghcr.io/apache/airflow/v3-2-test/prod/python3.10`, which didn't match, so
  `pull=True` was set and `docker compose pull` tried to fetch the image from GHCR —
  where it doesn't exist.
- The image is already loaded locally from CI artifacts via the `prepare_breeze_and_image`
  step, so pulling is unnecessary for any `ghcr.io/apache/airflow/` image. This matches
  how the UI e2e tests work — they use `docker compose up -d` directly without pulling.
- Broadened the prefix check from `ghcr.io/apache/airflow/main/` to
  `ghcr.io/apache/airflow/` so all branches (main, v3-2-test, future release branches)
  skip the pull and use the locally loaded image.


Failing test in v3-2-test https://github.com/apache/airflow/actions/runs/23756910688/job/69224619173?pr=64469

- [X] Yes (please specify the tool below)
Claude
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
