### PR TITLE
Skip notifier templating with empty template_fields

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/notifier.py
+++ b/task-sdk/src/airflow/sdk/bases/notifier.py
@@ -87,6 +87,8 @@ class BaseNotifier(LoggingMixin, Templater):
         :param context: Context dict with values to apply on content.
         :param jinja_env: Jinja environment to use for rendering.
         """
+        if not self.template_fields:
+            return
         dag = context.get("dag")
         if not jinja_env:
             jinja_env = self.get_template_env(dag=dag)

--- a/task-sdk/src/airflow/sdk/bases/notifier.py
+++ b/task-sdk/src/airflow/sdk/bases/notifier.py
@@ -91,7 +91,10 @@ class BaseNotifier(LoggingMixin, Templater):
             return
         dag = context.get("dag")
         if not jinja_env:
-            jinja_env = self.get_template_env(dag=dag)
+            if dag is not None and hasattr(dag, "get_template_env"):
+                jinja_env = self.get_template_env(dag=dag)
+            else:
+                jinja_env = self.get_template_env()
         self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())
 
     async def async_notify(self, context: Context) -> None:

--- a/task-sdk/tests/task_sdk/bases/test_notifier.py
+++ b/task-sdk/tests/task_sdk/bases/test_notifier.py
@@ -118,3 +118,15 @@ class TestBaseNotifier:
         notifier(context)
 
         notifier.notify.assert_called_once_with({"dag": serialized_dag})
+
+    def test_notifier_render_template_fields_with_serialized_dag(self):
+        with DAG("test_notifier_render_template_fields_with_serialized_dag") as dag:
+            EmptyOperator(task_id="test_id")
+
+        notifier = MockNotifier(message="Hello {{ dag.dag_id }}")
+        serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
+        context: Context = {"dag": serialized_dag}
+
+        notifier.render_template_fields(context)
+
+        assert notifier.message == "Hello test_notifier_render_template_fields_with_serialized_dag"

--- a/task-sdk/tests/task_sdk/bases/test_notifier.py
+++ b/task-sdk/tests/task_sdk/bases/test_notifier.py
@@ -24,6 +24,7 @@ import jinja2
 import pytest
 
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.sdk.bases.notifier import BaseNotifier
 from airflow.sdk.definitions.dag import DAG
 
@@ -40,6 +41,13 @@ class MockNotifier(BaseNotifier):
     def __init__(self, message: str | None = "This is a test message"):
         super().__init__()
         self.message = message
+
+    def notify(self, context: Context) -> None:
+        pass
+
+
+class NoTemplateNotifier(BaseNotifier):
+    """Notifier used to verify callbacks without templated fields."""
 
     def notify(self, context: Context) -> None:
         pass
@@ -97,3 +105,16 @@ class TestBaseNotifier:
             }
         )
         assert notifier.message == "task: some_task"
+
+    def test_notifier_call_with_serialized_dag_and_no_template_fields(self):
+        with DAG("test_notifier_call_with_serialized_dag_and_no_template_fields") as dag:
+            EmptyOperator(task_id="test_id")
+
+        notifier = NoTemplateNotifier()
+        notifier.notify = MagicMock()
+        serialized_dag = SerializedDAG.deserialize_dag(SerializedDAG.serialize_dag(dag))
+        context: Context = {"dag": serialized_dag}
+
+        notifier(context)
+
+        notifier.notify.assert_called_once_with({"dag": serialized_dag})


### PR DESCRIPTION
## Summary

Skip notifier templating setup when a notifier does not define any template fields.

When `airflow dags test` executes DAG callbacks, the callback context can include a `SerializedDAG`. `BaseNotifier.render_template_fields()` currently always requests a template environment from the context DAG, even when there is nothing to render. For notifiers that rely on the default empty `template_fields`, that raises `AttributeError` before the callback can run.

This change returns early when `template_fields` is empty and adds a regression test that exercises a notifier callback with a serialized DAG context.

Closes #64649

## Testing

- Added a regression test in `task-sdk/tests/task_sdk/bases/test_notifier.py`
- `git diff --check`

<!-- pr-triage-fold: triaged=2026-07-28T16:31:41Z head=a67e9a7 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @DaveT1991** · by `@potiuk` · 2026-07-28 16:31 UTC
>
> Some review feedback from `jroachgolf84` is waiting on you:
> - There are **2 unresolved review threads** on this PR from `jroachgolf84`.
>
> **The ball is in your court** — you've been assigned to this PR. Push a fix or reply in each thread explaining why the feedback does not apply, then mark them resolved and ping the reviewer (`jroachgolf84`) for a final look.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
