### PR TITLE
refactor(auth): split authorization from authentication in BaseAuthMa…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -139,6 +139,20 @@ def get_auth_manager_cls() -> type[BaseAuthManager]:
 
     Useful to save execution time if only static methods need to be called.
     """
+    authn_manager_cls = conf.getimport(section="core", key="authn_manager", fallback=None)
+    authz_manager_cls = conf.getimport(section="core", key="authz_manager", fallback=None)
+
+    if bool(authn_manager_cls) != bool(authz_manager_cls):
+        raise AirflowConfigException(
+            "Split auth manager configuration is incomplete. Please set both "
+            "[core/authn_manager] and [core/authz_manager], or neither."
+        )
+
+    if authn_manager_cls and authz_manager_cls:
+        from airflow.api_fastapi.auth.managers.composable_auth_manager import ComposableAuthManager
+
+        return ComposableAuthManager
+
     auth_manager_cls = conf.getimport(section="core", key="auth_manager")
 
     if not auth_manager_cls:

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/composable_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/composable_auth_manager.py
@@ -1,0 +1,277 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
+from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
+from airflow.configuration import conf
+from airflow.exceptions import AirflowConfigException
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from airflow.api_fastapi.auth.managers.base_auth_manager import ResourceMethod
+    from airflow.api_fastapi.auth.managers.models.resource_details import (
+        AccessView,
+        AssetAliasDetails,
+        AssetDetails,
+        ConfigurationDetails,
+        ConnectionDetails,
+        DagAccessEntity,
+        DagDetails,
+        PoolDetails,
+        TeamDetails,
+        VariableDetails,
+    )
+    from airflow.api_fastapi.common.types import ExtraMenuItem, MenuItem
+    from airflow.cli.cli_config import CLICommand
+
+
+class ComposableAuthManager(BaseAuthManager[BaseUser]):
+    """Compose authentication and authorization from two independent auth managers."""
+
+    def __init__(self) -> None:
+        authn_manager_cls = self._get_configured_manager_cls("authn_manager")
+        authz_manager_cls = self._get_configured_manager_cls("authz_manager")
+
+        if authn_manager_cls is authz_manager_cls:
+            manager = authn_manager_cls()
+            self._authn_manager = manager
+            self._authz_manager = manager
+        else:
+            self._authn_manager = authn_manager_cls()
+            self._authz_manager = authz_manager_cls()
+
+    @staticmethod
+    def _get_configured_manager_cls(config_key: str) -> type[BaseAuthManager]:
+        manager_cls = conf.getimport(section="core", key=config_key, fallback=None)
+        if manager_cls is None:
+            raise AirflowConfigException(
+                f"No auth manager defined in the config. Please specify [core] {config_key}."
+            )
+
+        if not isinstance(manager_cls, type) or not issubclass(manager_cls, BaseAuthManager):
+            raise AirflowConfigException(
+                f'The "{config_key}" key in "core" section must point to a BaseAuthManager subclass. '
+                f"Current value: {manager_cls!r}."
+            )
+        return manager_cls
+
+    @staticmethod
+    def _iter_unique_manager_classes() -> tuple[type[BaseAuthManager], ...]:
+        authn_manager_cls = ComposableAuthManager._get_configured_manager_cls("authn_manager")
+        authz_manager_cls = ComposableAuthManager._get_configured_manager_cls("authz_manager")
+        if authn_manager_cls is authz_manager_cls:
+            return (authn_manager_cls,)
+        return (authn_manager_cls, authz_manager_cls)
+
+    def _iter_unique_managers(self) -> tuple[BaseAuthManager, ...]:
+        if self._authn_manager is self._authz_manager:
+            return (self._authn_manager,)
+        return (self._authn_manager, self._authz_manager)
+
+    def init(self) -> None:
+        for manager in self._iter_unique_managers():
+            manager.init()
+
+    async def get_user_from_token(self, token: str) -> BaseUser:
+        return await self._authn_manager.get_user_from_token(token)
+
+    def generate_jwt(
+        self,
+        user: BaseUser,
+        *,
+        expiration_time_in_seconds: int = conf.getint("api_auth", "jwt_expiration_time"),
+    ) -> str:
+        return self._authn_manager.generate_jwt(
+            user=cast("Any", user), expiration_time_in_seconds=expiration_time_in_seconds
+        )
+
+    def revoke_token(self, token: str) -> None:
+        self._authn_manager.revoke_token(token)
+
+    def deserialize_user(self, token: dict[str, Any]) -> BaseUser:
+        return self._authn_manager.deserialize_user(token)
+
+    def serialize_user(self, user: BaseUser) -> dict[str, Any]:
+        return self._authn_manager.serialize_user(cast("Any", user))
+
+    def get_url_login(self, **kwargs) -> str:
+        return self._authn_manager.get_url_login(**kwargs)
+
+    def get_url_logout(self) -> str | None:
+        return self._authn_manager.get_url_logout()
+
+    def refresh_user(self, *, user: BaseUser) -> BaseUser | None:
+        return self._authn_manager.refresh_user(user=cast("Any", user))
+
+    def is_authorized_configuration(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: ConfigurationDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_configuration(
+            method=method, user=cast("Any", user), details=details
+        )
+
+    def is_authorized_connection(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: ConnectionDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_connection(
+            method=method, user=cast("Any", user), details=details
+        )
+
+    def is_authorized_dag(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        access_entity: DagAccessEntity | None = None,
+        details: DagDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_dag(
+            method=method,
+            user=cast("Any", user),
+            access_entity=access_entity,
+            details=details,
+        )
+
+    def is_authorized_asset(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: AssetDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_asset(method=method, user=cast("Any", user), details=details)
+
+    def is_authorized_asset_alias(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: AssetAliasDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_asset_alias(
+            method=method, user=cast("Any", user), details=details
+        )
+
+    def is_authorized_pool(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: PoolDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_pool(method=method, user=cast("Any", user), details=details)
+
+    def is_authorized_team(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: TeamDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_team(method=method, user=cast("Any", user), details=details)
+
+    def is_authorized_variable(
+        self,
+        *,
+        method: ResourceMethod,
+        user: BaseUser,
+        details: VariableDetails | None = None,
+    ) -> bool:
+        return self._authz_manager.is_authorized_variable(
+            method=method, user=cast("Any", user), details=details
+        )
+
+    def is_authorized_view(
+        self,
+        *,
+        access_view: AccessView,
+        user: BaseUser,
+    ) -> bool:
+        return self._authz_manager.is_authorized_view(access_view=access_view, user=cast("Any", user))
+
+    def is_authorized_custom_view(
+        self,
+        *,
+        method: ResourceMethod | str,
+        resource_name: str,
+        user: BaseUser,
+    ) -> bool:
+        return self._authz_manager.is_authorized_custom_view(
+            method=cast("Any", method),
+            resource_name=resource_name,
+            user=cast("Any", user),
+        )
+
+    def filter_authorized_menu_items(self, menu_items: list[MenuItem], *, user: BaseUser) -> list[MenuItem]:
+        return self._authz_manager.filter_authorized_menu_items(menu_items=menu_items, user=cast("Any", user))
+
+    def is_authorized_hitl_task(self, *, assigned_users: set[str], user: BaseUser) -> bool:
+        return self._authz_manager.is_authorized_hitl_task(
+            assigned_users=assigned_users, user=cast("Any", user)
+        )
+
+    def get_extra_menu_items(self, *, user: BaseUser) -> list[ExtraMenuItem]:
+        authn_items = self._authn_manager.get_extra_menu_items(user=cast("Any", user))
+        authz_items = self._authz_manager.get_extra_menu_items(user=cast("Any", user))
+        return [*authn_items, *authz_items]
+
+    def get_fastapi_app(self) -> FastAPI | None:
+        return self._authn_manager.get_fastapi_app()
+
+    @staticmethod
+    def get_cli_commands() -> list[CLICommand]:
+        commands: list[CLICommand] = []
+        seen_names: set[str] = set()
+        for manager_cls in ComposableAuthManager._iter_unique_manager_classes():
+            for command in manager_cls.get_cli_commands():
+                if command.name in seen_names:
+                    continue
+                seen_names.add(command.name)
+                commands.append(command)
+        return commands
+
+    def _get_teams(self) -> set[str]:
+        return self._authz_manager._get_teams()
+
+    @staticmethod
+    def get_db_manager() -> str | None:
+        db_managers = {
+            db_manager
+            for manager_cls in ComposableAuthManager._iter_unique_manager_classes()
+            if (db_manager := manager_cls.get_db_manager())
+        }
+
+        if len(db_managers) > 1:
+            raise AirflowConfigException(
+                "Configured authn/authz managers require different DB managers. "
+                "Please use managers that share the same DB manager or only one DB-backed manager."
+            )
+
+        return next(iter(db_managers), None)

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -83,6 +83,22 @@ core:
       type: string
       example: ~
       default: "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager"
+    authn_manager:
+      description: |
+        Optional authentication manager class path used with split auth manager mode.
+        When set, ``authz_manager`` must also be set.
+      version_added: 3.2.0
+      type: string
+      example: "airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager"
+      default: ~
+    authz_manager:
+      description: |
+        Optional authorization manager class path used with split auth manager mode.
+        When set, ``authn_manager`` must also be set.
+      version_added: 3.2.0
+      type: string
+      example: "airflow.providers.keycloak.auth_manager.keycloak_auth_manager.KeycloakAuthManager"
+      default: ~
     simple_auth_manager_users:
       description: |
         The list of users and their associated role in simple auth manager. If the simple auth manager is

--- a/airflow-core/src/airflow/configuration.py
+++ b/airflow-core/src/airflow/configuration.py
@@ -781,6 +781,20 @@ def initialize_auth_manager() -> BaseAuthManager:
     * import user manager class
     * instantiate it and return it
     """
