### PR TITLE
Add data-testid to task filter dropdowns for stable E2E selectors

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilterMulti.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/AttrSelectFilterMulti.tsx
@@ -22,6 +22,7 @@ import type { SelectValueChangeDetails } from "@chakra-ui/react";
 import { Select } from "src/components/ui";
 
 type Props = {
+  readonly dataTestId?: string;
   readonly displayPrefix: string | undefined;
   readonly handleSelect: (values: Array<CollectionItem>) => void;
   readonly placeholderText: string;
@@ -30,6 +31,7 @@ type Props = {
 };
 
 export const AttrSelectFilterMulti = ({
+  dataTestId,
   displayPrefix,
   handleSelect,
   placeholderText,
@@ -58,7 +60,7 @@ export const AttrSelectFilterMulti = ({
       onValueChange={handleValueChange}
       value={selectedValues}
     >
-      <Select.Trigger colorPalette="brand" minW="max-content">
+      <Select.Trigger colorPalette="brand" dataTestId={dataTestId} minW="max-content">
         <Select.ValueText placeholder={placeholderText} width="auto">
           {() => displayValue}
         </Select.ValueText>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/TaskFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Tasks/TaskFilters/TaskFilters.tsx
@@ -105,6 +105,7 @@ export const TaskFilters = ({ tasksData }: { readonly tasksData: TaskCollectionR
       </HStack>
       <HStack justifyContent="space-between">
         <AttrSelectFilterMulti
+          dataTestId="operator-filter"
           displayPrefix={undefined}
           handleSelect={handleSelectedOperators}
           placeholderText={translate("selectOperator")}
@@ -112,6 +113,7 @@ export const TaskFilters = ({ tasksData }: { readonly tasksData: TaskCollectionR
           values={allOperatorNames}
         />
         <AttrSelectFilterMulti
+          dataTestId="trigger-rule-filter"
           displayPrefix={undefined}
           handleSelect={handleSelectedTriggerRules}
           placeholderText={translate("selectTriggerRules")}
@@ -119,6 +121,7 @@ export const TaskFilters = ({ tasksData }: { readonly tasksData: TaskCollectionR
           values={allTriggerRules}
         />
         <AttrSelectFilterMulti
+          dataTestId="retries-filter"
           displayPrefix={translate("retries")}
           handleSelect={handleSelectedRetries}
           placeholderText={translate("selectRetryValues")}

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -58,9 +58,9 @@ export class DagsPage extends BasePage {
     this.stateElement = page.getByTestId("dag-run-state");
     this.searchBox = page.getByRole("textbox", { name: /search/i });
     this.searchInput = page.getByPlaceholder("Search DAGs");
-    this.operatorFilter = page.getByRole("combobox").filter({ hasText: /operator/i });
-    this.triggerRuleFilter = page.getByRole("combobox").filter({ hasText: /trigger/i });
-    this.retriesFilter = page.getByRole("combobox").filter({ hasText: /retr/i });
+    this.operatorFilter = page.getByTestId("operator-filter");
+    this.triggerRuleFilter = page.getByTestId("trigger-rule-filter");
+    this.retriesFilter = page.getByTestId("retries-filter");
     // View toggle buttons
     this.cardViewButton = page.getByRole("button", { name: "Show card view" });
     this.tableViewButton = page.getByRole("button", { name: "Show table view" });


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

The task filter dropdowns (operator, trigger rule, retries) previously used `getByRole("combobox").filter({ hasText: ... })` selectors in E2E tests.

These selectors are fragile against text changes and can match unintended elements, making tests flaky and harder to maintain.

This change introduces stable selectors using `data-testid`.
- `AttrSelectFilterMulti`: accept optional `dataTestId` prop to avoid impacting existing usages
- `TaskFilters`: pass stable, descriptive test IDs to each filter instance
- `DagsPage` E2E page object: switch to `getByTestId()` locators

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
