### PR TITLE
Use conf_vars in executor tests to avoid polluting config instance

### DIFF
--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import logging
-import textwrap
 from datetime import timedelta
 from unittest import mock
 from uuid import UUID
@@ -43,6 +42,7 @@ from airflow.sdk import BaseOperator
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
 from airflow.utils.state import State, TaskInstanceState
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
 
 
@@ -413,170 +413,128 @@ class TestExecutorConf:
 
     def test_executor_conf_get(self):
         """Test ExecutorConf.get() passes team_name to underlying conf.get()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            result_backend = DEFAULT_VALUE
+        with conf_vars(
+            {
+                ("celery", "result_backend"): "DEFAULT_VALUE",
+                ("test_team=celery", "result_backend"): "TEAM_VALUE",
+            }
+        ):
+            # Test without team_name
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.get("celery", "result_backend") == "DEFAULT_VALUE"
 
-            [test_team=celery]
-            result_backend = TEAM_VALUE
-            """
-        )
-        conf.read_string(test_config)
-
-        # Test without team_name
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.get("celery", "result_backend") == "DEFAULT_VALUE"
-
-        # Test with team_name
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.get("celery", "result_backend") == "TEAM_VALUE"
+            # Test with team_name
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.get("celery", "result_backend") == "TEAM_VALUE"
 
     def test_executor_conf_getboolean(self):
         """Test ExecutorConf.getboolean() passes team_name to underlying conf.getboolean()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            ssl_active = true
+        with conf_vars(
+            {
+                ("celery", "ssl_active"): "true",
+                ("test_team=celery", "ssl_active"): "false",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getboolean("celery", "ssl_active") is True
 
-            [test_team=celery]
-            ssl_active = false
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getboolean("celery", "ssl_active") is True
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getboolean("celery", "ssl_active") is False
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getboolean("celery", "ssl_active") is False
 
     def test_executor_conf_getint(self):
         """Test ExecutorConf.getint() passes team_name to underlying conf.getint()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            worker_concurrency = 16
