### PR TITLE
Prevent path traversal via AIRFLOW_CLI_ENVIRONMENT in airflowctl

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -176,7 +176,7 @@ class Credentials:
     def __init__(
         self,
         *,
-        client_kind: ClientKind,
+        client_kind: ClientKind = ClientKind.CLI,
         api_environment: str | None = None,
         api_url: str | None = None,
         api_token: str | None = None,

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -23,9 +23,11 @@ import getpass
 import json
 import logging
 import os
+import re
 import sys
 from collections.abc import Callable
 from functools import wraps
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
 import httpx
@@ -144,6 +146,25 @@ def _bounded_get_new_password() -> str:
     )
 
 
+_VALID_ENV_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+def _validate_api_environment(api_environment: str) -> str:
+    if not _VALID_ENV_RE.fullmatch(api_environment):
+        raise ValueError(
+            "Invalid AIRFLOW_CLI_ENVIRONMENT. Only letters, numbers, '.', '_' and '-' are allowed."
+        )
+    return api_environment
+
+
+def _safe_path_under_airflow_home(airflow_home: str, filename: str) -> str:
+    base = Path(airflow_home).resolve()
+    target = (base / filename).resolve()
+    if base not in target.parents and target != base:
+        raise ValueError(f"Resolved path escapes AIRFLOW_HOME: {target}")
+    return str(target)
+
+
 # Credentials for the API
 class Credentials:
     """Credentials for the API."""
@@ -154,27 +175,29 @@ class Credentials:
 
     def __init__(
         self,
+        *,
+        client_kind: ClientKind,
+        api_environment: str | None = None,
         api_url: str | None = None,
         api_token: str | None = None,
-        client_kind: ClientKind | None = None,
-        api_environment: str = "production",
     ):
+        self.client_kind = client_kind
+        raw_env = (
+            api_environment
+            if api_environment is not None
+            else os.getenv("AIRFLOW_CLI_ENVIRONMENT", "production")
+        )
+        self.api_environment = _validate_api_environment(raw_env)
+        self.input_cli_config_file = f"{self.api_environment}.json"
         self.api_url = api_url
         self.api_token = api_token
-        self.api_environment = os.getenv("AIRFLOW_CLI_ENVIRONMENT") or api_environment
-        self.client_kind = client_kind
-
-    @property
-    def input_cli_config_file(self) -> str:
-        """Generate path for the CLI config file."""
-        return f"{self.api_environment}.json"
 
     @staticmethod
     def token_key_for_environment(api_environment: str) -> str:
         """Build the keyring/debug token key for a given environment name."""
         return f"api_token_{api_environment}"
 
-    def save(self, skip_keyring: bool = False):
+    def save(self, skip_keyring: bool = False) -> Credentials:
         """
         Save the credentials to keyring and URL to disk as a file.
 
@@ -183,18 +206,21 @@ class Credentials:
         """
         default_config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
         os.makedirs(default_config_dir, exist_ok=True)
-        with open(os.path.join(default_config_dir, self.input_cli_config_file), "w") as f:
+
+        config_path = _safe_path_under_airflow_home(default_config_dir, self.input_cli_config_file)
+        with open(config_path, "w") as f:
             json.dump({"api_url": self.api_url}, f)
 
         try:
             if os.getenv("AIRFLOW_CLI_DEBUG_MODE") == "true":
-                with open(
-                    os.path.join(default_config_dir, f"debug_creds_{self.input_cli_config_file}"), "w"
-                ) as f:
+                debug_path = _safe_path_under_airflow_home(
+                    default_config_dir, f"debug_creds_{self.input_cli_config_file}"
+                )
+                with open(debug_path, "w") as f:
                     json.dump({self.token_key_for_environment(self.api_environment): self.api_token}, f)
             else:
                 if skip_keyring:
-                    return
+                    return self
                 # Replace the upstream EncryptedKeyring's unbounded password
                 # prompt with a bounded one before set_password can trigger it.
                 # The active backend may be a ChainerBackend that delegates to
@@ -222,11 +248,11 @@ class Credentials:
             # This happens when the token is None, which is not allowed by keyring
             if self.api_token is None and self.client_kind == ClientKind.CLI:
                 raise AirflowCtlCredentialNotFoundException("No API token found. Please login first.") from e
