### PR TITLE
fix(ui): use fixed menu positioning for dropdowns in connection forms

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
@@ -89,6 +89,7 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
       id={`element_${name}`}
       isClearable
       isDisabled={disabled}
+      menuPosition="fixed"
       name={`element_${name}`}
       onChange={handleChange}
       options={options}

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
@@ -76,6 +76,7 @@ export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: Flex
       isClearable
       isDisabled={disabled}
       isMulti
+      menuPosition="fixed"
       name={`element_${name}`}
       onChange={handleChange}
       options={


### PR DESCRIPTION
## Problem
Dropdown lists in custom connection parameter forms are not fully visible when rendered inside accordion panels. The dropdown menu gets clipped by the accordion container's overflow constraints, making some options inaccessible without a scrollbar.

Closes #65007

## Solution
Added `menuPosition="fixed"` prop to both `FieldDropdown` and `FieldMultiSelect` components. This ensures the dropdown menu is positioned relative to the viewport rather than its parent container, preventing clipping issues.

## Files Changed
- `airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx` - Added menuPosition="fixed"
- `airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx` - Added menuPosition="fixed"

## Testing
This fix ensures dropdown menus remain fully visible and scrollable regardless of their parent container's overflow settings.