### PR TITLE
Fix SecretCache import failure on Python 3.14 multiprocessing

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/cache.py
+++ b/task-sdk/src/airflow/sdk/execution_time/cache.py
@@ -21,7 +21,6 @@ import datetime
 import multiprocessing
 
 from airflow.sdk import timezone
-from airflow.sdk.configuration import conf
 
 
 class SecretCache:
@@ -55,6 +54,8 @@ class SecretCache:
         """
         if cls._cache is not None:
             return
+        from airflow.sdk.configuration import conf
+
         use_cache = conf.getboolean(section="secrets", key="use_cache", fallback=False)
         if not use_cache:
             return


### PR DESCRIPTION
The `conf` object in `airflow.sdk.configuration` is lazily initialized via `__getattr__`. Importing it at module level in `cache.py` causes `ImportError` when the module is deserialized in a multiprocessing child process on Python 3.14. Moving the import into `SecretCache.init()` where it's actually used avoids this issue.


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)