### PR TITLE
Reduce unneeded unit tests

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_health.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_health.py
@@ -26,3 +26,13 @@ def test_health(client):
 
     assert response.status_code == 200
     assert response.json() == {"status": "healthy"}
+
+
+def test_ping(client):
+    """All registered services should report healthy, returning 200 with no failures."""
+    response = client.get("/execution/health/ping")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "ok" in body
+    assert body["failing"] == {}, f"Unexpected failing services: {body['failing']}"

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/basic_tests/test_basic_dag_operations.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/basic_tests/test_basic_dag_operations.py
@@ -18,18 +18,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from airflow_e2e_tests.e2e_test_utils.clients import AirflowClient, TaskSDKClient
+from airflow_e2e_tests.e2e_test_utils.clients import AirflowClient
 
 
 class TestBasicDagFunctionality:
     """Test basic DAG functionality using the Airflow REST API."""
 
     airflow_client = AirflowClient()
-
-    def test_dag_unpause(self):
-        self.airflow_client.un_pause_dag(
-            "example_xcom_test",
-        )
 
     def test_xcom_value(self):
         resp = self.airflow_client.trigger_dag(
@@ -46,13 +41,3 @@ class TestBasicDagFunctionality:
             run_id=resp["dag_run_id"],
         )
         assert xcom_value_resp["value"] == "manually_pushed_value", xcom_value_resp
-
-
-class TestTaskSDKBasicFunctionality:
-    """Test basic functionality of Task SDK using the Task SDK REST API."""
-
-    task_sdk_client = TaskSDKClient()
-
-    def test_task_sdk_health_check(self):
-        response = self.task_sdk_client.health_check()
-        assert response.status_code == 200

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -31,11 +31,6 @@ class TestRemoteLogging:
     retry_interval_in_seconds = 5
     max_retries = 12
 
-    def test_dag_unpause(self):
-        self.airflow_client.un_pause_dag(
-            TestRemoteLogging.dag_id,
-        )
-
     def test_remote_logging_s3(self):
         """Test that a DAG using remote logging to S3 completes successfully."""
 


### PR DESCRIPTION
E2E tests are costly, so test ping with a unit test and don't test unpausing a dag so often.



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes Claude Sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
