### PR TITLE
Add workers.celery.serviceAccount & workers.kubernetes.serviceAccount

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -236,7 +236,11 @@ spec:
   terminationGracePeriodSeconds: {{ .Values.workers.kubernetes.terminationGracePeriodSeconds | default .Values.workers.terminationGracePeriodSeconds }}
   tolerations: {{- toYaml $tolerations | nindent 4 }}
   topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 4 }}
+  {{- if .Values.workers.kubernetes.serviceAccount.create }}
+  serviceAccountName: {{ include "worker.kubernetes.serviceAccountName" . }}
+  {{- else }}
   serviceAccountName: {{ include "worker.serviceAccountName" . }}
+  {{- end }}
   volumes:
   {{- if .Values.dags.persistence.enabled }}
   - name: dags

--- a/chart/newsfragments/64730.significant.rst
+++ b/chart/newsfragments/64730.significant.rst
@@ -1,0 +1,1 @@
+``workers.serviceAccount`` section is now deprecated in favor of ``workers.celery.serviceAccount`` and ``workers.kubernetes.serviceAccount``. Please update your configuration accordingly.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -413,6 +413,38 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if not .Values.workers.serviceAccount.automountServiceAccountToken }}
+
+ DEPRECATION WARNING:
+    `workers.serviceAccount.automountServiceAccountToken` has been renamed to `workers.celery.serviceAccount.automountServiceAccountToken`/`workers.kubernetes.serviceAccount.automountServiceAccountToken`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not .Values.workers.serviceAccount.create }}
+
+ DEPRECATION WARNING:
+    `workers.serviceAccount.create` has been renamed to `workers.celery.serviceAccount.create`/`workers.kubernetes.serviceAccount.create`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not (empty .Values.workers.serviceAccount.name) }}
+
+ DEPRECATION WARNING:
+    `workers.serviceAccount.name` has been renamed to `workers.celery.serviceAccount.name`/`workers.kubernetes.serviceAccount.name`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if not (empty .Values.workers.serviceAccount.annotations) }}
+
+ DEPRECATION WARNING:
+    `workers.serviceAccount.annotations` has been renamed to `workers.celery.serviceAccount.annotations`/`workers.kubernetes.serviceAccount.annotations`.
+    Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if .Values.workers.keda.enabled }}
 
  DEPRECATION WARNING:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -641,13 +641,23 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
-{{/* Helper to generate service account name respecting .Values.$section.serviceAccount flags */}}
-{{- define "_serviceAccountName" -}}
-  {{- $sa := get (get .Values .key) "serviceAccount" }}
-  {{- if $sa.create }}
-    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) (default .key .nameSuffix )) $sa.name | quote }}
+{{/* Helper for service account name generation */}}
+{{- define "_serviceAccountNameGen" -}}
+  {{- if .sa.create }}
+    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) (default .key .nameSuffix )) .sa.name | quote }}
   {{- else }}
-    {{- default "default" $sa.name | quote }}
+    {{- default "default" .sa.name | quote }}
+  {{- end }}
+{{- end }}
+
+{{/* Helper to generate service account name respecting .Values.$section.serviceAccount or .Values.$section.$subSection.serviceAccount flags */}}
+{{- define "_serviceAccountName" -}}
+  {{- if .subKey }}
+    {{- $sa := get (get (get .Values .key) .subKey) "serviceAccount" -}}
+    {{- include "_serviceAccountNameGen" (merge (dict "sa" $sa "key" .key "nameSuffix" .nameSuffix) .) }}
+  {{- else }}
+    {{- $sa := get (get .Values .key) "serviceAccount" }}
+    {{- include "_serviceAccountNameGen" (merge (dict "sa" $sa "key" .key "nameSuffix" .nameSuffix) .) }}
   {{- end }}
 {{- end }}
 
@@ -698,6 +708,11 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- else }}
     {{- include "_serviceAccountName" (merge (dict "key" "workers" "nameSuffix" "worker") .) -}}
   {{- end }}
+{{- end }}
+
+{{/* Create the name of the worker kubernetes service account to use */}}
+{{- define "worker.kubernetes.serviceAccountName" -}}
+  {{- include "_serviceAccountName" (merge (dict "key" "workers" "subKey" "kubernetes" "nameSuffix" "worker-kubernetes") .) -}}
 {{- end }}
 
 {{/* Create the name of the triggerer service account to use */}}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -644,7 +644,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{/* Helper for service account name generation */}}
 {{- define "_serviceAccountNameGen" -}}
   {{- if .sa.create }}
