### PR TITLE
[v3-2-test] Fix group/extra bug in initialize_virtualenv (#62230)

### DIFF
--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -55,7 +55,19 @@ def check_for_package_extras() -> str:
     return "dev"
 
 
-def uv_install_requirements() -> int:
+def get_dependency_groups(pyproject_toml_path: Path) -> list[str]:
+    """
+    Get the dependency groups from pyproject.toml
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+    airflow_core_toml_dict = tomllib.loads(pyproject_toml_path.read_text())
+    return airflow_core_toml_dict["dependency-groups"].keys()
+
+
+def uv_install_requirements(airflow_pyproject_toml_file: Path) -> int:
     """
     install the requirements of the current python version.
     return 0 if success, anything else is an error.
@@ -87,7 +99,12 @@ system packages. It's easier to install extras one-by-one as needed.
 
 """
     )
-    extra_param = [x for extra in extras.split(",") for x in ("--group", extra)]
+    dependency_groups = get_dependency_groups(airflow_pyproject_toml_file)
+    extra_param = [
+        flag
+        for extra in extras.split(",")
+        for flag in (["--group", extra] if extra in dependency_groups else ["--extra", extra])
+    ]
     uv_install_command = ["uv", "sync"] + extra_param
     quoted_command = " ".join([shlex.quote(parameter) for parameter in uv_install_command])
     print()
@@ -139,7 +156,8 @@ def main():
 
     clean_up_airflow_home(airflow_home_dir)
 
-    return_code = uv_install_requirements()
+    airflow_pyproject_toml_file = airflow_sources / "pyproject.toml"
+    return_code = uv_install_requirements(airflow_pyproject_toml_file)
 
     if return_code != 0:
         print(


### PR DESCRIPTION
Previously, the initialize_virtualenv script didn't correctly build the uv command to distinguish between `--group` and `--extra`. This updates the `extra_param` to fix that. (cherry picked from commit 6339d0947dcec547594798318bea221bf68bc299)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
