### PR TITLE
UI: Fix log line number gaps caused by group markers

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -274,7 +274,7 @@ const renderStructuredLogImpl = ({
   }
 
   return (
-    <chakra.div display="flex" key={index} lineHeight={1.5}>
+    <chakra.div alignItems="flex-start" display="flex" key={index} lineHeight={1.5}>
       <RouterLink
         id={index.toString()}
         key={`line_${index}`}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -353,4 +353,39 @@ describe("Task log search", () => {
     // Auto-expand should make it visible.
     await waitFor(() => expect(screen.getByText(/starting attempt 1 of 3/iu)).toBeInTheDocument());
   }, 10_000);
+
+  it("Has sequential line numbers with no gaps or duplicates", async () => {
+    render(
+      <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
+    );
+
+    await waitForLogs();
+
+    // Expand all groups so their content lines are in the DOM
+    const summaryPre = screen.getByTestId("summary-Pre task execution logs");
+
+    fireEvent.click(summaryPre);
+    await waitFor(() => expect(screen.getByText(/starting attempt 1 of 3/iu)).toBeVisible());
+
+    const summaryPost = screen.getByTestId("summary-Post task execution logs");
+
+    fireEvent.click(summaryPost);
+    await waitFor(() => expect(screen.queryByText(/Marking task as SUCCESS/iu)).toBeVisible());
+
+    // Collect all rendered line number links within the log component
+    const logContainer = screen.getByTestId("virtual-scroll-container");
+    const lineNumbers = [...logContainer.querySelectorAll<HTMLAnchorElement>("a[id]")]
+      .map((el) => parseInt(el.id, 10))
+      .filter((num) => !isNaN(num))
+      .sort((numA, numB) => numA - numB);
+
+    expect(lineNumbers.length).toBeGreaterThan(0);
+    expect(lineNumbers[0]).toBe(0);
+    expect(new Set(lineNumbers).size).toBe(lineNumbers.length);
+
+    // No gaps
+    lineNumbers.forEach((num, idx) => {
+      expect(num).toBe(idx);
+    });
+  }, 10_000);
 });

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -354,38 +354,35 @@ describe("Task log search", () => {
     await waitFor(() => expect(screen.getByText(/starting attempt 1 of 3/iu)).toBeInTheDocument());
   }, 10_000);
 
-  it("Has sequential line numbers with no gaps or duplicates", async () => {
+  it("skips group markers when assigning line numbers", async () => {
     render(
       <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
     );
 
     await waitForLogs();
 
-    // Expand all groups so their content lines are in the DOM
+    const expectRenderedLineNumber = async (pattern: RegExp, expectedLineNumber: number) => {
+      const row = (await screen.findByText(pattern)).closest('[data-testid^="virtualized-item-"]');
+
+      expect(row).not.toBeNull();
+
+      const anchor = row?.querySelector<HTMLAnchorElement>("a[id]");
+
+      expect(anchor).not.toBeNull();
+
+      expect(Number(anchor?.id)).toBe(expectedLineNumber);
+    };
+
     const summaryPre = screen.getByTestId("summary-Pre task execution logs");
 
     fireEvent.click(summaryPre);
-    await waitFor(() => expect(screen.getByText(/starting attempt 1 of 3/iu)).toBeVisible());
 
-    const summaryPost = screen.getByTestId("summary-Post task execution logs");
+    const summaryDependency = await screen.findByTestId("summary-Dependency check details");
 
-    fireEvent.click(summaryPost);
-    await waitFor(() => expect(screen.queryByText(/Marking task as SUCCESS/iu)).toBeVisible());
+    fireEvent.click(summaryDependency);
 
-    // Collect all rendered line number links within the log component
-    const logContainer = screen.getByTestId("virtual-scroll-container");
-    const lineNumbers = [...logContainer.querySelectorAll<HTMLAnchorElement>("a[id]")]
-      .map((el) => parseInt(el.id, 10))
-      .filter((num) => !isNaN(num))
-      .sort((numA, numB) => numA - numB);
-
-    expect(lineNumbers.length).toBeGreaterThan(0);
-    expect(lineNumbers[0]).toBe(0);
-    expect(new Set(lineNumbers).size).toBe(lineNumbers.length);
-
-    // No gaps
-    lineNumbers.forEach((num, idx) => {
-      expect(num).toBe(idx);
-    });
+    await expectRenderedLineNumber(/dep_context=non-requeueable/iu, 0);
+    await expectRenderedLineNumber(/dep_context=requeueable/iu, 1);
+    await expectRenderedLineNumber(/starting attempt 1 of 3/iu, 2);
   }, 10_000);
 });

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -75,6 +75,20 @@ const parseLogs = ({
   const logLink = taskInstance ? `${getTaskInstanceLink(taskInstance)}?try_number=${tryNumber}` : "";
 
   try {
+    let lineNumber = 0;
+    const lineNumbers = data.map((datum) => {
+      const text = typeof datum === "string" ? datum : datum.event;
+
+      if (text.includes("::group::") || text.includes("::endgroup::")) {
+        return undefined;
+      }
+      const current = lineNumber;
+
+      lineNumber += 1;
+
+      return current;
+    });
+
     parsedLines = data
       .map((datum, index) => {
         if (typeof datum !== "string" && "logger" in datum) {
@@ -86,7 +100,7 @@ const parseLogs = ({
         }
 
         return renderStructuredLog({
-          index,
+          index: lineNumbers[index] ?? index,
           logLevelFilters,
           logLink,
           logMessage: datum,


### PR DESCRIPTION
### Description
Group markers (`::group::` / `::endgroup::`) consumed line number indices but were removed during group processing, leaving gaps in the displayed line numbers (e.g. 0, 2, 3 instead of 0, 1, 2). Also fixed line number alignment on wrapped log lines.

- Pre-scan log data to assign sequential display line numbers that skip group markers
- Pin wrapped line numbers to the top with `alignItems: flex-start`
 
closes: https://github.com/apache/airflow/issues/47888

### Screenshot
<img width="777" height="425" alt="Screenshot 2026-04-10 at 8 37 50 PM" src="https://github.com/user-attachments/assets/c0a2f0f6-2843-41d4-828b-90e477bc3868" />

  ---

  ##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code

  Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
