### PR TITLE
Persist Celery external executor ids on send

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -37,8 +37,6 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 from celery import states as celery_states
 from deprecated import deprecated
 
-from sqlalchemy import update
-
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models.taskinstance import TaskInstance
@@ -238,6 +236,8 @@ class CeleryExecutor(BaseExecutor):
 
     def _persist_task_external_executor_id(self, key: WorkloadKey, task_id: str) -> None:
         """Persist Celery task ids for task workloads so they survive scheduler restarts."""
+        from sqlalchemy import update
+
         from airflow.utils.session import create_session
 
         if not isinstance(key, TaskInstanceKey):

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -37,8 +37,12 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 from celery import states as celery_states
 from deprecated import deprecated
 
+from sqlalchemy import update
+
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.executors.base_executor import BaseExecutor
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.celery.executors import (
     celery_executor_utils as _celery_executor_utils,  # noqa: F401 # Needed to register Celery tasks at worker startup, see #63043.
 )
@@ -59,8 +63,6 @@ if TYPE_CHECKING:
 
     from airflow.cli.cli_config import GroupCommand
     from airflow.executors import workloads
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.models.taskinstancekey import TaskInstanceKey
     from airflow.providers.celery.executors.celery_executor_utils import TaskTuple, WorkloadInCelery
 
     if AIRFLOW_V_3_2_PLUS:
@@ -236,10 +238,6 @@ class CeleryExecutor(BaseExecutor):
 
     def _persist_task_external_executor_id(self, key: WorkloadKey, task_id: str) -> None:
         """Persist Celery task ids for task workloads so they survive scheduler restarts."""
-        from sqlalchemy import update
-
-        from airflow.models.taskinstance import TaskInstance as TI
-        from airflow.models.taskinstancekey import TaskInstanceKey
         from airflow.utils.session import create_session
 
         if not isinstance(key, TaskInstanceKey):
@@ -247,12 +245,12 @@ class CeleryExecutor(BaseExecutor):
 
         with create_session() as session:
             result = session.execute(
-                update(TI)
+                update(TaskInstance)
                 .where(
-                    TI.dag_id == key.dag_id,
-                    TI.task_id == key.task_id,
-                    TI.run_id == key.run_id,
-                    TI.map_index == key.map_index,
+                    TaskInstance.dag_id == key.dag_id,
+                    TaskInstance.task_id == key.task_id,
+                    TaskInstance.run_id == key.run_id,
+                    TaskInstance.map_index == key.map_index,
                 )
                 .values(external_executor_id=task_id)
             )

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -225,11 +225,40 @@ class CeleryExecutor(BaseExecutor):
                 result.backend = cached_celery_backend
                 self.running.add(key)
                 self.workloads[key] = result
+                # Persist the Celery task_id before scheduler event handling so a replacement
+                # scheduler can still adopt the task after a crash/restart.
+                self._persist_task_external_executor_id(key, result.task_id)
 
                 # Store the Celery task_id (workload execution ID) in the event buffer. This will get "overwritten" if the task
                 # has another event, but that is fine, because the only other events are success/failed at
                 # which point we don't need the ID anymore anyway.
                 self.event_buffer[key] = (TaskInstanceState.QUEUED, result.task_id)
+
+    def _persist_task_external_executor_id(self, key: WorkloadKey, task_id: str) -> None:
+        """Persist Celery task ids for task workloads so they survive scheduler restarts."""
+        from sqlalchemy import update
+
+        from airflow.models.taskinstance import TaskInstance as TI
+        from airflow.models.taskinstancekey import TaskInstanceKey
+        from airflow.utils.session import create_session
+
+        if not isinstance(key, TaskInstanceKey):
+            return
+
+        with create_session() as session:
+            result = session.execute(
+                update(TI)
+                .where(
+                    TI.dag_id == key.dag_id,
+                    TI.task_id == key.task_id,
+                    TI.run_id == key.run_id,
+                    TI.map_index == key.map_index,
+                )
+                .values(external_executor_id=task_id)
+            )
+
+        if not getattr(result, "rowcount", 0):
+            self.log.debug("Could not persist external_executor_id for %s", key)
 
     def _send_workloads_to_celery(self, workload_tuples_to_send: Sequence[WorkloadInCelery]):
         from airflow.providers.celery.executors.celery_executor_utils import send_workload_to_executor

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -285,6 +285,45 @@ class TestCeleryExecutor:
         assert executor.workloads == {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
         assert not_adopted_tis == []
 
+    @pytest.mark.backend("mysql", "postgres")
+    def test_send_workloads_persists_external_executor_id(
+        self, clean_dags_dagruns_and_dagbundles, testing_dag_bundle
+    ):
+        from sqlalchemy import select
+
+        from airflow.utils.session import create_session
+
+        start_date = timezone.utcnow() - timedelta(days=2)
+
+        with DAG("test_send_workloads_persists_external_executor_id", schedule=None) as dag:
+            task = BaseOperator(task_id="task_1", start_date=start_date)
+
+        if AIRFLOW_V_3_0_PLUS:
+            sync_dag_to_db(dag)
+            dag_version = DagVersion.get_latest_version(dag.dag_id)
+            ti = create_task_instance(task=task, run_id=None, dag_version_id=dag_version.id)
+        else:
+            ti = TaskInstance(task=task, run_id=None)
+
+        celery_result = mock.Mock(task_id="celery-task-id", backend=None)
+        executor = celery_executor.CeleryExecutor()
+        executor._send_workloads_to_celery = mock.Mock(return_value=[(ti.key, None, celery_result)])
+
+        executor._send_workloads([(ti.key, None, task.queue, None)])
+
+        with create_session() as session:
+            stored_external_executor_id = session.scalar(
+                select(TaskInstance.external_executor_id).where(
+                    TaskInstance.dag_id == ti.dag_id,
+                    TaskInstance.task_id == ti.task_id,
+                    TaskInstance.run_id == ti.run_id,
+                    TaskInstance.map_index == ti.map_index,
+                )
+            )
+
+        assert stored_external_executor_id == "celery-task-id"
+        assert executor.event_buffer[ti.key] == (TaskInstanceState.QUEUED, "celery-task-id")
+
     @pytest.fixture
     def mock_celery_revoke(self):
         with _prepare_app() as app:


### PR DESCRIPTION
## Summary

Persist the Celery task id to `task_instance.external_executor_id` as soon as a workload is successfully submitted.

Today the Celery executor stores the returned `task_id` in `event_buffer`, and the scheduler later writes it to the database while handling the queued/running event. If the scheduler dies in that window, the replacement scheduler cannot adopt the in-flight task because `external_executor_id` is still `NULL`, so the task may be reset and re-queued instead of adopted.

This change persists the Celery task id immediately after a successful send for task-instance workloads, while keeping the existing event-buffer path as the normal reconciliation flow.

Closes #64971

## Testing

- Added regression coverage in `providers/celery/tests/unit/celery/executors/test_celery_executor.py`
- `git diff --check`
