### PR TITLE
fix: prevent log loading from scrolling ancestor elements in task Logs tab

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -39,14 +39,12 @@ const LogBlock = ({
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const codeBlockBottomDiv = useRef<HTMLDivElement>(null);
   const offsetTop = useOffsetTop(logBoxRef);
 
   const scrollToBottom = () => {
-    codeBlockBottomDiv.current?.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
-    });
+    if (logBoxRef.current) {
+      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+    }
   };
 
   useEffect(() => {
@@ -122,7 +120,6 @@ const LogBlock = ({
     >
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
-      <div ref={codeBlockBottomDiv} />
     </Code>
   );
 };

--- a/airflow/www/static/js/utils/useOffsetTop.ts
+++ b/airflow/www/static/js/utils/useOffsetTop.ts
@@ -21,7 +21,7 @@ import { debounce } from "lodash";
 import React, { useEffect, useState } from "react";
 
 // For an html element, keep it within view height by calculating the top offset and footer height
-const useOffsetTop = (contentRef: React.RefObject<HTMLElement>) => {
+const useOffsetTop = (contentRef: React.RefObject<HTMLElement | null>) => {
   const [top, setTop] = useState(0);
 
   useEffect(() => {

--- a/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
+++ b/tests/providers/fab/auth_manager/cli_commands/test_user_command.py
@@ -389,9 +389,9 @@ class TestCliUsers:
             user_command.users_manage_role(args, remove=False)
         assert 'User "test4" added to role "Op"' in stdout.getvalue()
 
-        assert _does_user_belong_to_role(appbuilder=self.appbuilder, email=TEST_USER1_EMAIL, rolename="Op"), (
-            "User should have been added to role 'Op'"
-        )
+        assert _does_user_belong_to_role(
+            appbuilder=self.appbuilder, email=TEST_USER1_EMAIL, rolename="Op"
+        ), "User should have been added to role 'Op'"
 
     def test_cli_remove_user_role(self, create_user_test4):
         assert _does_user_belong_to_role(


### PR DESCRIPTION
Closes: #64757

## Problem

When switching to the **Logs** tab on a task instance with many log lines, `scrollIntoView()` was called on a sentinel `<div>` at the bottom of the log content. This API walks up the DOM tree and scrolls every scrollable ancestor until the target is visible — causing the details panel (and page) to scroll irreversibly, not just the log box itself.

## Fix

Replace `scrollIntoView()` with a direct `scrollTop = scrollHeight` assignment on the log box element (`logBoxRef`). This only scrolls the log box itself, leaving all ancestor elements untouched.

Also updated `useOffsetTop` to accept `RefObject<HTMLElement | null>` to align with the stricter ref types in newer React/TypeScript versions.

## Changes

- `airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx` — replaced `scrollIntoView` with direct `scrollTop` scroll; removed unused sentinel `<div>`
- `airflow/www/static/js/utils/useOffsetTop.ts` — updated parameter type to `RefObject<HTMLElement | null>`

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (claude-sonnet-4-6) following the [guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)