### PR TITLE
Fix airflow-ctl fallback for failed constrained installs

### DIFF
--- a/scripts/in_container/install_airflow_and_providers.py
+++ b/scripts/in_container/install_airflow_and_providers.py
@@ -1192,13 +1192,16 @@ def _install_airflow_ctl_with_constraints(installation_spec: InstallationSpec, g
     if installation_spec.airflow_ctl_constraints_location:
         console.print(f"[bright_blue]Use constraints: {installation_spec.airflow_ctl_constraints_location}")
         install_airflow_ctl_cmd.extend(["--constraint", installation_spec.airflow_ctl_constraints_location])
-    console.print()
-    result = run_command(install_airflow_ctl_cmd, github_actions=github_actions, check=True)
-    if result.returncode != 0:
-        console.print(
-            "[warning]Installation with constraints failed - might be because there are"
-            " conflicting dependencies in PyPI. Falling back to a non-constraint installation."
-        )
+        console.print()
+        result = run_command(install_airflow_ctl_cmd, github_actions=github_actions, check=False)
+        if result.returncode != 0:
+            console.print(
+                "[warning]Installation with constraints failed - might be because there are"
+                " conflicting dependencies in PyPI. Falling back to a non-constraint installation."
+            )
+            run_command(base_install_airflow_ctl_cmd, github_actions=github_actions, check=True)
+    else:
+        console.print()
         run_command(base_install_airflow_ctl_cmd, github_actions=github_actions, check=True)
 
 


### PR DESCRIPTION
## Why
This change ensures the fallback behavior is actually reachable: try constrained install first, and only if it fails, retry without constraints.
It also aligns airflow-ctl behavior with existing constraint fallback patterns in the same installer flow.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
