### PR TITLE
Improve auto-triage TUI: check vault TTL, search, review questions

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/pr_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/pr_commands.py
@@ -248,9 +248,9 @@ def _cached_assess_pr(
         return result
 
     # Generate directed review questions from the diff if available.
-    # Note: diff_text is not yet passed by the background thread-pool submissions
-    # (the diff may not be fetched at LLM submission time). Review questions are
-    # active when diff_text is provided explicitly (e.g. sequential review mode).
+    # In the TUI, diff_text is passed when the diff has been fetched by the
+    # background executor before the LLM submission. In the non-TUI flow,
+    # it is passed explicitly during sequential review.
     review_questions: list[str] | None = None
     if diff_text:
         from airflow_breeze.utils.pr_vault import generate_review_questions
@@ -1856,6 +1856,42 @@ def _fetch_single_pr_graphql(token: str, github_repository: str, pr_number: int)
         labels=[lbl["name"] for lbl in (node.get("labels") or {}).get("nodes", []) if lbl],
         unresolved_threads=[],
         review_decisions=_extract_review_decisions(node),
+    )
+
+
+def _load_pr_from_vault(github_repository: str, pr_number: int) -> PRData | None:
+    """Try to load a PR from the vault. Returns None on miss or expired TTL.
+
+    The returned PRData has ``unresolved_threads=[]``, ``review_decisions=[]``,
+    and ``has_collaborator_review=False``. These are backfilled by
+    ``_enrich_candidate_details`` which runs during triage/review regardless
+    of whether the PR came from vault or the API.
+    """
+    from airflow_breeze.utils.pr_vault import load_pr
+
+    data = load_pr(github_repository, pr_number)
+    if data is None:
+        return None
+    return PRData(
+        number=data["number"],
+        title=data["title"],
+        body=data.get("body", ""),
+        url=data["url"],
+        created_at=data["created_at"],
+        updated_at=data["updated_at"],
+        node_id=data.get("node_id", ""),
+        author_login=data["author_login"],
+        author_association=data.get("author_association", "NONE"),
+        head_sha=data["head_sha"],
+        base_ref=data.get("base_ref", "main"),
+        check_summary=data.get("check_summary", ""),
+        checks_state=data.get("checks_state", "UNKNOWN"),
+        failed_checks=data.get("failed_checks", []),
+        commits_behind=data.get("commits_behind", 0),
+        is_draft=data.get("is_draft", False),
+        mergeable=data.get("mergeable", "UNKNOWN"),
+        labels=data.get("labels", []),
+        unresolved_threads=[],
     )
 
 
@@ -5322,6 +5358,7 @@ def _run_tui_triage(
                                     pr_body=cur_pr.body,
                                     check_status_summary=cur_pr.check_summary,
                                     llm_model=llm_model,
+                                    diff_text=diff_cache.get(cur_pr.number),
                                 )
                             ctx.llm_future_to_pr[fut] = cur_pr
                             # Keep as PASSING with LLM in progress
