### PR TITLE
Fix asset watcher triggers deleted on every dag-parsing loop

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -54,6 +54,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarningType
 from airflow.models.errors import ParseImportError
 from airflow.models.trigger import Trigger
+from airflow.serialization.decoders import smart_decode_trigger_kwargs
 from airflow.serialization.definitions.assets import (
     SerializedAsset,
     SerializedAssetAlias,
@@ -726,6 +727,23 @@ def _find_all_asset_aliases(dags: Iterable[LazyDeserializedDAG]) -> Iterator[Ser
             yield alias
 
 
+def _get_raw_trigger_kwargs(trigger) -> tuple[str, dict]:
+    """
+    Extract classpath and raw Python kwargs from a trigger.
+
+    Unlike ``encode_trigger``, this does NOT wrap values with
+    ``BaseSerialization``.  For dict triggers (from deserialized DAGs),
+    any BaseSerialization-wrapped values are unwrapped back to Python
+    objects, ensuring hash consistency with kwargs read back from the DB
+    via ``Trigger._decrypt_kwargs``.
+    """
+    if isinstance(trigger, dict):
+        classpath = trigger["classpath"]
+        raw_kwargs = trigger["kwargs"]
+        return classpath, {k: smart_decode_trigger_kwargs(v) for k, v in raw_kwargs.items()}
+    return trigger.serialize()
+
+
 def _find_active_assets(name_uri_assets: Iterable[tuple[str, str]], session: Session) -> set[tuple[str, str]]:
     return {
         (str(row[0]), str(row[1]))
@@ -1001,8 +1019,6 @@ class AssetModelOperation(NamedTuple):
     def add_asset_trigger_references(
         self, assets: dict[tuple[str, str], AssetModel], *, session: Session
     ) -> None:
-        from airflow.serialization.encoders import encode_trigger
-
         # Update references from assets being used
         refs_to_add: dict[tuple[str, str], set[int]] = {}
         refs_to_remove: dict[tuple[str, str], set[int]] = {}
@@ -1013,14 +1029,15 @@ class AssetModelOperation(NamedTuple):
 
         for name_uri, asset in self.assets.items():
             # If the asset belong to a DAG not active or paused, consider there is no watcher associated to it
-            asset_watcher_triggers = (
-                [
-                    {**encode_trigger(watcher.trigger), "watcher_name": watcher.name}
+            if name_uri in active_assets:
+                asset_watcher_triggers: list[dict[str, Any]] = [
+                    {"classpath": cp, "kwargs": kw, "watcher_name": watcher.name}
                     for watcher in asset.watchers
+                    for cp, kw in [_get_raw_trigger_kwargs(watcher.trigger)]
                 ]
-                if name_uri in active_assets
-                else []
-            )
+            else:
+                asset_watcher_triggers = []
+
             trigger_hash_to_trigger_dict: dict[int, dict] = {
                 BaseEventTrigger.hash(trigger["classpath"], trigger["kwargs"]): trigger
                 for trigger in asset_watcher_triggers
@@ -1029,6 +1046,7 @@ class AssetModelOperation(NamedTuple):
             trigger_hash_from_asset: set[int] = set(trigger_hash_to_trigger_dict.keys())
 
             asset_model = assets[name_uri]
+
             trigger_hash_from_asset_model: set[int] = {
                 BaseEventTrigger.hash(trigger.classpath, trigger.kwargs) for trigger in asset_model.triggers
             }

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -182,6 +182,59 @@ class TestAssetModelOperation:
         asset_model = session.scalars(select(AssetModel)).one()
         assert len(asset_model.triggers) == expected_num_triggers
 
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_add_asset_trigger_references_is_idempotent(self, dag_maker, session):
+        """Calling add_asset_trigger_references twice should be a no-op on the second call.
+
+        This guards against the bug where a serialization mismatch between DAG-defined
+        and DB-stored trigger kwargs caused BaseEventTrigger.hash() to produce different
+        hashes, resulting in triggers being deleted and recreated every parsing loop.
+        """
+        asset = Asset(
+            "test_idempotent_asset",
+            watchers=[AssetWatcher(name="test", trigger=FileDeleteTrigger(mock.Mock()))],
+        )
+
+        with dag_maker(dag_id="test_idempotent_dag", schedule=[asset]) as dag:
+            EmptyOperator(task_id="mytask")
+
+        dags = {dag.dag_id: LazyDeserializedDAG.from_dag(dag)}
+        orm_dags = DagModelOperation(dags, "testing", None).add_dags(session=session)
+        dag_model = orm_dags[dag.dag_id]
+        dag_model.is_stale = False
+        dag_model.is_paused = False
+
+        asset_op = AssetModelOperation.collect(dags)
+        orm_assets = asset_op.sync_assets(session=session)
+        session.flush()
+
+        asset_op.add_dag_asset_references(orm_dags, orm_assets, session=session)
+        asset_op.activate_assets_if_possible(orm_assets.values(), session=session)
+
+        # First call — creates the trigger.
+        asset_op.add_asset_trigger_references(orm_assets, session=session)
+        session.flush()
+
+        asset_model = session.scalars(select(AssetModel)).one()
+        assert len(asset_model.triggers) == 1
+        trigger_ids_first = {t.id for t in asset_model.triggers}
+
+        # Expire cached state so the second call reads fresh DB data,
+        # simulating a new parsing loop.
+        session.expire_all()
+
+        # Second call — should be a no-op (same trigger IDs, no churn).
+        asset_op.add_asset_trigger_references(orm_assets, session=session)
+        session.flush()
+
+        asset_model = session.scalars(select(AssetModel)).one()
+        assert len(asset_model.triggers) == 1
+        trigger_ids_second = {t.id for t in asset_model.triggers}
+
+        assert trigger_ids_first == trigger_ids_second, (
+            "Trigger IDs changed between parsing loops — add_asset_trigger_references is not idempotent"
+        )
+
     @pytest.mark.parametrize(
         ("schedule", "model", "columns", "expected"),
         [


### PR DESCRIPTION
## Summary
Fix asset watcher triggers being deleted and recreated on every dag-parsing loop.
`encode_trigger` wraps kwargs with `BaseSerialization.serialize()` (e.g., `tuple()` becomes
`{"__type": "tuple", "__var": []}`), which is correct for JSON-serializable DAG definitions.
However, `add_asset_trigger_references` needs raw Python kwargs because `Trigger._decrypt_kwargs`
returns native Python objects from the DB. This mismatch caused `BaseEventTrigger.hash()` to
produce different hashes for the same logical trigger, resulting in an infinite delete/recreate
cycle every parsing loop.
Replace `encode_trigger` with `_get_raw_trigger_kwargs` that unwraps any BaseSerialization-encoded
values back to native Python objects, ensuring hash consistency between DAG-defined and DB-stored
triggers. `encode_trigger` remains in use where it belongs — DAG serialization for JSON storage.


- [X] Yes (please specify the tool below)
Claude

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
