### PR TITLE
Add boringCyborgAsRecognisedContributor flag

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -17,6 +17,11 @@
 ---
 # Details: https://github.com/kaxil/boring-cyborg
 
+# This flag indicates boring-cyborg[bot] is a recognised contributor whose
+# workflow runs do not require manual approval.
+# See: https://github.com/kaxil/boring-cyborg
+boringCyborgAsRecognisedContributor: true
+
 labelPRBasedOnFilePath:
   provider:airbyte:
     - providers/airbyte/**


### PR DESCRIPTION
Adds the `boringCyborgAsRecognisedContributor: true` flag to `.github/boring-cyborg.yml`.

This is a preparatory change for an upcoming boring-cyborg app upgrade (https://github.com/kaxil/boring-cyborg/pull/185) that adds an "initial PR" feature. When the app is upgraded, it will automatically create a one-time PR from a fork for repos that don't have this flag — to establish `boring-cyborg[bot]` as a recognised contributor so its workflow runs no longer require manual approval.


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)