-    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) (default .key .nameSuffix )) .sa.name | quote }}
+    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) (default .key .nameSuffix)) .sa.name | quote }}
   {{- else }}
     {{- default "default" .sa.name | quote }}
   {{- end }}

--- a/chart/templates/workers/worker-kubernetes-serviceaccount.yaml
+++ b/chart/templates/workers/worker-kubernetes-serviceaccount.yaml
@@ -1,0 +1,41 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+###########################################
+## Airflow Worker Kubernetes ServiceAccount
+###########################################
+{{- if and .Values.workers.kubernetes.serviceAccount.create (contains "KubernetesExecutor" .Values.executor) }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ or .Values.workers.kubernetes.serviceAccount.automountServiceAccountToken (and (not (has .Values.workers.kubernetes.serviceAccount.automountServiceAccountToken (list true false))) .Values.workers.serviceAccount.automountServiceAccountToken) }}
+metadata:
+  name: {{ include "worker.kubernetes.serviceAccountName" . }}
+  labels:
+    tier: airflow
+    component: worker
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or .Values.labels .Values.workers.labels }}
+      {{- mustMerge .Values.workers.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with (.Values.workers.kubernetes.serviceAccount.annotations | default .Values.workers.serviceAccount.annotations) }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1848,21 +1848,21 @@
                     }
                 },
                 "serviceAccount": {
-                    "description": "Create ServiceAccount for Airflow Celery workers and pods created with pod-template-file.",
+                    "description": "Create ServiceAccount for Airflow Celery workers and pods created with pod-template-file (deprecated, use ``workers.celery.serviceAccount`` and/or ``workers.kubernetes.serviceAccount`` instead).",
                     "type": "object",
                     "properties": {
                         "automountServiceAccountToken": {
-                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods (deprecated, use ``workers.celery.serviceAccount.automountServiceAccountToken`` and/or ``workers.kubernetes.serviceAccount.automountServiceAccountToken`` instead)",
                             "type": "boolean",
                             "default": true
                         },
                         "create": {
-                            "description": "Specifies whether a ServiceAccount should be created.",
+                            "description": "Specifies whether a ServiceAccount should be created (deprecated, use ``workers.celery.serviceAccount.create`` and/or ``workers.kubernetes.serviceAccount.create`` instead).",
                             "type": "boolean",
                             "default": true
                         },
                         "name": {
-                            "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
+                            "description": "The name of the ServiceAccount to use (deprecated, use ``workers.celery.serviceAccount.name`` and/or ``workers.kubernetes.serviceAccount.name`` instead). If not set and create is true, a name is generated using the release name.",
                             "type": [
                                 "string",
                                 "null"
@@ -1870,7 +1870,7 @@
                             "default": null
                         },
                         "annotations": {
-                            "description": "Annotations to add to the worker Kubernetes ServiceAccount.",
+                            "description": "Annotations to add to the worker Kubernetes ServiceAccount (deprecated, use ``workers.celery.serviceAccount.annotations`` and/or ``workers.kubernetes.serviceAccount.annotations`` instead).",
                             "type": "object",
                             "default": {},
                             "additionalProperties": {
@@ -2921,6 +2921,44 @@
                                 }
                             }
                         },
+                        "serviceAccount": {
+                            "description": "Create ServiceAccount for Airflow Celery workers.",
+                            "type": "object",
+                            "properties": {
+                                "automountServiceAccountToken": {
+                                    "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "create": {
+                                    "description": "Specifies whether a ServiceAccount should be created.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "name": {
+                                    "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "annotations": {
+                                    "description": "Annotations to add to the worker Kubernetes ServiceAccount.",
+                                    "type": "object",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
                         "keda": {
                             "description": "KEDA configuration of Airflow Celery workers.",
                             "type": "object",
@@ -3533,6 +3571,44 @@
                                     }
                                 }
                             ]
+                        },
+                        "serviceAccount": {
+                            "description": "Create ServiceAccount for pods created with pod-template-file. When this section is specified, the Service Account is created from 'templates/workers/worker-kubernetes-serviceaccount.yaml' file.",
+                            "type": "object",
+                            "properties": {
+                                "automountServiceAccountToken": {
+                                    "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods. If not specified, the ``workers.serviceAccount.automountServiceAccountToken`` value will be taken.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "create": {
+                                    "description": "Specifies whether a ServiceAccount should be created. If not specified, the ServiceAccount will be generated and used from 'templates/workers/worker-serviceaccount.yaml' file if `workers.serviceAccount.create` will be 'true'.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "name": {
+                                    "description": "The name of the ServiceAccount to use. If not set and ``create`` is 'true', a name is generated using the release name with kubernetes dedicated name.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "annotations": {
+                                    "description": "Annotations to add to the worker Kubernetes ServiceAccount. If not specified, the ``workers.serviceAccount.annotations`` value will be taken.",
+                                    "type": "object",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         },
                         "kerberosSidecar": {
                             "description": "Kerberos sidecar for pods created with pod-template-file.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3573,7 +3573,7 @@
                             ]
                         },
                         "serviceAccount": {
-                            "description": "Create ServiceAccount for pods created with pod-template-file. When this section is specified, the Service Account is created from 'templates/workers/worker-kubernetes-serviceaccount.yaml' file.",
+                            "description": "Create ServiceAccount for pods created with pod-template-file. When this section is specified, the Service Account is created from ``templates/workers/worker-kubernetes-serviceaccount.yaml`` file.",
                             "type": "object",
                             "properties": {
                                 "automountServiceAccountToken": {
@@ -3585,7 +3585,7 @@
                                     "default": null
                                 },
                                 "create": {
-                                    "description": "Specifies whether a ServiceAccount should be created. If not specified, the ServiceAccount will be generated and used from 'templates/workers/worker-serviceaccount.yaml' file if `workers.serviceAccount.create` will be 'true'.",
+                                    "description": "Specifies whether a ServiceAccount should be created. If not specified, the ServiceAccount will be generated and used from ``templates/workers/worker-serviceaccount.yaml`` file if ``workers.serviceAccount.create`` will be 'true'.",
                                     "type": [
                                         "boolean",
                                         "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -770,7 +770,7 @@ workers:
       # (deprecated, use `workers.celery.podDisruptionBudget.config.minAvailable` instead)
       # minAvailable: 1
 
-  # Create ServiceAccount for Airflow Celery workers and pods created with pod-template-file
+  # Create Service Account for Airflow Celery workers and pods created with pod-template-file
   # (deprecated, use `workers.celery.serviceAccount` and/or `workers.kubernetes.serviceAccount` instead)
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -780,14 +780,14 @@ workers:
     # instead)
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     # (deprecated, use
     #   `workers.celery.serviceAccount.create` and/or
     #   `workers.kubernetes.serviceAccount.create`
     # instead)
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     # (deprecated, use
     #   `workers.celery.serviceAccount.name` and/or
@@ -1282,15 +1282,15 @@ workers:
         maxUnavailable: ~
         # minAvailable: ~
 
-    # Create ServiceAccount for Airflow Celery workers
+    # Create Service Account for Airflow Celery workers
     serviceAccount:
       # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
       automountServiceAccountToken: ~
 
-      # Specifies whether a ServiceAccount should be created
+      # Specifies whether a Service Account should be created
       create: ~
 
-      # The name of the ServiceAccount to use.
+      # The name of the Service Account to use.
       # If not set and `create` is 'true', a name is generated using the release name
       name: ~
 
@@ -1491,7 +1491,7 @@ workers:
     # Container level Lifecycle Hooks definition for pods created with pod-template-file
     containerLifecycleHooks: {}
 
-    # Create ServiceAccount for pods created with pod-template-file
+    # Create Service Account for pods created with pod-template-file
     # When this section is specified, the Service Account is created from
     # 'templates/workers/worker-kubernetes-serviceaccount.yaml' file
     serviceAccount:
@@ -1499,13 +1499,13 @@ workers:
       # If not specified, the `workers.serviceAccount.automountServiceAccountToken` value will be taken
       automountServiceAccountToken: ~
 
-      # Specifies whether a ServiceAccount should be created.
-      # If not specified, the ServiceAccount will be generated and used from
+      # Specifies whether a Service Account should be created.
+      # If not specified, the Service Account will be generated and used from
       # 'templates/workers/worker-serviceaccount.yaml' file if `workers.serviceAccount.create`
       # will be 'true'
       create: ~
 
-      # The name of the ServiceAccount to use.
+      # The name of the Service Account to use.
       # If not set and `create` is 'true', a name is generated using the release name
       # with Kubernetes dedicated name
       name: ~
@@ -1656,16 +1656,16 @@ scheduler:
   # Grace period for tasks to finish after SIGTERM is sent from Kubernetes
   terminationGracePeriodSeconds: 10
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # Affects all executors that launch pods
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -1885,15 +1885,15 @@ createUserJob:
   # Container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -1989,15 +1989,15 @@ migrateDatabaseJob:
   # Container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -2105,10 +2105,10 @@ apiServer:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -2335,15 +2335,15 @@ webserver:
     # Scaling behavior of the target in both Up and Down directions
     behavior: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -2549,15 +2549,15 @@ triggerer:
     periodSeconds: 60
     command: ~
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -2835,15 +2835,15 @@ dagProcessor:
     periodSeconds: 60
     command: ~
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3067,15 +3067,15 @@ flower:
   # Container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3207,15 +3207,15 @@ statsd:
   # Grace period for StatsD to finish after SIGTERM is sent from Kubernetes
   terminationGracePeriodSeconds: 30
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3312,15 +3312,15 @@ pgbouncer:
   # Add custom annotations to the PgBouncer certificates secret
   certificatesSecretAnnotations: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3506,15 +3506,15 @@ redis:
   # Annotations for Redis Statefulset
   annotations: {}
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3726,15 +3726,15 @@ cleanup:
   #   cpu: 100m
   #   memory: 128Mi
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 
@@ -3826,15 +3826,15 @@ databaseCleanup:
   #  cpu: 100m
   #  memory: 128Mi
 
-  # Create ServiceAccount
+  # Create Service Account
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
 
-    # Specifies whether a ServiceAccount should be created
+    # Specifies whether a Service Account should be created
     create: true
 
-    # The name of the ServiceAccount to use.
+    # The name of the Service Account to use.
     # If not set and `create` is 'true', a name is generated using the release name
     name: ~
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -771,18 +771,35 @@ workers:
       # minAvailable: 1
 
   # Create ServiceAccount for Airflow Celery workers and pods created with pod-template-file
+  # (deprecated, use `workers.celery.serviceAccount` and/or `workers.kubernetes.serviceAccount` instead)
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+    # (deprecated, use
+    #   `workers.celery.serviceAccount.automountServiceAccountToken` and/or
+    #   `workers.kubernetes.serviceAccount.automountServiceAccountToken`
+    # instead)
     automountServiceAccountToken: true
 
     # Specifies whether a ServiceAccount should be created
+    # (deprecated, use
+    #   `workers.celery.serviceAccount.create` and/or
+    #   `workers.kubernetes.serviceAccount.create`
+    # instead)
     create: true
 
     # The name of the ServiceAccount to use.
     # If not set and `create` is 'true', a name is generated using the release name
+    # (deprecated, use
+    #   `workers.celery.serviceAccount.name` and/or
+    #   `workers.kubernetes.serviceAccount.name`
+    # instead)
     name: ~
 
     # Annotations to add to worker Kubernetes Service Account.
+    # (deprecated, use
+    #   `workers.celery.serviceAccount.annotations` and/or
+    #   `workers.kubernetes.serviceAccount.annotations`
+    # instead)
     annotations: {}
 
   # Allow KEDA autoscaling for Airflow Celery workers
@@ -1265,6 +1282,21 @@ workers:
         maxUnavailable: ~
         # minAvailable: ~
 
+    # Create ServiceAccount for Airflow Celery workers
+    serviceAccount:
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+      automountServiceAccountToken: ~
+
+      # Specifies whether a ServiceAccount should be created
+      create: ~
+
+      # The name of the ServiceAccount to use.
+      # If not set and `create` is 'true', a name is generated using the release name
+      name: ~
+
+      # Annotations to add to worker Kubernetes Service Account.
+      annotations: {}
+
     # Allow KEDA autoscaling for Airflow Celery workers
     keda:
       enabled: ~
@@ -1458,6 +1490,29 @@ workers:
 
     # Container level Lifecycle Hooks definition for pods created with pod-template-file
     containerLifecycleHooks: {}
+
+    # Create ServiceAccount for pods created with pod-template-file
+    # When this section is specified, the Service Account is created from
+    # 'templates/workers/worker-kubernetes-serviceaccount.yaml' file
+    serviceAccount:
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+      # If not specified, the `workers.serviceAccount.automountServiceAccountToken` value will be taken
+      automountServiceAccountToken: ~
+
+      # Specifies whether a ServiceAccount should be created.
+      # If not specified, the ServiceAccount will be generated and used from
+      # 'templates/workers/worker-serviceaccount.yaml' file if `workers.serviceAccount.create`
+      # will be 'true'
+      create: ~
+
+      # The name of the ServiceAccount to use.
+      # If not set and `create` is 'true', a name is generated using the release name
+      # with Kubernetes dedicated name
+      name: ~
+
+      # Annotations to add to worker Kubernetes Service Account.
+      # If not specified, the `workers.serviceAccount.annotations` value will be taken
+      annotations: {}
 
     # Kerberos sidecar configuration for pods created with pod-template-file
     kerberosSidecar:

--- a/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_annotations.py
@@ -124,6 +124,105 @@ class TestServiceAccountAnnotations:
             ),
             (
                 {
+                    "workers": {
+                        "celery": {
+                            "serviceAccount": {
+                                "annotations": {
+                                    "example": "worker",
+                                },
+                            }
+                        },
+                    },
+                },
+                "templates/workers/worker-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
+                    "workers": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "worker": "example",
+                            },
+                        },
+                        "celery": {
+                            "serviceAccount": {
+                                "annotations": {
+                                    "example": "worker",
+                                },
+                            }
+                        },
+                    },
+                },
+                "templates/workers/worker-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
+                    "executor": "KubernetesExecutor",
+                    "workers": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "worker",
+                            },
+                        },
+                        "kubernetes": {"serviceAccount": {"create": True}},
+                    },
+                },
+                "templates/workers/worker-kubernetes-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
+                    "executor": "KubernetesExecutor",
+                    "workers": {
+                        "kubernetes": {
+                            "serviceAccount": {
+                                "create": True,
+                                "annotations": {
+                                    "example": "worker",
+                                },
+                            }
+                        },
+                    },
+                },
+                "templates/workers/worker-kubernetes-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
+                    "executor": "KubernetesExecutor",
+                    "workers": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "worker": "example",
+                            },
+                        },
+                        "kubernetes": {
+                            "serviceAccount": {
+                                "create": True,
+                                "annotations": {
+                                    "example": "worker",
+                                },
+                            }
+                        },
+                    },
+                },
+                "templates/workers/worker-kubernetes-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
                     "flower": {
                         "enabled": True,
                         "serviceAccount": {

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -1810,3 +1810,22 @@ class TestPodTemplateFile:
         assert jmespath.search("spec.initContainers[?name=='kerberos-init'] | [0].lifecycle", docs[0]) == {
             "postStart": {"exec": {"command": ["echo", "test-release"]}}
         }
+
+    def test_service_account_name_default(self):
+        docs = render_chart(
+            name="test-release",
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert jmespath.search("spec.serviceAccountName", docs[0]) == "test-release-airflow-worker"
+
+    def test_dedicated_service_account_name_default(self):
+        docs = render_chart(
+            name="test-release",
+            values={"workers": {"kubernetes": {"serviceAccount": {"create": True}}}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert jmespath.search("spec.serviceAccountName", docs[0]) == "test-release-airflow-worker-kubernetes"

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2327,14 +2327,43 @@ class TestWorkerService:
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
 
-class TestWorkerServiceAccount:
-    """Tests worker service account."""
+class TestWorkerCeleryServiceAccount:
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": False}},
+            {"celery": {"serviceAccount": {"create": False}}},
+            {"serviceAccount": {"create": True}, "celery": {"serviceAccount": {"create": False}}},
+        ],
+    )
+    def test_should_not_create_service_account_when_disabled(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
 
-    def test_should_not_create_worker_service_account_for_local_executor(self):
+        assert len(docs) == 0
+
+    def test_should_create_service_account_by_default(self):
+        docs = render_chart(
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 1
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True}},
+            {"celery": {"serviceAccount": {"create": True}}},
+            {"serviceAccount": {"create": False}, "celery": {"serviceAccount": {"create": True}}},
+        ],
+    )
+    def test_should_not_create_service_account_for_local_executor(self, workers_values):
         docs = render_chart(
             values={
                 "executor": "LocalExecutor",
-                "workers": {"serviceAccount": {"create": True}},
+                "workers": workers_values,
             },
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
@@ -2351,11 +2380,19 @@ class TestWorkerServiceAccount:
             "LocalKubernetesExecutor",
         ],
     )
