### PR TITLE
Fix CI Slack notifications never firing recovery alerts

### DIFF
--- a/scripts/ci/slack_notification_state.py
+++ b/scripts/ci/slack_notification_state.py
@@ -54,10 +54,15 @@ PREV_STATE_DIR = Path("./prev-slack-state")
 
 def download_previous_state(artifact_name: str, repo: str) -> dict | None:
     """Download previous notification state artifact from GitHub Actions."""
+    # `gh api` defaults to POST when -f/-F parameters are passed, which makes
+    # the artifacts list endpoint return 404. Force GET so the parameters are
+    # encoded as query string.
     result = subprocess.run(
         [
             "gh",
             "api",
+            "--method",
+            "GET",
             f"repos/{repo}/actions/artifacts",
             "-f",
             f"name={artifact_name}",

--- a/scripts/tests/ci/test_slack_notification_state.py
+++ b/scripts/tests/ci/test_slack_notification_state.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "scripts" / "ci" / "slack_notification_state.py"
+
+
+@pytest.fixture
+def slack_state_module():
+    module_name = "test_slack_notification_state_module"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestDownloadPreviousState:
+    def test_uses_explicit_get_method(self, slack_state_module):
+        """`gh api` defaults to POST when -f is passed; we must force GET to avoid 404."""
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="null", stderr="")
+        with patch.object(subprocess, "run", return_value=completed) as mock_run:
+            slack_state_module.download_previous_state("artifact", "apache/airflow")
+        args = mock_run.call_args[0][0]
+        assert "--method" in args
+        method_index = args.index("--method")
+        assert args[method_index + 1] == "GET"
+
+
+class TestDetermineAction:
+    def test_no_failures_no_prev_state(self, slack_state_module):
+        assert slack_state_module.determine_action([], None) == "skip"
+
+    def test_no_failures_no_prev_failures(self, slack_state_module):
+        prev = {"failures": [], "last_notified": "2025-01-01T00:00:00+00:00"}
+        assert slack_state_module.determine_action([], prev) == "skip"
+
+    def test_recovery_when_clear_after_failures(self, slack_state_module):
+        prev = {"failures": ["job-a"], "last_notified": "2025-01-01T00:00:00+00:00"}
+        assert slack_state_module.determine_action([], prev) == "notify_recovery"
+
+    def test_notify_new_on_first_failure(self, slack_state_module):
+        assert slack_state_module.determine_action(["job-a"], None) == "notify_new"
+
+    def test_notify_new_on_changed_failures(self, slack_state_module):
+        prev = {"failures": ["job-a"], "last_notified": "2025-01-01T00:00:00+00:00"}
+        assert slack_state_module.determine_action(["job-b"], prev) == "notify_new"


### PR DESCRIPTION
## Summary

The CI \"Notify Slack\" job (in `ci-amd-arm.yml`, `ci-notification.yml`, etc.) never sent the \"all tests passing\" recovery message after a failure was fixed. Looking at run [24310256628 / job 70982878551](https://github.com/apache/airflow/actions/runs/24310256628/job/70982878551), the determination step printed:

Root cause: `scripts/ci/slack_notification_state.py` calls `gh api repos/.../actions/artifacts -f name=...`. The `gh` CLI defaults to **POST** when any `-f`/`-F` parameter is passed, and the artifacts list endpoint returns 404 on POST. As a result, `download_previous_state()` always returned `None`, every run looked like the first run with no prior state, and `determine_action([], None)` always returned `\"skip\"` — so `notify_recovery` could never trigger.

## Fix

- Pass `--method GET` explicitly so the `-f` parameters are encoded as query string instead of a POST body.
- Add `scripts/tests/ci/test_slack_notification_state.py` covering:
  - The regression: `download_previous_state` must call `gh api` with `--method GET`.
  - The `determine_action` state machine (skip / notify_new / notify_recovery / change-of-failures).

Verified the broken call locally returns 404, and the fixed call returns the expected artifact metadata.

## Test plan

- [X] `uv run --project scripts pytest scripts/tests/ci/test_slack_notification_state.py -xvs`
- [ ] Next scheduled `ci-amd-arm.yml` run on `main` should now correctly send a recovery notification when a previously-failing run flips to all green.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)