### PR TITLE
Enable SQLAlchemy connection pool settings for file-based SQLite

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -30,7 +30,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import pluggy
 from packaging.version import Version
-from sqlalchemy import create_engine, make_url
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession as SAAsyncSession,

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -510,8 +510,12 @@ def prepare_engine_args(disable_connection_pool=False, pool_class=None):
     elif disable_connection_pool or not conf.getboolean("database", "SQL_ALCHEMY_POOL_ENABLED"):
         engine_args["poolclass"] = NullPool
         log.debug("settings.prepare_engine_args(): Using NullPool")
-    elif not SQL_ALCHEMY_CONN.startswith("sqlite"):
-        # Pool size engine args not supported by sqlite.
+    elif SQL_ALCHEMY_CONN in ("sqlite://", "sqlite:///:memory:"):
+        # In-memory SQLite uses SingletonThreadPool which doesn't support pool_size/max_overflow.
+        log.debug("settings.prepare_engine_args(): Skipping pool settings for in-memory SQLite")
+    else:
+        # Pool settings for all file-based databases including SQLite.
+        # SQLAlchemy 2.0+ uses QueuePool by default for file-based SQLite.
         # If no config value is defined for the pool size, select a reasonable value.
         # 0 means no limit, which could lead to exceeding the Database connection limit.
         pool_size = conf.getint("database", "SQL_ALCHEMY_POOL_SIZE", fallback=5)
@@ -538,7 +542,7 @@ def prepare_engine_args(disable_connection_pool=False, pool_class=None):
         # Typically, this is a simple statement like "SELECT 1", but may also make use
         # of some DBAPI-specific method to test the connection for liveness.
         # More information here:
-        # https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic
+        # https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic
         pool_pre_ping = conf.getboolean("database", "SQL_ALCHEMY_POOL_PRE_PING", fallback=True)
 
         log.debug(

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import pluggy
 from packaging.version import Version
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession as SAAsyncSession,
@@ -481,6 +481,20 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
         register_at_fork(after_in_child=clean_in_fork)
 
 
+def _is_sqlite_in_memory(url: str) -> bool:
+    """
+    Check if a SQLAlchemy connection URL points to an in-memory SQLite database.
+
+    Handles driver prefixes (e.g. ``sqlite+pysqlite://``), query parameters, and
+    various in-memory forms like ``:memory:`` and ``file::memory:``.
+    """
+    parsed = make_url(url)
+    if parsed.get_backend_name() != "sqlite":
+        return False
+    db = parsed.database
+    return not db or db == ":memory:" or ":memory:" in db
+
+
 def prepare_engine_args(disable_connection_pool=False, pool_class=None):
     """Prepare SQLAlchemy engine args."""
     DEFAULT_ENGINE_ARGS: dict[str, dict[str, Any]] = {
@@ -510,7 +524,7 @@ def prepare_engine_args(disable_connection_pool=False, pool_class=None):
     elif disable_connection_pool or not conf.getboolean("database", "SQL_ALCHEMY_POOL_ENABLED"):
         engine_args["poolclass"] = NullPool
         log.debug("settings.prepare_engine_args(): Using NullPool")
-    elif SQL_ALCHEMY_CONN in ("sqlite://", "sqlite:///:memory:"):
+    elif _is_sqlite_in_memory(SQL_ALCHEMY_CONN):
         # In-memory SQLite uses SingletonThreadPool which doesn't support pool_size/max_overflow.
         log.debug("settings.prepare_engine_args(): Skipping pool settings for in-memory SQLite")
     else:

--- a/airflow-core/tests/unit/core/test_sqlalchemy_config.py
+++ b/airflow-core/tests/unit/core/test_sqlalchemy_config.py
@@ -98,7 +98,16 @@ class TestSqlAlchemySettings:
             **expected_kwargs,
         )
 
-    @pytest.mark.parametrize("conn_str", ["sqlite://", "sqlite:///:memory:"])
+    @pytest.mark.parametrize(
+        "conn_str",
+        [
+            "sqlite://",
+            "sqlite:///:memory:",
+            "sqlite+pysqlite:///:memory:",
+            "sqlite:///:memory:?cache=shared",
+            "sqlite:///file::memory:?cache=shared",
+        ],
+    )
     def test_prepare_engine_args_sqlite_in_memory_skips_pool_settings(self, conn_str, monkeypatch):
         """In-memory SQLite uses SingletonThreadPool which doesn't support pool_size/max_overflow."""
         monkeypatch.setattr(settings, "SQL_ALCHEMY_CONN", conn_str)
@@ -106,6 +115,7 @@ class TestSqlAlchemySettings:
         assert "pool_size" not in engine_args
         assert "max_overflow" not in engine_args
         assert "pool_recycle" not in engine_args
+        assert "pool_pre_ping" not in engine_args
 
     @patch("airflow.settings.setup_event_handlers")
     @patch("airflow.settings.scoped_session")

--- a/airflow-core/tests/unit/core/test_sqlalchemy_config.py
+++ b/airflow-core/tests/unit/core/test_sqlalchemy_config.py
@@ -74,6 +74,43 @@ class TestSqlAlchemySettings:
     @patch("airflow.settings.scoped_session")
     @patch("airflow.settings.sessionmaker")
     @patch("airflow.settings.create_engine")
+    def test_configure_orm_sqlite_file_based_gets_pool_settings(
+        self,
+        mock_create_engine,
+        mock_sessionmaker,
+        mock_scoped_session,
+        mock_setup_event_handlers,
+        monkeypatch,
+    ):
+        """SQLAlchemy 2.0+ uses QueuePool for file-based SQLite, so pool settings should be applied."""
+        monkeypatch.setattr(settings, "SQL_ALCHEMY_CONN", "sqlite:////tmp/airflow.db")
+        settings.configure_orm()
+        expected_kwargs = dict(
+            connect_args={"check_same_thread": False},
+            max_overflow=10,
+            pool_pre_ping=True,
+            pool_recycle=1800,
+            pool_size=5,
+            future=True,
+        )
+        mock_create_engine.assert_called_once_with(
+            "sqlite:////tmp/airflow.db",
+            **expected_kwargs,
+        )
+
+    @pytest.mark.parametrize("conn_str", ["sqlite://", "sqlite:///:memory:"])
+    def test_prepare_engine_args_sqlite_in_memory_skips_pool_settings(self, conn_str, monkeypatch):
+        """In-memory SQLite uses SingletonThreadPool which doesn't support pool_size/max_overflow."""
+        monkeypatch.setattr(settings, "SQL_ALCHEMY_CONN", conn_str)
+        engine_args = settings.prepare_engine_args()
+        assert "pool_size" not in engine_args
+        assert "max_overflow" not in engine_args
+        assert "pool_recycle" not in engine_args
+
+    @patch("airflow.settings.setup_event_handlers")
+    @patch("airflow.settings.scoped_session")
+    @patch("airflow.settings.sessionmaker")
+    @patch("airflow.settings.create_engine")
     def test_sql_alchemy_connect_args(
         self, mock_create_engine, mock_sessionmaker, mock_scoped_session, mock_setup_event_handlers
     ):

--- a/airflow-core/tests/unit/core/test_sqlalchemy_config.py
+++ b/airflow-core/tests/unit/core/test_sqlalchemy_config.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from sqlalchemy.pool import NullPool
@@ -93,10 +93,14 @@ class TestSqlAlchemySettings:
             pool_size=5,
             future=True,
         )
-        mock_create_engine.assert_called_once_with(
-            "sqlite:////tmp/airflow.db",
-            **expected_kwargs,
-        )
+        assert mock_create_engine.mock_calls == [
+            call(
+                "sqlite:////tmp/airflow.db",
+                **expected_kwargs,
+            ),
+            call().url.password.__bool__(),
+            call().url.password.__iter__(),
+        ]
 
     @pytest.mark.parametrize(
         "conn_str",


### PR DESCRIPTION
## Why

SQLAlchemy 2.0+ uses `QueuePool` by default for file-based SQLite databases, but Airflow unconditionally skips all pool configuration (`pool_size`, `max_overflow`, `pool_recycle`, `pool_pre_ping`) for any SQLite connection — a guard that was only correct for SQLAlchemy 1.x.

## What

- Remove the blanket `not SQL_ALCHEMY_CONN.startswith("sqlite")` guard in `prepare_engine_args` and replace it with a targeted check that only skips pool settings for in-memory SQLite (`sqlite://`, `sqlite:///:memory:`), which uses `SingletonThreadPool` that doesn't support `max_overflow`.
- File-based SQLite now receives the same pool configuration as PostgreSQL and MySQL.
- Update the SQLAlchemy docs link from 1.4 to 2.0.
- Add unit tests covering both cases:
  - File-based SQLite gets pool settings through `configure_orm`.
  - In-memory SQLite skips pool settings (tested via `prepare_engine_args` directly, since `configure_orm` rejects `sqlite:///:memory:` as a relative path before reaching pool logic).