+        return self
 
     def load(self) -> Credentials:
-        """Load the credentials from keyring and URL from disk file."""
         default_config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
-        config_path = os.path.join(default_config_dir, self.input_cli_config_file)
+        config_path = _safe_path_under_airflow_home(default_config_dir, self.input_cli_config_file)
         try:
             with open(config_path) as f:
                 credentials = json.load(f)
@@ -234,7 +260,7 @@ class Credentials:
                 if self.api_token is not None:
                     return self
                 if os.getenv("AIRFLOW_CLI_DEBUG_MODE") == "true":
-                    debug_creds_path = os.path.join(
+                    debug_creds_path = _safe_path_under_airflow_home(
                         default_config_dir, f"debug_creds_{self.input_cli_config_file}"
                     )
                     try:

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -148,7 +148,7 @@ def _bounded_get_new_password() -> str:
 def _safe_path_under_airflow_home(airflow_home: str, filename: str) -> str:
     base = Path(airflow_home).resolve()
     target = (base / filename).resolve()
-    if base not in target.parents and target != base:
+    if not target.is_relative_to(base):
         raise ValueError(f"Resolved path escapes AIRFLOW_HOME: {target}")
     return str(target)
 

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -185,7 +185,7 @@ class Credentials:
         raw_env = (
             api_environment
             if api_environment is not None
-            else os.getenv("AIRFLOW_CLI_ENVIRONMENT", "production")
+            else (os.getenv("AIRFLOW_CLI_ENVIRONMENT") or os.getenv("AIRFLOW_CLI_ENV") or "production")
         )
         self.api_environment = _validate_api_environment(raw_env)
         self.input_cli_config_file = f"{self.api_environment}.json"

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -151,9 +151,7 @@ _VALID_ENV_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 
 def _validate_api_environment(api_environment: str) -> str:
     if not _VALID_ENV_RE.fullmatch(api_environment):
-        raise ValueError(
-            "Invalid AIRFLOW_CLI_ENVIRONMENT. Only letters, numbers, '.', '_' and '-' are allowed."
-        )
+        raise ValueError("Invalid AIRFLOW_CLI_ENVIRONMENT")
     return api_environment
 
 
@@ -175,29 +173,31 @@ class Credentials:
 
     def __init__(
         self,
-        *,
-        client_kind: ClientKind = ClientKind.CLI,
-        api_environment: str | None = None,
         api_url: str | None = None,
         api_token: str | None = None,
+        client_kind: ClientKind | None = None,
+        api_environment: str = "production",
     ):
-        self.client_kind = client_kind
-        raw_env = (
-            api_environment
-            if api_environment is not None
-            else (os.getenv("AIRFLOW_CLI_ENVIRONMENT") or os.getenv("AIRFLOW_CLI_ENV") or "production")
-        )
-        self.api_environment = _validate_api_environment(raw_env)
-        self.input_cli_config_file = f"{self.api_environment}.json"
         self.api_url = api_url
         self.api_token = api_token
+        raw_env = os.getenv("AIRFLOW_CLI_ENVIRONMENT")
+        if raw_env is None:
+            raw_env = api_environment
+        self.api_environment = _validate_api_environment(raw_env)
+        self.client_kind = client_kind
+
+    @property
+    def input_cli_config_file(self) -> str:
+        """Generate path for the CLI config file."""
+        env = _validate_api_environment(self.api_environment)
+        return f"{env}.json"
 
     @staticmethod
     def token_key_for_environment(api_environment: str) -> str:
         """Build the keyring/debug token key for a given environment name."""
         return f"api_token_{api_environment}"
 
-    def save(self, skip_keyring: bool = False) -> Credentials:
+    def save(self, skip_keyring: bool = False):
         """
         Save the credentials to keyring and URL to disk as a file.
 
@@ -206,7 +206,6 @@ class Credentials:
         """
         default_config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
         os.makedirs(default_config_dir, exist_ok=True)
-
         config_path = _safe_path_under_airflow_home(default_config_dir, self.input_cli_config_file)
         with open(config_path, "w") as f:
             json.dump({"api_url": self.api_url}, f)
@@ -220,7 +219,7 @@ class Credentials:
                     json.dump({self.token_key_for_environment(self.api_environment): self.api_token}, f)
             else:
                 if skip_keyring:
-                    return self
+                    return
                 # Replace the upstream EncryptedKeyring's unbounded password
                 # prompt with a bounded one before set_password can trigger it.
                 # The active backend may be a ChainerBackend that delegates to
@@ -248,9 +247,9 @@ class Credentials:
             # This happens when the token is None, which is not allowed by keyring
             if self.api_token is None and self.client_kind == ClientKind.CLI:
                 raise AirflowCtlCredentialNotFoundException("No API token found. Please login first.") from e
-        return self
 
     def load(self) -> Credentials:
+        """Load the credentials from keyring and URL from disk file."""
         default_config_dir = os.environ.get("AIRFLOW_HOME", os.path.expanduser("~/airflow"))
         config_path = _safe_path_under_airflow_home(default_config_dir, self.input_cli_config_file)
         try:

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -23,7 +23,6 @@ import getpass
 import json
 import logging
 import os
-import re
 import sys
 from collections.abc import Callable
 from functools import wraps
@@ -146,15 +145,6 @@ def _bounded_get_new_password() -> str:
     )
 
 
