### PR TITLE
Add docs for when to do E2E tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/README.md
+++ b/airflow-core/src/airflow/ui/tests/e2e/README.md
@@ -142,6 +142,16 @@ Common options:
 
 This framework uses the **Page Object Model (POM)** pattern. Each page's elements and interactions are encapsulated in a page class.
 
+### When to write an E2E test
+
+E2E tests are slow and expensive to run. Before adding a new E2E test, consider whether the behavior can be covered by a faster alternative:
+
+- **Prefer a Vitest unit test** for component logic, conditional rendering, state transitions, and anything that can be tested with mocked data. See `src/components/**/*.test.tsx` for examples.
+- **Prefer a Vitest integration test** (using React Testing Library) for multi-component interactions, form submissions, and API-driven rendering that doesn't require a real browser.
+- **Write an E2E test only when** the behavior requires a real browser and a running Airflow backend — for example, full authentication flows, cross-page navigation state, or interactions that depend on live scheduler/API behavior.
+
+When submitting a PR that adds new E2E coverage, briefly explain in the PR description why the behavior cannot be covered at the unit or integration test level.
+
 ### Steps to Add a New Test
 
 1. **Create a page object** (if needed) in `pages/`


### PR DESCRIPTION
Add an extra bit to E2E docs to make sure that we consider unit tests before E2E test.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes Clause Sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
