### PR TITLE
Trigger unit tests on shared/*.py changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -302,6 +302,7 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             r"^chart/templates/.*",
             r"^providers/.*/src/.*",
             r"^providers/.*/tests/.*",
+            r"^shared/.*\.py$",
             r"^task-sdk/src/.*",
             r"^task-sdk/tests/.*",
             r"^devel-common/src/.*",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1297,6 +1297,16 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 id="Shared logging library changes enable both remote logging e2e jobs",
             )
         ),
+        (
+            pytest.param(
+                ("shared/timezones/src/airflow_shared/timezones/timezone.py",),
+                {
+                    "ci-image-build": "true",
+                    "run-unit-tests": "true",
+                },
+                id="Shared library python changes trigger unit tests",
+            )
+        ),
     ],
 )
 def test_expected_output_pull_request_main(


### PR DESCRIPTION
Add `shared/*.py` pattern to `ALL_SOURCE_FILES` in selective checks so that changes that only touch the shared libraries (e.g. `shared/timezones`, `shared/logging`) trigger the unit test suite.

Previously, such changes were missed by selective checks because the `shared/` folder was not part of any source-file pattern. As a result, unit tests were skipped for changes that affect symlinked code consumed by `airflow-core`, `task-sdk`, and providers.

Includes a new test case `Shared library python changes trigger unit tests` covering this behavior.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)