### PR TITLE
Fix OTel metrics lost on exit by enabling MeterProvider shutdown_on_exit

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -437,7 +437,7 @@ def get_otel_logger(
         MeterProvider(
             resource=resource,
             metric_readers=readers,
-            shutdown_on_exit=False,
+            shutdown_on_exit=True,
         ),
     )
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

When a short-lived Airflow process (e.g. `LocalTaskJob` worker, `DagProcessorJobRunner`) exits, any metrics emitted after the last periodic export tick is silently lost. This happens because `MeterProvider` is configured with `shutdown_on_exit=False`, so the SDK never registered its `atexit` handler to call `MeterProvider.shutdown()`. The existing `force_flush()` atexit hook only flushed the current buffer but it did not trigger the final collect that `PeriodicExportingMetricReader.shutdown()` performs, leaving the last partial export interval unsent.

This PR sets `shutdown_on_exit=True` so the SDK registers an `atexit` handler that calls `MeterProvider.shutdown()`,  which stops the background ticker and runs one final collect+export before the process exits.

### Changes

- `get_otel_logger()` in `airflow_shared/observability/metrics/otel_logger.py`: `shutdown_on_exit=False` → `shutdown_on_exit=True`

### Users affected

All Airflow components that use the OTel metrics logger and exit soon after emitting metrics — particularly `LocalTaskJob` workers and `DagProcessorJobRunner`. Metrics that previously fell in the last export window before process exit will now be reliably flushed.

Note: this fix applies to normal Python teardown (`sys.exit`, end of `main`, uncaught exceptions). It does not cover hard exits (`os._exit()`, `SIGKILL`) as those require an explicit `force_flush()` / `shutdown()` call in application code before exit.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