@@ -10041,9 +10078,15 @@ def _fetch_initial_prs(
     _initial_review_requested_user: str | None = None if review_mode else review_requested_user
 
     if pr_number:
-        if not quiet:
-            console_print(f"[info]Fetching PR #{pr_number} via GraphQL...[/]")
-        all_prs = [_fetch_single_pr_graphql(token, github_repository, pr_number)]
+        cached = _load_pr_from_vault(github_repository, pr_number)
+        if cached is not None:
+            if not quiet:
+                console_print(f"[info]Loaded PR #{pr_number} from vault cache.[/]")
+            all_prs = [cached]
+        else:
+            if not quiet:
+                console_print(f"[info]Fetching PR #{pr_number} via GraphQL...[/]")
+            all_prs = [_fetch_single_pr_graphql(token, github_repository, pr_number)]
         total_matching_prs = 1
     elif len(review_requested_users) > 1 and not review_mode:
         if not quiet:

--- a/dev/breeze/src/airflow_breeze/utils/pr_vault.py
+++ b/dev/breeze/src/airflow_breeze/utils/pr_vault.py
@@ -74,8 +74,9 @@ def save_prs_batch(github_repository: str, prs) -> int:
 
 # ── Check status vault ───────────────────────────────────────────
 # Keyed by head_sha. Only caches fully-completed check results (no
-# IN_PROGRESS or QUEUED). Completed results never change for the same SHA.
-_check_vault = CacheStore("check_vault")
+# IN_PROGRESS or QUEUED). Uses a 4-hour TTL because checks can be
+# re-run on the same commit without a force push.
+_check_vault = CacheStore("check_vault", ttl_seconds=4 * 3600)
 
 # Statuses that indicate checks are still running
 _INCOMPLETE_STATUSES = {"IN_PROGRESS", "QUEUED", "PENDING"}

--- a/dev/breeze/src/airflow_breeze/utils/tui_display.py
+++ b/dev/breeze/src/airflow_breeze/utils/tui_display.py
@@ -1753,7 +1753,7 @@ class TriageTUI:
         matching entry. Pressing Escape cancels. Returns True if the cursor moved.
         """
         width, height = _get_terminal_size()
-        prompt = "/ Jump to PR #: "
+        prompt = "/ Search (PR#, title, author): "
         query = ""
 
         while True:
@@ -1786,18 +1786,28 @@ class TriageTUI:
         if not query:
             return False
 
-        # Match by PR number only
+        # Try exact PR number match first
+        stripped = query.lstrip("#")
         try:
-            target_num = int(query.lstrip("#"))
+            target_num = int(stripped)
         except ValueError:
-            return False
+            target_num = None
 
+        if target_num is not None:
+            for idx, entry in enumerate(self.entries):
+                if entry.pr.number == target_num:
+                    self.cursor = idx
+                    self.scroll_offset = idx
+                    self._focus = _FocusPanel.PR_LIST
+                    return True
+
+        # Fall back to text search on title/author (also for numeric queries
+        # that didn't match any PR number)
+        query_lower = query.lower()
         for idx, entry in enumerate(self.entries):
-            if entry.pr.number == target_num:
+            if query_lower in entry.pr.title.lower() or query_lower in entry.pr.author_login.lower():
                 self.cursor = idx
-                # Put the matched entry at the top of the visible list
                 self.scroll_offset = idx
-                # Switch focus to PR list so the selection is highlighted
                 self._focus = _FocusPanel.PR_LIST
                 return True
 

--- a/dev/breeze/tests/test_pr_vault.py
+++ b/dev/breeze/tests/test_pr_vault.py
@@ -152,12 +152,21 @@ class TestCheckStatusVault:
         save_check_status("apache/airflow", "sha_abc", {"SUCCESS": 1})
         assert load_check_status("apache/airflow", "sha_different") is None
 
-    def test_no_ttl_for_same_sha(self, _fake_cache_dir):
-        """Check vault has no TTL — same SHA always returns same results."""
+    def test_ttl_expires_stale_results(self, _fake_cache_dir):
+        """Check vault uses 4h TTL so re-run results are picked up."""
         save_check_status("apache/airflow", "sha_abc", {"SUCCESS": 1})
-        # Even with old timestamp, should still return (no TTL)
         loaded = load_check_status("apache/airflow", "sha_abc")
         assert loaded is not None
+
+        # Simulate expiry by backdating cached_at
+        import json
+
+        cache_file = _fake_cache_dir / "checks_sha_abc.json"
+        data = json.loads(cache_file.read_text())
+        data["cached_at"] = data["cached_at"] - 5 * 3600  # 5 hours ago
+        cache_file.write_text(json.dumps(data))
+
+        assert load_check_status("apache/airflow", "sha_abc") is None
 
 
 class TestWorkflowRunsVault:


### PR DESCRIPTION
## Summary

Four improvements to the auto-triage TUI, building on the vault layer merged in #64590.

**Vault fallback for single-PR fetch**: When `--pr-number` is passed at startup, checks the vault first before making the GraphQL call. If the cached PR data is still fresh (4h TTL), skips the API call entirely. This closes the loop on `load_pr` which was defined but never called.

**Check vault TTL**: The check status vault cached completed results with no expiration, which meant re-running checks on the same commit (without force push) would keep serving stale data. Now uses a 4-hour TTL matching the PR metadata vault.

**Search by title/author**: The `/` search prompt only matched by PR number. Now also matches by title substring and author login, with PR number match taking priority.

**Review questions in on-demand LLM**: `generate_review_questions` was only active in sequential review mode. On-demand LLM re-evaluation (the `l` key) now passes `diff_text` when available so the LLM prompt includes directed verification questions.

## Test plan

- Single PR fetch with `--pr-number`: second run within 4h serves from vault (no GraphQL call logged)
- Check vault TTL test updated: verifies that backdated cache entries expire after 4 hours
- Search: type `/` then a title substring or author name to jump to matching PR
- On-demand LLM: press `l` on a PR with a fetched diff, review questions appear in the LLM prompt
- All 27 vault tests pass

---

##### Was generative AI tooling used to co-author this PR?

- [ ] No