### PR TITLE
Do not cache kubeconfig for exec based auth in AsyncKubernetesHook

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -817,34 +817,45 @@ class AsyncKubernetesHook(KubernetesHook):
         self._extras: dict | None = connection_extras
         self._event_polling_fallback = False
         self._config_loaded = False
+        # Cached result of exec-auth detection. None means not yet detected.
+        # This is to optimise and not calling _uses_exec_auth repeatedly on every _load_config() call.
+        self._is_exec_auth: bool | None = None
 
     def _uses_exec_auth(self, kubeconfig_data: dict, context: str | None = None) -> bool:
         """
         Detect if the active kubeconfig context uses exec-based authentication.
 
         Exec plugins return short-lived tokens (EKS, GKE, etc). Only the user
-        tied to the active context is checked.
+        tied to the active context is checked. If the active context or its user
+        cannot be resolved, falls back to scanning all users and returns True if
+        any use exec auth — erring on the side of not caching.
         """
         active_context = context or kubeconfig_data.get("current-context")
 
         active_user: str | None = None
         for ctx in kubeconfig_data.get("contexts", []):
             if ctx.get("name") == active_context:
-                active_user = ctx.get("context", {}).get("user")
+                active_user = (ctx.get("context") or {}).get("user")
                 break
 
         users = kubeconfig_data.get("users", [])
         if active_user is not None:
             for user in users:
                 if user.get("name") == active_user:
-                    return "exec" in user.get("user", {})
+                    return "exec" in (user.get("user") or {})
             return False
 
         # fallback to check all users if active context user cannot be resolved; this is a safe fallback since it errs on the side of not caching
-        return any("exec" in u.get("user", {}) for u in users)
+        return any("exec" in (u.get("user") or {}) for u in users)
 
     async def _load_config(self):
-        """Load Kubernetes configuration once per hook instance."""
+        """
+        Load Kubernetes configuration.
+
+        For static auth (token, certificate), configuration is loaded once per hook instance
+        and cached. For exec-based auth (EKS, GKE), the config is reloaded on every call so
+        that short-lived tokens are always refreshed.
+        """
         if self._config_loaded:
             return
 
@@ -880,7 +891,10 @@ class AsyncKubernetesHook(KubernetesHook):
                 context=cluster_context,
             )
 
-            if not self._uses_exec_auth(self.config_dict, context=cluster_context):
+            if self._is_exec_auth is None:
+                self._is_exec_auth = self._uses_exec_auth(self.config_dict, context=cluster_context)
+
+            if not self._is_exec_auth:
                 self._config_loaded = True
 
             return
@@ -893,20 +907,23 @@ class AsyncKubernetesHook(KubernetesHook):
                 context=cluster_context,
             )
 
-            try:
-                async with aiofiles.open(kubeconfig_path) as f:
-                    content = await f.read()
-                    data = yaml.safe_load(content)
+            if self._is_exec_auth is None:
+                try:
+                    async with aiofiles.open(kubeconfig_path) as f:
+                        content = await f.read()
+                        data = yaml.safe_load(content)
+                    self._is_exec_auth = self._uses_exec_auth(data, context=cluster_context)
+                except Exception as exc:
+                    self.log.warning(
+                        "Error while parsing kube_config from %s to detect exec auth; "
+                        "continuing without caching the config: %s",
+                        kubeconfig_path,
+                        exc,
+                    )
+                    self._is_exec_auth = True
 
-                if not self._uses_exec_auth(data, context=cluster_context):
-                    self._config_loaded = True
-            except Exception as exc:
-                self.log.warning(
-                    "Error while parsing kube_config from %s to detect exec auth; "
-                    "continuing without caching the config: %s",
-                    kubeconfig_path,
-                    exc,
-                )
+            if not self._is_exec_auth:
+                self._config_loaded = True
 
             return
         if kubeconfig is not None:
@@ -935,7 +952,14 @@ class AsyncKubernetesHook(KubernetesHook):
                     context=cluster_context,
                 )
 
-                if kubeconfig_data and not self._uses_exec_auth(kubeconfig_data, context=cluster_context):
+                if self._is_exec_auth is None:
+                    self._is_exec_auth = (
+                        self._uses_exec_auth(kubeconfig_data, context=cluster_context)
+                        if kubeconfig_data
+                        else True
+                    )
+
+                if not self._is_exec_auth:
                     self._config_loaded = True
 
             return

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -818,6 +818,31 @@ class AsyncKubernetesHook(KubernetesHook):
         self._event_polling_fallback = False
         self._config_loaded = False
 
