### PR TITLE
feat: Add dagrun partition info to OpenLineage events

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -744,6 +744,8 @@ class DagRunInfo(InfoJsonEncodable):
         "execution_date",  # Airflow 2
         "external_trigger",  # Removed in Airflow 3, use run_type instead
         "logical_date",  # Airflow 3
+        "partition_key",  # Airflow 3.2+
+        "partition_date",  # Airflow 3.2+
         "run_after",  # Airflow 3
         "run_id",
         "run_type",

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -190,6 +190,8 @@ def test_get_airflow_dag_run_facet():
     dagrun_mock.triggering_user_name = "user1"
     dagrun_mock.triggered_by = "something"
     dagrun_mock.note = "note"
+    dagrun_mock.partition_key = "some_partition_key"
+    dagrun_mock.partition_date = datetime.datetime(2024, 6, 1, 2, 3, 34, tzinfo=datetime.timezone.utc)
     dagrun_mock.dag_versions = [
         MagicMock(
             bundle_name="bundle_name",
@@ -242,6 +244,8 @@ def test_get_airflow_dag_run_facet():
                 "dag_version_id": "version_id",
                 "dag_version_number": "version_number",
                 "triggering_user_name": "user1",
+                "partition_key": "some_partition_key",
+                "partition_date": "2024-06-01T02:03:34+00:00",
                 "triggered_by": "something",
                 "note": note,
             },
@@ -2893,6 +2897,8 @@ def test_dagrun_info_af3(mocked_dag_versions):
     optional_args = {}
     if AIRFLOW_V_3_2_PLUS:
         optional_args["note"] = "note"
+        optional_args["partition_key"] = "some_partition_key"
+        optional_args["partition_date"] = date
 
     mocked_dag_versions.return_value = [dv1, dv2]
     dagrun = DagRun(
@@ -2916,6 +2922,11 @@ def test_dagrun_info_af3(mocked_dag_versions):
     dagrun.end_date = date + datetime.timedelta(seconds=74, microseconds=546)
     dagrun.triggering_user_name = "my_user"
 
+    optional_result = {}
+    if AIRFLOW_V_3_2_PLUS:
+        optional_result["partition_key"] = "some_partition_key"
+        optional_result["partition_date"] = "2024-06-01T00:00:00+00:00"
+
     result = DagRunInfo(dagrun)
     assert dict(result) == {
         "conf": {"a": 1},
@@ -2938,6 +2949,7 @@ def test_dagrun_info_af3(mocked_dag_versions):
         "triggered_by": DagRunTriggeredByType.UI,
         "triggering_user_name": "my_user",
         "note": optional_args.get("note"),
+        **optional_result,
     }
 
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Adding information about partition_key and partition_date to DagRun models in OL events.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
