### PR TITLE
Allow newer packages when testing RC versions

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -23,6 +23,7 @@ import os
 import re
 import shutil
 import sys
+from datetime import datetime
 from functools import cache
 from pathlib import Path
 from typing import NamedTuple
@@ -1127,7 +1128,8 @@ def _install_airflow_and_optionally_providers_together(
         "install",
     ]
     if installation_spec.pre_release:
-        base_install_cmd.append("--pre")
+        console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
+        base_install_cmd.extend(["--pre", "--exclude-newer", datetime.now().isoformat()])
     if installation_spec.airflow_distribution:
         console.print(
             f"\n[bright_blue]Adding airflow distribution to installation: {installation_spec.airflow_distribution} "
@@ -1223,8 +1225,8 @@ def _install_only_airflow_airflow_core_task_sdk_with_constraints(
         "install",
     ]
     if installation_spec.pre_release:
-        console.print("[bright_blue]Allowing pre-release versions of airflow")
-        base_install_airflow_cmd.append("--pre")
+        console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
+        base_install_airflow_cmd.extend(["--pre", "--exclude-newer", datetime.now().isoformat()])
     if installation_spec.airflow_distribution:
         console.print(
             f"\n[bright_blue]Installing airflow distribution: {installation_spec.airflow_distribution} with constraints"


### PR DESCRIPTION
We nailed down a cooldown period recently to improve security. Unfortunately this contradicts with the aim to test RC candidate versions with breeze. Usually we have 72 hours time to test RC versions but cooldown period is set to 4 days. Beans breeze called with `breeze start-airflow --use-airflow-version 3.2.0rc2 --python 3.10 --backend postgres` fails in:
```
× No solution found when resolving dependencies:
  ╰─▶ Because there is no version of apache-airflow==3.2.0rc2 and you require apache-airflow==3.2.0rc2
```

As installation is usually made via constraints I think the risk is low to collect a drive-by problem.

See also discussion in https://apache-airflow.slack.com/archives/C03G9H97MM2/p1775488780621389

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
