### PR TITLE
Fix: Use a short-live session instead of passing sessionDeps into DagRunWaiter

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -566,7 +566,6 @@ def wait_dag_run_until_finished(
         run_id=dag_run_id,
         interval=interval,
         result_task_ids=result_task_ids,
-        session=session,
     )
     return StreamingResponse(waiter.wait())
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any
 import attrs
 from sqlalchemy import select
 
-from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.models.dagrun import DagRun
 from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
 from airflow.utils.session import create_session_async
@@ -34,8 +33,6 @@ from airflow.utils.state import State
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterator
-
-    from sqlalchemy import ScalarResult
 
 
 @attrs.define
@@ -46,22 +43,22 @@ class DagRunWaiter:
     run_id: str
     interval: float
     result_task_ids: list[str] | None
-    session: SessionDep
 
     async def _get_dag_run(self) -> DagRun:
         async with create_session_async() as session:
             return await session.scalar(select(DagRun).filter_by(dag_id=self.dag_id, run_id=self.run_id))
 
-    def _serialize_xcoms(self) -> dict[str, Any]:
+    async def _serialize_xcoms(self) -> dict[str, Any]:
         xcom_query = XComModel.get_many(
             run_id=self.run_id,
             key=XCOM_RETURN_KEY,
             task_ids=self.result_task_ids,
             dag_ids=self.dag_id,
         )
-        xcom_results: ScalarResult[tuple[XComModel]] = self.session.scalars(
-            xcom_query.order_by(XComModel.task_id, XComModel.map_index)
-        )
+        async with create_session_async() as session:
+            xcom_results = (
+                await session.scalars(xcom_query.order_by(XComModel.task_id, XComModel.map_index))
+            ).all()
 
         def _group_xcoms(g: Iterator[XComModel | tuple[XComModel]]) -> Any:
             entries = [row[0] if isinstance(row, tuple) else row for row in g]
@@ -74,18 +71,18 @@ class DagRunWaiter:
             for task_id, g in itertools.groupby(xcom_results, key=operator.attrgetter("task_id"))
         }
 
-    def _serialize_response(self, dag_run: DagRun) -> str:
+    async def _serialize_response(self, dag_run: DagRun) -> str:
         resp = {"state": dag_run.state}
         if dag_run.state not in State.finished_dr_states:
             return json.dumps(resp)
         if self.result_task_ids:
-            resp["results"] = self._serialize_xcoms()
+            resp["results"] = await self._serialize_xcoms()
         return json.dumps(resp)
 
     async def wait(self) -> AsyncGenerator[str, None]:
-        yield self._serialize_response(dag_run := await self._get_dag_run())
+        yield await self._serialize_response(dag_run := await self._get_dag_run())
         yield "\n"
         while dag_run.state not in State.finished_dr_states:
             await asyncio.sleep(self.interval)
-            yield self._serialize_response(dag_run := await self._get_dag_run())
+            yield await self._serialize_response(dag_run := await self._get_dag_run())
             yield "\n"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: #64415 

### Why

The `SessionDep` session is held open from the moment the endpoint function starts until the `StreamingResponse` generator is fully consumed and FastAPI cleans up the dependency. During the polling loop (while `dag_run.state` not in `State.finished_dr_states: await asyncio.sleep(self.interval)`), the sync DB connection sits idle but checked out from the pool. If a DAG run takes minutes or hours to complete, that connection is locked for the entire duration. With many concurrent `/wait` requests, this can exhaust the connection pool.

This PR improves the above by opening a short-live session in `_serialize_xcoms`, similar to what have been done in `_get_dag_run`. 

https://github.com/apache/airflow/pull/64415#discussion_r3007522560

### Test Cases

Tests should have been handled in **test_collect_task** and **test_should_respond_200_immediately_for_finished_run** 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude Code Opus 4.6] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
