### PR TITLE
Fix release check tooling for providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -4413,7 +4413,10 @@ def check_release_files(
         missing_files = check_providers(files, release_date, packages)
         pips = [f"{name}=={ver}" for name, ver in packages]
         create_docker(
-            PROVIDERS_DOCKER.format("RUN uv pip install --pre --system " + " ".join(f"'{p}'" for p in pips)),
+            PROVIDERS_DOCKER.format(
+                f"RUN uv pip install --pre --exclude-newer {datetime.now().isoformat()} --system "
+                + " ".join(f"'{p}'" for p in pips)
+            ),
             dockerfile_path,
             release_type,
         )

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -4413,10 +4413,7 @@ def check_release_files(
         missing_files = check_providers(files, release_date, packages)
         pips = [f"{name}=={ver}" for name, ver in packages]
         create_docker(
-            PROVIDERS_DOCKER.format(
-                f"RUN uv pip install --pre --exclude-newer {datetime.now().isoformat()} --system "
-                + " ".join(f"'{p}'" for p in pips)
-            ),
+            PROVIDERS_DOCKER.format("RUN uv pip install --pre --system " + " ".join(f"'{p}'" for p in pips)),
             dockerfile_path,
             release_type,
         )

--- a/dev/breeze/src/airflow_breeze/utils/check_release_files.py
+++ b/dev/breeze/src/airflow_breeze/utils/check_release_files.py
@@ -26,7 +26,8 @@ PROVIDERS_DOCKER = """\
 FROM ghcr.io/apache/airflow/main/ci/python3.10
 RUN cd airflow-core; uv sync --no-sources
 
-# Install providers
+# Install providers with providers pre-releases allowed
+COPY pyproject.toml .
 {}
 """
 

--- a/task-sdk/src/airflow/sdk/_shared/AGENTS.md
+++ b/task-sdk/src/airflow/sdk/_shared/AGENTS.md
@@ -1,1 +1,1 @@
-../../../../../airflow-core/src/airflow/_shared/AGENTS..md
+../../../../../airflow-core/src/airflow/_shared/AGENTS.md


### PR DESCRIPTION
Fix for challenges in PMC release checks for providers:
- RAT tool failed on broken symlink (`..md` --> `.md`)
- Docker build failed to install new packages due to cooldown period

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