-    def test_should_create_worker_service_account_for_specific_executors(self, executor):
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True}},
+            {"celery": {"serviceAccount": {"create": True}}},
+            {"serviceAccount": {"create": False}, "celery": {"serviceAccount": {"create": True}}},
+        ],
+    )
+    def test_should_create_service_account_for_specific_executors(self, executor, workers_values):
         docs = render_chart(
             values={
                 "executor": executor,
-                "workers": {"serviceAccount": {"create": True}},
+                "workers": workers_values,
             },
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
@@ -2363,36 +2400,57 @@ class TestWorkerServiceAccount:
         assert len(docs) == 1
         assert jmespath.search("kind", docs[0]) == "ServiceAccount"
 
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "serviceAccount": {"create": True},
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True}},
+            {"celery": {"serviceAccount": {"create": True}}},
+            {
+                "serviceAccount": {"automountServiceAccountToken": False},
+                "celery": {"serviceAccount": {"create": True, "automountServiceAccountToken": True}},
             },
+        ],
+    )
+    def test_automount_service_account_token_true(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
         assert jmespath.search("automountServiceAccountToken", docs[0]) is True
 
-    def test_override_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True, "automountServiceAccountToken": False}},
+            {"celery": {"serviceAccount": {"create": True, "automountServiceAccountToken": False}}},
+            {
+                "serviceAccount": {"automountServiceAccountToken": True},
+                "celery": {"serviceAccount": {"create": True, "automountServiceAccountToken": False}},
             },
