### PR TITLE
Fix clipped dropdowns in connection form

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.test.tsx
@@ -23,6 +23,28 @@ import { Wrapper } from "src/utils/Wrapper";
 
 import { FieldDropdown } from "./FieldDropdown";
 
+type MockSelectProps = {
+  readonly menuPortalTarget?: HTMLElement;
+  readonly menuPosition?: string;
+  readonly styles?: {
+    readonly menuPortal?: unknown;
+  };
+};
+
+let lastSelectProps: MockSelectProps | undefined;
+
+vi.mock("chakra-react-select", async () => {
+  const React = await import("react");
+
+  return {
+    Select: (props: MockSelectProps) => {
+      lastSelectProps = props;
+
+      return React.createElement("div", { role: "combobox" });
+    },
+  };
+});
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockParamsDict: Record<string, any> = {};
 const mockSetParamsDict = vi.fn();
@@ -46,6 +68,7 @@ describe("FieldDropdown", () => {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete mockParamsDict[key];
     });
+    lastSelectProps = undefined;
   });
 
   it("renders dropdown with null value in enum", () => {
@@ -168,5 +191,23 @@ describe("FieldDropdown", () => {
 
     expect(original).toBe(6);
     expect(typeof original).toBe("number");
+  });
+
+  it("renders the dropdown menu in a portal so accordion overflow does not clip it", () => {
+    mockParamsDict.test_param = {
+      schema: {
+        enum: ["value1", "value2"],
+        type: ["string"],
+      },
+      value: "value1",
+    };
+
+    render(<FieldDropdown name="test_param" onUpdate={vi.fn()} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(lastSelectProps?.menuPortalTarget).toBe(document.body);
+    expect(lastSelectProps?.menuPosition).toBe("fixed");
+    expect(lastSelectProps?.styles?.menuPortal).toBeTypeOf("function");
   });
 });

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
@@ -20,6 +20,7 @@ import { type SingleValue, Select as ReactSelect } from "chakra-react-select";
 import { useTranslation } from "react-i18next";
 
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
+import { getPortalledMenuTarget, portalledSelectStyles } from "src/utils/advancedSelectStyles";
 
 import type { FlexibleFormElementProps } from ".";
 
@@ -53,11 +54,10 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
 
   const currentValue =
     param.value === null
-      ? (options.find((opt) => opt.value === NULL_STRING_VALUE) ?? null)
+      ? options.find((opt) => opt.value === NULL_STRING_VALUE)
       : enumTypes.includes(typeof param.value)
-        ? (options.find((opt) => opt.value === String(param.value)) ?? null)
-        : // eslint-disable-next-line unicorn/no-null
-          null;
+        ? options.find((opt) => opt.value === String(param.value))
+        : undefined;
 
   const handleChange = (
     selected: SingleValue<{
@@ -89,11 +89,14 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
       id={`element_${name}`}
       isClearable
       isDisabled={disabled}
+      menuPortalTarget={getPortalledMenuTarget()}
+      menuPosition="fixed"
       name={`element_${name}`}
       onChange={handleChange}
       options={options}
       placeholder={translate("flexibleForm.placeholder")}
       size="sm"
+      styles={portalledSelectStyles}
       value={currentValue}
     />
   );

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
+import { getPortalledMenuTarget, portalledSelectStyles } from "src/utils/advancedSelectStyles";
 
 import type { FlexibleFormElementProps } from ".";
 
@@ -76,6 +77,8 @@ export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: Flex
       isClearable
       isDisabled={disabled}
       isMulti
+      menuPortalTarget={getPortalledMenuTarget()}
+      menuPosition="fixed"
       name={`element_${name}`}
       onChange={handleChange}
       options={
@@ -88,6 +91,7 @@ export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: Flex
       }
       placeholder={translate("flexibleForm.placeholderMulti")}
       size="sm"
+      styles={portalledSelectStyles}
       value={selectedOptions}
     />
   );

--- a/airflow-core/src/airflow/ui/src/components/TeamSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TeamSelector.tsx
@@ -23,6 +23,7 @@ import { type Control, Controller, type FieldValues, type Path } from "react-hoo
 import { useTranslation } from "react-i18next";
 
 import { useTeamsServiceListTeams } from "openapi/queries";
+import { getPortalledMenuTarget, portalledSelectStyles } from "src/utils/advancedSelectStyles";
 
 type Props<T extends FieldValues = FieldValues> = {
   readonly control: Control<T>;
@@ -62,10 +63,13 @@ export const TeamSelector = <T extends FieldValues = FieldValues>({ control }: P
                 data-testid="team-selector"
                 isClearable
                 isDisabled={isLoading}
+                menuPortalTarget={getPortalledMenuTarget()}
+                menuPosition="fixed"
                 // eslint-disable-next-line unicorn/no-null
                 onChange={(val) => onChange(val?.value ?? null)}
                 options={options}
                 placeholder={translate("team.selector.placeHolder")}
+                styles={portalledSelectStyles}
                 value={options.find((option) => option.value === value)}
               />
             </Stack>

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -32,6 +32,7 @@ import { useConfig } from "src/queries/useConfig.tsx";
 import { useConnectionTypeMeta } from "src/queries/useConnectionTypeMeta";
 import type { ParamsSpec } from "src/queries/useDagParams";
 import { useParamStore } from "src/queries/useParamStore";
+import { getPortalledMenuTarget, portalledSelectStyles } from "src/utils/advancedSelectStyles";
 
 import StandardFields from "./ConnectionStandardFields";
 import type { ConnectionBody } from "./Connections";
@@ -186,9 +187,12 @@ const ConnectionForm = ({
                   <Select
                     {...Field}
                     isDisabled={isMetaPending}
+                    menuPortalTarget={getPortalledMenuTarget()}
+                    menuPosition="fixed"
                     onChange={(val) => onChange(val?.value)}
                     options={connTypesOptions}
                     placeholder={translate("connections.form.selectConnectionType")}
+                    styles={portalledSelectStyles}
                     value={connTypesOptions.find((type) => type.value === value)}
                   />
                 </Stack>

--- a/airflow-core/src/airflow/ui/src/utils/advancedSelectStyles.ts
+++ b/airflow-core/src/airflow/ui/src/utils/advancedSelectStyles.ts
@@ -16,3 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { GroupBase, StylesConfig } from "chakra-react-select";
+
+type SelectOption = {
+  label: string;
+  value: string;
+};
+
+const PORTALLED_SELECT_Z_INDEX = "calc(var(--chakra-z-index-modal) + 1)";
+
+export const getPortalledMenuTarget = () => (typeof document === "undefined" ? undefined : document.body);
+
+export const portalledSelectStyles: StylesConfig<SelectOption, boolean, GroupBase<SelectOption>> = {
+  menuPortal: (provided) => ({
+    ...provided,
+    zIndex: PORTALLED_SELECT_Z_INDEX,
+  }),
+};


### PR DESCRIPTION
Fixes #65007

Connection form dropdowns can be clipped inside the dialog and accordion layout, which makes some values inaccessible when a custom connection field exposes a long enum list.

This change renders the affected `chakra-react-select` menus in a portal attached to `document.body`, uses `menuPosition="fixed"`, and applies a modal-safe z-index so the dropdown list can escape the accordion/container clipping and remain fully visible.

Changes:
- add shared portalled select menu styling for connection-form selects
- apply the shared portal configuration to flexible-form single-select fields
- apply the shared portal configuration to flexible-form multi-select fields
- apply the same portal configuration to the connection type and team selectors
- add a regression test asserting the flexible-form dropdown uses the portalled menu configuration

Validation:
- `pnpm exec eslint src/utils/advancedSelectStyles.ts src/components/FlexibleForm/FieldDropdown.tsx src/components/FlexibleForm/FieldMultiSelect.tsx src/components/TeamSelector.tsx src/pages/Connections/ConnectionForm.tsx src/components/FlexibleForm/FieldDropdown.test.tsx`
- `pnpm exec vitest run src/components/FlexibleForm/FieldDropdown.test.tsx`

