### PR TITLE
update release notes of 3.2.0 specifying `sqlalchemy[asyncio]>=2.0.48`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -395,6 +395,10 @@ Make start_date optional for @continuous schedule
 """""""""""""""""""""""""""""""""""""""""""""""""
 The ``schedule="@continuous"`` parameter now works without requiring a ``start_date``, and any Dags with this schedule will begin running immediately when unpaused. (#61405)
 
+Upgrade SQLAlchemy (SQLA) to 2.0
+"""""""""""""""""""""""""""""""""""""""""""""""""
+Airflow now only support SQLAlchemy version 2
+
 New Features
 ^^^^^^^^^^^^
 
@@ -589,6 +593,7 @@ Bug Fixes
 Miscellaneous
 ^^^^^^^^^^^^^
 
+- Set minimum version of ``sqlalchemy[asyncio]>=2.0.48``
 - Deprecate ``api.page_size`` config in favor of ``api.fallback_page_limit`` (#61067)
 - Improve Dag callback relevancy by passing a context-relevant task instance based on the Dag's final state instead of an arbitrary lexicographical selection (#61274)
 - Optimize ``get_dag_runs`` API endpoint performance (#63940)

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: abaded5036af286021accca232ea9054
-source-date-epoch: 1775568308
+release-notes-hash: 69929f06cb9064b6a360098240715e15
+source-date-epoch: 1776084530


### PR DESCRIPTION
users were reporting in Slack that we are missing entry in changelog notifying about the sqlalchemy version change.