### PR TITLE
Fix duplicate Date headers in Flask WSGI responses

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -68,6 +68,7 @@ def create_app(enable_plugins: bool):
             # Keep only the first one (typically from Uvicorn)
             response.headers.set("Date", date_headers[0])
         return response
+
     flask_app.secret_key = conf.get("api", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -62,11 +62,9 @@ def create_app(enable_plugins: bool):
 
     @flask_app.after_request
     def remove_duplicate_date_header(response):
-        date_headers = response.headers.getlist("Date")
-
-        if len(date_headers) > 1:
-            # Keep only the first one (typically from Uvicorn)
-            response.headers.set("Date", date_headers[0])
+        # Remove the application-level Date header so the ASGI/WSGI server
+        # can emit a single Date header for the final response.
+        response.headers.pop("Date", None)
         return response
 
     flask_app.secret_key = conf.get("api", "SECRET_KEY")

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -59,6 +59,13 @@ def create_app(enable_plugins: bool):
     from airflow.providers.fab.auth_manager.fab_auth_manager import FabAuthManager
 
     flask_app = Flask(__name__)
+
+    @flask_app.after_request
+    def remove_duplicate_date_header(response):
+        # Remove duplicate Date header added by Flask (Uvicorn already sets it)
+        response.headers.pop("Date", None)
+        response.headers.pop("date", None)
+        return response
     flask_app.secret_key = conf.get("api", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False

--- a/providers/fab/src/airflow/providers/fab/www/app.py
+++ b/providers/fab/src/airflow/providers/fab/www/app.py
@@ -62,9 +62,11 @@ def create_app(enable_plugins: bool):
 
     @flask_app.after_request
     def remove_duplicate_date_header(response):
-        # Remove duplicate Date header added by Flask (Uvicorn already sets it)
-        response.headers.pop("Date", None)
-        response.headers.pop("date", None)
+        date_headers = response.headers.getlist("Date")
+
+        if len(date_headers) > 1:
+            # Keep only the first one (typically from Uvicorn)
+            response.headers.set("Date", date_headers[0])
         return response
     flask_app.secret_key = conf.get("api", "SECRET_KEY")
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")


### PR DESCRIPTION
### What this PR does
This PR fixes an issue where duplicate `Date` headers appear in API responses when using Flask alongside Uvicorn.

Uvicorn already sets the `Date` header, and Flask adds another one during response processing, resulting in duplicate headers.

### How this is fixed
An `after_request` hook is added to the Flask app to remove any existing `Date` headers before returning the response.

### Why this approach
- Keeps behavior consistent regardless of server configuration
- Avoids modifying Uvicorn settings globally
- Ensures compatibility with existing Flask middleware

### Scope
- Affects only Flask WSGI response handling
- No impact on other components

### Testing
- Verified that responses no longer contain duplicate `Date` headers
