### PR TITLE
Increase Playwright E2E test retries to 4 in CI

### DIFF
--- a/airflow-core/src/airflow/ui/playwright.config.ts
+++ b/airflow-core/src/airflow/ui/playwright.config.ts
@@ -107,7 +107,7 @@ export default defineConfig({
     process.env.CI !== undefined && process.env.CI !== "" ? ["github"] : ["list"],
   ],
 
-  retries: process.env.CI !== undefined && process.env.CI !== "" ? 2 : 0,
+  retries: process.env.CI !== undefined && process.env.CI !== "" ? 4 : 0,
 
   testDir: "./tests/e2e/specs",
   // TODO: Temporarily ignore flaky specs until stabilized


### PR DESCRIPTION
Increase the number of Playwright E2E test retries from 2 to 4 in CI to reduce flaky test failures.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)  - finding it out. 

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)