### PR TITLE
Fix SecretCache import error in Python 3.14 with pytest-xdist

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/cache.py
+++ b/task-sdk/src/airflow/sdk/execution_time/cache.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import datetime
 import multiprocessing
 
-from airflow.sdk import timezone
-
 
 class SecretCache:
     """A static class to manage the global secret cache."""
@@ -35,10 +33,14 @@ class SecretCache:
 
     class _CacheValue:
         def __init__(self, value: str | None) -> None:
+            from airflow.sdk import timezone
+
             self.value = value
             self.date = timezone.utcnow()
 
         def is_expired(self, ttl: datetime.timedelta) -> bool:
+            from airflow.sdk import timezone
+
             return timezone.utcnow() - self.date > ttl
 
     _VARIABLE_PREFIX = "__v_"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

We noticed this recently and couple more times, one example: https://github.com/apache/airflow/actions/runs/23764195368/job/69256787158


Error:

```python
FAILED task-sdk/tests/task_sdk/execution_time/test_context_cache.py::TestVariableCacheIntegration::test_delete_variable_invalidates_cache - multiprocessing.managers.RemoteError: 
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/python/lib/python3.14/multiprocessing/managers.py", line 257, in serve_client
    request = recv()
  File "/usr/python/lib/python3.14/multiprocessing/connection.py", line 257, in recv
    return _ForkingPickler.loads(buf.getbuffer())
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/cache.py", line 24, in <module>
    from airflow.sdk.configuration import conf
ImportError: cannot import name 'conf' from 'airflow.sdk.configuration' (/opt/airflow/task-sdk/src/airflow/sdk/configuration.py)
```

Turns out that when running tests with `pytest-xdist` parallel execution for py 3.14, the multiprocessing manager subprocess fails to import the cache module due to a module-level timezone import that triggers conf initialization via `__getattr__`. In this specific subprocess context, the lazy module-level `__getattr__` mechanism does not work too reliably.

I have a fix that moves the timezone import from module-level to method-level
within `_CacheValue.__init__()` and `is_expired()`. This ensures that -
1. The cache module can be imported without triggering
   the conf import chain
2. The timezone functionality still works when `_CacheValue` is actually
   instantiated
3. No behavioral changes to the cache functionality
4. Tests pass both serially and with pytest-xdist parallel execution

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
