### PR TITLE
fix: sync SearchBar input with updated defaultValue prop

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -45,4 +45,19 @@ describe("Test SearchBar", () => {
 
     expect((input as HTMLInputElement).value).toBe("");
   });
+it("Updates input when defaultValue prop changes", async () => {
+    const { rerender } = render(
+      <SearchBar defaultValue="initial" onChange={vi.fn()} placeholder="Search Dags" />,
+      { wrapper: Wrapper },
+    );
+
+    const input = screen.getByTestId("search-dags");
+    expect((input as HTMLInputElement).value).toBe("initial");
+
+    rerender(
+      <SearchBar defaultValue="updated" onChange={vi.fn()} placeholder="Search Dags" />,
+    );
+
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe("updated"));
+  });
 });

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { CloseButton, Input, InputGroup, Kbd, type InputGroupProps } from "@chakra-ui/react";
-import { useState, useRef, type ChangeEvent } from "react";
+import { useState, useEffect, useRef, type ChangeEvent } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { FiSearch } from "react-icons/fi";
@@ -39,11 +39,14 @@ export const SearchBar = ({
   hotkeyDisabled = false,
   onChange,
   placeholder,
-  ...props
+  ...props                                                                                                                                 
 }: Props) => {
   const handleSearchChange = useDebouncedCallback((val: string) => onChange(val), debounceDelay);
   const searchRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
+  useEffect(() => {
+  setValue(defaultValue);
+}, [defaultValue]);
   const metaKey = getMetaKey();
   const { t: translate } = useTranslation(["dags"]);
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Problem

The `SearchBar` component initializes its internal state using the `defaultValue` prop, but does not stay in sync when `defaultValue` changes after the initial render.

This commonly happens when the search value is controlled via URL query parameters (e.g., in pages like DagsList, Connections, AssetsList). When navigation actions (such as back/forward) update the query params, the `defaultValue` prop changes, but the input field does not reflect the updated value.

**Current behavior:**
- The actual filter (URL/query param) updates
- The SearchBar input does NOT update
- UI and filter state become inconsistent

**Expected behavior:**
- SearchBar input should update whenever `defaultValue` changes
- UI should always reflect the current filter state
- No mismatch between visible input and actual filter

## Fix

Added `useEffect` to watch `defaultValue` and sync internal state:

```ts
useEffect(() => {
  setValue(defaultValue);
}, [defaultValue]);
```

Also added `useEffect` to the import statement.

## Testing

- Added new test: `Updates input when defaultValue prop changes`
- All 2 SearchBar tests pass 
- All 148 UI tests pass 

## Affected Pages

Any page using `SearchBar` with URL-driven filters:
- DagsList
- Connections
- AssetsList

Closes #65053 