### PR TITLE
Fix large XCom payload causing task heartbeat timeout

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -33,6 +33,7 @@ import time
 import weakref
 from collections import deque
 from collections.abc import Callable, Generator
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from http import HTTPStatus
@@ -541,6 +542,16 @@ class WatchedSubprocess:
     start_time: float = attrs.field(factory=time.monotonic)
     """The start time of the child process."""
 
+    _request_thread_pool: ThreadPoolExecutor = attrs.field(
+        factory=lambda: ThreadPoolExecutor(max_workers=1, thread_name_prefix="supervisor-request"),
+        init=False,
+        repr=False,
+    )
+    """Thread pool for offloading long-running API requests (e.g. large XCom uploads)."""
+
+    _pending_requests: deque[tuple[Future, int]] = attrs.field(factory=deque, init=False, repr=False)
+    """Futures from offloaded requests, paired with their request IDs."""
+
     @classmethod
     def start(
         cls,
@@ -791,6 +802,41 @@ class WatchedSubprocess:
 
         self.selector.close()
         self.stdin.close()
+        self._request_thread_pool.shutdown(wait=False)
+
+    def _drain_pending_requests(self):
+        """Send responses for any offloaded requests that have completed."""
+        remaining: deque[tuple[Future, int]] = deque()
+        while self._pending_requests:
+            future, req_id = self._pending_requests.popleft()
+            if not future.done():
+                remaining.append((future, req_id))
+                continue
+            exc = future.exception()
+            if exc is not None:
+                if isinstance(exc, ServerResponseError):
+                    error_details = exc.response.json() if exc.response else None
+                    log.error(
+                        "API server error",
+                        status_code=exc.response.status_code,
+                        detail=error_details,
+                        message=str(exc),
+                    )
+                    self.send_msg(
+                        msg=None,
+                        error=ErrorResponse(
+                            error=ErrorType.API_SERVER_ERROR,
+                            detail={
+                                "status_code": exc.response.status_code,
+                                "message": str(exc),
+                                "detail": error_details,
+                            },
+                        ),
+                        request_id=req_id,
+                    )
+            else:
+                self.send_msg(msg=None, request_id=req_id)
+        self._pending_requests = remaining
 
     def kill(
         self,
@@ -909,6 +955,8 @@ class WatchedSubprocess:
                 sock: socket = key.fileobj  # type: ignore[assignment]
                 on_close(sock)
                 sock.close()
+
+        self._drain_pending_requests()
 
         # Check if the subprocess has exited
         return self._check_subprocess_exit(raise_on_timeout=raise_on_timeout, expect_signal=expect_signal)
@@ -1459,7 +1507,11 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, SkipDownstreamTasks):
             self.client.task_instances.skip_downstream_tasks(self.id, msg)
         elif isinstance(msg, SetXCom):
-            self.client.xcoms.set(
+            # Offload XCom upload to a thread so that large payloads do not block the
+            # supervisor event loop and prevent heartbeats from being sent.
+            # See: https://github.com/apache/airflow/issues/64628
+            future = self._request_thread_pool.submit(
+                self.client.xcoms.set,
                 msg.dag_id,
                 msg.run_id,
                 msg.task_id,
@@ -1469,6 +1521,8 @@ class ActivitySubprocess(WatchedSubprocess):
                 dag_result=msg.dag_result,
                 mapped_length=msg.mapped_length,
             )
+            self._pending_requests.append((future, req_id))
+            return
         elif isinstance(msg, DeleteXCom):
             self.client.xcoms.delete(msg.dag_id, msg.run_id, msg.task_id, msg.key, msg.map_index)
         elif isinstance(msg, PutVariable):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -814,8 +814,11 @@ class WatchedSubprocess:
                 continue
             exc = future.exception()
             if exc is not None:
-                if isinstance(exc, ServerResponseError):
-                    error_details = exc.response.json() if exc.response else None
+                if isinstance(exc, ServerResponseError) and exc.response is not None:
+                    try:
+                        error_details: dict | None = exc.response.json()
+                    except Exception:
+                        error_details = None
                     log.error(
                         "API server error",
                         status_code=exc.response.status_code,
@@ -831,6 +834,16 @@ class WatchedSubprocess:
                                 "message": str(exc),
                                 "detail": error_details,
                             },
+                        ),
+                        request_id=req_id,
+                    )
+                else:
+                    log.error("Offloaded request failed", exc_info=exc)
+                    self.send_msg(
+                        msg=None,
+                        error=ErrorResponse(
+                            error=ErrorType.API_SERVER_ERROR,
+                            detail={"status_code": None, "message": str(exc), "detail": None},
                         ),
                         request_id=req_id,
                     )

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1733,6 +1733,16 @@ class InProcessSupervisorComms:
         with set_supervisor_comms(None):
             self.supervisor._handle_request(msg, log, 0)  # type: ignore[arg-type]
 
