### PR TITLE
Run release calendar verification on its own schedule

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -213,23 +213,6 @@ jobs:
       platform: ${{ needs.build-info.outputs.platform }}
       shared-distributions-as-json: ${{needs.build-info.outputs.shared-distributions-as-json}}
 
-  verify-release-calendar:
-    name: "Verify release calendar"
-    runs-on: ${{ fromJSON(needs.build-info.outputs.runner-type) }}
-    needs: [build-info]
-    # Only run on canary builds (push to main, scheduled runs, or manual dispatch)
-    if: needs.build-info.outputs.canary-run == 'true'
-    timeout-minutes: 10
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - name: "Install uv"
-        run: pip install "uv==${UV_VERSION}"
-      - name: "Verify release calendar"
-        run: uv run dev/verify_release_calendar.py
-
   build-ci-images:
     name: Build CI images
     needs: [build-info]

--- a/.github/workflows/scheduled-verify-release-calendar.yml
+++ b/.github/workflows/scheduled-verify-release-calendar.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: "Scheduled verify release calendar"
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+permissions:
+  contents: read
+env:
+  UV_VERSION: "0.11.3"  # Keep this comment to allow automatic replacement of uv version
+jobs:
+  verify-release-calendar:
+    name: "Verify release calendar"
+    runs-on: ["ubuntu-22.04"]
+    timeout-minutes: 10
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: "Install uv"
+        run: pip install "uv==${UV_VERSION}"
+      - name: "Verify release calendar"
+        run: uv run dev/verify_release_calendar.py
+      - name: "Notify Slack on failure"
+        if: failure()
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "release-management"
+            text: >-
+              :warning: Release calendar verification failed.
+              See:
+              ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: >-
+                    :warning: *Release calendar verification failed*
+
+                    The scheduled `verify_release_calendar.py` check
+                    failed. Please review and fix the mismatch between
+                    the Confluence release wiki and the Google
+                    Calendar entries.
+
+                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View
+                    failed run>

--- a/.github/workflows/scheduled-verify-release-calendar.yml
+++ b/.github/workflows/scheduled-verify-release-calendar.yml
@@ -40,6 +40,7 @@ jobs:
         run: pip install "uv==${UV_VERSION}"
       - name: "Verify release calendar"
         run: uv run dev/verify_release_calendar.py
+      # yamllint disable rule:line-length
       - name: "Notify Slack on failure"
         if: failure()
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
@@ -64,5 +65,8 @@ jobs:
                     the Confluence release wiki and the Google
                     Calendar entries.
 
-                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View
-                    failed run>
+                    • <https://cwiki.apache.org/confluence/display/AIRFLOW/Release+Plan|Release Plan wiki>
+
+                    • <https://calendar.google.com/calendar/u/0?cid=Y19kZTIxNGU5MmRmM2I3NTk3NzljYjY1ZjNlNDllNTYyNzk2YzYxMjZlNzUwMGNmYTdlNTI0YmY3ODE4NmQ4YjVlQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20|Release Calendar>
+
+                    • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed run>


### PR DESCRIPTION
Move `dev/verify_release_calendar.py` out of the canary `ci-amd-arm` pipeline into a dedicated `scheduled-verify-release-calendar.yml` workflow that runs daily at 06:00 UTC (and on `workflow_dispatch`). On failure, post a notification to the `#release-management` Slack channel using the existing `slackapi/slack-github-action` pattern, so release managers find out directly when the Confluence wiki and Google Calendar drift apart.

- Removes the `verify-release-calendar` job from `.github/workflows/ci-amd-arm.yml` (no other jobs depend on it).
- Adds `.github/workflows/scheduled-verify-release-calendar.yml` with a daily cron, manual dispatch, and Slack-on-failure step.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)