### PR TITLE
Fix stale system test documentation links

### DIFF
--- a/airflow-core/tests/system/example_empty.py
+++ b/airflow-core/tests/system/example_empty.py
@@ -44,5 +44,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/contributing-docs/12_provider_distributions.rst
+++ b/contributing-docs/12_provider_distributions.rst
@@ -297,7 +297,7 @@ You can see for example ``google`` provider which has very comprehensive documen
 * `Documentation <../../providers/google/docs>`_
 * `System tests/Example Dags <../providers/google/tests/system/google/>`_
 
-Part of the documentation are example dags (placed in the ``tests/system`` folder). The reason why
+Part of the documentation are example dags (placed in the ``providers/<provider>/tests/system`` folder). The reason why
 they are in ``tests/system`` is because we are using the example dags for various purposes:
 
 * showing real examples of how your provider classes (Operators/Sensors/Transfers) can be used

--- a/contributing-docs/testing/system_tests.rst
+++ b/contributing-docs/testing/system_tests.rst
@@ -114,7 +114,7 @@ There are multiple ways of running system tests. Each system test is a self-cont
 other Dag. Some tests may require access to external services, enabled APIs or specific permissions. Make sure to
 prepare your  environment correctly, depending on the system tests you want to run - some may require additional
 configuration which should be documented by the relevant providers in their subdirectory
-``tests/system/<provider_name>/README.md``.
+``providers/<provider_name>/tests/system/<provider_name>/README.md``.
 
 Running as Airflow Dags
 .......................
@@ -125,8 +125,8 @@ your Airflow instance as Dags and they will be automatically triggered. If the s
 how to set up the environment is documented in each provider's system tests directory. Make sure that all resource
 required by the tests are also imported.
 
-Running via Pytest + Breezee
-............................
+Running via Pytest + Breeze
+...........................
 
 Running system tests with pytest is the easiest with `Breeze <https://github.com/apache/airflow/blob/main/dev/breeze/doc/README.rst>`_.
 Breeze makes sure that the environment is pre-configured, and all additional required services are started,

--- a/providers/airbyte/tests/system/airbyte/example_airbyte_trigger_job.py
+++ b/providers/airbyte/tests/system/airbyte/example_airbyte_trigger_job.py
@@ -63,5 +63,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/alibaba/tests/system/alibaba/example_adb_spark_batch.py
+++ b/providers/alibaba/tests/system/alibaba/example_adb_spark_batch.py
@@ -65,5 +65,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/alibaba/tests/system/alibaba/example_adb_spark_sql.py
+++ b/providers/alibaba/tests/system/alibaba/example_adb_spark_sql.py
@@ -63,5 +63,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/alibaba/tests/system/alibaba/example_maxcompute_sql.py
+++ b/providers/alibaba/tests/system/alibaba/example_maxcompute_sql.py
@@ -48,5 +48,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/alibaba/tests/system/alibaba/example_oss_bucket.py
+++ b/providers/alibaba/tests/system/alibaba/example_oss_bucket.py
@@ -50,5 +50,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/alibaba/tests/system/alibaba/example_oss_object.py
+++ b/providers/alibaba/tests/system/alibaba/example_oss_object.py
@@ -80,5 +80,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/CONTRIBUTING.md
+++ b/providers/amazon/tests/system/amazon/CONTRIBUTING.md
@@ -30,7 +30,7 @@ will always be given.  For example, I stole that line from @potiuk!
 # Scope
 
 This guide is meant to be used in addition to the [community system test design
-guide](/tests/system/README.md) and only applies to system tests within the Amazon
+guide](/contributing-docs/testing/system_tests.rst) and only applies to system tests within the Amazon
 provider package, though other providers are welcome to adopt them as well.  In any
 cases of conflicting information or confusion, this document should take precedence
 within the Amazon provider package.

