### PR TITLE
Skip newsfragment check on label events to avoid approval requirement

### DIFF
--- a/.github/workflows/check-newsfragment-pr-number.yml
+++ b/.github/workflows/check-newsfragment-pr-number.yml
@@ -21,7 +21,7 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches:
       - main
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove `labeled` and `unlabeled` event types from the newsfragment PR number
check workflow trigger. When boring-cyborg bot adds labels to PRs, it triggers
this workflow which then requires manual approval to run — adding unnecessary
noise. Since the newsfragment check only needs to run on actual code changes
(opened, reopened, synchronize), removing label events avoids these unnecessary
workflow runs.

The `skip newsfragment check` label still works as before — it's evaluated
at job level via the existing `if` condition, which runs on the remaining
event types.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)