### PR TITLE
Log on_kill job deletion in kubernetes spark operator at INFO level

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -421,7 +421,7 @@ class SparkKubernetesOperator(KubernetesPodOperator):
         return self.find_spark_job(context, exclude_checked=exclude_checked)
 
     def on_kill(self) -> None:
-        self.log.debug("Deleting spark job for task %s", self.task_id)
+        self.log.info("Deleting spark job for task %s", self.task_id)
         job_name = self.name
         if self.pod and self.pod.metadata and self.pod.metadata.name:
             if self.pod.metadata.name.endswith("-driver"):


### PR DESCRIPTION
Sorry for making a PR for such a small change 😂 

I am trying to debug some SparkApplications which are being mysteriously deleted in one of our environments, I believe it is due to Airflow tasks failing and invoking their `on_kill` method, but I'm not getting any logs since this is at DEBUG-level. 

Deleting a running application is a pretty consequential action, I think its reasonable to log at INFO.