### PR TITLE
Fix TriggerDagRunOperator 404 in dag.test()

### DIFF
--- a/airflow-core/tests/unit/dags/test_dag_test_trigger_dagrun_operator.py
+++ b/airflow-core/tests/unit/dags/test_dag_test_trigger_dagrun_operator.py
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.models.dag import DAG
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
+
+DEFAULT_DATE = datetime(2024, 1, 1)
+
+with DAG(
+    dag_id="test_dag_test_trigger_parent",
+    schedule=None,
+    start_date=DEFAULT_DATE,
+    is_paused_upon_creation=False,
+) as parent_dag:
+    TriggerDagRunOperator(
+        task_id="trigger_target_dag",
+        trigger_dag_id="test_dag_test_trigger_target",
+    )
+
+with DAG(
+    dag_id="test_dag_test_trigger_target",
+    schedule=None,
+    start_date=DEFAULT_DATE,
+    is_paused_upon_creation=False,
+) as target_dag:
+    EmptyOperator(task_id="target_task")

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1533,6 +1533,83 @@ class TestDag:
         dag.test()
         mock_object.assert_called_with("output of first task")
 
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_dag_test_with_trigger_dagrun_operator(self, test_dags_bundle, session):
+        dag_id = "test_dag_test_trigger_parent"
+        target_dag_id = "test_dag_test_trigger_target"
+
+        dagbag = DagBag(dag_folder=os.fspath(TEST_DAGS_FOLDER), include_examples=False)
+        dag = dagbag.dags.get(dag_id)
+        assert dag is not None
+
+        dr = dag.test()
+
+        assert dr.state == DagRunState.SUCCESS
+        assert session.scalar(select(DagRun).where(DagRun.dag_id == target_dag_id)) is not None
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_dag_test_with_trigger_dagrun_operator_multi_bundle(
+        self, tmp_path, configure_dag_bundles, session
+    ):
+        # Setup bundle 1 (Parent)
+        dir1 = tmp_path / "bundle1"
+        dir1.mkdir()
+        parent_file = dir1 / "parent.py"
+        parent_file.write_text("""
+from airflow.sdk import DAG
+from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
+from datetime import datetime
+
+with DAG(dag_id="parent_dag_multi", schedule=None, start_date=datetime(2024, 1, 1)):
+    TriggerDagRunOperator(task_id="trigger", trigger_dag_id="target_dag_multi")
+""")
+
+        # Setup bundle 2 (Target)
+        dir2 = tmp_path / "bundle2"
+        dir2.mkdir()
+        target_file = dir2 / "target.py"
+        target_file.write_text("""
+from airflow.sdk import DAG
+from airflow.providers.standard.operators.empty import EmptyOperator
+from datetime import datetime
+
+with DAG(dag_id="target_dag_multi", schedule=None, start_date=datetime(2024, 1, 1)):
+    EmptyOperator(task_id="target_task")
+""")
+
+        # Bundle names are sorted alphabetically. parent_bundle comes before target_bundle.
+        with configure_dag_bundles(
+            {
+                "aaa_parent_bundle": dir1,
+                "bbb_target_bundle": dir2,
+            }
+        ):
+            from airflow.models.dag_version import DagVersion
+
+            # Pre-check: No versions in DB
+            assert DagVersion.get_version("parent_dag_multi") is None
+            assert DagVersion.get_version("target_dag_multi") is None
+
+            # Load parent DAG from file manually to call test() on it
+            dagbag = DagBag(dag_folder=os.fspath(parent_file), include_examples=False)
+            parent_dag = dagbag.get_dag("parent_dag_multi")
+            assert parent_dag is not None
+
+            # This works because we now sync ALL bundles even if parent is found early.
+            dr = parent_dag.test()
+            assert dr.state == DagRunState.SUCCESS
+
+            # Verify target dag run was created
+            target_dr = session.scalar(select(DagRun).where(DagRun.dag_id == "target_dag_multi").limit(1))
+            assert target_dr is not None
+
+            # Cleanup dynamically created rows to avoid leaking state to other tests
+            session.execute(delete(DagRun).where(DagRun.dag_id.in_(["parent_dag_multi", "target_dag_multi"])))
+            session.execute(
+                delete(DagModel).where(DagModel.dag_id.in_(["parent_dag_multi", "target_dag_multi"]))
+            )
+            session.commit()
+
     def test_dag_test_with_fail_handler(self, testing_dag_bundle):
         mock_handle_object_1 = mock.MagicMock()
         mock_handle_object_2 = mock.MagicMock()

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1289,34 +1289,39 @@ class DAG:
             else:
                 timetable = coerce_to_core_timetable(self.timetable)
                 data_interval = timetable.infer_manual_data_interval(run_after=logical_date)
-            from airflow.models.dag_version import DagVersion
+            from airflow.dag_processing.bundles.manager import DagBundlesManager
+            from airflow.dag_processing.dagbag import BundleDagBag, sync_bag_to_db
+            from airflow.models.dag import DagModel
 
