### PR TITLE
Fix macOS `SIGSEGV` in task execution by using `fork`+`exec`

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1099,8 +1099,12 @@ class ActivitySubprocess(WatchedSubprocess):
         **kwargs,
     ) -> Self:
         """Fork and start a new subprocess to execute the given task."""
+        # Tests override `target` with a local stub to exercise the base
+        # infrastructure; keep bare fork for those. Only the real task runner
+        # path opts in to fork+exec.
+        use_exec = target is _subprocess_main
         proc: Self = super().start(
-            id=what.id, client=client, target=target, logger=logger, use_exec=True, **kwargs
+            id=what.id, client=client, target=target, logger=logger, use_exec=use_exec, **kwargs
         )
         # Tell the task process what it needs to do!
         proc._on_child_started(

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -483,12 +483,10 @@ def _child_exec_main():
     instead, the task runner requests it from the supervisor via the existing
     ``ResendLoggingFD`` mechanism after startup.
     """
-    import socket as _socket
-
     # FDs 0, 1, 2 were dup2'd onto the socketpairs before exec.
-    child_requests = _socket.socket(fileno=0)
-    child_stdout = _socket.socket(fileno=1)
-    child_stderr = _socket.socket(fileno=2)
+    child_requests = socket(fileno=0)
+    child_stdout = socket(fileno=1)
+    child_stderr = socket(fileno=2)
 
     # _fork_main always exits via os._exit(), so the socket objects above are
     # never GC'd (which would close their underlying FDs). This is safe but
@@ -557,7 +555,14 @@ class WatchedSubprocess:
             immediately ``os.execv`` a fresh Python interpreter after ``os.fork``.
             This avoids macOS fork-safety issues with Objective-C frameworks.
             Task execution opts in; DAG processor and triggerer do not.
+
+        The exec'd child always runs ``_subprocess_main``, so ``use_exec=True``
+        is only valid when ``target is _subprocess_main``.
         """
+        if use_exec and target is not _subprocess_main:
+            raise ValueError(
+                f"use_exec=True is only supported with target=_subprocess_main; got target={target!r}"
+            )
         # Create socketpairs/"pipes" to connect to the stdin and out from the subprocess
         child_stdout, read_stdout = socketpair()
         child_stderr, read_stderr = socketpair()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -465,9 +465,9 @@ FDs survive the upcoming exec because ``os.dup2(inheritable=True)`` (the default
 clears ``FD_CLOEXEC`` on the destination FDs.  The log channel is obtained after
 startup via the existing ``ResendLoggingFD`` mechanism.
 
-Only task execution opts in (via ``use_exec=True`` in ``ActivitySubprocess.start``).
-DAG processor and triggerer keep bare fork -- they don't make network calls that
-trigger the macOS crash.
+Currently only task execution opts in (via ``ActivitySubprocess.start``).  DAG
+processor and triggerer can also hit this crash and will need the same treatment
+as a follow-up (see https://github.com/apache/airflow/issues/65691).
 
 See: https://github.com/python/cpython/issues/105912
      https://github.com/apache/airflow/discussions/24463
@@ -584,7 +584,7 @@ class WatchedSubprocess:
             del logger
 
             try:
-                if use_exec and sys.platform in _FORK_EXEC_PLATFORMS:
+                if use_exec:
                     # macOS: exec a fresh Python interpreter to replace the
                     # inherited ObjC/CoreFoundation state that is not fork-safe.
                     # dup2 copies the socketpairs onto FDs 0/1/2; os.dup2 clears
@@ -1099,10 +1099,10 @@ class ActivitySubprocess(WatchedSubprocess):
         **kwargs,
     ) -> Self:
         """Fork and start a new subprocess to execute the given task."""
+        # Opt in to fork+exec on platforms that need it (currently macOS).
         # Tests override `target` with a local stub to exercise the base
-        # infrastructure; keep bare fork for those. Only the real task runner
-        # path opts in to fork+exec.
-        use_exec = target is _subprocess_main
+        # infrastructure; keep bare fork for those.
+        use_exec = target is _subprocess_main and sys.platform in _FORK_EXEC_PLATFORMS
         proc: Self = super().start(
             id=what.id, client=client, target=target, logger=logger, use_exec=use_exec, **kwargs
         )

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -195,10 +195,18 @@ Note: Only Linux-based distros supported as "Production" execution environment f
 
 macOS
 -----
- 1. Due to limitations in Apple's libraries not every process might 'fork' safe.
-    One of the general error is unable to query the macOS system configuration for network proxies.
-    If your are not using a proxy you could disable it by set environment variable 'no_proxy' to '*'.
-    See: https://github.com/python/cpython/issues/58037 and https://bugs.python.org/issue30385#msg293958
+ Apple's Objective-C runtime and system frameworks (Security.framework,
+ CoreFoundation, libdispatch) are not safe to use after fork() without exec().
+ Airflow's task supervisor uses fork+exec on macOS to avoid this, but other
+ code paths (DAG processor, triggerer) still use bare fork.  If you see
+ crashes mentioning "+[NSNumber initialize]" or "_scproxy", the most likely
+ cause is a bare fork touching Apple frameworks.
+
+ Common triggers: socket.getaddrinfo (DNS resolver), urllib proxy lookup,
+ SSL context initialization via Security.framework.
+
+ See: https://github.com/python/cpython/issues/105912
+      https://github.com/python/cpython/issues/58037
 ********************************************************************************************************"""
 
 
@@ -441,6 +449,56 @@ def _fork_main(
             exit(125)
 
 
+_USE_FORK_EXEC = sys.platform == "darwin"
+"""On macOS, use fork + exec (``os.fork`` then ``os.execv``) instead of bare ``os.fork``.
+
+macOS system libraries (Security.framework, CoreFoundation, ``_scproxy``) use
+Objective-C, which is not fork-safe.  A bare ``os.fork()`` copies the parent's
+ObjC runtime state; if the child then triggers ObjC class initialization
+(e.g. via ``socket.getaddrinfo`` -> system DNS resolver -> proxy lookup), the
+runtime detects the corrupted state and crashes with SIGABRT.
+
+Calling ``os.execv`` immediately after ``os.fork`` replaces the child's address
+space, giving it clean ObjC state.  The socketpair FDs survive across exec
+because they are marked inheritable; the child reads FD numbers from an env var
+and reconstructs the communication channels.
+
+This applies to all executors (Local, Celery, etc.) but only on macOS and only
+for task execution (``target is _subprocess_main``).  DAG processor and triggerer
+use different targets and keep bare fork -- they don't make network calls that
+trigger the macOS crash.
+
+See: https://github.com/python/cpython/issues/105912
+     https://github.com/apache/airflow/discussions/24463
+"""
+
+# Env var key used to pass socket FDs to the child when using fork+exec.
+_CHILD_FDS_ENV_VAR = "_AIRFLOW_SUPERVISOR_CHILD_FDS"
+
+
+def _child_exec_main():
+    """
+    Entry point for the child process when using fork+exec (macOS).
+
+    Reads socket FD numbers from the environment, reconstructs the sockets,
+    and hands off to ``_fork_main`` -- the same code path as the bare-fork
+    child.
+    """
+    import json
+    import socket as _socket
+
+    fds = json.loads(os.environ.pop(_CHILD_FDS_ENV_VAR))
+    child_requests = _socket.socket(fileno=fds["requests"])
+    child_stdout = _socket.socket(fileno=fds["stdout"])
+    child_stderr = _socket.socket(fileno=fds["stderr"])
+    log_fd = fds["logs"]
+
+    # _fork_main always exits via os._exit(), so the socket objects above are
+    # never GC'd (which would close their underlying FDs). This is safe but
+    # depends on that invariant -- do not refactor _fork_main to return.
+    _fork_main(child_requests, child_stdout, child_stderr, log_fd, _subprocess_main)
+
+
 @attrs.define(kw_only=True)
 class WatchedSubprocess:
     """
@@ -511,16 +569,49 @@ class WatchedSubprocess:
             del constructor_kwargs
             del logger
 
-            try:
-                # Run the child entrypoint
-                _fork_main(child_requests, child_stdout, child_stderr, child_logs.fileno(), target)
-            except BaseException as e:
-                import traceback
+            if _USE_FORK_EXEC and target is _subprocess_main:
+                # macOS: immediately exec a fresh Python interpreter to replace the
+                # inherited ObjC/CoreFoundation state that is not fork-safe.  Only
+                # for task execution (_subprocess_main); DAG processor and triggerer
+                # use different targets and keep bare fork.  The socketpair FDs
+                # survive across exec because we mark them inheritable.
+                try:
+                    import json
 
-                with suppress(BaseException):
-                    # We can't use log here, as if we except out of _fork_main something _weird_ went on.
-                    print("Exception in _fork_main, exiting with code 124", file=sys.stderr)
-                    traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
+                    fds = {
+                        "requests": child_requests.fileno(),
+                        "stdout": child_stdout.fileno(),
+                        "stderr": child_stderr.fileno(),
+                        "logs": child_logs.fileno(),
+                    }
+                    for fd in fds.values():
+                        os.set_inheritable(fd, True)
+
+                    os.environ[_CHILD_FDS_ENV_VAR] = json.dumps(fds)
+                    os.execv(sys.executable, [
+                        sys.executable,
+                        "-c",
+                        "from airflow.sdk.execution_time.supervisor import _child_exec_main;"
+                        " _child_exec_main()",
+                    ])
+                    # execv replaces the process -- we never reach here
+                except BaseException as e:
+                    import traceback
+
+                    with suppress(BaseException):
+                        print(f"execv failed, exiting with code 124: {e}", file=sys.stderr)
+                        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
+            else:
+                try:
+                    # Run the child entrypoint
+                    _fork_main(child_requests, child_stdout, child_stderr, child_logs.fileno(), target)
+                except BaseException as e:
+                    import traceback
+
+                    with suppress(BaseException):
+                        # We can't use log here, as if we except out of _fork_main something _weird_ went on.
+                        print("Exception in _fork_main, exiting with code 124", file=sys.stderr)
+                        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
 
             # It's really super super important we never exit this block. We are in the forked child, and if we
             # do then _THINGS GET WEIRD_.. (Normally `_fork_main` itself will `_exit()` so we never get here)

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -461,8 +461,8 @@ runtime detects the corrupted state and crashes with SIGABRT.
 Calling ``os.execv`` immediately after ``os.fork`` replaces the child's address
 space, giving it clean ObjC state.  Before exec, the supervisor dup2s the
 socketpairs onto FDs 0 (requests/stdin), 1 (stdout), 2 (stderr) -- these are
-inheritable by default and survive across exec.  Only the log channel FD has no
-well-known number and is passed via ``_AIRFLOW_SUPERVISOR_LOG_FD``.
+inheritable by default and survive across exec.  The log channel is obtained
+after startup via the existing ``ResendLoggingFD`` mechanism.
 
 This applies to all executors (Local, Celery, etc.) but only on macOS and only
 for task execution (``target is _subprocess_main``).  DAG processor and triggerer
@@ -473,22 +473,16 @@ See: https://github.com/python/cpython/issues/105912
      https://github.com/apache/airflow/discussions/24463
 """
 
-# Env var used to pass the log channel FD to the exec'd child (macOS fork+exec).
-_LOG_FD_ENV_VAR = "_AIRFLOW_SUPERVISOR_LOG_FD"
-
-
 def _child_exec_main():
     """
     Entry point for the child process when using fork+exec (macOS).
 
     After exec, FDs 0/1/2 are already the requests/stdout/stderr sockets
-    (dup2'd by the parent before exec).  Only the log FD is read from the
-    environment.  Hands off to ``_fork_main`` -- the same code path as the
-    bare-fork child.
+    (dup2'd by the parent before exec).  The log channel is NOT inherited;
+    instead, the task runner requests it from the supervisor via the existing
+    ``ResendLoggingFD`` mechanism after startup.
     """
     import socket as _socket
-
-    log_fd = int(os.environ.pop(_LOG_FD_ENV_VAR))
 
     # FDs 0, 1, 2 were dup2'd onto the socketpairs before exec.
     child_requests = _socket.socket(fileno=0)
@@ -498,7 +492,11 @@ def _child_exec_main():
     # _fork_main always exits via os._exit(), so the socket objects above are
     # never GC'd (which would close their underlying FDs). This is safe but
     # depends on that invariant -- do not refactor _fork_main to return.
-    _fork_main(child_requests, child_stdout, child_stderr, log_fd, _subprocess_main)
+    #
+    # log_fd=0 tells _fork_main to skip structured log channel setup.
+    # Signal to the task runner to request it via ResendLoggingFD after startup.
+    os.environ["_AIRFLOW_FORK_EXEC"] = "1"
+    _fork_main(child_requests, child_stdout, child_stderr, 0, _subprocess_main)
 
 
 @attrs.define(kw_only=True)
@@ -585,10 +583,8 @@ class WatchedSubprocess:
                     os.dup2(child_stdout.fileno(), 1)
                     os.dup2(child_stderr.fileno(), 2)
 
-                    log_fd = child_logs.fileno()
-                    os.set_inheritable(log_fd, True)
-                    os.environ[_LOG_FD_ENV_VAR] = str(log_fd)
-
+                    # Log channel FD is NOT passed to the child. The task
+                    # runner will request it via ResendLoggingFD after startup.
                     os.execv(sys.executable, [
                         sys.executable,
                         "-c",

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -449,8 +449,8 @@ def _fork_main(
             exit(125)
 
 
-_USE_FORK_EXEC = sys.platform == "darwin"
-"""On macOS, use fork + exec (``os.fork`` then ``os.execv``) instead of bare ``os.fork``.
+_FORK_EXEC_PLATFORMS = {"darwin"}
+"""Platforms where we fork+exec instead of bare ``os.fork`` for task execution.
 
 macOS system libraries (Security.framework, CoreFoundation, ``_scproxy``) use
 Objective-C, which is not fork-safe.  A bare ``os.fork()`` copies the parent's
@@ -459,19 +459,20 @@ ObjC runtime state; if the child then triggers ObjC class initialization
 runtime detects the corrupted state and crashes with SIGABRT.
 
 Calling ``os.execv`` immediately after ``os.fork`` replaces the child's address
-space, giving it clean ObjC state.  Before exec, the supervisor dup2s the
-socketpairs onto FDs 0 (requests/stdin), 1 (stdout), 2 (stderr) -- these are
-inheritable by default and survive across exec.  The log channel is obtained
-after startup via the existing ``ResendLoggingFD`` mechanism.
+space, giving it clean ObjC state.  Before exec, the supervisor ``dup2``s the
+socketpairs onto FDs 0 (requests/stdin), 1 (stdout), 2 (stderr).  The duplicated
+FDs survive the upcoming exec because ``os.dup2(inheritable=True)`` (the default)
+clears ``FD_CLOEXEC`` on the destination FDs.  The log channel is obtained after
+startup via the existing ``ResendLoggingFD`` mechanism.
 
-This applies to all executors (Local, Celery, etc.) but only on macOS and only
-for task execution (``target is _subprocess_main``).  DAG processor and triggerer
-use different targets and keep bare fork -- they don't make network calls that
+Only task execution opts in (via ``use_exec=True`` in ``ActivitySubprocess.start``).
+DAG processor and triggerer keep bare fork -- they don't make network calls that
 trigger the macOS crash.
 
 See: https://github.com/python/cpython/issues/105912
      https://github.com/apache/airflow/discussions/24463
 """
+
 
 def _child_exec_main():
     """
@@ -546,9 +547,16 @@ class WatchedSubprocess:
         *,
         target: Callable[[], None] = _subprocess_main,
         logger: FilteringBoundLogger | None = None,
+        use_exec: bool = False,
         **constructor_kwargs,
     ) -> Self:
-        """Fork and start a new subprocess with the specified target function."""
+        """Fork and start a new subprocess with the specified target function.
+
+        :param use_exec: If True, on platforms that need it (currently macOS),
+            immediately ``os.execv`` a fresh Python interpreter after ``os.fork``.
+            This avoids macOS fork-safety issues with Objective-C frameworks.
+            Task execution opts in; DAG processor and triggerer do not.
+        """
         # Create socketpairs/"pipes" to connect to the stdin and out from the subprocess
         child_stdout, read_stdout = socketpair()
         child_stderr, read_stderr = socketpair()
@@ -569,46 +577,33 @@ class WatchedSubprocess:
             del constructor_kwargs
             del logger
 
-            if _USE_FORK_EXEC and target is _subprocess_main:
-                # macOS: immediately exec a fresh Python interpreter to replace the
-                # inherited ObjC/CoreFoundation state that is not fork-safe.  Only
-                # for task execution (_subprocess_main); DAG processor and triggerer
-                # use different targets and keep bare fork.
-                #
-                # dup2 the socketpairs onto FDs 0/1/2 (which are inheritable by
-                # default and survive across exec).  Only the log FD needs to be
-                # passed explicitly.
-                try:
+            try:
+                if use_exec and sys.platform in _FORK_EXEC_PLATFORMS:
+                    # macOS: exec a fresh Python interpreter to replace the
+                    # inherited ObjC/CoreFoundation state that is not fork-safe.
+                    # dup2 copies the socketpairs onto FDs 0/1/2; os.dup2 clears
+                    # FD_CLOEXEC on the destination FDs, so they survive exec.
+                    # The log channel is requested later via ResendLoggingFD.
                     os.dup2(child_requests.fileno(), 0)
                     os.dup2(child_stdout.fileno(), 1)
                     os.dup2(child_stderr.fileno(), 2)
-
-                    # Log channel FD is NOT passed to the child. The task
-                    # runner will request it via ResendLoggingFD after startup.
                     os.execv(sys.executable, [
                         sys.executable,
                         "-c",
                         "from airflow.sdk.execution_time.supervisor import _child_exec_main;"
                         " _child_exec_main()",
                     ])
-                    # execv replaces the process -- we never reach here
-                except BaseException as e:
-                    import traceback
-
-                    with suppress(BaseException):
-                        print(f"execv failed, exiting with code 124: {e}", file=sys.stderr)
-                        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
-            else:
-                try:
+                    # execv replaces the process -- unreachable on success
+                else:
                     # Run the child entrypoint
                     _fork_main(child_requests, child_stdout, child_stderr, child_logs.fileno(), target)
-                except BaseException as e:
-                    import traceback
+            except BaseException as e:
+                import traceback
 
-                    with suppress(BaseException):
-                        # We can't use log here, as if we except out of _fork_main something _weird_ went on.
-                        print("Exception in _fork_main, exiting with code 124", file=sys.stderr)
-                        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
+                with suppress(BaseException):
+                    # We can't use log here, as if we except out of the child something _weird_ went on.
+                    print("Exception in child process, exiting with code 124", file=sys.stderr)
+                    traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
 
             # It's really super super important we never exit this block. We are in the forked child, and if we
             # do then _THINGS GET WEIRD_.. (Normally `_fork_main` itself will `_exit()` so we never get here)
@@ -1095,7 +1090,9 @@ class ActivitySubprocess(WatchedSubprocess):
         **kwargs,
     ) -> Self:
         """Fork and start a new subprocess to execute the given task."""
-        proc: Self = super().start(id=what.id, client=client, target=target, logger=logger, **kwargs)
+        proc: Self = super().start(
+            id=what.id, client=client, target=target, logger=logger, use_exec=True, **kwargs
+        )
         # Tell the task process what it needs to do!
         proc._on_child_started(
             ti=what,

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -550,7 +550,8 @@ class WatchedSubprocess:
         use_exec: bool = False,
         **constructor_kwargs,
     ) -> Self:
-        """Fork and start a new subprocess with the specified target function.
+        """
+        Fork and start a new subprocess with the specified target function.
 
         :param use_exec: If True, on platforms that need it (currently macOS),
             immediately ``os.execv`` a fresh Python interpreter after ``os.fork``.
@@ -587,12 +588,15 @@ class WatchedSubprocess:
                     os.dup2(child_requests.fileno(), 0)
                     os.dup2(child_stdout.fileno(), 1)
                     os.dup2(child_stderr.fileno(), 2)
-                    os.execv(sys.executable, [
+                    os.execv(
                         sys.executable,
-                        "-c",
-                        "from airflow.sdk.execution_time.supervisor import _child_exec_main;"
-                        " _child_exec_main()",
-                    ])
+                        [
+                            sys.executable,
+                            "-c",
+                            "from airflow.sdk.execution_time.supervisor import _child_exec_main;"
+                            " _child_exec_main()",
+                        ],
+                    )
                     # execv replaces the process -- unreachable on success
                 else:
                     # Run the child entrypoint

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -459,9 +459,10 @@ ObjC runtime state; if the child then triggers ObjC class initialization
 runtime detects the corrupted state and crashes with SIGABRT.
 
 Calling ``os.execv`` immediately after ``os.fork`` replaces the child's address
-space, giving it clean ObjC state.  The socketpair FDs survive across exec
-because they are marked inheritable; the child reads FD numbers from an env var
-and reconstructs the communication channels.
+space, giving it clean ObjC state.  Before exec, the supervisor dup2s the
+socketpairs onto FDs 0 (requests/stdin), 1 (stdout), 2 (stderr) -- these are
+inheritable by default and survive across exec.  Only the log channel FD has no
+well-known number and is passed via ``_AIRFLOW_SUPERVISOR_LOG_FD``.
 
 This applies to all executors (Local, Celery, etc.) but only on macOS and only
 for task execution (``target is _subprocess_main``).  DAG processor and triggerer
@@ -472,26 +473,27 @@ See: https://github.com/python/cpython/issues/105912
      https://github.com/apache/airflow/discussions/24463
 """
 
-# Env var key used to pass socket FDs to the child when using fork+exec.
-_CHILD_FDS_ENV_VAR = "_AIRFLOW_SUPERVISOR_CHILD_FDS"
+# Env var used to pass the log channel FD to the exec'd child (macOS fork+exec).
+_LOG_FD_ENV_VAR = "_AIRFLOW_SUPERVISOR_LOG_FD"
 
 
 def _child_exec_main():
     """
     Entry point for the child process when using fork+exec (macOS).
 
-    Reads socket FD numbers from the environment, reconstructs the sockets,
-    and hands off to ``_fork_main`` -- the same code path as the bare-fork
-    child.
+    After exec, FDs 0/1/2 are already the requests/stdout/stderr sockets
+    (dup2'd by the parent before exec).  Only the log FD is read from the
+    environment.  Hands off to ``_fork_main`` -- the same code path as the
+    bare-fork child.
     """
-    import json
     import socket as _socket
 
-    fds = json.loads(os.environ.pop(_CHILD_FDS_ENV_VAR))
-    child_requests = _socket.socket(fileno=fds["requests"])
-    child_stdout = _socket.socket(fileno=fds["stdout"])
-    child_stderr = _socket.socket(fileno=fds["stderr"])
-    log_fd = fds["logs"]
+    log_fd = int(os.environ.pop(_LOG_FD_ENV_VAR))
+
+    # FDs 0, 1, 2 were dup2'd onto the socketpairs before exec.
+    child_requests = _socket.socket(fileno=0)
+    child_stdout = _socket.socket(fileno=1)
+    child_stderr = _socket.socket(fileno=2)
 
     # _fork_main always exits via os._exit(), so the socket objects above are
     # never GC'd (which would close their underlying FDs). This is safe but
@@ -573,21 +575,20 @@ class WatchedSubprocess:
                 # macOS: immediately exec a fresh Python interpreter to replace the
                 # inherited ObjC/CoreFoundation state that is not fork-safe.  Only
                 # for task execution (_subprocess_main); DAG processor and triggerer
-                # use different targets and keep bare fork.  The socketpair FDs
-                # survive across exec because we mark them inheritable.
+                # use different targets and keep bare fork.
+                #
+                # dup2 the socketpairs onto FDs 0/1/2 (which are inheritable by
+                # default and survive across exec).  Only the log FD needs to be
+                # passed explicitly.
                 try:
-                    import json
+                    os.dup2(child_requests.fileno(), 0)
+                    os.dup2(child_stdout.fileno(), 1)
+                    os.dup2(child_stderr.fileno(), 2)
 
-                    fds = {
-                        "requests": child_requests.fileno(),
-                        "stdout": child_stdout.fileno(),
-                        "stderr": child_stderr.fileno(),
-                        "logs": child_logs.fileno(),
-                    }
-                    for fd in fds.values():
-                        os.set_inheritable(fd, True)
+                    log_fd = child_logs.fileno()
+                    os.set_inheritable(log_fd, True)
+                    os.environ[_LOG_FD_ENV_VAR] = str(log_fd)
 
-                    os.environ[_CHILD_FDS_ENV_VAR] = json.dumps(fds)
                     os.execv(sys.executable, [
                         sys.executable,
                         "-c",

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1871,6 +1871,14 @@ def main():
         try:
             try:
                 startup_details = get_startup_details()
+
+                # On macOS fork+exec path, the structured log channel wasn't
+                # inherited (exec replaces the address space). Request it from
+                # the supervisor using the existing ResendLoggingFD mechanism.
+                # Must happen after get_startup_details() so we don't read the
+                # startup message as a ResendLoggingFD response.
+                if os.environ.pop("_AIRFLOW_FORK_EXEC", None):
+                    reinit_supervisor_comms()
                 span = _make_task_span(msg=startup_details)
                 stack.enter_context(span)
                 ti, context, log = startup(msg=startup_details)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1877,7 +1877,7 @@ def main():
                 # the supervisor using the existing ResendLoggingFD mechanism.
                 # Must happen after get_startup_details() so we don't read the
                 # startup message as a ResendLoggingFD response.
-                if os.environ.pop("_AIRFLOW_FORK_EXEC", None):
+                if os.environ.pop("_AIRFLOW_FORK_EXEC", None) == "1":
                     reinit_supervisor_comms()
                 span = _make_task_span(msg=startup_details)
                 stack.enter_context(span)

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3422,15 +3422,14 @@ def test_api_client_clears_dag_bag_override_when_dag_is_none():
 class TestChildExecMain:
     """Test the macOS fork+exec child entry point."""
 
-    def test_reconstructs_sockets_from_env_and_calls_fork_main(self, monkeypatch):
-        """_child_exec_main reads log FD from env, uses FDs 0/1/2 for sockets, calls _fork_main."""
+    def test_uses_fds_012_and_requests_log_channel(self, monkeypatch):
+        """_child_exec_main wraps FDs 0/1/2 as sockets, passes log_fd=0, sets _AIRFLOW_FORK_EXEC."""
         # _child_exec_main expects FDs 0/1/2 to be sockets (dup2'd by the
-        # parent before exec).  We dup2 real sockets onto 0/1/2 for the test,
-        # then restore the originals afterward.
+        # parent before exec).  It passes log_fd=0 to _fork_main (structured
+        # logging is requested later via ResendLoggingFD).
         req_a, req_b = socket.socketpair()
         out_a, out_b = socket.socketpair()
         err_a, err_b = socket.socketpair()
-        log_child, log_parent = socket.socketpair()
 
         # Save originals so we can restore after the test.
         saved_0 = os.dup(0)
@@ -3441,8 +3440,6 @@ class TestChildExecMain:
             os.dup2(req_a.fileno(), 0)
             os.dup2(out_a.fileno(), 1)
             os.dup2(err_a.fileno(), 2)
-
-            monkeypatch.setenv(supervisor._LOG_FD_ENV_VAR, str(log_child.fileno()))
 
             captured = {}
 
@@ -3465,9 +3462,11 @@ class TestChildExecMain:
             assert captured["requests_fd"] == 0
             assert captured["stdout_fd"] == 1
             assert captured["stderr_fd"] == 2
-            assert captured["log_fd"] == log_child.fileno()
+            assert captured["log_fd"] == 0
             assert captured["target"] is supervisor._subprocess_main
-            assert supervisor._LOG_FD_ENV_VAR not in os.environ
+            # _child_exec_main sets this so the task runner knows to request
+            # the log channel via ResendLoggingFD.
+            assert os.environ.pop("_AIRFLOW_FORK_EXEC") == "1"
         finally:
             # Restore original FDs.
             os.dup2(saved_0, 0)
@@ -3476,5 +3475,5 @@ class TestChildExecMain:
             os.close(saved_0)
             os.close(saved_1)
             os.close(saved_2)
-            for s in [req_a, req_b, out_a, out_b, err_a, err_b, log_child, log_parent]:
+            for s in [req_a, req_b, out_a, out_b, err_a, err_b]:
                 s.close()

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3419,6 +3419,7 @@ def test_api_client_clears_dag_bag_override_when_dag_is_none():
         in_process_api_server.cache_clear()
 
 
+@pytest.mark.usefixtures("disable_capturing")
 class TestChildExecMain:
     """Test the macOS fork+exec child entry point."""
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3423,23 +3423,26 @@ class TestChildExecMain:
     """Test the macOS fork+exec child entry point."""
 
     def test_reconstructs_sockets_from_env_and_calls_fork_main(self, monkeypatch):
-        """_child_exec_main reads FD numbers from env, wraps them in sockets, calls _fork_main."""
-        # Create socketpairs. _child_exec_main will wrap the "child" ends in
-        # new socket objects via socket.socket(fileno=N), taking ownership of
-        # those FDs. We only need to clean up the "parent" ends (s2, s4, s6).
-        s1, s2 = socket.socketpair()
-        s3, s4 = socket.socketpair()
-        s5, s6 = socket.socketpair()
-        parent_sockets = [s2, s4, s6]
+        """_child_exec_main reads log FD from env, uses FDs 0/1/2 for sockets, calls _fork_main."""
+        # _child_exec_main expects FDs 0/1/2 to be sockets (dup2'd by the
+        # parent before exec).  We dup2 real sockets onto 0/1/2 for the test,
+        # then restore the originals afterward.
+        req_a, req_b = socket.socketpair()
+        out_a, out_b = socket.socketpair()
+        err_a, err_b = socket.socketpair()
+        log_child, log_parent = socket.socketpair()
+
+        # Save originals so we can restore after the test.
+        saved_0 = os.dup(0)
+        saved_1 = os.dup(1)
+        saved_2 = os.dup(2)
 
         try:
-            fds = {
-                "requests": s1.fileno(),
-                "stdout": s3.fileno(),
-                "stderr": s5.fileno(),
-                "logs": s2.fileno(),
-            }
-            monkeypatch.setenv(supervisor._CHILD_FDS_ENV_VAR, json.dumps(fds))
+            os.dup2(req_a.fileno(), 0)
+            os.dup2(out_a.fileno(), 1)
+            os.dup2(err_a.fileno(), 2)
+
+            monkeypatch.setenv(supervisor._LOG_FD_ENV_VAR, str(log_child.fileno()))
 
             captured = {}
 
@@ -3459,12 +3462,19 @@ class TestChildExecMain:
 
             supervisor._child_exec_main()
 
-            assert captured["requests_fd"] == fds["requests"]
-            assert captured["stdout_fd"] == fds["stdout"]
-            assert captured["stderr_fd"] == fds["stderr"]
-            assert captured["log_fd"] == fds["logs"]
+            assert captured["requests_fd"] == 0
+            assert captured["stdout_fd"] == 1
+            assert captured["stderr_fd"] == 2
+            assert captured["log_fd"] == log_child.fileno()
             assert captured["target"] is supervisor._subprocess_main
-            assert supervisor._CHILD_FDS_ENV_VAR not in os.environ
+            assert supervisor._LOG_FD_ENV_VAR not in os.environ
         finally:
-            for s in parent_sockets:
+            # Restore original FDs.
+            os.dup2(saved_0, 0)
+            os.dup2(saved_1, 1)
+            os.dup2(saved_2, 2)
+            os.close(saved_0)
+            os.close(saved_1)
+            os.close(saved_2)
+            for s in [req_a, req_b, out_a, out_b, err_a, err_b, log_child, log_parent]:
                 s.close()

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -64,7 +64,7 @@ from airflow.sdk.api.datamodels._generated import (
     TaskInstanceState,
 )
 from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType, TaskAlreadyRunningError
-from airflow.sdk.execution_time import task_runner
+from airflow.sdk.execution_time import supervisor, task_runner
 from airflow.sdk.execution_time.comms import (
     AssetEventsResult,
     AssetResult,
@@ -3417,3 +3417,54 @@ def test_api_client_clears_dag_bag_override_when_dag_is_none():
         assert dag_bag_from_app not in api.app.dependency_overrides
     finally:
         in_process_api_server.cache_clear()
+
+
+class TestChildExecMain:
+    """Test the macOS fork+exec child entry point."""
+
+    def test_reconstructs_sockets_from_env_and_calls_fork_main(self, monkeypatch):
+        """_child_exec_main reads FD numbers from env, wraps them in sockets, calls _fork_main."""
+        # Create socketpairs. _child_exec_main will wrap the "child" ends in
+        # new socket objects via socket.socket(fileno=N), taking ownership of
+        # those FDs. We only need to clean up the "parent" ends (s2, s4, s6).
+        s1, s2 = socket.socketpair()
+        s3, s4 = socket.socketpair()
+        s5, s6 = socket.socketpair()
+        parent_sockets = [s2, s4, s6]
+
+        try:
+            fds = {
+                "requests": s1.fileno(),
+                "stdout": s3.fileno(),
+                "stderr": s5.fileno(),
+                "logs": s2.fileno(),
+            }
+            monkeypatch.setenv(supervisor._CHILD_FDS_ENV_VAR, json.dumps(fds))
+
+            captured = {}
+
+            def mock_fork_main(requests, stdout, stderr, log_fd, target):
+                captured["requests_fd"] = requests.fileno()
+                captured["stdout_fd"] = stdout.fileno()
+                captured["stderr_fd"] = stderr.fileno()
+                captured["log_fd"] = log_fd
+                captured["target"] = target
+                # Detach so the mock return doesn't double-close FDs that
+                # _child_exec_main's socket objects also own.
+                requests.detach()
+                stdout.detach()
+                stderr.detach()
+
+            monkeypatch.setattr(supervisor, "_fork_main", mock_fork_main)
+
+            supervisor._child_exec_main()
+
+            assert captured["requests_fd"] == fds["requests"]
+            assert captured["stdout_fd"] == fds["stdout"]
+            assert captured["stderr_fd"] == fds["stderr"]
+            assert captured["log_fd"] == fds["logs"]
+            assert captured["target"] is supervisor._subprocess_main
+            assert supervisor._CHILD_FDS_ENV_VAR not in os.environ
+        finally:
+            for s in parent_sockets:
+                s.close()


### PR DESCRIPTION
## Summary

Discovered while testing the AIP-99 `LLMSQLQueryOperator` example DAGs from #64824 on macOS. Tasks that make network calls (LLM API requests, HTTP calls) crash intermittently with `SIGSEGV` or `SIGABRT` when running via `airflow standalone` or any executor on macOS.

**Root cause**: `WatchedSubprocess.start()` in `supervisor.py` uses bare `os.fork()` to create task child processes. On macOS, the forked child inherits corrupted Objective-C runtime state from the parent. When the child later triggers ObjC class initialization -- for example via `socket.getaddrinfo()` -> macOS system DNS resolver -> `Security.framework` -> `+[NSNumber initialize]` -- the ObjC runtime detects the half-initialized state and deliberately crashes.

**The fix**: Add a `use_exec: bool = False` kwarg to `WatchedSubprocess.start()`. `ActivitySubprocess.start()` passes `use_exec=True`; DAG processor and triggerer use the default. On platforms in `_FORK_EXEC_PLATFORMS` (currently `{"darwin"}`), the fork+exec path runs `os.dup2` on the socketpairs to place them on FDs 0/1/2, then `os.execv` a fresh Python interpreter. `os.dup2` (with the default `inheritable=True`) clears `FD_CLOEXEC` on the destination FDs, so they survive `execv`. The structured log channel is NOT inherited; instead, the exec'd child sets `_AIRFLOW_FORK_EXEC=1`, and after `startup()` in `task_runner.main` the existing `reinit_supervisor_comms()` requests the log FD from the supervisor via `ResendLoggingFD` + SCM_RIGHTS (the same mechanism used by the `sudo` / virtualenv re-exec path).

## The crash chain

```
supervisor.py: os.fork()
  -> child runs pydantic_ai.Agent.run_sync()
    -> httpx creates ThreadPoolExecutor for DNS
      -> socket.getaddrinfo() in worker thread
        -> macOS system resolver (not glibc)
          -> _scproxy / Security.framework
            -> ObjC runtime detects fork-unsafe state
              -> SIGABRT / SIGSEGV
```

The faulthandler traceback that identified the root cause:

```
Current thread (most recent call first):
  File "socket.py", line 978 in getaddrinfo
  File "concurrent/futures/thread.py", line 59 in run
  ...
```

## Why macOS only

Apple's ObjC runtime, CoreFoundation, and `libdispatch` are not fork-safe. This is why CPython changed `multiprocessing`'s default start method from `fork` to `spawn` on macOS in Python 3.8 ([BPO-33725](https://bugs.python.org/issue33725)). Linux uses glibc's resolver which has no ObjC dependency, so bare `fork()` works fine there. The `_FORK_EXEC_PLATFORMS` set is the extension point if another platform needs the same treatment later.

## Scope: task execution only (for now)

This PR only applies fork+exec to task execution (`ActivitySubprocess`). DAG processor and triggerer also use `WatchedSubprocess` and can hit the same macOS fork-safety crash -- DAG files often have top-level network calls (secret backends, connection / variable lookups, in-process API server threads), and triggerers run user-defined async triggers that poll APIs. We observed the DAG processor crash earlier in this investigation (the `InProcessExecutionAPI` + `a2wsgi` background thread initializing `httpx` / `ssl` / `Security.framework`).

Extending fork+exec to them requires reworking `_child_exec_main()` to rehydrate arbitrary targets across `execv` (it currently hardcodes `_subprocess_main`; DAG processor passes `target=_parse_file_entrypoint`, triggerer passes `target=TriggerRunnerSupervisor.run_in_process`). Tracked as follow-up in #65691.

## Scope: all executors on macOS, not just LocalExecutor

This affects **any** executor running on macOS (Local, Celery worker, etc.) because the fork happens inside `supervise()` in the Task SDK, not in the executor itself. The executor spawns a worker process (which is safe -- `multiprocessing.Process` uses `spawn` on macOS), but that worker then calls `supervise()` which does the bare `os.fork()`.

The two-fork architecture:
```
Executor -> multiprocessing.Process (spawn, safe)
  -> worker calls supervise()
    -> os.fork() (bare fork, UNSAFE on macOS without exec)
      -> child runs task
```

## How the log channel is obtained after exec

`_fork_main` needs a log FD to set up structured logging. In the bare-fork path it's inherited. In the fork+exec path:

1. `_child_exec_main` (the exec'd entry point) calls `_fork_main(..., log_fd=0, ...)` -- zero means skip structured-log setup. It also sets `_AIRFLOW_FORK_EXEC=1`.
2. `_fork_main` runs through its usual setup (signals, stdio, etc.) with logging going to the stderr socket.
3. `task_runner.main` calls `startup()` to receive `StartupDetails` from the supervisor.
4. After `startup()`, `main` checks `_AIRFLOW_FORK_EXEC` and calls the existing [`reinit_supervisor_comms()`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/execution_time/task_runner.py), which sends `ResendLoggingFD()` over the requests socket and receives a fresh log FD via SCM_RIGHTS.

The timing works because the supervisor enters its event loop (`process.wait()`) after `_on_child_started` has sent the startup message. By the time the child requests the log channel, the supervisor is in the loop and ready to handle it.

## What we tried that didn't work

| Approach | Why it failed |
|---|---|
| Lazy imports (`pydantic_ai`, `datafusion`) | Crash happens at runtime during DNS resolution, not at import time |
| `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` | Undocumented Apple debug knob. Suppresses the abort but doesn't fix the underlying memory corruption. Cached at ObjC runtime init, unreliable on newer macOS |
| `NO_PROXY='*'` | Python-level env var; `socket.getaddrinfo()` is a C library call that uses the macOS system resolver directly |
| Pre-initialize `_scproxy` before fork | Fragile -- any new dependency that touches ObjC frameworks would break it again |
| `subprocess.Popen` instead of `os.fork()` | Loses the socketpair FDs. The child can't communicate with the supervisor |

## Why `fork` + `exec` and not `spawn`

Python's `multiprocessing.Process(start_method='spawn')` would also work, but it requires pickling the target function and arguments. The supervisor's communication is built around socketpairs created before fork, with FDs inherited by the child. `fork` + `exec` preserves this design: the three socketpairs are placed at FDs 0/1/2 via `dup2` (which clears `FD_CLOEXEC`), and the log channel is obtained after startup via the existing `ResendLoggingFD` protocol. No new cross-process communication path needed.

## References

- https://github.com/python/cpython/issues/105912 -- `getaddrinfo` SIGSEGV after fork on macOS
- https://github.com/python/cpython/issues/58037 -- `_scproxy` crash after fork
- https://github.com/apache/airflow/discussions/24463 -- Airflow SIGSEGV reports on macOS
- https://bugs.python.org/issue30385 -- original macOS fork-safety discussion
- #65691 -- follow-up to extend fork+exec to DAG processor and triggerer


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes -- Claude Code

<!--
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->