### PR TITLE
Fix GenericTransfer docs link in operators reference (#62470)

### DIFF
--- a/airflow-core/docs/operators-and-hooks-ref.rst
+++ b/airflow-core/docs/operators-and-hooks-ref.rst
@@ -65,7 +65,7 @@ For details see: :doc:`apache-airflow-providers:operators-and-hooks-ref/index`.
    * - :mod:`airflow.providers.standard.operators.empty`
      -
 
-   * - :mod:`airflow.providers.common.sql.operators.generic_transfer.GenericTransfer`
+   * - :class:`~airflow.providers.common.sql.operators.generic_transfer.GenericTransfer`
      - :doc:`How to use <apache-airflow-providers-common-sql:operators>`
 
    * - :mod:`airflow.providers.standard.operators.latest_only`


### PR DESCRIPTION
## Summary
The operators reference listed `GenericTransfer` with a `:mod:` role even though the entry points to a class path. Because of that mismatch, Sphinx rendered plain text instead of a clickable link. This switches the entry to `:class:` so the reference resolves to the provider docs as expected.

## Changes
- **`airflow-core/docs/operators-and-hooks-ref.rst`** -- change the `GenericTransfer` entry from a module role to a class role.

## Evidence it works
- Before the change, a local Sphinx build rendered the entry as plain code:
  `<code class="xref py py-mod ...">airflow.providers.common.sql.operators.generic_transfer.GenericTransfer</code>`
- After the change, the same page rebuilt with a provider-docs link:
  `<a class="reference external" href="/docs/apache-airflow-providers-common-sql/stable/_api/...#airflow.providers.common.sql.operators.generic_transfer.GenericTransfer">...`
- Scoped docs checks passed with:
  `prek run --stage pre-commit --files airflow-core/docs/operators-and-hooks-ref.rst`

## Test plan
- [x] `prek run --stage pre-commit --files airflow-core/docs/operators-and-hooks-ref.rst`
- [x] Local Sphinx rebuild of `operators-and-hooks-ref.html` confirmed the `GenericTransfer` entry changes from plain text to a clickable link.
- [ ] CI passes (ruff, mypy, pytest)

Fixes #62470