-            version = DagVersion.get_version(self.dag_id)
-            if not version:
-                from airflow.dag_processing.bundles.manager import DagBundlesManager
-                from airflow.dag_processing.dagbag import BundleDagBag, sync_bag_to_db
-                from airflow.sdk.definitions._internal.dag_parsing_context import (
-                    _airflow_parsing_context_manager,
+            manager = DagBundlesManager()
+            manager.sync_bundles_to_db(session=session)
+            session.commit()
+
+            # Find the bundle name for this DAG from the DB
+            bundle_name = session.query(DagModel.bundle_name).filter(DagModel.dag_id == self.dag_id).scalar()
+
+            bundles_to_sync = []
+            if bundle_name:
+                bundle = manager.get_bundle(bundle_name)
+                if bundle:
+                    bundles_to_sync = [bundle]
+
+            if not bundles_to_sync:
+                # Fallback to all bundles if not found or bundle gone
+                bundles_to_sync = list(manager.get_all_dag_bundles())
+
+            for bundle in bundles_to_sync:
+                if not bundle.is_initialized:
+                    bundle.initialize()
+
+                # We don't use _airflow_parsing_context_manager here because we want to sync
+                # all DAGs in the bundle (especially triggered ones)
+                dagbag = BundleDagBag(
+                    dag_folder=bundle.path,
+                    bundle_path=bundle.path,
+                    bundle_name=bundle.name,
                 )
-
-                manager = DagBundlesManager()
-                manager.sync_bundles_to_db(session=session)
-                session.commit()
-                # sync all bundles? or use the dags-folder bundle?
-                # What if the test dag is in a different bundle?
-                for bundle in manager.get_all_dag_bundles():
-                    if not bundle.is_initialized:
-                        bundle.initialize()
-                    with _airflow_parsing_context_manager(dag_id=self.dag_id):
-                        dagbag = BundleDagBag(
-                            dag_folder=bundle.path,
-                            bundle_path=bundle.path,
-                            bundle_name=bundle.name,
-                        )
-                        sync_bag_to_db(dagbag, bundle.name, bundle.version)
-                    version = DagVersion.get_version(self.dag_id)
-                    if version:
-                        break
+                sync_bag_to_db(dagbag, bundle.name, bundle.version)
 
             # Preserve callback functions from original Dag since they're lost during serialization
             # and yes it is a hack for now! It is a tradeoff for code simplicity.

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1270,7 +1270,7 @@ def run(
     signal.signal(signal.SIGTERM, _on_term)
 
     msg: ToSupervisor | None = None
-    state: TaskInstanceState
+    state: TaskInstanceState = TaskInstanceState.FAILED
     error: BaseException | None = None
 
     stats_tags = {"dag_id": ti.dag_id, "task_id": ti.task_id}

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner_uninitialized_state.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner_uninitialized_state.py
@@ -1,0 +1,81 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airflow.sdk.api.datamodels._generated import TaskInstanceState
+from airflow.sdk.exceptions import DagRunTriggerException
+from airflow.sdk.execution_time.task_runner import run
+
+
+def test_run_uninitialized_state_on_handle_trigger_dag_run_failure():
+    """
+    Test that if _handle_trigger_dag_run raises an exception (e.g. COMMS failure),
+    the finally block does not crash with UnboundLocalError for 'state'.
+    """
+    ti = MagicMock()
+    ti.dag_id = "test_dag"
+    ti.task_id = "test_task"
+    ti.run_id = "test_run"
+    ti.map_index = -1
+    ti._ti_context_from_server = None
+    ti.rendered_map_index = None
+
+    context = MagicMock()
+    log = MagicMock()
+
+    # Mock _execute_task to raise DagRunTriggerException
+    # Mock _handle_trigger_dag_run to raise an exception itself
+    exception = DagRunTriggerException(
+        trigger_dag_id="target",
+        dag_run_id="run",
+        logical_date=None,
+        conf=None,
+        reset_dag_run=False,
+        skip_when_already_exists=False,
+        wait_for_completion=False,
+        allowed_states=None,
+        failed_states=None,
+        poke_interval=60,
+        deferrable=False,
+        note=None,
+    )
+    with (
+        patch("airflow.sdk.execution_time.task_runner._prepare", return_value=None),
+        patch("airflow.sdk.execution_time.task_runner._execute_task", side_effect=exception),
+        patch(
+            "airflow.sdk.execution_time.task_runner._handle_trigger_dag_run",
+            side_effect=RuntimeError("COMMS failure"),
+        ),
+        patch(
+            "airflow.sdk.execution_time.task_runner._handle_current_task_failed",
+            side_effect=RuntimeError("Handler failure"),
+        ),
+        patch("airflow.sdk.execution_time.task_runner.stats") as mock_stats,
+    ):
+        with pytest.raises(RuntimeError, match="Handler failure"):
+            run(ti, context, log)
+
+        # Verify that state was FAILED (the default) in the stats.incr calls
+        mock_stats.incr.assert_any_call(
+            "ti.finish",
+            tags={"dag_id": "test_dag", "task_id": "test_task", "state": TaskInstanceState.FAILED},
+        )


### PR DESCRIPTION
This PR fixes a bug where TriggerDagRunOperator failed with a 404 Not Found error when executed via dag.test().

The issue was caused by an overly restrictive parsing context in the test() method that limited DAG synchronization to only the specific DAG being tested. This meant that any target DAGs (triggered by the test) were never synchronized to the metadata database, making them invisible to the in-process Execution API.

Changes:

Removed the _airflow_parsing_context_manager restriction from the bundle synchronization loop in dag.test().
This ensures all DAGs in the test environment's bundles are properly synchronized to the DB before execution begins.

closes: #64884

Was generative AI tooling used to co-author this PR?
 Yes — Claude (For pr description)