### PR TITLE
Fix bulk task instance authorization error message rendering

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -342,7 +342,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         """Bulk Update Task Instances."""
         # Validate and categorize entities into specific and all map index update sets
         update_specific_map_index_task_keys, update_all_map_index_task_keys = self._categorize_entities(
-            action.entities, results, method="PUT", action_name=action.action
+            action.entities, results, method="PUT", action_name=action.action.value
         )
 
         try:
@@ -444,7 +444,7 @@ class BulkTaskInstanceService(BulkService[BulkTaskInstanceBody]):
         """Bulk delete task instances."""
         # Validate and categorize entities into specific and all map index delete sets
         delete_specific_map_index_task_keys, delete_all_map_index_task_keys = self._categorize_entities(
-            action.entities, results, method="DELETE", action_name=action.action
+            action.entities, results, method="DELETE", action_name=action.action.value
         )
 
         try:


### PR DESCRIPTION
Fix authorization error messages in bulk task instance operations showing
`BulkAction.UPDATE` / `BulkAction.DELETE` instead of `update` / `delete`.

Python's (3.11+) `str` enum `__format__` returns the enum repr (e.g., `BulkAction.UPDATE`)
rather than the value (`update`). Changed to use `.value` when passing the action
name to the error message formatter.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-6)

Generated-by: Claude Code (claude-opus-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)