### PR TITLE
E2E: prevent Dag parsing races and improve Dag run cleanup

### DIFF
--- a/airflow-core/src/airflow/ui/playwright.config.ts
+++ b/airflow-core/src/airflow/ui/playwright.config.ts
@@ -50,7 +50,7 @@ export const AUTH_FILE = path.join(currentDirname, "playwright/.auth/user.json")
 
 export default defineConfig({
   expect: {
-    timeout: 5000,
+    timeout: 10_000,
   },
   forbidOnly: process.env.CI !== undefined && process.env.CI !== "",
   fullyParallel: true,

--- a/airflow-core/src/airflow/ui/tests/e2e/global-setup.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/global-setup.ts
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { chromium, firefox, webkit, type FullConfig } from "@playwright/test";
+import { chromium, firefox, request, webkit, type FullConfig } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 
 import { AUTH_FILE, testConfig } from "../../playwright.config";
 import { LoginPage } from "./pages/LoginPage";
+import { waitForDagReady } from "./utils/test-helpers";
 
 const browsers = { chromium, firefox, webkit };
 
@@ -52,6 +53,25 @@ async function globalSetup(config: FullConfig) {
     await context.storageState({ path: AUTH_FILE });
   } finally {
     await browser.close();
+  }
+
+  // Pre-warm: wait for all Dags used by E2E tests to be parsed before workers start.
+  const apiContext = await request.newContext({
+    baseURL,
+    storageState: AUTH_FILE,
+  });
+
+  try {
+    await Promise.all(
+      [
+        testConfig.testDag.id,
+        testConfig.testDag.hitlId,
+        testConfig.xcomDag.id,
+        "example_python_operator",
+      ].map((dagId) => waitForDagReady(apiContext, dagId, { timeout: 300_000 })),
+    );
+  } finally {
+    await apiContext.dispose();
   }
 }
 

--- a/airflow-core/src/airflow/ui/tests/e2e/global-teardown.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/global-teardown.ts
@@ -48,8 +48,8 @@ async function globalTeardown() {
         timeout: 10_000,
       });
     } catch (error) {
-      console.warn(
-        `[e2e teardown] Failed to re-pause DAG ${dagId}: ${error instanceof Error ? error.message : String(error)}`,
+      console.debug(
+        `[e2e teardown] Could not re-pause DAG ${dagId}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/airflow-core/src/airflow/ui/tests/e2e/utils/test-helpers.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/utils/test-helpers.ts
@@ -69,7 +69,7 @@ export async function waitForDagReady(
     .poll(
       async () => {
         try {
-          const response = await request.get(`${baseUrl}/api/v2/dags/${dagId}`, { timeout: 30_000 });
+          const response = await request.get(`${baseUrl}/api/v2/dags/${dagId}`, { timeout: 10_000 });
 
           return response.ok();
         } catch {
@@ -107,7 +107,7 @@ export async function apiTriggerDagRun(
         note: "e2e test",
       },
       headers: { "Content-Type": "application/json" },
-      timeout: 30_000,
+      timeout: 10_000,
     });
 
     if (!response.ok()) {
@@ -152,7 +152,7 @@ export async function apiCreateDagRun(source: RequestLike, dagId: string, data: 
         note: data.note ?? "e2e test",
       },
       headers: { "Content-Type": "application/json" },
-      timeout: 30_000,
+      timeout: 10_000,
     });
 
     if (!response.ok()) {
@@ -187,7 +187,7 @@ export async function apiSetDagRunState(
     const response = await request.patch(`${baseUrl}/api/v2/dags/${dagId}/dagRuns/${runId}`, {
       data: { state },
       headers: { "Content-Type": "application/json" },
-      timeout: 30_000,
+      timeout: 10_000,
     });
 
     if (response.status() !== 409 && !response.ok()) {
@@ -213,7 +213,7 @@ export async function waitForDagRunStatus(
       async () => {
         try {
           const response = await request.get(`${baseUrl}/api/v2/dags/${dagId}/dagRuns/${runId}`, {
-            timeout: 30_000,
+            timeout: 10_000,
           });
 
           if (!response.ok()) {
@@ -272,7 +272,7 @@ export async function waitForTaskInstanceState(
         try {
           const response = await request.get(
             `${baseUrl}/api/v2/dags/${dagId}/dagRuns/${runId}/taskInstances/${taskId}`,
-            { timeout: 30_000 },
+            { timeout: 10_000 },
           );
 
           if (!response.ok()) {
@@ -331,7 +331,7 @@ export async function apiRespondToHITL(
       {
         data: { chosen_options: chosenOptions, params_input: paramsInput },
         headers: { "Content-Type": "application/json" },
-        timeout: 30_000,
+        timeout: 10_000,
       },
     );
 
@@ -478,7 +478,7 @@ export async function apiDeleteDagRun(source: RequestLike, dagId: string, runId:
   const request = getRequestContext(source);
 
   const response = await request.delete(`${baseUrl}/api/v2/dags/${dagId}/dagRuns/${runId}`, {
-    timeout: 30_000,
+    timeout: 10_000,
   });
 
   // 404 = already deleted by another worker or cleanup; acceptable.
@@ -497,29 +497,40 @@ export async function apiDeleteDagRun(source: RequestLike, dagId: string, runId:
  * Delete a DAG run, logging (not throwing) unexpected errors.
  * Use this in fixture teardown where cleanup must not abort the loop.
  * 404 is already handled inside `apiDeleteDagRun`.
- * 409 (running state) is handled by force-failing the run first, then retrying.
+ *
+ * Strategy: force-fail the run first so the server doesn't wait for
+ * running tasks during deletion, then delete with one retry on timeout.
  */
 export async function safeCleanupDagRun(source: RequestLike, dagId: string, runId: string): Promise<void> {
-  try {
-    await apiDeleteDagRun(source, dagId, runId);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  const request = getRequestContext(source);
 
-    // 409 = DAG run is still running — force-fail, then retry deletion.
-    if (message.includes("409")) {
-      try {
-        await apiSetDagRunState(source, { dagId, runId, state: "failed" });
-        await apiDeleteDagRun(source, dagId, runId);
-      } catch (retryError) {
-        console.warn(
-          `[e2e cleanup] Retry failed for DAG run ${dagId}/${runId}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,
-        );
+  try {
+    await request.patch(`${baseUrl}/api/v2/dags/${dagId}/dagRuns/${runId}`, {
+      data: { state: "failed" },
+      headers: { "Content-Type": "application/json" },
+      timeout: 10_000,
+    });
+  } catch {
+    // Run may already be terminal or deleted — ignore.
+  }
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await apiDeleteDagRun(source, dagId, runId);
+
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isTimeout = message.includes("Timeout");
+
+      if (isTimeout && attempt === 0) {
+        continue;
       }
+
+      console.warn(`[e2e cleanup] Failed to delete DAG run ${dagId}/${runId}: ${message}`);
 
       return;
     }
-
-    console.warn(`[e2e cleanup] Failed to delete DAG run ${dagId}/${runId}: ${message}`);
   }
 }
 
