### PR TITLE
fix(migrations): move UPDATEs inside disable_sqlite_fkeys in migration 0097

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0097_3_2_0_enforce_log_event_and_dag_is_stale_not_null.py
+++ b/airflow-core/src/airflow/migrations/versions/0097_3_2_0_enforce_log_event_and_dag_is_stale_not_null.py
@@ -40,13 +40,10 @@ airflow_version = "3.2.0"
 
 def upgrade():
     """Bring existing deployments in line with 0010 and 0067."""
-    # Ensure `log.event` can safely transition to NOT NULL.
-    op.execute("UPDATE log SET event = '' WHERE event IS NULL")
-
-    # Make sure DAG rows that survived the old 0067 path are not NULL.
-    op.execute("UPDATE dag SET is_stale = false WHERE is_stale IS NULL")
-
     with disable_sqlite_fkeys(op):
+        op.execute("UPDATE log SET event = '' WHERE event IS NULL")
+        op.execute("UPDATE dag SET is_stale = false WHERE is_stale IS NULL")
+
         with op.batch_alter_table("log") as batch_op:
             batch_op.alter_column("event", existing_type=sa.String(60), nullable=False)
 


### PR DESCRIPTION
## Why

Migration 0097 failed on SQLite with FOREIGN KEY constraint failed when running DROP TABLE dag. PRAGMA foreign_keys=off (issued inside disable_sqlite_fkeys) is silently ignored when a transaction is already active — SQLite limitation. The two UPDATE statements before disable_sqlite_fkeys triggered SQLAlchemy's autobegin, starting a transaction before the PRAGMA ran.

### How to reproduce

1. Bring up a 3.1.8 instance

```python
breeze start-airflow  --backend sqlite --load-example-dags --use-airflow-version 3.1.8
```

2. Run a few Dags randomly. We need rows in the Dag run and task instance (or whatever rows that references Dag using FK)

3. Go to the `Shell` tab in the breeze terminal
4. Run 

```python
uv pip install apache-airflow==3.2.0
uv run airflow db migrate
```

## What
Move the UPDATE statements inside disable_sqlite_fkeys so PRAGMA foreign_keys=off executes before autobegin opens a transaction.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