+    authn_manager_cls = conf.getimport(section="core", key="authn_manager", fallback=None)
+    authz_manager_cls = conf.getimport(section="core", key="authz_manager", fallback=None)
+
+    if bool(authn_manager_cls) != bool(authz_manager_cls):
+        raise AirflowConfigException(
+            "Split auth manager configuration is incomplete. Please set both "
+            "[core/authn_manager] and [core/authz_manager], or neither."
+        )
+
+    if authn_manager_cls and authz_manager_cls:
+        from airflow.api_fastapi.auth.managers.composable_auth_manager import ComposableAuthManager
+
+        return ComposableAuthManager()
+
     auth_manager_cls = conf.getimport(section="core", key="auth_manager")
 
     if not auth_manager_cls:

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -24,6 +24,8 @@ from fastapi import FastAPI
 
 import airflow.api_fastapi.app as app_module
 import airflow.plugins_manager as plugins_manager
+from airflow.api_fastapi.auth.managers.composable_auth_manager import ComposableAuthManager
+from airflow.exceptions import AirflowConfigException
 
 pytestmark = pytest.mark.db_test
 
@@ -175,3 +177,54 @@ def test_create_auth_manager_thread_safety():
     assert call_count == 1
 
     app_module.purge_cached_app()
+
+
+def test_get_auth_manager_cls_falls_back_to_single_manager_when_split_not_configured():
+    class LegacyAuthManager:
+        pass
+
+    def _getimport(*, section, key, fallback=None):
+        if key in {"authn_manager", "authz_manager"}:
+            return None
+        if key == "auth_manager":
+            return LegacyAuthManager
+        return fallback
+
+    with mock.patch.object(app_module.conf, "getimport", side_effect=_getimport):
+        assert app_module.get_auth_manager_cls() is LegacyAuthManager
+
+
+def test_get_auth_manager_cls_uses_composable_manager_when_split_configured():
+    class AuthN:
+        pass
+
+    class AuthZ:
+        pass
+
+    def _getimport(*, section, key, fallback=None):
+        if key == "authn_manager":
+            return AuthN
+        if key == "authz_manager":
+            return AuthZ
+        if key == "auth_manager":
+            pytest.fail("auth_manager should not be read when split auth is configured")
+        return fallback
+
+    with mock.patch.object(app_module.conf, "getimport", side_effect=_getimport):
+        assert app_module.get_auth_manager_cls() is ComposableAuthManager
+
+
+def test_get_auth_manager_cls_raises_if_split_config_is_partial():
+    class AuthN:
+        pass
+
+    def _getimport(*, section, key, fallback=None):
+        if key == "authn_manager":
+            return AuthN
+        if key == "authz_manager":
+            return None
+        return fallback
+
+    with mock.patch.object(app_module.conf, "getimport", side_effect=_getimport):
+        with pytest.raises(AirflowConfigException, match="Split auth manager configuration is incomplete"):
+            app_module.get_auth_manager_cls()


