### PR TITLE
Isolate uv cache for lowest-dependencies tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1457,36 +1457,56 @@ function check_force_lowest_dependencies() {
     if [[ ${FORCE_LOWEST_DEPENDENCIES=} != "true" ]]; then
         return
     fi
+    # Copy the shared uv cache to a per-test temporary directory so that parallel
+    # lowest-dependency tests do not interfere with each other. The temp directory
+    # is automatically cleaned up when the container is removed.
+    local tmp_cache
+    tmp_cache="$(mktemp -d /tmp/uv-cache-XXXXXX)"
+    if [[ -d /root/.cache/uv ]]; then
+        echo "${COLOR_BLUE}Copying shared uv cache to isolated temp cache: ${tmp_cache}${COLOR_RESET}"
+        cp -a /root/.cache/uv/. "${tmp_cache}"/
+    fi
+    export UV_CACHE_DIR="${tmp_cache}"
+    local project_dir
     if [[ ${TEST_TYPE=} =~ Providers\[.*\] ]]; then
         local provider_id
         # shellcheck disable=SC2001
         provider_id=$(echo "${TEST_TYPE}" | sed 's/Providers\[\(.*\)\]/\1/')
-        echo
-        echo "${COLOR_BLUE}Forcing dependencies to lowest versions for provider: ${provider_id}${COLOR_RESET}"
-        echo
+
         if ! /opt/airflow/scripts/in_container/is_provider_excluded.py "${provider_id}"; then
             echo
             echo "S${COLOR_YELLOW}Skipping ${provider_id} provider check on Python ${PYTHON_MAJOR_MINOR_VERSION}!${COLOR_RESET}"
             echo
             exit 0
         fi
-        cd "${AIRFLOW_SOURCES}/providers/${provider_id/.//}" || exit 1
+        echo
+        echo "${COLOR_BLUE}Forcing dependencies to lowest versions for provider: ${provider_id}${COLOR_RESET}"
+        echo
+        project_dir="${AIRFLOW_SOURCES}/providers/${provider_id/.//}" || exit 1
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        set -x
+        uv sync --project "${project_dir}" --resolution lowest-direct \
+            --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
+        set +x
     else
         echo
         echo "${COLOR_BLUE}Forcing dependencies to lowest versions for Airflow.${COLOR_RESET}"
         echo
-        cd "${AIRFLOW_SOURCES}/airflow-core"
+        project_dir="${AIRFLOW_SOURCES}/airflow-core"
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        set -x
+        uv sync --project "${project_dir}"--resolution lowest-direct \
+            --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
+        set +x
     fi
+    echo "Changing directory to ${project_dir}"
+    cd "${project_dir}"
 }
 
 function check_airflow_python_client_installation() {

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -431,6 +431,72 @@ def pull_images_for_docker_compose(shell_params: ShellParams):
     run_command(pull_cmd, output=None, check=False, env=env)
 
 
+def _warm_uv_cache_for_lowest_deps(shell_params: ShellParams) -> None:
+    """Run a single ``uv sync`` (normal resolution) so the shared uv cache is populated.
+
+    Each parallel lowest-deps test will copy this warm cache to its own temp
+    directory, avoiding redundant downloads across parallel containers.
+    """
+    console_print("\n[info]Warming up the shared uv cache before lowest-deps tests …[/]\n")
+    env = shell_params.env_variables_for_docker_commands
+    # Use normal resolution (not lowest-direct) and skip test execution —
+    # we only want to populate the shared uv cache.
+    env["SKIP_ENVIRONMENT_INITIALIZATION"] = "true"
+    env["FORCE_LOWEST_DEPENDENCIES"] = "false"
+    env["RUN_TESTS"] = "false"
+    compose_project_name = "airflow-warm-uv-cache"
+    down_cmd = [
+        "docker",
+        "compose",
+        "--project-name",
+        compose_project_name,
+        "down",
+        "--remove-orphans",
+        "--volumes",
+    ]
+    run_command(down_cmd, output=None, check=False, env=env)
+    # Run uv sync with normal resolution to download packages into the shared cache.
+    # --no-binary-package flags mirror what check_force_lowest_dependencies() uses.
+    run_cmd = [
+        "docker",
+        "compose",
+        "--project-name",
+        compose_project_name,
+        "run",
+        "-T",
+        "--rm",
+        "airflow",
+        "-c",
+        "uv sync --all-extras"
+        " --no-binary-package lxml --no-binary-package xmlsec"
+        " --no-python-downloads --no-managed-python",
+    ]
+    try:
+        console_print("[info]Running 'uv sync' with normal resolution to warm up the shared uv cache …[/]")
+        result = run_command(run_cmd, output=None, check=False, env=env)
+        if result.returncode != 0:
+            console_print("[warning]uv cache warm-up failed – tests will still run but may be slower[/]")
+    finally:
+        run_command(
+            [
+                "docker",
+                "compose",
+                "--project-name",
+                compose_project_name,
+                "rm",
+                "--stop",
+                "--force",
+                "-v",
+            ],
+            output=None,
+            check=False,
+            verbose_override=False,
+            quiet=True,
+        )
+        remove_docker_networks(networks=[f"{compose_project_name}_default"])
+    console_print("[success]uv cache warm-up complete[/]\n")
+
+
 def run_tests_in_parallel(
     shell_params: ShellParams,
     extra_pytest_args: tuple,
@@ -453,6 +519,8 @@ def run_tests_in_parallel(
     console_print("[info]Shell params:")
     console_print(shell_params.__dict__)
     pull_images_for_docker_compose(shell_params)
+    if shell_params.force_lowest_dependencies:
+        _warm_uv_cache_for_lowest_deps(shell_params)
     _run_tests_in_pool(
         tests_to_run=shell_params.parallel_test_types_list,
         parallelism=parallelism,

--- a/dev/registry/pyproject.toml
+++ b/dev/registry/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest"]
+dev = ["pytest>=9.0.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["registry_tools"]

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -29,20 +29,21 @@ classifiers = [
 
 dependencies = [
     "aioresponses>=0.7.6",
+    "apache-airflow-devel-common[basic]",
     "black>=26.1.0",
     "filelock>=3.13.0",
     "jmespath>=0.7.0",
     "kgb>=7.2.0",
+    "python-on-whales>=0.70.0",
     "requests_mock>=1.11.0",
     "rich>=13.6.0",
     "ruff==0.15.8",
     "semver>=3.0.2",
-    "typer-slim>=0.15.1",
+    "testcontainers>=4.12.0",
     "time-machine[dateutil]>=3.0.0",
+    "typer-slim>=0.15.1",
     "wheel>=0.42.0",
     "yamllint>=1.33.0",
-    "python-on-whales>=0.70.0",
-    "apache-airflow-devel-common[basic]"
 ]
 
 [project.optional-dependencies]
@@ -104,7 +105,7 @@ dependencies = [
     "sphinxcontrib-spelling>=8.0.0",
     # setuptools 82.0.0+ causes redoc to fail due to pkg_resources removal
     # until https://github.com/sphinx-contrib/redoc/issues/53 is resolved
-    "setuptools<82.0.0",
+    "setuptools>=80.0.0,<82.0.0",
 ]
 "docs-gen" = [
     "diagrams>=0.24.4",

--- a/providers/apache/spark/pyproject.toml
+++ b/providers/apache/spark/pyproject.toml
@@ -87,7 +87,7 @@ dev = [
     "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-openlineage",
-    "pyspark"
+    "pyspark>=4.0.0"
 ]
 
 # To build docs:

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -75,11 +75,11 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
-"anthropic" = ["pydantic-ai-slim[anthropic]"]
-"bedrock" = ["pydantic-ai-slim[bedrock]"]
-"google" = ["pydantic-ai-slim[google]"]
-"openai" = ["pydantic-ai-slim[openai]"]
-"mcp" = ["pydantic-ai-slim[mcp]"]
+"anthropic" = ["pydantic-ai-slim[anthropic]>=1.34.0"]
+"bedrock" = ["pydantic-ai-slim[bedrock]>=1.34.0"]
+"google" = ["pydantic-ai-slim[google]>=1.34.0"]
+"openai" = ["pydantic-ai-slim[openai]>=1.34.0"]
+"mcp" = ["pydantic-ai-slim[mcp]>=1.34.0"]
 "avro" = [
     'fastavro>=1.10.0; python_version < "3.14"',
     'fastavro>=1.12.1; python_version >= "3.14"',
@@ -106,7 +106,7 @@ dev = [
     "apache-airflow-providers-standard",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "sqlglot>=30.0.0",
-    "pydantic-ai-slim[mcp]",
+    "pydantic-ai-slim[mcp]>=1.34.0",
     "apache-airflow-providers-common-sql[datafusion]"
 ]
 

--- a/providers/mongo/pyproject.toml
+++ b/providers/mongo/pyproject.toml
@@ -72,7 +72,6 @@ dev = [
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "testcontainers>=4.12.0"
 ]
 
 # To build docs:

--- a/scripts/ci/docker-compose/ci-tests.yml
+++ b/scripts/ci/docker-compose/ci-tests.yml
@@ -18,6 +18,9 @@
 services:
   airflow:
     volumes:
-      # We should be ok with sharing the cache between the builds - now that we are using uv
+      # We should be ok with sharing the cache between the builds - now that we are using uv.
       # The cache should be safe to share between parallel builds.
+      # Note: for lowest-dependencies tests, the entrypoint copies this shared cache to a
+      # per-test temporary directory (via UV_CACHE_DIR) so that each test has its own
+      # isolated copy and does not interfere with other parallel tests.
       - /mnt/.cache/uv:/root/.cache/uv

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -396,36 +396,56 @@ function check_force_lowest_dependencies() {
     if [[ ${FORCE_LOWEST_DEPENDENCIES=} != "true" ]]; then
         return
     fi
+    # Copy the shared uv cache to a per-test temporary directory so that parallel
+    # lowest-dependency tests do not interfere with each other. The temp directory
+    # is automatically cleaned up when the container is removed.
+    local tmp_cache
+    tmp_cache="$(mktemp -d /tmp/uv-cache-XXXXXX)"
+    if [[ -d /root/.cache/uv ]]; then
+        echo "${COLOR_BLUE}Copying shared uv cache to isolated temp cache: ${tmp_cache}${COLOR_RESET}"
+        cp -a /root/.cache/uv/. "${tmp_cache}"/
+    fi
+    export UV_CACHE_DIR="${tmp_cache}"
+    local project_dir
     if [[ ${TEST_TYPE=} =~ Providers\[.*\] ]]; then
         local provider_id
         # shellcheck disable=SC2001
         provider_id=$(echo "${TEST_TYPE}" | sed 's/Providers\[\(.*\)\]/\1/')
-        echo
-        echo "${COLOR_BLUE}Forcing dependencies to lowest versions for provider: ${provider_id}${COLOR_RESET}"
-        echo
+
         if ! /opt/airflow/scripts/in_container/is_provider_excluded.py "${provider_id}"; then
             echo
             echo "S${COLOR_YELLOW}Skipping ${provider_id} provider check on Python ${PYTHON_MAJOR_MINOR_VERSION}!${COLOR_RESET}"
             echo
             exit 0
         fi
-        cd "${AIRFLOW_SOURCES}/providers/${provider_id/.//}" || exit 1
+        echo
+        echo "${COLOR_BLUE}Forcing dependencies to lowest versions for provider: ${provider_id}${COLOR_RESET}"
+        echo
+        project_dir="${AIRFLOW_SOURCES}/providers/${provider_id/.//}" || exit 1
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        set -x
+        uv sync --project "${project_dir}" --resolution lowest-direct \
+            --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
+        set +x
     else
         echo
         echo "${COLOR_BLUE}Forcing dependencies to lowest versions for Airflow.${COLOR_RESET}"
         echo
-        cd "${AIRFLOW_SOURCES}/airflow-core"
+        project_dir="${AIRFLOW_SOURCES}/airflow-core"
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        set -x
+        uv sync --project "${project_dir}"--resolution lowest-direct \
+            --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
+        set +x
     fi
+    echo "Changing directory to ${project_dir}"
+    cd "${project_dir}"
 }
 
 function check_airflow_python_client_installation() {


### PR DESCRIPTION
When running lowest-dependencies tests in parallel, all containers shared the same host uv cache volume. This copies the shared cache to a per-test temporary directory before running uv sync, so each test operates on its own isolated copy that is cleaned up when the container is removed.

A warm-up step runs a single uv sync (normal resolution) at the workspace level before spawning parallel tests, ensuring the shared cache is populated with all needed packages.