### PR TITLE
Fix/ log viewer Scrolling for 2.11 version 

### DIFF
--- a/airflow/www/static/js/dag/details/gantt/InstanceBar.tsx
+++ b/airflow/www/static/js/dag/details/gantt/InstanceBar.tsx
@@ -97,6 +97,7 @@ const InstanceBar = ({
       portalProps={{ containerRef }}
       placement="top"
       openDelay={hoverDelay}
+      zIndex="tooltip"
     >
       <Flex
         position="absolute"

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -39,14 +39,12 @@ const LogBlock = ({
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const codeBlockBottomDiv = useRef<HTMLDivElement>(null);
   const offsetTop = useOffsetTop(logBoxRef);
 
   const scrollToBottom = () => {
-    codeBlockBottomDiv.current?.scrollIntoView({
-      block: "nearest",
-      inline: "nearest",
-    });
+    if (logBoxRef.current) {
+      logBoxRef.current.scrollTop = logBoxRef.current.scrollHeight;
+    }
   };
 
   useEffect(() => {
@@ -122,7 +120,6 @@ const LogBlock = ({
     >
       {/* eslint-disable-next-line react/no-danger */}
       <div dangerouslySetInnerHTML={{ __html: parsedLogs }} />
-      <div ref={codeBlockBottomDiv} />
     </Code>
   );
 };

--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -125,6 +125,7 @@ const DagRunBar = ({
           placement="top"
           openDelay={hoverDelay}
           maxW="md"
+          zIndex="tooltip"
         >
           <Flex
             width="10px"
@@ -159,7 +160,7 @@ const DagRunBar = ({
           top="0"
           left="8px"
           spacing={0}
-          zIndex={0}
+          zIndex={2}
           width={0}
         >
           <Text


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/64757

adding Zindex InstanceBar.tsx and to Bar.tsx to make sure bar renders above log content when scrolling

and Removing ScrollIntoView from the LogBox.tsx it was moving the whole page and not just logs messing up the DOM tree 


#### Before 
https://github.com/user-attachments/assets/76cf62d8-cfeb-4fec-9640-62721b0eef1a

#### After
https://github.com/user-attachments/assets/e5a0d073-4a76-4bf6-96d3-e5d561830831


used Claude code

- [x] used AI 