### PR TITLE
Fix KubernetesJobTrigger hang for parallelism > completions case (#64867)

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/job.py
@@ -19,8 +19,13 @@ from __future__ import annotations
 import asyncio
 import warnings
 from collections.abc import AsyncIterator
+from contextlib import suppress
+from dataclasses import dataclass
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
+
+from kubernetes.client.rest import ApiException as SyncApiException
+from kubernetes_asyncio.client.exceptions import ApiException as AsyncApiException
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook, KubernetesHook
@@ -30,6 +35,32 @@ from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 if TYPE_CHECKING:
     from kubernetes.client import V1Job
+
+
+WaitOutcome = Literal["ready", "job_done", "pod_missing"]
+XComExtractOutcome = Literal["success", "missing", "error", "timeout"]
+K8S_API_EXCEPTIONS = (SyncApiException, AsyncApiException)
+MIN_POST_JOB_XCOM_TIMEOUT = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class PodXComAttempt:
+    """Outcome of a single best-effort XCom extraction attempt for one pod."""
+
+    pod_name: str
+    outcome: XComExtractOutcome
+    result: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PostJobXComSummary:
+    """Aggregated counters for post-job best-effort XCom extraction attempts."""
+
+    total: int
+    succeeded: int
+    skipped_missing: int
+    timed_out: int
+    failed_other: int
 
 
 class KubernetesJobTrigger(BaseTrigger):
@@ -83,6 +114,8 @@ class KubernetesJobTrigger(BaseTrigger):
         self.pod_namespace = pod_namespace
         self.base_container_name = base_container_name
         self.kubernetes_conn_id = kubernetes_conn_id
+        if poll_interval <= 0:
+            raise ValueError("Invalid value for poll_interval. Expected value greater than 0")
         self.poll_interval = poll_interval
         self.cluster_context = cluster_context
         self.config_file = config_file
@@ -121,24 +154,28 @@ class KubernetesJobTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Get current job status and yield a TriggerEvent."""
-        if self.do_xcom_push:
-            xcom_results = []
-            for pod_name in self.pod_names:
-                pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
-                await self.hook.wait_until_container_complete(
-                    name=pod_name, namespace=self.pod_namespace, container_name=self.base_container_name
+        xcom_results: list[str] | None = None
+
+        job_task = asyncio.create_task(
+            self.hook.wait_until_job_complete(
+                name=self.job_name,
+                namespace=self.job_namespace,
+                poll_interval=self.poll_interval,
+            )
+        )
+        try:
+            if self.do_xcom_push:
+                xcom_results = await self._collect_xcom_results(
+                    job_task=job_task,
                 )
-                self.log.info("Checking if xcom sidecar container is started.")
-                await self.hook.wait_until_container_started(
-                    name=pod_name,
-                    namespace=self.pod_namespace,
-                    container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
-                )
-                self.log.info("Extracting result from xcom sidecar container.")
-                loop = asyncio.get_running_loop()
-                xcom_result = await loop.run_in_executor(None, self.pod_manager.extract_xcom, pod)
-                xcom_results.append(xcom_result)
-        job: V1Job = await self.hook.wait_until_job_complete(name=self.job_name, namespace=self.job_namespace)
+
+            job: V1Job = await job_task
+        finally:
+            if not job_task.done():
+                job_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await job_task
+
         job_dict = job.to_dict()
         error_message = self.hook.is_job_failed(job=job)
         yield TriggerEvent(
@@ -155,6 +192,207 @@ class KubernetesJobTrigger(BaseTrigger):
                 "xcom_result": xcom_results if self.do_xcom_push else None,
             }
         )
+
+    async def _wait_until_container_state_or_job_done(
+        self,
+        pod_name: str,
+        container_name: str,
+        wait_method: Any,
+        job_task: asyncio.Task[V1Job],
+        state_label: str,
+    ) -> WaitOutcome:
+        wait_task = asyncio.create_task(
+            wait_method(
+                name=pod_name,
+                namespace=self.pod_namespace,
+                container_name=container_name,
+                poll_interval=self.poll_interval,
+            )
+        )
+
+        try:
+            while not wait_task.done() and not job_task.done():
+                # This timeout controls how frequently we re-check "job done vs container state" and does
+                # not enforce container-level readiness timeout.
+                await asyncio.wait(
+                    {wait_task, job_task},
+                    timeout=self.poll_interval,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+            if wait_task.done():
+                try:
+                    await wait_task
+                    return "ready"
+                except K8S_API_EXCEPTIONS as err:
+                    if self._is_not_found_error(err):
+                        self.log.info(
+                            "Pod '%s' no longer exists while waiting for container '%s' state '%s'; skipping.",
+                            pod_name,
+                            container_name,
+                            state_label,
+                        )
+                        return "pod_missing"
+                    raise
+
+            self.log.info(
+                "Job '%s' finished before pod '%s' container '%s' reached state '%s'; stopping XCom wait.",
+                self.job_name,
+                pod_name,
+                container_name,
+                state_label,
+            )
+            return "job_done"
+        finally:
+            if not wait_task.done():
+                wait_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await wait_task
+
+    async def _collect_xcom_results(
+        self,
+        job_task: asyncio.Task[V1Job],
+    ) -> list[str]:
+        pre_job_results, post_job_pod_names = await self._collect_xcom_until_job_done(job_task=job_task)
+        if not post_job_pod_names:
+            return pre_job_results
+
+        attempts = await self._collect_xcom_after_job_done_best_effort(
+            pod_names=post_job_pod_names,
+        )
+        summary = self._summarize_post_job_attempts(attempts)
+        self.log.info(
+            "Best-effort XCom collection summary after job completion: "
+            "total=%d, succeeded=%d, skipped_missing=%d, timed_out=%d, failed_other=%d",
+            summary.total,
+            summary.succeeded,
+            summary.skipped_missing,
+            summary.timed_out,
+            summary.failed_other,
+        )
+        # Only successful extraction attempts carry a concrete XCom payload.
+        pre_job_results.extend(attempt.result for attempt in attempts if attempt.result is not None)
+        return pre_job_results
+
+    async def _collect_xcom_until_job_done(
+        self,
+        job_task: asyncio.Task[V1Job],
+    ) -> tuple[list[str], list[str]]:
+        xcom_results: list[str] = []
+        post_job_pod_names: list[str] = []
+
+        for pod_index, pod_name in enumerate(self.pod_names):
+            try:
+                pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
+            except K8S_API_EXCEPTIONS as err:
+                if self._is_not_found_error(err):
+                    self.log.info("Pod '%s' no longer exists; skipping XCom extraction.", pod_name)
+                    continue
+                raise
+
+            completion_outcome = await self._wait_until_container_state_or_job_done(
+                pod_name=pod_name,
+                container_name=self.base_container_name,
+                wait_method=self.hook.wait_until_container_complete,
+                job_task=job_task,
+                state_label="completed",
+            )
+            if completion_outcome == "job_done":
+                post_job_pod_names = self.pod_names[pod_index:]
+                break
+            if completion_outcome == "pod_missing":
+                continue
+
+            self.log.info("Checking if xcom sidecar container is started.")
+            sidecar_outcome = await self._wait_until_container_state_or_job_done(
+                pod_name=pod_name,
+                container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
+                wait_method=self.hook.wait_until_container_started,
+                job_task=job_task,
+                state_label="running",
+            )
+            if sidecar_outcome == "job_done":
+                post_job_pod_names = self.pod_names[pod_index:]
+                break
+            if sidecar_outcome == "pod_missing":
+                continue
+
+            self.log.info("Extracting result from xcom sidecar container.")
+            loop = asyncio.get_running_loop()
+            xcom_results.append(await loop.run_in_executor(None, self.pod_manager.extract_xcom, pod))
+
+        return xcom_results, post_job_pod_names
+
+    async def _collect_xcom_after_job_done_best_effort(
+        self,
+        pod_names: list[str],
+    ) -> list[PodXComAttempt]:
+        if not pod_names:
+            return []
+
+        # Post-job extraction is best-effort: bound each pod attempt so stale pods cannot block trigger
+        # completion. Keep a small floor so tiny poll intervals do not cause immediate timeout.
+        per_pod_timeout = max(self.poll_interval, MIN_POST_JOB_XCOM_TIMEOUT)
+        max_concurrency = min(5, len(pod_names))
+        semaphore = asyncio.Semaphore(max_concurrency)
+
+        self.log.info(
+            "Job is done; collecting XCom best-effort for %d pod(s) with per-pod timeout %.2f seconds and max concurrency %d.",
+            len(pod_names),
+            per_pod_timeout,
+            max_concurrency,
+        )
+
+        async def extract_one_pod(pod_name: str) -> PodXComAttempt:
+            async with semaphore:
+                try:
+                    return await asyncio.wait_for(
+                        self._extract_xcom_for_pod_best_effort(pod_name=pod_name),
+                        timeout=per_pod_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    self.log.warning(
+                        "Timed out extracting XCom from pod '%s' after job completion; skipping.",
+                        pod_name,
+                    )
+                    return PodXComAttempt(pod_name=pod_name, outcome="timeout")
+
+        return await asyncio.gather(*(extract_one_pod(pod_name) for pod_name in pod_names))
+
+    async def _extract_xcom_for_pod_best_effort(self, pod_name: str) -> PodXComAttempt:
+        try:
+            pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
+        except K8S_API_EXCEPTIONS as err:
+            if self._is_not_found_error(err):
+                self.log.info("Pod '%s' no longer exists; skipping XCom extraction.", pod_name)
+                return PodXComAttempt(pod_name=pod_name, outcome="missing")
+            raise
+
+        self.log.info("Extracting result from xcom sidecar container (best-effort).")
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(None, self.pod_manager.extract_xcom, pod)
+            return PodXComAttempt(pod_name=pod_name, outcome="success", result=result)
+        except Exception as err:
+            if self._is_not_found_error(err):
+                self.log.info("Pod '%s' no longer exists during XCom extraction; skipping.", pod_name)
+                return PodXComAttempt(pod_name=pod_name, outcome="missing")
+            self.log.warning("Unable to extract XCom from pod '%s': %r. Skipping.", pod_name, err)
+            return PodXComAttempt(pod_name=pod_name, outcome="error")
+
+    @staticmethod
+    def _summarize_post_job_attempts(attempts: list[PodXComAttempt]) -> PostJobXComSummary:
+        return PostJobXComSummary(
+            total=len(attempts),
+            succeeded=sum(1 for attempt in attempts if attempt.outcome == "success"),
+            skipped_missing=sum(1 for attempt in attempts if attempt.outcome == "missing"),
+            timed_out=sum(1 for attempt in attempts if attempt.outcome == "timeout"),
+            failed_other=sum(1 for attempt in attempts if attempt.outcome == "error"),
+        )
+
+    @staticmethod
+    def _is_not_found_error(err: Exception) -> bool:
+        return getattr(err, "status", None) == 404
 
     @cached_property
     def hook(self) -> AsyncKubernetesHook:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -57,6 +57,22 @@ POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodMana
 ON_KILL_PROPAGATION_POLICY = "Foreground"
 
 
+def _build_execute_complete_event(
+    *,
+    job,
+    get_logs: bool,
+    xcom_result: list[str] | None,
+    pod_names: list[str] | None = None,
+) -> dict:
+    return {
+        "job": job,
+        "status": "success",
+        "pod_names": pod_names if get_logs else None,
+        "pod_namespace": POD_NAMESPACE if get_logs else None,
+        "xcom_result": xcom_result,
+    }
+
+
 def create_context(task, persist_to_db=False, map_index=None):
     if task.has_dag():
         dag = task.dag
@@ -816,21 +832,12 @@ class TestKubernetesJobOperator:
         mock_ti = mock.MagicMock()
         context = {"ti": mock_ti}
         mock_job = mock.MagicMock()
-        event = {
-            "job": mock_job,
-            "status": "success",
-            "pod_names": [
-                POD_NAME,
-            ]
-            if get_logs
-            else None,
-            "pod_namespace": POD_NAMESPACE if get_logs else None,
-            "xcom_result": [
-                TEST_XCOM_RESULT,
-            ]
-            if do_xcom_push
-            else None,
-        }
+        event = _build_execute_complete_event(
+            job=mock_job,
+            get_logs=get_logs,
+            pod_names=[POD_NAME],
+            xcom_result=[TEST_XCOM_RESULT] if do_xcom_push else None,
+        )
 
         KubernetesJobOperator(
             task_id="test_task_id", get_logs=get_logs, do_xcom_push=do_xcom_push
@@ -842,6 +849,35 @@ class TestKubernetesJobOperator:
             mocked_write_logs.assert_called_once()
         else:
             mocked_write_logs.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("unwrap_single", "expected_result"),
+        [
+            (False, [{"result": "test-xcom-result"}]),
+            (True, {"result": "test-xcom-result"}),
+        ],
+    )
+    def test_execute_complete_supports_partial_xcom_results(self, unwrap_single, expected_result):
+        """Regression test for #64867."""
+        mock_ti = mock.MagicMock()
+        context = {"ti": mock_ti}
+        mock_job = mock.MagicMock()
+        event = _build_execute_complete_event(
+            job=mock_job,
+            get_logs=False,
+            # In #64867 trigger can return fewer XCom payloads than pods from initial snapshot.
+            xcom_result=[TEST_XCOM_RESULT],
+        )
+
+        result = KubernetesJobOperator(
+            task_id="test_task_id",
+            get_logs=False,
+            do_xcom_push=True,
+            unwrap_single=unwrap_single,
+        ).execute_complete(context=context, event=event)
+
+        mock_ti.xcom_push.assert_called_once_with(key="job", value=mock_job)
+        assert result == expected_result
 
     @pytest.mark.non_db_test_override
     def test_execute_complete_fail(self):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_job.py
@@ -17,9 +17,13 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from unittest import mock
 
 import pytest
+from kubernetes.client.rest import ApiException
 
 from airflow.providers.cncf.kubernetes.triggers.job import KubernetesJobTrigger
 from airflow.triggers.base import TriggerEvent
@@ -38,6 +42,41 @@ CONFIG_FILE = "/path/to/config/file"
 IN_CLUSTER = False
 GET_LOGS = True
 XCOM_PUSH = False
+
+
+@dataclass(slots=True)
+class TriggerHarness:
+    """Convenience wrapper for trigger tests with patched hook and pod manager."""
+
+    trigger: KubernetesJobTrigger
+    hook: mock.MagicMock
+    pod_manager: mock.MagicMock
+
+    async def run_once(self) -> TriggerEvent:
+        return await asyncio.wait_for(self.trigger.run().__anext__(), timeout=0.2)
+
+
+def _make_pod(name: str, namespace: str = "default") -> mock.MagicMock:
+    pod = mock.MagicMock()
+    pod.metadata.name = name
+    pod.metadata.namespace = namespace
+    return pod
+
+
+@asynccontextmanager
+async def _pending_job_task():
+    """Create and clean up a job task that never finishes."""
+
+    async def never_finishes():
+        await asyncio.Future()
+
+    job_task = asyncio.create_task(never_finishes())
+    try:
+        yield job_task
+    finally:
+        job_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await job_task
 
 
 @pytest.fixture
@@ -60,7 +99,57 @@ def trigger():
     )
 
 