+    def _uses_exec_auth(self, kubeconfig_data: dict, context: str | None = None) -> bool:
+        """
+        Detect if the active kubeconfig context uses exec-based authentication.
+
+        Exec plugins return short-lived tokens (EKS, GKE, etc). Only the user
+        tied to the active context is checked.
+        """
+        active_context = context or kubeconfig_data.get("current-context")
+
+        active_user: str | None = None
+        for ctx in kubeconfig_data.get("contexts", []):
+            if ctx.get("name") == active_context:
+                active_user = ctx.get("context", {}).get("user")
+                break
+
+        users = kubeconfig_data.get("users", [])
+        if active_user is not None:
+            for user in users:
+                if user.get("name") == active_user:
+                    return "exec" in user.get("user", {})
+            return False
+
+        # fallback to check all users if active context user cannot be resolved; this is a safe fallback since it errs on the side of not caching
+        return any("exec" in u.get("user", {}) for u in users)
+
     async def _load_config(self):
         """Load Kubernetes configuration once per hook instance."""
         if self._config_loaded:
@@ -846,39 +871,62 @@ class AsyncKubernetesHook(KubernetesHook):
             self._config_loaded = True
             return
 
-        # If above block does not return, we are not in a cluster.
         self._is_in_cluster = False
-
         if self.config_dict:
             self.log.debug(LOADING_KUBE_CONFIG_FILE_RESOURCE.format("config dictionary"))
-            await async_config.load_kube_config_from_dict(self.config_dict, context=cluster_context)
-            self._config_loaded = True
-            return
 
+            await async_config.load_kube_config_from_dict(
+                self.config_dict,
+                context=cluster_context,
+            )
+
+            if not self._uses_exec_auth(self.config_dict, context=cluster_context):
+                self._config_loaded = True
+
+            return
         if kubeconfig_path is not None:
             self.log.debug("loading kube_config from: %s", kubeconfig_path)
+
             await async_config.load_kube_config(
                 config_file=kubeconfig_path,
                 client_configuration=self.client_configuration,
                 context=cluster_context,
             )
-            self._config_loaded = True
-            return
 
+            try:
+                async with aiofiles.open(kubeconfig_path) as f:
+                    content = await f.read()
+                    data = yaml.safe_load(content)
+
+                if not self._uses_exec_auth(data, context=cluster_context):
+                    self._config_loaded = True
+            except Exception as exc:
+                self.log.warning(
+                    "Error while parsing kube_config from %s to detect exec auth; "
+                    "continuing without caching the config: %s",
+                    kubeconfig_path,
+                    exc,
+                )
+
+            return
         if kubeconfig is not None:
             async with aiofiles.tempfile.NamedTemporaryFile() as temp_config:
-                self.log.debug(
-                    "Reading kubernetes configuration file from connection "
-                    "object and writing temporary config file with its content",
-                )
                 if isinstance(kubeconfig, dict):