### PR DESCRIPTION
## Summary

This PR implements the decoupling of Authentication (AuthN) and Authorization (AuthZ) by introducing a `ComposableAuthManager`. This allows users to mix and match different providers.

## Changes

### Core Logic
- **Introduced `ComposableAuthManager`**: A new manager that delegates authentication and authorization tasks to two independent sub-managers.
- **Automatic Split Detection**: Updated `app.py` and `configuration.py` to determine the manager type at startup:
    - If both `core.authn_manager` and `core.authz_manager` are configured, the system initializes `ComposableAuthManager`.
    - If neither is set, the system falls back to the legacy `core.auth_manager`.
    - If only one of the two is configured, the system raises an `AirflowConfigException` to prevent inconsistent states.

### Configuration & Integration
- **Config Template**: Added `authn_manager` and `authz_manager` keys to `core` section in `config.yml`.
- **Validation**: Implemented checks to ensure both managers are subclasses of `BaseAuthManager`.
- **Consistency Guard**: Added logic to prevent initialization if the two managers return conflicting DB managers, ensuring database integrity.

### Testing & Quality
- **Unit Tests**: Added comprehensive tests in `test_app.py` covering:
    - Fallback logic for legacy configurations.
    - Successful initialization of `ComposableAuthManager` with split settings.
    - Error handling for partial configurations.

* related: #65089
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