--- a/providers/amazon/tests/system/amazon/aws/example_appflow.py
+++ b/providers/amazon/tests/system/amazon/aws/example_appflow.py
@@ -122,5 +122,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_appflow_run.py
+++ b/providers/amazon/tests/system/amazon/aws/example_appflow_run.py
@@ -212,5 +212,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_athena.py
+++ b/providers/amazon/tests/system/amazon/aws/example_athena.py
@@ -193,5 +193,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_azure_blob_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_azure_blob_to_s3.py
@@ -83,5 +83,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_batch.py
+++ b/providers/amazon/tests/system/amazon/aws/example_batch.py
@@ -302,5 +302,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock.py
@@ -253,5 +253,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_batch_inference.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_batch_inference.py
@@ -183,5 +183,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
@@ -603,5 +603,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_cloudformation.py
+++ b/providers/amazon/tests/system/amazon/aws/example_cloudformation.py
@@ -120,5 +120,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_comprehend.py
+++ b/providers/amazon/tests/system/amazon/aws/example_comprehend.py
@@ -145,5 +145,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_comprehend_document_classifier.py
+++ b/providers/amazon/tests/system/amazon/aws/example_comprehend_document_classifier.py
@@ -226,5 +226,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_datasync.py
+++ b/providers/amazon/tests/system/amazon/aws/example_datasync.py
@@ -254,5 +254,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_dms.py
+++ b/providers/amazon/tests/system/amazon/aws/example_dms.py
@@ -448,5 +448,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_dms_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_dms_serverless.py
@@ -380,5 +380,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_dynamodb.py
+++ b/providers/amazon/tests/system/amazon/aws/example_dynamodb.py
@@ -136,5 +136,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_dynamodb_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_dynamodb_to_s3.py
@@ -269,5 +269,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ec2.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ec2.py
@@ -191,5 +191,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ecs.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ecs.py
@@ -238,5 +238,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ecs_fargate.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ecs_fargate.py
@@ -177,5 +177,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eks_templated.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_templated.py
@@ -154,5 +154,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_in_one_step.py
@@ -168,5 +168,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_fargate_profile.py
@@ -210,5 +210,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroup_in_one_step.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroup_in_one_step.py
@@ -189,5 +189,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eks_with_nodegroups.py
@@ -241,5 +241,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_emr.py
+++ b/providers/amazon/tests/system/amazon/aws/example_emr.py
@@ -238,5 +238,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_emr_eks.py
+++ b/providers/amazon/tests/system/amazon/aws/example_emr_eks.py
@@ -353,5 +353,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_emr_notebook_execution.py
+++ b/providers/amazon/tests/system/amazon/aws/example_emr_notebook_execution.py
@@ -118,5 +118,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_emr_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_emr_serverless.py
@@ -166,5 +166,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_eventbridge.py
+++ b/providers/amazon/tests/system/amazon/aws/example_eventbridge.py
@@ -81,5 +81,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ftp_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ftp_to_s3.py
@@ -83,5 +83,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_gcs_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_gcs_to_s3.py
@@ -134,5 +134,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_glacier_to_gcs.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glacier_to_gcs.py
@@ -127,5 +127,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_glue.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue.py
@@ -223,5 +223,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_glue_data_quality.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_data_quality.py
@@ -217,5 +217,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_glue_data_quality_with_recommendation.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_data_quality_with_recommendation.py
@@ -216,5 +216,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_glue_databrew.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_databrew.py
@@ -175,5 +175,5 @@ with DAG(DAG_ID, schedule="@once", start_date=pendulum.datetime(2023, 1, 1, tz="
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_google_api_sheets_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_google_api_sheets_to_s3.py
@@ -94,5 +94,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_google_api_youtube_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_google_api_youtube_to_s3.py
@@ -214,5 +214,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_hive_to_dynamodb.py
+++ b/providers/amazon/tests/system/amazon/aws/example_hive_to_dynamodb.py
@@ -173,5 +173,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_http_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_http_to_s3.py
@@ -142,5 +142,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_imap_attachment_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_imap_attachment_to_s3.py
@@ -101,5 +101,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py
+++ b/providers/amazon/tests/system/amazon/aws/example_kinesis_analytics.py
@@ -288,5 +288,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_lambda.py
+++ b/providers/amazon/tests/system/amazon/aws/example_lambda.py
@@ -148,5 +148,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_local_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_local_to_s3.py
@@ -102,5 +102,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_mongo_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mongo_to_s3.py
@@ -94,5 +94,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_mwaa.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa.py
@@ -179,5 +179,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_mwaa_airflow2.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa_airflow2.py
@@ -172,5 +172,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_neptune.py
+++ b/providers/amazon/tests/system/amazon/aws/example_neptune.py
@@ -92,5 +92,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_quicksight.py
+++ b/providers/amazon/tests/system/amazon/aws/example_quicksight.py
@@ -240,5 +240,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_rds_event.py
+++ b/providers/amazon/tests/system/amazon/aws/example_rds_event.py
@@ -138,5 +138,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_rds_export.py
+++ b/providers/amazon/tests/system/amazon/aws/example_rds_export.py
@@ -197,5 +197,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_rds_instance.py
+++ b/providers/amazon/tests/system/amazon/aws/example_rds_instance.py
@@ -123,5 +123,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_rds_snapshot.py
+++ b/providers/amazon/tests/system/amazon/aws/example_rds_snapshot.py
@@ -150,5 +150,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_redshift.py
+++ b/providers/amazon/tests/system/amazon/aws/example_redshift.py
@@ -264,5 +264,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_redshift_s3_transfers.py
+++ b/providers/amazon/tests/system/amazon/aws/example_redshift_s3_transfers.py
@@ -330,5 +330,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3.py
@@ -326,5 +326,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_dynamodb.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_dynamodb.py
@@ -200,5 +200,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_ftp.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_ftp.py
@@ -82,5 +82,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sftp.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sftp.py
@@ -82,5 +82,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
@@ -277,5 +277,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker.py
@@ -737,5 +737,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_condition.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_condition.py
@@ -175,5 +175,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_endpoint.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_endpoint.py
@@ -310,5 +310,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_notebook.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_notebook.py
@@ -103,5 +103,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_pipeline.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_pipeline.py
@@ -136,5 +136,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio.py
@@ -208,5 +208,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_salesforce_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_salesforce_to_s3.py
@@ -89,5 +89,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ses.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ses.py
@@ -114,5 +114,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sftp_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sftp_to_s3.py
@@ -82,5 +82,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sns.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sns.py
@@ -94,5 +94,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
@@ -227,5 +227,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_sqs.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sqs.py
@@ -118,5 +118,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_ssm.py
+++ b/providers/amazon/tests/system/amazon/aws/example_ssm.py
@@ -338,5 +338,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/amazon/tests/system/amazon/aws/example_step_functions.py
+++ b/providers/amazon/tests/system/amazon/aws/example_step_functions.py
@@ -127,5 +127,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_beam.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_beam.py
@@ -63,5 +63,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_beam_java_flink.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_beam_java_flink.py
@@ -62,5 +62,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_beam_java_spark.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_beam_java_spark.py
@@ -62,5 +62,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_go.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_go.py
@@ -105,5 +105,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_go_dataflow.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_go_dataflow.py
@@ -78,5 +78,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_java_dataflow.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_java_dataflow.py
@@ -68,5 +68,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_python.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_python.py
@@ -122,5 +122,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_python_async.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_python_async.py
@@ -131,5 +131,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/beam/tests/system/apache/beam/example_python_dataflow.py
+++ b/providers/apache/beam/tests/system/apache/beam/example_python_dataflow.py
@@ -81,5 +81,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/cassandra/tests/system/apache/cassandra/example_cassandra_dag.py
+++ b/providers/apache/cassandra/tests/system/apache/cassandra/example_cassandra_dag.py
@@ -57,5 +57,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/drill/tests/system/apache/drill/example_drill_dag.py
+++ b/providers/apache/drill/tests/system/apache/drill/example_drill_dag.py
@@ -49,5 +49,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/druid/tests/system/apache/druid/example_druid_dag.py
+++ b/providers/apache/druid/tests/system/apache/druid/example_druid_dag.py
@@ -57,5 +57,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/hive/tests/system/apache/hive/example_hive.py
+++ b/providers/apache/hive/tests/system/apache/hive/example_hive.py
@@ -79,5 +79,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/hive/tests/system/apache/hive/example_twitter_dag.py
+++ b/providers/apache/hive/tests/system/apache/hive/example_twitter_dag.py
@@ -159,5 +159,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/iceberg/tests/system/apache/iceberg/example_iceberg.py
+++ b/providers/apache/iceberg/tests/system/apache/iceberg/example_iceberg.py
@@ -50,5 +50,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/impala/tests/system/apache/impala/example_impala.py
+++ b/providers/apache/impala/tests/system/apache/impala/example_impala.py
@@ -85,5 +85,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/kafka/tests/system/apache/kafka/example_dag_event_listener.py
+++ b/providers/apache/kafka/tests/system/apache/kafka/example_dag_event_listener.py
@@ -122,5 +122,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/kafka/tests/system/apache/kafka/example_dag_hello_kafka.py
+++ b/providers/apache/kafka/tests/system/apache/kafka/example_dag_hello_kafka.py
@@ -242,5 +242,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/kafka/tests/system/apache/kafka/example_dag_kafka_message_queue_trigger.py
+++ b/providers/apache/kafka/tests/system/apache/kafka/example_dag_kafka_message_queue_trigger.py
@@ -51,5 +51,5 @@ with DAG(dag_id="example_kafka_watcher_1", schedule=[asset]) as dag:
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/kafka/tests/system/apache/kafka/example_dag_message_queue_trigger.py
+++ b/providers/apache/kafka/tests/system/apache/kafka/example_dag_message_queue_trigger.py
@@ -47,5 +47,5 @@ with DAG(dag_id="example_kafka_watcher_2", schedule=[asset]) as dag:
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/kylin/tests/system/apache/kylin/example_kylin_dag.py
+++ b/providers/apache/kylin/tests/system/apache/kylin/example_kylin_dag.py
@@ -129,5 +129,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/livy/tests/system/apache/livy/example_livy.py
+++ b/providers/apache/livy/tests/system/apache/livy/example_livy.py
@@ -81,5 +81,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/pig/tests/system/apache/pig/example_pig.py
+++ b/providers/apache/pig/tests/system/apache/pig/example_pig.py
@@ -46,5 +46,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/pinot/tests/system/apache/pinot/example_pinot_dag.py
+++ b/providers/apache/pinot/tests/system/apache/pinot/example_pinot_dag.py
@@ -61,5 +61,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/spark/tests/system/apache/spark/example_pyspark.py
+++ b/providers/apache/spark/tests/system/apache/spark/example_pyspark.py
@@ -75,5 +75,5 @@ dag = example_pyspark()  # type: ignore
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/spark/tests/system/apache/spark/example_spark_dag.py
+++ b/providers/apache/spark/tests/system/apache/spark/example_spark_dag.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/apache/tinkerpop/tests/system/apache/tinkerpop/example_gremlin_dag.py
+++ b/providers/apache/tinkerpop/tests/system/apache/tinkerpop/example_gremlin_dag.py
@@ -48,5 +48,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/asana/tests/system/asana/example_asana.py
+++ b/providers/asana/tests/system/asana/example_asana.py
@@ -109,5 +109,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes.py
@@ -175,5 +175,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_async.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_async.py
@@ -206,5 +206,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_cmd_decorator.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_cmd_decorator.py
@@ -72,5 +72,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_decorator.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_decorator.py
@@ -70,5 +70,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_job.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_job.py
@@ -102,5 +102,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_kueue.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_kueue.py
@@ -140,5 +140,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_resource.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_kubernetes_resource.py
@@ -80,5 +80,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_spark_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/system/cncf/kubernetes/example_spark_kubernetes.py
@@ -84,5 +84,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/cohere/tests/system/cohere/example_cohere_embedding_operator.py
+++ b/providers/cohere/tests/system/cohere/example_cohere_embedding_operator.py
@@ -36,5 +36,5 @@ with DAG("example_cohere_embedding", schedule=None, start_date=datetime(2023, 1,
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/io/tests/system/common/io/example_file_transfer_local_to_s3.py
+++ b/providers/common/io/tests/system/common/io/example_file_transfer_local_to_s3.py
@@ -99,5 +99,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/messaging/tests/system/common/messaging/example_message_queue_trigger.py
+++ b/providers/common/messaging/tests/system/common/messaging/example_message_queue_trigger.py
@@ -33,5 +33,5 @@ with DAG(dag_id="example_msgq_watcher", schedule=[asset]) as dag:
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_generic_transfer.py
+++ b/providers/common/sql/tests/system/common/sql/example_generic_transfer.py
@@ -58,5 +58,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_sql_column_table_check.py
+++ b/providers/common/sql/tests/system/common/sql/example_sql_column_table_check.py
@@ -81,5 +81,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_sql_execute_query.py
+++ b/providers/common/sql/tests/system/common/sql/example_sql_execute_query.py
@@ -68,5 +68,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_sql_insert_rows.py
+++ b/providers/common/sql/tests/system/common/sql/example_sql_insert_rows.py
@@ -86,5 +86,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_sql_threshold_check.py
+++ b/providers/common/sql/tests/system/common/sql/example_sql_threshold_check.py
@@ -58,5 +58,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/common/sql/tests/system/common/sql/example_sql_value_check.py
+++ b/providers/common/sql/tests/system/common/sql/example_sql_value_check.py
@@ -58,5 +58,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/databricks/tests/system/databricks/example_databricks.py
+++ b/providers/databricks/tests/system/databricks/example_databricks.py
@@ -255,5 +255,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/databricks/tests/system/databricks/example_databricks_repos.py
+++ b/providers/databricks/tests/system/databricks/example_databricks_repos.py
@@ -86,5 +86,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/databricks/tests/system/databricks/example_databricks_sensors.py
+++ b/providers/databricks/tests/system/databricks/example_databricks_sensors.py
@@ -112,5 +112,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/databricks/tests/system/databricks/example_databricks_sql.py
+++ b/providers/databricks/tests/system/databricks/example_databricks_sql.py
@@ -121,5 +121,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/databricks/tests/system/databricks/example_databricks_workflow.py
+++ b/providers/databricks/tests/system/databricks/example_databricks_workflow.py
@@ -151,5 +151,5 @@ with dag:
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/dbt/cloud/tests/system/dbt/cloud/example_dbt_cloud.py
+++ b/providers/dbt/cloud/tests/system/dbt/cloud/example_dbt_cloud.py
@@ -111,5 +111,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/dingding/tests/system/dingding/example_dingding.py
+++ b/providers/dingding/tests/system/dingding/example_dingding.py
@@ -207,5 +207,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/docker/tests/system/docker/example_docker.py
+++ b/providers/docker/tests/system/docker/example_docker.py
@@ -59,5 +59,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/docker/tests/system/docker/example_docker_copy_data.py
+++ b/providers/docker/tests/system/docker/example_docker_copy_data.py
@@ -106,5 +106,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/docker/tests/system/docker/example_docker_swarm.py
+++ b/providers/docker/tests/system/docker/example_docker_swarm.py
@@ -49,5 +49,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/docker/tests/system/docker/example_taskflow_api_docker_virtualenv.py
+++ b/providers/docker/tests/system/docker/example_taskflow_api_docker_virtualenv.py
@@ -123,7 +123,7 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)
 
 # [END tutorial]
@@ -131,5 +131,5 @@ test_run = get_test_run(dag)
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/elasticsearch/tests/system/elasticsearch/example_elasticsearch_query.py
+++ b/providers/elasticsearch/tests/system/elasticsearch/example_elasticsearch_query.py
@@ -82,5 +82,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/exasol/tests/system/exasol/example_exasol.py
+++ b/providers/exasol/tests/system/exasol/example_exasol.py
@@ -87,5 +87,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/ftp/tests/system/ftp/example_ftp.py
+++ b/providers/ftp/tests/system/ftp/example_ftp.py
@@ -95,5 +95,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/github/tests/system/github/example_github.py
+++ b/providers/github/tests/system/github/example_github.py
@@ -102,5 +102,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/ads/example_ads.py
+++ b/providers/google/tests/system/google/ads/example_ads.py
@@ -268,5 +268,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/alloy_db/example_alloy_db.py
+++ b/providers/google/tests/system/google/cloud/alloy_db/example_alloy_db.py
@@ -302,5 +302,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/azure/example_azure_blob_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/azure/example_azure_blob_to_gcs.py
@@ -67,5 +67,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/azure/example_azure_fileshare_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/azure/example_azure_fileshare_to_gcs.py
@@ -92,5 +92,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_dataset.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_dataset.py
@@ -99,5 +99,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_dts.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_dts.py
@@ -204,5 +204,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_jobs.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_jobs.py
@@ -200,5 +200,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_operations.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_operations.py
@@ -162,5 +162,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries.py
@@ -257,5 +257,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries_async.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_queries_async.py
@@ -283,5 +283,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
@@ -181,5 +181,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_tables.py
@@ -288,5 +288,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_bigquery.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_bigquery.py
@@ -116,5 +116,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_gcs.py
@@ -123,5 +123,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_mssql.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_mssql.py
@@ -328,5 +328,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_mysql.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_mysql.py
@@ -99,5 +99,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_postgres.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_to_postgres.py
@@ -361,5 +361,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_transfer.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_transfer.py
@@ -140,5 +140,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_value_check.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_value_check.py
@@ -144,11 +144,11 @@ with DAG(
     # when "tearDown" task with trigger rule is part of the DAG
     list(dag.tasks) >> watcher()
 
-    # Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+    # Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
     test_run = get_test_run(dag)
 
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/bigtable/example_bigtable.py
+++ b/providers/google/tests/system/google/cloud/bigtable/example_bigtable.py
@@ -243,5 +243,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_batch/example_cloud_batch.py
+++ b/providers/google/tests/system/google/cloud/cloud_batch/example_cloud_batch.py
@@ -203,5 +203,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_build/example_cloud_build.py
+++ b/providers/google/tests/system/google/cloud/cloud_build/example_cloud_build.py
@@ -285,5 +285,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_build/example_cloud_build_trigger.py
+++ b/providers/google/tests/system/google/cloud/cloud_build/example_cloud_build_trigger.py
@@ -200,5 +200,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_functions/example_functions.py
+++ b/providers/google/tests/system/google/cloud/cloud_functions/example_functions.py
@@ -132,5 +132,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
+++ b/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
@@ -212,5 +212,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
+++ b/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
@@ -280,5 +280,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_run/example_cloud_run.py
+++ b/providers/google/tests/system/google/cloud/cloud_run/example_cloud_run.py
@@ -450,5 +450,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_run/example_cloud_run_service.py
+++ b/providers/google/tests/system/google/cloud/cloud_run/example_cloud_run_service.py
@@ -97,5 +97,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql.py
+++ b/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql.py
@@ -308,5 +308,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query.py
+++ b/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query.py
@@ -555,5 +555,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query_iam.py
+++ b/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query_iam.py
@@ -439,5 +439,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query_ssl.py
+++ b/providers/google/tests/system/google/cloud/cloud_sql/example_cloud_sql_query_ssl.py
@@ -500,5 +500,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/composer/example_cloud_composer.py
+++ b/providers/google/tests/system/google/cloud/composer/example_cloud_composer.py
@@ -305,5 +305,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/compute/example_compute.py
+++ b/providers/google/tests/system/google/cloud/compute/example_compute.py
@@ -282,5 +282,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/compute/example_compute_igm.py
+++ b/providers/google/tests/system/google/cloud/compute/example_compute_igm.py
@@ -249,5 +249,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/compute/example_compute_ssh.py
+++ b/providers/google/tests/system/google/cloud/compute/example_compute_ssh.py
@@ -153,5 +153,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/compute/example_compute_ssh_os_login.py
+++ b/providers/google/tests/system/google/cloud/compute/example_compute_ssh_os_login.py
@@ -161,5 +161,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/compute/example_compute_ssh_parallel.py
+++ b/providers/google/tests/system/google/cloud/compute/example_compute_ssh_parallel.py
@@ -154,5 +154,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_deidentify_content.py
+++ b/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_deidentify_content.py
@@ -171,5 +171,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_info_types.py
+++ b/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_info_types.py
@@ -168,5 +168,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_inspect_template.py
+++ b/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_inspect_template.py
@@ -129,5 +129,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_job.py
+++ b/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_job.py
@@ -104,5 +104,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_job_trigger.py
+++ b/providers/google/tests/system/google/cloud/data_loss_prevention/example_dlp_job_trigger.py
@@ -109,5 +109,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_go.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_go.py
@@ -156,5 +156,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_java_streaming.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_java_streaming.py
@@ -184,5 +184,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_java.py
@@ -133,5 +133,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_python.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_python.py
@@ -129,5 +129,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_python_async.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_native_python_async.py
@@ -193,5 +193,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_pipeline.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_pipeline.py
@@ -151,5 +151,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_pipeline_streaming.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_pipeline_streaming.py
@@ -161,5 +161,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_sensors_deferrable.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_sensors_deferrable.py
@@ -192,5 +192,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_streaming_python.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_streaming_python.py
@@ -169,5 +169,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_template.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_template.py
@@ -172,5 +172,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataflow/example_dataflow_yaml.py
+++ b/providers/google/tests/system/google/cloud/dataflow/example_dataflow_yaml.py
@@ -178,5 +178,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataform/example_dataform.py
+++ b/providers/google/tests/system/google/cloud/dataform/example_dataform.py
@@ -384,5 +384,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/datafusion/example_datafusion.py
+++ b/providers/google/tests/system/google/cloud/datafusion/example_datafusion.py
@@ -358,5 +358,5 @@ list(dag.tasks) >> watcher()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataplex/example_dataplex.py
+++ b/providers/google/tests/system/google/cloud/dataplex/example_dataplex.py
@@ -220,5 +220,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataplex/example_dataplex_catalog.py
+++ b/providers/google/tests/system/google/cloud/dataplex/example_dataplex_catalog.py
@@ -358,5 +358,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataplex/example_dataplex_dp.py
+++ b/providers/google/tests/system/google/cloud/dataplex/example_dataplex_dp.py
@@ -347,5 +347,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataplex/example_dataplex_dq.py
+++ b/providers/google/tests/system/google/cloud/dataplex/example_dataplex_dq.py
@@ -381,5 +381,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataprep/example_dataprep.py
+++ b/providers/google/tests/system/google/cloud/dataprep/example_dataprep.py
@@ -319,5 +319,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch.py
@@ -189,5 +189,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch_deferrable.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch_deferrable.py
@@ -105,5 +105,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch_persistent.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_batch_persistent.py
@@ -155,5 +155,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_create_existing_stopped_cluster.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_create_existing_stopped_cluster.py
@@ -134,5 +134,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_deferrable.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_deferrable.py
@@ -151,5 +151,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_diagnose.py
@@ -131,5 +131,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_generator.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_generator.py
@@ -151,5 +151,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_start_stop.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_start_stop.py
@@ -124,5 +124,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_update.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_cluster_update.py
@@ -134,5 +134,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_flink.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_flink.py
@@ -138,5 +138,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_gke.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_gke.py
@@ -157,5 +157,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_hadoop.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_hadoop.py
@@ -137,5 +137,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_hive.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_hive.py
@@ -140,5 +140,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_pig.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_pig.py
@@ -124,5 +124,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_presto.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_presto.py
@@ -129,5 +129,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_pyspark.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_pyspark.py
@@ -156,5 +156,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark.py
@@ -125,5 +125,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_async.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_async.py
@@ -135,5 +135,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_deferrable.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_deferrable.py
@@ -126,5 +126,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_sql.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_spark_sql.py
@@ -122,5 +122,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_sparkr.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_sparkr.py
@@ -153,5 +153,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_trino.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_trino.py
@@ -131,5 +131,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_workflow.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_workflow.py
@@ -113,5 +113,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc/example_dataproc_workflow_deferrable.py
+++ b/providers/google/tests/system/google/cloud/dataproc/example_dataproc_workflow_deferrable.py
@@ -117,5 +117,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore.py
+++ b/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore.py
@@ -206,5 +206,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore_backup.py
+++ b/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore_backup.py
@@ -134,5 +134,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore_hive_partition_sensor.py
+++ b/providers/google/tests/system/google/cloud/dataproc_metastore/example_dataproc_metastore_hive_partition_sensor.py
@@ -251,5 +251,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/datastore/example_datastore_commit.py
+++ b/providers/google/tests/system/google/cloud/datastore/example_datastore_commit.py
@@ -174,5 +174,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/datastore/example_datastore_query.py
+++ b/providers/google/tests/system/google/cloud/datastore/example_datastore_query.py
@@ -89,5 +89,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/datastore/example_datastore_rollback.py
+++ b/providers/google/tests/system/google/cloud/datastore/example_datastore_rollback.py
@@ -72,5 +72,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_calendar_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_calendar_to_gcs.py
@@ -123,5 +123,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_firestore.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_firestore.py
@@ -180,5 +180,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_acl.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_acl.py
@@ -122,5 +122,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_copy_delete.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_copy_delete.py
@@ -143,5 +143,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_sensor.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_sensor.py
@@ -205,5 +205,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_bigquery.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_bigquery.py
@@ -102,5 +102,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_bigquery_async.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_bigquery_async.py
@@ -195,5 +195,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gcs.py
@@ -306,5 +306,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gdrive.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gdrive.py
@@ -209,5 +209,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_sftp.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_sftp.py
@@ -134,5 +134,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_sheets.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_sheets.py
@@ -137,5 +137,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_transform.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_transform.py
@@ -115,5 +115,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_transform_timespan.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_transform_timespan.py
@@ -150,5 +150,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_upload_download.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_upload_download.py
@@ -112,5 +112,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_gdrive_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gdrive_to_gcs.py
@@ -171,5 +171,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_http_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_http_to_gcs.py
@@ -111,5 +111,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_mssql_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_mssql_to_gcs.py
@@ -98,5 +98,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_mysql_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_mysql_to_gcs.py
@@ -308,5 +308,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_oracle_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_oracle_to_gcs.py
@@ -77,5 +77,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_presto_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_presto_to_gcs.py
@@ -219,5 +219,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_s3_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_s3_to_gcs.py
@@ -137,5 +137,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_salesforce_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_salesforce_to_gcs.py
@@ -160,5 +160,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_sftp_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_sftp_to_gcs.py
@@ -140,5 +140,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_sheets.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_sheets.py
@@ -152,5 +152,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_sheets_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_sheets_to_gcs.py
@@ -128,5 +128,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gcs/example_trino_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_trino_to_gcs.py
@@ -233,5 +233,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_gemini_batch_api.py
+++ b/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_gemini_batch_api.py
@@ -373,5 +373,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_generative_model.py
+++ b/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_generative_model.py
@@ -351,5 +351,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_generative_model_tuning.py
+++ b/providers/google/tests/system/google/cloud/gen_ai/example_gen_ai_generative_model_tuning.py
@@ -185,5 +185,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine.py
@@ -135,5 +135,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
@@ -139,5 +139,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_job.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_job.py
@@ -278,5 +278,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_kueue.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_kueue.py
@@ -193,5 +193,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_ray.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_ray.py
@@ -97,5 +97,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
+++ b/providers/google/tests/system/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
@@ -115,5 +115,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/looker/example_looker.py
+++ b/providers/google/tests/system/google/cloud/looker/example_looker.py
@@ -78,5 +78,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_cluster.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_cluster.py
@@ -141,5 +141,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_consumer_group.py
@@ -266,5 +266,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_topic.py
+++ b/providers/google/tests/system/google/cloud/managed_kafka/example_managed_kafka_topic.py
@@ -184,5 +184,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/ml_engine/example_mlengine.py
+++ b/providers/google/tests/system/google/cloud/ml_engine/example_mlengine.py
@@ -293,5 +293,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/natural_language/example_natural_language.py
+++ b/providers/google/tests/system/google/cloud/natural_language/example_natural_language.py
@@ -127,5 +127,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/pubsub/example_pubsub.py
+++ b/providers/google/tests/system/google/cloud/pubsub/example_pubsub.py
@@ -160,5 +160,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/pubsub/example_pubsub_deferrable.py
+++ b/providers/google/tests/system/google/cloud/pubsub/example_pubsub_deferrable.py
@@ -115,5 +115,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/ray/example_ray_job.py
+++ b/providers/google/tests/system/google/cloud/ray/example_ray_job.py
@@ -163,5 +163,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/spanner/example_spanner.py
+++ b/providers/google/tests/system/google/cloud/spanner/example_spanner.py
@@ -175,5 +175,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/speech_to_text/example_speech_to_text.py
+++ b/providers/google/tests/system/google/cloud/speech_to_text/example_speech_to_text.py
@@ -103,5 +103,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/sql_to_sheets/example_sql_to_sheets.py
+++ b/providers/google/tests/system/google/cloud/sql_to_sheets/example_sql_to_sheets.py
@@ -311,5 +311,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/stackdriver/example_stackdriver.py
+++ b/providers/google/tests/system/google/cloud/stackdriver/example_stackdriver.py
@@ -241,5 +241,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
+++ b/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_aws.py
@@ -297,5 +297,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_gcp.py
+++ b/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_gcp.py
@@ -216,5 +216,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_gcs_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/storage_transfer/example_cloud_storage_transfer_service_gcs_to_gcs.py
@@ -132,5 +132,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/tasks/example_queue.py
+++ b/providers/google/tests/system/google/cloud/tasks/example_queue.py
@@ -188,5 +188,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/tasks/example_tasks.py
+++ b/providers/google/tests/system/google/cloud/tasks/example_tasks.py
@@ -171,5 +171,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/text_to_speech/example_text_to_speech.py
+++ b/providers/google/tests/system/google/cloud/text_to_speech/example_text_to_speech.py
@@ -92,5 +92,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/transfers/example_facebook_ads_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/transfers/example_facebook_ads_to_gcs.py
@@ -165,5 +165,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/transfers/example_gcs_to_sftp.py
+++ b/providers/google/tests/system/google/cloud/transfers/example_gcs_to_sftp.py
@@ -185,5 +185,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/transfers/example_gdrive_to_local.py
+++ b/providers/google/tests/system/google/cloud/transfers/example_gdrive_to_local.py
@@ -173,5 +173,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/transfers/example_postgres_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/transfers/example_postgres_to_gcs.py
@@ -289,5 +289,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate.py
@@ -75,5 +75,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate_dataset.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate_dataset.py
@@ -154,5 +154,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate_document.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate_document.py
@@ -132,5 +132,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate_glossary.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate_glossary.py
@@ -112,5 +112,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate_model.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate_model.py
@@ -180,5 +180,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate/example_translate_text.py
+++ b/providers/google/tests/system/google/cloud/translate/example_translate_text.py
@@ -113,5 +113,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/translate_speech/example_translate_speech.py
+++ b/providers/google/tests/system/google/cloud/translate_speech/example_translate_speech.py
@@ -124,5 +124,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_forecasting_training.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_forecasting_training.py
@@ -163,5 +163,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_image_object_detection.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_image_object_detection.py
@@ -146,5 +146,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_list_training.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_list_training.py
@@ -60,5 +60,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_tabular_training.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_auto_ml_tabular_training.py
@@ -153,5 +153,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_batch_prediction_job.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_batch_prediction_job.py
@@ -244,5 +244,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_container.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_container.py
@@ -220,5 +220,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_job.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_job.py
@@ -265,5 +265,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_job_python_package.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_custom_job_python_package.py
@@ -224,5 +224,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_dataset.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_dataset.py
@@ -243,5 +243,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_endpoint.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_endpoint.py
@@ -222,5 +222,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_experiment_service.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_experiment_service.py
@@ -139,5 +139,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
@@ -251,5 +251,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_hyperparameter_tuning_job.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_hyperparameter_tuning_job.py
@@ -192,5 +192,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_list_custom_jobs.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_list_custom_jobs.py
@@ -59,5 +59,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_model_service.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_model_service.py
@@ -374,5 +374,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_pipeline_job.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_pipeline_job.py
@@ -188,5 +188,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_ray.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_ray.py
@@ -133,5 +133,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/video_intelligence/example_video_intelligence.py
+++ b/providers/google/tests/system/google/cloud/video_intelligence/example_video_intelligence.py
@@ -168,5 +168,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
@@ -205,5 +205,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vision/example_vision_autogenerated.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_autogenerated.py
@@ -282,5 +282,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/vision/example_vision_explicit.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_explicit.py
@@ -293,5 +293,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/cloud/workflows/example_workflows.py
+++ b/providers/google/tests/system/google/cloud/workflows/example_workflows.py
@@ -241,5 +241,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/event_scheduling/example_event_schedule_pubsub.py
+++ b/providers/google/tests/system/google/event_scheduling/example_event_schedule_pubsub.py
@@ -92,5 +92,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/leveldb/example_leveldb.py
+++ b/providers/google/tests/system/google/leveldb/example_leveldb.py
@@ -73,5 +73,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
+++ b/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
@@ -218,5 +218,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/marketing_platform/example_bid_manager.py
+++ b/providers/google/tests/system/google/marketing_platform/example_bid_manager.py
@@ -210,5 +210,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/marketing_platform/example_campaign_manager.py
+++ b/providers/google/tests/system/google/marketing_platform/example_campaign_manager.py
@@ -325,5 +325,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/marketing_platform/example_display_video.py
+++ b/providers/google/tests/system/google/marketing_platform/example_display_video.py
@@ -234,5 +234,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/marketing_platform/example_search_ads.py
+++ b/providers/google/tests/system/google/marketing_platform/example_search_ads.py
@@ -104,5 +104,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/google/tests/system/google/suite/example_local_to_drive.py
+++ b/providers/google/tests/system/google/suite/example_local_to_drive.py
@@ -153,5 +153,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/http/tests/system/http/example_http.py
+++ b/providers/http/tests/system/http/example_http.py
@@ -159,5 +159,5 @@ task_post_op_formenc >> task_get_paginated
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/influxdb/tests/system/influxdb/example_influxdb.py
+++ b/providers/influxdb/tests/system/influxdb/example_influxdb.py
@@ -73,5 +73,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/influxdb/tests/system/influxdb/example_influxdb_query.py
+++ b/providers/influxdb/tests/system/influxdb/example_influxdb_query.py
@@ -45,5 +45,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/jdbc/tests/system/jdbc/example_jdbc_queries.py
+++ b/providers/jdbc/tests/system/jdbc/example_jdbc_queries.py
@@ -67,5 +67,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/jenkins/tests/system/jenkins/example_jenkins_job_trigger.py
+++ b/providers/jenkins/tests/system/jenkins/example_jenkins_job_trigger.py
@@ -79,5 +79,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_adf_run_pipeline.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_adf_run_pipeline.py
@@ -115,5 +115,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_create.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_create.py
@@ -54,5 +54,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_delete.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_delete.py
@@ -54,5 +54,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_list.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_adls_list.py
@@ -51,5 +51,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_batch_operator.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_batch_operator.py
@@ -59,5 +59,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_container_instances.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_container_instances.py
@@ -92,5 +92,5 @@ with DAG(
     )
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_cosmosdb.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_cosmosdb.py
@@ -72,5 +72,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_service_bus.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_service_bus.py
@@ -180,5 +180,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_synapse.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_azure_synapse.py
@@ -71,5 +71,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_event_schedule_asb.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_event_schedule_asb.py
@@ -70,5 +70,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_fileshare.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_fileshare.py
@@ -67,5 +67,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_local_to_adls.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_local_to_adls.py
@@ -55,5 +55,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_local_to_wasb.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_local_to_wasb.py
@@ -57,5 +57,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_msfabric.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_msfabric.py
@@ -59,5 +59,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_msgraph.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_msgraph.py
@@ -57,5 +57,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi.py
@@ -106,5 +106,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_list.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_list.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_dataset_refresh.py
@@ -97,5 +97,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_workspace_list.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_powerbi_workspace_list.py
@@ -86,5 +86,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_s3_to_wasb.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_s3_to_wasb.py
@@ -116,5 +116,5 @@ with DAG(dag_id=DAG_ID, start_date=datetime(2024, 1, 1), schedule="@once", catch
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_sftp_to_wasb.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_sftp_to_wasb.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_synapse_run_pipeline.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_synapse_run_pipeline.py
@@ -51,5 +51,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/azure/tests/system/microsoft/azure/example_wasb_sensors.py
+++ b/providers/microsoft/azure/tests/system/microsoft/azure/example_wasb_sensors.py
@@ -64,5 +64,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/mssql/tests/system/microsoft/mssql/example_mssql.py
+++ b/providers/microsoft/mssql/tests/system/microsoft/mssql/example_mssql.py
@@ -153,5 +153,5 @@ with DAG(
     list(dag.tasks) >> watcher()
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/microsoft/winrm/tests/system/microsoft/winrm/example_winrm.py
+++ b/providers/microsoft/winrm/tests/system/microsoft/winrm/example_winrm.py
@@ -72,5 +72,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/mysql/tests/system/mysql/example_mysql.py
+++ b/providers/mysql/tests/system/mysql/example_mysql.py
@@ -61,5 +61,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/neo4j/tests/system/neo4j/example_neo4j.py
+++ b/providers/neo4j/tests/system/neo4j/example_neo4j.py
@@ -50,5 +50,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/neo4j/tests/system/neo4j/example_neo4j_query.py
+++ b/providers/neo4j/tests/system/neo4j/example_neo4j_query.py
@@ -51,5 +51,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/neo4j/tests/system/neo4j/example_neo4j_sensor.py
+++ b/providers/neo4j/tests/system/neo4j/example_neo4j_sensor.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openai/tests/system/openai/example_openai.py
+++ b/providers/openai/tests/system/openai/example_openai.py
@@ -108,5 +108,5 @@ example_openai_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openai/tests/system/openai/example_trigger_batch_operator.py
+++ b/providers/openai/tests/system/openai/example_trigger_batch_operator.py
@@ -117,5 +117,5 @@ openai_batch_chat_completions()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_base_complex_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_base_complex_dag.py
@@ -162,5 +162,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_base_simple_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_base_simple_dag.py
@@ -63,5 +63,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_defer_simple_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_defer_simple_dag.py
@@ -69,5 +69,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_docs_file_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_docs_file_dag.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_simple_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_mapped_simple_dag.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_asset_or_time_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_asset_or_time_dag.py
@@ -74,5 +74,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_cron_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_cron_dag.py
@@ -51,5 +51,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_complex_assets_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_complex_assets_dag.py
@@ -63,5 +63,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_multiple_assets_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_multiple_assets_dag.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_single_asset_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_list_single_asset_dag.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_multiple_assets_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_multiple_assets_dag.py
@@ -55,5 +55,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_single_asset_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_single_asset_dag.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_timetable_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_schedule_timetable_dag.py
@@ -61,5 +61,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_setup_teardown_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_setup_teardown_dag.py
@@ -66,5 +66,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_short_circuit_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_short_circuit_dag.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_task_groups_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_task_groups_dag.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_taskflow_simple_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_taskflow_simple_dag.py
@@ -59,5 +59,5 @@ openlineage_taskflow_simple_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag.py
@@ -84,5 +84,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag_deferrable.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_trigger_dag_deferrable.py
@@ -89,5 +89,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/openlineage/tests/system/openlineage/example_openlineage_versioned_dag.py
+++ b/providers/openlineage/tests/system/openlineage/example_openlineage_versioned_dag.py
@@ -58,5 +58,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/opensearch/tests/system/opensearch/example_opensearch.py
+++ b/providers/opensearch/tests/system/opensearch/example_opensearch.py
@@ -126,5 +126,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/opsgenie/tests/system/opsgenie/example_opsgenie_alert.py
+++ b/providers/opsgenie/tests/system/opsgenie/example_opsgenie_alert.py
@@ -53,5 +53,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/opsgenie/tests/system/opsgenie/example_opsgenie_notifier.py
+++ b/providers/opsgenie/tests/system/opsgenie/example_opsgenie_notifier.py
@@ -39,5 +39,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/oracle/tests/system/oracle/example_oracle.py
+++ b/providers/oracle/tests/system/oracle/example_oracle.py
@@ -89,5 +89,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/papermill/tests/system/papermill/example_papermill.py
+++ b/providers/papermill/tests/system/papermill/example_papermill.py
@@ -54,5 +54,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/papermill/tests/system/papermill/example_papermill_remote_verify.py
+++ b/providers/papermill/tests/system/papermill/example_papermill_remote_verify.py
@@ -82,5 +82,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/papermill/tests/system/papermill/example_papermill_verify.py
+++ b/providers/papermill/tests/system/papermill/example_papermill_verify.py
@@ -79,5 +79,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pgvector/tests/system/pgvector/example_pgvector.py
+++ b/providers/pgvector/tests/system/pgvector/example_pgvector.py
@@ -80,5 +80,5 @@ example_pgvector_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pgvector/tests/system/pgvector/example_pgvector_openai.py
+++ b/providers/pgvector/tests/system/pgvector/example_pgvector_openai.py
@@ -94,5 +94,5 @@ example_pgvector_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pinecone/tests/system/pinecone/example_create_pod_index.py
+++ b/providers/pinecone/tests/system/pinecone/example_create_pod_index.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pinecone/tests/system/pinecone/example_create_serverless_index.py
+++ b/providers/pinecone/tests/system/pinecone/example_create_serverless_index.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pinecone/tests/system/pinecone/example_dag_pinecone.py
+++ b/providers/pinecone/tests/system/pinecone/example_dag_pinecone.py
@@ -54,5 +54,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_cohere.py
@@ -90,5 +90,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
+++ b/providers/pinecone/tests/system/pinecone/example_pinecone_openai.py
@@ -120,5 +120,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/postgres/tests/system/postgres/example_postgres.py
+++ b/providers/postgres/tests/system/postgres/example_postgres.py
@@ -88,5 +88,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/presto/tests/system/presto/example_gcs_to_presto.py
+++ b/providers/presto/tests/system/presto/example_gcs_to_presto.py
@@ -52,5 +52,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/presto/tests/system/presto/example_presto.py
+++ b/providers/presto/tests/system/presto/example_presto.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/qdrant/tests/system/qdrant/example_dag_qdrant.py
+++ b/providers/qdrant/tests/system/qdrant/example_dag_qdrant.py
@@ -45,5 +45,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/redis/tests/system/redis/example_dag_message_queue_trigger.py
+++ b/providers/redis/tests/system/redis/example_dag_message_queue_trigger.py
@@ -34,5 +34,5 @@ with DAG(dag_id="example_redis_watcher_1", schedule=[asset]) as dag:
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/redis/tests/system/redis/example_redis_publish.py
+++ b/providers/redis/tests/system/redis/example_redis_publish.py
@@ -81,5 +81,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/salesforce/tests/system/salesforce/example_bulk.py
+++ b/providers/salesforce/tests/system/salesforce/example_bulk.py
@@ -92,5 +92,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/salesforce/tests/system/salesforce/example_salesforce_apex_rest.py
+++ b/providers/salesforce/tests/system/salesforce/example_salesforce_apex_rest.py
@@ -43,5 +43,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/samba/tests/system/samba/example_gcs_to_samba.py
+++ b/providers/samba/tests/system/samba/example_gcs_to_samba.py
@@ -152,5 +152,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/sftp/tests/system/sftp/example_sftp_sensor.py
+++ b/providers/sftp/tests/system/sftp/example_sftp_sensor.py
@@ -102,5 +102,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/singularity/tests/system/singularity/example_singularity.py
+++ b/providers/singularity/tests/system/singularity/example_singularity.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/slack/tests/system/slack/example_slack.py
+++ b/providers/slack/tests/system/slack/example_slack.py
@@ -110,5 +110,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/slack/tests/system/slack/example_slack_webhook.py
+++ b/providers/slack/tests/system/slack/example_slack_webhook.py
@@ -73,5 +73,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/slack/tests/system/slack/example_sql_to_slack.py
+++ b/providers/slack/tests/system/slack/example_sql_to_slack.py
@@ -54,5 +54,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/slack/tests/system/slack/example_sql_to_slack_webhook.py
+++ b/providers/slack/tests/system/slack/example_sql_to_slack_webhook.py
@@ -53,5 +53,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/snowflake/tests/system/snowflake/example_copy_into_snowflake.py
+++ b/providers/snowflake/tests/system/snowflake/example_copy_into_snowflake.py
@@ -62,5 +62,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/snowflake/tests/system/snowflake/example_snowflake.py
+++ b/providers/snowflake/tests/system/snowflake/example_snowflake.py
@@ -98,5 +98,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/snowflake/tests/system/snowflake/example_snowpark_decorator.py
+++ b/providers/snowflake/tests/system/snowflake/example_snowpark_decorator.py
@@ -87,5 +87,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/snowflake/tests/system/snowflake/example_snowpark_operator.py
+++ b/providers/snowflake/tests/system/snowflake/example_snowpark_operator.py
@@ -91,5 +91,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/sqlite/tests/system/sqlite/example_sqlite.py
+++ b/providers/sqlite/tests/system/sqlite/example_sqlite.py
@@ -99,5 +99,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/tableau/tests/system/tableau/example_tableau.py
+++ b/providers/tableau/tests/system/tableau/example_tableau.py
@@ -73,5 +73,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/telegram/tests/system/telegram/example_telegram.py
+++ b/providers/telegram/tests/system/telegram/example_telegram.py
@@ -47,5 +47,5 @@ with DAG(DAG_ID, start_date=datetime(2021, 1, 1), schedule=None, tags=["example"
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_azure_blob_to_teradata_transfer.py
+++ b/providers/teradata/tests/system/teradata/example_azure_blob_to_teradata_transfer.py
@@ -213,5 +213,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_bteq.py
+++ b/providers/teradata/tests/system/teradata/example_bteq.py
@@ -268,5 +268,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_remote_bteq.py
+++ b/providers/teradata/tests/system/teradata/example_remote_bteq.py
@@ -268,5 +268,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_remote_tpt.py
+++ b/providers/teradata/tests/system/teradata/example_remote_tpt.py
@@ -255,6 +255,6 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)
 # [END tdload_operator_howto_guide_remote]

--- a/providers/teradata/tests/system/teradata/example_s3_to_teradata_transfer.py
+++ b/providers/teradata/tests/system/teradata/example_s3_to_teradata_transfer.py
@@ -214,5 +214,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_ssl_teradata.py
+++ b/providers/teradata/tests/system/teradata/example_ssl_teradata.py
@@ -129,5 +129,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_teradata.py
+++ b/providers/teradata/tests/system/teradata/example_teradata.py
@@ -172,5 +172,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_teradata_call_sp.py
+++ b/providers/teradata/tests/system/teradata/example_teradata_call_sp.py
@@ -170,5 +170,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
+++ b/providers/teradata/tests/system/teradata/example_teradata_compute_cluster.py
@@ -154,5 +154,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_teradata_to_teradata_transfer.py
+++ b/providers/teradata/tests/system/teradata/example_teradata_to_teradata_transfer.py
@@ -156,5 +156,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/teradata/tests/system/teradata/example_tpt.py
+++ b/providers/teradata/tests/system/teradata/example_tpt.py
@@ -256,6 +256,6 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)
 # [END tdload_operator_howto_guide]

--- a/providers/trino/tests/system/trino/example_gcs_to_trino.py
+++ b/providers/trino/tests/system/trino/example_gcs_to_trino.py
@@ -52,5 +52,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/trino/tests/system/trino/example_trino.py
+++ b/providers/trino/tests/system/trino/example_trino.py
@@ -94,5 +94,5 @@ with models.DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_cohere.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_cohere.py
@@ -130,5 +130,5 @@ example_weaviate_cohere()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_dynamic_mapping_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_dynamic_mapping_dag.py
@@ -107,5 +107,5 @@ example_weaviate_dynamic_mapping_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_openai.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_openai.py
@@ -137,5 +137,5 @@ example_weaviate_openai()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_operator.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_operator.py
@@ -313,5 +313,5 @@ example_weaviate_using_operator()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_using_hook.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_using_hook.py
@@ -155,5 +155,5 @@ example_weaviate_dag_using_hook()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_vectorizer_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_vectorizer_dag.py
@@ -114,5 +114,5 @@ example_weaviate_vectorizer_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_without_vectorizer_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_without_vectorizer_dag.py
@@ -126,5 +126,5 @@ example_weaviate_without_vectorizer_dag()
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/yandex/tests/system/yandex/example_yandexcloud.py
+++ b/providers/yandex/tests/system/yandex/example_yandexcloud.py
@@ -211,5 +211,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/yandex/tests/system/yandex/example_yandexcloud_dataproc.py
+++ b/providers/yandex/tests/system/yandex/example_yandexcloud_dataproc.py
@@ -175,5 +175,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/yandex/tests/system/yandex/example_yandexcloud_dataproc_lightweight.py
+++ b/providers/yandex/tests/system/yandex/example_yandexcloud_dataproc_lightweight.py
@@ -83,5 +83,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/yandex/tests/system/yandex/example_yandexcloud_yq.py
+++ b/providers/yandex/tests/system/yandex/example_yandexcloud_yq.py
@@ -48,5 +48,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/ydb/tests/system/ydb/example_ydb.py
+++ b/providers/ydb/tests/system/ydb/example_ydb.py
@@ -147,5 +147,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)

--- a/providers/zendesk/tests/system/zendesk/example_zendesk_custom_get.py
+++ b/providers/zendesk/tests/system/zendesk/example_zendesk_custom_get.py
@@ -52,5 +52,5 @@ with DAG(
 
 from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
 
-# Needed to run the example DAG with pytest (see: tests/system/README.md#run_via_pytest)
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
 test_run = get_test_run(dag)


### PR DESCRIPTION

1. Based on #62197 , replacing all outdated links from `tests/system/README.md#run_via_pytest` with `contributing-docs/testing/system_tests.rst` in `system_test` files.
2. Fix typo in related docs.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
