### PR TITLE
Remove non-main branch triggers from newsfragment check

### DIFF
--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -21,9 +21,6 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - main
-      - v[0-9]+-[0-9]+-test
-      - v[0-9]+-[0-9]+-stable
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
     types: [opened, reopened, synchronize, labeled, unlabeled]
 
 permissions:


### PR DESCRIPTION
Remove the v*-test, v*-stable, and providers-* branch patterns from the newsfragment PR number check workflow. This check only needs to run for PRs targeting the main branch.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)