### PR TITLE
Clarify logs when a DAG is being processed in DPM

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1220,11 +1220,11 @@ class DagFileProcessorManager(LoggingMixin):
 
         if self.log.isEnabledFor(logging.DEBUG):
             for path, processor in self._processors.items():
+                now_monotonic = time.monotonic()
                 self.log.debug(
-                    "File path %s is still being processed (started at: %.2f, duration: %.2fs)",
+                    "File path %s is still being processed (duration: %.2fs)",
                     path,
-                    processor.start_time,
-                    time.monotonic() - processor.start_time,
+                    now_monotonic - processor.start_time,
                 )
 
             self.log.debug(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1221,7 +1221,10 @@ class DagFileProcessorManager(LoggingMixin):
         if self.log.isEnabledFor(logging.DEBUG):
             for path, processor in self._processors.items():
                 self.log.debug(
-                    "File path %s is still being processed (started: %s)", path, processor.start_time
+                    "File path %s is still being processed (started at: %.2f, duration: %.2fs)",
+                    path,
+                    processor.start_time,
+                    time.monotonic() - processor.start_time,
                 )
 
             self.log.debug(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

The "still being processed" debug log in the DAG file processor manager was logging
`processor.start_time` which is a `time.monotonic()` value, and honestly that is confusing while debugging

For example, it could lead to misreading `2637` as
"this file has been processing for 2637 seconds" when it is actually the monotonic clock value at process start).

I propose to add the elapsed duration (`now - processor.start_time`) alongside the start time (not removing it if someone has processes that rely on it), so the log now reads:

`File path my_dag.py is still being processed (started: 2637.46, duration: 12.34s)`


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
