### PR TITLE
Support all bq load job and ext table config options in GCSToBigQueryOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +37,7 @@ from google.cloud.bigquery import (
 )
 from google.cloud.bigquery.table import EncryptionConfiguration, Table, TableReference
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import AirflowException, conf
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -136,7 +138,15 @@ class GCSToBigQueryOperator(BaseOperator):
         future executions, you can pick up from the max ID.
     :param schema_update_options: Allows the schema of the destination
         table to be updated as a side effect of the load job.
-    :param src_fmt_configs: configure optional fields specific to the source format
+    :param src_fmt_configs: (Deprecated) configure optional fields specific to the source format.
+        Use ``extra_config`` instead.
+    :param extra_config: Dict of additional properties to merge into the BigQuery job configuration.
+        When ``external_table=False``, merged into the load job configuration
+        (see `JobConfigurationLoad <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad>`_).
+        When ``external_table=True``, merged into the external table configuration
+        (see `ExternalDataConfiguration <https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration>`_).
+        Merged after all top-level params, so keys here take precedence over overlapping top-level
+        operator params.
     :param external_table: Flag to specify if the destination table should be
         a BigQuery external table. Default Value is False.
     :param time_partitioning: configure optional time partitioning fields i.e.
@@ -189,6 +199,7 @@ class GCSToBigQueryOperator(BaseOperator):
         "destination_project_dataset_table",
         "impersonation_chain",
         "src_fmt_configs",
+        "extra_config",
     )
     template_ext: Sequence[str] = (".sql",)
     ui_color = "#f0eee4"
@@ -219,6 +230,7 @@ class GCSToBigQueryOperator(BaseOperator):
         gcp_conn_id="google_cloud_default",
         schema_update_options=(),
         src_fmt_configs=None,
+        extra_config: dict | None = None,
         external_table=False,
         time_partitioning=None,
         range_partitioning=None,
@@ -289,6 +301,13 @@ class GCSToBigQueryOperator(BaseOperator):
 
         self.schema_update_options = schema_update_options
         self.src_fmt_configs = src_fmt_configs
+        if src_fmt_configs:
+            warnings.warn(
+                "The 'src_fmt_configs' parameter is deprecated. Use 'extra_config' instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
+        self.extra_config = extra_config
         self.time_partitioning = time_partitioning
         self.range_partitioning = range_partitioning
         self.cluster_fields = cluster_fields
@@ -570,6 +589,9 @@ class GCSToBigQueryOperator(BaseOperator):
             )
             external_config_api_repr[src_fmt_to_param_mapping[self.source_format]] = self.src_fmt_configs
 
+        if self.extra_config:
+            external_config_api_repr.update(self.extra_config)
+
         external_config = ExternalConfig.from_api_repr(external_config_api_repr)
         if self.schema_fields:
             external_config.schema = [SchemaField.from_api_repr(f) for f in self.schema_fields]
@@ -728,6 +750,10 @@ class GCSToBigQueryOperator(BaseOperator):
 
         if self.allow_jagged_rows:
             self.configuration["load"]["allowJaggedRows"] = self.allow_jagged_rows
