### PR TITLE
fix(cli): change is_alive default to None in jobs list

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -646,10 +646,20 @@ class JobsOperations(BaseOperations):
     """Job operations."""
 
     def list(
-        self, job_type: str, hostname: str, is_alive: bool
+        self,
+        job_type: str | None = None,
+        hostname: str | None = None,
+        is_alive: bool | None = None,
     ) -> JobCollectionResponse | ServerResponseError:
         """List all jobs."""
-        params = {"job_type": job_type, "hostname": hostname, "is_alive": is_alive}
+        params: dict[str, Any] = {}
+        if job_type:
+            params["job_type"] = job_type
+        if hostname:
+            params["hostname"] = hostname
+        if is_alive is not None:
+            params["is_alive"] = is_alive
+
         return super().execute_list(path="jobs", data_model=JobCollectionResponse, params=params)
 
 

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -580,14 +580,15 @@ class CommandFactory:
             for parameter in operation.get("parameters"):
                 for parameter_key, parameter_type in parameter.items():
                     if self._is_primitive_type(type_name=parameter_type):
-                        is_bool = parameter_type == "bool"
+                        base_parameter_type = parameter_type.replace(" | None", "").strip()
+                        is_bool = base_parameter_type == "bool"
                         args.append(
                             self._create_arg(
                                 arg_flags=("--" + self._sanitize_arg_parameter_key(parameter_key),),
                                 arg_type=self._python_type_from_string(parameter_type),
                                 arg_action=argparse.BooleanOptionalAction if is_bool else None,
                                 arg_help=f"{parameter_key} for {operation.get('name')} operation in {operation.get('parent').name}",
-                                arg_default=False if is_bool else None,
+                                arg_default=None,
                             )
                         )
                     else:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1158,6 +1158,11 @@ class TestJobsOperations:
     def test_list(self):
         def handle_request(request: httpx.Request) -> httpx.Response:
             assert request.url.path == "/api/v2/jobs"
+            params = dict(request.url.params)
+            assert params["job_type"] == "job_type"
+            assert params["hostname"] == "hostname"
+            assert params["is_alive"] == "true"
+            assert params["limit"] == "50"
             return httpx.Response(200, json=json.loads(self.job_collection_response.model_dump_json()))
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))
@@ -1166,6 +1171,32 @@ class TestJobsOperations:
             hostname="hostname",
             is_alive=True,
         )
+        assert response == self.job_collection_response
+
+    @pytest.mark.parametrize(
+        ("job_type", "hostname", "is_alive", "expected_subset"),
+        [
+            (None, None, None, {}),
+            ("scheduler", None, None, {"job_type": "scheduler"}),
+            (None, "host-a", None, {"hostname": "host-a"}),
+            (None, None, False, {"is_alive": "false"}),
+        ],
+    )
+    def test_list_omits_empty_filters(self, job_type, hostname, is_alive, expected_subset):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v2/jobs"
+            params = dict(request.url.params)
+            assert params["limit"] == "50"
+            for key, value in expected_subset.items():
+                assert params[key] == value
+
+            assert ("job_type" in params) is ("job_type" in expected_subset)
+            assert ("hostname" in params) is ("hostname" in expected_subset)
+            assert ("is_alive" in params) is ("is_alive" in expected_subset)
+            return httpx.Response(200, json=json.loads(self.job_collection_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.jobs.list(job_type=job_type, hostname=hostname, is_alive=is_alive)
         assert response == self.job_collection_response
 
 

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -296,6 +296,36 @@ class TestCommandFactory:
                         assert arg.kwargs["default"] == test_arg[1]["default"]
                         assert arg.kwargs["type"] == test_arg[1]["type"]
 
+    def test_command_factory_optional_bool_uses_boolean_optional_action(self):
+        """Optional bool parameters should support --flag and --no-flag forms."""
+        temp_file = "test_command.py"
+        self._save_temp_operations_py(
+            temp_file=temp_file,
+            file_content="""
+                class JobsOperations(BaseOperations):
+                    def list(self, is_alive: bool | None = None) -> JobCollectionResponse | ServerResponseError:
+                        self.response = self.client.get("jobs")
+                        return JobCollectionResponse.model_validate_json(self.response.content)
+            """,
+        )
+
+        command_factory = CommandFactory(file_path=temp_file)
+        generated_group_commands = command_factory.group_commands
+
+        jobs_list_args = []
+        for generated_group_command in generated_group_commands:
+            if generated_group_command.name != "jobs":
+                continue
+            for sub_command in generated_group_command.subcommands:
+                if sub_command.name == "list":
+                    jobs_list_args = list(sub_command.args)
+                    break
+
+        is_alive_arg = next(arg for arg in jobs_list_args if arg.flags == ("--is-alive",))
+        assert is_alive_arg.kwargs["action"] == BooleanOptionalAction
+        assert is_alive_arg.kwargs["default"] is None
+        assert is_alive_arg.kwargs["type"] is bool
+
 
 class TestCliConfigMethods:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
This PR fixes a logic error where `jobs list` unintentionally filtered out active jobs because the `is_alive` parameter defaulted to `False`. By implementing three-state logic (True/False/None) and setting the default to `None`, the command now correctly returns all jobs unless an explicit filter is applied.

## Changes
- **CLI Configuration**: Updated the argument generation logic to set `arg_default=None` for boolean parameters to distinguish between "not specified" and "explicitly false."
- **Operations Layer**: Refactored `JobsOperations.list` to use a dynamic parameter mapping, ensuring `is_alive` is only sent to the API if explicitly set by the user.
- **Type Safety**: Improved type handling to support `bool | None` (Optional[bool]) and fixed Mypy type mismatch errors in the parameter dictionary.
- **Testing**: Added  unit tests to verify that `CommandFactory` correctly generates `BooleanOptionalAction` with a `None` default for optional boolean fields.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
