### PR TITLE
Ignore closed DAG processor loggers during log drain

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1919,7 +1919,12 @@ def process_log_messages_from_subprocess(
         if level := NAME_TO_LEVEL.get(event.pop("level")):
             msg = event.pop("event", None)
             for target in loggers:
-                target.log(level, msg, **event)
+                try:
+                    target.log(level, msg, **event)
+                except ValueError as e:
+                    if str(e) != "write to closed file":
+                        raise
+                    log.debug("Dropping subprocess log line for closed logger", pid=os.getpid(), level=level)
 
 
 def forward_to_log(

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3145,6 +3145,30 @@ def test_process_log_messages_from_subprocess(monkeypatch, caplog):
     ]
 
 
+def test_process_log_messages_from_subprocess_ignores_closed_loggers(monkeypatch):
+    class ClosedLogger:
+        def log(self, level, msg, **event):
+            raise ValueError("write to closed file")
+
+    class OpenLogger:
+        def __init__(self):
+            self.messages = []
+
+        def log(self, level, msg, **event):
+            self.messages.append((level, msg, event))
+
+    open_logger = OpenLogger()
+
+    monkeypatch.setattr("airflow.sdk.execution_time.supervisor.reconfigure_logger", lambda log, *_, **__: log)
+
+    gen = process_log_messages_from_subprocess(loggers=(ClosedLogger(), open_logger))
+    next(gen)
+
+    gen.send(b'{"level": "error", "event": "still delivered", "source": "subprocess"}\n')
+
+    assert open_logger.messages == [(logging.ERROR, "still delivered", {"source": "subprocess"})]
+
+
 def test_reinit_supervisor_comms(monkeypatch, client_with_ti_start, caplog):
     def subprocess_main():
         # This is run in the subprocess!


### PR DESCRIPTION
## Summary

Prevent DAG processor crashes when late subprocess log events arrive after a DAG file processor's log file handle has already been closed.

`process_log_messages_from_subprocess()` currently forwards every decoded log event directly to each configured logger. During orphan process termination, buffered socket events can still be delivered after the DAG processor has already closed the corresponding BytesLogger file handle, which raises `ValueError: write to closed file` and brings down the whole job.

This change treats that specific closed-file logger error as a dropped late log line instead of letting it propagate, and adds regression coverage for the mixed case where one target logger is already closed while another is still able to receive the message.

Closes #64959

## Testing

- Added regression coverage in `task-sdk/tests/task_sdk/execution_time/test_supervisor.py`
- `git diff --check`

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=b1f81de action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @DaveT1991** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~52 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->