### PR TITLE
Move Cherry Picker CLI to main dev/README

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -29,6 +29,7 @@
   - [Configure PyPI uploads](#configure-pypi-uploads)
   - [Setup and authorize GitHub client](#setup-and-authorize-github-client)
   - [Hardware used to prepare and verify the packages](#hardware-used-to-prepare-and-verify-the-packages)
+- [How to backport PR with `cherry-picker` CLI](#how-to-backport-pr-with-cherry-picker-cli)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -101,7 +102,7 @@ There are also convenience packages released as "apache-airflow-providers"separa
 And available in PyPI:
 [PyPI query for backport providers](https://pypi.org/search/?q=apache-airflow-backport-providers).
 
-Note that Backport Providers for Airflow 1.10.* series are not released any more. The last release
+Note that Backport Providers for Airflow 1.10.* series are not released anymore. The last release
 of Backport Providers was done  on March 17, 2021.
 
 Detailed instruction of releasing provider distributions can be found in the
@@ -204,3 +205,68 @@ by the committer acting as release manager. While strictly speaking, releases mu
 on hardware owned and controlled by the committer, for practical reasons it's best if the packages are
 prepared using such hardware. More information can be found in this
 [FAQ](http://www.apache.org/legal/release-policy.html#owned-controlled-hardware)
+
+# How to backport PR with `cherry-picker` CLI
+
+Backporting via CLI might be more convenient for some users. Also, it is necessary if you want to backport
+PR that has conflicts. It also allows to backport commit to multiple branches in the same command.
+
+To backport PRs to any branch (for example: `v2-11-test`, `v3-2-test` or `chart/v1-2x-test`), you can use the following command:
+
+It's easiest to install it (and keep cherry-picker up-to-date) using `uv tool`:
+
+```bash
+uv tool install cherry-picker
+````
+
+And upgrade it with:
+
+```bash
+uv tool upgrade cherry-picker
+```
+
+Then, in order to backport a commit to a branch, you can use the following command:
+
+```bash
+cherry_picker COMMIT_SHA BRANCH_NAME1 [BRANCH_NAME2 ...]
+```
+
+If you are using your fork repository while keeping Airflow repository as remote (i.e. `apache`), please use
+
+```bash
+cherry_picker COMMIT_SHA BRANCH_NAME1 [BRANCH_NAME2 ...]  --upstream-remote [REMOTE_REPOSITORY_NAME]
+```
+
+This will create a new branch with the cherry-picked commit and open a PR against the target branch in
+your browser.
+
+If the GH_AUTH environment variable is set in your command line, the cherry-picker automatically creates a new pull request when there are no conflicts. To set GH_AUTH, use the token from your GitHub repository.
+
+To set GH_AUTH run this:
+
+```bash
+export GH_AUTH={token}
+```
+
+Sometimes it might result with conflict. In such case, you should manually resolve the conflicts.
+Some IDEs like IntelliJ has a fantastic conflict resolution tool - just follow `Git -> Resolve conflicts`
+menu after you get the conflict. But you can also resolve the conflicts manually; see [How conflicts are
+are presented](https://git-scm.com/docs/git-merge#_how_conflicts_are_presented) and
+[How to resolve conflicts](https://git-scm.com/docs/git-merge#_how_to_resolve_conflicts) for more details.
+
+```bash
+cherry_picker --status  # Should show if all conflicts are resolved
+cherry_picker --continue  # Should continue cherry-picking process
+```
+
+> [!WARNING]
+> Sometimes, when you stop cherry-picking process in the middle, you might end up with your repo in a bad
+> state and cherry-picker might print this message:
+>
+> > 🐍 🍒 ⛏
+> >
+> > You're not inside a cpython repo right now! 🙅
+>
+> You should then run `cherry-picker --abort` to clean up the mess and start over. If that does not work
+> you might need to run `git config --local --remove-section cherry-picker` to clean up the configuration
+> stored in `.git/config`.

--- a/dev/README_AIRFLOW3_DEV.md
+++ b/dev/README_AIRFLOW3_DEV.md
@@ -33,6 +33,7 @@
   - [What do we backport to `v3-2-test` branch?](#what-do-we-backport-to-v3-2-test-branch)
   - [Backporting during pre-release period (before 3.2.0 GA)](#backporting-during-pre-release-period-before-320-ga)
   - [How to backport PR with GitHub Actions](#how-to-backport-pr-with-github-actions)
+  - [How to backport PR with `cherry-picker` CLI](#how-to-backport-pr-with-cherry-picker-cli)
   - [Merging PRs for Airflow 2.11.x](#merging-prs-for-airflow-211x)
   - [Merging PRs for Airflow 3](#merging-prs-for-airflow-3)
 - [Milestones for PR](#milestones-for-pr)
@@ -250,6 +251,8 @@ Use `main` as source of the workflow and copy the commit hash and enter the targ
 The action should create a new PR with the cherry-picked commit and add a comment in the PR when it is
 successful (or when it fails). If automatic backporting fails because of conflicts, you have to revert to
 manual backporting using `cherry-picker` CLI.
+
+## [How to backport PR with `cherry-picker` CLI](README.md#how-to-backport-pr-with-cherry-picker-cli)
 
 ## Merging PRs for Airflow 2.11.x
 

--- a/dev/README_AIRFLOW3_DEV.md
+++ b/dev/README_AIRFLOW3_DEV.md
@@ -33,7 +33,6 @@
   - [What do we backport to `v3-2-test` branch?](#what-do-we-backport-to-v3-2-test-branch)
   - [Backporting during pre-release period (before 3.2.0 GA)](#backporting-during-pre-release-period-before-320-ga)
   - [How to backport PR with GitHub Actions](#how-to-backport-pr-with-github-actions)
-  - [How to backport PR with `cherry-picker` CLI](#how-to-backport-pr-with-cherry-picker-cli)
   - [Merging PRs for Airflow 2.11.x](#merging-prs-for-airflow-211x)
   - [Merging PRs for Airflow 3](#merging-prs-for-airflow-3)
 - [Milestones for PR](#milestones-for-pr)
@@ -251,65 +250,6 @@ Use `main` as source of the workflow and copy the commit hash and enter the targ
 The action should create a new PR with the cherry-picked commit and add a comment in the PR when it is
 successful (or when it fails). If automatic backporting fails because of conflicts, you have to revert to
 manual backporting using `cherry-picker` CLI.
-
-## How to backport PR with `cherry-picker` CLI
-
-Backporting via CLI might be more convenient for some users. Also it is necessary if you want to backport
-PR that has conflicts. It also allows to backport commit to multiple branches in the same command.
-
-To backport PRs to any branch (for example: v2-11-test), you can use the following command:
-
-It's easiest to install it (and keep cherry-picker up-to-date) using `uv tool`:
-
-```bash
-uv tool install cherry-picker
-````
-
-And upgrade it with:
-
-```bash
-uv tool upgrade cherry-picker
-```
-
-Then, in order to backport a commit to a branch, you can use the following command:
-
-```bash
-cherry_picker COMMIT_SHA BRANCH_NAME1 [BRANCH_NAME2 ...]
-```
-
-This will create a new branch with the cherry-picked commit and open a PR against the target branch in
-your browser.
-
-If the GH_AUTH environment variable is set in your command line, the cherry-picker automatically creates a new pull request when there are no conflicts. To set GH_AUTH, use the token from your GitHub repository.
-
-To set GH_AUTH run this:
-
-```bash
-export GH_AUTH={token}
-```
-
-Sometimes it might result with conflict. In such case, you should manually resolve the conflicts.
-Some IDEs like IntelliJ has a fantastic conflict resolution tool - just follow `Git -> Resolve conflicts`
-menu after you get the conflict. But you can also resolve the conflicts manually; see [How conflicts are
-are presented](https://git-scm.com/docs/git-merge#_how_conflicts_are_presented) and
-[How to resolve conflicts](https://git-scm.com/docs/git-merge#_how_to_resolve_conflicts) for more details.
-
-```bash
-cherry_picker --status  # Should show if all conflicts are resolved
-cherry_picker --continue  # Should continue cherry-picking process
-```
-
-> [!WARNING]
-> Sometimes, when you stop cherry-picking process in the middle, you might end up with your repo in a bad
-> state and cherry-picker might print this message:
->
-> > 🐍 🍒 ⛏
-> >
-> > You're not inside a cpython repo right now! 🙅
->
-> You should then run `cherry-picker --abort` to clean up the mess and start over. If that does not work
-> you might need to run `git config --local --remove-section cherry-picker` to clean up the configuration
-> stored in `.git/config`.
 
 ## Merging PRs for Airflow 2.11.x
 

--- a/dev/README_HELM_CHART2_DEV.md
+++ b/dev/README_HELM_CHART2_DEV.md
@@ -28,6 +28,7 @@
 - [Committers / PMCs](#committers--pmcs)
   - [Merging PRs targeted for Airflow Helm Chart 2.X](#merging-prs-targeted-for-airflow-helm-chart-2x)
   - [What do we backport to `chart/v1-2x-test` branch?](#what-do-we-backport-to-chartv1-2x-test-branch)
+  - [How to backport PR with `cherry-picker` CLI](#how-to-backport-pr-with-cherry-picker-cli)
   - [Merging PRs for Airflow Chart 1.2x.x](#merging-prs-for-airflow-chart-12xx)
 - [Milestones for PR](#milestones-for-pr)
   - [Set Airflow Helm Chart 2.0.0](#set-airflow-helm-chart-200)
@@ -109,6 +110,7 @@ We will not backport new features or refactorings.
 * **Refactorings in active areas** do not cherry-pick.
 * **New features** do not cherry-pick.
 
+## [How to backport PR with `cherry-picker` CLI](README.md#how-to-backport-pr-with-cherry-picker-cli)
 
 ## Merging PRs for Airflow Chart 1.2x.x
 


### PR DESCRIPTION
* Add upstream-remote option
* Mention from helm branch

I moved the cherry picker part to `main` README since we have started cherry picking from main to `chart/v1-2x-test` as well, to further release Helm Charts from the branch to maintain the change transition better.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
