### PR TITLE
Fix broken pytest/main after PR 64923

### DIFF
--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -1855,6 +1855,7 @@ def test_sensitive_values():
         ("database", "sql_alchemy_conn"),
         ("database", "sql_alchemy_conn_async"),
         ("core", "fernet_key"),
+        ("core", "sql_alchemy_conn"),  # NOTE: Added for 3.2.1
         ("api_auth", "jwt_secret"),
         ("api", "secret_key"),
         ("secrets", "backend_kwargs"),


### PR DESCRIPTION
Fix broken main (e.g. see https://github.com/apache/airflow/actions/runs/24207078526/job/70668730149?pr=64920) after PR #64923

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
