### PR TITLE
Document OpenSearch logging override needed on Airflow 3.0.0 – 3.2.0

### DIFF
--- a/providers/opensearch/docs/logging/index.rst
+++ b/providers/opensearch/docs/logging/index.rst
@@ -21,7 +21,9 @@ Writing logs to Opensearch
 -----------------------------
 
 *Added in provider version 1.5.0*
-Available only with Airflow>=3.0
+
+Only ``apache-airflow-providers-opensearch`` **1.9.0+** is compatible with Airflow 3. Earlier
+provider versions do not work on Airflow 3.x and must not be installed there.
 
 Airflow can be configured to read task logs from Opensearch and optionally write logs to stdout in standard or json format. These logs can later be collected and forwarded to the cluster using tools like fluentd, logstash or others.
 
@@ -71,6 +73,71 @@ To output task logs to OpenSearch directly, the following config could be used: 
     json_format = True
     write_to_os = True
     target_index = [name of the index to store logs]
+
+.. _opensearch-airflow-3-0-to-3-2-local-settings:
+
+Enabling the OpenSearch task handler on Airflow 3.0.0 – 3.2.0
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+The wiring that registers ``OpensearchTaskHandler`` inside the stock
+``airflow_local_settings.py`` (the file that builds ``DEFAULT_LOGGING_CONFIG``) only landed
+in Airflow **3.2.1**. On Airflow **3.0.0 – 3.2.0** installing the provider is not enough:
+you must ship a custom logging config that swaps the ``task`` handler. The handler
+self-registers as the remote-log reader on construction (via ``REMOTE_TASK_LOG`` on
+3.0/3.1 and ``_ActiveLoggingConfig`` on 3.2), so swapping the handler class is the only
+change required.
+
+Create a module on the Python path — for example ``config/airflow_local_settings.py`` —
+and point Airflow at it via ``[logging] logging_config_class``:
+
+.. code-block:: python
+
+    from airflow.config_templates.airflow_local_settings import (
+        BASE_LOG_FOLDER,
+        DEFAULT_LOGGING_CONFIG,
+    )
+    from airflow.providers.common.compat.sdk import conf
+
+    OPENSEARCH_HOST = conf.get("opensearch", "host", fallback=None)
+
+    if OPENSEARCH_HOST:
+        DEFAULT_LOGGING_CONFIG["handlers"]["task"] = {
+            "class": "airflow.providers.opensearch.log.os_task_handler.OpensearchTaskHandler",
+            "formatter": "airflow",
+            "base_log_folder": str(BASE_LOG_FOLDER),
+            "end_of_log_mark": "end_of_log",
+            "host": OPENSEARCH_HOST,
+            "port": conf.getint("opensearch", "port", fallback=9200),
+            "username": conf.get("opensearch", "username"),
+            "password": conf.get("opensearch", "password"),
+            "write_stdout": conf.getboolean("opensearch", "write_stdout"),
+            "json_format": conf.getboolean("opensearch", "json_format"),
+            "json_fields": conf.get("opensearch", "json_fields"),
+            "host_field": conf.get("opensearch", "host_field", fallback="host"),
+            "offset_field": conf.get("opensearch", "offset_field", fallback="offset"),
+            "write_to_opensearch": conf.getboolean("opensearch", "write_to_os", fallback=False),
+            "target_index": conf.get("opensearch", "target_index", fallback="airflow-logs"),
+        }
+
+Then, in ``airflow.cfg``:
+
+.. code-block:: ini
+
+    [logging]
+    remote_logging = True
+    logging_config_class = config.airflow_local_settings.DEFAULT_LOGGING_CONFIG
+
+On Airflow **3.2.1+** this override is unnecessary — the stock ``airflow_local_settings.py``
+already contains an ``elif OPENSEARCH_HOST:`` branch, so configuring the ``[opensearch]``
+section in ``airflow.cfg`` is sufficient.
+
+.. note::
+
+    Reading task logs from OpenSearch works on Airflow 3.0.0 – 3.2.0 with the override
+    above. The ``write_to_os = True`` direct-write path depends on the remote-log-IO
+    plumbing that is only fully wired through the supervisor in Airflow **3.2.1+**. On
+    3.0.0 – 3.2.0, prefer shipping logs with fluentd / logstash rather than enabling
+    ``write_to_os``.
 
 .. _write-logs-elasticsearch-tls:
 

