### PR TITLE
Fix broken RST link in New PMC Member Onboarding steps

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -283,7 +283,7 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
 New PMC Member Onboarding steps
 -------------------------------
 
-1.  Familiarise yourself with `<PMC Responsibilities>https://community.apache.org/pmc/responsibilities.html`_
+1.  Familiarise yourself with `PMC Responsibilities <https://community.apache.org/pmc/responsibilities.html>`_
 2.  Subscribe to the private mailing list: ``private@airflow.apache.org``. Do this by sending an empty email to
     ``private-subscribe@airflow.apache.org`` and following the instructions in the automated response you'll receive.
 3.  Ask another PMC member to add you to ``#pmc-private`` channel on slack


### PR DESCRIPTION
Fix malformed RST hyperlink syntax in the New PMC Member Onboarding section of `COMMITTERS.rst`.

The link was written as:
```
`<PMC Responsibilities>https://community.apache.org/pmc/responsibilities.html`_
```

Which is invalid RST — the display text and URL were swapped. Corrected to:
```
`PMC Responsibilities <https://community.apache.org/pmc/responsibilities.html>`_
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)