### PR TITLE
Temporarily upgrade allowlist-check to latest version

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -31,4 +31,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@493edcdbd80d9e78a767f256a877b1cc6c9712ba  # main
+      - uses: apache/infrastructure-actions/allowlist-check@e9aff90d22568865baa7d1d12676c01fa29f59c4  # main


### PR DESCRIPTION
Temporary switch to the latest commit of `apache/infrastructure-actions` allowlist-check action.

This is needed until https://github.com/apache/infrastructure-actions/pull/662 is merged, which will provide a proper tagged release. Once that PR is merged, we should update to the tagged version.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)