### PR TITLE
Simple LLM scenario example based on the Airflow survey data

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -113,6 +113,7 @@ attr
 attrs
 au
 auditability
+auditable
 Auth
 auth
 authenticator
@@ -1355,6 +1356,7 @@ responder
 reStructuredText
 resultset
 resumable
+retryable
 Reusability
 rfc
 rmse

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
@@ -105,7 +105,7 @@ Key columns (quote all names in SQL):
 """
 
 survey_datasource = DataSourceConfig(
-    conn_id="",
+    conn_id="",  # No connection needed for local file-based sources
     table_name="survey",
     uri=SURVEY_CSV_URI,
     format="csv",
@@ -114,11 +114,10 @@ survey_datasource = DataSourceConfig(
 # Dimension labels -- order must match the sub-questions returned by decompose_question.
 DIMENSION_KEYS = ["executor", "deployment", "cloud", "airflow_version"]
 
-SYNTHESIS_SYSTEM_PROMPT = (
-    "You are a data analyst summarizing survey results about Apache Airflow practitioners. "
-    "Write in plain, concise language suitable for a technical audience. "
-    "Focus on patterns and proportions rather than raw counts."
-)
+SYNTHESIS_SYSTEM_PROMPT = """\
+You are a data analyst summarizing survey results about Apache Airflow practitioners. \
+Write in plain, concise language suitable for a technical audience. \
+Focus on patterns and proportions rather than raw counts."""
 
 
 # ---------------------------------------------------------------------------
@@ -151,25 +150,21 @@ def example_llm_survey_agentic():
     @task
     def decompose_question() -> list[str]:
         return [
-            (
-                "Among respondents who use AI/LLM tools to write Airflow code, "
-                "what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor) "
-                "are most commonly enabled? Return the count per executor type."
-            ),
-            (
-                "Among respondents who use AI/LLM tools to write Airflow code, "
-                "how do they deploy Airflow? Return the count per deployment method."
-            ),
-            (
-                "Among respondents who use AI/LLM tools to write Airflow code, "
-                "which cloud providers are most commonly used for Airflow? "
-                "Return the count per cloud provider."
-            ),
-            (
-                "Among respondents who use AI/LLM tools to write Airflow code, "
-                "what version of Airflow are they currently running? "
-                "Return the count per version."
-            ),
+            """\
+Among respondents who use AI/LLM tools to write Airflow code, \
+what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor) \
+are most commonly enabled? Return the count per executor type.""",
+            """\
+Among respondents who use AI/LLM tools to write Airflow code, \
+how do they deploy Airflow? Return the count per deployment method.""",
+            """\
+Among respondents who use AI/LLM tools to write Airflow code, \
+which cloud providers are most commonly used for Airflow? \
+Return the count per cloud provider.""",
+            """\
+Among respondents who use AI/LLM tools to write Airflow code, \
+what version of Airflow are they currently running? \
+Return the count per version.""",
         ]
 
     sub_questions = decompose_question()
@@ -237,27 +232,25 @@ def example_llm_survey_agentic():
         task_id="synthesize_answer",
         llm_conn_id=LLM_CONN_ID,
         system_prompt=SYNTHESIS_SYSTEM_PROMPT,
-        prompt=(
-            "Given these four independent survey query results about practitioners "
-            "who use AI tools to write Airflow code, write a 2-3 sentence "
-            "characterization of what a typical Airflow deployment looks like for "
-            "this group.\n\n"
-            "Results: {{ ti.xcom_pull(task_ids='collect_results') }}"
-        ),
+        prompt="""\
+Given these four independent survey query results about practitioners \
+who use AI tools to write Airflow code, write a 2-3 sentence \
+characterization of what a typical Airflow deployment looks like for \
+this group.
+
+Results: {{ ti.xcom_pull(task_ids='collect_results') }}""",
     )
     collected >> synthesize_answer
 
     # ------------------------------------------------------------------
     # Step 7: Human reviews the synthesized narrative before the DAG ends.
     # ------------------------------------------------------------------
-    result_confirmation = ApprovalOperator(
+    result_confirmation = ApprovalOperator(  # noqa: F841
         task_id="result_confirmation",
         subject="Review the synthesized survey analysis",
-        body="{{ ti.xcom_pull(task_ids='synthesize_answer') }}",
+        body=synthesize_answer.output,
         response_timeout=datetime.timedelta(hours=1),
     )
-
-    synthesize_answer >> result_confirmation
 
 
 # [END example_llm_survey_agentic]

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Multi-query synthesis — an agentic survey analysis pattern.
+Multi-query synthesis -- an agentic survey analysis pattern.
 
 Demonstrates how Dynamic Task Mapping turns a multi-dimensional research
 question into a fan-out / fan-in pipeline that is observable, retryable,
@@ -25,8 +25,8 @@ and auditable at each step.
 practitioners who actively use AI tools in their workflow?"*
 
 This question cannot be answered with a single SQL query.  It requires
-querying four independent dimensions — executor type, deployment method,
-cloud provider, and Airflow version — all filtered to respondents who use
+querying four independent dimensions -- executor type, deployment method,
+cloud provider, and Airflow version -- all filtered to respondents who use
 AI tools to write Airflow code.  The results are then synthesized by a
 second LLM call into a single narrative characterization.
 
@@ -44,10 +44,10 @@ second LLM call into a single narrative characterization.
 
 **What this makes visible that an agent harness hides:**
 
-* Each sub-query is a named, logged task instance — not a hidden tool call.
+* Each sub-query is a named, logged task instance -- not a hidden tool call.
 * If the cloud-provider query fails, only that mapped instance retries;
   the other three results are preserved in XCom.
-* The synthesis step's inputs are fully auditable XCom values — not an
+* The synthesis step's inputs are fully auditable XCom values -- not an
   opaque continuation of an LLM reasoning loop.
 
 Before running:
@@ -111,7 +111,7 @@ survey_datasource = DataSourceConfig(
     format="csv",
 )
 
-# Dimension labels — order must match the sub-questions returned by decompose_question.
+# Dimension labels -- order must match the sub-questions returned by decompose_question.
 DIMENSION_KEYS = ["executor", "deployment", "cloud", "airflow_version"]
 
 SYNTHESIS_SYSTEM_PROMPT = (
@@ -127,7 +127,7 @@ SYNTHESIS_SYSTEM_PROMPT = (
 
 
 # [START example_llm_survey_agentic]
-@dag(schedule=None)
+@dag
 def example_llm_survey_agentic():
     """
     Fan-out across four survey dimensions, then synthesize into a single narrative.
@@ -176,7 +176,7 @@ def example_llm_survey_agentic():
 
     # ------------------------------------------------------------------
     # Step 2: Generate SQL for each sub-question in parallel.
-    # LLMSQLQueryOperator is expanded over the sub-question list —
+    # LLMSQLQueryOperator is expanded over the sub-question list --
     # four mapped instances, each translating one natural-language
     # question into validated SQL.
     # ------------------------------------------------------------------
@@ -201,7 +201,7 @@ def example_llm_survey_agentic():
     # ------------------------------------------------------------------
     # Step 4: Execute each SQL against the survey CSV via DataFusion.
     # Four mapped instances run in parallel.  If one fails, only that