+        with conf_vars(
+            {
+                ("celery", "worker_concurrency"): "16",
+                ("test_team=celery", "worker_concurrency"): "32",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getint("celery", "worker_concurrency") == 16
 
-            [test_team=celery]
-            worker_concurrency = 32
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getint("celery", "worker_concurrency") == 16
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getint("celery", "worker_concurrency") == 32
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getint("celery", "worker_concurrency") == 32
 
     def test_executor_conf_getjson(self):
         """Test ExecutorConf.getjson() passes team_name to underlying conf.getjson()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            broker_transport_options = {"visibility_timeout": 3600}
+        with conf_vars(
+            {
+                ("celery", "broker_transport_options"): '{"visibility_timeout": 3600}',
+                ("test_team=celery", "broker_transport_options"): '{"visibility_timeout": 7200}',
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.getjson("celery", "broker_transport_options") == {"visibility_timeout": 3600}
 
-            [test_team=celery]
-            broker_transport_options = {"visibility_timeout": 7200}
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.getjson("celery", "broker_transport_options") == {"visibility_timeout": 3600}
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.getjson("celery", "broker_transport_options") == {
-            "visibility_timeout": 7200
-        }
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.getjson("celery", "broker_transport_options") == {
+                "visibility_timeout": 7200
+            }
 
     def test_executor_conf_getsection(self):
         """Test ExecutorConf.getsection() passes team_name to underlying conf.getsection()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            worker_concurrency = 16
-            result_backend = DEFAULT_BACKEND
+        with conf_vars(
+            {
+                ("celery", "worker_concurrency"): "16",
+                ("celery", "result_backend"): "DEFAULT_BACKEND",
+                ("test_team=celery", "worker_concurrency"): "32",
+                ("test_team=celery", "result_backend"): "TEAM_BACKEND",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            section = executor_conf.getsection("celery")
+            assert section["worker_concurrency"] == 16
+            assert section["result_backend"] == "DEFAULT_BACKEND"
 
-            [test_team=celery]
-            worker_concurrency = 32
-            result_backend = TEAM_BACKEND
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        section = executor_conf.getsection("celery")
-        assert section["worker_concurrency"] == 16
-        assert section["result_backend"] == "DEFAULT_BACKEND"
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        team_section = team_executor_conf.getsection("celery")
-        assert team_section["worker_concurrency"] == 32
-        assert team_section["result_backend"] == "TEAM_BACKEND"
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            team_section = team_executor_conf.getsection("celery")
+            assert team_section["worker_concurrency"] == 32
+            assert team_section["result_backend"] == "TEAM_BACKEND"
 
     def test_executor_conf_has_option(self):
         """Test ExecutorConf.has_option() passes team_name to underlying conf.has_option()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            result_backend = DEFAULT
+        with conf_vars(
+            {
+                ("celery", "result_backend"): "DEFAULT",
+                ("test_team=celery", "result_backend"): "TEAM",
+                ("test_team=celery", "team_specific_option"): "VALUE",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.has_option("celery", "result_backend") is True
+            assert executor_conf.has_option("celery", "team_specific_option") is False
 
-            [test_team=celery]
-            result_backend = TEAM
-            team_specific_option = VALUE
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.has_option("celery", "result_backend") is True
-        assert executor_conf.has_option("celery", "team_specific_option") is False
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.has_option("celery", "result_backend") is True
-        assert team_executor_conf.has_option("celery", "team_specific_option") is True
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.has_option("celery", "result_backend") is True
+            assert team_executor_conf.has_option("celery", "team_specific_option") is True
 
     def test_executor_conf_get_mandatory_value(self):
         """Test ExecutorConf.get_mandatory_value() passes team_name to underlying conf.get_mandatory_value()."""
-        from airflow.configuration import conf
         from airflow.executors.base_executor import ExecutorConf
 
-        test_config = textwrap.dedent(
-            """
-            [celery]
-            broker_url = redis://localhost
+        with conf_vars(
+            {
+                ("celery", "broker_url"): "redis://localhost",
+                ("test_team=celery", "broker_url"): "redis://team-redis",
+            }
+        ):
+            executor_conf = ExecutorConf(team_name=None)
+            assert executor_conf.get_mandatory_value("celery", "broker_url") == "redis://localhost"
 
-            [test_team=celery]
-            broker_url = redis://team-redis
-            """
-        )
-        conf.read_string(test_config)
-
-        executor_conf = ExecutorConf(team_name=None)
-        assert executor_conf.get_mandatory_value("celery", "broker_url") == "redis://localhost"
-
-        team_executor_conf = ExecutorConf(team_name="test_team")
-        assert team_executor_conf.get_mandatory_value("celery", "broker_url") == "redis://team-redis"
+            team_executor_conf = ExecutorConf(team_name="test_team")
+            assert team_executor_conf.get_mandatory_value("celery", "broker_url") == "redis://team-redis"
 
 
 class TestCallbackSupport:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Follow up to: https://github.com/apache/airflow/pull/64767


`TestExecutorConf` class uses `conf.read_string()` to temporarily set config values  for testing, but it never cleans them up. This leaks config state into subsequent tests and pollutes the `conf` instance.

When https://github.com/apache/airflow/pull/64767 which added SSL validation to `CeleryExecutor`, the leaked `ssl_active=true` from `test_executor_conf_getboolean()` triggered a `ValueError` during executor initialization in unrelated tests like `test_executor_loader`, leading to errors like: 
```
_________________________________________________________________________________ TestExecutorLoader.test_init_executors _________________________________________________________________________________
[gw3] linux -- Python 3.10.20 /usr/local/bin/python3
airflow-core/tests/unit/executors/test_executor_loader.py:323: in test_init_executors
    executors = executor_loader.ExecutorLoader.init_executors()
airflow-core/src/airflow/executors/executor_loader.py:304: in init_executors
    loaded_executor = cls.load_executor(executor_name)
airflow-core/src/airflow/executors/executor_loader.py:368: in load_executor
    executor = executor_cls()
providers/celery/src/airflow/providers/celery/executors/celery_executor.py:137: in __init__
    self.celery_app = create_celery_app(self.conf)
providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py:143: in create_celery_app
    config = get_default_celery_config(team_conf)
providers/celery/src/airflow/providers/celery/executors/default_celery.py:150: in get_default_celery_config
    raise ValueError(
E   ValueError: SSL_MUTUAL_TLS is True (default) but SSL_KEY and/or SSL_CERT are not set. Set both for mutual TLS, or set SSL_MUTUAL_TLS=False for one-way TLS.
```

in https://github.com/apache/airflow/actions/runs/24325740827/job/71021649692

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
