### PR TITLE
UI: Fix mapped task XCom navigation from Grid #64875

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -271,4 +271,16 @@ describe("buildTaskInstanceUrl", () => {
       }),
     ).toBe("/dags/my_dag/runs/run_1/tasks/group/my_group");
   });
+
+  it("should not preserve sub-routes for mapped tasks without map index", () => {
+    expect(
+      buildTaskInstanceUrl({
+        currentPathname: "/dags/old_dag/runs/old_run/tasks/old_task/mapped/2/xcom",
+        dagId: "new_dag",
+        isMapped: true,
+        runId: "new_run",
+        taskId: "new_task",
+      }),
+    ).toBe("/dags/new_dag/runs/new_run/tasks/new_task/mapped");
+  });
 });

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -84,8 +84,10 @@ export const buildTaskInstanceUrl = (params: {
 }): string => {
   const { currentPathname, dagId, isGroup = false, isMapped = false, mapIndex, runId, taskId } = params;
   const groupPath = isGroup ? "group/" : "";
-  // Task groups only have "Task Instances" tab, so never preserve tabs for groups
-  const additionalPath = isGroup ? "" : getTaskInstanceAdditionalPath(currentPathname);
+  const additionalPath =
+    isGroup || (isMapped && (mapIndex === undefined || mapIndex === "-1"))
+      ? ""
+      : getTaskInstanceAdditionalPath(currentPathname);
 
   let basePath = `/dags/${dagId}/runs/${runId}/tasks/${groupPath}${taskId}`;
 


### PR DESCRIPTION
Fixes #64875 
## What changed

This fixes UI navigation when switching between dynamically mapped tasks from Grid while viewing a task-instance tab such as XCom.

Previously, navigating from a mapped task instance page like:

`/tasks/task_1/mapped/0/xcom`

to another mapped task from Grid could preserve the `xcom` sub-route even when no concrete mapped index was selected for the destination task. That could produce an invalid route and result in `map_index=NaN`.

## Result

Instead of failing with an invalid `map_index`, navigation now lands on:

`/tasks/<task_id>/mapped` i.e
<img width="877" height="38" alt="image" src="https://github.com/user-attachments/assets/4b059142-6fc3-4518-85bb-745122f1a49d" />


which lets the user choose a mapped task instance before opening XCom or other task-instance tabs.

I have not added a regression test in this PR yet. If maintainers prefer, I can add one in a follow-up or update this PR.
