### PR TITLE
Remove dependabot alarms in fab provider npm dependencies

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/package.json
+++ b/providers/fab/src/airflow/providers/fab/www/package.json
@@ -75,7 +75,9 @@
       "flatted@<=3.4.1": ">=3.4.2",
       "picomatch@<4.0.4": ">=4.0.4",
       "brace-expansion@>=4.0.0 <5.0.5": ">=5.0.5",
-      "serialize-javascript@<7.0.5": ">=7.0.5"
+      "serialize-javascript@<7.0.5": ">=7.0.5",
+      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
+      "lodash@<=4.17.23": ">=4.18.0"
     }
   },
   "resolutions": {

--- a/providers/fab/src/airflow/providers/fab/www/pnpm-lock.yaml
+++ b/providers/fab/src/airflow/providers/fab/www/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   picomatch@<4.0.4: '>=4.0.4'
   brace-expansion@>=4.0.0 <5.0.5: '>=5.0.5'
   serialize-javascript@<7.0.5: '>=7.0.5'
+  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
+  lodash@<=4.17.23: '>=4.18.0'
 
 importers:
 
@@ -1603,8 +1605,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3992,7 +3994,7 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4627,7 +4629,7 @@ snapshots:
   webpack-license-plugin@4.5.1(webpack@5.105.4):
     dependencies:
       chalk: 5.6.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       needle: 3.3.1
       spdx-expression-validate: 2.0.0
       webpack: 5.105.4(webpack-cli@7.0.2)


### PR DESCRIPTION
Remove current dependabot alerts in FAB Provider

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
