### PR TITLE
Fix Contributors' Guide link format in boring-cyborg welcome comment

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -578,7 +578,7 @@ labelerFlags:
 firstPRWelcomeComment: >
   Congratulations on your first Pull Request and welcome to the Apache Airflow community!
   If you have any issues or are unsure about any anything please check our
-  Contributors' Guide (https://github.com/apache/airflow/blob/main/contributing-docs/README.rst)
+  [Contributors' Guide](https://github.com/apache/airflow/blob/main/contributing-docs/README.rst)
 
   Here are some useful points:
 


### PR DESCRIPTION
The Contributors' Guide link in the boring-cyborg first-PR welcome comment was formatted as plain text with the URL in parentheses:

```
Contributors' Guide (https://github.com/apache/airflow/blob/main/contributing-docs/README.rst)
```

Changed to a proper markdown hyperlink:

```
[Contributors' Guide](https://github.com/apache/airflow/blob/main/contributing-docs/README.rst)
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)