### PR TITLE
Add debug logging to Lambda hook

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/lambda_function.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/lambda_function.py
@@ -80,7 +80,19 @@ class LambdaHook(AwsBaseHook):
             "Payload": payload,
             "Qualifier": qualifier,
         }
-        return self.conn.invoke(**trim_none_values(invoke_args))
+        self.log.debug(
+            "Invoking Lambda function %s with invocation type %s, qualifier %s",
+            function_name,
+            invocation_type,
+            qualifier,
+        )
+        response = self.conn.invoke(**trim_none_values(invoke_args))
+        self.log.debug(
+            "Lambda invoke response: StatusCode=%s, FunctionError=%s",
+            response.get("StatusCode"),
+            response.get("FunctionError"),
+        )
+        return response
 
     def create_lambda(
         self,
@@ -192,7 +204,20 @@ class LambdaHook(AwsBaseHook):
             "SnapStart": snap_start,
             "LoggingConfig": logging_config,
         }
-        return self.conn.create_function(**trim_none_values(create_function_args))
+        self.log.debug(
+            "Creating Lambda function %s with runtime %s, handler %s, package type %s",
+            function_name,
+            runtime,
+            handler,
+            package_type,
+        )
+        response = self.conn.create_function(**trim_none_values(create_function_args))
+        self.log.debug(
+            "Lambda function created: ARN=%s, State=%s",
+            response.get("FunctionArn"),
+            response.get("State"),
+        )
+        return response
 
     @staticmethod
     @return_on_error(None)


### PR DESCRIPTION
Add debug logging before/after API calls in the Lambda hook
(`invoke_lambda` and `create_lambda`).

Follows the pattern established by the Airbyte provider in #51503 and
the DynamoDB hook in #64629. All logs are at `DEBUG` level so they are
no-ops unless explicitly enabled.

Part of the [Debugging Improvements — Airflow 3](https://github.com/orgs/apache/projects/329) initiative.

related: #51503, #64629

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)