### PR TITLE
Fix OS detection in providers release vote script snippet

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -600,13 +600,13 @@ email.
 export VOTE_DURATION_IN_HOURS=72
 export IS_SHORTEN_VOTE=$([ $VOTE_DURATION_IN_HOURS -ge 72 ] && echo "false" || echo "true")
 export SHORTEN_VOTE_TEXT="This is a shortened ($VOTE_DURATION_IN_HOURS hours vote) as agreed by policy set it https://lists.apache.org/thread/cv194w1fqqykrhswhmm54zy9gnnv6kgm"
-if [ "$OS" = "Darwin" ]; then  # MacOS (BSD date)
+if [[ "${OSTYPE}" == *darwin* ]]; then
   export VOTE_END_TIME=$(date -u -v "+${VOTE_DURATION_IN_HOURS}H" -v "+10M" +'%Y-%m-%d %H:%M')
 else  # Linux
   export VOTE_END_TIME=$(date --utc -d "now + $VOTE_DURATION_IN_HOURS hours + 10 minutes" +'%Y-%m-%d %H:%M')
 fi
-export RELEASE_MANAGER_NAME="RELEASE_MANAGER_NAME_HERE"
-export GITHUB_ISSUE_LINK="LINK_TO_GITHUB_ISSUE"
+export RELEASE_MANAGER_NAME="TODO:RELEASE_MANAGER_NAME"
+export GITHUB_ISSUE_LINK="TODO:ISSUE_LINK"
 ```
 
 subject:


### PR DESCRIPTION
The release-vote shell snippet in `dev/README_RELEASE_PROVIDERS.md` branched on an undefined `$OS` variable, so the macOS path was never taken. Switch to `OSTYPE` so `date -u -v` is actually used on macOS, and rename the placeholder values to `TODO:` prefixes so they're easier to spot before sending the vote email.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)