### PR TITLE
Lock TriggerCommsDecoder sync req-res cycle

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -883,12 +883,14 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
     def _read_frame(self):
         from asgiref.sync import async_to_sync
 
-        return async_to_sync(self._aread_frame)()
+        with self._thread_lock:
+            return async_to_sync(self._aread_frame)()
 
     def send(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
         from asgiref.sync import async_to_sync
 
-        return async_to_sync(self.asend)(msg)
+        with self._thread_lock:
+            return async_to_sync(self.asend)(msg)
 
     async def _aread_frame(self):
         try:


### PR DESCRIPTION
Synchronous methods in TriggerCommsDecoder need an additional threading.Lock to ensure communications happening in different threads don't interlace. While the async methods are guarded by an asyncio.Lock, this is not enough for sync methods.

This is also (mostly) what the sync-based CommsDecoder is doing, except since that one's sync-based, sync methods only have a thread lock, and the async ones use double-locking.

Fix #64620.