+
+        if self.extra_config:
+            self.configuration["load"].update(self.extra_config)
+
         return self.configuration
 
     def _validate_src_fmt_configs(

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -138,14 +138,17 @@ class GCSToBigQueryOperator(BaseOperator):
     :param schema_update_options: Allows the schema of the destination
         table to be updated as a side effect of the load job.
     :param src_fmt_configs: (Deprecated) configure optional fields specific to the source format.
-        Use ``extra_config`` instead.
-    :param extra_config: Dict of additional properties to merge into the BigQuery job configuration.
-        When ``external_table=False``, merged into the load job configuration
+        Use ``extra_config`` instead. Note when migrating that ``extra_config`` uses the fully-nested API
+        structure, so format-specific options must be nested under their parent key
+        (e.g., ``{"parquetOptions": {"enableListInference": True}}`` rather than
+        ``{"enableListInference": True}``).
+    :param extra_config: Dict of additional properties to apply over the BigQuery job configuration.
+        When ``external_table=False``, applied over the load job configuration
         (see `JobConfigurationLoad <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#JobConfigurationLoad>`_).
-        When ``external_table=True``, merged into the external table configuration
+        When ``external_table=True``, applied over the external table configuration
         (see `ExternalDataConfiguration <https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ExternalDataConfiguration>`_).
-        Merged after all top-level params, so keys here take precedence over overlapping top-level
-        operator params.
+        Applied after all top-level params, so keys here take precedence over overlapping top-level
+        operator params. Nested dicts are replaced entirely, not deep-merged.
     :param external_table: Flag to specify if the destination table should be
         a BigQuery external table. Default Value is False.
     :param time_partitioning: configure optional time partitioning fields i.e.
@@ -302,7 +305,11 @@ class GCSToBigQueryOperator(BaseOperator):
         self.src_fmt_configs = src_fmt_configs
         if src_fmt_configs:
             warnings.warn(
-                "The 'src_fmt_configs' parameter is deprecated. Use 'extra_config' instead.",
+                "The 'src_fmt_configs' parameter is deprecated. Use 'extra_config' instead. "
+                "Note: 'extra_config' uses the fully-nested API structure, so format-specific "
+                "options must be nested under their parent key "
+                "(e.g., {'parquetOptions': {'enableListInference': True}} rather than "
+                "{'enableListInference': True}).",
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -32,7 +32,6 @@ from google.cloud.bigquery import (
     ExtractJob,
     LoadJob,
     QueryJob,
-    SchemaField,
     UnknownJob,
 )
 from google.cloud.bigquery.table import EncryptionConfiguration, Table, TableReference
@@ -589,14 +588,15 @@ class GCSToBigQueryOperator(BaseOperator):
             )
             external_config_api_repr[src_fmt_to_param_mapping[self.source_format]] = self.src_fmt_configs
 
+        if self.schema_fields:
+            external_config_api_repr["schema"] = {"fields": self.schema_fields}
+        if self.max_bad_records:
+            external_config_api_repr["maxBadRecords"] = self.max_bad_records
+
         if self.extra_config:
             external_config_api_repr.update(self.extra_config)
 
         external_config = ExternalConfig.from_api_repr(external_config_api_repr)
-        if self.schema_fields:
-            external_config.schema = [SchemaField.from_api_repr(f) for f in self.schema_fields]
-        if self.max_bad_records:
-            external_config.max_bad_records = self.max_bad_records
 
         # build table definition
         table = Table(

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -1979,6 +1979,74 @@ class TestGCSToBigQueryOperator:
         assert table_resource["externalDataConfiguration"]["maxBadRecords"] == 10
 
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_max_bad_records_set_from_top_level_param_in_external_table(self, hook):
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            max_bad_records=5,
+        )
+
+        operator.execute(context=MagicMock())
+
+        table_resource = hook.return_value.create_table.call_args[1]["table_resource"]
+        assert table_resource["externalDataConfiguration"]["maxBadRecords"] == 5
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_takes_precedence_over_max_bad_records_in_external_table(self, hook):
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            max_bad_records=5,
+            extra_config={"maxBadRecords": 10},
+        )
+
+        operator.execute(context=MagicMock())
+
+        table_resource = hook.return_value.create_table.call_args[1]["table_resource"]
+        assert table_resource["externalDataConfiguration"]["maxBadRecords"] == 10
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_takes_precedence_over_schema_fields_in_external_table(self, hook):
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        override_schema = [{"name": "override_col", "type": "INTEGER", "mode": "NULLABLE"}]
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            extra_config={"schema": {"fields": override_schema}},
+        )
+
+        operator.execute(context=MagicMock())
+
+        table_resource = hook.return_value.create_table.call_args[1]["table_resource"]
+        assert table_resource["externalDataConfiguration"]["schema"]["fields"] == override_schema
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_src_fmt_configs_emits_deprecation_warning(self, hook):
         hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
         hook.return_value.generate_job_id.return_value = REAL_JOB_ID

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -27,6 +27,7 @@ from google.cloud.bigquery import DEFAULT_RETRY, Table
 from google.cloud.exceptions import Conflict
 from sqlalchemy import select
 
