### PR TITLE
fix(ui): cancel debounce on clear to prevent stale search value

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -16,16 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
 
 import { SearchBar } from "./SearchBar";
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("Test SearchBar", () => {
   it("Renders and clear button works", async () => {
-    render(<SearchBar defaultValue="" onChange={vi.fn()} placeholder="Search Dags" />, {
+    const onChange = vi.fn();
+
+    render(<SearchBar defaultValue="" onChange={onChange} placeholder="Search Dags" />, {
       wrapper: Wrapper,
     });
 
@@ -44,5 +50,35 @@ describe("Test SearchBar", () => {
     fireEvent.click(clearButton);
 
     expect((input as HTMLInputElement).value).toBe("");
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("cancels pending debounced changes when clearing", () => {
+    vi.useFakeTimers();
+
+    const onChange = vi.fn();
+
+    render(<SearchBar defaultValue="" onChange={onChange} placeholder="Search Dags" />, {
+      wrapper: Wrapper,
+    });
+
+    const input = screen.getByTestId("search-dags");
+
+    fireEvent.change(input, { target: { value: "air" } });
+
+    expect((input as HTMLInputElement).value).toBe("air");
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("clear-search"));
+
+    expect((input as HTMLInputElement).value).toBe("");
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenNthCalledWith(1, "");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -50,6 +50,11 @@ export const SearchBar = ({
     setValue(event.target.value);
     handleSearchChange(event.target.value);
   };
+  const clearSearch = () => {
+    handleSearchChange.cancel();
+    setValue("");
+    onChange("");
+  };
 
   useHotkeys(
     "mod+k",
@@ -70,10 +75,7 @@ export const SearchBar = ({
               aria-label={translate("search.clear")}
               colorPalette="brand"
               data-testid="clear-search"
-              onClick={() => {
-                setValue("");
-                onChange("");
-              }}
+              onClick={clearSearch}
               size="xs"
             />
           ) : undefined}


### PR DESCRIPTION
Fixes #64892

## Problem
The SearchBar uses a debounced `onChange` handler. If a user types a query and immediately clears the input, the pending debounce callback is not cancelled.

As a result, the old query value is applied again after the debounce delay, causing the cleared input to revert to the previous value.

## Solution
Cancel the pending debounce when clearing the input before calling `onChange("")`.

## Tests
- Added regression test to ensure stale values are not applied after clearing
- Verified clearing emits empty value immediately