### PR TITLE
Remove no-longer-used HIDE_ATTRS_FROM_UI

### DIFF
--- a/scripts/ci/prek/check_base_operator_partial_arguments.py
+++ b/scripts/ci/prek/check_base_operator_partial_arguments.py
@@ -49,8 +49,6 @@ IGNORED = {
     "default_args",
     # Deprecated and is aliased to max_active_tis_per_dag.
     "task_concurrency",
-    # attrs internals.
-    "HIDE_ATTRS_FROM_UI",
     # Only on BaseOperator.
     "_dag",
     "output",

--- a/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/_internal/abstractoperator.py
@@ -26,7 +26,7 @@ from collections.abc import (
     Iterable,
     Iterator,
 )
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from airflow.sdk import TriggerRule, WeightRule
 from airflow.sdk.configuration import conf
@@ -113,29 +113,6 @@ class AbstractOperator(Templater, DAGNode):
     _on_failure_fail_dagrun = False
     is_setup: bool = False
     is_teardown: bool = False
-
-    HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = frozenset(
-        (
-            "log",
-            "dag",  # We show dag_id, don't need to show this too
-            "node_id",  # Duplicates task_id
-            "task_group",  # Doesn't have a useful repr, no point showing in UI
-            "inherits_from_empty_operator",  # impl detail
-            "inherits_from_skipmixin",  # impl detail
-            # Decide whether to start task execution from triggerer
-            "start_trigger_args",
-            "start_from_trigger",
-            # For compatibility with TG, for operators these are just the current task, no point showing
-            "roots",
-            "leaves",
-            # These lists are already shown via *_task_ids
-            "upstream_list",
-            "downstream_list",
-            # Not useful, implementation detail, already shown elsewhere
-            "global_operator_extra_link_dict",
-            "operator_extra_link_dict",
-        )
-    )
 
     @property
     def is_async(self) -> bool:

--- a/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
+++ b/task-sdk/src/airflow/sdk/definitions/mappedoperator.py
@@ -21,7 +21,7 @@ import contextlib
 import copy
 import warnings
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeGuard
+from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 import attrs
 import methodtools
@@ -334,10 +334,6 @@ class MappedOperator(AbstractOperator):
 
     This should be a name to call ``getattr()`` on.
     """
-
-    HIDE_ATTRS_FROM_UI: ClassVar[frozenset[str]] = AbstractOperator.HIDE_ATTRS_FROM_UI | frozenset(
-        ("parse_time_mapped_ti_count", "operator_class", "start_trigger_args", "start_from_trigger")
-    )
 
     def __hash__(self):
         return id(self)


### PR DESCRIPTION
I think this is a leftover from when we still inherit AbstractOperator from serialized operator types? This is no longer used anywhere since serialized operator types now have their own logic for what is shown.