### PR TITLE
remove deprecated email utils and email_backend configs

### DIFF
--- a/airflow-core/docs/howto/email-config.rst
+++ b/airflow-core/docs/howto/email-config.rst
@@ -25,7 +25,6 @@ in the ``[email]`` section.
 .. code-block:: ini
 
   [email]
-  email_backend = airflow.utils.email.send_email_smtp
   subject_template = /path/to/my_subject_template_file
   html_content_template = /path/to/my_html_content_template_file
 
@@ -33,7 +32,6 @@ Equivalent environment variables look like:
 
 .. code-block:: sh
 
-  AIRFLOW__EMAIL__EMAIL_BACKEND=airflow.utils.email.send_email_smtp
   AIRFLOW__EMAIL__SUBJECT_TEMPLATE=/path/to/my_subject_template_file
   AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE=/path/to/my_html_content_template_file
 
@@ -56,14 +54,6 @@ If you do not want to store the SMTP credentials in the config or in the environ
 connection called ``smtp_default`` of ``Email`` type, or choose a custom connection name and set the ``email_conn_id`` with its name in
 the configuration & store SMTP username-password in it. Other SMTP settings like host, port etc always gets picked up
 from the configuration only. The connection can be of any type (for example 'HTTP connection').
-
-If you want to check which email backend is currently set, you can use ``airflow config get-value email email_backend`` command as in
-the example below.
-
-.. code-block:: bash
-
-    $ airflow config get-value email email_backend
-    airflow.utils.email.send_email_smtp
 
 To access the task's information you use `Jinja Templating <http://jinja.pocoo.org/docs/dev/>`_  in your template files.
 

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -818,12 +818,6 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("triggerer", "default_capacity"),
         renamed_to=ConfigParameter("triggerer", "capacity"),
     ),
-    # email
-    ConfigChange(
-        config=ConfigParameter("email", "email_backend"),
-        was_removed=True,
-        remove_if_equals="airflow.contrib.utils.sendgrid.send_email",
-    ),
     # elasticsearch
     ConfigChange(
         config=ConfigParameter("elasticsearch", "log_id_template"),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2192,6 +2192,10 @@ email:
     email_backend:
       description: Email backend to use
       version_added: ~
+      version_deprecated: 3.2.0
+      deprecation_reason: |
+        Since the legacy email_on_failure and email_on_retry attributes are replaced with SmtpNotifier
+        from apache-airflow-providers-smtp, email_backend is no longer used.
       type: string
       example: ~
       default: "airflow.utils.email.send_email_smtp"

--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -700,12 +700,6 @@ CONFIGS_CHANGES = [
         renamed_to=ConfigParameter("triggerer", "capacity"),
         breaking=True,
     ),
-    # email
-    ConfigChange(
-        config=ConfigParameter("email", "email_backend"),
-        was_removed=True,
-        remove_if_equals="airflow.contrib.utils.sendgrid.send_email",
-    ),
     # elasticsearch
     ConfigChange(
         config=ConfigParameter("elasticsearch", "log_id_template"),


### PR DESCRIPTION
With this PR(https://github.com/apache/airflow/pull/57354), `send_email` from airflow.utils is no longer used in the task runner. Additionally, since `email_backend` is also no longer used, it has been marked as deprecated.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=fa3a4bf action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @wjddn279** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~35 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->