### PR TITLE
Simplify ci_image_build and add test coverage for remote logging e2e

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -1081,12 +1081,10 @@ class SelectiveChecks:
             self.run_unit_tests
             or self.docs_build
             or self.run_kubernetes_tests
-            or self.run_task_sdk_integration_tests
-            or self.run_airflow_ctl_integration_tests
-            or self.run_helm_tests
             or self.run_ui_tests
             or self.pyproject_toml_changed
             or self.any_provider_yaml_or_pyproject_toml_changed
+            or self.prod_image_build
         )
 
     @cached_property

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1256,6 +1256,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "run-remote-logging-s3-e2e-tests": "true",
                     "run-remote-logging-elasticsearch-e2e-tests": "false",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                 },
                 id="S3 remote logging changes enable only S3 e2e",
@@ -1267,6 +1268,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "run-remote-logging-s3-e2e-tests": "false",
                     "run-remote-logging-elasticsearch-e2e-tests": "true",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                 },
                 id="Elasticsearch remote logging changes enable only Elasticsearch e2e",
@@ -1278,6 +1280,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "run-remote-logging-s3-e2e-tests": "false",
                     "run-remote-logging-elasticsearch-e2e-tests": "true",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                 },
                 id="Elasticsearch helper changes enable Elasticsearch e2e",
@@ -1289,6 +1292,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "run-remote-logging-s3-e2e-tests": "true",
                     "run-remote-logging-elasticsearch-e2e-tests": "true",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                 },
                 id="Shared remote logging changes enable both remote logging e2e jobs",
@@ -1300,6 +1304,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "run-remote-logging-s3-e2e-tests": "true",
                     "run-remote-logging-elasticsearch-e2e-tests": "true",
+                    "ci-image-build": "true",
                     "prod-image-build": "true",
                 },
                 id="Shared logging library changes enable both remote logging e2e jobs",


### PR DESCRIPTION
Refactor `ci_image_build` to delegate to `prod_image_build` instead of duplicating conditions, and add `ci-image-build: true` assertions to all 5 remote logging e2e test cases to verify CI image is built when remote logging files change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)