### PR TITLE
Incorrect fallback logic

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -244,7 +244,7 @@ class Credentials:
                         if self.client_kind == ClientKind.CLI:
                             raise AirflowCtlCredentialNotFoundException(
                                 f"Debug credentials file not found: {debug_creds_path}. "
-                                "Set AIRFLOW_CLI_DEBUG_MODE=false or login in debug mode first."
+                                "Set AIRFLOW_CLI_DEBUG_MODE=false or log in with debug mode enabled first."
                             ) from e
                         self.api_token = None
                 else:

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -236,11 +236,17 @@ class Credentials:
                     debug_creds_path = os.path.join(
                         default_config_dir, f"debug_creds_{self.input_cli_config_file}"
                     )
-                    with open(debug_creds_path) as df:
-                        debug_credentials = json.load(df)
-                        self.api_token = debug_credentials.get(
-                            self.token_key_for_environment(self.api_environment)
-                        )
+                    try:
+                        with open(debug_creds_path) as df:
+                            debug_credentials = json.load(df)
+                            self.api_token = debug_credentials.get(self.token_key_for_environment(self.api_environment))
+                    except FileNotFoundError as e:
+                        if self.client_kind == ClientKind.CLI:
+                            raise AirflowCtlCredentialNotFoundException(
+                                f"Debug credentials file not found: {debug_creds_path}. "
+                                "Set AIRFLOW_CLI_DEBUG_MODE=false or login in debug mode first."
+                            ) from e
+                        self.api_token = None
                 else:
                     try:
                         self.api_token = keyring.get_password(

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -387,7 +387,7 @@ class TestSaveKeyringPatching:
 
         config_path = tmp_path / "TEST_DEBUG.json"
         config_path.write_text(json.dumps({"api_url": "http://localhost:8080"}), encoding="utf-8")
-        # 不建立 debug_creds_TEST_DEBUG.json，模擬缺檔
+        # Intentionally do not create debug_creds_TEST_DEBUG.json to simulate a missing file
 
         creds = Credentials(client_kind=ClientKind.CLI, api_environment="TEST_DEBUG")
         with pytest.raises(AirflowCtlCredentialNotFoundException, match="Debug credentials file not found"):

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -30,7 +30,10 @@ from httpx import URL
 
 from airflowctl.api.client import Client, ClientKind, Credentials, _bounded_get_new_password
 from airflowctl.api.operations import ServerResponseError
-from airflowctl.exceptions import AirflowCtlCredentialNotFoundException, AirflowCtlKeyringException
+from airflowctl.exceptions import (
+    AirflowCtlCredentialNotFoundException,
+    AirflowCtlKeyringException,
+)
 
 
 def make_client_w_responses(responses: list[httpx.Response]) -> Client:
@@ -376,3 +379,16 @@ class TestSaveKeyringPatching:
             response = client.get("http://error")
             assert response.status_code == 200
             assert len(responses) == 1
+
+    def test_debug_mode_missing_debug_creds_reports_correct_error(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AIRFLOW_HOME", str(tmp_path))
+        monkeypatch.setenv("AIRFLOW_CLI_DEBUG_MODE", "true")
+        monkeypatch.setenv("AIRFLOW_CLI_ENVIRONMENT", "TEST_DEBUG")
+
+        config_path = tmp_path / "TEST_DEBUG.json"
+        config_path.write_text(json.dumps({"api_url": "http://localhost:8080"}), encoding="utf-8")
+        # 不建立 debug_creds_TEST_DEBUG.json，模擬缺檔
+
+        creds = Credentials(client_kind=ClientKind.CLI, api_environment="TEST_DEBUG")
+        with pytest.raises(AirflowCtlCredentialNotFoundException, match="Debug credentials file not found"):
+            creds.load()


### PR DESCRIPTION
### Description
When ``AIRFLOW_CLI_DEBUG_MODE`` is set to true, if the primary config file exists but the debug_credentials file is missing, the system incorrectly reports "No credentials file found" instead of the expected debug-specific error.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
