### PR TITLE
`aip-93-scoping`: Adding `AssetWatcher.asset` functionality

### DIFF
--- a/airflow-core/src/airflow/executors/workloads/trigger.py
+++ b/airflow-core/src/airflow/executors/workloads/trigger.py
@@ -47,6 +47,6 @@ class RunTrigger(BaseModel):
         None  # Serialized DagRun data in dict format so it can be deserialized in trigger subprocess.
     )
 
-    # aip-93
+    # aip-93: Add asset_name and asset_uri to pass through to BaseEventTrigger
     asset_name: str | None = None
     asset_uri: str | None = None

--- a/airflow-core/src/airflow/executors/workloads/trigger.py
+++ b/airflow-core/src/airflow/executors/workloads/trigger.py
@@ -46,3 +46,7 @@ class RunTrigger(BaseModel):
     dag_run_data: dict | None = (
         None  # Serialized DagRun data in dict format so it can be deserialized in trigger subprocess.
     )
+
+    # aip-93
+    asset_name: str | None = None
+    asset_uri: str | None = None

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -677,10 +677,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         session: Session,
     ) -> workloads.RunTrigger | None:
         if trigger.task_instance is None:
+            # aip-93: Retrieve any Assets associated with the AssetWatcher
+            asset = trigger.assets[0] if trigger.assets else None
             return workloads.RunTrigger(
                 id=trigger.id,
                 classpath=trigger.classpath,
                 encrypted_kwargs=trigger.encrypted_kwargs,
+                asset_name=asset.name if asset else None,
+                asset_uri=asset.uri if asset else None,
             )
 
         if not trigger.task_instance.dag_version_id:
@@ -1119,6 +1123,11 @@ class TriggerRunner:
             trigger_instance.trigger_id = trigger_id
             trigger_instance.triggerer_job_id = self.job_id
             trigger_instance.timeout_after = workload.timeout_after
+
+            # aip-93: Inject asset identity for watcher triggers
+            if workload.asset_name is not None:
+                trigger_instance.asset_name = workload.asset_name
+                trigger_instance.asset_uri = workload.asset_uri
 
             self.triggers[trigger_id] = {
                 "task": asyncio.create_task(

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -679,6 +679,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         if trigger.task_instance is None:
             # aip-93: Retrieve any Assets associated with the AssetWatcher
             asset = trigger.assets[0] if trigger.assets else None
+
             return workloads.RunTrigger(
                 id=trigger.id,
                 classpath=trigger.classpath,

--- a/airflow-core/src/airflow/serialization/decoders.py
+++ b/airflow-core/src/airflow/serialization/decoders.py
@@ -103,6 +103,8 @@ def _decode_asset(var: dict[str, Any]):
                     "classpath": watcher["trigger"]["classpath"],
                     "kwargs": smart_decode_trigger_kwargs(watcher["trigger"]["kwargs"]),
                 },
+                asset_name=watcher.get("asset_name"),
+                asset_uri=watcher.get("asset_uri"),
             )
             for watcher in watchers
         ],

--- a/airflow-core/src/airflow/serialization/definitions/assets.py
+++ b/airflow-core/src/airflow/serialization/definitions/assets.py
@@ -109,6 +109,8 @@ class SerializedAssetWatcher:
 
     name: str
     trigger: dict
+    asset_name: str | None = None
+    asset_uri: str | None = None
 
 
 @attrs.define

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -189,7 +189,16 @@ def encode_asset_like(a: BaseAsset | SerializedAssetBase) -> dict[str, Any]:
         case Asset() | SerializedAsset():
             d = {"__type": DAT.ASSET, "name": a.name, "uri": a.uri, "group": a.group, "extra": a.extra}
             if a.watchers:
