### PR TITLE
Support `log_output` for PapermillOperator

### DIFF
--- a/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
+++ b/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
@@ -54,6 +54,8 @@ class PapermillOperator(BaseOperator):
     :param parameters: the notebook parameters to set
     :param kernel_name: (optional) name of kernel to execute the notebook against
         (ignores kernel name in the notebook document metadata)
+    :param log_output: (optional) Log the notebook cell output to the task log.
+        When True, the stdout/stderr of each cell execution is visible in the Airflow task log.
     """
 
     # TODO: Remove this when provider drops 2.x support.
@@ -79,6 +81,7 @@ class PapermillOperator(BaseOperator):
         kernel_name: str | None = None,
         language_name: str | None = None,
         kernel_conn_id: str | None = None,
+        log_output: bool = False,
         nbconvert: bool = False,
         nbconvert_args: list[str] | None = None,
         **kwargs,
@@ -97,6 +100,7 @@ class PapermillOperator(BaseOperator):
         self.kernel_name = kernel_name
         self.language_name = language_name
         self.kernel_conn_id = kernel_conn_id
+        self.log_output = log_output
         self.nbconvert = nbconvert
         self.nbconvert_args = nbconvert_args
 
@@ -131,6 +135,7 @@ class PapermillOperator(BaseOperator):
             parameters=self.input_nb.parameters,
             progress_bar=False,
             report_mode=True,
+            log_output=self.log_output,
             kernel_name=self.kernel_name,
             language=self.language_name,
             engine_name=engine_name,

--- a/providers/papermill/tests/unit/papermill/operators/test_papermill.py
+++ b/providers/papermill/tests/unit/papermill/operators/test_papermill.py
@@ -118,6 +118,7 @@ class TestPapermillOperator:
             language=language_name,
             progress_bar=False,
             report_mode=True,
+            log_output=False,
             engine_name=None,
         )
 
@@ -166,6 +167,7 @@ class TestPapermillOperator:
             language=language_name,
             progress_bar=False,
             report_mode=True,
+            log_output=False,
             engine_name=REMOTE_KERNEL_ENGINE,
             kernel_session_key="notebooks",
             kernel_shell_port=JUPYTER_KERNEL_SHELL_PORT,
@@ -175,6 +177,20 @@ class TestPapermillOperator:
             kernel_hb_port=JUPYTER_KERNEL_HB_PORT,
             kernel_ip="127.0.0.1",
         )
+
+    @patch("airflow.providers.papermill.operators.papermill.pm")
+    def test_execute_with_log_output(self, mock_papermill):
+        from airflow.providers.papermill.operators.papermill import PapermillOperator
+
+        op = PapermillOperator(
+            input_nb="/tmp/in.ipynb",
+            output_nb="/tmp/out.ipynb",
+            task_id="test_log_output",
+            log_output=True,
+        )
+        op.execute(context={})
+        call_kwargs = mock_papermill.execute_notebook.call_args
+        assert call_kwargs.kwargs["log_output"] is True
 
     @pytest.mark.db_test
     def test_render_template(self, create_task_instance_of_operator):


### PR DESCRIPTION
* closes: #35408

Support the `log_output` parameter for PapermillOperator so that it can show logs from the notebook in the Airflow UI.

+ Before

<img width="1920" height="557" alt="35408_before" src="https://github.com/user-attachments/assets/c990967d-1fd8-4a3e-a432-3019f77fa1a8" />

+ After

<img width="1918" height="703" alt="35408_after" src="https://github.com/user-attachments/assets/644f299c-4c56-48fd-b2bf-c875b9a71a6c" />

### The Dag and Notebook code I used
+ Dag
```python
from datetime import datetime

from airflow import DAG
from airflow.providers.papermill.operators.papermill import PapermillOperator

NOTEBOOK_PATH = "/files/dags/test_papermill_log.ipynb"
OUTPUT_PATH = "/tmp/test_papermill_log_output.ipynb"

with DAG(
    dag_id="test_papermill_log",
    start_date=datetime(2026, 1, 1),
    schedule=None,
    catchup=False,
) as dag:
    run_notebook = PapermillOperator(
        task_id="run_notebook",
        input_nb=NOTEBOOK_PATH,
        output_nb=OUTPUT_PATH,
        parameters={"msg": "hello_from_airflow"},
        log_output=True,
    )
```

+ Notebook
```python
import time

for i in range(5):
    print(f"[Step {i+1}/5] msg={msg}")
    time.sleep(1)

print("Notebook execution complete.")
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude 4.6] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
