### PR TITLE
Retry uv pip install on cargo-related transient failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1195,6 +1195,40 @@ COPY <<"EOF" /install_airflow_when_building_images.sh
 
 . "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
 
+function run_uv_with_cargo_retry() {
+    local max_attempts=5
+    local sleep_seconds=30
+    local attempt
+    local exit_code
+    local output_file
+    output_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f ${output_file}" RETURN
+    for attempt in $(seq 1 ${max_attempts}); do
+        echo "${COLOR_BLUE}Attempt ${attempt} of ${max_attempts} for: $*${COLOR_RESET}"
+        set +e
+        set -x
+        "$@" 2>&1 | tee "${output_file}"
+        exit_code=${PIPESTATUS[0]}
+        set +x
+        set -e
+        if [[ ${exit_code} == 0 ]]; then
+            return 0
+        fi
+        if ! grep -qi -e "cargo" -e "maturin" "${output_file}"; then
+            echo "${COLOR_YELLOW}Failure is not cargo-related, not retrying.${COLOR_RESET}"
+            return ${exit_code}
+        fi
+        if [[ ${attempt} -lt ${max_attempts} ]]; then
+            echo "${COLOR_YELLOW}Attempt ${attempt} failed with cargo-related error. Sleeping ${sleep_seconds}s before retry...${COLOR_RESET}"
+            sleep ${sleep_seconds}
+        else
+            echo "${COLOR_RED}All ${max_attempts} attempts failed.${COLOR_RESET}"
+        fi
+    done
+    return ${exit_code}
+}
+
 function install_from_sources() {
     local extra_sync_flags
     extra_sync_flags=""
@@ -1216,12 +1250,10 @@ function install_from_sources() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
+        run_uv_with_cargo_retry uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python
     else
-        set +x
         echo
         echo "${COLOR_BLUE}Installing all packages from uv.lock (frozen).${COLOR_RESET}"
         echo
@@ -1229,11 +1261,9 @@ function install_from_sources() {
         # --no-binary-package is needed in order to avoid libxml and xmlsec using different version of
         # libxml2 (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        if ! uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
+        if ! run_uv_with_cargo_retry uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python; then
-            set +x
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because frozen uv.lock installation failed and fallback is disabled.${COLOR_RESET}"
@@ -1245,11 +1275,9 @@ function install_from_sources() {
             echo
             echo "${COLOR_BLUE}Falling back to re-resolving dependencies (uv sync without --frozen).${COLOR_RESET}"
             echo
-            set -x
-            uv sync --all-packages --group dev --group docs --group docs-gen \
+            run_uv_with_cargo_retry uv sync --all-packages --group dev --group docs --group docs-gen \
                 --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
                 --no-python-downloads --no-managed-python
-            set +x
         fi
     fi
 }
@@ -1276,16 +1304,12 @@ function install_from_external_spec() {
         echo
         echo "${COLOR_BLUE}Installing all packages with highest resolutions. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-        set +x
+        run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
     else
         echo
         echo "${COLOR_BLUE}Installing all packages with constraints. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        if ! ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
-            set +x
+        if ! run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because constraints installation failed and fallback is disabled.${COLOR_RESET}"
@@ -1297,9 +1321,7 @@ function install_from_external_spec() {
             echo
             echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
-            set -x
-            ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-            set +x
+            run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
         fi
     fi
 }

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -900,6 +900,40 @@ COPY <<"EOF" /install_airflow_when_building_images.sh
 
 . "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
 
+function run_uv_with_cargo_retry() {
+    local max_attempts=5
+    local sleep_seconds=30
+    local attempt
+    local exit_code
+    local output_file
+    output_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f ${output_file}" RETURN
+    for attempt in $(seq 1 ${max_attempts}); do
+        echo "${COLOR_BLUE}Attempt ${attempt} of ${max_attempts} for: $*${COLOR_RESET}"
+        set +e
+        set -x
+        "$@" 2>&1 | tee "${output_file}"
+        exit_code=${PIPESTATUS[0]}
+        set +x
+        set -e
+        if [[ ${exit_code} == 0 ]]; then
+            return 0
+        fi
+        if ! grep -qi -e "cargo" -e "maturin" "${output_file}"; then
+            echo "${COLOR_YELLOW}Failure is not cargo-related, not retrying.${COLOR_RESET}"
+            return ${exit_code}
+        fi
+        if [[ ${attempt} -lt ${max_attempts} ]]; then
+            echo "${COLOR_YELLOW}Attempt ${attempt} failed with cargo-related error. Sleeping ${sleep_seconds}s before retry...${COLOR_RESET}"
+            sleep ${sleep_seconds}
+        else
+            echo "${COLOR_RED}All ${max_attempts} attempts failed.${COLOR_RESET}"
+        fi
+    done
+    return ${exit_code}
+}
+
 function install_from_sources() {
     local extra_sync_flags
     extra_sync_flags=""
@@ -921,12 +955,10 @@ function install_from_sources() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
+        run_uv_with_cargo_retry uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python
     else
-        set +x
         echo
         echo "${COLOR_BLUE}Installing all packages from uv.lock (frozen).${COLOR_RESET}"
         echo
@@ -934,11 +966,9 @@ function install_from_sources() {
         # --no-binary-package is needed in order to avoid libxml and xmlsec using different version of
         # libxml2 (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        if ! uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
+        if ! run_uv_with_cargo_retry uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python; then
-            set +x
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because frozen uv.lock installation failed and fallback is disabled.${COLOR_RESET}"
@@ -950,11 +980,9 @@ function install_from_sources() {
             echo
             echo "${COLOR_BLUE}Falling back to re-resolving dependencies (uv sync without --frozen).${COLOR_RESET}"
             echo
-            set -x
-            uv sync --all-packages --group dev --group docs --group docs-gen \
+            run_uv_with_cargo_retry uv sync --all-packages --group dev --group docs --group docs-gen \
                 --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
                 --no-python-downloads --no-managed-python
-            set +x
         fi
     fi
 }
@@ -981,16 +1009,12 @@ function install_from_external_spec() {
         echo
         echo "${COLOR_BLUE}Installing all packages with highest resolutions. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-        set +x
+        run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
     else
         echo
         echo "${COLOR_BLUE}Installing all packages with constraints. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        if ! ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
-            set +x
+        if ! run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because constraints installation failed and fallback is disabled.${COLOR_RESET}"
@@ -1002,9 +1026,7 @@ function install_from_external_spec() {
             echo
             echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
-            set -x
-            ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-            set +x
+            run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
         fi
     fi
 }

--- a/scripts/docker/install_airflow_when_building_images.sh
+++ b/scripts/docker/install_airflow_when_building_images.sh
@@ -35,6 +35,45 @@
 # shellcheck source=scripts/docker/common.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
 
+# Retry wrapper for uv commands that may fail with transient cargo/maturin build errors.
+# Workaround for https://github.com/astral-sh/uv/issues/18801
+# Usage: run_uv_with_cargo_retry <command...>
+# Returns the exit code of the command (non-zero only after all retries exhausted for cargo errors,
+# or immediately for non-cargo failures).
+function run_uv_with_cargo_retry() {
+    local max_attempts=5
+    local sleep_seconds=30
+    local attempt
+    local exit_code
+    local output_file
+    output_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f ${output_file}" RETURN
+    for attempt in $(seq 1 ${max_attempts}); do
+        echo "${COLOR_BLUE}Attempt ${attempt} of ${max_attempts} for: $*${COLOR_RESET}"
+        set +e
+        set -x
+        "$@" 2>&1 | tee "${output_file}"
+        exit_code=${PIPESTATUS[0]}
+        set +x
+        set -e
+        if [[ ${exit_code} == 0 ]]; then
+            return 0
+        fi
+        if ! grep -qi -e "cargo" -e "maturin" "${output_file}"; then
+            echo "${COLOR_YELLOW}Failure is not cargo-related, not retrying.${COLOR_RESET}"
+            return ${exit_code}
+        fi
+        if [[ ${attempt} -lt ${max_attempts} ]]; then
+            echo "${COLOR_YELLOW}Attempt ${attempt} failed with cargo-related error. Sleeping ${sleep_seconds}s before retry...${COLOR_RESET}"
+            sleep ${sleep_seconds}
+        else
+            echo "${COLOR_RED}All ${max_attempts} attempts failed.${COLOR_RESET}"
+        fi
+    done
+    return ${exit_code}
+}
+
 function install_from_sources() {
     local extra_sync_flags
     extra_sync_flags=""
@@ -56,12 +95,10 @@ function install_from_sources() {
         # --no-binary  is needed in order to avoid libxml and xmlsec using different version of libxml2
         # (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
+        run_uv_with_cargo_retry uv sync --all-packages --resolution highest --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python
     else
-        set +x
         echo
         echo "${COLOR_BLUE}Installing all packages from uv.lock (frozen).${COLOR_RESET}"
         echo
@@ -69,11 +106,9 @@ function install_from_sources() {
         # --no-binary-package is needed in order to avoid libxml and xmlsec using different version of
         # libxml2 (binary lxml embeds its own libxml2, while xmlsec uses system one).
         # See https://bugs.launchpad.net/lxml/+bug/2110068
-        set -x
-        if ! uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
+        if ! run_uv_with_cargo_retry uv sync --all-packages --frozen --group dev --group docs --group docs-gen \
             --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
             --no-python-downloads --no-managed-python; then
-            set +x
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because frozen uv.lock installation failed and fallback is disabled.${COLOR_RESET}"
@@ -85,11 +120,9 @@ function install_from_sources() {
             echo
             echo "${COLOR_BLUE}Falling back to re-resolving dependencies (uv sync without --frozen).${COLOR_RESET}"
             echo
-            set -x
-            uv sync --all-packages --group dev --group docs --group docs-gen \
+            run_uv_with_cargo_retry uv sync --all-packages --group dev --group docs --group docs-gen \
                 --group leveldb ${extra_sync_flags} --no-binary-package lxml --no-binary-package xmlsec \
                 --no-python-downloads --no-managed-python
-            set +x
         fi
     fi
 }
@@ -116,16 +149,12 @@ function install_from_external_spec() {
         echo
         echo "${COLOR_BLUE}Installing all packages with highest resolutions. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-        set +x
+        run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_TO_HIGHEST_RESOLUTION} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
     else
         echo
         echo "${COLOR_BLUE}Installing all packages with constraints. Installation method: ${AIRFLOW_INSTALLATION_METHOD}${COLOR_RESET}"
         echo
-        set -x
-        if ! ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
-            set +x
+        if ! run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags} --constraint "${HOME}/constraints.txt"; then
             if [[ ${AIRFLOW_FALLBACK_NO_CONSTRAINTS_INSTALLATION} != "true" ]]; then
                 echo
                 echo "${COLOR_RED}Failing because constraints installation failed and fallback is disabled.${COLOR_RESET}"
@@ -137,9 +166,7 @@ function install_from_external_spec() {
             echo
             echo "${COLOR_BLUE}Falling back to no-constraints installation.${COLOR_RESET}"
             echo
-            set -x
-            ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
-            set +x
+            run_uv_with_cargo_retry ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} ${UPGRADE_IF_NEEDED} ${ADDITIONAL_PIP_INSTALL_FLAGS} ${installation_command_flags}
         fi
     fi
 }

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import subprocess
 import sys
+import time
 from functools import cache
 from pathlib import Path
 from typing import NamedTuple
@@ -1117,6 +1119,50 @@ def install_airflow_and_providers(
     console.print("\n[green]Done!")
 
 
+def _run_uv_install_with_retry(
+    cmd: list[str],
+    github_actions: bool,
+    check: bool = True,
+    max_attempts: int = 5,
+    sleep_seconds: int = 30,
+) -> subprocess.CompletedProcess:
+    """Run a uv pip install command with retry logic for cargo-related transient failures.
+
+    Workaround for https://github.com/astral-sh/uv/issues/18801 — uv can fail with cargo-related
+    errors during package builds. When a failure contains "cargo" or "maturin" in the output, we retry up to
+    max_attempts times. Non-cargo failures are returned immediately without retry.
+    """
+    for attempt in range(1, max_attempts + 1):
+        console.print(f"[bright_blue]Attempt {attempt} of {max_attempts} for uv install")
+        result = run_command(
+            cmd,
+            github_actions=github_actions,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        output = result.stdout.decode() if result.stdout else ""
+        if output:
+            console.print(output)
+        if result.returncode == 0:
+            return result
+        if "cargo" not in output and "maturin" not in output:
+            console.print("[yellow]Failure is not cargo-related, not retrying.")
+            if check:
+                sys.exit(result.returncode)
+            return result
+        if attempt < max_attempts:
+            console.print(
+                f"[yellow]Attempt {attempt} failed with cargo-related error. Sleeping {sleep_seconds}s before retry..."
+            )
+            time.sleep(sleep_seconds)
+        else:
+            console.print(f"[red]All {max_attempts} attempts failed.")
+            if check:
+                sys.exit(result.returncode)
+    return result
+
+
 def _install_airflow_and_optionally_providers_together(
     installation_spec: InstallationSpec, github_actions: bool
 ):
@@ -1161,15 +1207,17 @@ def _install_airflow_and_optionally_providers_together(
         )
         install_providers_command.extend(["--constraint", installation_spec.provider_constraints_location])
         console.print()
-        result = run_command(install_providers_command, github_actions=github_actions, check=False)
+        result = _run_uv_install_with_retry(
+            install_providers_command, github_actions=github_actions, check=False
+        )
         if result.returncode != 0:
             console.print(
                 "[warning]Installation with constraints failed - might be because pre-installed provider"
                 " has conflicting dependencies in PyPI. Falling back to a non-constraint installation."
             )
-            run_command(base_install_cmd, github_actions=github_actions, check=True)
+            _run_uv_install_with_retry(base_install_cmd, github_actions=github_actions, check=True)
     else:
-        run_command(base_install_cmd, github_actions=github_actions, check=True)
+        _run_uv_install_with_retry(base_install_cmd, github_actions=github_actions, check=True)
 
 
 def _install_airflow_ctl_with_constraints(installation_spec: InstallationSpec, github_actions: bool):
@@ -1192,13 +1240,13 @@ def _install_airflow_ctl_with_constraints(installation_spec: InstallationSpec, g
         console.print(f"[bright_blue]Use constraints: {installation_spec.airflow_ctl_constraints_location}")
         install_airflow_ctl_cmd.extend(["--constraint", installation_spec.airflow_ctl_constraints_location])
     console.print()
-    result = run_command(install_airflow_ctl_cmd, github_actions=github_actions, check=True)
+    result = _run_uv_install_with_retry(install_airflow_ctl_cmd, github_actions=github_actions, check=False)
     if result.returncode != 0:
         console.print(
             "[warning]Installation with constraints failed - might be because there are"
             " conflicting dependencies in PyPI. Falling back to a non-constraint installation."
         )
-        run_command(base_install_airflow_ctl_cmd, github_actions=github_actions, check=True)
+        _run_uv_install_with_retry(base_install_airflow_ctl_cmd, github_actions=github_actions, check=True)
 
 
 def _install_only_airflow_airflow_core_task_sdk_with_constraints(
@@ -1247,13 +1295,13 @@ def _install_only_airflow_airflow_core_task_sdk_with_constraints(
         console.print(f"[bright_blue]Use constraints: {installation_spec.airflow_constraints_location}")
         install_airflow_cmd.extend(["--constraint", installation_spec.airflow_constraints_location])
     console.print()
-    result = run_command(install_airflow_cmd, github_actions=github_actions, check=False)
+    result = _run_uv_install_with_retry(install_airflow_cmd, github_actions=github_actions, check=False)
     if result.returncode != 0:
         console.print(
             "[warning]Installation with constraints failed - might be because pre-installed provider"
             " has conflicting dependencies in PyPI. Falling back to a non-constraint installation."
         )
-        run_command(base_install_airflow_cmd, github_actions=github_actions, check=True)
+        _run_uv_install_with_retry(base_install_airflow_cmd, github_actions=github_actions, check=True)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-27T13:44:39.000056016Z"
+exclude-newer = "2026-03-28T19:05:27.784559812Z"
 exclude-newer-span = "P4D"
 
 [manifest]
@@ -4581,6 +4581,9 @@ dependencies = [
 kerberos = [
     { name = "kerberos" },
 ]
+oauth = [
+    { name = "authlib" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -4588,6 +4591,7 @@ dev = [
     { name = "apache-airflow-devel-common" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-task-sdk" },
+    { name = "authlib" },
     { name = "kerberos" },
     { name = "requests-kerberos" },
 ]
@@ -4599,6 +4603,7 @@ docs = [
 requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
+    { name = "authlib", marker = "extra == 'oauth'", specifier = ">=1.0.0" },
     { name = "blinker", specifier = ">=1.6.2" },
     { name = "cachetools", specifier = ">=6.0" },
     { name = "flask", specifier = ">=2.2.1" },
@@ -4618,7 +4623,7 @@ requires-dist = [
     { name = "werkzeug", marker = "python_full_version >= '3.14'", specifier = ">=3.1.6" },
     { name = "wtforms", specifier = ">=3.0" },
 ]
-provides-extras = ["kerberos"]
+provides-extras = ["kerberos", "oauth"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4626,6 +4631,7 @@ dev = [
     { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
+    { name = "authlib", specifier = ">=1.0.0" },
     { name = "kerberos", specifier = ">=1.3.0" },
     { name = "requests-kerberos", specifier = ">=0.14.0" },
 ]
@@ -19651,8 +19657,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Retry `uv pip install` commands in `install_airflow_and_providers.py` when failures
are cargo-related (`.cargo` in output), to handle transient build failures.

Workaround for https://github.com/astral-sh/uv/issues/18801

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)