--- a/providers/opensearch/docs/logging/index.rst
+++ b/providers/opensearch/docs/logging/index.rst
@@ -20,10 +20,9 @@
 Writing logs to Opensearch
 -----------------------------
 
-*Added in provider version 1.5.0*
-
-Only ``apache-airflow-providers-opensearch`` **1.9.0+** is compatible with Airflow 3. Earlier
-provider versions do not work on Airflow 3.x and must not be installed there.
+Only ``apache-airflow-providers-opensearch`` **1.9.0+** is compatible with Airflow 3 for
+viewing task logs in the UI. Earlier provider versions can still be installed on Airflow
+3.x, but the UI will not be able to render task logs from OpenSearch.
 
 Airflow can be configured to read task logs from Opensearch and optionally write logs to stdout in standard or json format. These logs can later be collected and forwarded to the cluster using tools like fluentd, logstash or others.
 

--- a/providers/opensearch/docs/logging/index.rst
+++ b/providers/opensearch/docs/logging/index.rst
@@ -79,13 +79,19 @@ To output task logs to OpenSearch directly, the following config could be used: 
 Enabling the OpenSearch task handler on Airflow 3.0.0 – 3.2.0
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
+This section is **only about reading task logs back into the Airflow UI**. Tasks running
+on workers will write logs as usual (to local files, stdout, or — with appropriate log
+shipping — to OpenSearch) regardless of the override below. Without the override on
+Airflow 3.0.0 – 3.2.0, logs reach OpenSearch fine but the **UI cannot render them**
+because no handler is registered to fetch them back.
+
 The wiring that registers ``OpensearchTaskHandler`` inside the stock
 ``airflow_local_settings.py`` (the file that builds ``DEFAULT_LOGGING_CONFIG``) only landed
 in Airflow **3.2.1**. On Airflow **3.0.0 – 3.2.0** installing the provider is not enough:
-you must ship a custom logging config that swaps the ``task`` handler. The handler
-self-registers as the remote-log reader on construction (via ``REMOTE_TASK_LOG`` on
-3.0/3.1 and ``_ActiveLoggingConfig`` on 3.2), so swapping the handler class is the only
-change required.
+to make the UI's log viewer fetch logs from OpenSearch you must ship a custom logging
+config that swaps the ``task`` handler. The handler self-registers as the remote-log
+reader on construction (via ``REMOTE_TASK_LOG`` on 3.0/3.1 and ``_ActiveLoggingConfig``
+on 3.2), so swapping the handler class is the only change required.
 
 Create a module on the Python path — for example ``config/airflow_local_settings.py`` —
 and point Airflow at it via ``[logging] logging_config_class``:


### PR DESCRIPTION
The OpenSearch task handler wiring in the stock `airflow_local_settings.py` only landed in Airflow **3.2.1**. On Airflow **3.0.0 – 3.2.0** the provider alone is not enough to **read OpenSearch-stored task logs back into the Airflow UI** — users must ship a custom `logging_config_class` that swaps the `task` handler so the UI's log viewer can fetch logs from OpenSearch.

To be clear about scope: this is **only about accessing logs in the UI**. Tasks running on workers will still write logs as usual (to local files, stdout, or — with appropriate shipping — to OpenSearch). Without the override on 3.0.0 – 3.2.0, those logs reach OpenSearch fine but the **UI cannot render them** because no handler is registered to read them back.

This adds a new section to `providers/opensearch/docs/logging/index.rst` that:

- Notes that only `apache-airflow-providers-opensearch` **1.9.0+** is compatible with Airflow 3.
- Provides a copy-pasteable custom `airflow_local_settings.py` snippet that wires `OpensearchTaskHandler` so the UI can read logs from OpenSearch on Airflow 3.0.0 – 3.2.0.
- Explains that on 3.2.1+ the override is unnecessary — the stock settings file already contains the `OPENSEARCH_HOST` branch.
- Warns that the `write_to_os = True` direct-write path also depends on supervisor plumbing only fully wired in 3.2.1+, so on 3.0.0 – 3.2.0 users should still ship logs with fluentd / logstash.

Docs-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)