### PR TITLE
Add duration, queued_dttm, and start_date to RuntimeTaskInstance for listener hooks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -384,6 +384,12 @@ class TIRunContext(BaseModel):
     should_retry: bool = False
     """If the ti encounters an error, whether it should enter retry or failed state."""
 
+    queued_dttm: UtcDateTime | None = None
+    """When the task instance was queued."""
+
+    start_date: UtcDateTime | None = None
+    """When the task instance started (persisted from DB, preserved across deferrals)."""
+
 
 class PrevSuccessfulDagRunResponse(BaseModel):
     """Schema for response with previous successful DagRun information for Task Template Context."""

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -140,6 +140,8 @@ def ti_run(
             TI.hostname,
             TI.unixname,
             TI.pid,
+            TI.queued_dttm,
+            TI.start_date,
             # This selects the raw JSON value, bypassing the deserialization -- we want that to happen on the
             # client
             column("next_kwargs", JSON),
@@ -287,6 +289,13 @@ def ti_run(
         if ti.next_method:
             context.next_method = ti.next_method
             context.next_kwargs = ti.next_kwargs
+        if ti.queued_dttm:
+            context.queued_dttm = ti.queued_dttm
+        # For deferred tasks resuming, use the persisted DB start_date (preserved from original run).
+        # For fresh tasks, use the start_date from the request (just written to DB).
+        effective_start_date = ti.start_date or ti_run_payload.start_date
+        if effective_start_date:
+            context.start_date = effective_start_date
 
         return context
     except SQLAlchemyError:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -33,6 +33,8 @@ from airflow.api_fastapi.execution_api.versions.v2026_04_06 import (
     AddDagRunDetailEndpoint,
     AddNoteField,
     AddPartitionKeyField,
+    AddQueuedDttmField,
+    AddStartDateField,
     MakeDagRunStartDateNullable,
     ModifyDeferredTaskKwargsToJsonValue,
     MovePreviousRunEndpoint,
@@ -44,6 +46,8 @@ bundle = VersionBundle(
     Version(
         "2026-04-06",
         AddPartitionKeyField,
+        AddQueuedDttmField,
+        AddStartDateField,
         MovePreviousRunEndpoint,
         AddDagRunDetailEndpoint,
         MakeDagRunStartDateNullable,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_06.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_04_06.py
@@ -178,6 +178,32 @@ class AddNoteField(VersionChange):
             response.body["dag_run"].pop("note", None)
 
 
+class AddQueuedDttmField(VersionChange):
+    """Add the `queued_dttm` field to TIRunContext."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (schema(TIRunContext).field("queued_dttm").didnt_exist,)
+
+    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
+    def remove_queued_dttm(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove queued_dttm for older API versions."""
+        response.body.pop("queued_dttm", None)
+
+
+class AddStartDateField(VersionChange):
+    """Add the `start_date` field to TIRunContext."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (schema(TIRunContext).field("start_date").didnt_exist,)
+
+    @convert_response_to_previous_version_for(TIRunContext)  # type: ignore[arg-type]
+    def remove_start_date(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove start_date for older API versions."""
+        response.body.pop("start_date", None)
+
+
 class AddDagEndpoint(VersionChange):
     """Add the `/dags/{dag_id}` endpoint."""
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -236,6 +236,7 @@ class TestTIRunState:
             "variables": [],
             "connections": [],
             "xcom_keys_to_clear": [],
+            "start_date": instant_str,
         }
         # upstream_map_indexes is now computed by Task SDK, not returned by the server in HEAD version
         assert "upstream_map_indexes" not in result
@@ -599,6 +600,7 @@ class TestTIRunState:
             "xcom_keys_to_clear": [],
             "next_method": "execute_complete",
             "next_kwargs": expected_next_kwargs,
+            "start_date": instant_str,
         }
 
     @pytest.mark.parametrize("resume", [True, False])
@@ -670,6 +672,7 @@ class TestTIRunState:
             "xcom_keys_to_clear": [],
             "next_method": "execute_complete",
             "next_kwargs": expected_next_kwargs,
+            "start_date": orig_task_start_time.isoformat().replace("+00:00", "Z"),
         }
         session.expunge_all()
         ti = session.get(TaskInstance, ti.id)
@@ -863,6 +866,107 @@ class TestTIRunState:
         assert logs[0].logical_date == instant
         assert logs[0].owner == ti.task.owner
         assert logs[0].extra == '{"host_name": "random-hostname"}'
+
+    def test_ti_run_includes_queued_dttm(self, client, session, create_task_instance, time_machine):
+        """Test that queued_dttm is included in the TIRunContext response when set on the TaskInstance."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        queued_str = "2024-09-30T11:55:00Z"
+        queued_time = timezone.parse(queued_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_queued_dttm",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_time
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["queued_dttm"] == queued_str
+
+    def test_ti_run_excludes_queued_dttm_when_not_set(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """Test that queued_dttm is excluded from the response when not set on the TaskInstance."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_no_queued_dttm",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert "queued_dttm" not in result
+
+    def test_ti_run_includes_start_date(self, client, session, create_task_instance, time_machine):
+        """Test that start_date from DB is included in the TIRunContext response."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        original_start_str = "2024-09-30T11:50:00Z"
+        original_start = timezone.parse(original_start_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_start_date",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.start_date = original_start
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": instant_str,
+            },
+        )
+
+        assert response.status_code == 200
+        result = response.json()
+        assert result["start_date"] == original_start_str
 
 
 class TestTIUpdateState:

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -2414,7 +2414,8 @@ def mocked_parse(spy_agency):
             task=task,
             _ti_context_from_server=what.ti_context,
             max_tries=what.ti_context.max_tries,
-            start_date=what.start_date,
+            queued_dttm=getattr(what.ti_context, "queued_dttm", None),
+            start_date=getattr(what.ti_context, "start_date", None) or what.start_date,
         )
         if hasattr(parse, "spy"):
             spy_agency.unspy(parse)

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -3032,13 +3032,19 @@ def test_taskinstance_info_af3():
     bundle_instance.name = "bundle_name"
     runtime_ti.bundle_instance = bundle_instance
 
-    assert dict(TaskInstanceInfo(runtime_ti)) == {
+    expected = {
         "log_url": runtime_ti.log_url,
         "map_index": 2,
         "try_number": 1,
         "dag_bundle_version": "bundle_version",
         "dag_bundle_name": "bundle_name",
     }
+    if hasattr(runtime_ti, "duration"):
+        expected["duration"] = 12.345
+    if hasattr(runtime_ti, "queued_dttm"):
+        expected["queued_dttm"] = None
+
+    assert dict(TaskInstanceInfo(runtime_ti)) == expected
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 test")

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -663,3 +663,5 @@ class TIRunContext(BaseModel):
     next_kwargs: Annotated[dict[str, Any] | str | None, Field(title="Next Kwargs")] = None
     xcom_keys_to_clear: Annotated[list[str] | None, Field(title="Xcom Keys To Clear")] = None
     should_retry: Annotated[bool | None, Field(title="Should Retry")] = False
+    queued_dttm: Annotated[AwareDatetime | None, Field(title="Queued Dttm")] = None
+    start_date: Annotated[AwareDatetime | None, Field(title="Start Date")] = None

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -190,6 +190,9 @@ class RuntimeTaskInstance(TaskInstance):
 
     end_date: AwareDatetime | None = None
 
+    queued_dttm: AwareDatetime | None = None
+    """When the task instance was queued."""
+
     state: TaskInstanceState | None = None
 
     is_mapped: bool | None = None
@@ -198,6 +201,13 @@ class RuntimeTaskInstance(TaskInstance):
     rendered_map_index: str | None = None
 
     sentry_integration: str = ""
+
+    @property
+    def duration(self) -> float | None:
+        """Duration of the task execution in seconds, computed from start_date and end_date."""
+        if self.end_date and self.start_date:
+            return (self.end_date - self.start_date).total_seconds()
+        return None
 
     def __rich_repr__(self):
         yield "id", self.id
@@ -248,6 +258,7 @@ class RuntimeTaskInstance(TaskInstance):
                 },
                 "conn": ConnectionAccessor(),
             }
+
         if TYPE_CHECKING:
             assert self._cached_template_context is not None
         if from_server:
@@ -827,7 +838,8 @@ def parse(what: StartupDetails, log: Logger) -> RuntimeTaskInstance:
         bundle_instance=bundle_instance,
         _ti_context_from_server=what.ti_context,
         max_tries=what.ti_context.max_tries,
-        start_date=what.start_date,
+        queued_dttm=what.ti_context.queued_dttm,
+        start_date=what.ti_context.start_date or what.start_date,
         state=TaskInstanceState.RUNNING,
         sentry_integration=what.sentry_integration,
     )

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -123,7 +123,13 @@ class RuntimeTaskInstanceProtocol(Protocol):
     hostname: str | None = None
     start_date: AwareDatetime
     end_date: AwareDatetime | None = None
+    queued_dttm: AwareDatetime | None = None
     state: TaskInstanceState | None = None
+
+    @property
+    def duration(self) -> float | None:
+        """Duration of the task execution in seconds, computed from start_date and end_date."""
+        ...
 
     def xcom_pull(
         self,

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4741,3 +4741,126 @@ def test_dag_add_result(create_runtime_ti, mock_supervisor_comms):
             dag_result=True,
         )
     )
+
+
+class TestRuntimeTaskInstanceDuration:
+    """Tests for the duration property on RuntimeTaskInstance."""
+
+    def test_duration_with_both_dates(self, create_runtime_ti):
+        """Test duration is computed correctly when both start_date and end_date are set."""
+        task = BaseOperator(task_id="test_duration")
+        ti = create_runtime_ti(task=task)
+        ti.start_date = timezone.parse("2024-12-01T01:00:00Z")
+        ti.end_date = timezone.parse("2024-12-01T01:05:30Z")
+        assert ti.duration == 330.0  # 5 minutes and 30 seconds
+
+    def test_duration_without_end_date(self, create_runtime_ti):
+        """Test duration is None when end_date is not set (task still running)."""
+        task = BaseOperator(task_id="test_duration_no_end")
+        ti = create_runtime_ti(task=task)
+        ti.start_date = timezone.parse("2024-12-01T01:00:00Z")
+        ti.end_date = None
+        assert ti.duration is None
+
+    def test_duration_zero(self, create_runtime_ti):
+        """Test duration is zero when start_date equals end_date."""
+        task = BaseOperator(task_id="test_duration_zero")
+        ti = create_runtime_ti(task=task)
+        same_time = timezone.parse("2024-12-01T01:00:00Z")
+        ti.start_date = same_time
+        ti.end_date = same_time
+        assert ti.duration == 0.0
+
+
+class TestRuntimeTaskInstanceQueuedDttm:
+    """Tests for the queued_dttm field on RuntimeTaskInstance."""
+
+    def test_queued_dttm_from_ti_context(self, mocked_parse, make_ti_context):
+        """Test that queued_dttm flows from TIRunContext to RuntimeTaskInstance via parse."""
+        queued_time = timezone.parse("2024-12-01T00:30:00Z")
+        ti_context = make_ti_context()
+        ti_context.queued_dttm = queued_time
+
+        task = BaseOperator(task_id="test_queued")
+        task.dag = DAG(dag_id="test_dag", start_date=timezone.datetime(2024, 12, 3))
+
+        startup = StartupDetails(
+            ti=TaskInstance(
+                id=uuid7(),
+                task_id="test_queued",
+                dag_id="test_dag",
+                run_id="test_run",
+                try_number=1,
+                dag_version_id=uuid7(),
+            ),
+            dag_rel_path="",
+            bundle_info=BundleInfo(name="anything", version="any"),
+            ti_context=ti_context,
+            start_date=timezone.utcnow(),
+            sentry_integration="",
+        )
+
+        ti = mocked_parse(startup, "test_dag", task)
+        assert ti.queued_dttm == queued_time
+
+    def test_queued_dttm_none_by_default(self, create_runtime_ti):
+        """Test that queued_dttm is None when not provided."""
+        task = BaseOperator(task_id="test_no_queued")
+        ti = create_runtime_ti(task=task)
+        assert ti.queued_dttm is None
+
+    def test_start_date_from_ti_context(self, mocked_parse, make_ti_context):
+        """Test that DB-persisted start_date from TIRunContext is used over supervisor start_date."""
+        db_start = timezone.parse("2024-12-01T00:00:00Z")
+        supervisor_start = timezone.parse("2024-12-01T01:00:00Z")
+        ti_context = make_ti_context()
+        ti_context.start_date = db_start
+
+        task = BaseOperator(task_id="test_start_date")
+        task.dag = DAG(dag_id="test_dag", start_date=timezone.datetime(2024, 12, 3))
+
+        startup = StartupDetails(
+            ti=TaskInstance(
+                id=uuid7(),
+                task_id="test_start_date",
+                dag_id="test_dag",
+                run_id="test_run",
+                try_number=1,
+                dag_version_id=uuid7(),
+            ),
+            dag_rel_path="",
+            bundle_info=BundleInfo(name="anything", version="any"),
+            ti_context=ti_context,
+            start_date=supervisor_start,
+            sentry_integration="",
+        )
+
+        ti = mocked_parse(startup, "test_dag", task)
+        assert ti.start_date == db_start
+
+    def test_start_date_falls_back_to_supervisor(self, mocked_parse, make_ti_context):
+        """Test that supervisor start_date is used when TIRunContext has no start_date."""
+        supervisor_start = timezone.parse("2024-12-01T01:00:00Z")
+        ti_context = make_ti_context()
+
+        task = BaseOperator(task_id="test_start_fallback")
+        task.dag = DAG(dag_id="test_dag", start_date=timezone.datetime(2024, 12, 3))
+
+        startup = StartupDetails(
+            ti=TaskInstance(
+                id=uuid7(),
+                task_id="test_start_fallback",
+                dag_id="test_dag",
+                run_id="test_run",
+                try_number=1,
+                dag_version_id=uuid7(),
+            ),
+            dag_rel_path="",
+            bundle_info=BundleInfo(name="anything", version="any"),
+            ti_context=ti_context,
+            start_date=supervisor_start,
+            sentry_integration="",
+        )
+
+        ti = mocked_parse(startup, "test_dag", task)
+        assert ti.start_date == supervisor_start


### PR DESCRIPTION
### Description:
In AF2, listener hooks (`on_task_instance_success/failed`) received the full ORM `TaskInstance` model, which includes `duration`, `queued_dttm`, and `start_date`. In AF3, these hooks receive `RuntimeTaskInstance` — a minimal runtime object missing these fields. Plugins relying on them for metrics break when migrating to AF3.

Additionally, DAG-level hooks (`on_dag_run_*`) already expose queue time via `DagRun.queued_at`, but task-level hooks do not expose the equivalent `queued_dttm`. This is inconsistent across the listener API.

### Changes

- **`duration`** : added as a computed property on `RuntimeTaskInstance`: `(end_date - start_date).total_seconds()`. This matches the ORM's `set_duration()` formula. 
- **`queued_dttm`**: Flows from DB → `TIRunContext` → `RuntimeTaskInstance` via the Execution API `ti_run` endpoint.
- **start_date**: Flows from DB → TIRunContext → RuntimeTaskInstance. Preserves the original start time across deferrals so that `duration` is computed correctly for deferred tasks (previously used the supervisor process start time, under-reporting duration).

All three fields added to RuntimeTaskInstanceProtocol.

### Use case

  Listener plugins that publish task execution metrics need `duration` (how long the task ran) and `queued_dttm` (how long it waited in queue before starting). Without these fields, plugin authors must either query the DB directly from the listener hook or accept missing metrics, neither is ideal.

  ---

  - [X] Yes (please specify the tool below)

  Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
