### PR TITLE
Fix SQLAlchemy mapper init failure when DB tests are skipped

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -434,6 +434,12 @@ def configure_orm(disable_connection_pool=False, pool_class=None):
         # Skip DB initialization in unit tests, if DB tests are skipped
         Session = SkipDBTestsSession
         engine = None
+
+        # Ensure all models are imported so SQLAlchemy can resolve string-based relationships in tests.
+        from airflow.models import import_all_models
+
+        import_all_models()
+
         return
     log.debug("Setting up DB connection pool (PID %s)", os.getpid())
     engine_args = prepare_engine_args(disable_connection_pool, pool_class)


### PR DESCRIPTION
test fail: https://github.com/apache/airflow/actions/runs/24328439584/job/71030412976?pr=63871

### Problem

When running non-DB tests, the following error occurs.
```
E   sqlalchemy.exc.InvalidRequestError: When initializing mapper Mapper[DagVersion(dag_version)], expression 'DagCode' failed to locate a name ('DagCode'). If this is a class name, consider adding this relationship() to the <class 'airflow.models.dag_version.DagVersion'> class after both dependent classes have been defined.
```

 This also reproduces on `main` branch when executing the tests with those pytest arguments: 
```
airflow-core/tests/unit/serialization --verbosity=0 --strict-markers --durations=100 --maxfail=50 --color=yes --junitxml=/files/test_result-all-none.xml --timeouts-order=moi --setup-timeout=60 --execution-timeout=60 --teardown-timeout=60 --disable-warnings -rfEX --skip-db-tests --ignore-glob=*/tests/system/* --ignore-glob=airflow-core/tests/integration/* --ignore-glob=providers/apache/cassandra/tests/integration/* --ignore-glob=providers/apache/drill/tests/integration/* --ignore-glob=providers/apache/hive/tests/integration/* --ignore-glob=providers/apache/kafka/tests/integration/* --ignore-glob=providers/apache/pinot/tests/integration/* --ignore-glob=providers/apache/tinkerpop/tests/integration/* --ignore-glob=providers/celery/tests/integration/* --ignore-glob=providers/elasticsearch/tests/integration/* --ignore-glob=providers/google/tests/integration/* --ignore-glob=providers/microsoft/mssql/tests/integration/* --ignore-glob=providers/mongo/tests/integration/* --ignore-glob=providers/openlineage/tests/integration/* --ignore-glob=providers/opensearch/tests/integration/* --ignore-glob=providers/qdrant/tests/integration/* --ignore-glob=providers/redis/tests/integration/* --ignore-glob=providers/trino/tests/integration/* --ignore-glob=providers/ydb/tests/integration/* --warning-output-path=/files/warnings-all-none.txt --ignore=helm-tests --with-db-init --ignore=providers/apache/beam/tests -n 4 --no-cov --no-db-cleanup
```
same in test, only testing `airflow-core/tests/unit/serialization`with `skip-db-tests`

### Cause

The root cause is that when DB initialization is skipped, Airflow models that require SQLAlchemy relations are never imported. In a typical non-DB test run, multiple modules are executed together, and the models get imported as a side effect during that process. However, when only airflow-core/tests/unit/serialization is tested in isolation — as is the case for certain changes — these models are never imported, causing the failure.


### Solution

Import all airflow.module using `import_all_models` when testing with `--skip-db-tests`. It makes non-db test deterministic from sqlalchemy mapper


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
