### PR TITLE
Fix RESOURCE_ASSET compatibility with Airflow 2.x in common-compat

### DIFF
--- a/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
@@ -26,4 +26,4 @@ RESOURCE_ASSET_ALIAS = "Asset Aliases"
 if AIRFLOW_V_3_0_PLUS:
     RESOURCE_ASSET = "Assets"
 else:
-    from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET  # noqa: F401
+    from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET  # noqa: F401  # type: ignore[attr-defined, no-redef]

--- a/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
@@ -22,10 +22,9 @@ from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 RESOURCE_BACKFILL = "Backfills"
 RESOURCE_DAG_VERSION = "DAG Versions"
 RESOURCE_ASSET_ALIAS = "Asset Aliases"
-
 if AIRFLOW_V_3_0_PLUS:
     RESOURCE_ASSET = "Assets"
 else:
-    from airflow.security.permissions import (
-        RESOURCE_DATASET as RESOURCE_ASSET,  # noqa: F401  # type: ignore[attr-defined, no-redef]
+    from airflow.security.permissions import (  # type: ignore[attr-defined, no-redef]
+        RESOURCE_DATASET as RESOURCE_ASSET,  # noqa: F401
     )

--- a/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
@@ -16,8 +16,14 @@
 # under the License.
 from __future__ import annotations
 
+from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
+
 # Resource Constants
 RESOURCE_BACKFILL = "Backfills"
 RESOURCE_DAG_VERSION = "DAG Versions"
-RESOURCE_ASSET = "Assets"
 RESOURCE_ASSET_ALIAS = "Asset Aliases"
+
+if AIRFLOW_V_3_0_PLUS:
+    RESOURCE_ASSET = "Assets"
+else:
+    from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET  # noqa: F401

--- a/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/security/permissions.py
@@ -26,4 +26,6 @@ RESOURCE_ASSET_ALIAS = "Asset Aliases"
 if AIRFLOW_V_3_0_PLUS:
     RESOURCE_ASSET = "Assets"
 else:
-    from airflow.security.permissions import RESOURCE_DATASET as RESOURCE_ASSET  # noqa: F401  # type: ignore[attr-defined, no-redef]
+    from airflow.security.permissions import (
+        RESOURCE_DATASET as RESOURCE_ASSET,  # noqa: F401  # type: ignore[attr-defined, no-redef]
+    )


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #63335, which hardcoded `RESOURCE_ASSET = "Assets"`
in `providers/common/compat/security/permissions.py`. This value is correct for
Airflow 3, but breaks Airflow 2.x in two ways:

1. **Wrong resource name in Airflow 2.x.** `apache-airflow-providers-fab` imports
   `RESOURCE_ASSET` from this module at runtime. FAB's role sync updates stock roles
   to grant the `"Assets"` resource, but the correct Airflow 2.x name is `"Datasets"`.
   This creates an inconsistency and pollutes the permission model with a resource that
   doesn't belong in Airflow 2.x.

2. **Custom roles break.** Any role with `"Datasets"` permissions stops working, since
   auth checks now look for `"Assets"`. While you could re-grant permissions against
   `"Assets"` after upgrading, existing roles are silently broken.

## Fix

Gate on `AIRFLOW_V_3_0_PLUS`: return `"Assets"` for Airflow 3, and fall back to
`RESOURCE_DATASET` from `airflow.security.permissions` (not deprecated in Airflow 2.x)
for Airflow 2.x.

## Related

- Reverts the behavioral change from: #63335

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code