### PR TITLE
Fix scheduled CI upgrade check workflows failing at startup

### DIFF
--- a/.github/workflows/scheduled-upgrade-check-main.yml
+++ b/.github/workflows/scheduled-upgrade-check-main.yml
@@ -23,7 +23,8 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 6 * * 1,3,5'
   workflow_dispatch:
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 jobs:
   upgrade-main:
     name: "[main] Upgrade"

--- a/.github/workflows/scheduled-upgrade-check-v3-2-test.yml
+++ b/.github/workflows/scheduled-upgrade-check-v3-2-test.yml
@@ -23,7 +23,8 @@ on:  # yamllint disable-line rule:truthy
     - cron: '0 6 * * 2,4'
   workflow_dispatch:
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 jobs:
   upgrade-v3-2-test:
     name: "[v3-2-test] Upgrade"


### PR DESCRIPTION
The scheduled upgrade-check wrappers (`scheduled-upgrade-check-main.yml` and `scheduled-upgrade-check-v3-2-test.yml`) declared `permissions: contents: read`, which capped the permissions of the reusable `upgrade-check.yml` workflow they call. That workflow needs `contents: write` and `pull-requests: write` to push the upgrade branch and open the draft PR via `breeze ci upgrade --create-pr`.

As a result every scheduled run since #64836 failed immediately with `startup_failure`:

> The workflow is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

See failing run: https://github.com/apache/airflow/actions/runs/24329934582

This raises the caller permissions in both scheduled wrappers to match the ceiling required by the callee so the upgrade PR job can actually run.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)