+from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.trigger import Trigger
 from airflow.providers.common.compat.openlineage.facet import (
     ColumnLineageDatasetFacet,
@@ -1739,20 +1740,21 @@ class TestGCSToBigQueryOperator:
         hook.return_value.generate_job_id.return_value = REAL_JOB_ID
         hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
 
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            schema_fields=SCHEMA_FIELDS,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=True,
-            project_id=JOB_PROJECT_ID,
-            source_format="PARQUET",
-            src_fmt_configs={
-                "enableListInference": True,
-            },
-        )
+        with pytest.warns(AirflowProviderDeprecationWarning, match="src_fmt_configs"):
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                schema_fields=SCHEMA_FIELDS,
+                write_disposition=WRITE_DISPOSITION,
+                external_table=True,
+                project_id=JOB_PROJECT_ID,
+                source_format="PARQUET",
+                src_fmt_configs={
+                    "enableListInference": True,
+                },
+            )
 
         operator.execute(context=MagicMock())
 
@@ -1841,19 +1843,20 @@ class TestGCSToBigQueryOperator:
         ]
         hook.return_value.generate_job_id.return_value = REAL_JOB_ID
         hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            write_disposition=WRITE_DISPOSITION,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            external_table=False,
-            project_id=JOB_PROJECT_ID,
-            source_format="PARQUET",
-            src_fmt_configs={
-                "enableListInference": True,
-            },
-        )
+        with pytest.warns(AirflowProviderDeprecationWarning, match="src_fmt_configs"):
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                write_disposition=WRITE_DISPOSITION,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                external_table=False,
+                project_id=JOB_PROJECT_ID,
+                source_format="PARQUET",
+                src_fmt_configs={
+                    "enableListInference": True,
+                },
+            )
 
         operator.execute(context=MagicMock())
 
@@ -1887,6 +1890,140 @@ class TestGCSToBigQueryOperator:
         ]
 
         hook.return_value.insert_job.assert_has_calls(calls)
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_is_merged_into_load_config(self, hook):
+        hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            project_id=JOB_PROJECT_ID,
+            extra_config={"columnNameCharacterMap": "STRICT"},
+        )
+
+        operator.execute(context=MagicMock())
+
+        config = hook.return_value.insert_job.call_args[1]["configuration"]
+        assert config["load"]["columnNameCharacterMap"] == "STRICT"
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_takes_precedence_over_top_level_params(self, hook):
+        hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            project_id=JOB_PROJECT_ID,
+            autodetect=True,
+            extra_config={"autodetect": False},
+        )
+
+        operator.execute(context=MagicMock())
+
+        config = hook.return_value.insert_job.call_args[1]["configuration"]
+        assert config["load"]["autodetect"] is False
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_with_nested_format_options(self, hook):
+        hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            project_id=JOB_PROJECT_ID,
+            source_format="PARQUET",
+            extra_config={"parquetOptions": {"enableListInference": True}},
+        )
+
+        operator.execute(context=MagicMock())
+
+        config = hook.return_value.insert_job.call_args[1]["configuration"]
+        assert config["load"]["parquetOptions"] == {"enableListInference": True}
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_extra_config_is_merged_into_external_config(self, hook):
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            schema_fields=SCHEMA_FIELDS,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            project_id=JOB_PROJECT_ID,
+            extra_config={"maxBadRecords": 10},
+        )
+
+        operator.execute(context=MagicMock())
+
+        table_resource = hook.return_value.create_table.call_args[1]["table_resource"]
+        assert table_resource["externalDataConfiguration"]["maxBadRecords"] == 10
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_src_fmt_configs_emits_deprecation_warning(self, hook):
+        hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        with pytest.warns(AirflowProviderDeprecationWarning, match="src_fmt_configs"):
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                write_disposition=WRITE_DISPOSITION,
+                project_id=JOB_PROJECT_ID,
+                src_fmt_configs={"skipLeadingRows": 1},
+            )
+
+        operator.execute(context=MagicMock())
+
+        config = hook.return_value.insert_job.call_args[1]["configuration"]
+        assert config["load"]["skipLeadingRows"] == 1
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_src_fmt_configs_and_extra_config_both_applied_with_precedence(self, hook):
+        hook.return_value.insert_job.return_value = MagicMock(job_id=REAL_JOB_ID, error_result=False)
+        hook.return_value.generate_job_id.return_value = REAL_JOB_ID
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+
+        with pytest.warns(AirflowProviderDeprecationWarning, match="src_fmt_configs"):
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                write_disposition=WRITE_DISPOSITION,
+                project_id=JOB_PROJECT_ID,
+                src_fmt_configs={"skipLeadingRows": 1},
+                extra_config={"skipLeadingRows": 5, "columnNameCharacterMap": "STRICT"},
+            )
+
+        operator.execute(context=MagicMock())
+
+        config = hook.return_value.insert_job.call_args[1]["configuration"]
+        # extra_config wins for overlapping key
+        assert config["load"]["skipLeadingRows"] == 5
+        assert config["load"]["columnNameCharacterMap"] == "STRICT"
 
 
 @pytest.fixture


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## Description 