-    # instance retries — the other three hold their XCom results.
+    # instance retries -- the other three hold their XCom results.
     # ------------------------------------------------------------------
     run_query = AnalyticsOperator.partial(
         task_id="run_query",
@@ -211,10 +211,10 @@ def example_llm_survey_agentic():
 
     # ------------------------------------------------------------------
     # Step 5: Collect all four JSON results and label them by dimension.
-    # trigger_rule="all_success" ensures synthesis only runs when the
-    # complete picture is available.
+    # The default trigger rule (all_success) ensures synthesis only runs
+    # when the complete picture is available.
     # ------------------------------------------------------------------
-    @task(trigger_rule="all_success")
+    @task
     def collect_results(results: list[str]) -> dict:
         # Airflow preserves index order for mapped task outputs, so zip is safe here:
         # results[i] corresponds to the mapped instance at index i, which matches
@@ -230,7 +230,7 @@ def example_llm_survey_agentic():
 
     # ------------------------------------------------------------------
     # Step 6: Synthesize the four labeled result sets into a narrative.
-    # This is the second LLM call — the first four generated SQL,
+    # This is the second LLM call -- the first four generated SQL,
     # this one interprets the results.  Inputs are fully visible in XCom.
     # ------------------------------------------------------------------
     synthesize_answer = LLMOperator(

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
@@ -1,0 +1,265 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Multi-query synthesis — an agentic survey analysis pattern.
+
+Demonstrates how Dynamic Task Mapping turns a multi-dimensional research
+question into a fan-out / fan-in pipeline that is observable, retryable,
+and auditable at each step.
+
+**Question:** *"What does a typical Airflow deployment look like for
+practitioners who actively use AI tools in their workflow?"*
+
+This question cannot be answered with a single SQL query.  It requires
+querying four independent dimensions — executor type, deployment method,
+cloud provider, and Airflow version — all filtered to respondents who use
+AI tools to write Airflow code.  The results are then synthesized by a
+second LLM call into a single narrative characterization.
+
+``example_llm_survey_agentic`` (manual trigger):
+
+.. code-block:: text
+
+    decompose_question (@task)
+        → generate_sql  (LLMSQLQueryOperator, mapped ×4)
+        → wrap_query    (@task, mapped ×4)
+        → run_query     (AnalyticsOperator, mapped ×4)
+        → collect_results (@task)
+        → synthesize_answer (LLMOperator)
+        → result_confirmation (ApprovalOperator)
+
+**What this makes visible that an agent harness hides:**
+
+* Each sub-query is a named, logged task instance — not a hidden tool call.
+* If the cloud-provider query fails, only that mapped instance retries;
+  the other three results are preserved in XCom.
+* The synthesis step's inputs are fully auditable XCom values — not an
+  opaque continuation of an LLM reasoning loop.
+
+Before running:
+
+1. Create an LLM connection named ``pydanticai_default`` (or the value of
+   ``LLM_CONN_ID``) for your chosen model provider.
+2. Place the cleaned survey CSV at the path set by ``SURVEY_CSV_PATH``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+
+from airflow.providers.common.ai.operators.llm import LLMOperator
+from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
+from airflow.providers.common.compat.sdk import dag, task
+from airflow.providers.common.sql.config import DataSourceConfig
+from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
+from airflow.providers.standard.operators.hitl import ApprovalOperator
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+LLM_CONN_ID = "pydanticai_default"
+
+SURVEY_CSV_PATH = os.environ.get(
+    "SURVEY_CSV_PATH",
+    "/opt/airflow/data/airflow-user-survey-2025.csv",
+)
+SURVEY_CSV_URI = f"file://{SURVEY_CSV_PATH}"
+
+# Schema context for LLMSQLQueryOperator.
+# All column names must be quoted in SQL because they contain spaces and punctuation.
+SURVEY_SCHEMA = """
+Table: survey
+Key columns (quote all names in SQL):
+  "How important is Airflow to your business?"                                                TEXT
+  "Which version of Airflow do you currently use?"                                            TEXT
+  "CeleryExecutor"                                                                            TEXT
+  "KubernetesExecutor"                                                                        TEXT
+  "LocalExecutor"                                                                             TEXT
+  "How do you deploy Airflow?"                                                                TEXT
+  "What best describes your current occupation?"                                              TEXT
+  "What industry do you currently work in?"                                                   TEXT
+  "How many years of experience do you have with Airflow?"                                    TEXT
+  "Which of the following is your company's primary cloud provider for Airflow?"              TEXT
+  "How many people work at your company?"                                                     TEXT
+  "How many people at your company directly work on data?"                                    TEXT
+  "How many people at your company use Airflow?"                                              TEXT
+  "How likely are you to recommend Apache Airflow?"                                           TEXT
+  "Are you using AI/LLM (ChatGPT/Cursor/Claude etc) to assist you in writing Airflow code?"  TEXT
+"""
+
+survey_datasource = DataSourceConfig(
+    conn_id="",
+    table_name="survey",
+    uri=SURVEY_CSV_URI,
+    format="csv",
+)
+
+# Dimension labels — order must match the sub-questions returned by decompose_question.
+DIMENSION_KEYS = ["executor", "deployment", "cloud", "airflow_version"]
+
+SYNTHESIS_SYSTEM_PROMPT = (
+    "You are a data analyst summarizing survey results about Apache Airflow practitioners. "
+    "Write in plain, concise language suitable for a technical audience. "
+    "Focus on patterns and proportions rather than raw counts."
+)
+
+
+# ---------------------------------------------------------------------------
+# DAG: Agentic multi-query synthesis
+# ---------------------------------------------------------------------------
+
+
+# [START example_llm_survey_agentic]
+@dag(schedule=None)
+def example_llm_survey_agentic():
+    """
+    Fan-out across four survey dimensions, then synthesize into a single narrative.
+
+    Task graph::
+
+        decompose_question (@task)
+            → generate_sql  (LLMSQLQueryOperator ×4, via Dynamic Task Mapping)
+            → wrap_query    (@task ×4)
+            → run_query     (AnalyticsOperator ×4, via Dynamic Task Mapping)
+            → collect_results (@task)
+            → synthesize_answer (LLMOperator)
+            → result_confirmation (ApprovalOperator)
+    """
+
+    # ------------------------------------------------------------------
+    # Step 1: Decompose the high-level question into sub-questions,
+    # one per dimension.  Each string becomes one mapped task instance
+    # in the next step.
+    # ------------------------------------------------------------------
+    @task
+    def decompose_question() -> list[str]:
+        return [
+            (
+                "Among respondents who use AI/LLM tools to write Airflow code, "
+                "what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor) "
+                "are most commonly enabled? Return the count per executor type."
+            ),
+            (
+                "Among respondents who use AI/LLM tools to write Airflow code, "
+                "how do they deploy Airflow? Return the count per deployment method."
+            ),
+            (
+                "Among respondents who use AI/LLM tools to write Airflow code, "
+                "which cloud providers are most commonly used for Airflow? "
+                "Return the count per cloud provider."
+            ),
+            (
+                "Among respondents who use AI/LLM tools to write Airflow code, "
+                "what version of Airflow are they currently running? "
+                "Return the count per version."
+            ),
+        ]
+
+    sub_questions = decompose_question()
+
+    # ------------------------------------------------------------------
+    # Step 2: Generate SQL for each sub-question in parallel.
+    # LLMSQLQueryOperator is expanded over the sub-question list —
+    # four mapped instances, each translating one natural-language
+    # question into validated SQL.
+    # ------------------------------------------------------------------
+    generate_sql = LLMSQLQueryOperator.partial(
+        task_id="generate_sql",
+        llm_conn_id=LLM_CONN_ID,
+        datasource_config=survey_datasource,
+        schema_context=SURVEY_SCHEMA,
+    ).expand(prompt=sub_questions)
+
+    # ------------------------------------------------------------------
+    # Step 3: Wrap each SQL string into a single-element list.
+    # AnalyticsOperator expects queries: list[str]; this step bridges
+    # the scalar output of LLMSQLQueryOperator to that interface.
+    # ------------------------------------------------------------------
+    @task
+    def wrap_query(sql: str) -> list[str]:
+        return [sql]
+
+    wrapped_queries = wrap_query.expand(sql=generate_sql.output)
+
+    # ------------------------------------------------------------------
+    # Step 4: Execute each SQL against the survey CSV via DataFusion.
+    # Four mapped instances run in parallel.  If one fails, only that
+    # instance retries — the other three hold their XCom results.
+    # ------------------------------------------------------------------
+    run_query = AnalyticsOperator.partial(
+        task_id="run_query",
+        datasource_configs=[survey_datasource],
+        result_output_format="json",
+    ).expand(queries=wrapped_queries)
+
+    # ------------------------------------------------------------------
+    # Step 5: Collect all four JSON results and label them by dimension.
+    # trigger_rule="all_success" ensures synthesis only runs when the
+    # complete picture is available.
+    # ------------------------------------------------------------------
+    @task(trigger_rule="all_success")
+    def collect_results(results: list[str]) -> dict:
+        # Airflow preserves index order for mapped task outputs, so zip is safe here:
+        # results[i] corresponds to the mapped instance at index i, which matches
+        # the sub-question at DIMENSION_KEYS[i].
+        labeled: dict[str, list] = {}
+        for key, raw in zip(DIMENSION_KEYS, results):
+            items = json.loads(raw)
+            data = [row for item in items for row in item["data"]]
+            labeled[key] = data
+        return labeled
+
+    collected = collect_results(run_query.output)
+
+    # ------------------------------------------------------------------
+    # Step 6: Synthesize the four labeled result sets into a narrative.
+    # This is the second LLM call — the first four generated SQL,
+    # this one interprets the results.  Inputs are fully visible in XCom.
+    # ------------------------------------------------------------------
+    synthesize_answer = LLMOperator(
+        task_id="synthesize_answer",
+        llm_conn_id=LLM_CONN_ID,
+        system_prompt=SYNTHESIS_SYSTEM_PROMPT,
+        prompt=(
+            "Given these four independent survey query results about practitioners "
+            "who use AI tools to write Airflow code, write a 2-3 sentence "
+            "characterization of what a typical Airflow deployment looks like for "
+            "this group.\n\n"
+            "Results: {{ ti.xcom_pull(task_ids='collect_results') }}"
+        ),
+    )
+    collected >> synthesize_answer
+
+    # ------------------------------------------------------------------
+    # Step 7: Human reviews the synthesized narrative before the DAG ends.
+    # ------------------------------------------------------------------
+    result_confirmation = ApprovalOperator(
+        task_id="result_confirmation",
+        subject="Review the synthesized survey analysis",
+        body="{{ ti.xcom_pull(task_ids='synthesize_answer') }}",
+        response_timeout=datetime.timedelta(hours=1),
+    )
+
+    synthesize_answer >> result_confirmation
+
+
+# [END example_llm_survey_agentic]
+
+example_llm_survey_agentic()

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
@@ -115,18 +115,18 @@ survey_datasource = DataSourceConfig(
 DIMENSION_KEYS = ["executor", "deployment", "cloud", "airflow_version"]
 
 SQL_SYSTEM_PROMPT = """\
-You are a SQL analysis agent working on the table "survey". \
+You are a SQL analysis agent working on the table "survey".
 Always quote all table and column names with double quotes.
 
-For the AI usage filter column \
+For the AI usage filter column
 "Are you using AI/LLM (ChatGPT/Cursor/Claude etc) to assist you in writing Airflow code?":
 - Treat affirmative free text (yes, sometimes, occasionally, rarely, often, regularly) as AI users.
 - Treat explicit negatives (no, never) as non-users.
 - Exclude blank, NULL, and ambiguous responses from the filtered set."""
 
 SYNTHESIS_SYSTEM_PROMPT = """\
-You are a data analyst summarizing survey results about Apache Airflow practitioners. \
-Write in plain, concise language suitable for a technical audience. \
+You are a data analyst summarizing survey results about Apache Airflow practitioners.
+Write in plain, concise language suitable for a technical audience.
 Focus on patterns and proportions rather than raw counts."""
 
 
@@ -161,21 +161,21 @@ def example_llm_survey_agentic():
     def decompose_question() -> list[str]:
         return [
             """\
-Among respondents who use AI/LLM tools to write Airflow code, \
-what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor) \
-are most commonly enabled? Count an executor as enabled only if the \
-column value is clearly affirmative. Treat blank, NULL, and negative \
+Among respondents who use AI/LLM tools to write Airflow code,
+what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor)
+are most commonly enabled? Count an executor as enabled only if the
+column value is clearly affirmative. Treat blank, NULL, and negative
 values as not enabled. Return the count per executor type.""",
             """\
-Among respondents who use AI/LLM tools to write Airflow code, \
+Among respondents who use AI/LLM tools to write Airflow code,
 how do they deploy Airflow? Return the count per deployment method.""",
             """\
-Among respondents who use AI/LLM tools to write Airflow code, \
-which cloud providers are most commonly used for Airflow? \
+Among respondents who use AI/LLM tools to write Airflow code,
+which cloud providers are most commonly used for Airflow?
 Return the count per cloud provider.""",
             """\
-Among respondents who use AI/LLM tools to write Airflow code, \
-what version of Airflow are they currently running? \
+Among respondents who use AI/LLM tools to write Airflow code,
+what version of Airflow are they currently running?
 Return the count per version.""",
         ]
 
@@ -246,9 +246,9 @@ Return the count per version.""",
         llm_conn_id=LLM_CONN_ID,
         system_prompt=SYNTHESIS_SYSTEM_PROMPT,
         prompt="""\
-Given these four independent survey query results about practitioners \
-who use AI tools to write Airflow code, write a 2-3 sentence \
-characterization of what a typical Airflow deployment looks like for \
+Given these four independent survey query results about practitioners
+who use AI tools to write Airflow code, write a 2-3 sentence
+characterization of what a typical Airflow deployment looks like for
 this group.
 
 Results: {{ ti.xcom_pull(task_ids='collect_results') }}""",

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_agentic.py
@@ -114,6 +114,16 @@ survey_datasource = DataSourceConfig(
 # Dimension labels -- order must match the sub-questions returned by decompose_question.
 DIMENSION_KEYS = ["executor", "deployment", "cloud", "airflow_version"]
 
+SQL_SYSTEM_PROMPT = """\
+You are a SQL analysis agent working on the table "survey". \
+Always quote all table and column names with double quotes.
+
+For the AI usage filter column \
+"Are you using AI/LLM (ChatGPT/Cursor/Claude etc) to assist you in writing Airflow code?":
+- Treat affirmative free text (yes, sometimes, occasionally, rarely, often, regularly) as AI users.
+- Treat explicit negatives (no, never) as non-users.
+- Exclude blank, NULL, and ambiguous responses from the filtered set."""
+
 SYNTHESIS_SYSTEM_PROMPT = """\
 You are a data analyst summarizing survey results about Apache Airflow practitioners. \
 Write in plain, concise language suitable for a technical audience. \
@@ -153,7 +163,9 @@ def example_llm_survey_agentic():
             """\
 Among respondents who use AI/LLM tools to write Airflow code, \
 what executor types (CeleryExecutor, KubernetesExecutor, LocalExecutor) \
-are most commonly enabled? Return the count per executor type.""",
+are most commonly enabled? Count an executor as enabled only if the \
+column value is clearly affirmative. Treat blank, NULL, and negative \
+values as not enabled. Return the count per executor type.""",
             """\
 Among respondents who use AI/LLM tools to write Airflow code, \
 how do they deploy Airflow? Return the count per deployment method.""",
@@ -180,6 +192,7 @@ Return the count per version.""",
         llm_conn_id=LLM_CONN_ID,
         datasource_config=survey_datasource,
         schema_context=SURVEY_SCHEMA,
+        system_prompt=SQL_SYSTEM_PROMPT,
     ).expand(prompt=sub_questions)
 
     # ------------------------------------------------------------------

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -237,7 +237,7 @@ example_llm_survey_interactive()
 
 
 # [START example_llm_survey_scheduled]
-@dag(schedule="@monthly", start_date=datetime.datetime(2025, 1, 1))
+@dag(schedule="@monthly", start_date=datetime.datetime(2025, 1, 1), catchup=False)
 def example_llm_survey_scheduled():
     """
     Download, validate, query, and report on the survey CSV on a schedule.

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -125,14 +125,14 @@ Key columns (quote all names in SQL):
 """
 
 survey_datasource = DataSourceConfig(
-    conn_id="",
+    conn_id="",  # No connection needed for local file-based sources
     table_name="survey",
     uri=SURVEY_CSV_URI,
     format="csv",
 )
 
 reference_datasource = DataSourceConfig(
-    conn_id="",
+    conn_id="",  # No connection needed for local file-based sources
     table_name="survey_reference",
     uri=REFERENCE_CSV_URI,
     format="csv",
@@ -216,14 +216,14 @@ def example_llm_survey_interactive():
     # ------------------------------------------------------------------
     # Step 5: Result confirmation -- approve or reject the query result.
     # ------------------------------------------------------------------
-    result_confirmation = ApprovalOperator(
+    result_confirmation = ApprovalOperator(  # noqa: F841
         task_id="result_confirmation",
         subject="Review the survey query result",
-        body="{{ ti.xcom_pull(task_ids='extract_data') }}",
+        body=result_data,
         response_timeout=datetime.timedelta(hours=1),
     )
 
-    prompt_confirmation >> generate_sql >> run_query >> result_data >> result_confirmation
+    prompt_confirmation >> generate_sql >> run_query
 
 
 # [END example_llm_survey_interactive]
@@ -299,10 +299,9 @@ def example_llm_survey_scheduled():
     # ------------------------------------------------------------------
     check_schema = LLMSchemaCompareOperator(
         task_id="check_schema",
-        prompt=(
-            "Compare the survey CSV schema against the reference schema. "
-            "Flag any missing or renamed columns that would break the downstream SQL queries."
-        ),
+        prompt="""\
+Compare the survey CSV schema against the reference schema. \
+Flag any missing or renamed columns that would break the downstream SQL queries.""",
         llm_conn_id=LLM_CONN_ID,
         data_sources=[survey_datasource, reference_datasource],
         context_strategy="basic",

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -256,6 +256,7 @@ def example_llm_survey_scheduled():
     the run frequency.
 
     Prerequisites:
+
     - HTTP connection ``airflow_website`` pointing at ``https://airflow.apache.org``.
     - Set ``SMTP_CONN_ID`` and ``NOTIFY_EMAIL`` environment variables to enable
       email delivery of results; otherwise results are logged to the task log.

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -1,0 +1,423 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+<<<<<<< HEAD
+Natural language analysis of a survey CSV — interactive and scheduled variants.
+
+Both DAGs query the `Airflow Community Survey 2025
+<https://airflow.apache.org/survey/>`__ CSV using
+:class:`~airflow.providers.common.ai.operators.llm_sql.LLMSQLQueryOperator`
+and :class:`~airflow.providers.common.sql.operators.analytics.AnalyticsOperator`.
+
+``example_llm_survey_interactive`` (five tasks, manual trigger)
+  Adds human-in-the-loop review at both ends of the pipeline:
+
+  1. **HITLEntryOperator** — human reviews and optionally edits the question.
+  2. **LLMSQLQueryOperator** — translates the confirmed question into SQL.
+  3. **AnalyticsOperator** — executes the SQL against the CSV via Apache DataFusion.
+  4. A ``@task`` function — extracts the data rows from the JSON payload.
+  5. **ApprovalOperator** — human approves or rejects the query result.
+
+``example_llm_survey_scheduled`` (three tasks, runs on a schedule)
+  Runs a fixed question end-to-end without human review — suitable for
+  recurring reporting or dashboards:
+
+  1. **LLMSQLQueryOperator** — translates the question into SQL.
+  2. **AnalyticsOperator** — executes the SQL against the CSV.
+  3. A ``@task`` function — extracts the data rows from the JSON payload.
+
+Before running either DAG:
+=======
+Interactive natural language analysis of a survey CSV.
+
+``example_llm_survey_interactive`` queries the `Airflow Community Survey 2025
+<https://airflow.apache.org/survey/>`__ CSV using a five-step pipeline:
+
+  1. **HITLEntryOperator** — human reviews and optionally edits the question.
+  2. **LLMSQLQueryOperator** — translates the confirmed question into SQL.
+  3. **AnalyticsOperator** — executes the SQL against the CSV via Apache
+     DataFusion and returns the results as JSON.
+  4. A ``@task`` function — extracts the data rows from the JSON payload.
+  5. **ApprovalOperator** — human approves or rejects the query result.
+
+Before running:
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+
+1. Create an LLM connection named ``pydanticai_default`` (or the value of
+   ``LLM_CONN_ID`` below) for your chosen model provider.
+2. Place the survey CSV at the path set by the ``SURVEY_CSV_PATH``
+   environment variable, or update ``SURVEY_CSV_PATH`` below.
+   A cleaned copy of the 2025 survey CSV (duplicate columns renamed, embedded
+   newlines removed) is required — Apache DataFusion is strict about these.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+
+<<<<<<< HEAD
+from airflow.providers.common.ai.operators.llm_schema_compare import LLMSchemaCompareOperator
+=======
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
+from airflow.providers.common.compat.sdk import dag, task
+from airflow.providers.common.sql.config import DataSourceConfig
+from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
+from airflow.providers.standard.operators.hitl import ApprovalOperator, HITLEntryOperator
+from airflow.sdk import Param
+
+<<<<<<< HEAD
+try:
+    from airflow.providers.http.operators.http import HttpOperator
+
+    _has_http_provider = True
+except ImportError:
+    _has_http_provider = False
+
+=======
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# LLM provider connection (OpenAI, Anthropic, Vertex AI, etc.)
+LLM_CONN_ID = "pydanticai_default"
+
+<<<<<<< HEAD
+# HTTP connection pointing at https://airflow.apache.org (scheduled DAG only).
+# Create a connection with host=https://airflow.apache.org, no auth required.
+AIRFLOW_WEBSITE_CONN_ID = "airflow_website"
+
+# Endpoint path for the survey CSV download, relative to the HTTP connection base URL.
+SURVEY_CSV_ENDPOINT = "/survey/airflow-user-survey-2025.csv"
+
+=======
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+# Path to the survey CSV.  Set the SURVEY_CSV_PATH environment variable to
+# override — no code change needed when moving between environments.
+SURVEY_CSV_PATH = os.environ.get(
+    "SURVEY_CSV_PATH",
+    "/opt/airflow/data/airflow-user-survey-2025.csv",
+)
+SURVEY_CSV_URI = f"file://{SURVEY_CSV_PATH}"
+
+<<<<<<< HEAD
+# Path where the reference schema CSV is written at runtime (scheduled DAG only).
+REFERENCE_CSV_PATH = os.environ.get(
+    "REFERENCE_CSV_PATH",
+    "/opt/airflow/data/airflow-user-survey-2025-reference.csv",
+)
+REFERENCE_CSV_URI = f"file://{REFERENCE_CSV_PATH}"
+
+# SMTP connection for the result notification step (scheduled DAG only).
+# Set to None to skip email and log the result instead.
+SMTP_CONN_ID = os.environ.get("SMTP_CONN_ID", None)
+NOTIFY_EMAIL = os.environ.get("NOTIFY_EMAIL", None)
+
+# Default question for the interactive DAG — the human can edit it in the first HITL step.
+INTERACTIVE_PROMPT = (
+    "How does AI tool usage for writing Airflow code compare between Airflow 3 users and Airflow 2 users?"
+)
+
+# Fixed question for the scheduled DAG — runs unattended on every trigger.
+SCHEDULED_PROMPT = "What is the breakdown of respondents by Airflow version currently in use?"
+=======
+# Default question — the human can edit it in the first HITL step.
+INTERACTIVE_PROMPT = "Which city had the highest number of respondents?"
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+
+# Schema context for LLMSQLQueryOperator.
+# Lists the analytically relevant columns from the 2025 survey CSV (168 total).
+# All column names must be quoted in SQL because they contain spaces and
+# punctuation.
+SURVEY_SCHEMA = """
+Table: survey
+Key columns (quote all names in SQL):
+  "How important is Airflow to your business?"                                                TEXT
+  "Which version of Airflow do you currently use?"                                            TEXT
+  "CeleryExecutor"                                                                            TEXT
+  "KubernetesExecutor"                                                                        TEXT
+  "LocalExecutor"                                                                             TEXT
+  "How do you deploy Airflow?"                                                                TEXT
+  "What best describes your current occupation?"                                              TEXT
+  "What industry do you currently work in?"                                                   TEXT
+  "What city do you currently reside in?"                                                     TEXT
+  "How many years of experience do you have with Airflow?"                                    TEXT
+  "Which of the following is your company's primary cloud provider for Airflow?"              TEXT
+  "How many people work at your company?"                                                     TEXT
+  "How many people at your company directly work on data?"                                    TEXT
+  "How many people at your company use Airflow?"                                              TEXT
+  "How likely are you to recommend Apache Airflow?"                                           TEXT
+  "Are you using AI/LLM (ChatGPT/Cursor/Claude etc) to assist you in writing Airflow code?"  TEXT
+"""
+
+survey_datasource = DataSourceConfig(
+    conn_id="",
+    table_name="survey",
+    uri=SURVEY_CSV_URI,
+    format="csv",
+)
+
+<<<<<<< HEAD
+reference_datasource = DataSourceConfig(
+    conn_id="",
+    table_name="survey_reference",
+    uri=REFERENCE_CSV_URI,
+    format="csv",
+)
+
+=======
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
+
+# ---------------------------------------------------------------------------
+# DAG 1: Interactive survey question example
+# ---------------------------------------------------------------------------
+
+
+# [START example_llm_survey_interactive]
+@dag(schedule=None)
+def example_llm_survey_interactive():
+    """
+    Ask a natural language question about the survey with human review at each end.
+
+    Task graph::
+
+        prompt_confirmation (HITLEntryOperator)
+            → generate_sql (LLMSQLQueryOperator)
+            → run_query (AnalyticsOperator)
+            → extract_data (@task)
+            → result_confirmation (ApprovalOperator)
+
+    The first HITL step lets the analyst review and optionally reword the
+    question before it reaches the LLM.  The final HITL step presents the
+    query result for approval or rejection.
+    """
+
+    # ------------------------------------------------------------------
+    # Step 1: Prompt confirmation — review or edit the question.
+    # ------------------------------------------------------------------
+    prompt_confirmation = HITLEntryOperator(
+        task_id="prompt_confirmation",
+        subject="Review the survey analysis question",
+        params={
+            "prompt": Param(
+                INTERACTIVE_PROMPT,
+                type="string",
+                description="The natural language question to answer via SQL",
+            )
+        },
+        response_timeout=datetime.timedelta(hours=1),
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: SQL generation — LLM translates the confirmed question.
+    # ------------------------------------------------------------------
+    generate_sql = LLMSQLQueryOperator(
+        task_id="generate_sql",
+        prompt="{{ ti.xcom_pull(task_ids='prompt_confirmation')['params_input']['prompt'] }}",
+        llm_conn_id=LLM_CONN_ID,
+        datasource_config=survey_datasource,
+        schema_context=SURVEY_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: SQL execution via Apache DataFusion.
+    # ------------------------------------------------------------------
+    run_query = AnalyticsOperator(
+        task_id="run_query",
+        datasource_configs=[survey_datasource],
+        queries=["{{ ti.xcom_pull(task_ids='generate_sql') }}"],
+        result_output_format="json",
+    )
+
+    # ------------------------------------------------------------------
+    # Step 4: Extract data rows from the JSON result.
+    # AnalyticsOperator returns [{"query": "...", "data": [...]}, ...]
+    # This step strips the query field so only the rows reach the reviewer.
+    # ------------------------------------------------------------------
+    @task
+    def extract_data(raw: str) -> str:
+        results = json.loads(raw)
+        data = [row for item in results for row in item["data"]]
+        return json.dumps(data, indent=2)
+
+    result_data = extract_data(run_query.output)
+
+    # ------------------------------------------------------------------
+    # Step 5: Result confirmation — approve or reject the query result.
+    # ------------------------------------------------------------------
+    result_confirmation = ApprovalOperator(
+        task_id="result_confirmation",
+        subject="Review the survey query result",
+        body="{{ ti.xcom_pull(task_ids='extract_data') }}",
+        response_timeout=datetime.timedelta(hours=1),
+    )
+
+    prompt_confirmation >> generate_sql >> run_query >> result_data >> result_confirmation
+
+
+# [END example_llm_survey_interactive]
+
+example_llm_survey_interactive()
+<<<<<<< HEAD
+
+
+# ---------------------------------------------------------------------------
+# DAG 2: Scheduled survey question example
+# ---------------------------------------------------------------------------
+
+
+# [START example_llm_survey_scheduled]
+@dag(schedule="@monthly", start_date=None)
+def example_llm_survey_scheduled():
+    """
+    Download, validate, query, and report on the survey CSV on a schedule.
+
+    Task graph::
+
+        download_survey (HttpOperator)
+            → prepare_csv (@task)
+            → check_schema (LLMSchemaCompareOperator)
+            → generate_sql (LLMSQLQueryOperator)
+            → run_query (AnalyticsOperator)
+            → extract_data (@task)
+            → send_result (@task)
+
+    No human review steps — suitable for recurring reporting or dashboards.
+    Change ``schedule`` to any cron expression or Airflow timetable to adjust
+    the run frequency.
+
+    Prerequisites:
+    - HTTP connection ``airflow_website`` pointing at ``https://airflow.apache.org``.
+    - Set ``SMTP_CONN_ID`` and ``NOTIFY_EMAIL`` environment variables to enable
+      email delivery of results; otherwise results are logged to the task log.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: Download the survey CSV from the Airflow website.
+    # ------------------------------------------------------------------
+    download_survey = HttpOperator(
+        task_id="download_survey",
+        http_conn_id=AIRFLOW_WEBSITE_CONN_ID,
+        endpoint=SURVEY_CSV_ENDPOINT,
+        method="GET",
+        response_filter=lambda r: r.text,
+        log_response=False,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Write the downloaded CSV to disk and generate a reference
+    # schema file for the schema comparison step.
+    # ------------------------------------------------------------------
+    @task
+    def prepare_csv(csv_text: str) -> None:
+        import csv as csv_mod
+        import os
+
+        os.makedirs(os.path.dirname(SURVEY_CSV_PATH), exist_ok=True)
+        with open(SURVEY_CSV_PATH, "w", encoding="utf-8") as f:
+            f.write(csv_text)
+
+        # Write a single-row reference CSV from the schema context so
+        # LLMSchemaCompareOperator has a structured baseline to compare against.
+        os.makedirs(os.path.dirname(REFERENCE_CSV_PATH), exist_ok=True)
+        columns = [line.split('"')[1] for line in SURVEY_SCHEMA.strip().splitlines() if '"' in line]
+        with open(REFERENCE_CSV_PATH, "w", newline="", encoding="utf-8") as ref:
+            csv_mod.writer(ref).writerow(columns)
+
+    csv_ready = prepare_csv(download_survey.output)
+
+    # ------------------------------------------------------------------
+    # Step 3: Validate the downloaded CSV schema against the reference.
+    # Raises if critical columns are missing or renamed.
+    # ------------------------------------------------------------------
+    check_schema = LLMSchemaCompareOperator(
+        task_id="check_schema",
+        prompt=(
+            "Compare the survey CSV schema against the reference schema. "
+            "Flag any missing or renamed columns that would break the downstream SQL queries."
+        ),
+        llm_conn_id=LLM_CONN_ID,
+        data_sources=[survey_datasource, reference_datasource],
+        context_strategy="basic",
+    )
+    csv_ready >> check_schema
+
+    # ------------------------------------------------------------------
+    # Step 4: SQL generation — LLM translates the fixed question.
+    # ------------------------------------------------------------------
+    generate_sql = LLMSQLQueryOperator(
+        task_id="generate_sql",
+        prompt=SCHEDULED_PROMPT,
+        llm_conn_id=LLM_CONN_ID,
+        datasource_config=survey_datasource,
+        schema_context=SURVEY_SCHEMA,
+    )
+    check_schema >> generate_sql
+
+    # ------------------------------------------------------------------
+    # Step 5: SQL execution via Apache DataFusion.
+    # ------------------------------------------------------------------
+    run_query = AnalyticsOperator(
+        task_id="run_query",
+        datasource_configs=[survey_datasource],
+        queries=["{{ ti.xcom_pull(task_ids='generate_sql') }}"],
+        result_output_format="json",
+    )
+
+    # ------------------------------------------------------------------
+    # Step 6: Extract data rows from the JSON result.
+    # AnalyticsOperator returns [{"query": "...", "data": [...]}, ...]
+    # ------------------------------------------------------------------
+    @task
+    def extract_data(raw: str) -> str:
+        results = json.loads(raw)
+        data = [row for item in results for row in item["data"]]
+        return json.dumps(data, indent=2)
+
+    result_data = extract_data(run_query.output)
+
+    # ------------------------------------------------------------------
+    # Step 7: Send result via email if SMTP is configured, otherwise log.
+    # Set the SMTP_CONN_ID and NOTIFY_EMAIL environment variables to enable
+    # email delivery.
+    # ------------------------------------------------------------------
+    @task
+    def send_result(data: str) -> None:
+        if SMTP_CONN_ID and NOTIFY_EMAIL:
+            from airflow.providers.smtp.operators.smtp import EmailOperator
+
+            EmailOperator(
+                task_id="_send_email",
+                smtp_conn_id=SMTP_CONN_ID,
+                to=NOTIFY_EMAIL,
+                subject=f"Airflow Survey Analysis: {SCHEDULED_PROMPT}",
+                html_content=f"<pre>{data}</pre>",
+            ).execute({})
+        else:
+            print(f"Survey analysis result:\n{data}")
+
+    generate_sql >> run_query >> result_data >> send_result(result_data)
+
+
+# [END example_llm_survey_scheduled]
+
+if _has_http_provider:
+    example_llm_survey_scheduled()
+=======
+>>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -60,15 +60,9 @@ from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
 from airflow.providers.common.compat.sdk import dag, task
 from airflow.providers.common.sql.config import DataSourceConfig
 from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
+from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.standard.operators.hitl import ApprovalOperator, HITLEntryOperator
 from airflow.sdk import Param, log
-
-try:
-    from airflow.providers.http.operators.http import HttpOperator
-
-    _has_http_provider = True
-except ImportError:
-    _has_http_provider = False
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -382,5 +376,4 @@ def example_llm_survey_scheduled():
 
 # [END example_llm_survey_scheduled]
 
-if _has_http_provider:
-    example_llm_survey_scheduled()
+example_llm_survey_scheduled()

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-<<<<<<< HEAD
-Natural language analysis of a survey CSV — interactive and scheduled variants.
+Natural language analysis of a survey CSV -- interactive and scheduled variants.
 
 Both DAGs query the `Airflow Community Survey 2025
 <https://airflow.apache.org/survey/>`__ CSV using
@@ -26,43 +25,28 @@ and :class:`~airflow.providers.common.sql.operators.analytics.AnalyticsOperator`
 ``example_llm_survey_interactive`` (five tasks, manual trigger)
   Adds human-in-the-loop review at both ends of the pipeline:
 
-  1. **HITLEntryOperator** — human reviews and optionally edits the question.
-  2. **LLMSQLQueryOperator** — translates the confirmed question into SQL.
-  3. **AnalyticsOperator** — executes the SQL against the CSV via Apache DataFusion.
-  4. A ``@task`` function — extracts the data rows from the JSON payload.
-  5. **ApprovalOperator** — human approves or rejects the query result.
+  1. **HITLEntryOperator** -- human reviews and optionally edits the question.
+  2. **LLMSQLQueryOperator** -- translates the confirmed question into SQL.
+  3. **AnalyticsOperator** -- executes the SQL against the CSV via Apache DataFusion.
+  4. A ``@task`` function -- extracts the data rows from the JSON payload.
+  5. **ApprovalOperator** -- human approves or rejects the query result.
 
 ``example_llm_survey_scheduled`` (three tasks, runs on a schedule)
-  Runs a fixed question end-to-end without human review — suitable for
+  Runs a fixed question end-to-end without human review -- suitable for
   recurring reporting or dashboards:
 
-  1. **LLMSQLQueryOperator** — translates the question into SQL.
-  2. **AnalyticsOperator** — executes the SQL against the CSV.
-  3. A ``@task`` function — extracts the data rows from the JSON payload.
+  1. **LLMSQLQueryOperator** -- translates the question into SQL.
+  2. **AnalyticsOperator** -- executes the SQL against the CSV.
+  3. A ``@task`` function -- extracts the data rows from the JSON payload.
 
 Before running either DAG:
-=======
-Interactive natural language analysis of a survey CSV.
-
-``example_llm_survey_interactive`` queries the `Airflow Community Survey 2025
-<https://airflow.apache.org/survey/>`__ CSV using a five-step pipeline:
-
-  1. **HITLEntryOperator** — human reviews and optionally edits the question.
-  2. **LLMSQLQueryOperator** — translates the confirmed question into SQL.
-  3. **AnalyticsOperator** — executes the SQL against the CSV via Apache
-     DataFusion and returns the results as JSON.
-  4. A ``@task`` function — extracts the data rows from the JSON payload.
-  5. **ApprovalOperator** — human approves or rejects the query result.
-
-Before running:
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 
 1. Create an LLM connection named ``pydanticai_default`` (or the value of
    ``LLM_CONN_ID`` below) for your chosen model provider.
 2. Place the survey CSV at the path set by the ``SURVEY_CSV_PATH``
    environment variable, or update ``SURVEY_CSV_PATH`` below.
    A cleaned copy of the 2025 survey CSV (duplicate columns renamed, embedded
-   newlines removed) is required — Apache DataFusion is strict about these.
+   newlines removed) is required -- Apache DataFusion is strict about these.
 """
 
 from __future__ import annotations
@@ -71,10 +55,7 @@ import datetime
 import json
 import os
 
-<<<<<<< HEAD
 from airflow.providers.common.ai.operators.llm_schema_compare import LLMSchemaCompareOperator
-=======
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 from airflow.providers.common.ai.operators.llm_sql import LLMSQLQueryOperator
 from airflow.providers.common.compat.sdk import dag, task
 from airflow.providers.common.sql.config import DataSourceConfig
@@ -82,7 +63,6 @@ from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
 from airflow.providers.standard.operators.hitl import ApprovalOperator, HITLEntryOperator
 from airflow.sdk import Param
 
-<<<<<<< HEAD
 try:
     from airflow.providers.http.operators.http import HttpOperator
 
@@ -90,8 +70,6 @@ try:
 except ImportError:
     _has_http_provider = False
 
-=======
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -99,7 +77,6 @@ except ImportError:
 # LLM provider connection (OpenAI, Anthropic, Vertex AI, etc.)
 LLM_CONN_ID = "pydanticai_default"
 
-<<<<<<< HEAD
 # HTTP connection pointing at https://airflow.apache.org (scheduled DAG only).
 # Create a connection with host=https://airflow.apache.org, no auth required.
 AIRFLOW_WEBSITE_CONN_ID = "airflow_website"
@@ -107,17 +84,14 @@ AIRFLOW_WEBSITE_CONN_ID = "airflow_website"
 # Endpoint path for the survey CSV download, relative to the HTTP connection base URL.
 SURVEY_CSV_ENDPOINT = "/survey/airflow-user-survey-2025.csv"
 
-=======
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 # Path to the survey CSV.  Set the SURVEY_CSV_PATH environment variable to
-# override — no code change needed when moving between environments.
+# override -- no code change needed when moving between environments.
 SURVEY_CSV_PATH = os.environ.get(
     "SURVEY_CSV_PATH",
     "/opt/airflow/data/airflow-user-survey-2025.csv",
 )
 SURVEY_CSV_URI = f"file://{SURVEY_CSV_PATH}"
 
-<<<<<<< HEAD
 # Path where the reference schema CSV is written at runtime (scheduled DAG only).
 REFERENCE_CSV_PATH = os.environ.get(
     "REFERENCE_CSV_PATH",
@@ -130,17 +104,13 @@ REFERENCE_CSV_URI = f"file://{REFERENCE_CSV_PATH}"
 SMTP_CONN_ID = os.environ.get("SMTP_CONN_ID", None)
 NOTIFY_EMAIL = os.environ.get("NOTIFY_EMAIL", None)
 
-# Default question for the interactive DAG — the human can edit it in the first HITL step.
+# Default question for the interactive DAG -- the human can edit it in the first HITL step.
 INTERACTIVE_PROMPT = (
     "How does AI tool usage for writing Airflow code compare between Airflow 3 users and Airflow 2 users?"
 )
 
-# Fixed question for the scheduled DAG — runs unattended on every trigger.
+# Fixed question for the scheduled DAG -- runs unattended on every trigger.
 SCHEDULED_PROMPT = "What is the breakdown of respondents by Airflow version currently in use?"
-=======
-# Default question — the human can edit it in the first HITL step.
-INTERACTIVE_PROMPT = "Which city had the highest number of respondents?"
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 
 # Schema context for LLMSQLQueryOperator.
 # Lists the analytically relevant columns from the 2025 survey CSV (168 total).
@@ -174,7 +144,6 @@ survey_datasource = DataSourceConfig(
     format="csv",
 )
 
-<<<<<<< HEAD
 reference_datasource = DataSourceConfig(
     conn_id="",
     table_name="survey_reference",
@@ -182,8 +151,6 @@ reference_datasource = DataSourceConfig(
     format="csv",
 )
 
-=======
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3
 
 # ---------------------------------------------------------------------------
 # DAG 1: Interactive survey question example
@@ -191,7 +158,7 @@ reference_datasource = DataSourceConfig(
 
 
 # [START example_llm_survey_interactive]
-@dag(schedule=None)
+@dag
 def example_llm_survey_interactive():
     """
     Ask a natural language question about the survey with human review at each end.
@@ -210,7 +177,7 @@ def example_llm_survey_interactive():
     """
 
     # ------------------------------------------------------------------
-    # Step 1: Prompt confirmation — review or edit the question.
+    # Step 1: Prompt confirmation -- review or edit the question.
     # ------------------------------------------------------------------
     prompt_confirmation = HITLEntryOperator(
         task_id="prompt_confirmation",
@@ -226,7 +193,7 @@ def example_llm_survey_interactive():
     )
 
     # ------------------------------------------------------------------
-    # Step 2: SQL generation — LLM translates the confirmed question.
+    # Step 2: SQL generation -- LLM translates the confirmed question.
     # ------------------------------------------------------------------
     generate_sql = LLMSQLQueryOperator(
         task_id="generate_sql",
@@ -260,7 +227,7 @@ def example_llm_survey_interactive():
     result_data = extract_data(run_query.output)
 
     # ------------------------------------------------------------------
-    # Step 5: Result confirmation — approve or reject the query result.
+    # Step 5: Result confirmation -- approve or reject the query result.
     # ------------------------------------------------------------------
     result_confirmation = ApprovalOperator(
         task_id="result_confirmation",
@@ -275,7 +242,6 @@ def example_llm_survey_interactive():
 # [END example_llm_survey_interactive]
 
 example_llm_survey_interactive()
-<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +265,7 @@ def example_llm_survey_scheduled():
             → extract_data (@task)
             → send_result (@task)
 
-    No human review steps — suitable for recurring reporting or dashboards.
+    No human review steps -- suitable for recurring reporting or dashboards.
     Change ``schedule`` to any cron expression or Airflow timetable to adjust
     the run frequency.
 
@@ -359,7 +325,7 @@ def example_llm_survey_scheduled():
     csv_ready >> check_schema
 
     # ------------------------------------------------------------------
-    # Step 4: SQL generation — LLM translates the fixed question.
+    # Step 4: SQL generation -- LLM translates the fixed question.
     # ------------------------------------------------------------------
     generate_sql = LLMSQLQueryOperator(
         task_id="generate_sql",
@@ -419,5 +385,3 @@ def example_llm_survey_scheduled():
 
 if _has_http_provider:
     example_llm_survey_scheduled()
-=======
->>>>>>> 6d60bff29b8b7c6916d49033f0956ae6ceff5ab3

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -300,7 +300,7 @@ def example_llm_survey_scheduled():
     check_schema = LLMSchemaCompareOperator(
         task_id="check_schema",
         prompt="""\
-Compare the survey CSV schema against the reference schema. \
+Compare the survey CSV schema against the reference schema.
 Flag any missing or renamed columns that would break the downstream SQL queries.""",
         llm_conn_id=LLM_CONN_ID,
         data_sources=[survey_datasource, reference_datasource],

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -22,22 +22,14 @@ Both DAGs query the `Airflow Community Survey 2025
 :class:`~airflow.providers.common.ai.operators.llm_sql.LLMSQLQueryOperator`
 and :class:`~airflow.providers.common.sql.operators.analytics.AnalyticsOperator`.
 
-``example_llm_survey_interactive`` (five tasks, manual trigger)
-  Adds human-in-the-loop review at both ends of the pipeline:
+**example_llm_survey_interactive** (five tasks, manual trigger) adds
+human-in-the-loop review at both ends of the pipeline: HITLEntryOperator,
+LLMSQLQueryOperator, AnalyticsOperator, a ``@task`` extraction step, and
+ApprovalOperator.
 
-  1. **HITLEntryOperator** -- human reviews and optionally edits the question.
-  2. **LLMSQLQueryOperator** -- translates the confirmed question into SQL.
-  3. **AnalyticsOperator** -- executes the SQL against the CSV via Apache DataFusion.
-  4. A ``@task`` function -- extracts the data rows from the JSON payload.
-  5. **ApprovalOperator** -- human approves or rejects the query result.
-
-``example_llm_survey_scheduled`` (three tasks, runs on a schedule)
-  Runs a fixed question end-to-end without human review -- suitable for
-  recurring reporting or dashboards:
-
-  1. **LLMSQLQueryOperator** -- translates the question into SQL.
-  2. **AnalyticsOperator** -- executes the SQL against the CSV.
-  3. A ``@task`` function -- extracts the data rows from the JSON payload.
+**example_llm_survey_scheduled** (seven tasks, runs monthly) downloads the CSV,
+validates its schema, generates and executes SQL, then emails or logs the result.
+No human review steps -- suitable for recurring reporting or dashboards.
 
 Before running either DAG:
 
@@ -62,7 +54,7 @@ from airflow.providers.common.sql.config import DataSourceConfig
 from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
 from airflow.providers.http.operators.http import HttpOperator
 from airflow.providers.standard.operators.hitl import ApprovalOperator, HITLEntryOperator
-from airflow.sdk import Param, log
+from airflow.sdk import Param
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -369,7 +361,7 @@ def example_llm_survey_scheduled():
                     html_content=f"<pre>{data}</pre>",
                 )
         else:
-            log.info("Survey analysis result:\n%s", data)
+            print(f"Survey analysis result:\n{data}")
 
     generate_sql >> run_query >> result_data >> send_result(result_data)
 

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -61,7 +61,7 @@ from airflow.providers.common.compat.sdk import dag, task
 from airflow.providers.common.sql.config import DataSourceConfig
 from airflow.providers.common.sql.operators.analytics import AnalyticsOperator
 from airflow.providers.standard.operators.hitl import ApprovalOperator, HITLEntryOperator
-from airflow.sdk import Param
+from airflow.sdk import Param, log
 
 try:
     from airflow.providers.http.operators.http import HttpOperator
@@ -250,7 +250,7 @@ example_llm_survey_interactive()
 
 
 # [START example_llm_survey_scheduled]
-@dag(schedule="@monthly", start_date=None)
+@dag(schedule="@monthly", start_date=datetime.datetime(2025, 1, 1))
 def example_llm_survey_scheduled():
     """
     Download, validate, query, and report on the survey CSV on a schedule.
@@ -366,17 +366,16 @@ def example_llm_survey_scheduled():
     @task
     def send_result(data: str) -> None:
         if SMTP_CONN_ID and NOTIFY_EMAIL:
-            from airflow.providers.smtp.operators.smtp import EmailOperator
+            from airflow.providers.smtp.hooks.smtp import SmtpHook
 
-            EmailOperator(
-                task_id="_send_email",
-                smtp_conn_id=SMTP_CONN_ID,
-                to=NOTIFY_EMAIL,
-                subject=f"Airflow Survey Analysis: {SCHEDULED_PROMPT}",
-                html_content=f"<pre>{data}</pre>",
-            ).execute({})
+            with SmtpHook(smtp_conn_id=SMTP_CONN_ID) as hook:
+                hook.send_email_smtp(
+                    to=NOTIFY_EMAIL,
+                    subject=f"Airflow Survey Analysis: {SCHEDULED_PROMPT}",
+                    html_content=f"<pre>{data}</pre>",
+                )
         else:
-            print(f"Survey analysis result:\n{data}")
+            log.info("Survey analysis result:\n%s", data)
 
     generate_sql >> run_query >> result_data >> send_result(result_data)
 

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_survey_analysis.py
@@ -43,6 +43,7 @@ Before running either DAG:
 
 from __future__ import annotations
 
+import csv as csv_mod
 import datetime
 import json
 import os
@@ -279,9 +280,6 @@ def example_llm_survey_scheduled():
     # ------------------------------------------------------------------
     @task
     def prepare_csv(csv_text: str) -> None:
-        import csv as csv_mod
-        import os
-
         os.makedirs(os.path.dirname(SURVEY_CSV_PATH), exist_ok=True)
         with open(SURVEY_CSV_PATH, "w", encoding="utf-8") as f:
             f.write(csv_text)


### PR DESCRIPTION
Here is a simple example for the common.ai provider based on public data which happens to be the Airflow 2025 Survey data.

The goal is to demonstrate an interactive LLM use case which can be used to try out exploratory data analysis and then a scheduled LLM use case which would be more representative of expected usage.

Both of these can be used by the developer as  starting points, where the data extraction and LLM prompts can be replaced with other integrations pulling other data sets.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x] Yes (please specify the tool below)

<!--
Generated-by: [Claude Code] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
