### PR TITLE
fix stmp email callback to use email_conn_id

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/smtp.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.common.compat.notifier import BaseNotifier
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.smtp.hooks.smtp import SmtpHook
 from airflow.providers.smtp.version_compat import AIRFLOW_V_3_1_PLUS
 
@@ -80,7 +81,7 @@ class SmtpNotifier(BaseNotifier):
         mime_subtype: str = "mixed",
         mime_charset: str = "utf-8",
         custom_headers: dict[str, Any] | None = None,
-        smtp_conn_id: str = SmtpHook.default_conn_name,
+        smtp_conn_id: str | None = None,
         auth_type: str = "basic",
         *,
         template: str | None = None,
@@ -91,7 +92,9 @@ class SmtpNotifier(BaseNotifier):
             super().__init__(**kwargs)
         else:
             super().__init__()
-        self.smtp_conn_id = smtp_conn_id
+        self.smtp_conn_id = smtp_conn_id or conf.get(
+            "email", "email_conn_id", fallback=SmtpHook.default_conn_name
+        )
         self.from_email = from_email
         self.to = to
         self.files = files

--- a/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
@@ -26,6 +26,7 @@ import pytest
 
 from airflow.providers.smtp.notifications.smtp import SmtpNotifier, send_smtp_notification
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
 TRY_NUMBER = 0
@@ -209,6 +210,30 @@ class TestSmtpNotifier:
                 smtp_conn_id=SMTP_CONN_ID,
                 **DEFAULT_EMAIL_PARAMS,
             )
+
+    @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
+    def test_notifier_with_custom_smtp_conn_id(self, mock_smtphook_hook, create_dag_without_db):
+        """Test that a custom smtp_conn_id is correctly passed to SmtpHook."""
+        custom_conn_id = "my_custom_smtp"
+        notifier = SmtpNotifier(**NOTIFIER_DEFAULT_PARAMS, smtp_conn_id=custom_conn_id)
+        notifier({"dag": create_dag_without_db(TEST_DAG_ID)})
+        mock_smtphook_hook.assert_called_once_with(smtp_conn_id=custom_conn_id, auth_type="basic")
+        mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
+            **NOTIFIER_DEFAULT_PARAMS,
+            smtp_conn_id=custom_conn_id,
+            **DEFAULT_EMAIL_PARAMS,
+        )
+
+    def test_notifier_default_smtp_conn_id_from_config(self):
+        """Test that smtp_conn_id defaults to email.email_conn_id from config."""
+        with conf_vars({("email", "email_conn_id"): "config_smtp_conn"}):
+            notifier = SmtpNotifier(
+                to=TEST_RECEIVER,
+                from_email=TEST_SENDER,
+                subject=TEST_SUBJECT,
+                html_content=TEST_BODY,
+            )
+            assert notifier.smtp_conn_id == "config_smtp_conn"
 
     @mock.patch("airflow.providers.smtp.notifications.smtp.SmtpHook")
     def test_notifier_oauth2_passes_auth_type(self, mock_smtphook_hook, create_dag_without_db):


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/65012

Updated to read `email_conn_id` as the default connection ID for SmtpHook, in order to maintain backward compatibility with the existing functionality.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
