### PR TITLE
Prevent cross-DAG task lookups from crashing the scheduler

### DIFF
--- a/airflow-core/newsfragments/64957.bugfix.rst
+++ b/airflow-core/newsfragments/64957.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed missing ``dag_id`` filter in ``TaskInstance.get_task_instance`` that could cause scheduler crashes
+when multiple DAGs share the same ``task_id`` and ``run_id``.

--- a/airflow-core/newsfragments/64957.bugfix.rst
+++ b/airflow-core/newsfragments/64957.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed missing ``dag_id`` filter in ``TaskInstance.get_task_instance`` that could cause scheduler crashes
-when multiple DAGs share the same ``task_id`` and ``run_id``.

--- a/airflow-core/newsfragments/64988.bugfix.rst
+++ b/airflow-core/newsfragments/64988.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed missing ``dag_id`` filter in ``TaskInstance.get_task_instance`` that could cause scheduler crashes
+when multiple DAGs share the same ``task_id`` and ``run_id``.

--- a/airflow-core/newsfragments/64988.bugfix.rst
+++ b/airflow-core/newsfragments/64988.bugfix.rst
@@ -1,2 +1,1 @@
-Fixed missing ``dag_id`` filter in ``TaskInstance.get_task_instance`` that could cause scheduler crashes
-when multiple DAGs share the same ``task_id`` and ``run_id``.
+Fixed missing ``dag_id`` filter in ``TaskInstance.get_task_instance`` that could cause scheduler crashes when multiple DAGs share the same ``task_id`` and ``run_id``.

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -794,6 +794,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             select(TaskInstance)
             .options(lazyload(TaskInstance.dag_run))  # lazy load dag run to avoid locking it
             .filter_by(
+                dag_id=dag_id,
                 run_id=run_id,
                 task_id=task_id,
                 map_index=map_index,

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -1321,6 +1321,48 @@ class TestTaskInstance:
         assert completed == expect_completed
         assert ti.state == expect_state
 
+    def test_get_task_instance_filters_by_dag_id(self, dag_maker, session):
+        shared_run_id = "manual__shared_run_id"
+        task_id = "common_task"
+
+        with dag_maker(dag_id="dag_one", session=session):
+            EmptyOperator(task_id=task_id)
+        dag_maker.create_dagrun(
+            session=session,
+            run_id=shared_run_id,
+            run_type=DagRunType.MANUAL,
+            logical_date=timezone.datetime(2024, 1, 1),
+        )
+
+        with dag_maker(dag_id="dag_two", session=session):
+            EmptyOperator(task_id=task_id)
+        dag_maker.create_dagrun(
+            session=session,
+            run_id=shared_run_id,
+            run_type=DagRunType.MANUAL,
+            logical_date=timezone.datetime(2024, 1, 2),
+        )
+
+        ti_one = TaskInstance.get_task_instance(
+            dag_id="dag_one",
+            run_id=shared_run_id,
+            task_id=task_id,
+            map_index=-1,
+            session=session,
+        )
+        ti_two = TaskInstance.get_task_instance(
+            dag_id="dag_two",
+            run_id=shared_run_id,
+            task_id=task_id,
+            map_index=-1,
+            session=session,
+        )
+
+        assert ti_one is not None
+        assert ti_two is not None
+        assert ti_one.dag_id == "dag_one"
+        assert ti_two.dag_id == "dag_two"
+
     def test_respects_prev_dagrun_dep(self, dag_maker, session):
         with dag_maker("test_respects_prev_dagrun_dep", serialized=True) as dag:
             EmptyOperator(task_id="t")


### PR DESCRIPTION
Task instance lookup is expected to return exactly one row for a given `(dag_id, task_id, run_id, map_index)` combination. Today, `TaskInstance.get_task_instance` can lose that DAG scoping even though its callers already provide `dag_id`.

That becomes a real scheduler stability problem when two different DAGs use the same `run_id`, `task_id`, and `map_index`. `run_id` overlap across DAGs is normal because DagRun uniqueness is scoped by `dag_id`, so values such as `manual__...` can legitimately appear in more than one DAG. In that case this lookup can match multiple task instances, and the retrieval path fails instead of returning the intended row.

Restoring DAG scoping keeps this helper aligned with the TaskInstance uniqueness key and prevents cross-DAG collisions from turning into scheduler or executor-side lookup failures. All current call sites already pass `dag_id`, so this also preserves the row they were already intending to fetch.

A regression test covers two DAGs that share the same `run_id` and `task_id` and verifies that each lookup returns the task instance for the requested DAG.

closes: #64957

### Validation

- `breeze run pytest airflow-core/tests/unit/models/test_taskinstance.py::TestTaskInstance::test_get_task_instance_filters_by_dag_id -xvs`
- `prek run --from-ref main --stage pre-commit`
- `prek run --from-ref main --stage manual`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex GPT-5

Generated-by: Codex GPT-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)