### PR TITLE
Clarify Task SDK docs publishing workflow (#64350)

### DIFF
--- a/contributing-docs/11_documentation_building.rst
+++ b/contributing-docs/11_documentation_building.rst
@@ -31,7 +31,7 @@ Documentation in separate distributions:
 * ``airflow-core/docs`` - documentation for Airflow Core
 * ``providers/**/docs`` - documentation for Providers
 * ``chart/docs`` - documentation for Helm Chart
-* ``task-sdk/docs`` - documentation for Task SDK (new format not yet published)
+* ``task-sdk/docs`` - documentation for Task SDK (new format not yet published through the release manager workflow)
 * ``airflow-ctl/docs`` - documentation for Airflow CLI (future)
 
 Documentation for general overview and summaries not connected with any specific distribution:

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ Documentation in separate distributions:
 * `airflow-core/docs` - documentation for Airflow Core
 * `providers/**/docs` - documentation for Providers
 * `chart/docs` - documentation for the Helm Chart
-* `task-sdk/docs` - documentation for Task SDK (new format not yet published)
+* `task-sdk/docs` - documentation for Task SDK (new format not yet published through the release manager workflow)
 * `airflow-ctl/docs` - documentation for Airflow CLI
 
 Documentation for a general overview and summaries not connected with any specific distribution:
@@ -143,9 +143,12 @@ the auto-detection.
 The person who triggers the build (release manager) should specify the tag name of the docs to be published
 and the list of documentation packages to be published. Usually it is:
 
-* Airflow: `apache-airflow docker-stack task-sdk apache-airflow-ctl`
+* Airflow: `apache-airflow docker-stack apache-airflow-ctl`
 * Helm chart: `helm-chart`
 * Providers: `provider_id1 provider_id2` or `all providers` if all providers should be published.
+
+Task SDK docs are intentionally not listed here yet. The documentation sources live in `task-sdk/docs`,
+but that new-format documentation is not part of the release manager publishing workflow at the moment.
 
 Optionally - specifically if we run `all-providers` and the release manager wants to exclude some providers,
 they can specify documentation packages to exclude. Leaving "no-docs-excluded" will publish all packages


### PR DESCRIPTION
## Summary
The docs currently say `task-sdk/docs` exists, but they also tell release managers to publish `task-sdk` alongside the regular Airflow docs. This update removes that contradiction by clarifying that Task SDK docs live in the repo today but are not part of the current release manager publishing workflow.

## Changes
- **`docs/README.md`** -- remove `task-sdk` from the default Airflow docs publishing package list and explain that Task SDK docs are not published through the release manager workflow yet.
- **`contributing-docs/11_documentation_building.rst`** -- align the package overview wording with the same workflow clarification.

## Evidence it works
- The publishing instructions are now internally consistent: `task-sdk/docs` is still documented as a source tree, but it is no longer listed in the default release manager package list.
- Scoped docs checks passed with:
  `prek run --stage pre-commit --files docs/README.md contributing-docs/11_documentation_building.rst`

## Test plan
- [x] `prek run --stage pre-commit --files docs/README.md contributing-docs/11_documentation_building.rst`
- [ ] CI passes (ruff, mypy, pytest)

Fixes #64350
