### PR TITLE
fix(webserver): remove duplicate Date headers in responses

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/response_header_dedup.py
+++ b/airflow-core/src/airflow/api_fastapi/common/response_header_dedup.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Middleware to remove duplicate response headers."""
+
+from __future__ import annotations
+
+from starlette.datastructures import MutableHeaders
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class ResponseHeaderDedupMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to remove duplicate response headers.
+
+    When Flask is mounted via WSGIMiddleware, both uvicorn and Flask may add
+    the same headers (e.g., 'Date'), resulting in duplicate header entries.
+    This middleware removes duplicates, keeping only the first occurrence.
+    """
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        response = await call_next(request)
+
+        # Track seen headers (case-insensitive)
+        seen_headers = set()
+        deduped_headers = MutableHeaders()
+
+        for name, value in response.headers.raw:
+            name_lower = name.decode("latin1").lower()
+            if name_lower not in seen_headers:
+                seen_headers.add(name_lower)
+                deduped_headers.append(name.decode("latin1"), value.decode("latin1"))
+
+        # Replace headers with deduplicated version
+        response.headers.clear()
+        for key, value in deduped_headers.items():
+            response.headers[key] = value
+
+        return response

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -167,6 +167,7 @@ def init_error_handlers(app: FastAPI) -> None:
 def init_middlewares(app: FastAPI) -> None:
     from airflow.api_fastapi.auth.middlewares.refresh_token import JWTRefreshMiddleware
     from airflow.api_fastapi.common.http_access_log import HttpAccessLogMiddleware
+    from airflow.api_fastapi.common.response_header_dedup import ResponseHeaderDedupMiddleware
 
     app.add_middleware(JWTRefreshMiddleware)
     if conf.getboolean("core", "simple_auth_manager_all_admins"):
@@ -178,6 +179,8 @@ def init_middlewares(app: FastAPI) -> None:
     # the full end-to-end duration including compression time.
     # See https://github.com/apache/airflow/issues/60165
     app.add_middleware(GZipMiddleware, minimum_size=1024, compresslevel=5)
+    # ResponseHeaderDedupMiddleware removes duplicate headers (e.g., Date headers from both uvicorn and Flask)
+    app.add_middleware(ResponseHeaderDedupMiddleware)
     # HttpAccessLogMiddleware must be outermost (added last) so it times the full
     # request lifecycle including all inner middleware.
     app.add_middleware(HttpAccessLogMiddleware)


### PR DESCRIPTION
## Problem
HTTP responses from the Airflow webserver contain duplicate `Date` headers. This occurs because both uvicorn (the ASGI server) and Flask (mounted via WSGIMiddleware) each add their own `Date` header, violating HTTP specifications which require headers to be unique.

Example:
```
date: Thu, 12 Mar 2026 04:38:44 GMT  <-- from uvicorn
server: uvicorn
...
date: Thu, 12 Mar 2026 04:38:44 GMT  <-- from Flask
```

Closes #64678

## Solution
Added `ResponseHeaderDedupMiddleware` that:
- Removes duplicate headers (case-insensitive matching)
- Keeps only the first occurrence of each header
- Runs before `HttpAccessLogMiddleware` to ensure clean responses are logged

## Files Changed
- `airflow-core/src/airflow/api_fastapi/core_api/app.py` - Added middleware registration
- `airflow-core/src/airflow/api_fastapi/common/response_header_dedup.py` - New middleware implementation

## Testing
This middleware ensures all responses have unique headers, regardless of whether they come from FastAPI routes or Flask routes mounted via WSGIMiddleware.