### PR TITLE
CI: Build CI image after Dockerfiles are updated in breeze ci upgrade

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -778,17 +778,9 @@ def upgrade(
             "Commands may fail if they require authentication.[/]"
         )
 
-    # Build the CI image for Python 3.10 first so that subsequent steps (e.g. uv lock
-    # updates inside the image) use an up-to-date environment.
-    console_print("[info]Building CI image for Python 3.10 …[/]")
-    run_command(
-        ["breeze", "ci-image", "build", "--python", "3.10"],
-        check=False,
-        env=command_env,
-    )
-
-    # Define all upgrade commands to run (all run with check=False to continue on errors)
-    upgrade_commands: list[tuple[str, str]] = [
+    # Define upgrade commands to run before building the CI image (all run with check=False
+    # to continue on errors). These may update Dockerfiles and other build inputs.
+    pre_image_commands: list[tuple[str, str]] = [
         ("autoupdate", "prek autoupdate --cooldown-days 4 --freeze"),
         (
             "update-chart-dependencies",
@@ -798,11 +790,17 @@ def upgrade(
             "upgrade-important-versions",
             "prek --all-files --show-diff-on-failure --color always --verbose --stage manual upgrade-important-versions",
         ),
+    ]
+
+    # Define upgrade commands to run after building the CI image (they run inside the image
+    # and need an up-to-date environment).
+    post_image_commands: list[tuple[str, str]] = [
         (
             "update-uv-lock",
             "prek --all-files --show-diff-on-failure --color always --verbose update-uv-lock --stage manual",
         ),
     ]
+
     step_enabled = {
         "autoupdate": autoupdate,
         "update-chart-dependencies": update_chart_dependencies,
@@ -810,8 +808,24 @@ def upgrade(
         "update-uv-lock": update_uv_lock,
     }
 
-    # Execute enabled upgrade commands with the environment containing GitHub token
-    for step_name, command in upgrade_commands:
+    # Execute pre-image upgrade commands (may update Dockerfiles)
+    for step_name, command in pre_image_commands:
+        if step_enabled[step_name]:
+            run_command(command.split(), check=False, env=command_env)
+        else:
+            console_print(f"[info]Skipping {step_name} (disabled).[/]")
+
+    # Build the CI image for Python 3.10 after Dockerfiles have been updated so that
+    # subsequent steps (e.g. uv lock updates inside the image) use an up-to-date environment.
+    console_print("[info]Building CI image for Python 3.10 …[/]")
+    run_command(
+        ["breeze", "ci-image", "build", "--python", "3.10"],
+        check=False,
+        env=command_env,
+    )
+
+    # Execute post-image upgrade commands (run inside the freshly built image)
+    for step_name, command in post_image_commands:
         if step_enabled[step_name]:
             run_command(command.split(), check=False, env=command_env)
         else:


### PR DESCRIPTION
Previously, `breeze ci upgrade` built the CI image *before* running
`upgrade-important-versions`, which updates Dockerfiles. This meant
the `update-uv-lock` step (which runs inside the image) used a stale
image that didn't reflect the Dockerfile changes.

Now the upgrade commands are split into two phases:
- **Pre-image**: autoupdate, update-chart-dependencies, upgrade-important-versions
- **Image build**: `breeze ci-image build --python 3.10`
- **Post-image**: update-uv-lock (runs inside the freshly built image)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)