### PR TITLE
Skip UI E2E tests on derived full tests needed, canary, and scheduled builds

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -953,7 +953,26 @@ class SelectiveChecks:
 
     @cached_property
     def run_ui_e2e_tests(self) -> bool:
-        return self._should_be_run(FileGroupForCi.UI_FILES)
+        # E2E tests should not be triggered by derived full_tests_needed (push events,
+        # env file changes, large PRs, etc.) - only by explicit label or actual file changes.
+        if FULL_TESTS_NEEDED_LABEL in self._pr_labels:
+            console_print(
+                f"[warning]{FileGroupForCi.UI_FILES} e2e enabled because "
+                f"'{FULL_TESTS_NEEDED_LABEL}' label is set[/]"
+            )
+            return True
+        matched_files = self._matching_files(FileGroupForCi.UI_FILES, CI_FILE_GROUP_MATCHES)
+        if matched_files:
+            console_print(
+                f"[warning]{FileGroupForCi.UI_FILES} e2e enabled because "
+                f"it matched {len(matched_files)} changed files[/]"
+            )
+            return True
+        console_print(
+            f"[warning]{FileGroupForCi.UI_FILES} e2e disabled because "
+            f"it did not match any changed files and no explicit label[/]"
+        )
+        return False
 
     @cached_property
     def run_remote_logging_s3_e2e_tests(self) -> bool:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1628,6 +1628,7 @@ def test_full_test_needed_when_scripts_changes(files: tuple[str, ...], expected_
                     "providers-test-types-list-as-strings-in-json": ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON,
                     "run-mypy": "true",
                     "mypy-checks": ALL_MYPY_CHECKS,
+                    "run-ui-e2e-tests": "true",
                 },
                 id="Everything should run including all providers when full tests are needed "
                 "but with single python and kubernetes if no version label is set",
@@ -1969,6 +1970,7 @@ def test_expected_output_pull_request_v2_7(
                 "core-test-types-list-as-strings-in-json": ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON,
                 "run-mypy": "true",
                 "mypy-checks": ALL_MYPY_CHECKS,
+                "run-ui-e2e-tests": "false",
             },
             id="All tests run on push if core file changed",
         ),


### PR DESCRIPTION
UI E2E tests are expensive and should only run when UI files actually
changed or the "full tests needed" label is explicitly set on a PR.

Previously they ran on every push to main, canary build, scheduled run,
and any PR that triggered derived `full_tests_needed` (env file changes,
large PRs, pyproject.toml changes, etc.) because `run_ui_e2e_tests`
delegated to `_should_be_run()` which returns `True` whenever
`full_tests_needed` is `True`.

Now `run_ui_e2e_tests` only returns `True` when:
- The `"full tests needed"` label is explicitly set on the PR, **or**
- UI files actually changed (matched by `FileGroupForCi.UI_FILES`)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)