### PR TITLE
Fix dagrun.duration.failed missing run_type tag on dagrun_timeout

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2421,7 +2421,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 stats.timing(
                     "dagrun.duration.failed",
                     duration,
-                    tags={"dag_id": dag_run.dag_id},
+                    tags=dag_run.stats_tags,
                 )
             return callback_to_execute
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3720,12 +3720,14 @@ class TestSchedulerJob:
         with dag_maker(
             dag_id="test_scheduler_fail_dagrun_timeout_stats",
             dagrun_timeout=datetime.timedelta(seconds=60),
-            schedule="@daily",
             session=session,
         ):
             EmptyOperator(task_id="dummy")
 
-        dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
+        dr = dag_maker.create_dagrun(
+            start_date=timezone.utcnow() - datetime.timedelta(days=1),
+            run_type=DagRunType.SCHEDULED,
+        )
 
         scheduler_job = Job()
         self.job_runner = SchedulerJobRunner(job=scheduler_job)
@@ -3737,7 +3739,7 @@ class TestSchedulerJob:
         timing_calls = {call.args[0]: call.kwargs for call in mock_timing.call_args_list}
         assert "dagrun.duration.failed" in timing_calls
         tags = timing_calls["dagrun.duration.failed"].get("tags", {})
-        assert "run_type" in tags, f"run_type missing from dagrun.duration.failed tags: {tags}"
+        assert tags.get("run_type") == "scheduled", f"Expected run_type=scheduled in dagrun.duration.failed tags: {tags}"
 
         session.rollback()
         session.close()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3711,6 +3711,37 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    def test_dagrun_timeout_emits_run_type_in_stats_tags(self, dag_maker):
+        """
+        Test that dagrun.duration.failed metric includes run_type tag when failure
+        is caused by dagrun_timeout (regression test for missing run_type tag).
+        """
+        session = settings.Session()
+        with dag_maker(
+            dag_id="test_scheduler_fail_dagrun_timeout_stats",
+            dagrun_timeout=datetime.timedelta(seconds=60),
+            schedule="@daily",
+            session=session,
+        ):
+            EmptyOperator(task_id="dummy")
+
+        dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with mock.patch("airflow.jobs.scheduler_job_runner.DualStatsManager.timing") as mock_timing:
+            self.job_runner._schedule_dag_run(dr, session)
+            session.flush()
+
+        timing_calls = {call.args[0]: call.kwargs for call in mock_timing.call_args_list}
+        assert "dagrun.duration.failed" in timing_calls
+        tags = timing_calls["dagrun.duration.failed"].get("tags", {})
+        assert "run_type" in tags, f"run_type missing from dagrun.duration.failed tags: {tags}"
+
+        session.rollback()
+        session.close()
+
     def test_dagrun_timeout_fails_run_and_update_next_dagrun(self, dag_maker):
         """
         Test that dagrun timeout fails run and update the next dagrun


### PR DESCRIPTION
When a dag run fails due to `dagrun_timeout`, the `DualStatsManager.timing` call for `dagrun.duration.failed` used `tags={"dag_id": dag_run.dag_id}` instead of `dag_run.stats_tags`. This meant `run_type` was always absent from timeout-caused failures, making it impossible to filter the metric by `run_type` in monitoring queries.

The normal finish path in `dagrun.py` correctly uses `self.stats_tags` (which includes both `dag_id` and `run_type`). This aligns the timeout path to match.

closes: #64765

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)