### PR TITLE
Add stairway test for DB migrations

### DIFF
--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Stairway test for Airflow DB migrations.
+
+Walks every individual migration step forward (upgrade) then backward (downgrade)
+to verify that all migrations are fully reversible.  This catches problems like:
+- a migration that creates a constraint the downgrade forgets to drop
+- a downgrade that references a column that was never added by the upgrade
+
+The test starts from the squashed baseline (revision 4bc4d934e2bc, the 2.6.2
+snapshot) and iterates through each revision in topological order.
+"""
+
+from __future__ import annotations
+
+import pytest
+from alembic import command
+from alembic.script import ScriptDirectory
+
+from airflow.utils.db import _get_alembic_config
+
+pytestmark = pytest.mark.db_test
+
+# The squashed "start-of-history" revision – stairway starts here.
+_SQUASHED_BASE_REVISION = "4bc4d934e2bc"
+
+
+def _get_revisions_in_order() -> list[str]:
+    """Return revision IDs in upgrade order, starting after the squashed base."""
+    config = _get_alembic_config()
+    script = ScriptDirectory.from_config(config)
+
+    # walk_revisions() yields from head → base; reverse for upgrade order
+    all_revisions = list(script.walk_revisions())
+    all_revisions.reverse()
+
+    revision_ids = [rev.revision for rev in all_revisions]
+
+    # Find the squashed base and return everything *after* it (the incremental steps)
+    try:
+        base_index = revision_ids.index(_SQUASHED_BASE_REVISION)
+    except ValueError:
+        return revision_ids  # squashed revision not present, return all
+
+    return revision_ids[base_index + 1 :]
+
+
+# Force these tests to run sequentially on the same worker to prevent DB state 
+# conflicts during parallel testing (e.g., when using pytest-xdist).
+@pytest.mark.xdist_group(name="migration_stairway")
+@pytest.mark.parametrize(
+    "revision_id",
+    [pytest.param(rev, id=rev) for rev in _get_revisions_in_order()],
+)
+def test_migration_stairway(revision_id: str) -> None:
+    """
+    For each migration step verify that upgrade followed by downgrade works.
+
+    The test applies the migration under test (upgrade to *revision_id*), then
+    immediately rolls it back (downgrade to the previous revision), and finally
+    re-applies it so that subsequent parametrized steps start from the correct
+    state.
+    """
+    config = _get_alembic_config()
+    script = ScriptDirectory.from_config(config)
+
+    revision_obj = script.get_revision(revision_id)
+    if revision_obj is None:
+        pytest.skip(f"Revision {revision_id!r} not found in migration scripts")
+
+    prev_revision = revision_obj.down_revision
+    if isinstance(prev_revision, tuple):
+        # Merge point – pick the first parent.
+        prev_revision = prev_revision[0]
+
+    # Step 1: upgrade to this revision
+    command.upgrade(config, revision=revision_id)
+
+    # Determine the target revision for downgrade
+    target = prev_revision if prev_revision else "base"
+    
+    try:
+        # Step 2: downgrade back to the previous revision
+        command.downgrade(config, revision=target)
+    finally:
+        # Step 3: re-apply so subsequent steps see a consistent DB state.
+        command.upgrade(config, revision=revision_id)

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -68,7 +68,7 @@ def _get_revisions_in_order() -> list[str]:
         )
 
     base_index = revision_ids.index(_STAIRWAY_START_REVISION)
-    return revision_ids[base_index + 1:]
+    return revision_ids[base_index + 1 :]
 
 
 @pytest.fixture(scope="module")

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -22,8 +22,9 @@ to verify that all migrations are fully reversible.  This catches problems like:
 - a migration that creates a constraint the downgrade forgets to drop
 - a downgrade that references a column that was never added by the upgrade
 
-The test starts from the squashed baseline (revision 4bc4d934e2bc, the 2.6.2
-snapshot) and iterates through each revision in topological order.
+The test starts from the squashed baseline (the 2.6.2 snapshot, looked up via
+``_REVISION_HEADS_MAP["2.6.2"]``) and iterates through each subsequent revision
+in topological order.
 """
 
 from __future__ import annotations
