### PR TITLE
Fix xcom_pull() ignoring default parameter when map_indexes not set

### DIFF
--- a/airflow-core/newsfragments/64295.bugfix.rst
+++ b/airflow-core/newsfragments/64295.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :meth:`~airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.xcom_pull` ignoring the ``default`` parameter when ``map_indexes`` is not specified. Previously, if no XCom was found for a task on the no-map-index path, ``None`` was always appended to the result instead of the caller-supplied ``default`` value.

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -413,7 +413,7 @@ class RuntimeTaskInstance(TaskInstance):
                 )
 
                 if values is None:
-                    xcoms.append(None)
+                    xcoms.append(default)
                 else:
                     xcoms.extend(values)
             # For single task pulling from unmapped task, return single value

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2073,6 +2073,31 @@ class TestRuntimeTaskInstance:
             ),
         )
 
+
+    def test_xcom_pull_default_respected_when_no_map_indexes(
+        self,
+        create_runtime_ti,
+        mock_supervisor_comms,
+    ):
+        """Test that ``default`` is returned when map_indexes is not specified and no XCom is found.
+
+        Previously, ``xcoms.append(None)`` was used unconditionally on the no-map-indexes
+        path, so a user-supplied ``default`` was silently ignored.
+        """
+
+        class CustomOperator(BaseOperator):
+            def execute(self, context):
+                pass
+
+        task = CustomOperator(task_id="pull_task")
+        runtime_ti = create_runtime_ti(task=task)
+
+        with patch.object(XCom, "get_all") as mock_get_all:
+            mock_get_all.return_value = None
+            result = runtime_ti.xcom_pull(key="missing_key", task_ids="task_a", default="fallback_value")
+
+        assert result == "fallback_value"
+
     def test_get_param_from_context(
         self, mocked_parse, make_ti_context, mock_supervisor_comms, create_runtime_ti
     ):


### PR DESCRIPTION
Noticed that `xcom_pull()` wasn't respecting the `default` argument in a specific case. If you call it without specifying `map_indexes`, it internally calls `XCom.get_all()` for each task id. When that comes back `None` (meaning the task hasn't pushed any XCom yet), the result was always `None` regardless of what you passed as `default`.

  The explicit `map_indexes` path a few lines below already had `xcoms.append(default)` — this just fixes the branch above to match:

  ```python
  # before
  if values is None:
      xcoms.append(None)

  # after
  if values is None:
      xcoms.append(default)
  ```

  Added a test that covers this directly and a newsfragment.

  Closes #64295