+        ],
+    )
+    def test_automount_service_account_token_false(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
 
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 
-    def test_override_name(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "serviceAccount": {"create": True, "name": "test"},
-                },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True, "name": "test"}},
+            {"celery": {"serviceAccount": {"create": True, "name": "test"}}},
+            {
+                "serviceAccount": {"name": "none"},
+                "celery": {"serviceAccount": {"create": True, "name": "test"}},
             },
+        ],
+    )
+    def test_overwrite_name(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
 
@@ -2403,11 +2461,165 @@ class TestWorkerServiceAccount:
             values={
                 "executor": "CeleryExecutor",
                 "workers": {
-                    "serviceAccount": {"create": True},
+                    "celery": {"serviceAccount": {"create": True}},
                     "labels": {"test_label": "test_label_value"},
                 },
             },
             show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert "test_label" in jmespath.search("metadata.labels", docs[0])
+        assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
+
+
+class TestWorkerKubernetesServiceAccount:
+    def test_should_not_create_service_account_by_default(self):
+        docs = render_chart(
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"serviceAccount": {"create": True}},  # Should not have effect
+            {"kubernetes": {"serviceAccount": {"create": False}}},
+            {"serviceAccount": {"create": True}, "kubernetes": {"serviceAccount": {"create": False}}},
+        ],
+    )
+    def test_should_not_create_service_account_when_disabled(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    def test_should_create_service_account_when_enabled(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "workers": {"kubernetes": {"serviceAccount": {"create": True}}},
+            },
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 1
+
+    @pytest.mark.parametrize(
+        "executor",
+        [
+            "CeleryExecutor",
+            "LocalExecutor",
+            "LocalExecutor,CeleryExecutor",
+        ],
+    )
+    def test_should_not_create_service_account_non_k8s_executors(self, executor):
+        docs = render_chart(
+            values={"executor": executor, "workers": {"kubernetes": {"serviceAccount": {"create": True}}}},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    @pytest.mark.parametrize(
+        "executor",
+        [
+            "CeleryKubernetesExecutor",
+            "CeleryExecutor,KubernetesExecutor",
+            "KubernetesExecutor",
+            "LocalKubernetesExecutor",
+        ],
+    )
+    def test_should_create_service_account_when_k8s_executors(self, executor):
+        docs = render_chart(
+            values={"executor": executor, "workers": {"kubernetes": {"serviceAccount": {"create": True}}}},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 1
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"kubernetes": {"serviceAccount": {"create": True}}},
+            {"kubernetes": {"serviceAccount": {"create": True, "automountServiceAccountToken": True}}},
+            {
+                "serviceAccount": {"automountServiceAccountToken": False},
+                "kubernetes": {"serviceAccount": {"create": True, "automountServiceAccountToken": True}},
+            },
+        ],
+    )
+    def test_automount_service_account_token_true(self, workers_values):
+        docs = render_chart(
+            values={"executor": "KubernetesExecutor", "workers": workers_values},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"kubernetes": {"serviceAccount": {"create": True, "automountServiceAccountToken": False}}},
+            {
+                "serviceAccount": {"automountServiceAccountToken": True},
+                "kubernetes": {"serviceAccount": {"create": True, "automountServiceAccountToken": False}},
+            },
+        ],
+    )
+    def test_automount_service_account_token_false(self, workers_values):
+        docs = render_chart(
+            values={"executor": "KubernetesExecutor", "workers": workers_values},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"kubernetes": {"serviceAccount": {"create": True}}},
+            {"serviceAccount": {"name": "test"}, "kubernetes": {"serviceAccount": {"create": True}}},
+        ],
+    )
+    def test_default_name(self, workers_values):
+        docs = render_chart(
+            name="test",
+            values={"executor": "KubernetesExecutor", "workers": workers_values},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("metadata.name", docs[0]) == "test-airflow-worker-kubernetes"
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {"kubernetes": {"serviceAccount": {"create": True, "name": "test"}}},
+            {
+                "serviceAccount": {"name": "none"},
+                "kubernetes": {"serviceAccount": {"create": True, "name": "test"}},
+            },
+        ],
+    )
+    def test_overwrite_name(self, workers_values):
+        docs = render_chart(
+            values={"executor": "KubernetesExecutor", "workers": workers_values},
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("metadata.name", docs[0]) == "test"
+
+    def test_should_add_component_specific_labels(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "workers": {
+                    "kubernetes": {"serviceAccount": {"create": True}},
+                    "labels": {"test_label": "test_label_value"},
+                },
+            },
+            show_only=["templates/workers/worker-kubernetes-serviceaccount.yaml"],
         )
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2330,6 +2330,74 @@ class TestWorkerService:
 class TestWorkerServiceAccount:
     """Tests worker service account."""
 
