### PR TITLE
Fix serializer for empty string extra connection

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -53,16 +53,16 @@ class ConnectionResponse(BaseModel):
     @field_validator("extra", mode="before")
     @classmethod
     def redact_extra(cls, v: str | None) -> str | None:
-        if v is None:
-            return None
+        if v is None or v == "":
+            return v
         try:
             extra_dict = json.loads(v)
             redacted_dict = redact(extra_dict)
             return json.dumps(redacted_dict)
         except json.JSONDecodeError:
             # Do not return un-redacted extra because this could cause sensitive information to be exposed.
-            # This code path should never been hit as ``Connection._validate_extra`` sure that ``extra`` is
-            # always a valid JSON string. We add this safeguard just in case and to make the coupling
+            # This code path should never been hit as ``Connection._validate_extra`` makes sure that ``extra`` is
+            # always a valid JSON string (if truthy). We add this safeguard just in case and to make the coupling
             # explicit.
             raise ValueError(
                 "This code path should never happen as persisted Connections (DB layer) should always enforce `extra` as a JSON string."

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -61,7 +61,7 @@ class ConnectionResponse(BaseModel):
             return json.dumps(redacted_dict)
         except json.JSONDecodeError:
             # Do not return un-redacted extra because this could cause sensitive information to be exposed.
-            # This code path should never been hit as ``Connection._validate_extra`` makes sure that ``extra`` is
+            # This code path should never be hit as ``Connection._validate_extra`` makes sure that ``extra`` is
             # always a valid JSON string (if truthy). We add this safeguard just in case and to make the coupling
             # explicit.
             raise ValueError(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -168,6 +168,19 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["conn_type"] == TEST_CONN_TYPE
         assert body["extra"] == '{"extra_key": "extra_value"}'
 
+    @pytest.mark.parametrize("extra_value", [None, ""])
+    def test_get_should_respond_200_with_empty_extra(self, test_client, session, extra_value):
+        """Empty string or NULL extra should not break serialization (regression test for #64950)."""
+        self.create_connection()
+        connection = session.scalars(select(Connection)).first()
+        connection.extra = extra_value
+        session.commit()
+        response = test_client.get(f"/connections/{TEST_CONN_ID}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["connection_id"] == TEST_CONN_ID
+        assert body["extra"] == extra_value
+
     @pytest.mark.enable_redact
     def test_get_should_respond_200_with_extra_redacted(self, test_client, session):
         self.create_connection()


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/64950

For backward compatibility reasons (since AF2 I believe, empty string `""` is still supported as a valid value for extra field in connection)
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
