### PR TITLE
Fix registry CI pnpm lockfile mismatch

### DIFF
--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -188,7 +188,7 @@ jobs:
       - name: "Setup pnpm"
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
-          version: 9
+          version: 10
 
       - name: "Setup Node.js"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -219,7 +219,7 @@ jobs:
       - name: "Setup pnpm"
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
-          version: 9
+          version: 10
 
       - name: "Setup Node.js"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0


### PR DESCRIPTION

The registry build and backfill workflows fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because they install pnpm v9, but the lockfile was generated with pnpm v10.

pnpm v9 and v10 handle `pnpm-workspace.yaml` overrides differently. The overrides section in the workspace config is written into the lockfile by pnpm v10, but pnpm v9 doesn't recognize it as matching, so `--frozen-lockfile` always fails.

## Fix

Bump pnpm from v9 to v10 in both `registry-build.yml` and `registry-backfill.yml`.