+    def test_should_not_create_worker_service_account_for_local_executor(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "workers": {"serviceAccount": {"create": True}},
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    @pytest.mark.parametrize(
+        "executor",
+        [
+            "CeleryExecutor",
+            "CeleryKubernetesExecutor",
+            "CeleryExecutor,KubernetesExecutor",
+            "KubernetesExecutor",
+            "LocalKubernetesExecutor",
+        ],
+    )
+    def test_should_create_worker_service_account_for_specific_executors(self, executor):
+        docs = render_chart(
+            values={
+                "executor": executor,
+                "workers": {"serviceAccount": {"create": True}},
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert jmespath.search("kind", docs[0]) == "ServiceAccount"
+
+    def test_default_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "serviceAccount": {"create": True},
+                },
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
+
+    def test_override_automount_service_account_token(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
+                },
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
+    def test_override_name(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "serviceAccount": {"create": True, "name": "test"},
+                },
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("metadata.name", docs[0]) == "test"
+
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={
@@ -2344,56 +2412,3 @@ class TestWorkerServiceAccount:
 
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
-
-    @pytest.mark.parametrize(
-        ("executor", "creates_service_account"),
-        [
-            ("LocalExecutor", False),
-            ("CeleryExecutor", True),
-            ("CeleryKubernetesExecutor", True),
-            ("CeleryExecutor,KubernetesExecutor", True),
-            ("KubernetesExecutor", True),
-            ("LocalKubernetesExecutor", True),
-        ],
-    )
-    def test_should_create_worker_service_account_for_specific_executors(
-        self, executor, creates_service_account
-    ):
-        docs = render_chart(
-            values={
-                "executor": executor,
-                "workers": {
-                    "serviceAccount": {"create": True},
-                    "labels": {"test_label": "test_label_value"},
-                },
-            },
-            show_only=["templates/workers/worker-serviceaccount.yaml"],
-        )
-        if creates_service_account:
-            assert jmespath.search("kind", docs[0]) == "ServiceAccount"
-            assert "test_label" in jmespath.search("metadata.labels", docs[0])
-            assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
-        else:
-            assert docs == []
-
-    def test_default_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "serviceAccount": {"create": True},
-                },
-            },
-            show_only=["templates/workers/worker-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is True
-
-    def test_overridden_automount_service_account_token(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "serviceAccount": {"create": True, "automountServiceAccountToken": False},
-                },
-            },
-            show_only=["templates/workers/worker-serviceaccount.yaml"],
-        )
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1205,46 +1205,100 @@ class TestWorkerSets:
 
         assert jmespath.search("[*].metadata.name", docs) == expected
 
