### PR TITLE
Elasticsearch: Request only required source fields for task logs

### DIFF
--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -26,7 +26,7 @@ import shutil
 import sys
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from operator import attrgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -80,6 +80,11 @@ LOG_LINE_DEFAULTS = {"exc_text": "", "stack_info": ""}
 USE_PER_RUN_LOG_ID = hasattr(DagRun, "get_log_template")
 
 TASK_LOG_FIELDS = ["timestamp", "event", "level", "chan", "logger", "error_detail", "message", "levelname"]
+
+
+def _deduplicate_fields(fields: Iterable[str]) -> list[str]:
+    """Return non-empty field names in order without duplicates."""
+    return list(dict.fromkeys(field for field in fields if field))
 
 
 def _format_error_detail(error_detail: Any) -> str | None:
@@ -318,6 +323,10 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     def _read_grouped_logs(self):
         return True
 
+    def _get_es_source_includes(self) -> list[str]:
+        extra_fields = self.json_fields if self.json_format and not AIRFLOW_V_3_0_PLUS else []
+        return self.io._get_source_includes(extra_fields=extra_fields)
+
     def _read(
         self, ti: TaskInstance, try_number: int, metadata: LogMetadata | None = None
     ) -> tuple[EsLogMsgType, LogMetadata]:
@@ -339,7 +348,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
 
         offset = metadata["offset"]
         log_id = _render_log_id(self.log_id_template, ti, try_number)
-        response = self.io._es_read(log_id, offset, ti)
+        response = self.io._es_read(log_id, offset, ti, source_includes=self._get_es_source_includes())
         # TODO: Can we skip group logs by host ?
         if response is not None and response.hits:
             logs_by_host = self.io._group_logs_by_host(response)
@@ -629,6 +638,12 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
         self._doc_type_map: dict[Any, Any] = {}
         self._doc_type: list[Any] = []
 
+    def _get_source_includes(self, extra_fields: Iterable[str] = ()) -> list[str]:
+        """Return the Elasticsearch source fields to include when reading task logs."""
+        return _deduplicate_fields(
+            ["@timestamp", *TASK_LOG_FIELDS, self.host_field, self.offset_field, *extra_fields]
+        )
+
     def upload(self, path: os.PathLike | str, ti: RuntimeTI):
         """Write the log to ElasticSearch."""
         path = Path(path)
@@ -693,7 +708,7 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
         log_id = _render_log_id(self.log_id_template, ti, ti.try_number)  # type: ignore[arg-type]
         self.log.info("Reading log %s from Elasticsearch", log_id)
         offset = 0
-        response = self._es_read(log_id, offset, ti)
+        response = self._es_read(log_id, offset, ti, source_includes=self._get_source_includes())
         if response is not None and response.hits:
             logs_by_host = self._group_logs_by_host(response)
         else:
@@ -720,7 +735,14 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
         return header, message
 
-    def _es_read(self, log_id: str, offset: int | str, ti: RuntimeTI) -> ElasticSearchResponse | None:
+    def _es_read(
+        self,
+        log_id: str,
+        offset: int | str,
+        ti: RuntimeTI,
+        *,
+        source_includes: Iterable[str] | None = None,
+    ) -> ElasticSearchResponse | None:
         """
         Return the logs matching log_id in Elasticsearch and next offset or ''.
 
@@ -730,6 +752,9 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
         :meta private:
         """
+        source_includes = _deduplicate_fields(
+            self._get_source_includes() if source_includes is None else source_includes
+        )
         query: dict[Any, Any] = {
             "bool": {
                 "filter": [{"range": {self.offset_field: {"gt": int(offset)}}}],
@@ -745,6 +770,7 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
                 sort=[self.offset_field],
                 size=self.MAX_LINE_PER_PAGE,
                 from_=self.MAX_LINE_PER_PAGE * self.PAGE,
+                source_includes=source_includes,
             )
         except NotFoundError:
             self.log.exception("The target index pattern %s does not exist", index_patterns)

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -35,6 +35,7 @@ from airflow.providers.common.compat.sdk import conf
 from airflow.providers.elasticsearch.log.es_json_formatter import ElasticsearchJSONFormatter
 from airflow.providers.elasticsearch.log.es_response import ElasticSearchResponse
 from airflow.providers.elasticsearch.log.es_task_handler import (
+    TASK_LOG_FIELDS,
     VALID_ES_CONFIG_KEYS,
     ElasticsearchRemoteLogIO,
     ElasticsearchTaskHandler,
@@ -538,6 +539,23 @@ class TestElasticsearchTaskHandler:
             filename_template=None,
         )
 
+    def test_get_es_source_includes_legacy_json_format_includes_json_fields(self):
+        self.es_task_handler.json_format = True
+
+        with patch("airflow.providers.elasticsearch.log.es_task_handler.AIRFLOW_V_3_0_PLUS", False):
+            fields = self.es_task_handler._get_es_source_includes()
+
+        assert fields == [
+            "@timestamp",
+            *TASK_LOG_FIELDS,
+            self.host_field,
+            self.offset_field,
+            "asctime",
+            "filename",
+            "lineno",
+            "exc_text",
+        ]
+
 
 class TestTaskHandlerHelpers:
     def test_safe_attrgetter(self):
@@ -634,6 +652,30 @@ class TestElasticsearchRemoteLogIO:
         assert [line["offset"] for line in json_log_lines] == [1, 2, 3]
         assert all(line["log_id"] == log_id for line in json_log_lines)
 
+    def test_get_source_includes(self):
+        assert self.elasticsearch_io._get_source_includes() == [
+            "@timestamp",
+            *TASK_LOG_FIELDS,
+            self.elasticsearch_io.host_field,
+            self.elasticsearch_io.offset_field,
+        ]
+
+    def test_get_source_includes_with_custom_host_and_offset_fields(self):
+        self.elasticsearch_io.host_field = "host.name"
+        self.elasticsearch_io.offset_field = "log.offset"
+
+        assert self.elasticsearch_io._get_source_includes() == [
+            "@timestamp",
+            *TASK_LOG_FIELDS,
+            "host.name",
+            "log.offset",
+        ]
+
+    def test_get_source_includes_deduplicates_when_offset_overlaps_task_fields(self):
+        self.elasticsearch_io.offset_field = "timestamp"  # already in TASK_LOG_FIELDS
+        fields = self.elasticsearch_io._get_source_includes()
+        assert fields.count("timestamp") == 1
+
     def test_es_read_builds_expected_query(self, ti):
         self.elasticsearch_io.client = Mock()
         self.elasticsearch_io.client.search.return_value = _build_es_search_response(
@@ -661,6 +703,12 @@ class TestElasticsearchRemoteLogIO:
             sort=[self.elasticsearch_io.offset_field],
             size=self.elasticsearch_io.MAX_LINE_PER_PAGE,
             from_=0,
+            source_includes=[
+                "@timestamp",
+                *TASK_LOG_FIELDS,
+                self.elasticsearch_io.host_field,
+                self.elasticsearch_io.offset_field,
+            ],
         )
         assert response is not None
         assert response.hits[0].event == "hello"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Update the Elasticsearch task handler to fetch only the `_source` fields needed to render task logs instead of reading full documents.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude for planning and testing.

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---