### PR TITLE
Fix redirect loop when stale root-path `_token` cookie exists from older Airflow instance

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
@@ -61,16 +61,29 @@ class JWTRefreshMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
 
             if new_token is not None:
+                cookie_path = get_cookie_path()
                 secure = bool(conf.get("api", "ssl_cert", fallback=""))
                 response.set_cookie(
                     COOKIE_NAME_JWT_TOKEN,
                     new_token,
-                    path=get_cookie_path(),
+                    path=cookie_path,
                     httponly=True,
                     secure=secure,
                     samesite="lax",
                     max_age=0 if new_token == "" else None,
                 )
+                # Clear any stale _token cookie at root path "/".
+                # Older Airflow instances may have set the cookie there;
+                # without this, the root-path cookie keeps being sent on
+                # every request, causing an infinite redirect loop.
+                if new_token == "" and cookie_path != "/":
+                    response.delete_cookie(
+                        key=COOKIE_NAME_JWT_TOKEN,
+                        path="/",
+                        httponly=True,
+                        secure=secure,
+                        samesite="lax",
+                    )
         except HTTPException as exc:
             # If any HTTPException is raised during user resolution or refresh, return it as response
             return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})

--- a/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
@@ -76,7 +76,7 @@ class JWTRefreshMiddleware(BaseHTTPMiddleware):
                 # Older Airflow instances may have set the cookie there;
                 # without this, the root-path cookie keeps being sent on
                 # every request, causing an infinite redirect loop.
-                if new_token == "" and cookie_path != "/":
+                if cookie_path != "/":
                     response.delete_cookie(
                         key=COOKIE_NAME_JWT_TOKEN,
                         path="/",

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -66,12 +66,22 @@ def logout(request: Request, auth_manager: AuthManagerDep) -> RedirectResponse:
         auth_manager.revoke_token(token_str)
 
     secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
+    cookie_path = get_cookie_path()
     response = RedirectResponse(auth_manager.get_url_login())
     response.delete_cookie(
         key=COOKIE_NAME_JWT_TOKEN,
-        path=get_cookie_path(),
+        path=cookie_path,
         secure=secure,
         httponly=True,
     )
+    # Clear any stale _token cookie at root path "/" left by
+    # older Airflow instances to prevent redirect loops.
+    if cookie_path != "/":
+        response.delete_cookie(
+            key=COOKIE_NAME_JWT_TOKEN,
+            path="/",
+            secure=secure,
+            httponly=True,
+        )
 
     return response

--- a/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
@@ -161,3 +161,33 @@ class TestJWTRefreshMiddleware:
 
         set_cookie_headers = response.headers.get("set-cookie", "")
         assert "Path=/team-a/" in set_cookie_headers
+
+    @patch("airflow.api_fastapi.auth.middlewares.refresh_token.get_cookie_path", return_value="/team-a/")
+    @patch.object(
+        JWTRefreshMiddleware,
+        "_refresh_user",
+        side_effect=HTTPException(status_code=403, detail="Invalid JWT token"),
+    )
+    @patch("airflow.api_fastapi.auth.middlewares.refresh_token.conf")
+    @pytest.mark.asyncio
+    async def test_dispatch_invalid_token_clears_root_cookie(
+        self,
+        mock_conf,
+        mock_refresh_user,
+        mock_cookie_path,
+        middleware,
+        mock_request,
+    ):
+        """When a stale _token exists at root path, clearing must target both the subpath and root."""
+        mock_request.cookies = {COOKIE_NAME_JWT_TOKEN: "stale_root_token"}
+        mock_conf.get.return_value = ""
+
+        call_next = AsyncMock(return_value=Response(status_code=401))
+        response = await middleware.dispatch(mock_request, call_next)
+
+        set_cookie_headers = response.headers.getlist("set-cookie")
+        # Expect two delete cookies: one at the subpath and one at root "/"
+        assert any("Path=/team-a/" in h and "Max-Age=0" in h for h in set_cookie_headers)
+        assert any(
+            "Path=/" in h and "Path=/team-a/" not in h and "Max-Age=0" in h for h in set_cookie_headers
+        )

--- a/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
@@ -159,8 +159,12 @@ class TestJWTRefreshMiddleware:
         call_next = AsyncMock(return_value=Response())
         response = await middleware.dispatch(mock_request, call_next)
 
-        set_cookie_headers = response.headers.get("set-cookie", "")
-        assert "Path=/team-a/" in set_cookie_headers
+        set_cookie_headers = response.headers.getlist("set-cookie")
+        assert any("Path=/team-a/" in h for h in set_cookie_headers)
+        # Stale root-path cookie must also be cleared
+        assert any(
+            "Path=/" in h and "Path=/team-a/" not in h and "Max-Age=0" in h for h in set_cookie_headers
+        )
 
     @patch("airflow.api_fastapi.auth.middlewares.refresh_token.get_cookie_path", return_value="/team-a/")
     @patch.object(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_auth.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_auth.py
@@ -149,8 +149,12 @@ class TestLogout(TestAuthEndpoint):
 
         assert response.status_code == 307
         cookies = response.headers.get_list("set-cookie")
-        token_cookie = next(c for c in cookies if f"{COOKIE_NAME_JWT_TOKEN}=" in c)
+        token_cookie = next(c for c in cookies if f"{COOKIE_NAME_JWT_TOKEN}=" in c and f"Path={SUBPATH}" in c)
         assert f"Path={SUBPATH}" in token_cookie
+        # Stale root-path cookie must also be cleared
+        assert any(
+            f"{COOKIE_NAME_JWT_TOKEN}=" in c and "Path=/" in c and f"Path={SUBPATH}" not in c for c in cookies
+        )
 
 
 class TestLogoutTokenRevocation:


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Problem Description

This PR fixes a bug that was introduced by this PR: https://github.com/apache/airflow/pull/62771

When multiple Airflow instances are hosted on the same domain under different subpaths
(e.g. `/team-a/airflow/`, `/team-b/airflow/`), users who previously visited an older
Airflow instance end up in an infinite redirect loop on the newer instance.

The older instance sets the `_token` cookie at `Path=/`. The newer instance scopes its
cookie to the subpath (e.g. `Path=/team-a/airflow/`). When the browser sends both cookies,
the `JWTRefreshMiddleware` detects the stale root-path token as invalid and clears it —
but only at the subpath. The root-path cookie is never removed, so it keeps being sent on
every subsequent request:

```
GET /team-a/airflow/  (with stale _token at Path=/)
  → middleware rejects token, deletes cookie for Path=/team-a/airflow/
  → 307 redirect to login
GET /team-a/airflow/auth/login  (root _token still present)
  → middleware rejects token again, deletes cookie for Path=/team-a/airflow/
  → 302 redirect to /team-a/airflow/auth/
  → ...infinite loop
```

## Solution

When the middleware or the logout endpoint clears the `_token` cookie and the configured
cookie path is not `/`, also delete the cookie at `Path=/`. This removes the stale
root-path cookie on the very first failed validation, breaking the loop immediately.

## Changes

- **`airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py`** -
  When invalidating an expired/invalid token, also `delete_cookie` at `Path=/`
- **`airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py`** -
  On logout, also `delete_cookie` at `Path=/`


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  GitHub Copilot - Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
