### PR TITLE
Google: Fix false success in Cloud Composer DAG run sensor

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -217,16 +217,16 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         start_date: datetime,
         end_date: datetime,
     ) -> bool:
+        found_in_range = False
         for dag_run in dag_runs:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    dag_run["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and dag_run["state"] not in self.allowed_states:
-                return False
-        return True
+            dag_run_date = parser.parse(
+                dag_run["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
+            ).timestamp()
+            if start_date.timestamp() < dag_run_date < end_date.timestamp():
+                found_in_range = True
+                if dag_run["state"] not in self.allowed_states:
+                    return False
+        return found_in_range
 
     def _get_composer_airflow_version(self) -> int:
         """Return Composer Airflow version."""

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -267,16 +267,16 @@ class CloudComposerDAGRunTrigger(BaseTrigger):
         start_date: datetime,
         end_date: datetime,
     ) -> bool:
+        found_in_range = False
         for dag_run in dag_runs:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    dag_run["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and dag_run["state"] not in self.allowed_states:
-                return False
-        return True
+            dag_run_date = parser.parse(
+                dag_run["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
+            ).timestamp()
+            if start_date.timestamp() < dag_run_date < end_date.timestamp():
+                found_in_range = True
+                if dag_run["state"] not in self.allowed_states:
+                    return False
+        return found_in_range
 
     def _get_async_hook(self) -> CloudComposerAsyncHook:
         return CloudComposerAsyncHook(

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -53,6 +53,20 @@ TEST_GET_RESULT = lambda state, date_key: {
     "dag_runs": TEST_DAG_RUNS_RESULT(state, date_key, "dag_run_id"),
     "total_entries": 1,
 }
+TEST_DAG_RUN_EXECUTION_RANGE = [datetime(2024, 5, 22, 11, 0, 0), datetime(2024, 5, 22, 12, 0, 0)]
+TEST_DAG_RUN_RESULT_WITH_DATE = lambda state, date_key, dag_run_date: {
+    "dag_runs": [
+        {
+            "dag_id": "test_dag_id",
+            "dag_run_id": TEST_COMPOSER_DAG_RUN_ID,
+            "state": state,
+            date_key: dag_run_date,
+            "start_date": "2024-05-22T11:20:01.531988+00:00",
+            "end_date": "2024-05-22T11:20:11.997479+00:00",
+        }
+    ],
+    "total_entries": 1,
+}
 TEST_COMPOSER_EXTERNAL_TASK_ID = "test_external_task_id"
 TEST_COMPOSER_EXTERNAL_TASK_GROUP_ID = "test_external_task_group_id"
 TEST_TASK_INSTANCES_RESULT = lambda state, date_key, task_id: [
@@ -90,6 +104,7 @@ class TestCloudComposerDAGRunSensor:
                 environment_id=TEST_ENVIRONMENT_ID,
                 composer_dag_id="test_dag_id",
                 allowed_states=["success"],
+                execution_range=TEST_DAG_RUN_EXECUTION_RANGE,
                 use_rest_api=use_rest_api,
             )
         task._composer_airflow_version = composer_airflow_version
@@ -114,6 +129,7 @@ class TestCloudComposerDAGRunSensor:
                 environment_id=TEST_ENVIRONMENT_ID,
                 composer_dag_id="test_dag_id",
                 allowed_states=["success"],
+                execution_range=TEST_DAG_RUN_EXECUTION_RANGE,
                 use_rest_api=use_rest_api,
             )
         task._composer_airflow_version = composer_airflow_version
@@ -141,6 +157,91 @@ class TestCloudComposerDAGRunSensor:
                 environment_id=TEST_ENVIRONMENT_ID,
                 composer_dag_id="test_dag_id",
                 allowed_states=["success"],
+                use_rest_api=use_rest_api,
+            )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
+
+    @pytest.mark.parametrize("use_rest_api", [True, False])
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_wait_ready_in_range(self, mock_hook, composer_airflow_version, use_rest_api):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT(
+            "success", date_key
+        )
+        mock_hook.return_value.get_dag_runs.return_value = TEST_DAG_RUN_RESULT_WITH_DATE(
+            "success",
+            date_key,
+            "2024-05-22T11:10:00+00:00",
+        )
+
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            task = CloudComposerDAGRunSensor(
+                task_id="task-id",
+                project_id=TEST_PROJECT_ID,
+                region=TEST_REGION,
+                environment_id=TEST_ENVIRONMENT_ID,
+                composer_dag_id="test_dag_id",
+                allowed_states=["success"],
+                use_rest_api=use_rest_api,
+            )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
+
+    @pytest.mark.parametrize("use_rest_api", [True, False])
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_wait_not_ready_in_range(self, mock_hook, composer_airflow_version, use_rest_api):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT(
+            "running", date_key
+        )
+        mock_hook.return_value.get_dag_runs.return_value = TEST_DAG_RUN_RESULT_WITH_DATE(
+            "running",
+            date_key,
+            "2024-05-22T11:10:00+00:00",
+        )
+
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            task = CloudComposerDAGRunSensor(
+                task_id="task-id",
+                project_id=TEST_PROJECT_ID,
+                region=TEST_REGION,
+                environment_id=TEST_ENVIRONMENT_ID,
+                composer_dag_id="test_dag_id",
+                allowed_states=["success"],
+                use_rest_api=use_rest_api,
+            )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert not task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
+
+    @pytest.mark.parametrize("use_rest_api", [True, False])
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_only_out_of_range_runs_return_false(self, mock_hook, composer_airflow_version, use_rest_api):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.wait_command_execution_result.return_value = TEST_EXEC_RESULT(
+            "success", date_key
+        )
+        mock_hook.return_value.get_dag_runs.return_value = TEST_DAG_RUN_RESULT_WITH_DATE(
+            "success",
+            date_key,
+            "2024-05-22T10:50:00+00:00",
+        )
+
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            task = CloudComposerDAGRunSensor(
+                task_id="task-id",
+                project_id=TEST_PROJECT_ID,
+                region=TEST_REGION,
+                environment_id=TEST_ENVIRONMENT_ID,
+                composer_dag_id="test_dag_id",
+                allowed_states=["success"],
+                execution_range=TEST_DAG_RUN_EXECUTION_RANGE,
                 use_rest_api=use_rest_api,
             )
         task._composer_airflow_version = composer_airflow_version

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
@@ -59,6 +59,14 @@ TEST_EXEC_RESULT = {
     "output_end": True,
     "exit_info": {"exit_code": 0, "error": ""},
 }
+TEST_DAG_RUNS_RESULT = lambda state, date_key, dag_run_date: [
+    {
+        "dag_id": TEST_COMPOSER_DAG_ID,
+        "dag_run_id": TEST_COMPOSER_DAG_RUN_ID,
+        "state": state,
+        date_key: dag_run_date,
+    }
+]
 
 
 @pytest.fixture
@@ -183,6 +191,29 @@ class TestCloudComposerDAGRunTrigger:
             },
         )
         assert actual_data == expected_data
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @pytest.mark.parametrize(
+        ("state", "dag_run_date", "expected"),
+        [
+            pytest.param("success", "2024-03-22T11:10:00", True, id="allowed-in-range"),
+            pytest.param("running", "2024-03-22T11:10:00", False, id="disallowed-in-range"),
+            pytest.param("success", "2024-03-22T10:50:00", False, id="only-out-of-range"),
+        ],
+    )
+    def test_check_dag_runs_states(
+        self, dag_run_trigger, composer_airflow_version, state, dag_run_date, expected
+    ):
+        dag_run_trigger.composer_airflow_version = composer_airflow_version
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+
+        actual = dag_run_trigger._check_dag_runs_states(
+            dag_runs=TEST_DAG_RUNS_RESULT(state, date_key, dag_run_date),
+            start_date=TEST_START_DATE,
+            end_date=TEST_END_DATE,
+        )
+
+        assert actual is expected
 
 
 class TestCloudComposerExternalTaskTrigger:


### PR DESCRIPTION
CloudComposer DAG-run waits could report success even when no DAG run existed inside the requested execution window. That can let downstream work continue before the expected Composer run is actually present.

This change keeps both synchronous and deferrable DAG-run waits pending until:
- at least one DAG run exists inside the requested execution window, and
- every in-window DAG run is in an allowed state.

It also adds regression coverage for:
- allowed in-window runs
- disallowed in-window runs
- responses where all returned runs are outside the requested window
- both Airflow 2 (`execution_date`) and Airflow 3 (`logical_date`) response shapes

Validation:
- `breeze run pytest providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py -xvs`
- `breeze run pytest providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py -xvs`
- `prek run --from-ref main --stage pre-commit`

closes: #57512

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