-                    self.log.debug(
-                        LOADING_KUBE_CONFIG_FILE_RESOURCE.format(
-                            "connection kube_config dictionary (serializing)"
+                    kubeconfig_data = kubeconfig
+                    kubeconfig_str = json.dumps(kubeconfig)
+                else:
+                    try:
+                        kubeconfig_data = _load_body_to_dict(kubeconfig)
+                    except AirflowException as exc:
+                        self.log.debug(
+                            "Could not parse kubeconfig string to detect exec auth; "
+                            "config will not be cached: %s",
+                            exc,
                         )
-                    )
-                    kubeconfig = json.dumps(kubeconfig)
-                await temp_config.write(kubeconfig.encode())
+                        kubeconfig_data = None
+                    kubeconfig_str = kubeconfig
+
+                await temp_config.write(kubeconfig_str.encode())
                 await temp_config.flush()
 
                 await async_config.load_kube_config(
@@ -886,10 +934,13 @@ class AsyncKubernetesHook(KubernetesHook):
                     client_configuration=self.client_configuration,
                     context=cluster_context,
                 )
-                self._config_loaded = True
-                return
 
+                if kubeconfig_data and not self._uses_exec_auth(kubeconfig_data, context=cluster_context):
+                    self._config_loaded = True
+
+            return
         self.log.debug(LOADING_KUBE_CONFIG_FILE_RESOURCE.format("default configuration file"))
+
         await async_config.load_kube_config(
             client_configuration=self.client_configuration,
             context=cluster_context,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1155,6 +1155,45 @@ class TestAsyncKubernetesHook:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
+        ("kubeconfig_content", "expected_cached"),
+        [
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    exec:\n      command: aws eks get-token\n"
+                ),
+                False,
+                id="kube_config_path_with_exec",
+            ),
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    token: static-token\n"
+                ),
+                True,
+                id="kube_config_path_no_exec",
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config")
+    async def test_load_config_caching_behavior_kube_config_path(
+        self, mock_load_file, tmp_path, kubeconfig_content, expected_cached
+    ):
+        mock_load_file.return_value = None
+        kubeconfig_file = tmp_path / "kubeconfig.yaml"
+        kubeconfig_file.write_text(kubeconfig_content)
+
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+        hook._get_field = mock.AsyncMock(
+            side_effect=lambda field: str(kubeconfig_file) if field == "kube_config_path" else None
+        )
+        await hook._load_config()
+        assert hook._config_loaded is expected_cached
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
         ("kubeconfig", "expected_cached"),
         [
             pytest.param(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1090,6 +1090,119 @@ class TestAsyncKubernetesHook:
         with pytest.raises(AirflowException):
             await hook._load_config()
 
+    @pytest.mark.parametrize(
+        ("kubeconfig_data", "context", "expected"),
+        [
+            pytest.param(
+                {
+                    "current-context": "ctx1",
+                    "contexts": [{"name": "ctx1", "context": {"user": "user1"}}],
+                    "users": [{"name": "user1", "user": {"exec": {"command": "aws"}}}],
+                },
+                None,
+                True,
+                id="active_context_user_has_exec",
+            ),
+            pytest.param(
+                {
+                    "current-context": "ctx1",
+                    "contexts": [{"name": "ctx1", "context": {"user": "user1"}}],
+                    "users": [{"name": "user1", "user": {"token": "abc123"}}],
+                },
+                None,
+                False,
+                id="active_context_user_has_static_token",
+            ),
+            pytest.param(
+                {
+                    "current-context": "ctx1",
+                    "contexts": [{"name": "ctx1", "context": {"user": "user1"}}],
+                    "users": [
+                        {"name": "user1", "user": {"token": "abc123"}},
+                        {"name": "user2", "user": {"exec": {"command": "aws"}}},
+                    ],
+                },
+                None,
+                False,
+                id="only_inactive_user_has_exec",
+            ),
+            pytest.param(
+                {
+                    "users": [{"name": "user1", "user": {"exec": {"command": "aws"}}}],
+                },
+                None,
+                True,
+                id="no_contexts_fallback_any_user_has_exec",
+            ),
+        ],
+    )
+    def test_uses_exec_auth(self, kubeconfig_data, context, expected):
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+        assert hook._uses_exec_auth(kubeconfig_data, context=context) is expected
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config_from_dict")
+    async def test_load_config_no_caching_when_exec_auth(self, mock_load):
+        mock_load.return_value = None
+        exec_config = {
+            "current-context": "ctx1",
+            "contexts": [{"name": "ctx1", "context": {"user": "user1"}}],
+            "users": [{"name": "user1", "user": {"exec": {"command": "aws eks get-token"}}}],
+        }
+        hook = AsyncKubernetesHook(conn_id=None, in_cluster=False, config_dict=exec_config)
+        await hook._load_config()
+        assert hook._config_loaded is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("kubeconfig", "expected_cached"),
+        [
+            pytest.param(
+                {
+                    "current-context": "ctx1",
+                    "contexts": [{"name": "ctx1", "context": {"user": "user1"}}],
+                    "users": [{"name": "user1", "user": {"token": "static-token"}}],
+                },
+                True,
+                id="dict_kubeconfig_no_exec",
+            ),
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    exec:\n      command: aws\n"
+                ),
+                False,
+                id="string_kubeconfig_with_exec",
+            ),
+            pytest.param(
+                (
+                    "current-context: ctx1\n"
+                    "contexts:\n- name: ctx1\n  context:\n    user: user1\n"
+                    "users:\n- name: user1\n  user:\n    token: static-token\n"
+                ),
+                True,
+                id="string_kubeconfig_no_exec",
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.async_config.load_kube_config_from_dict")
+    async def test_load_config_caching_behavior(
+        self, mock_load_dict, mock_load_file, kubeconfig, expected_cached
+    ):
+        mock_load_dict.return_value = None
+        mock_load_file.return_value = None
+        if isinstance(kubeconfig, dict):
+            hook = AsyncKubernetesHook(conn_id=None, in_cluster=False, config_dict=kubeconfig)
+        else:
+            hook = AsyncKubernetesHook(conn_id=None, in_cluster=False)
+            hook._get_field = mock.AsyncMock(
+                side_effect=lambda field: kubeconfig if field == "kube_config" else None
+            )
+        await hook._load_config()
+        assert hook._config_loaded is expected_cached
+
     @pytest.mark.asyncio
     @mock.patch(KUBE_API.format("list_namespaced_event"))
     async def test_async_get_pod_events_with_resource_version(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - Cursor with Sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Reattempt at: https://github.com/apache/airflow/pull/61738/

closes: https://github.com/apache/airflow/pull/61738/

Deferrable tasks on EKS/GKE can run longer than the 15-minute token lifetime issued by exec auth plugins (aws eks get-token, gke-gcloud-auth-plugin). Because `_load_config()` caches the kubeconfig on the first call, subsequent
calls are no operations and the expired token gets reused, causing auth failures.

Attempting to redo the PR by addressing review comments from myself
- Add `_uses_exec_auth()` to detect exec-based auth in the active context user only (not any user in the file), passing 
- Skip caching when exec auth is detected; all other auth paths continue to cache as before

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
