### PR TITLE
fix RedshiftSQLHook._get_conn_params connection mutation with IAM

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -88,16 +88,20 @@ class RedshiftSQLHook(DbApiHook):
         conn_params: dict[str, str | int] = {}
 
         if conn.extra_dejson.get("iam", False):
-            conn.login, conn.password, conn.port = self.get_iam_token(conn)
+            login, password, port = self.get_iam_token(conn)
+        else:
+            login = conn.login
+            password = conn.password
+            port = conn.port
 
-        if conn.login:
-            conn_params["user"] = conn.login
-        if conn.password:
-            conn_params["password"] = conn.password
+        if login:
+            conn_params["user"] = login
+        if password:
+            conn_params["password"] = password
+        if port:
+            conn_params["port"] = port
         if conn.host:
             conn_params["host"] = conn.host
-        if conn.port:
-            conn_params["port"] = conn.port
         if conn.schema:
             conn_params["database"] = conn.schema
 

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
@@ -242,6 +242,33 @@ class TestRedshiftSQLHookConn:
                 AutoCreate=False,
             )
 
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.conn")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
+    def test_get_conn_iam_does_not_mutate_connection(self, mock_connect, mock_aws_hook_conn):
+        self.connection.extra = json.dumps(
+            {"iam": True, "profile": "default", "cluster_identifier": "my-test-cluster"}
+        )
+
+        mock_db_user = f"IAM:{LOGIN_USER}"
+        mock_db_pass = "aws_token"
+
+        mock_aws_hook_conn.get_cluster_credentials.return_value = {
+            "DbPassword": mock_db_pass,
+            "DbUser": mock_db_user,
+        }
+        self.db_hook.get_conn()
+        self.db_hook.get_conn()
+        assert mock_aws_hook_conn.get_cluster_credentials.call_count == 2
+        for call in mock_aws_hook_conn.get_cluster_credentials.call_args_list:
+            assert call == mock.call(
+                DbUser=LOGIN_USER,
+                DbName=LOGIN_SCHEMA,
+                ClusterIdentifier="my-test-cluster",
+                AutoCreate=False,
+            )
+
+        assert self.connection.login == LOGIN_USER
+
     @mock.patch.dict("os.environ", AIRFLOW_CONN_AWS_DEFAULT=f"aws://?region_name={MOCK_REGION_NAME}")
     @pytest.mark.parametrize(
         ("connection_host", "connection_extra", "expected_identity"),


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
When iam=True,` _get_conn_params()` writes the IAM:-prefixed username back to conn.login. Any subsequent get_conn() calls feed the prefixed value into get_cluster_credentials, which ends up failing due to the : being an invalid character. I modified the method so that login, password, and port are assigned as local variables and added an additional test case to ensure repeated calls respect the connections username.

closes #64985
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
