### PR TITLE
docs: refresh INSTALLING.md stable version examples

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -67,7 +67,7 @@ source airflow_venv/bin/activate
 5. **Install Apache Airflow**: Apache Airflow is available on PyPI. To install it, you can use the following command in your terminal:
 
 ```bash
-pip install apache-airflow==3.0.0 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.0/constraints-3.11.txt"
+pip install apache-airflow==3.1.8 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.8/constraints-3.11.txt"
 ```
 
 Note that installing with constraints - at least initially - is recommended for reproducible installation. It might sometimes happen that 3rd-party distributions are released and their latest versions break airflow. Using constraints makes the installation reproducible with versions of dependencies that were "frozen" at the time of releasing airflow. Note you have to specify both - airflow version and Python version you are using.
@@ -75,7 +75,7 @@ Note that installing with constraints - at least initially - is recommended for 
 You can also specify additional extras - when you want to install airflow with additional providers:
 
 ```bash
-pip install apache-airflow[amazon,google]==3.0.0 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.0.0/constraints-3.11.txt"
+pip install apache-airflow[amazon,google]==3.1.8 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.1.8/constraints-3.11.txt"
 ```
 
 6. **Set the AIRFLOW_HOME Environment Variable**: Apache Airflow requires a directory to store configuration files, logs, and other data. Set the AIRFLOW_HOME variable to specify this directory.


### PR DESCRIPTION
## Summary\n- update the quick-start PyPI install example in  from Airflow 3.0.0 to the current stable 3.1.8 release\n- update the matching constraints URL in the plain install example\n- update the matching constraints URL in the extras example\n\n## Why\nThe root  quick-start examples still point readers at  and , while the current stable install examples in the repo have already moved forward to 3.1.8. This keeps the quick-start copy-paste path aligned with the current stable release surface without changing the surrounding installation guidance.\n\n## Testing\n- git diff --check