@@ -549,7 +560,7 @@ export async function apiDeleteVariable(source: RequestLike, key: string): Promi
   const request = getRequestContext(source);
 
   const response = await request.delete(`${baseUrl}/api/v2/variables/${encodeURIComponent(key)}`, {
-    timeout: 30_000,
+    timeout: 10_000,
   });
 
   // 404 = already deleted by another worker or cleanup; acceptable.
@@ -569,7 +580,7 @@ export async function apiCancelBackfill(source: RequestLike, backfillId: number)
   const request = getRequestContext(source);
 
   const response = await request.put(`${baseUrl}/api/v2/backfills/${backfillId}/cancel`, {
-    timeout: 30_000,
+    timeout: 10_000,
   });
 
   if (response.status() !== 200 && response.status() !== 409) {
@@ -582,7 +593,7 @@ export async function apiCancelAllActiveBackfills(source: RequestLike, dagId: st
   const request = getRequestContext(source);
 
   const response = await request.get(`${baseUrl}/api/v2/backfills?dag_id=${dagId}&limit=100`, {
-    timeout: 30_000,
+    timeout: 10_000,
   });
 
   if (!response.ok()) {
@@ -611,7 +622,7 @@ export async function apiWaitForNoActiveBackfill(
       async () => {
         try {
           const response = await request.get(`${baseUrl}/api/v2/backfills?dag_id=${dagId}&limit=100`, {
-            timeout: 30_000,
+            timeout: 10_000,
           });
 
           if (!response.ok()) {
@@ -649,7 +660,7 @@ export async function apiWaitForBackfillComplete(
       async () => {
         try {
           const response = await request.get(`${baseUrl}/api/v2/backfills/${backfillId}`, {
-            timeout: 30_000,
+            timeout: 10_000,
           });
 
           if (!response.ok()) {
@@ -700,7 +711,7 @@ export async function apiCreateBackfill(
   const response = await request.post(`${baseUrl}/api/v2/backfills`, {
     data: body,
     headers: { "Content-Type": "application/json" },
-    timeout: 30_000,
+    timeout: 10_000,
   });
 
   if (response.status() === 409) {
@@ -710,7 +721,7 @@ export async function apiCreateBackfill(
     const retryResponse = await request.post(`${baseUrl}/api/v2/backfills`, {
       data: body,
       headers: { "Content-Type": "application/json" },
-      timeout: 30_000,
+      timeout: 10_000,
     });
 
     if (!retryResponse.ok()) {


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## Why
* Tests starting before Dags are parsed → API calls intermittently return 404 or stale state.
* Cleanup failing on running Dag runs (409) or timing out under CI load, leaving residual state that affects subsequent tests.

## Change
* **Pre-warm Dags in global setup**: Explicitly wait until all test Dags are present in the DagBag before Playwright workers start. This eliminates race conditions where tests begin before the scheduler has registered the Dags.
* **Normalize per-request timeouts to 10s**: Individual API call timeouts in polling helpers were 30s — unnecessarily long for calls that are retried in tight loops. Reduced to 10s so failures surface faster while polling still provides overall tolerance.
* **Harden Dag run cleanup**: `safeCleanupDagRun` now always force-fails the run before attempting deletion (instead of reacting to 409 conflicts after the fact), and retries once on timeout. This ensures the API does not block on active task execution during deletion.
* **Increase expect timeout to 10s**: Assertion timeout raised from 5s to 10s to reduce flaky failures on slower CI environments.

part of: #64024
related: #63036
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
