### PR TITLE
Add fast-path heartbeat UPDATE to avoid row lock in the common case

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -695,8 +695,24 @@ def ti_heartbeat(
     bind_contextvars(ti_id=str(task_instance_id))
     log.debug("Processing heartbeat", hostname=ti_payload.hostname, pid=ti_payload.pid)
 
-    # Hot path: since heartbeating a task is a very common operation, we try to do minimize the number of queries
-    # and DB round trips as much as possible.
+    # Hot path: in the common case the TI is still running on the same host and pid,
+    # so we can update last_heartbeat_at directly without first taking a row lock.
+    fast_path_result = session.execute(
+        update(TI)
+        .where(
+            TI.id == task_instance_id,
+            TI.state == TaskInstanceState.RUNNING,
+            TI.hostname == ti_payload.hostname,
+            TI.pid == ti_payload.pid,
+        )
+        .values(last_heartbeat_at=timezone.utcnow())
+        .execution_options(synchronize_session=False)
+    )
+    if fast_path_result.rowcount:
+        log.debug("Heartbeat updated via fast path")
+        return
+
+    log.info("Heartbeat fast path missed; falling back to diagnostic checks")
 
     old = select(TI.state, TI.hostname, TI.pid).where(TI.id == task_instance_id).with_for_update()
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -700,15 +700,15 @@ def ti_heartbeat(
     fast_path_result = cast(
         "CursorResult[Any]",
         session.execute(
-        update(TI)
-        .where(
-            TI.id == task_instance_id,
-            TI.state == TaskInstanceState.RUNNING,
-            TI.hostname == ti_payload.hostname,
-            TI.pid == ti_payload.pid,
-        )
-        .values(last_heartbeat_at=timezone.utcnow())
-        .execution_options(synchronize_session=False)
+            update(TI)
+            .where(
+                TI.id == task_instance_id,
+                TI.state == TaskInstanceState.RUNNING,
+                TI.hostname == ti_payload.hostname,
+                TI.pid == ti_payload.pid,
+            )
+            .values(last_heartbeat_at=timezone.utcnow())
+            .execution_options(synchronize_session=False)
         ),
     )
     if fast_path_result.rowcount is not None and fast_path_result.rowcount > 0:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -697,7 +697,9 @@ def ti_heartbeat(
 
     # Hot path: in the common case the TI is still running on the same host and pid,
     # so we can update last_heartbeat_at directly without first taking a row lock.
-    fast_path_result = session.execute(
+    fast_path_result = cast(
+        "CursorResult[Any]",
+        session.execute(
         update(TI)
         .where(
             TI.id == task_instance_id,
@@ -707,12 +709,13 @@ def ti_heartbeat(
         )
         .values(last_heartbeat_at=timezone.utcnow())
         .execution_options(synchronize_session=False)
+        ),
     )
-    if fast_path_result.rowcount:
+    if fast_path_result.rowcount is not None and fast_path_result.rowcount > 0:
         log.debug("Heartbeat updated via fast path")
         return
 
-    log.info("Heartbeat fast path missed; falling back to diagnostic checks")
+    log.debug("Heartbeat fast path missed; falling back to diagnostic checks")
 
     old = select(TI.state, TI.hostname, TI.pid).where(TI.id == task_instance_id).with_for_update()
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -82,7 +82,7 @@ def _where_column_keys(statement) -> set[str]:
     while stack:
         clause = stack.pop()
         left = getattr(clause, "left", None)
-        if getattr(left, "key", None) is not None:
+        if left is not None and getattr(left, "key", None) is not None:
             keys.add(left.key)
         stack.extend(clause.get_children())
     return keys

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -73,7 +73,19 @@ DEFAULT_RENDERED_MAP_INDEX = "test rendered map index"
 
 
 def _where_column_keys(statement) -> set[str]:
-    return {criterion.left.key for criterion in statement._where_criteria}
+    whereclause = getattr(statement, "whereclause", None)
+    if whereclause is None:
+        return set()
+
+    keys: set[str] = set()
+    stack = [whereclause]
+    while stack:
+        clause = stack.pop()
+        left = getattr(clause, "left", None)
+        if getattr(left, "key", None) is not None:
+            keys.add(left.key)
+        stack.extend(clause.get_children())
+    return keys
 
 
 def _is_task_instance_update(statement) -> bool:
@@ -81,7 +93,7 @@ def _is_task_instance_update(statement) -> bool:
 
 
 def _is_select_for_update(statement) -> bool:
-    return getattr(statement, "is_select", False) and getattr(statement, "_for_update_arg", None) is not None
+    return getattr(statement, "is_select", False) and "FOR UPDATE" in str(statement.compile()).upper()
 
 
 def _create_asset_aliases(session, num: int = 2) -> None:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -72,6 +72,18 @@ DEFAULT_END_DATE = timezone.parse("2024-10-31T12:00:00Z")
 DEFAULT_RENDERED_MAP_INDEX = "test rendered map index"
 
 
+def _where_column_keys(statement) -> set[str]:
+    return {criterion.left.key for criterion in statement._where_criteria}
+
+
+def _is_task_instance_update(statement) -> bool:
+    return getattr(statement, "is_update", False) and statement.table.name == TaskInstance.__table__.name
+
+
+def _is_select_for_update(statement) -> bool:
+    return getattr(statement, "is_select", False) and getattr(statement, "_for_update_arg", None) is not None
+
+
 def _create_asset_aliases(session, num: int = 2) -> None:
     asset_aliases = [
         AssetAliasModel(
@@ -1950,12 +1962,14 @@ class TestTIHealthEndpoint:
         time_machine.move_to(new_time, tick=False)
 
         original_execute = Session.execute
-        update_count = 0
+        task_instance_updates = []
+        for_update_selects = []
 
         def counting_execute(session_obj, statement, *args, **kwargs):
-            nonlocal update_count
-            if getattr(statement, "is_update", False) and statement.table.name == TaskInstance.__table__.name:
-                update_count += 1
+            if _is_task_instance_update(statement):
+                task_instance_updates.append(statement)
+            if _is_select_for_update(statement):
+                for_update_selects.append(statement)
             return original_execute(session_obj, statement, *args, **kwargs)
 
         monkeypatch.setattr(Session, "execute", counting_execute)
@@ -1966,8 +1980,9 @@ class TestTIHealthEndpoint:
         )
 
         assert response.status_code == 204
-        # Only the fast-path UPDATE should have executed; no fallback UPDATE
-        assert update_count == 1
+        assert len(task_instance_updates) == 1
+        assert _where_column_keys(task_instance_updates[0]) == {"id", "state", "hostname", "pid"}
+        assert len(for_update_selects) == 0
         session.refresh(ti)
         assert ti.last_heartbeat_at == new_time
 
@@ -2007,6 +2022,52 @@ class TestTIHealthEndpoint:
             return original_execute(session_obj, statement, *args, **kwargs)
 
         monkeypatch.setattr(Session, "execute", execute_with_fast_path_miss)
+
+        response = client.put(
+            f"/execution/task-instances/{ti.id}/heartbeat",
+            json={"hostname": "random-hostname", "pid": 1547},
+        )
+
+        assert response.status_code == 204
+        assert fast_path_intercepted
+        session.refresh(ti)
+        assert ti.last_heartbeat_at == new_time
+
+    def test_ti_heartbeat_fallback_updates_on_unknown_fast_path_rowcount(
+        self, client, session, create_task_instance, monkeypatch, time_machine
+    ):
+        """A truthy-but-unknown rowcount must not be treated as fast-path success."""
+        time_now = timezone.parse("2024-10-31T12:00:00Z")
+        time_machine.move_to(time_now, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_heartbeat_fallback_updates_on_unknown_fast_path_rowcount",
+            state=State.RUNNING,
+            hostname="random-hostname",
+            pid=1547,
+            last_heartbeat_at=time_now,
+            session=session,
+        )
+        session.commit()
+
+        new_time = time_now.add(minutes=10)
+        time_machine.move_to(new_time, tick=False)
+
+        original_execute = Session.execute
+        fast_path_intercepted = False
+
+        def execute_with_unknown_fast_path_rowcount(session_obj, statement, *args, **kwargs):
+            nonlocal fast_path_intercepted
+            if (
+                not fast_path_intercepted
+                and getattr(statement, "is_update", False)
+                and statement.table.name == TaskInstance.__table__.name
+            ):
+                fast_path_intercepted = True
+                return mock.MagicMock(rowcount=-1)
+            return original_execute(session_obj, statement, *args, **kwargs)
+
+        monkeypatch.setattr(Session, "execute", execute_with_unknown_fast_path_rowcount)
 
         response = client.put(
             f"/execution/task-instances/{ti.id}/heartbeat",

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1929,6 +1929,95 @@ class TestTIHealthEndpoint:
         session.refresh(ti)
         assert ti.last_heartbeat_at == time_now.add(minutes=10)
 
+    def test_ti_heartbeat_fast_path_skips_fallback(
+        self, client, session, create_task_instance, monkeypatch, time_machine
+    ):
+        """When the fast-path UPDATE succeeds, the fallback path does not run."""
+        time_now = timezone.parse("2024-10-31T12:00:00Z")
+        time_machine.move_to(time_now, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_heartbeat_fast_path_skips_fallback",
+            state=State.RUNNING,
+            hostname="random-hostname",
+            pid=1547,
+            last_heartbeat_at=time_now,
+            session=session,
+        )
+        session.commit()
+
+        new_time = time_now.add(minutes=10)
+        time_machine.move_to(new_time, tick=False)
+
+        original_execute = Session.execute
+        update_count = 0
+
+        def counting_execute(session_obj, statement, *args, **kwargs):
+            nonlocal update_count
+            if getattr(statement, "is_update", False) and statement.table.name == TaskInstance.__table__.name:
+                update_count += 1
+            return original_execute(session_obj, statement, *args, **kwargs)
+
+        monkeypatch.setattr(Session, "execute", counting_execute)
+
+        response = client.put(
+            f"/execution/task-instances/{ti.id}/heartbeat",
+            json={"hostname": "random-hostname", "pid": 1547},
+        )
+
+        assert response.status_code == 204
+        # Only the fast-path UPDATE should have executed; no fallback UPDATE
+        assert update_count == 1
+        session.refresh(ti)
+        assert ti.last_heartbeat_at == new_time
+
+    def test_ti_heartbeat_fallback_updates_on_fast_path_miss(
+        self, client, session, create_task_instance, monkeypatch, time_machine
+    ):
+        """When the fast-path UPDATE returns rowcount=0 the fallback path should
+        still update last_heartbeat_at."""
+        time_now = timezone.parse("2024-10-31T12:00:00Z")
+        time_machine.move_to(time_now, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_heartbeat_fallback_updates_on_fast_path_miss",
+            state=State.RUNNING,
+            hostname="random-hostname",
+            pid=1547,
+            last_heartbeat_at=time_now,
+            session=session,
+        )
+        session.commit()
+
+        new_time = time_now.add(minutes=10)
+        time_machine.move_to(new_time, tick=False)
+
+        original_execute = Session.execute
+        fast_path_intercepted = False
+
+        def execute_with_fast_path_miss(session_obj, statement, *args, **kwargs):
+            nonlocal fast_path_intercepted
+            if (
+                not fast_path_intercepted
+                and getattr(statement, "is_update", False)
+                and statement.table.name == TaskInstance.__table__.name
+            ):
+                fast_path_intercepted = True
+                return mock.MagicMock(rowcount=0)
+            return original_execute(session_obj, statement, *args, **kwargs)
+
+        monkeypatch.setattr(Session, "execute", execute_with_fast_path_miss)
+
+        response = client.put(
+            f"/execution/task-instances/{ti.id}/heartbeat",
+            json={"hostname": "random-hostname", "pid": 1547},
+        )
+
+        assert response.status_code == 204
+        assert fast_path_intercepted
+        session.refresh(ti)
+        assert ti.last_heartbeat_at == new_time
+
 
 class TestTIPutRTIF:
     def setup_method(self):


### PR DESCRIPTION
The ti_heartbeat endpoint now attempts a single guarded UPDATE (matching id, state, hostname, and pid) before falling back to the existing SELECT FOR UPDATE path. When the task is still running on the expected host this returns immediately, eliminating the row lock and a round trip for the vast majority of heartbeat calls.

 