### PR TITLE
Fix provider registry never updating after docs publish

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -167,13 +167,21 @@ jobs:
              echo "airflow-base-version=no-airflow" >> ${GITHUB_OUTPUT}
           fi
           # Extract provider IDs for registry update
-          # include-docs contains package names like "apache-airflow-providers-amazon"
-          # Strip the "apache-airflow-providers-" prefix to get provider IDs
+          # include-docs contains short names like "amazon", "common.ai", "openlineage"
+          # or full package names like "apache-airflow-providers-amazon"
           REGISTRY_PROVIDERS=""
           for pkg in ${INCLUDE_DOCS}; do
             case "${pkg}" in
               apache-airflow-providers-*)
                 PROVIDER_ID="${pkg#apache-airflow-providers-}"
+                REGISTRY_PROVIDERS="${REGISTRY_PROVIDERS:+${REGISTRY_PROVIDERS} }${PROVIDER_ID}"
+                ;;
+              apache-airflow|all-providers|apache-airflow-providers|helm-chart|docker-stack)
+                # Not a provider package, skip
+                ;;
+              *)
+                # Short name like "amazon" or "common.ai" -- convert dots to hyphens
+                PROVIDER_ID="${pkg//./-}"
                 REGISTRY_PROVIDERS="${REGISTRY_PROVIDERS:+${REGISTRY_PROVIDERS} }${PROVIDER_ID}"
                 ;;
             esac


### PR DESCRIPTION

The "Update Provider Registry" job in `publish-docs-to-s3.yml` has never actually run. Every docs publish since the registry integration was added has skipped it.

The `include-docs` workflow input uses short provider names (`amazon`, `common.ai`, `openlineage`), but the extraction logic only matched full package names (`apache-airflow-providers-amazon`). Since nothing matched, `registry-providers` was always empty and the job was always skipped.

Past registry updates succeeded only through manual `registry-build.yml` dispatches.

## Fix

Handle both input formats:
- Full package names: strip `apache-airflow-providers-` prefix (existing behavior)
- Short names: convert dots to hyphens (`common.ai` -> `common-ai`)
- Non-provider packages (`apache-airflow`, `helm-chart`, etc.): skip

Verified with the April 13 input (`common.compat amazon openlineage common.ai`) -- all four now correctly produce registry provider IDs.