### PR TITLE
Fix config leak in TestExecutorConf causing CeleryExecutor test failures

### DIFF
--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import logging
-import textwrap
 from datetime import timedelta
 from unittest import mock
 from uuid import UUID
@@ -43,6 +42,7 @@ from airflow.sdk import BaseOperator
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.utils.state import State, TaskInstanceState
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
 
@@ -411,189 +411,128 @@ def test_repr():
 class TestExecutorConf:
     """Test ExecutorConf shim class that provides team-specific configuration access."""
 
-    @pytest.fixture(autouse=True)
-    def _restore_conf(self):
-        """Restore conf state after each test to prevent config leaks."""
-        from airflow.configuration import conf
-
-        original_sections = {s: dict(conf.items(s)) for s in conf.sections()}
-        yield
-        for section in list(conf.sections()):
-            if section not in original_sections:
-                conf.remove_section(section)
-            else:
-                for key in list(conf.options(section)):
-                    if key not in original_sections.get(section, {}):
-                        conf.remove_option(section, key)
-                    elif conf.get(section, key) != original_sections[section].get(key):
-                        conf.set(section, key, original_sections[section][key])
-
     def test_executor_conf_get(self):
         """Test ExecutorConf.get() passes team_name to underlying conf.get()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            result_backend = DEFAULT_VALUE
+        with conf_vars(
+            {
+                ("celery", "result_backend"): "DEFAULT_VALUE",
+                ("test_team=celery", "result_backend"): "TEAM_VALUE",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.get("celery", "result_backend") == "DEFAULT_VALUE"
 
-            [test_team=celery]
-            result_backend = TEAM_VALUE
-            """
-        )
-        conf.read_string(test_config)
-
-        # Test without team_name
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.get("celery", "result_backend") == "DEFAULT_VALUE"
-
-        # Test with team_name
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.get("celery", "result_backend") == "TEAM_VALUE"
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.get("celery", "result_backend") == "TEAM_VALUE"
 
     def test_executor_conf_getboolean(self):
         """Test ExecutorConf.getboolean() passes team_name to underlying conf.getboolean()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            ssl_active = true
+        with conf_vars(
+            {
+                ("celery", "ssl_active"): "true",
+                ("test_team=celery", "ssl_active"): "false",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getboolean("celery", "ssl_active") is True
 
-            [test_team=celery]
-            ssl_active = false
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getboolean("celery", "ssl_active") is True
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getboolean("celery", "ssl_active") is False
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getboolean("celery", "ssl_active") is False
 
     def test_executor_conf_getint(self):
         """Test ExecutorConf.getint() passes team_name to underlying conf.getint()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            worker_concurrency = 16
