### PR TITLE
Fix CARGO_HOME location for airflow user builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1874,7 +1874,7 @@ ENV DEV_APT_DEPS=${DEV_APT_DEPS} \
 ARG PYTHON_LTO
 
 ENV RUSTUP_HOME="/usr/local/rustup"
-ENV CARGO_HOME="/usr/local/cargo"
+ENV CARGO_HOME="/home/airflow/.cargo"
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
 
 COPY --from=scripts install_os_dependencies.sh /scripts/docker/


### PR DESCRIPTION
Move CARGO_HOME from `/usr/local/cargo` to `/home/airflow/.cargo` so that
cargo builds work correctly when running as the airflow user, avoiding
permission issues with the system-wide cargo directory.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)