### PR TITLE
Use set for llm_completed and remove dead pending branch in TUI

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/pr_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/pr_commands.py
@@ -2670,7 +2670,7 @@ def _llm_progress_status(completed: int, total: int, flagged: int, errors: int) 
 def _collect_llm_results(
     future_to_pr: dict,
     llm_assessments: dict,
-    llm_completed: list[int],
+    llm_completed: set,
     llm_errors: list[int],
     llm_passing: list,
     block: bool = False,
@@ -2692,7 +2692,7 @@ def _collect_llm_results(
 
     done_futures = [f for f in future_to_pr if f.done() and f not in llm_completed]
     for future in done_futures:
-        llm_completed.append(future)
+        llm_completed.add(future)
         pr = future_to_pr[future]
         try:
             assessment = future.result()
@@ -2777,7 +2777,7 @@ class TriageContext:
     # LLM background state
     llm_future_to_pr: dict
     llm_assessments: dict
-    llm_completed: list
+    llm_completed: set
     llm_errors: list[int]
     llm_passing: list
     # LLM durations: PR number → actual execution time in seconds
@@ -8762,7 +8762,7 @@ def _launch_llm_and_build_context(
     """Launch LLM executor for candidates and build a TriageContext."""
     llm_future_to_pr: dict = {}
     llm_assessments: dict[int, PRAssessment] = {}
-    llm_completed: list = []
+    llm_completed: set = set()
     llm_errors: list[int] = []
     llm_passing: list[PRData] = []
     llm_executor = None
@@ -10302,7 +10302,7 @@ def auto_triage(
                 main_failures=main_failures,
                 llm_future_to_pr={},
                 llm_assessments={},
-                llm_completed=[],
+                llm_completed=set(),
                 llm_errors=[],
                 llm_passing=[],
             )

--- a/dev/breeze/src/airflow_breeze/utils/tui_display.py
+++ b/dev/breeze/src/airflow_breeze/utils/tui_display.py
@@ -729,8 +729,6 @@ class TriageTUI:
                 llm_text = "[red]error[/]"
             elif entry.llm_status == "disabled":
                 llm_text = "[dim]disabled[/]"
-            elif entry.llm_status == "pending":
-                llm_text = "[dim]queued[/]"
             else:
                 llm_text = "[dim]—[/]"
 


### PR DESCRIPTION
## Summary

### Why
llm_completed is checked on every poll cycle to filter out already-collected futures, and as a list that check is O(n) per future which gets noticeable with larger batches.

`llm_completed` is used to track which LLM futures have already been collected. It was a list, so the `f not in llm_completed` check in `_collect_llm_results` was O(n) on every poll cycle,. With many PRs this adds up. Switched to a set for O(1) lookup. No behavior change since the container is never iterated, indexed, or ordered.

Also removed a duplicate `elif entry.llm_status == "pending"` branch in the TUI PR table builder that was shadowed by an earlier branch in the same chain and could never execute.

## Test plan

- All existing tests pass (75 TUI + 39 LLM = 114 tests)
- `breeze pr auto-triage --tui` works as before

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
