### PR TITLE
fix(ui): correct external link target and add rel attributes

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Tests for NothingFoundInfo component
+ *
+ * Ensures external documentation links use correct security attributes:
+ * - target="_blank"
+ * - rel="noopener noreferrer"
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { NothingFoundInfo } from "./NothingFoundInfo";
+
+describe("NothingFoundInfo", () => {
+  it("should have correct external link attributes", () => {
+    render(<NothingFoundInfo />);
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
@@ -1,7 +1,28 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+
 import { Wrapper } from "src/utils/Wrapper";
+
 import { NothingFoundInfo } from "./NothingFoundInfo";
 
 describe("NothingFoundInfo", () => {

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
@@ -1,19 +1,12 @@
-/**
- * Tests for NothingFoundInfo component
- *
- * Ensures external documentation links use correct security attributes:
- * - target="_blank"
- * - rel="noopener noreferrer"
- */
-
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
+import { Wrapper } from "src/utils/Wrapper";
 import { NothingFoundInfo } from "./NothingFoundInfo";
 
 describe("NothingFoundInfo", () => {
   it("should have correct external link attributes", () => {
-    render(<NothingFoundInfo />);
+    render(<NothingFoundInfo />, { wrapper: Wrapper });
 
     const link = screen.getByRole("link");
 

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
@@ -35,7 +35,7 @@ export const NothingFoundInfo = () => {
         <Text>{translate("connections.nothingFound.description")}</Text>
         <Text>
           {translate("connections.nothingFound.learnMore")}{" "}
-          <Link href={docsLink} target="blank">
+          <Link href={docsLink} rel="noopener noreferrer" target="_blank">
             {translate("connections.nothingFound.documentationLink")}
           </Link>
         </Text>


### PR DESCRIPTION
#64541

## Problem

Additionally, `NothingFoundInfo.tsx` was using `target="blank"` instead of the correct `target="_blank"`.

## Changes

* Updated external link attributes to use `target="_blank"` with `rel="noopener noreferrer"`
* Added tests to verify correct link behavior

## Result

* External links now open securely in a new tab
* Link attributes follow best practices