-    def test_overwrite_service_account_automount_service_account_token_disable(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "celery": {
-                        "enableDefault": False,
-                        "sets": [{"name": "test", "serviceAccount": {"automountServiceAccountToken": False}}],
-                    },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"create": False}}],
                 }
             },
-            show_only=["templates/workers/worker-serviceaccount.yaml"],
-        )
-
-        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
-
-    def test_overwrite_service_account_create_disable(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "celery": {
-                        "enableDefault": False,
-                        "sets": [{"name": "test", "serviceAccount": {"create": False}}],
-                    },
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "serviceAccount": {"create": True},
+                    "sets": [{"name": "test", "serviceAccount": {"create": False}}],
                 }
             },
+            {
+                "serviceAccount": {"create": True},
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"create": False}}],
+                },
+            },
+        ],
+    )
+    def test_overwrite_service_account_create_disable(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
 
         assert len(docs) == 0
 
-    def test_overwrite_service_account_name(self):
-        docs = render_chart(
-            values={
-                "workers": {
-                    "celery": {
-                        "enableDefault": False,
-                        "sets": [{"name": "test", "serviceAccount": {"name": "test"}}],
-                    },
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"automountServiceAccountToken": False}}],
                 }
             },
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "serviceAccount": {"automountServiceAccountToken": True},
+                    "sets": [{"name": "test", "serviceAccount": {"automountServiceAccountToken": False}}],
+                }
+            },
+            {
+                "serviceAccount": {"automountServiceAccountToken": True},
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"automountServiceAccountToken": False}}],
+                },
+            },
+        ],
+    )
+    def test_overwrite_service_account_automount_service_account_token_disable(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert jmespath.search("automountServiceAccountToken", docs[0]) is False
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"name": "test"}}],
+                }
+            },
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "serviceAccount": {"name": "nontest"},
+                    "sets": [{"name": "test", "serviceAccount": {"name": "test"}}],
+                }
+            },
+            {
+                "serviceAccount": {"name": "nontest"},
+                "celery": {
+                    "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"name": "test"}}],
+                },
+            },
+        ],
+    )
+    def test_overwrite_service_account_name(self, workers_values):
+        docs = render_chart(
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-serviceaccount.yaml"],
         )
 
