### PR TITLE
Fix serde deserialization of old-format builtin types in trigger kwargs

### DIFF
--- a/shared/serialization/src/airflow_shared/serialization/__init__.py
+++ b/shared/serialization/src/airflow_shared/serialization/__init__.py
@@ -42,7 +42,7 @@ FORBIDDEN_XCOM_KEYS = frozenset(
     }
 )
 
-OLD_TYPE_TO_QUALNAME: dict[str, str] = {
+OLD_TYPE_TO_FULL_QUALNAME: dict[str, str] = {
     "tuple": "builtins.tuple",
     "set": "builtins.set",
     "frozenset": "builtins.frozenset",

--- a/shared/serialization/src/airflow_shared/serialization/__init__.py
+++ b/shared/serialization/src/airflow_shared/serialization/__init__.py
@@ -41,3 +41,10 @@ FORBIDDEN_XCOM_KEYS = frozenset(
         OLD_DATA,
     }
 )
+
+OLD_TYPE_TO_QUALNAME: dict[str, str] = {
+    "tuple": "builtins.tuple",
+    "set": "builtins.set",
+    "frozenset": "builtins.frozenset",
+    "timedelta": "datetime.timedelta",
+}

--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -37,6 +37,7 @@ from airflow.sdk._shared.serialization import (
     OLD_DATA,
     OLD_DICT,
     OLD_TYPE,
+    OLD_TYPE_TO_QUALNAME,
     SCHEMA_ID,
     VERSION,
 )
@@ -307,7 +308,8 @@ def _convert(old: dict) -> dict:
         # Return old style dicts directly as they do not need wrapping
         if old[OLD_TYPE] == OLD_DICT:
             return old[OLD_DATA]
-        return {CLASSNAME: old[OLD_TYPE], VERSION: DEFAULT_VERSION, DATA: old[OLD_DATA]}
+        type_name = OLD_TYPE_TO_QUALNAME.get(old[OLD_TYPE], old[OLD_TYPE])
+        return {CLASSNAME: type_name, VERSION: DEFAULT_VERSION, DATA: old[OLD_DATA]}
 
     return old
 

--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -37,7 +37,7 @@ from airflow.sdk._shared.serialization import (
     OLD_DATA,
     OLD_DICT,
     OLD_TYPE,
-    OLD_TYPE_TO_QUALNAME,
+    OLD_TYPE_TO_FULL_QUALNAME,
     SCHEMA_ID,
     VERSION,
 )
@@ -308,8 +308,11 @@ def _convert(old: dict) -> dict:
         # Return old style dicts directly as they do not need wrapping
         if old[OLD_TYPE] == OLD_DICT:
             return old[OLD_DATA]
-        type_name = OLD_TYPE_TO_QUALNAME.get(old[OLD_TYPE], old[OLD_TYPE])
-        return {CLASSNAME: type_name, VERSION: DEFAULT_VERSION, DATA: old[OLD_DATA]}
+        return {
+            CLASSNAME: OLD_TYPE_TO_FULL_QUALNAME.get(old[OLD_TYPE], old[OLD_TYPE]),
+            VERSION: DEFAULT_VERSION,
+            DATA: old[OLD_DATA],
+        }
 
     return old
 

--- a/task-sdk/tests/task_sdk/serde/test_serde.py
+++ b/task-sdk/tests/task_sdk/serde/test_serde.py
@@ -447,6 +447,38 @@ class TestSerDe:
         e = deserialize(i)
         assert e["extra"] == {"hi": "bye"}
 
+    @pytest.mark.parametrize(
+        ("old_type", "expected"),
+        [
+            ("tuple", (1, 2, 3)),
+            ("set", {1, 2, 3}),
+            ("frozenset", frozenset([1, 2, 3])),
+        ],
+    )
+    def test_backwards_compat_builtin_collections(self, old_type, expected):
+        """Verify deserialization of old-style builtin collections (tuple/set/frozenset)."""
+        data = {"__type": old_type, "__var": [1, 2, 3]}
+        result = deserialize(data)
+        assert result == expected
+        assert type(result) is type(expected)
+
+    def test_backwards_compat_builtin_collection_nested(self):
+        """Verify deserialization of old-style tuple nested inside a dict."""
+        data = {
+            "arg1": "hello",
+            "arg2": {"__type": "tuple", "__var": [1, 2]},
+        }
+        result = deserialize(data)
+        assert result == {"arg1": "hello", "arg2": (1, 2)}
+
+    def test_backwards_compat_timedelta(self):
+        """Verify deserialization of old-style timedelta."""
+        import datetime
+
+        data = {"__type": "timedelta", "__var": 3600.0}
+        result = deserialize(data)
+        assert result == datetime.timedelta(seconds=3600)
+
     def test_encode_asset(self):
         asset = Asset(uri="mytest://asset", name="test")
         obj = deserialize(serialize(asset))


### PR DESCRIPTION

* closes: #64613
* related: #64598

## Why

Trigger kwargs stored in the old serialization format (e.g., `{"__type": "tuple", "__var": [1, 2]}`) fail to deserialize because `_convert` preserves the short type name
(`"tuple"`) while the serde deserializer only recognizes fully-qualified names (`"builtins.tuple"`), causing an `ImportError` that cascades into a `KeyError` on the
`BaseSerialization` fallback path.

## What

- Add `OLD_TYPE_TO_QUALNAME` dict to shared/serialization mapping `tuple` -> `builtins.tuple`, `set` -> `builtins.set`, `frozenset` -> `builtins.frozenset`, `timedelta` -> `datetime.timedelta`
- Update `_convert` in `task-sdk/src/airflow/sdk/serde/__init__.py` to resolve old type names via the mapping before constructing the new-format dict
- Add tests for old-format deserialization of builtin collections (`tuple`, `set`, `frozenset`), nested old-format tuples inside dicts, and old-format `timedelta`


##### Was generative AI tooling used to co-author this PR?


- [x] Yes, Claude Code
