### PR TITLE
Hide legacy sql connection

### DIFF
--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -258,6 +258,7 @@ class AirflowConfigParser(ConfigParser):
         ("api", "fallback_page_limit"): ("api", "page_size", "3.2.0"),
         ("workers", "missing_dag_retries"): ("workers", "missing_dag_retires", "3.1.8"),
         ("core", "execution_api_server_url"): ("workers", "execution_api_server_url", "3.0"),
+        ("database", "sql_alchemy_conn"): ("core", "sql_alchemy_conn", "3.0"),
     }
 
     # A mapping of new section -> (old section, since_version).


### PR DESCRIPTION
I noticed while testing 3.2.0 with helm chart <=1.19.0 that the auto-templates env AIRFLOW__CORE__SQL_ALCHEMY_CONN is not masked. This is not happening in Chart 1.20++ but if you have not upgraded and Airflow 3.0.0 is used with `expose_config: non-sensitive-only` (or True) then the db credentials from the legacy key are not masked/visible.

This PR adds it to the list of sensitive values.. with the trade-off that implicitly the legacy options gets supported. If wanted I can alternatively implement a more complex option as well which adds another masking list for non-supported legacy values.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