+        # Some requests (e.g. SetXCom) are offloaded to the supervisor's thread pool to
+        # avoid blocking its event loop. In the in-process path there is no event loop
+        # calling _drain_pending_requests(), so we wait for any in-flight futures here
+        # and drain them so that the response is available before we try to pop it.
+        if self.supervisor._pending_requests:
+            from concurrent.futures import wait as futures_wait
+
+            futures_wait([f for f, _ in self.supervisor._pending_requests])
+            self.supervisor._drain_pending_requests()
+
         return self._get_response()
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2681,8 +2681,12 @@ class TestHandleRequest:
 
         # SetXCom is offloaded to a thread to avoid blocking the event loop.
         # We need to wait for the future and drain it before reading the response.
+        # Use concurrent.futures.wait() rather than shutdown() so the executor
+        # remains usable for subsequent SetXCom calls in the same test.
         if isinstance(message, SetXCom):
-            watched_subprocess._request_thread_pool.shutdown(wait=True)
+            from concurrent.futures import wait as futures_wait
+
+            futures_wait([f for f, _ in watched_subprocess._pending_requests])
             watched_subprocess._drain_pending_requests()
 
         if mask_secret_args is not None:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2679,6 +2679,12 @@ class TestHandleRequest:
         req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=message.model_dump())
         generator.send(req_frame)
 
+        # SetXCom is offloaded to a thread to avoid blocking the event loop.
+        # We need to wait for the future and drain it before reading the response.
+        if isinstance(message, SetXCom):
+            watched_subprocess._request_thread_pool.shutdown(wait=True)
+            watched_subprocess._drain_pending_requests()
+
         if mask_secret_args is not None:
             mock_mask_secret.assert_called_with(*mask_secret_args)
 


### PR DESCRIPTION
When a task pushes a large XCom payload (e.g. 300 MB), the supervisor's single-threaded event loop is blocked on the synchronous HTTP POST to the API server. During that time no heartbeats can be sent, and the scheduler eventually marks the task instance as failed with a heartbeat timeout — even though the task itself is still running successfully.

**Root cause:** `ActivitySubprocess._handle_request()` calls `self.client.xcoms.set()` synchronously. Because the supervisor uses a `selectors`-based event loop, any blocking call inside a handler stalls the entire loop, including `_send_heartbeat_if_needed()`.

**Fix:** Offload the `SetXCom` API call to a single-worker `ThreadPoolExecutor`. The handler submits the future and returns immediately, so the event loop keeps ticking and heartbeats continue uninterrupted. A new `_drain_pending_requests()` helper is called on every loop iteration; it inspects completed futures and sends the appropriate response (or error) back to the task process.

- `max_workers=1` preserves ordering of concurrent XCom writes from the same task.
- `httpx.Client` is thread-safe, so sharing the existing client with the worker thread is safe.
- On process cleanup `shutdown(wait=False)` discards any in-flight upload because the task process is already gone.

closes: #64628

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-06-17T14:18:21Z head=b84491d action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @skymensch** · by `@potiuk` · 2026-06-17 14:18 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Merge conflicts with `main`.** Please rebase your branch on the latest `main` and resolve the conflicts, then push. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->