### PR TITLE
Allow newer packages when testing stable release versions in compat tests

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1130,9 +1130,10 @@ def _install_airflow_and_optionally_providers_together(
     if installation_spec.pre_release or (
         installation_spec.airflow_distribution and "==" in installation_spec.airflow_distribution
     ):
-        console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
+        console.print("[bright_blue]Allowing install w/ cooldown as specific distribution requested.")
         base_install_cmd.extend(["--exclude-newer", datetime.now().isoformat()])
     if installation_spec.pre_release:
+        console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
         base_install_cmd.append("--pre")
     if installation_spec.airflow_distribution:
         console.print(

--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1127,9 +1127,13 @@ def _install_airflow_and_optionally_providers_together(
         "pip",
         "install",
     ]
-    if installation_spec.pre_release:
+    if installation_spec.pre_release or (
+        installation_spec.airflow_distribution and "==" in installation_spec.airflow_distribution
+    ):
         console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
-        base_install_cmd.extend(["--pre", "--exclude-newer", datetime.now().isoformat()])
+        base_install_cmd.extend(["--exclude-newer", datetime.now().isoformat()])
+    if installation_spec.pre_release:
+        base_install_cmd.append("--pre")
     if installation_spec.airflow_distribution:
         console.print(
             f"\n[bright_blue]Adding airflow distribution to installation: {installation_spec.airflow_distribution} "
@@ -1224,9 +1228,13 @@ def _install_only_airflow_airflow_core_task_sdk_with_constraints(
         "pip",
         "install",
     ]
-    if installation_spec.pre_release:
+    if installation_spec.pre_release or (
+        installation_spec.airflow_distribution and "==" in installation_spec.airflow_distribution
+    ):
         console.print("[bright_blue]Allowing pre-release versions of airflow and providers")
-        base_install_airflow_cmd.extend(["--pre", "--exclude-newer", datetime.now().isoformat()])
+        base_install_airflow_cmd.extend(["--exclude-newer", datetime.now().isoformat()])
+    if installation_spec.pre_release:
+        base_install_airflow_cmd.append("--pre")
     if installation_spec.airflow_distribution:
         console.print(
             f"\n[bright_blue]Installing airflow distribution: {installation_spec.airflow_distribution} with constraints"


### PR DESCRIPTION
Fixes [Compat tests](https://github.com/apache/airflow/actions/runs/24090433996/job/70278258564
) failing for 3.2
Extends #64774 to also cover stable releases. The same `exclude-newer = "4 days"` 
cooldown in `pyproject.toml` blocks compat tests from installing a newly released 
stable version (e.g. `apache-airflow==3.2.0`) within the 4-day window. Safe to 
override since both functions always install pinned specific versions.



- [X] Yes (please specify the tool below)
Claude


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
