### PR TITLE
fix(ui): handle version-based docs links with fallback for dev versions

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.test.tsx
@@ -53,4 +53,24 @@ describe("DocsButton", () => {
 
     expect(await screen.findByText("docs.restApiReference")).toBeInTheDocument();
   });
+
+  it("uses version-specific docs for published releases", async () => {
+    render(<DocsButton externalViews={[]} version="3.1.8" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /nav.docs/iu }));
+
+    const link = await screen.findByRole("link", { name: "3.1.8" });
+
+    expect(link).toHaveAttribute("href", "https://airflow.apache.org/docs/apache-airflow/3.1.8/index.html");
+  });
+
+  it.each(["3.2.0", "3.2.0.dev0"])("falls back to stable docs for unpublished versions (%s)", async (version) => {
+    render(<DocsButton externalViews={[]} version={version} />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /nav.docs/iu }));
+
+    const link = await screen.findByRole("link", { name: version });
+
+    expect(link).toHaveAttribute("href", "https://airflow.apache.org/docs/apache-airflow/stable/index.html");
+  });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -20,6 +20,7 @@ import { Box, Icon, Link } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiBookOpen, FiExternalLink } from "react-icons/fi";
 
+import supportedVersions from "../../../../../../docs/installation/supported-versions.rst?raw";
 import { Menu } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
 import type { NavItemResponse } from "src/utils/types";
@@ -28,6 +29,9 @@ import { NavButton } from "./NavButton";
 import { PluginMenuItem } from "./PluginMenuItem";
 
 const baseUrl = document.querySelector("base")?.href ?? "http://localhost:8080/";
+const airflowDocsBaseUrl = "https://airflow.apache.org/docs/apache-airflow";
+const currentStableAirflowVersion =
+  supportedVersions.match(/^\s*\d+(?:\.\d+)?\s+(\d+\.\d+\.\d+)\s+/mu)?.[1];
 
 const links = [
   {
@@ -44,6 +48,45 @@ const links = [
   },
 ];
 
+const getReleaseVersionParts = (version: string): [number, number, number] | undefined => {
+  if (!/^\d+\.\d+\.\d+$/u.test(version)) {
+    return undefined;
+  }
+
+  const [major, minor, patch] = version.split(".").map(Number);
+
+  return [major, minor, patch];
+};
+
+const compareReleaseVersions = (left: [number, number, number], right: [number, number, number]) => {
+  for (const [index, part] of left.entries()) {
+    const otherPart = right[index];
+
+    if (part !== otherPart) {
+      return part - otherPart;
+    }
+  }
+
+  return 0;
+};
+
+const isPublishedReleaseVersion = (version: string) => {
+  const releaseVersionParts = getReleaseVersionParts(version);
+  const stableVersionParts =
+    currentStableAirflowVersion === undefined ? undefined : getReleaseVersionParts(currentStableAirflowVersion);
+
+  if (releaseVersionParts === undefined || stableVersionParts === undefined) {
+    return false;
+  }
+
+  return compareReleaseVersions(releaseVersionParts, stableVersionParts) <= 0;
+};
+
+const getVersionLink = (version: string) =>
+  isPublishedReleaseVersion(version)
+    ? `${airflowDocsBaseUrl}/${version}/index.html`
+    : `${airflowDocsBaseUrl}/stable/index.html`;
+
 export const DocsButton = ({
   externalViews,
   showAPI,
@@ -56,7 +99,7 @@ export const DocsButton = ({
   const { t: translate } = useTranslation("common");
   const showAPIDocs = Boolean(useConfig("enable_swagger_ui")) && showAPI;
 
-  const versionLink = `https://airflow.apache.org/docs/apache-airflow/${version}/index.html`;
+  const versionLink = version === undefined ? undefined : getVersionLink(version);
 
   return (
     <Menu.Root positioning={{ placement: "right" }}>


### PR DESCRIPTION
Fixes #64541

### Problem
DocsButton was always pointing to the stable documentation, even for released versions.

This removes version-specific behavior and is not the intended logic.

### Changes
- Added logic to detect dev/unreleased versions
- Use stable docs for dev versions
- Use version-specific docs for released versions
- Updated tests to cover both cases

### Result
- Docs link works correctly for both released and dev versions
- Prevents 404 errors while preserving correct version navigation