### PR TITLE
Protect against cache-clashing when running tests in parallel

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1389,7 +1389,7 @@ function check_boto_upgrade() {
     # removed in 2.6.0 `getheaders()` call (instead of `headers` property.
     # Tracked in https://github.com/kubernetes-client/python/issues/2477
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
 }
 
 function check_upgrade_sqlalchemy() {
@@ -1401,7 +1401,7 @@ function check_upgrade_sqlalchemy() {
     echo
     echo "${COLOR_BLUE}Upgrading sqlalchemy to the latest version to run tests with it${COLOR_RESET}"
     echo
-    uv sync --all-packages --no-install-package apache-airflow-providers-fab --resolution highest \
+    uv sync --no-cache --all-packages --no-install-package apache-airflow-providers-fab --resolution highest \
         --no-python-downloads --no-managed-python
 }
 
@@ -1415,7 +1415,7 @@ function check_downgrade_sqlalchemy() {
     echo "${COLOR_BLUE}Downgrading sqlalchemy to minimum supported version: ${min_sqlalchemy_version}${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
@@ -1433,7 +1433,7 @@ function check_downgrade_pendulum() {
     echo "${COLOR_BLUE}Downgrading pendulum to minimum supported version: ${min_pendulum_version}${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "pendulum==${min_pendulum_version}"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache "pendulum==${min_pendulum_version}"
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
@@ -1474,7 +1474,7 @@ function check_force_lowest_dependencies() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        uv sync --no-cache --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     else
         echo
@@ -1484,7 +1484,7 @@ function check_force_lowest_dependencies() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        uv sync --no-cache --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     fi
 }

--- a/dev/registry/pyproject.toml
+++ b/dev/registry/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest"]
+dev = ["pytest>=9.0.0"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["registry_tools"]

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -29,20 +29,21 @@ classifiers = [
 
 dependencies = [
     "aioresponses>=0.7.6",
+    "apache-airflow-devel-common[basic]",
     "black>=26.1.0",
     "filelock>=3.13.0",
     "jmespath>=0.7.0",
     "kgb>=7.2.0",
+    "python-on-whales>=0.70.0",
     "requests_mock>=1.11.0",
     "rich>=13.6.0",
     "ruff==0.15.8",
     "semver>=3.0.2",
-    "typer-slim>=0.15.1",
+    "testcontainers>=4.12.0",
     "time-machine[dateutil]>=3.0.0",
+    "typer-slim>=0.15.1",
     "wheel>=0.42.0",
     "yamllint>=1.33.0",
-    "python-on-whales>=0.70.0",
-    "apache-airflow-devel-common[basic]"
 ]
 
 [project.optional-dependencies]
@@ -104,7 +105,7 @@ dependencies = [
     "sphinxcontrib-spelling>=8.0.0",
     # setuptools 82.0.0+ causes redoc to fail due to pkg_resources removal
     # until https://github.com/sphinx-contrib/redoc/issues/53 is resolved
-    "setuptools<82.0.0",
+    "setuptools>=80.0.0,<82.0.0",
 ]
 "docs-gen" = [
     "diagrams>=0.24.4",

--- a/providers/apache/spark/pyproject.toml
+++ b/providers/apache/spark/pyproject.toml
@@ -87,7 +87,7 @@ dev = [
     "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "apache-airflow-providers-openlineage",
-    "pyspark"
+    "pyspark>=4.0.0"
 ]
 
 # To build docs:

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -75,11 +75,11 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
-"anthropic" = ["pydantic-ai-slim[anthropic]"]
-"bedrock" = ["pydantic-ai-slim[bedrock]"]
-"google" = ["pydantic-ai-slim[google]"]
-"openai" = ["pydantic-ai-slim[openai]"]
-"mcp" = ["pydantic-ai-slim[mcp]"]
+"anthropic" = ["pydantic-ai-slim[anthropic]>=1.34.0"]
+"bedrock" = ["pydantic-ai-slim[bedrock]>=1.34.0"]
+"google" = ["pydantic-ai-slim[google]>=1.34.0"]
+"openai" = ["pydantic-ai-slim[openai]>=1.34.0"]
+"mcp" = ["pydantic-ai-slim[mcp]>=1.34.0"]
 "avro" = [
     'fastavro>=1.10.0; python_version < "3.14"',
     'fastavro>=1.12.1; python_version >= "3.14"',
@@ -106,7 +106,7 @@ dev = [
     "apache-airflow-providers-standard",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "sqlglot>=30.0.0",
-    "pydantic-ai-slim[mcp]",
+    "pydantic-ai-slim[mcp]>=1.34.0",
     "apache-airflow-providers-common-sql[datafusion]"
 ]
 

--- a/providers/mongo/pyproject.toml
+++ b/providers/mongo/pyproject.toml
@@ -72,7 +72,6 @@ dev = [
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-compat",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
-    "testcontainers>=4.12.0"
 ]
 
 # To build docs:

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -324,7 +324,7 @@ function check_boto_upgrade() {
     # removed in 2.6.0 `getheaders()` call (instead of `headers` property.
     # Tracked in https://github.com/kubernetes-client/python/issues/2477
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
 }
 
 # Upgrade sqlalchemy to the latest version to run tests with it
@@ -337,7 +337,7 @@ function check_upgrade_sqlalchemy() {
     echo
     echo "${COLOR_BLUE}Upgrading sqlalchemy to the latest version to run tests with it${COLOR_RESET}"
     echo
-    uv sync --all-packages --no-install-package apache-airflow-providers-fab --resolution highest \
+    uv sync --no-cache --all-packages --no-install-package apache-airflow-providers-fab --resolution highest \
         --no-python-downloads --no-managed-python
 }
 
@@ -352,7 +352,7 @@ function check_downgrade_sqlalchemy() {
     echo "${COLOR_BLUE}Downgrading sqlalchemy to minimum supported version: ${min_sqlalchemy_version}${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache "sqlalchemy[asyncio]==${min_sqlalchemy_version}"
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
@@ -371,7 +371,7 @@ function check_downgrade_pendulum() {
     echo "${COLOR_BLUE}Downgrading pendulum to minimum supported version: ${min_pendulum_version}${COLOR_RESET}"
     echo
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} "pendulum==${min_pendulum_version}"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --no-cache "pendulum==${min_pendulum_version}"
     echo
     echo "${COLOR_BLUE}Running 'pip check'${COLOR_RESET}"
     echo
@@ -413,7 +413,7 @@ function check_force_lowest_dependencies() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        uv sync --no-cache --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     else
         echo
@@ -423,7 +423,7 @@ function check_force_lowest_dependencies() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
+        uv sync --no-cache --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     fi
 }

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1125,6 +1125,7 @@ def _install_airflow_and_optionally_providers_together(
         "uv",
         "pip",
         "install",
+        "--no-cache",
     ]
     if installation_spec.pre_release:
         base_install_cmd.append("--pre")
@@ -1181,6 +1182,7 @@ def _install_airflow_ctl_with_constraints(installation_spec: InstallationSpec, g
         "uv",
         "pip",
         "install",
+        "--no-cache",
     ]
     # if airflow is also being installed we should add airflow to the base_install_providers_cmd
     # to avoid accidentally upgrading airflow to a version that is different from installed in the
@@ -1221,6 +1223,7 @@ def _install_only_airflow_airflow_core_task_sdk_with_constraints(
         "uv",
         "pip",
         "install",
+        "--no-cache",
     ]
     if installation_spec.pre_release:
         console.print("[bright_blue]Allowing pre-release versions of airflow")

--- a/scripts/in_container/install_development_dependencies.py
+++ b/scripts/in_container/install_development_dependencies.py
@@ -78,12 +78,12 @@ def install_development_dependencies(constraint: str, github_actions: bool):
     )
     for provider_id in providers_dependencies:
         development_dependencies.extend(providers_dependencies[provider_id]["devel-deps"])
-    command = ["uv", "pip", "install", *development_dependencies, "--constraints", constraint]
+    command = ["uv", "pip", "install", "--no-cache", *development_dependencies, "--constraints", constraint]
     result = run_command(command, check=False, github_actions=github_actions)
     if result.returncode != 0:
         console.print("[yellow]Failed to install development dependencies with constraints[/]\n")
         console.print("Trying without constraints\n")
-        command = ["uv", "pip", "install", *development_dependencies]
+        command = ["uv", "pip", "install", "--no-cache", *development_dependencies]
         result = run_command(command, check=False, github_actions=github_actions)
         if result.returncode != 0:
             console.print("[red]Failed to install development dependencies even without constraints[/]")

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T13:44:39.000056016Z"
+exclude-newer = "2026-03-27T17:51:54.245101475Z"
 exclude-newer-span = "P4D"
 
 [manifest]
@@ -1960,6 +1960,7 @@ dependencies = [
     { name = "semver" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlalchemy-utils" },
+    { name = "testcontainers" },
     { name = "time-machine", extra = ["dateutil"] },
     { name = "typer-slim" },
     { name = "types-aiofiles" },
@@ -2290,7 +2291,7 @@ requires-dist = [
     { name = "ruff", specifier = "==0.15.8" },
     { name = "semver", specifier = ">=3.0.2" },
     { name = "semver", marker = "extra == 'devscripts'", specifier = ">=3.0.2" },
-    { name = "setuptools", marker = "extra == 'docs'", specifier = "<82.0.0" },
+    { name = "setuptools", marker = "extra == 'docs'", specifier = ">=80.0.0,<82.0.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
     { name = "sphinx-airflow-theme", marker = "extra == 'docs'", url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.5-py3-none-any.whl" },
     { name = "sphinx-argparse", marker = "extra == 'docs'", specifier = ">=0.4.0" },
@@ -2312,6 +2313,7 @@ requires-dist = [
     { name = "sphinxcontrib-spelling", marker = "extra == 'docs'", specifier = ">=8.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sqlalchemy'", specifier = ">=1.4.49" },
     { name = "sqlalchemy-utils", marker = "extra == 'sqlalchemy'", specifier = ">=0.41.2" },
+    { name = "testcontainers", specifier = ">=4.12.0" },
     { name = "time-machine", extras = ["dateutil"], specifier = ">=3.0.0" },
     { name = "towncrier", marker = "extra == 'devscripts'", specifier = ">=23.11.0" },
     { name = "twine", marker = "extra == 'devscripts'", specifier = ">=4.0.2" },
@@ -3406,7 +3408,7 @@ dev = [
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
-    { name = "pyspark" },
+    { name = "pyspark", specifier = ">=4.0.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
 
@@ -3840,11 +3842,11 @@ requires-dist = [
     { name = "pyarrow", marker = "python_full_version >= '3.14' and extra == 'parquet'", specifier = ">=22.0.0" },
     { name = "pyarrow", marker = "python_full_version < '3.14' and extra == 'parquet'", specifier = ">=18.0.0" },
     { name = "pydantic-ai-slim", specifier = ">=1.34.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'" },
-    { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'" },
-    { name = "pydantic-ai-slim", extras = ["google"], marker = "extra == 'google'" },
-    { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'mcp'" },
-    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'openai'" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=1.34.0" },
+    { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=1.34.0" },
+    { name = "pydantic-ai-slim", extras = ["google"], marker = "extra == 'google'", specifier = ">=1.34.0" },
+    { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'mcp'", specifier = ">=1.34.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'openai'", specifier = ">=1.34.0" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=30.0.0" },
 ]
 provides-extras = ["anthropic", "bedrock", "google", "openai", "mcp", "avro", "parquet", "sql", "common-sql"]
@@ -3858,7 +3860,7 @@ dev = [
     { name = "apache-airflow-providers-common-sql", extras = ["datafusion"], editable = "providers/common/sql" },
     { name = "apache-airflow-providers-standard", editable = "providers/standard" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
-    { name = "pydantic-ai-slim", extras = ["mcp"] },
+    { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=1.34.0" },
     { name = "sqlglot", specifier = ">=30.0.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
@@ -5721,7 +5723,6 @@ dev = [
     { name = "apache-airflow-devel-common" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-task-sdk" },
-    { name = "testcontainers" },
 ]
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
@@ -5741,7 +5742,6 @@ dev = [
     { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
-    { name = "testcontainers", specifier = ">=4.12.0" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
 
@@ -7569,7 +7569,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest" }]
+dev = [{ name = "pytest", specifier = ">=9.0.0" }]
 
 [[package]]
 name = "apache-airflow-scripts"
@@ -19651,8 +19651,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Add `--no-cache` to all `uv sync` and `uv pip install` commands that run dynamically
inside the CI container entrypoint (testing_command context). When tests run in parallel,
multiple containers may simultaneously resolve/install dependencies, and the shared uv cache
can clash between these parallel processes causing intermittent failures.

The `uv run --no-cache` for development dependency installation already had this fix.
This extends it to all other dynamic install paths:
- `check_boto_upgrade()` — boto3/botocore upgrade
- `check_upgrade_sqlalchemy()` — sqlalchemy upgrade to highest
- `check_downgrade_sqlalchemy()` — sqlalchemy downgrade to minimum
- `check_downgrade_pendulum()` — pendulum downgrade to minimum
- `check_force_lowest_dependencies()` — lowest-direct resolution (both provider and core)
- `install_development_dependencies.py` — dev deps installation
- `install_airflow_and_providers.py` — airflow/providers/ctl installation

Also bumps several dependency lower bounds to fix lowest-dependency test failures.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)