+@pytest.fixture
+def parallelism_gt_completions_trigger():
+    """Fixture for issue #64867: parallelism > completions snapshot can contain extra pods."""
+    return KubernetesJobTrigger(
+        job_name="job",
+        job_namespace="default",
+        pod_names=["pod-1", "pod-2"],  # parallelism=2, completions=1
+        pod_namespace="default",
+        base_container_name="base",
+        do_xcom_push=True,
+        get_logs=False,
+        poll_interval=0.01,
+    )
+
+
+@pytest.fixture
+def parallelism_gt_completions_harness(parallelism_gt_completions_trigger):
+    with (
+        mock.patch(
+            "airflow.providers.cncf.kubernetes.triggers.job.KubernetesJobTrigger.pod_manager"
+        ) as pod_manager,
+        mock.patch("airflow.providers.cncf.kubernetes.triggers.job.KubernetesJobTrigger.hook") as hook,
+    ):
+        mock_job = mock.MagicMock()
+        mock_job.metadata.name = "job"
+        mock_job.metadata.namespace = "default"
+        mock_job.to_dict.return_value = {"status": {"succeeded": 1}}
+        hook.wait_until_job_complete = mock.AsyncMock(return_value=mock_job)
+        hook.is_job_failed.return_value = False
+        yield TriggerHarness(
+            trigger=parallelism_gt_completions_trigger,
+            hook=hook,
+            pod_manager=pod_manager,
+        )
+
+
 class TestKubernetesJobTrigger:
