### PR TITLE
[Helm-Chart] BugFix: Wrong broker URL secret ref

### DIFF
--- a/chart/newsfragments/65006.bugfix.rst
+++ b/chart/newsfragments/65006.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed broker URL secret name resolution to use ``airflow.fullname`` consistently. This fixes deployments where ``useStandardNaming=True`` and ``airflow.fullname != .Release.Name``, for example when using ``fullnameOverride``, ``nameOverride``, or the Airflow Helm chart as a dependency.

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -130,7 +130,7 @@ If release name contains chart name it will be used as a full name.
   - name: AIRFLOW__CELERY__BROKER_URL
     valueFrom:
       secretKeyRef:
-        name: {{ default (printf "%s-broker-url" .Release.Name) .Values.data.brokerUrlSecretName }}
+        name: {{ template "airflow_broker_url_secret" . }}
         key: connection
     {{- end }}
   {{- end }}
@@ -429,6 +429,10 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "redis_password_secret" -}}
   {{- default (printf "%s-redis-password" (include "airflow.fullname" .)) .Values.redis.passwordSecretName }}
+{{- end }}
+
+{{- define "airflow_broker_url_secret" -}}
+  {{- default (printf "%s-broker-url" (include "airflow.fullname" .)) .Values.data.brokerUrlSecretName }}
 {{- end }}
 
 {{- define "airflow_metadata_secret" -}}

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -33,7 +33,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "airflow.fullname" . }}-redis-password
+  name: {{ include "redis_password_secret" . }}
   labels:
     tier: airflow
     component: redis
@@ -62,7 +62,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "airflow.fullname" . }}-broker-url
+  name: {{ include "airflow_broker_url_secret" . }}
   labels:
     tier: airflow
     component: redis

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,9 +34,6 @@ nameOverride: ""
 # For existing installations, this will rename and redeploy your resources with the new names. Be aware that
 # this will recreate your Deployment/StatefulSets along with their persistent volume claims and data storage
 # migration may be needed to keep your old data
-#
-# Note:fernet-key,redis-password and broker-url secrets don't use this logic yet,
-# As this may break existing installations due to how they get installed via pre-install hook.
 useStandardNaming: false
 
 # Max number of old replicasets to retain. Can be overridden by each Deployment's revisionHistoryLimit

--- a/helm-tests/tests/helm_tests/other/test_redis.py
+++ b/helm-tests/tests/helm_tests/other/test_redis.py
@@ -56,8 +56,10 @@ class TestRedis:
         return password_in_obj
 
     @staticmethod
-    def get_broker_url_secret_in_deployment(k8s_obj_by_key, kind: str, name: str) -> str:
-        deployment_obj = k8s_obj_by_key[(kind, f"{RELEASE_NAME_REDIS}-{name}")]
+    def get_broker_url_secret_in_deployment(
+        k8s_obj_by_key, kind: str, name: str, airflow_fullname: str = RELEASE_NAME_REDIS
+    ) -> str:
+        deployment_obj = k8s_obj_by_key[(kind, f"{airflow_fullname}-{name}")]
         containers = deployment_obj["spec"]["template"]["spec"]["containers"]
         container = next(obj for obj in containers if obj["name"] == name)
 
@@ -82,14 +84,17 @@ class TestRedis:
             assert REDIS_OBJECTS["SECRET_BROKER_URL"] not in k8s_obj_by_key.keys()
 
     def assert_broker_url_env(
-        self, k8s_obj_by_key, expected_broker_url_secret_name=REDIS_OBJECTS["SECRET_BROKER_URL"][1]
+        self,
+        k8s_obj_by_key,
+        expected_broker_url_secret_name=REDIS_OBJECTS["SECRET_BROKER_URL"][1],
+        airflow_fullname: str = RELEASE_NAME_REDIS,
     ):
         broker_url_secret_in_scheduler = self.get_broker_url_secret_in_deployment(
-            k8s_obj_by_key, "StatefulSet", "worker"
+            k8s_obj_by_key, "Deployment", "scheduler", airflow_fullname
         )
         assert broker_url_secret_in_scheduler == expected_broker_url_secret_name
         broker_url_secret_in_worker = self.get_broker_url_secret_in_deployment(
-            k8s_obj_by_key, "Deployment", "scheduler"
+            k8s_obj_by_key, "StatefulSet", "worker", airflow_fullname
         )
         assert broker_url_secret_in_worker == expected_broker_url_secret_name
 
@@ -275,6 +280,36 @@ class TestRedis:
         )
 
         self.assert_broker_url_env(k8s_obj_by_key, expected_broker_url_secret_name)
+
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
+    def test_redis_secrets_support_fullname_override(self, executor):
+        fullname_override = "redis-fullname-override"
+        fullname_override_objects = {
+            "NETWORK_POLICY": ("NetworkPolicy", f"{fullname_override}-redis-policy"),
+            "SERVICE": ("Service", f"{fullname_override}-redis"),
+            "STATEFUL_SET": ("StatefulSet", f"{fullname_override}-redis"),
+            "SECRET_PASSWORD": ("Secret", f"{fullname_override}-redis-password"),
+            "SECRET_BROKER_URL": ("Secret", f"{fullname_override}-broker-url"),
+        }
+
+        k8s_objects = render_chart(
+            RELEASE_NAME_REDIS,
+            {
+                "fullnameOverride": fullname_override,
+                "useStandardNaming": True,
+                "networkPolicies": {"enabled": True},
+                "executor": executor,
+                "redis": {"enabled": True},
+            },
+        )
+        k8s_obj_by_key = prepare_k8s_lookup_dict(k8s_objects)
+        created_redis_objects = set(fullname_override_objects.values()) & set(k8s_obj_by_key.keys())
+        assert created_redis_objects == set(fullname_override_objects.values())
+        self.assert_broker_url_env(
+            k8s_obj_by_key,
+            expected_broker_url_secret_name=fullname_override_objects["SECRET_BROKER_URL"][1],
+            airflow_fullname=fullname_override,
+        )
 
     def test_default_redis_secrets_created_with_non_celery_executor(self):
         # We want to make sure default redis secrets (if needed) are still


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
If the helm chart creates the secret for the broker URL it uses the template `{{ include "airflow.fullname" . }}-broker-url` - see [Source](https://github.com/apache/airflow/blob/main/chart/templates/secrets/redis-secrets.yaml#L65)

However the default airflow env variables use a different template, just using the Release. `{{ default (printf "%s-broker-url" .Release.Name) .Values.data.brokerUrlSecretName }}` see [Source](https://github.com/apache/airflow/blob/main/chart/templates/_helpers.yaml#L125)

This is fatal as soon as someone uses the original chart as a dependency, so that `airflow-fullname != Release.Name` resulting in wrong secret key references and therefore a failed deployment due to `Init:CreateContainerConfigError`. 
It is broken since https://github.com/apache/airflow/commit/eabe6b8dd77204f7c0d117c9d9ad1f4166869671 -> since v1.19. We hit it today while upgrading from 1.18 -> 1.20

This PR fixes this issue. 


Please note, that I saw that the secrets are all not using the secrets names as set in the helpers, so that the name is duplicated. 
https://github.com/apache/airflow/blob/main/chart/templates/_helpers.yaml#L406-L480 and following lines. 
If it is desired I could use the helper templates also to set the name of the secrets in the secrets dir. This could be done in another PR ofc.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
