### PR TITLE
fix: prevent log loading from scrolling ancestor elements in task Logs tab

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -39,14 +39,12 @@ const LogBlock = ({
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const codeBlockBottomDiv = useRef<HTMLDivElement>(null);
   const offsetTop = useOffsetTop(logBoxRef);
 
   const scrollToBottom = () => {
-    codeBlockBottomDiv.current?.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
-    });
+    if (logBoxRef.current) {
+      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+    }
   };
 
   useEffect(() => {
@@ -122,7 +120,6 @@ const LogBlock = ({
     >
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
-      <div ref={codeBlockBottomDiv} />
     </Code>
   );
 };

--- a/airflow/www/static/js/utils/useOffsetTop.ts
+++ b/airflow/www/static/js/utils/useOffsetTop.ts
@@ -21,7 +21,7 @@ import { debounce } from "lodash";
 import React, { useEffect, useState } from "react";
 
 // For an html element, keep it within view height by calculating the top offset and footer height
-const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
+const useOffsetTop = (contentRef: React.RefObject<HTMLElement | null>) => {
   const [top, setTop] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION
Closes: #64757

## Problem

When switching to the **Logs** tab on a task with many log lines, the entire details panel scrolls irreversibly instead of just the log box.

**Root cause:** `scrollToBottom()` called `scrollIntoView()` on a sentinel `<div>` at the bottom of log content. `scrollIntoView` walks up the DOM tree scrolling every ancestor element until the target is visible — so `div.c-5s5pdh` (the details panel) was being scrolled, not just the log box.

## Fix

**`LogBlock.tsx`**

```diff
- const codeBlockBottomDiv = useRef<HTMLDivElement>(null);

  const scrollToBottom = () => {
-   codeBlockBottomDiv.current?.scrollIntoView({
-     block: "nearest",
-     inline: "nearest",
-   });
+   if (logBoxRef.current) {
+     logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+   }
  };
```

```diff
  <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
- <div ref={codeBlockBottomDiv} />
```

`scrollTop = scrollHeight` sets the scroll position directly on the log box element only. Nothing outside it moves.

**`useOffsetTop.ts`**

```diff
- const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
+ const useOffsetTop = (contentRef: React.RefObject<HTMLElement | null>) => {
```

Updated parameter type to accept `null` inside the generic — required because `useRef<HTMLElement>(null)` now returns `RefObject<HTMLElement | null>` in newer React/TypeScript versions.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (claude-sonnet-4-6) following the [guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)