### PR TITLE
Bugfix/skip commit checks on automated ci upgrades

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -849,16 +849,28 @@ def upgrade(
 
         run_command(["git", "checkout", "-b", branch_name])
         run_command(["git", "add", "."])
-        run_command(
-            [
-                "git",
-                "commit",
-                # postpone pre-commit checks to CI, not to fail in automation if e.g. mypy changes force code checks
-                "--no-verify",
-                "--message",
-                f"[{target_branch}] CI: Upgrade important CI environment",
-            ]
-        )
+        try:
+            run_command(
+                [
+                    "git",
+                    "commit",
+                    "--message",
+                    f"[{target_branch}] CI: Upgrade important CI environment",
+                ]
+            )
+        except subprocess.CalledProcessError:
+            console_print("[info]Commit failed, assume some auto-fixes might have been made...[/]")
+            run_command(["git", "add", "."])
+            run_command(
+                [
+                    "git",
+                    "commit",
+                    # postpone pre-commit checks to CI, not to fail in automation if e.g. mypy changes force code checks
+                    "--no-verify",
+                    "--message",
+                    f"[{target_branch}] CI: Upgrade important CI environment",
+                ]
+            )
 
         # Push the branch to origin (use detected origin or fallback to 'origin')
         push_remote = origin_remote_name if origin_remote_name else "origin"

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -853,6 +853,7 @@ def upgrade(
             [
                 "git",
                 "commit",
+                # postpone pre-commit checks to CI, not to fail in automation if e.g. mypy changes force code checks
                 "--no-verify",
                 "--message",
                 f"[{target_branch}] CI: Upgrade important CI environment",

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -851,12 +851,7 @@ def upgrade(
         run_command(["git", "add", "."])
         try:
             run_command(
-                [
-                    "git",
-                    "commit",
-                    "--message",
-                    f"[{target_branch}] CI: Upgrade important CI environment",
-                ]
+                ["git", "commit", "--message", f"[{target_branch}] CI: Upgrade important CI environment"]
             )
         except subprocess.CalledProcessError:
             console_print("[info]Commit failed, assume some auto-fixes might have been made...[/]")

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -849,7 +849,15 @@ def upgrade(
 
         run_command(["git", "checkout", "-b", branch_name])
         run_command(["git", "add", "."])
-        run_command(["git", "commit", "-m", f"[{target_branch}] CI: Upgrade important CI environment"])
+        run_command(
+            [
+                "git",
+                "commit",
+                "--no-verify",
+                "--message",
+                f"[{target_branch}] CI: Upgrade important CI environment",
+            ]
+        )
 
         # Push the branch to origin (use detected origin or fallback to 'origin')
         push_remote = origin_remote_name if origin_remote_name else "origin"


### PR DESCRIPTION
Follow-up from #64836 and comment https://github.com/apache/airflow/pull/64836#pullrequestreview-4070117343

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
