### PR TITLE
Avoid false recovery alerts when failed job lookup fails

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/workflow_status.py
+++ b/dev/breeze/src/airflow_breeze/utils/workflow_status.py
@@ -31,7 +31,13 @@ import sys
 from rich.console import Console
 
 console = Console(width=400, color_system="standard")
-FAILED_JOBS_LOOKUP_ERROR = "ERROR: failed to fetch failed jobs; inspect the workflow run directly"
+
+
+def format_failed_jobs_lookup_error(run_id: int) -> str:
+    return (
+        "ERROR: failed to fetch failed jobs for workflow run "
+        f"{run_id}; inspect it directly with: gh run view {run_id} --json jobs --repo apache/airflow"
+    )
 
 
 def workflow_status(
@@ -94,7 +100,7 @@ def get_failed_jobs(run_id: int) -> list[str]:
     )
     if result.returncode != 0:
         console.print(f"[red]Error fetching failed jobs: {result.stderr}[/red]")
-        return [FAILED_JOBS_LOOKUP_ERROR]
+        return [format_failed_jobs_lookup_error(run_id)]
 
     return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
 

--- a/dev/breeze/src/airflow_breeze/utils/workflow_status.py
+++ b/dev/breeze/src/airflow_breeze/utils/workflow_status.py
@@ -31,6 +31,7 @@ import sys
 from rich.console import Console
 
 console = Console(width=400, color_system="standard")
+FAILED_JOBS_LOOKUP_ERROR = "ERROR: failed to fetch failed jobs; inspect the workflow run directly"
 
 
 def workflow_status(
@@ -93,7 +94,7 @@ def get_failed_jobs(run_id: int) -> list[str]:
     )
     if result.returncode != 0:
         console.print(f"[red]Error fetching failed jobs: {result.stderr}[/red]")
-        return []
+        return [FAILED_JOBS_LOOKUP_ERROR]
 
     return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
 


### PR DESCRIPTION
## Why

The CI notification flow currently fails open when it cannot fetch failed jobs for a failed workflow run. When `gh run view` fails, `workflow_status.py` falls back to an empty failed-jobs output, and the downstream notification logic interprets that as “no current failures.” 
This can incorrectly mark an actually failing run as recovered, or skip notifications entirely.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
