### PR TITLE
Fix E2E Flaky Tests Report failing with gh api 404

### DIFF
--- a/scripts/ci/analyze_e2e_flaky_tests.py
+++ b/scripts/ci/analyze_e2e_flaky_tests.py
@@ -65,8 +65,13 @@ def escape_slack_mrkdwn(text: str) -> str:
 
 
 def gh_api(endpoint: str, **kwargs: str) -> str | None:
-    """Call GitHub API via gh CLI."""
-    cmd = ["gh", "api", endpoint]
+    """Call GitHub API via gh CLI.
+
+    Forces ``--method GET``: ``gh api`` defaults to POST whenever ``-f``
+    parameters are present, which makes read-only endpoints (such as the
+    workflow runs list) return 404.
+    """
+    cmd = ["gh", "api", "--method", "GET", endpoint]
     for key, value in kwargs.items():
         cmd.extend(["-f", f"{key}={value}"])
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)

--- a/scripts/tests/ci/test_analyze_e2e_flaky_tests.py
+++ b/scripts/tests/ci/test_analyze_e2e_flaky_tests.py
@@ -17,8 +17,10 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -35,6 +37,17 @@ def analyze_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+class TestGhApi:
+    def test_forces_get_method(self, analyze_module):
+        """`gh api` defaults to POST when -f is passed; we must force GET to avoid 404."""
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}", stderr="")
+        with patch.object(subprocess, "run", return_value=completed) as mock_run:
+            analyze_module.gh_api("repos/apache/airflow/actions/workflows/x/runs", branch="main")
+        args = mock_run.call_args[0][0]
+        assert "--method" in args
+        assert args[args.index("--method") + 1] == "GET"
 
 
 class TestEscapeSlackMrkdwn:


### PR DESCRIPTION
## Summary

The nightly **E2E Flaky Tests Report** workflow has been failing — see [run 24320225760 / job 71004915159](https://github.com/apache/airflow/actions/runs/24320225760/job/71004915159#step:4:14). The \"Analyze E2E test results\" step prints:

## Root cause

The \`gh\` CLI defaults to **POST** whenever \`-f\`/\`-F\` parameters are present. The workflow runs list endpoint returns 404 on POST, which is exactly the error in the log.

## Fix

- Add \`--method GET\` to the \`gh api\` command in \`scripts/ci/analyze_e2e_flaky_tests.py\` so the \`-f\` params are encoded as query string instead of a POST body.
- Add a regression test in \`scripts/tests/ci/test_analyze_e2e_flaky_tests.py\` that asserts the helper passes \`--method GET\`.

Verified locally that the broken call returns 404 and the fixed call returns the expected payload.

## Test plan

- [X] \`uv run --project scripts pytest scripts/tests/ci/test_analyze_e2e_flaky_tests.py -xvs\` — 13 passed (1 new + 12 existing).
- [ ] Next nightly E2E Flaky Tests Report run on \`main\` should now post to Slack instead of failing.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)