+    @pytest.mark.parametrize("invalid_poll_interval", [0, -0.1])
+    def test_init_raises_on_non_positive_poll_interval(self, invalid_poll_interval):
+        with pytest.raises(
+            ValueError, match="Invalid value for poll_interval. Expected value greater than 0"
+        ):
+            KubernetesJobTrigger(
+                job_name=JOB_NAME,
+                job_namespace=NAMESPACE,
+                pod_names=[POD_NAME],
+                pod_namespace=NAMESPACE,
+                base_container_name=CONTAINER_NAME,
+                poll_interval=invalid_poll_interval,
+            )
+
     def test_serialize(self, trigger):
         classpath, kwargs_dict = trigger.serialize()
 
@@ -102,7 +191,11 @@ class TestKubernetesJobTrigger:
 
         event_actual = await trigger.run().asend(None)
 
-        mock_hook.wait_until_job_complete.assert_called_once_with(name=JOB_NAME, namespace=NAMESPACE)
+        mock_hook.wait_until_job_complete.assert_called_once_with(
+            name=JOB_NAME,
+            namespace=NAMESPACE,
+            poll_interval=POLL_INTERVAL,
+        )
         mock_job.to_dict.assert_called_once()
         mock_is_job_failed.assert_called_once_with(job=mock_job)
         assert event_actual == TriggerEvent(
@@ -140,7 +233,11 @@ class TestKubernetesJobTrigger:
 
         event_actual = await trigger.run().asend(None)
 
-        mock_hook.wait_until_job_complete.assert_called_once_with(name=JOB_NAME, namespace=NAMESPACE)
+        mock_hook.wait_until_job_complete.assert_called_once_with(
+            name=JOB_NAME,
+            namespace=NAMESPACE,
+            poll_interval=POLL_INTERVAL,
+        )
         mock_job.to_dict.assert_called_once()
         mock_is_job_failed.assert_called_once_with(job=mock_job)
         assert event_actual == TriggerEvent(
@@ -171,3 +268,158 @@ class TestKubernetesJobTrigger:
             cluster_context=CLUSTER_CONTEXT,
         )
         assert hook_actual == hook_expected
+
+    @pytest.mark.asyncio
+    async def test_run_completes_when_job_is_done_even_if_some_snapshot_pods_never_complete(
+        self, parallelism_gt_completions_harness
+    ):
+        """Regression test for #64867."""
+        pod_1 = _make_pod("pod-1")
+        pod_2 = _make_pod("pod-2")
+
+        async def get_pod(name, namespace):
+            return pod_1 if name == "pod-1" else pod_2
+
+        async def wait_until_container_complete(name, namespace, container_name, poll_interval):
+            if name == "pod-1":
+                return None
+            # emulate stale pod from snapshot that never reaches completed state
+            await asyncio.Future()
+
+        async def wait_until_container_started(name, namespace, container_name, poll_interval):
+            return None
+
+        harness = parallelism_gt_completions_harness
+        harness.hook.get_pod.side_effect = get_pod
+        harness.hook.wait_until_container_complete.side_effect = wait_until_container_complete
+        harness.hook.wait_until_container_started.side_effect = wait_until_container_started
+        harness.pod_manager.extract_xcom.return_value = '{"ok": true}'
+
+        event_actual = await harness.run_once()
+
+        harness.hook.wait_until_job_complete.assert_called_once_with(
+            name="job",
+            namespace="default",
+            poll_interval=0.01,
+        )
+        assert event_actual == TriggerEvent(
+            {
+                "name": "job",
+                "namespace": "default",
+                "pod_names": None,
+                "pod_namespace": None,
+                "status": "success",
+                "message": "Job completed successfully",
+                "job": {"status": {"succeeded": 1}},
+                "xcom_result": ['{"ok": true}', '{"ok": true}'],
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_skips_deleted_snapshot_pod_and_completes_when_job_is_done(
+        self, parallelism_gt_completions_harness
+    ):
+        """Regression test for #64867."""
+        pod = _make_pod("pod-1")
+
+        async def get_pod(name, namespace):
+            if name == "pod-2":
+                raise ApiException(status=404, reason="Not Found")
+            return pod
+
+        harness = parallelism_gt_completions_harness
+        harness.hook.get_pod.side_effect = get_pod
+        harness.hook.wait_until_container_complete = mock.AsyncMock(return_value=None)
+        harness.hook.wait_until_container_started = mock.AsyncMock(return_value=None)
+        harness.pod_manager.extract_xcom.return_value = '{"ok": true}'
+
+        event_actual = await harness.run_once()
+
+        assert event_actual.payload["status"] == "success"
+        assert event_actual.payload["xcom_result"] == ['{"ok": true}']
+
+    @pytest.mark.asyncio
+    async def test_run_collects_later_pod_xcom_best_effort_after_job_done(
+        self, parallelism_gt_completions_harness
+    ):
+        """Regression test for #64867: continue collecting from remaining pods after job completion."""
+        pod_1 = _make_pod("pod-1")
+        pod_2 = _make_pod("pod-2")
+
+        async def get_pod(name, namespace):
+            return pod_1 if name == "pod-1" else pod_2
+
+        async def wait_until_container_complete(name, namespace, container_name, poll_interval):
+            if name == "pod-1":
+                await asyncio.Future()
+            return None
+
+        def extract_xcom(pod):
+            if pod.metadata.name == "pod-1":
+                raise RuntimeError("pod-1 xcom unavailable")
+            return '{"from":"pod-2"}'
+
+        harness = parallelism_gt_completions_harness
+        harness.hook.get_pod.side_effect = get_pod
+        harness.hook.wait_until_container_complete.side_effect = wait_until_container_complete
+        harness.hook.wait_until_container_started = mock.AsyncMock(return_value=None)
+        harness.pod_manager.extract_xcom.side_effect = extract_xcom
+
+        event_actual = await harness.run_once()
+
+        assert event_actual.payload["status"] == "success"
+        assert event_actual.payload["xcom_result"] == ['{"from":"pod-2"}']
+        harness.hook.wait_until_container_complete.assert_called_once()
+        harness.hook.wait_until_container_started.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wait_until_container_state_or_job_done_does_not_restart_wait_task(self, trigger):
+        # Polling loop must not cancel/recreate wait_method on every tick.
+        # If it does, slow/loaded clusters can starve readiness detection forever.
+        trigger.poll_interval = 1
+        wait_method_calls = 0
+        wait_loop_calls = 0
+        # Gate that allows us to complete wait_method exactly when we want.
+        wait_gate: asyncio.Future[None] = asyncio.Future()
+
+        async def slow_wait_method(name, namespace, container_name, poll_interval):
+            nonlocal wait_method_calls
+            wait_method_calls += 1
+            await wait_gate
+            return None
+
+        async def fake_asyncio_wait(tasks, timeout=None, return_when=None):
+            nonlocal wait_loop_calls
+            wait_loop_calls += 1
+            # Simulate a few poll ticks where nothing finishes yet.
+            if wait_loop_calls < 3:
+                return set(), set(tasks)
+
+            # Then release wait_method and let event loop settle task completion.
+            if not wait_gate.done():
+                wait_gate.set_result(None)
+            await asyncio.sleep(0)
+            done = {task for task in tasks if task.done()}
+            return done, set(tasks) - done
+
+        # Job task stays pending; readiness must come from wait_method task itself.
+        async with _pending_job_task() as job_task:
+            with mock.patch(
+                "airflow.providers.cncf.kubernetes.triggers.job.asyncio.wait",
+                side_effect=fake_asyncio_wait,
+            ):
+                outcome = await asyncio.wait_for(
+                    trigger._wait_until_container_state_or_job_done(
+                        pod_name=POD_NAME,
+                        container_name=CONTAINER_NAME,
+                        wait_method=slow_wait_method,
+                        job_task=job_task,
+                        state_label="completed",
+                    ),
+                    timeout=0.3,
+                )
+
+        assert outcome == "ready"
+        # Key assertion: wait_method coroutine is started once and stays alive across poll ticks.
+        assert wait_method_calls == 1
+        assert wait_loop_calls >= 3


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Closes #64867

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
        Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


This PR resolves the hanging `Running` state issue in `KubernetesJobOperator` / `KubernetesJobTrigger` for `deferrable=True` / `do_xcom_push=True`.

### Problem description

The trigger waits for container completion for every pod name from a precomputed snapshot (pod_names) before checking the final Job status. That snapshot is built from pod discovery tied to parallelism, not to actual successful completions.

**Example** (`parallelism=2`, `completions=1`):
- Airflow creates a Job
- Kubernetes starts 2 pods
- One pod succeeds
- Job becomes `Complete` (`completions=1` reached)
- The second pod may never reach the expected terminal state
- `KubernetesJobTrigger` keeps waiting on the second pod and does not reach Job-status evaluation, so the task can remain Running/Deferred forever.

**Proposed fix:** Task completion should be driven by Job terminal status (`Complete` / `Failed`), which already reflects `completions`:
- Make Job status the primary completion condition.
- Collect XCom/logs only as best-effort from pods that actually finished and are still readable.
- Do not block task finalization on missing/non-terminal pods from the initial snapshot.

### What does this PR do?

Updates logic for `KubernetesJobTrigger`:
- The waiting flow is now job-first: completion is driven by final Job status, not by requiring all pods from the initial snapshot to finish.
- XCom collection is now best-effort: results are collected only from pods that are available and successfully processed.
- 404 for missing/deleted pods is handled as skip instead of failing the trigger.
- The previous unbounded pod-first waits were removed: container waits are now bounded and periodically re-check whether the Job has already completed.

**Regresssion tests for #64867**

- Trigger regression tests (triggers/test_job.py)

  - `test_run_completes_when_job_is_done_even_if_some_snapshot_pods_never_complete`: Verify the trigger does not hang when a pod from the initial snapshot never reaches terminal state after the Job is already complete.
  
  - `test_run_skips_deleted_snapshot_pod_and_completes_when_job_is_done`: verifies the trigger handles stale snapshot pods gracefully by skipping 404 Not Found pods and still finishing successfully with available XCom results.

  - `test_run_collects_later_pod_xcom_best_effort_after_job_done`: verifies post-completion best-effort behavior: once the Job is already complete, the trigger continues processing remaining snapshot pods, skips per-pod extraction failures, and still returns XCom from pods that can be read.

- Operator regression test (operators/test_job.py)

  - `test_execute_complete_supports_partial_xcom_results`: Verify `execute_complete` correctly handles partial `xcom_result` payloads (fewer XCom entries than initial pod snapshot), which is expected in `parallelism > completions` scenarios.

**Additional tests for new code**

- `test_wait_until_container_state_or_job_done_does_not_restart_wait_task`: Copilot pointed out that the naive implementation of the waiting loop may not work as expected on slow clusters because of constant coroutine retrying. The test validates that we don't recreate `wait_method` on every tick on a slow cluster. 

### Behavior change
- Task finalization is now Job-driven.
- `xcom_result` may be partial (fewer entries than initial `pod_names`) and this is expected.
- Missing pods (`404`) do not fail task completion.

### Risks

- With very small `poll_interval` values, the new bounded wait loop may generate extra timeout/cancel/retry iterations while waiting for pod container states. This does not fail the task by itself (it is expected retry behavior), but it can increase polling overhead and log noise until the Job reaches a terminal state.
- Best-effort post-job XCom no longer fails the task on per-pod extraction errors (e.g. RBAC/network). To keep this observable, the trigger now emits warnings and a summary with counters (`succeeded`, `skipped_missing`, `timed_out`, `failed_other`).

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-22T06:40:22.912388+00:00 head=6945383 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @holmuk** · by `@potiuk` · 2026-06-22 06:40 UTC
>
> Following up on a confirmation request from 34 days ago — review feedback from `@shahar1` is still waiting:
> - 1 unresolved review thread(s) need a reply or a fix.
>
> **The ball is in your court** — Reply or push a fix in each thread, then mark them resolved and ping `@shahar1` when ready.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->