@@ -32,12 +33,12 @@ import pytest
 from alembic import command
 from alembic.script import ScriptDirectory
 
-from airflow.utils.db import _get_alembic_config
+from airflow.utils.db import _REVISION_HEADS_MAP, _get_alembic_config, upgradedb
 
 pytestmark = pytest.mark.db_test
 
 # The squashed "start-of-history" revision – stairway starts here.
-_SQUASHED_BASE_REVISION = "4bc4d934e2bc"
+_SQUASHED_BASE_REVISION = _REVISION_HEADS_MAP["2.6.2"]
 
 
 def _get_revisions_in_order() -> list[str]:
@@ -51,52 +52,52 @@ def _get_revisions_in_order() -> list[str]:
 
     revision_ids = [rev.revision for rev in all_revisions]
 
-    # Find the squashed base and return everything *after* it (the incremental steps)
     try:
         base_index = revision_ids.index(_SQUASHED_BASE_REVISION)
     except ValueError:
         return revision_ids  # squashed revision not present, return all
 
-    return revision_ids[base_index + 1 :]
+    return revision_ids[base_index + 1:]
 
 
-# Force these tests to run sequentially on the same worker to prevent DB state 
-# conflicts during parallel testing (e.g., when using pytest-xdist).
-@pytest.mark.xdist_group(name="migration_stairway")
-@pytest.mark.parametrize(
-    "revision_id",
-    [pytest.param(rev, id=rev) for rev in _get_revisions_in_order()],
-)
-def test_migration_stairway(revision_id: str) -> None:
+@pytest.fixture(scope="module")
+def stairway_db():
     """
-    For each migration step verify that upgrade followed by downgrade works.
-
-    The test applies the migration under test (upgrade to *revision_id*), then
-    immediately rolls it back (downgrade to the previous revision), and finally
-    re-applies it so that subsequent parametrized steps start from the correct
-    state.
+    Bring the DB to the squashed baseline before the stairway test runs, and
+    restore it to the current heads afterwards so other tests are unaffected.
     """
     config = _get_alembic_config()
-    script = ScriptDirectory.from_config(config)
 
-    revision_obj = script.get_revision(revision_id)
-    if revision_obj is None:
-        pytest.skip(f"Revision {revision_id!r} not found in migration scripts")
+    # Downgrade to the squashed base so the stairway starts from a known state.
+    command.downgrade(config, revision=_SQUASHED_BASE_REVISION)
 
-    prev_revision = revision_obj.down_revision
-    if isinstance(prev_revision, tuple):
-        # Merge point – pick the first parent.
-        prev_revision = prev_revision[0]
+    yield
 
-    # Step 1: upgrade to this revision
-    command.upgrade(config, revision=revision_id)
+    # Always restore to the latest heads, even if the test failed mid-way.
+    upgradedb()
 