+        with conf_vars(
+            {
+                ("celery", "worker_concurrency"): "16",
+                ("test_team=celery", "worker_concurrency"): "32",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getint("celery", "worker_concurrency") == 16
 
-            [test_team=celery]
-            worker_concurrency = 32
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getint("celery", "worker_concurrency") == 16
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getint("celery", "worker_concurrency") == 32
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getint("celery", "worker_concurrency") == 32
 
     def test_executor_conf_getjson(self):
         """Test ExecutorConf.getjson() passes team_name to underlying conf.getjson()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            broker_transport_options = {"visibility_timeout": 3600}
+        with conf_vars(
+            {
+                ("celery", "broker_transport_options"): '{"visibility_timeout": 3600}',
+                ("test_team=celery", "broker_transport_options"): '{"visibility_timeout": 7200}',
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getjson("celery", "broker_transport_options") == {"visibility_timeout": 3600}
 
-            [test_team=celery]
-            broker_transport_options = {"visibility_timeout": 7200}
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getjson("celery", "broker_transport_options") == {"visibility_timeout": 3600}
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getjson("celery", "broker_transport_options") == {
-            "visibility_timeout": 7200
-        }
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getjson("celery", "broker_transport_options") == {
+                "visibility_timeout": 7200
+            }
 
     def test_executor_conf_getsection(self):
         """Test ExecutorConf.getsection() passes team_name to underlying conf.getsection()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            worker_concurrency = 16
-            result_backend = DEFAULT_BACKEND
+        with conf_vars(
+            {
+                ("celery", "worker_concurrency"): "16",
+                ("celery", "result_backend"): "DEFAULT_BACKEND",
+                ("test_team=celery", "worker_concurrency"): "32",
+                ("test_team=celery", "result_backend"): "TEAM_BACKEND",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            section = executor_conf.getsection("celery")
+            assert section["worker_concurrency"] == 16
+            assert section["result_backend"] == "DEFAULT_BACKEND"
 
-            [test_team=celery]
-            worker_concurrency = 32
-            result_backend = TEAM_BACKEND
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        section = executor_conf.getsection("celery")
-        assert section["worker_concurrency"] == 16
-        assert section["result_backend"] == "DEFAULT_BACKEND"
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        team_section = team_executor_conf.getsection("celery")
-        assert team_section["worker_concurrency"] == 32
-        assert team_section["result_backend"] == "TEAM_BACKEND"
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            team_section = team_executor_conf.getsection("celery")
+            assert team_section["worker_concurrency"] == 32
+            assert team_section["result_backend"] == "TEAM_BACKEND"
 
     def test_executor_conf_has_option(self):
         """Test ExecutorConf.has_option() passes team_name to underlying conf.has_option()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            result_backend = DEFAULT
+        with conf_vars(
+            {
+                ("celery", "result_backend"): "DEFAULT",
+                ("test_team=celery", "result_backend"): "TEAM",
+                ("test_team=celery", "team_specific_option"): "VALUE",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.has_option("celery", "result_backend") is True
+            assert executor_conf.has_option("celery", "team_specific_option") is False
 
-            [test_team=celery]
-            result_backend = TEAM
-            team_specific_option = VALUE
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.has_option("celery", "result_backend") is True
-        assert executor_conf.has_option("celery", "team_specific_option") is False
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.has_option("celery", "result_backend") is True
-        assert team_executor_conf.has_option("celery", "team_specific_option") is True
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.has_option("celery", "result_backend") is True
+            assert team_executor_conf.has_option("celery", "team_specific_option") is True
 
     def test_executor_conf_get_mandatory_value(self):
         """Test ExecutorConf.get_mandatory_value() passes team_name to underlying conf.get_mandatory_value()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            broker_url = redis://localhost
+        with conf_vars(
+            {
+                ("celery", "broker_url"): "redis://localhost",
+                ("test_team=celery", "broker_url"): "redis://team-redis",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.get_mandatory_value("celery", "broker_url") == "redis://localhost"
 
-            [test_team=celery]
-            broker_url = redis://team-redis
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.get_mandatory_value("celery", "broker_url") == "redis://localhost"
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.get_mandatory_value("celery", "broker_url") == "redis://team-redis"
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.get_mandatory_value("celery", "broker_url") == "redis://team-redis"
 
 
 class TestCallbackSupport:

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -411,6 +411,23 @@ def test_repr():
 class TestExecutorConf:
     """Test ExecutorConf shim class that provides team-specific configuration access."""
 
+    @pytest.fixture(autouse=True)
+    def _restore_conf(self):
+        """Restore conf state after each test to prevent config leaks."""
+        from airflow.configuration import conf
+
+        original_sections = {s: dict(conf.items(s)) for s in conf.sections()}
+        yield
+        for section in list(conf.sections()):
+            if section not in original_sections:
+                conf.remove_section(section)
+            else:
+                for key in list(conf.options(section)):
+                    if key not in original_sections.get(section, {}):
+                        conf.remove_option(section, key)
+                    elif conf.get(section, key) != original_sections[section].get(key):
+                        conf.set(section, key, original_sections[section][key])
+
     def test_executor_conf_get(self):
         """Test ExecutorConf.get() passes team_name to underlying conf.get()."""
         from airflow.configuration import conf


### PR DESCRIPTION
### Description
`TestExecutorConf` tests used `conf.read_string()` to set config values like `ssl_active=true` without cleanup, leaking state into subsequent tests. This was harmless until [#64767](https://github.com/apache/airflow/pull/64767) added SSL validation to the CeleryExecutor. So the leaked `ssl_active=true` now triggers a `ValueError` in unrelated `test_executor_loader` tests.

Added an `autouse` fixture that snapshots and restores the config state after each test.

follow-up: [#64767](https://github.com/apache/airflow/pull/64767)

---

##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)