### PR TITLE
Add cleanup to Kafka AwaitMessageTrigger for consumer management

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -108,6 +108,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
 
         async_get_consumer = sync_to_async(consumer_hook.get_consumer)
         consumer = await async_get_consumer()
+        self._consumer = consumer  # store for cleanup
 
         async_poll = sync_to_async(consumer.poll)
         async_commit = sync_to_async(consumer.commit)
@@ -141,3 +142,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
                     if self.commit_offset:
                         await async_commit(message=message, asynchronous=False)
                     await asyncio.sleep(self.poll_interval)
+
+    async def cleanup(self) -> None:
+        if consumer := getattr(self, "_consumer", None):
+            consumer.close()

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Sequence
 from functools import partial
 from typing import Any
@@ -33,6 +34,8 @@ if AIRFLOW_V_3_0_PLUS:
     from airflow.triggers.base import BaseEventTrigger
 else:
     from airflow.triggers.base import BaseTrigger as BaseEventTrigger  # type: ignore
+
+log = logging.getLogger(__name__)
 
 
 class AwaitMessageTrigger(BaseEventTrigger):
@@ -87,6 +90,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
         self.poll_timeout = poll_timeout
         self.poll_interval = poll_interval
         self.commit_offset = commit_offset
+        self._consumer = None
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return (
@@ -107,11 +111,10 @@ class AwaitMessageTrigger(BaseEventTrigger):
         consumer_hook = KafkaConsumerHook(topics=self.topics, kafka_config_id=self.kafka_config_id)
 
         async_get_consumer = sync_to_async(consumer_hook.get_consumer)
-        consumer = await async_get_consumer()
-        self._consumer = consumer  # store for cleanup
+        self._consumer = await async_get_consumer()
 
-        async_poll = sync_to_async(consumer.poll)
-        async_commit = sync_to_async(consumer.commit)
+        async_poll = sync_to_async(self._consumer.poll)
+        async_commit = sync_to_async(self._consumer.commit)
 
         async_message_process = None
         if self.apply_function:
@@ -144,5 +147,10 @@ class AwaitMessageTrigger(BaseEventTrigger):
                     await asyncio.sleep(self.poll_interval)
 
     async def cleanup(self) -> None:
-        if consumer := getattr(self, "_consumer", None):
-            consumer.close()
+        consumer = self._consumer
+        if consumer is not None:
+            self._consumer = None
+            try:
+                await sync_to_async(consumer.close)()
+            except Exception:
+                log.warning("Failed to close Kafka consumer", exc_info=True)

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -59,6 +59,9 @@ class MockedConsumer:
     def commit(*args, **kwargs):
         return True
 
+    def close(*args, **kwargs):
+        return None
+
 
 class TestTrigger:
     @pytest.fixture(autouse=True)
@@ -141,6 +144,40 @@ class TestTrigger:
         await asyncio.sleep(1.0)
         assert task.done() is False
         asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_closes_consumer(self, mocker):
+        consumer = MockedConsumer()
+        close_mock = mocker.patch.object(consumer, "close")
+
+        mocker.patch.object(KafkaConsumerHook, "get_consumer", return_value=consumer)
+
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            apply_function="unit.apache.kafka.triggers.test_await_message.apply_function_true",
+            topics=["noop"],
+            poll_timeout=0.0001,
+            poll_interval=5,
+        )
+
+        generator = trigger.run()
+        await generator.__anext__()
+        await trigger.cleanup()
+        await generator.aclose()
+
+        close_mock.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_consumer_is_noop(self):
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            apply_function="unit.apache.kafka.triggers.test_await_message.apply_function_true",
+            topics=["noop"],
+            poll_timeout=0.0001,
+            poll_interval=5,
+        )
+
+        await trigger.cleanup()
 
 
 @mark_common_msg_queue_test

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest.mock import call
 
 import pytest
 
@@ -165,10 +166,10 @@ class TestTrigger:
         await trigger.cleanup()
         await generator.aclose()
 
-        close_mock.assert_called_once_with()
+        assert close_mock.mock_calls == [call()]
 
     @pytest.mark.asyncio
-    async def test_cleanup_without_consumer_is_noop(self):
+    async def test_cleanup_does_not_raise_without_consumer(self):
         trigger = AwaitMessageTrigger(
             kafka_config_id="kafka_d",
             apply_function="unit.apache.kafka.triggers.test_await_message.apply_function_true",


### PR DESCRIPTION

* related: #64205


## Why

When testing out Kafka external-event driven Dag for ##64205 scenario, I encounter the following error with only enabling one consumer Dag

```
max.poll.interval.ms default 300000 timeout ...
```

## What

I verify locally that adding proper resource cleanup for Kafka Consumer can avoid the above error.

---

##### Was generative AI tooling used to co-author this PR?


- [x] Yes (please specify the tool below) Codex for unit tests following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)