-    # Determine the target revision for downgrade
-    target = prev_revision if prev_revision else "base"
-    
-    try:
-        # Step 2: downgrade back to the previous revision
-        command.downgrade(config, revision=target)
-    finally:
-        # Step 3: re-apply so subsequent steps see a consistent DB state.
+
+def test_migration_stairway(stairway_db) -> None:
+    """
+    Walk every incremental migration step: upgrade → downgrade → re-upgrade.
+
+    Runs as a single test (not parametrized) so execution order and DB state
+    are guaranteed without relying on xdist grouping or cross-test ordering.
+    Each step uses Alembic's relative ``-1`` target for downgrade so that merge
+    revisions are handled correctly — it always rolls back exactly one step from
+    the current head regardless of how many parents a merge revision has.
+    """
+    config = _get_alembic_config()
+    revisions = _get_revisions_in_order()
+
+    for revision_id in revisions:
+        # Step 1: upgrade to this revision
+        command.upgrade(config, revision=revision_id)
+
+        # Step 2: downgrade exactly one step back.
+        # Using the relative specifier "-1" from the current head is correct for
+        # both normal and merge revisions — it never picks an arbitrary parent.
+        command.downgrade(config, revision="-1")
+
+        # Step 3: re-apply so the next iteration starts from the right state.
         command.upgrade(config, revision=revision_id)

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -17,87 +17,102 @@
 """
 Stairway test for Airflow DB migrations.
 
-Walks every individual migration step forward (upgrade) then backward (downgrade)
-to verify that all migrations are fully reversible.  This catches problems like:
+Walks every migration step since the 3.0.0 release forward (upgrade) then
+backward (downgrade) to verify that all migrations are fully reversible.
+This catches problems like:
 - a migration that creates a constraint the downgrade forgets to drop
 - a downgrade that references a column that was never added by the upgrade
 
-The test starts from the squashed baseline (the 2.6.2 snapshot, looked up via
-``_REVISION_HEADS_MAP["2.6.2"]``) and iterates through each subsequent revision
-in topological order.
+The test runs as a single (non-parametrized) function so that execution order
+and DB state are guaranteed without relying on xdist grouping or cross-test
+state.  Failures include the specific revision ID so the broken migration is
+immediately identifiable in CI logs.
 """
 
 from __future__ import annotations
 
 import pytest
-from alembic import command
 from alembic.script import ScriptDirectory
 
-from airflow.utils.db import _REVISION_HEADS_MAP, _get_alembic_config, upgradedb
+from airflow.utils.db import (
+    _REVISION_HEADS_MAP,
+    _get_alembic_config,
+    downgrade,
+    upgradedb,
+)
 
 pytestmark = pytest.mark.db_test
 
-# The squashed "start-of-history" revision – stairway starts here.
-_SQUASHED_BASE_REVISION = _REVISION_HEADS_MAP["2.6.2"]
+# Stairway starts from the 3.0.0 head revision.  Starting here (rather than
+# the 2.6.2 squashed baseline) avoids triggering FAB-provider downgrade
+# handling that airflow.utils.db.downgrade() applies when the target is below
+# 2.10.3, and keeps the number of steps manageable on slower backends.
+_STAIRWAY_START_REVISION = _REVISION_HEADS_MAP["3.0.0"]
 
 
 def _get_revisions_in_order() -> list[str]:
-    """Return revision IDs in upgrade order, starting after the squashed base."""
+    """Return revision IDs in upgrade order, starting after the stairway base."""
     config = _get_alembic_config()
     script = ScriptDirectory.from_config(config)
 
-    # walk_revisions() yields from head → base; reverse for upgrade order
+    # walk_revisions() yields from head → base; reverse for upgrade order.
     all_revisions = list(script.walk_revisions())
     all_revisions.reverse()
 
     revision_ids = [rev.revision for rev in all_revisions]
 
-    try:
-        base_index = revision_ids.index(_SQUASHED_BASE_REVISION)
-    except ValueError:
-        return revision_ids  # squashed revision not present, return all
+    if _STAIRWAY_START_REVISION not in revision_ids:
+        raise ValueError(
+            f"Stairway base revision {_STAIRWAY_START_REVISION!r} not found in migration scripts. "
+            "Update _STAIRWAY_START_REVISION to a valid revision from _REVISION_HEADS_MAP."
+        )
 
+    base_index = revision_ids.index(_STAIRWAY_START_REVISION)
     return revision_ids[base_index + 1:]
 
 
 @pytest.fixture(scope="module")
 def stairway_db():
     """
-    Bring the DB to the squashed baseline before the stairway test runs, and
+    Bring the DB to the stairway base revision before the test runs, and
     restore it to the current heads afterwards so other tests are unaffected.
-    """
-    config = _get_alembic_config()
 
