### PR TITLE
Docs: Resolve task-sdk vs publish-docs contradiction

### DIFF
--- a/airflow-core/newsfragments/64648.doc.rst
+++ b/airflow-core/newsfragments/64648.doc.rst
@@ -1,0 +1,1 @@
+Clarify that Task SDK documentation is not published via the release ``publish-docs`` workflow yet; align ``dev/README_RELEASE_AIRFLOW.md`` examples with ``contributing-docs/11_documentation_building.rst``.

--- a/contributing-docs/11_documentation_building.rst
+++ b/contributing-docs/11_documentation_building.rst
@@ -31,7 +31,9 @@ Documentation in separate distributions:
 * ``airflow-core/docs`` - documentation for Airflow Core
 * ``providers/**/docs`` - documentation for Providers
 * ``chart/docs`` - documentation for Helm Chart
-* ``task-sdk/docs`` - documentation for Task SDK (new format not yet published)
+* ``task-sdk/docs`` - documentation for Task SDK (new format not yet published on the site). The
+  ``breeze workflow-run publish-docs`` steps in ``dev/README_RELEASE_AIRFLOW.md`` only publish
+  ``apache-airflow`` and ``docker-stack`` documentation; Task SDK docs are not part of that workflow yet.
 * ``airflow-ctl/docs`` - documentation for Airflow CLI (future)
 
 Documentation for general overview and summaries not connected with any specific distribution:

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -587,11 +587,16 @@ The command does the following:
 3. Triggers S3 to GitHub Sync
 
 ```shell script
-breeze workflow-run publish-docs --ref <tag> --site-env <staging/live/auto> apache-airflow docker-stack task-sdk
+breeze workflow-run publish-docs --ref <tag> --site-env <staging/live/auto> apache-airflow docker-stack
 
 # Example for RC
-breeze workflow-run publish-docs --ref ${VERSION_RC} --site-env staging apache-airflow docker-stack task-sdk
+breeze workflow-run publish-docs --ref ${VERSION_RC} --site-env staging apache-airflow docker-stack
 ```
+
+> **Note:** Task SDK documentation under `task-sdk/docs` is not published through this `publish-docs`
+> workflow yet (see [Building documentation](../contributing-docs/11_documentation_building.rst)). Pass
+> only `apache-airflow` and `docker-stack` here; do not add `task-sdk` as a package until that workflow
+> supports it.
 
 The `--ref` parameter should be the tag of the release candidate you are publishing.
 
@@ -620,7 +625,7 @@ previous version of the distribution). Example:
 breeze workflow-run publish-docs --ref 3.0.3 --site-env staging \
   --apply-commits 4ae273cbedec66c87dc40218c7a94863390a380d,e61e9618bdd6be8213d277b1427f67079fcb1d9b \
   --skip-write-to-stable-folder \
-  apache-airflow docker-stack task-sdk
+  apache-airflow docker-stack
 ```
 
 ### Manually using GitHub Actions
@@ -634,8 +639,9 @@ The release manager publishes the documentation using GitHub Actions workflow
 the tag you use - pre-release tags go to staging. But you can also override it and specify the destination
 manually to be `live` or `staging`.
 
-You should specify 'apache-airflow docker-stack task-sdk' passed as packages to be
-built.
+You should specify `apache-airflow docker-stack` as the packages to be built (Task SDK docs are not
+published via this workflow yet; see the **Note** in
+[Publish release candidate documentation (staging)](#publish-release-candidate-documentation-staging)).
 
 After that step, the provider documentation should be available under https://airflow.stage.apache.org//
 URL (RC PyPI packages are build with the staging urls) but stable links and drop-down boxes are not updated yet.
@@ -1360,7 +1366,7 @@ The command does the following:
 
 ```shell script
 # Example for final release
-breeze workflow-run publish-docs --ref ${VERSION} --site-env live apache-airflow docker-stack task-sdk
+breeze workflow-run publish-docs --ref ${VERSION} --site-env live apache-airflow docker-stack
 ```
 
 The `--ref` parameter should be the tag of the final version you are publishing.


### PR DESCRIPTION
## Summary

Closes #64350.

The documentation building guide describes `task-sdk/docs` as not yet published, while the release README listed `task-sdk` alongside `apache-airflow` and `docker-stack` in `publish-docs` examples. This updates the release instructions to match reality and points readers to where Task SDK docs stand.

## Changes

- `dev/README_RELEASE_AIRFLOW.md`: use `apache-airflow docker-stack` only in `publish-docs` examples; add a short note that Task SDK documentation is not published through this workflow yet.
- `contributing-docs/11_documentation_building.rst`: clarify that the release `publish-docs` steps do not include Task SDK docs yet.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes
- [ ] No



Made with [Cursor](https://cursor.com)