### PR TITLE
Fix recreating autoincrement sequence in callback table migration (#65000)

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0093_3_2_0_restructure_callback_table.py
+++ b/airflow-core/src/airflow/migrations/versions/0093_3_2_0_restructure_callback_table.py
@@ -96,3 +96,23 @@ def downgrade():
         batch_op.drop_column("type")
 
     op.rename_table("callback", "callback_request")
+
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        op.execute("CREATE SEQUENCE IF NOT EXISTS callback_request_id_seq")
+        op.execute("ALTER SEQUENCE callback_request_id_seq OWNED BY callback_request.id")
+        with op.batch_alter_table("callback_request", schema=None) as batch_op:
+            batch_op.alter_column(
+                "id",
+                existing_type=sa.INTEGER(),
+                nullable=False,
+                server_default=sa.text("nextval('callback_request_id_seq')"),
+            )
+    elif dialect_name == "mysql":
+        with op.batch_alter_table("callback_request", schema=None) as batch_op:
+            batch_op.alter_column(
+                "id",
+                existing_type=sa.INTEGER(),
+                nullable=False,
+                autoincrement=True,
+            )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #65000

The problem is that `0093_3_2_0_restructure_callback_table.py` migration doesn't recreate the auto-increment sequence linked to `callback_request.id` column during downgrade.

This PR fixes the issue:
- PostgreSQL: Create the auto-increment sequence for `callback_request.id` column and link it with the sequence.
- MySQL: Restore auto-increment after the table was renamed.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
