### PR TITLE
[v3-2-test] Fix backport test for log line number gap fix (#65039)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -274,7 +274,7 @@ const renderStructuredLogImpl = ({
   }
 
   return (
-    <chakra.div display="flex" key={index} lineHeight={1.5}>
+    <chakra.div alignItems="flex-start" display="flex" key={index} lineHeight={1.5}>
       <RouterLink
         id={index.toString()}
         key={`line_${index}`}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -133,4 +133,36 @@ describe("Task log grouping", () => {
 
     await waitFor(() => expect(screen.queryByText(/Marking task as SUCCESS/iu)).not.toBeVisible());
   }, 10_000);
+
+  it("skips group markers when assigning line numbers", async () => {
+    render(
+      <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/generate"]} />,
+    );
+
+    await waitForLogs();
+
+    const expectRenderedLineNumber = async (pattern: RegExp, expectedLineNumber: number) => {
+      const row = (await screen.findByText(pattern)).closest('[data-testid^="virtualized-item-"]');
+
+      expect(row).not.toBeNull();
+
+      const anchor = row?.querySelector<HTMLAnchorElement>("a[id]");
+
+      expect(anchor).not.toBeNull();
+
+      expect(Number(anchor?.id)).toBe(expectedLineNumber);
+    };
+
+    const summaryPre = screen.getByTestId("summary-Pre task execution logs");
+
+    fireEvent.click(summaryPre);
+
+    const summaryDependency = await screen.findByTestId("summary-Dependency check details");
+
+    fireEvent.click(summaryDependency);
+
+    await expectRenderedLineNumber(/dep_context=non-requeueable/iu, 0);
+    await expectRenderedLineNumber(/dep_context=requeueable/iu, 1);
+    await expectRenderedLineNumber(/starting attempt 1 of 3/iu, 2);
+  }, 10_000);
 });

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -141,28 +141,17 @@ describe("Task log grouping", () => {
 
     await waitForLogs();
 
-    const expectRenderedLineNumber = async (pattern: RegExp, expectedLineNumber: number) => {
-      const row = (await screen.findByText(pattern)).closest('[data-testid^="virtualized-item-"]');
+    const logContainer = screen.getByTestId("virtual-scroll-container");
+    const lineNumbers = [...logContainer.querySelectorAll<HTMLAnchorElement>("a[id]")]
+      .map((el) => parseInt(el.id, 10))
+      .filter((num) => !isNaN(num))
+      .sort((numA, numB) => numA - numB);
 
-      expect(row).not.toBeNull();
-
-      const anchor = row?.querySelector<HTMLAnchorElement>("a[id]");
-
-      expect(anchor).not.toBeNull();
-
-      expect(Number(anchor?.id)).toBe(expectedLineNumber);
-    };
-
-    const summaryPre = screen.getByTestId("summary-Pre task execution logs");
-
-    fireEvent.click(summaryPre);
-
-    const summaryDependency = await screen.findByTestId("summary-Dependency check details");
-
-    fireEvent.click(summaryDependency);
-
-    await expectRenderedLineNumber(/dep_context=non-requeueable/iu, 0);
-    await expectRenderedLineNumber(/dep_context=requeueable/iu, 1);
-    await expectRenderedLineNumber(/starting attempt 1 of 3/iu, 2);
+    expect(lineNumbers.length).toBeGreaterThan(0);
+    expect(lineNumbers[0]).toBe(0);
+    expect(new Set(lineNumbers).size).toBe(lineNumbers.length);
+    lineNumbers.forEach((num, idx) => {
+      expect(num).toBe(idx);
+    });
   }, 10_000);
 });

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -75,6 +75,20 @@ const parseLogs = ({
   const logLink = taskInstance ? `${getTaskInstanceLink(taskInstance)}?try_number=${tryNumber}` : "";
 
   try {
+    let lineNumber = 0;
+    const lineNumbers = data.map((datum) => {
+      const text = typeof datum === "string" ? datum : datum.event;
+
+      if (text.includes("::group::") || text.includes("::endgroup::")) {
+        return undefined;
+      }
+      const current = lineNumber;
+
+      lineNumber += 1;
+
+      return current;
+    });
+
     parsedLines = data
       .map((datum, index) => {
         if (typeof datum !== "string" && "logger" in datum) {
@@ -86,7 +100,7 @@ const parseLogs = ({
         }
 
         return renderStructuredLog({
-          index,
+          index: lineNumbers[index] ?? index,
           logLevelFilters,
           logLink,
           logMessage: datum,


### PR DESCRIPTION
The auto-backport [PR #65183](https://github.com/apache/airflow/pull/65183) fails CI because the test was written against main's new log architecture ([#63467](https://github.com/apache/airflow/pull/63467), which doesn't exist on `v3-2-test`.

Only the test needed adapting.

Supersedes: [#65183](https://github.com/apache/airflow/pull/65183)
closes: [#47888](https://github.com/apache/airflow/issues/47888)
related: [#65039](https://github.com/apache/airflow/pull/65039)

---

##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