-                d["watchers"] = [{"name": w.name, "trigger": encode_trigger(w.trigger)} for w in a.watchers]
+                d["watchers"] = [
+                    {
+                        "name": w.name,
+                        "trigger": encode_trigger(w.trigger),
+                        "asset_name": w.asset.name if getattr(w, "asset", None) else getattr(w, "asset_name", None),
+                        "asset_uri": w.asset.uri if getattr(w, "asset", None) else getattr(w, "asset_uri", None),
+                    }
+                    for w in a.watchers
+                ]
+
             return d
         case AssetAlias() | SerializedAssetAlias():
             return {"__type": DAT.ASSET_ALIAS, "name": a.name, "group": a.group}

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -212,6 +212,13 @@ class BaseEventTrigger(BaseTrigger):
 
     supports_triggerer_queue: bool = False
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # aip-93: Making these accessible for Triggers inheriting from it
+        self.asset_name: str | None = None
+        self.asset_uri: str | None = None
+
     @staticmethod
     def hash(classpath: str, kwargs: dict[str, Any]) -> int:
         """

--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -219,6 +219,8 @@ class BaseEventTrigger(BaseTrigger):
         self.asset_name: str | None = None
         self.asset_uri: str | None = None
 
+        # TODO: aip-103, create self.asset_state using asset_name/uri (if provided)
+
     @staticmethod
     def hash(classpath: str, kwargs: dict[str, Any]) -> int:
         """

--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -254,6 +254,11 @@ class AssetWatcher:
 
     name: str
     trigger: BaseEventTrigger = attrs.field(validator=_validate_asset_watcher_trigger)
+    asset: Asset | None = attrs.field(default=None, eq=False, repr=False)
+
+    def __attrs_post_init__(self):
+        if self.asset is not None and self not in self.asset.watchers:
+            self.asset.watchers.append(self)
 
 
 @attrs.define(init=False, unsafe_hash=False)


### PR DESCRIPTION
## Description

With AIP-103 adding an interface to persist state for Assets, AIP-93 shifts more towards implementing a way to use this state when building `BaseEventTrigger` for "Asset-watching". Currently, any Trigger defined for "Asset watching" is Asset-unaware. This PR adds the ability to make these Trigger Asset-aware. 

*The new pattern implemented here allows for an `Asset` object to be passed to the `AssetWatcher` (via the `trigger`). This makes much more sense; first, I define an Asset. Then, I define a way to "watch" that Asset.*

**Note, this approach is fully backwards-compatible as it stands.**

```python
from airflow.sdk import Asset, AssetWatcher
from plugins.triggers import GenericEventTrigger

...  # Other imports

# Defining the Asset first
random_integer_asset = Asset(name="random_integer_asset")

random_integer_watcher = AssetWatcher(
    name="random_integer_watcher",
    asset=random_integer_asset,  # Passing the Asset to the AssetWatcher
    trigger=GenericEventTrigger(
        target_number=7,
        waiter_delay=30
    )
)

with DAG(
    dag_id="random_integer_downstream_dag",
    start_date=datetime(2026, 1, 1),
    schedule=[random_integer_asset]
) as dag:
    ...

```

The majority of these changes are setting up for AIP-103, and the ability to use an `asset_name` and `asset_uri` to instantiate some object to retrieve and set state. The only changes that were required for the new paradigm to be enabled was the changes to `task-sdk/src/airflow/sdk/definitions/asset/__init__.py`, adding the asset field and adding the `__attrs_post_init__` to `AssetWatcher`. 

## Future State

Eventually, I'd love to get to the following syntax, which is SIGNIFICANTLY more intuitive for DAG authors. This is just an example, and I'm sure the syntax would actually look a bit different.

```python
from airflow.sdk import asset, DAG

...  # Other imports

@asset.watcher(
    name="random_integer_asset_watcher",
    waiter_delay=30
)
def random_integer_asset(target_number):
    generated_number: int = random.randint(0, 10)
    
    # Anything "truthy" yields a TriggerEvent and breaks execution 
    if generated_number == target_number:
        return {"generated_number": generated_number}


with DAG(
    dag_id="random_integer_downstream_dag",
    start_date=datetime(2026, 1, 1),
    schedule=[random_integer_asset(7)]
) as dag:
    ...

```

## Testing

Note, no unit tests have been implemented yet; this PR is just providing a forum for discussion. Tests will be added after discussion.


No, an LLM was not used to generate this code/create this PR.
