### PR TITLE
Pin pyarrow>=22.0.0 on Python 3.14 in constraints generation

### DIFF
--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -358,9 +358,13 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
     #
     # Current exclusions:
     #
-    # * no exclusions
+    # * pyarrow>=22.0.0 on Python 3.14 — older pyarrow releases have no prebuilt wheels for
+    #   Python 3.14 and uv falls back to building from source, which fails. pyarrow 22.0.0 is
+    #   the first release shipping cp314 wheels.
     #
-    additional_constraints_for_highest_resolution: list[str] = []
+    additional_constraints_for_highest_resolution: list[str] = [
+        "pyarrow>=22.0.0; python_version >= '3.14'",
+    ]
 
     result = run_command(
         cmd=[


### PR DESCRIPTION
When generating the highest-resolution constraints for provider dependencies on Python 3.14, `uv` attempts to resolve older `pyarrow` versions that do not ship `cp314` wheels on PyPI. It then falls back to building `pyarrow` from source, which fails in the constraints-generation environment.

`pyarrow 22.0.0` is the first release that publishes Python 3.14 wheels, so this adds an additional constraint `pyarrow>=22.0.0; python_version >= '3.14'` to the highest-resolution constraints pin list used by `generate_constraints_pypi_providers`. The comment block above the pin is updated to document the current exclusion and the rationale.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)