-    # Downgrade to the squashed base so the stairway starts from a known state.
-    command.downgrade(config, revision=_SQUASHED_BASE_REVISION)
+    Uses Airflow's downgrade()/upgradedb() wrappers so that backend-specific
+    handling (MySQL metadata-lock, global migration lock, single-connection
+    pool) is applied consistently.
+    """
+    downgrade(to_revision=_STAIRWAY_START_REVISION)
 
     yield
 
-    # Always restore to the latest heads, even if the test failed mid-way.
+    # Restore to latest heads even if the test failed mid-way.
     upgradedb()
 
 
 def test_migration_stairway(stairway_db) -> None:
     """
-    Walk every incremental migration step: upgrade → downgrade → re-upgrade.
+    Walk every incremental migration step since 3.0.0: upgrade → downgrade → re-upgrade.
 
-    Runs as a single test (not parametrized) so execution order and DB state
-    are guaranteed without relying on xdist grouping or cross-test ordering.
-    Each step uses Alembic's relative ``-1`` target for downgrade so that merge
-    revisions are handled correctly — it always rolls back exactly one step from
-    the current head regardless of how many parents a merge revision has.
+    Uses Airflow's upgradedb()/downgrade() wrappers for every step so that
+    the global migration lock, MySQL metadata-lock handling, and
+    single-connection pool are active — matching real-world upgrade/downgrade
+    behaviour and preventing backend-specific hangs.
+
+    The relative ``-1`` specifier is used for downgrade so that merge revisions
+    are handled correctly: it always rolls back exactly one step from the
+    current head regardless of how many parents a merge revision has.
     """
-    config = _get_alembic_config()
     revisions = _get_revisions_in_order()
 
     for revision_id in revisions:
-        # Step 1: upgrade to this revision
-        command.upgrade(config, revision=revision_id)
+        try:
+            # Step 1: upgrade to this revision.
+            upgradedb(to_revision=revision_id)
 
-        # Step 2: downgrade exactly one step back.
-        # Using the relative specifier "-1" from the current head is correct for
-        # both normal and merge revisions — it never picks an arbitrary parent.
-        command.downgrade(config, revision="-1")
+            # Step 2: downgrade exactly one step back.
+            downgrade(to_revision="-1")
 
-        # Step 3: re-apply so the next iteration starts from the right state.
-        command.upgrade(config, revision=revision_id)
+            # Step 3: re-apply so the next iteration starts from the right state.
+            upgradedb(to_revision=revision_id)
+        except Exception as e:
+            pytest.fail(f"Stairway test failed at revision {revision_id!r}: {e}")

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -115,4 +115,4 @@ def test_migration_stairway(stairway_db) -> None:
             # Step 3: re-apply so the next iteration starts from the right state.
             upgradedb(to_revision=revision_id)
         except Exception as e:
-            pytest.fail(f"Stairway test failed at revision {revision_id!r}: {e}")
+            raise AssertionError(f"Stairway test failed at revision {revision_id!r}") from e


### PR DESCRIPTION

Adds a test that walks every incremental Alembic migration one step at a time  **upgrade → downgrade → re-upgrade**  to verify all migrations are fully reversible.

## Why:
Silent breakage can occur when a downgrade forgets to drop a constraint/column added by its upgrade, or references something that doesn't exist. The existing `test_database_schema_and_sqlalchemy_model_are_in_sync` only checks the final state; it won't catch a broken intermediate step.

## How to test:
```bash
uv run --project airflow-core pytest airflow-core/tests/unit/migrations/test_migration_utils.py -xvs
```
When a step fails, the error message includes the specific revision ID so the broken migration is immediately identifiable in CI logs.

**Was generative AI tooling used to co-author this PR?**
- [x] Yes (please specify the tool below) Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)