### PR TITLE
Speed up cleanup_python_generated_files by skipping node_modules and hidden dirs

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -418,22 +418,26 @@ def cleanup_python_generated_files():
     if get_verbose():
         console_print("[info]Cleaning .pyc and __pycache__")
     permission_errors = []
-    for path in AIRFLOW_ROOT_PATH.rglob("*.pyc"):
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            # File has been removed in the meantime.
-            pass
-        except PermissionError:
-            permission_errors.append(path)
-    for path in AIRFLOW_ROOT_PATH.rglob("__pycache__"):
-        try:
-            shutil.rmtree(path)
-        except FileNotFoundError:
-            # File has been removed in the meantime.
-            pass
-        except PermissionError:
-            permission_errors.append(path)
+    for dirpath, dirnames, filenames in os.walk(AIRFLOW_ROOT_PATH):
+        # Skip node_modules and hidden directories (.*) — modify in place to prune os.walk
+        dirnames[:] = [d for d in dirnames if d != "node_modules" and not d.startswith(".")]
+        for filename in filenames:
+            if filename.endswith(".pyc"):
+                path = Path(dirpath) / filename
+                try:
+                    path.unlink()
+                except FileNotFoundError:
+                    pass
+                except PermissionError:
+                    permission_errors.append(path)
+        if Path(dirpath).name == "__pycache__":
+            try:
+                shutil.rmtree(dirpath)
+            except FileNotFoundError:
+                pass
+            except PermissionError:
+                permission_errors.append(Path(dirpath))
+            dirnames.clear()
     if permission_errors:
         if platform.uname().system.lower() == "linux":
             console_print("[warning]There were files that you could not clean-up:\n")


### PR DESCRIPTION
Replace two `rglob` calls with a single `os.walk` that prunes `node_modules` and hidden directories (e.g. `.git`, `.venv`) in-place, avoiding unnecessary traversal of large directory trees that never contain relevant `.pyc` files or `__pycache__` directories.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Opus 4.6)

Generated-by: Claude Code (Claude Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)