-_VALID_ENV_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
-
-
-def _validate_api_environment(api_environment: str) -> str:
-    if not _VALID_ENV_RE.fullmatch(api_environment):
-        raise ValueError("Invalid AIRFLOW_CLI_ENVIRONMENT")
-    return api_environment
-
-
 def _safe_path_under_airflow_home(airflow_home: str, filename: str) -> str:
     base = Path(airflow_home).resolve()
     target = (base / filename).resolve()
@@ -183,14 +173,13 @@ class Credentials:
         raw_env = os.getenv("AIRFLOW_CLI_ENVIRONMENT")
         if raw_env is None:
             raw_env = api_environment
-        self.api_environment = _validate_api_environment(raw_env)
         self.client_kind = client_kind
+        self.api_environment = os.getenv("AIRFLOW_CLI_ENVIRONMENT") or api_environment
 
     @property
     def input_cli_config_file(self) -> str:
         """Generate path for the CLI config file."""
-        env = _validate_api_environment(self.api_environment)
-        return f"{env}.json"
+        return f"{self.api_environment}.json"
 
     @staticmethod
     def token_key_for_environment(api_environment: str) -> str:

--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -63,6 +63,7 @@ from airflowctl.api.operations import (
 )
 from airflowctl.exceptions import (
     AirflowCtlCredentialNotFoundException,
+    AirflowCtlException,
     AirflowCtlKeyringException,
     AirflowCtlNotFoundException,
 )
@@ -149,7 +150,10 @@ def _safe_path_under_airflow_home(airflow_home: str, filename: str) -> str:
     base = Path(airflow_home).resolve()
     target = (base / filename).resolve()
     if not target.is_relative_to(base):
-        raise ValueError(f"Resolved path escapes AIRFLOW_HOME: {target}")
+        raise AirflowCtlException(
+            f"Security Error: Path traversal detected in '{filename}'. "
+            f"The resolved path must stay within AIRFLOW_HOME."
+        )
     return str(target)
 
 
@@ -170,11 +174,15 @@ class Credentials:
     ):
         self.api_url = api_url
         self.api_token = api_token
-        raw_env = os.getenv("AIRFLOW_CLI_ENVIRONMENT")
-        if raw_env is None:
-            raw_env = api_environment
         self.client_kind = client_kind
-        self.api_environment = os.getenv("AIRFLOW_CLI_ENVIRONMENT") or api_environment
+        raw_env = os.getenv("AIRFLOW_CLI_ENVIRONMENT") or api_environment
+        if "/" in raw_env or "\\" in raw_env or ".." in raw_env:
+            raise AirflowCtlException(
+                f"Invalid environment name: '{raw_env}'. "
+                f"Environment names cannot contain path separators ('/', '\\') or '..'."
+            )
+
+        self.api_environment = raw_env
 
     @property
     def input_cli_config_file(self) -> str:

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -32,6 +32,7 @@ from airflowctl.api.client import Client, ClientKind, Credentials, _bounded_get_
 from airflowctl.api.operations import ServerResponseError
 from airflowctl.exceptions import (
     AirflowCtlCredentialNotFoundException,
+    AirflowCtlException,
     AirflowCtlKeyringException,
 )
 