@@ -1261,6 +1315,13 @@ class TestWorkerSets:
                 "serviceAccount": {"annotations": {"echo": "test"}},
                 "celery": {
                     "enableDefault": False,
+                    "sets": [{"name": "test", "serviceAccount": {"annotations": {"test": "echo"}}}],
+                },
+            },
+            {
+                "celery": {
+                    "enableDefault": False,
+                    "serviceAccount": {"annotations": {"echo": "test"}},
                     "sets": [{"name": "test", "serviceAccount": {"annotations": {"test": "echo"}}}],
                 },
             },


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: https://github.com/apache/airflow/issues/28880

This PR introduces two new sections: `workers.celery.serviceAccount` and `workers.kubernetes.serviceAccount`. The `workers.serviceAccount` section is now deprecated.

In terms of logic, it works a little differently than other fields/sections moved to the `workers.celery`/`workers.kubernetes` section. All fields under `workers.celery` override values under `workers` section, but when `workers.kubernetes` section is used, the Service Account is generated from `templates/workers/worker-kubernetes-serviceaccount.yaml` file instead of `templates/workers/worker-serviceaccount.yaml`. Despite that separation, some fields have fallbacks to the `workers` section to match behaviour of other, already moved, fields/sections.

Additional change - all `ServiceAccount` was changed to `Service Account` in `values.yaml` as that was missed.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
