### PR TITLE
fix(ui): sync SearchBar value with defaultValue changes

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -81,4 +81,32 @@ describe("Test SearchBar", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
+
+  it("syncs input value when defaultValue changes", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<SearchBar defaultValue="initial-search" onChange={onChange} placeholder="Search Dags" />, {
+      wrapper: Wrapper,
+    });
+    const input = screen.getByTestId("search-dags");
+
+    expect((input as HTMLInputElement).value).toBe("initial-search");
+
+    rerender(<SearchBar defaultValue="updated-search" onChange={onChange} placeholder="Search Dags" />);
+
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe("updated-search"));
+  });
+
+  it("does not override local typing when defaultValue rerenders unchanged", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<SearchBar defaultValue="initial" onChange={onChange} placeholder="Search Dags" />, {
+      wrapper: Wrapper,
+    });
+    const input = screen.getByTestId("search-dags");
+
+    fireEvent.change(input, { target: { value: "user-typing" } });
+
+    rerender(<SearchBar defaultValue="initial" onChange={onChange} placeholder="Search Dags" />);
+
+    expect((input as HTMLInputElement).value).toBe("user-typing");
+  });
 });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -84,9 +84,12 @@ describe("Test SearchBar", () => {
 
   it("syncs input value when defaultValue changes", async () => {
     const onChange = vi.fn();
-    const { rerender } = render(<SearchBar defaultValue="initial-search" onChange={onChange} placeholder="Search Dags" />, {
-      wrapper: Wrapper,
-    });
+    const { rerender } = render(
+      <SearchBar defaultValue="initial-search" onChange={onChange} placeholder="Search Dags" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const input = screen.getByTestId("search-dags");
 
     expect((input as HTMLInputElement).value).toBe("initial-search");
@@ -98,9 +101,12 @@ describe("Test SearchBar", () => {
 
   it("does not override local typing when defaultValue rerenders unchanged", () => {
     const onChange = vi.fn();
-    const { rerender } = render(<SearchBar defaultValue="initial" onChange={onChange} placeholder="Search Dags" />, {
-      wrapper: Wrapper,
-    });
+    const { rerender } = render(
+      <SearchBar defaultValue="initial" onChange={onChange} placeholder="Search Dags" />,
+      {
+        wrapper: Wrapper,
+      },
+    );
     const input = screen.getByTestId("search-dags");
 
     fireEvent.change(input, { target: { value: "user-typing" } });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -48,10 +48,8 @@ export const SearchBar = ({
   const { t: translate } = useTranslation(["dags"]);
 
   useEffect(() => {
-    if (defaultValue !== value) {
-      setValue(defaultValue);
-    }
-  }, [defaultValue, value]);
+    setValue(defaultValue);
+  }, [defaultValue]);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -48,10 +48,10 @@ export const SearchBar = ({
   const { t: translate } = useTranslation(["dags"]);
 
   useEffect(() => {
-  if (defaultValue !== value) {
-    setValue(defaultValue);
-  }
-}, [defaultValue]);
+    if (defaultValue !== value) {
+      setValue(defaultValue);
+    }
+  }, [defaultValue]);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { CloseButton, Input, InputGroup, Kbd, type InputGroupProps } from "@chakra-ui/react";
-import { useState, useRef, type ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { FiSearch } from "react-icons/fi";
@@ -46,6 +46,13 @@ export const SearchBar = ({
   const [value, setValue] = useState(defaultValue);
   const metaKey = getMetaKey();
   const { t: translate } = useTranslation(["dags"]);
+
+  useEffect(() => {
+  if (defaultValue !== value) {
+    setValue(defaultValue);
+  }
+}, [defaultValue]);
+
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
     handleSearchChange(event.target.value);

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -51,7 +51,7 @@ export const SearchBar = ({
     if (defaultValue !== value) {
       setValue(defaultValue);
     }
-  }, [defaultValue]);
+  }, [defaultValue, value]);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);


### PR DESCRIPTION
Fixes #65053

## Problem
SearchBar initializes its internal state from `defaultValue` but does not update when `defaultValue` changes (e.g., via URL query params or navigation).

This causes the input value to go out of sync with the actual filter state.

## Solution
Synchronize internal state with `defaultValue` using useEffect, ensuring UI reflects current filter state while preserving user input behavior.

## Tests
- Added test to verify syncing when `defaultValue` changes
- Added test to ensure user typing is not overridden unnecessarily
- Existing debounce and clear behavior preserved