Adds an ``extra_config`` parameter that is merged into the BigQuery load job configuration (when ``external_table=False``) or the external table configuration (when ``external_table=True``), allowing callers to set any API field not exposed as a top-level operator param without subclassing.

Deprecates ``src_fmt_configs`` in favor of ``extra_config``.

### Rationale 

GCSToBigQueryOperator explicitly validates every parameter it accepts against a known list of valid BigQuery configuration fields. This makes it impossible to use any API option that isn't already exposed as a top-level operator param without subclassing or monkey-patching. In order to support all possible configuration options, we'd need to add a lot of complexity to the operator, and we'd need to change it any time google added a parameter.

Rather than continuing to add individual params for every possible API option, this PR adds a single extra_config dict that is merged directly into the underlying BigQuery configuration at execution time — into `JobConfigurationLoad` when loading into an existing table, or into `ExternalDataConfiguration` when creating an external table. Keys in `extra_config` take precedence over the operator's own top-level params (just as keys in `src_format_configs` took precedence over the top level params.

This follows a similar pattern to the `configuration` passthrough in `BigQueryInsertJobOperator`.

### Testing

- Added unit tests and ran tests to ensure they pass
- Ran airflow locally and ran an integration test using a custom dag

Parquet list inference using extra_config and external table

```
    gcs_to_bq_task = GCSToBigQueryOperator(
        task_id="gcs_to_bigquery_parquet_ext_table_options",
        bucket="etldata-prod-adhoc-data-hkwv8r",
        source_objects=["user/mlauter/gcs_to_bq_parquet/input/part-00007-9c1d416d-505b-490e-b783-31ba43a6befc-c000.snappy.parquet"],
        destination_project_dataset_table="etsy-data-warehouse-dev.mlauter.gcs_to_bigquery_parquet_list_test_ext_table",
        source_format="PARQUET",
        write_disposition="WRITE_TRUNCATE",
        external_table=True,
        extra_config={"parquetOptions": {"enableListInference": True}},
    )
```

<img width="543" height="529" alt="extra_config_ext_table" src="https://github.com/user-attachments/assets/9f66e3b4-49eb-414c-9d93-58fd73741a60" />


Parquet list inference using extra config 
```
    gcs_to_bq_task = GCSToBigQueryOperator(
        task_id="gcs_to_bigquery_parquet_options",
        bucket="etldata-prod-adhoc-data-hkwv8r",
        source_objects=["user/mlauter/gcs_to_bq_parquet/input/part-00007-9c1d416d-505b-490e-b783-31ba43a6befc-c000.snappy.parquet"],
        destination_project_dataset_table="etsy-data-warehouse-dev.mlauter.gcs_to_bigquery_parquet_list_test",
        source_format="PARQUET",
        write_disposition="WRITE_TRUNCATE",
        extra_config={"parquetOptions": {"enableListInference": True}, "columnNameCharacterMap": "V2"},
    )
```

<img width="543" height="529" alt="extra_config_load_job" src="https://github.com/user-attachments/assets/8878a6f5-6965-4e23-8a3e-a731ea37dacd" />

Dag succeeded and tables were created as expected. The parquet option here is not related to the PR, its just a setting I'm familiar with, and I was confirming that configuration options passed in `extra_config` indeed work.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