@@ -401,12 +402,12 @@ def test_credentials_accepts_safe_env():
 
 @pytest.mark.parametrize("api_environment", ["../evil", "..\\evil", "a/b", "a\\b"])
 def test_credentials_rejects_unsafe_env_argument(api_environment):
-    with pytest.raises(ValueError, match="environment"):
+    with pytest.raises(AirflowCtlException, match="environment"):
         Credentials(client_kind=ClientKind.CLI, api_environment=api_environment)
 
 
 @pytest.mark.parametrize("api_environment", ["../evil", "..\\evil", "a/b", "a\\b"])
 def test_credentials_rejects_unsafe_env_from_environment_variable(monkeypatch, api_environment):
     monkeypatch.setenv("AIRFLOW_CLI_ENVIRONMENT", api_environment)
-    with pytest.raises(ValueError, match="environment"):
+    with pytest.raises(AirflowCtlException, match="environment"):
         Credentials(client_kind=ClientKind.CLI)

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -394,12 +394,6 @@ class TestSaveKeyringPatching:
             creds.load()
 
 
-@pytest.mark.parametrize("bad_env", ["../evil", "..\\evil", "a/b", "a\\b", ""])
-def test_credentials_rejects_path_traversal_env(bad_env):
-    with pytest.raises(ValueError, match="Invalid AIRFLOW_CLI_ENVIRONMENT"):
-        Credentials(client_kind=ClientKind.CLI, api_environment=bad_env)
-
-
 def test_credentials_accepts_safe_env():
     creds = Credentials(client_kind=ClientKind.CLI, api_environment="prod-us_1")
     assert creds.api_environment == "prod-us_1"

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -397,3 +397,16 @@ class TestSaveKeyringPatching:
 def test_credentials_accepts_safe_env():
     creds = Credentials(client_kind=ClientKind.CLI, api_environment="prod-us_1")
     assert creds.api_environment == "prod-us_1"
+
+
+@pytest.mark.parametrize("api_environment", ["../evil", "..\\evil", "a/b", "a\\b"])
+def test_credentials_rejects_unsafe_env_argument(api_environment):
+    with pytest.raises(ValueError, match="environment"):
+        Credentials(client_kind=ClientKind.CLI, api_environment=api_environment)
+
+
+@pytest.mark.parametrize("api_environment", ["../evil", "..\\evil", "a/b", "a\\b"])
+def test_credentials_rejects_unsafe_env_from_environment_variable(monkeypatch, api_environment):
+    monkeypatch.setenv("AIRFLOW_CLI_ENVIRONMENT", api_environment)
+    with pytest.raises(ValueError, match="environment"):
+        Credentials(client_kind=ClientKind.CLI)

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -392,3 +392,14 @@ class TestSaveKeyringPatching:
         creds = Credentials(client_kind=ClientKind.CLI, api_environment="TEST_DEBUG")
         with pytest.raises(AirflowCtlCredentialNotFoundException, match="Debug credentials file not found"):
             creds.load()
+
+
+@pytest.mark.parametrize("bad_env", ["../evil", "..\\evil", "a/b", "a\\b", ""])
+def test_credentials_rejects_path_traversal_env(bad_env):
+    with pytest.raises(ValueError, match="Invalid AIRFLOW_CLI_ENVIRONMENT"):
+        Credentials(client_kind=ClientKind.CLI, api_environment=bad_env)
+
+
+def test_credentials_accepts_safe_env():
+    creds = Credentials(client_kind=ClientKind.CLI, api_environment="prod-us_1")
+    assert creds.api_environment == "prod-us_1"


### PR DESCRIPTION
 ### Description
 Fixes a path traversal vulnerability where api_environment could be used to read/write files outside of AIRFLOW_HOME using ``../``.

### Key Changes

* Path Enforcement: Used `pathlib.Path.resolve()` to ensure all credential files remain physically constrained within the `AIRFLOW_HOME `directory.

* Regression Tests: Added `pytest` cases to verify rejection of malicious paths (e.g., ../evil) and acceptance of safe environment names.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
