### PR TITLE
fix(amazon): extend SQS QUEUE_REGEXP to match AWS China endpoints

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/queues/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/queues/sqs.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from airflow.triggers.base import BaseEventTrigger
 
 # [START queue_regexp]
-QUEUE_REGEXP = r"^https://sqs\.[^.]+\.amazonaws\.com/[0-9]+/.+"
+QUEUE_REGEXP = r"^https://sqs\.[^.]+\.(amazonaws\.com|amazonaws\.cn)/[0-9]+/.+"
 # [END queue_regexp]
 
 

--- a/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
@@ -35,10 +35,15 @@ def test_message_sqs_queue_matches():
     from airflow.providers.amazon.aws.queues.sqs import SqsMessageQueueProvider
 
     provider = SqsMessageQueueProvider()
+    # Standard AWS regions
     assert provider.queue_matches("https://sqs.us-east-1.amazonaws.com/123456789012/my-queue")
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/123456789012")
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/123456789012/")
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/")
+    # AWS China regions (cn-north-1, cn-northwest-1)
+    assert provider.queue_matches("https://sqs.cn-north-1.amazonaws.cn/123456789012/my-queue")
+    assert provider.queue_matches("https://sqs.cn-northwest-1.amazonaws.cn/123456789012/my-queue")
+    assert not provider.queue_matches("https://sqs.cn-north-1.amazonaws.cn/123456789012")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

`QUEUE_REGEXP` only matched `amazonaws.com` domains, so `SqsMessageQueueProvider.queue_matches()` returned `False` for AWS China region URLs such as:

```
https://sqs.cn-north-1.amazonaws.cn/123456789012/my-queue
```

Extends the regex to accept `amazonaws.cn` as an alternate domain suffix, supporting China regions `cn-north-1` and `cn-northwest-1`.

Fixes #65128

## Are there any user-facing changes?

SQS queue URLs in AWS China regions are now correctly recognised by the `SqsMessageQueueProvider`.

## Checklist

- [x] Added test cases for `cn-north-1` and `cn-northwest-1` China region URLs in `test_message_sqs_queue_matches`

Signed-off-by: Ali <alliasgher123@gmail.com>