### PR TITLE
fix(triggerer): fix thread-safety in TriggerCommsDecoder.asend()

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -911,13 +911,22 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
         return self._from_frame(frame)
 
     async def asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
-        frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
-        bytes = frame.as_bytes()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._thread_lock.acquire)
+        try:
+            # Generate the frame ID and bytes INSIDE the lock to ensure the order of
+            # messages written to the socket matches the order of the IDs.
+            # This prevents "Response read out of order" errors.
+            frame_id = next(self.id_counter)
+            frame = _RequestFrame(id=frame_id, body=msg.model_dump())
+            bytes = frame.as_bytes()
 
-        async with self._async_lock:
             self._async_writer.write(bytes)
+            await self._async_writer.drain()
 
-            return await self._aget_response(frame.id)
+            return await self._aget_response(frame_id)
+        finally:
+            self._thread_lock.release()
 
 
 class TriggerRunner:

--- a/airflow-core/tests/unit/jobs/test_triggerer_comms_concurrency.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_comms_concurrency.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+import queue
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.jobs.triggerer_job_runner import TriggerCommsDecoder
+from airflow.sdk.execution_time.comms import GetVariable, OKResponse, _new_encoder, _RequestFrame
+
+
+class MockReader:
+    def __init__(self):
+        self._queue = queue.Queue()
+
+    async def readexactly(self, n):
+        loop = asyncio.get_running_loop()
+        try:
+            return await loop.run_in_executor(None, self._queue.get, True, 2)
+        except queue.Empty:
+            raise EOFError("Mock queue timeout - prevents hanging during test failure")
+
+
+class SimpleMockWriter:
+    """Manual mock of StreamWriter to avoid OSError 88 (Socket operation on non-socket)."""
+
+    def __init__(self):
+        self.write_count = 0
+
+    def write(self, data: bytes):
+        self.write_count += 1
+
+    async def drain(self):
+        await asyncio.sleep(0.01)
+
+    def get_extra_info(self, name, default=None):
+        return None
+
+    def close(self):
+        pass
+
+    async def wait_closed(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_trigger_comms_decoder_concurrency():
+    """Test that TriggerCommsDecoder.asend is thread-safe when called from multiple threads."""
+    mock_reader = MockReader()
+    mock_writer = SimpleMockWriter()
+
+    decoder = TriggerCommsDecoder(async_reader=mock_reader, async_writer=mock_writer, socket=MagicMock())
+    decoder.id_counter = iter(range(1, 1000))
+
+    responses_sent = 0
+
+    def provide_response(msg_id):
+        nonlocal responses_sent
+        # We must explicitly set type="OKResponse" because the comms encoder
+        # uses exclude_unset=True, and Pydantic requires the discriminator "type".
+        resp = OKResponse(ok=True, type="OKResponse")
+        frame = _RequestFrame(id=msg_id, body=resp)
+        encoder = _new_encoder()
+        body = encoder.encode(frame)
+        length = len(body).to_bytes(4, byteorder="big")
+
+        mock_reader._queue.put(length)
+        mock_reader._queue.put(body)
+        responses_sent += 1
+
+    msg = GetVariable(key="test")
+
+    def thread_task():
+        return decoder.send(msg)
+
+    async def supervisor_sim():
+        for i in range(20):
+            while mock_writer.write_count <= i:
+                await asyncio.sleep(0.001)
+            provide_response(i + 1)
+
+    loop = asyncio.get_running_loop()
+    # Increase the default executor's thread limit to prevent deadlock from thread exhaustion
+    # during high-concurrency testing.
+    loop.set_default_executor(ThreadPoolExecutor(max_workers=50))
+
+    decoder.id_counter = itertools.count(1)
+    sim_task = asyncio.create_task(supervisor_sim())
+
+    try:
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [loop.run_in_executor(executor, thread_task) for _ in range(20)]
+            results = await asyncio.gather(*futures)
+    finally:
+        sim_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await sim_task
+
+    assert len(results) == 20
+    assert all(isinstance(r, OKResponse) for r in results)


### PR DESCRIPTION
# #64620 fix: TriggerCommsDecoder.asend() asyncio.Lock is not thread-safe

### Description
The `TriggerCommsDecoder` used an `asyncio.Lock` to protect access to the communication socket. When called from a different event loop (e.g., via `sync_to_async` inside a trigger), `asyncio.Lock` would either fail to provide mutual exclusion or raise a `RuntimeError`.

This PR replaces the `asyncio.Lock` with an asynchronously-acquired `threading.Lock`, which is safe across all threads and loops. It also adds an explicit `drain()` to ensure reliability.

### Changes
- Replaced loop-bound `asyncio.Lock` with `threading.Lock` acquired via `run_in_executor`.
- Added `await self._async_writer.drain()` to `asend()` to ensure reliable message delivery.
