### PR TITLE
Fix XCom prior-dates lookup for duplicate run_id across Dags

### DIFF
--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -314,16 +314,15 @@ class XComModel(TaskInstanceDependencies):
             query = query.where(cls.map_index == map_indexes)
 
         if include_prior_dates:
-            dr = (
-                select(
-                    func.coalesce(DagRun.logical_date, DagRun.run_after).label("logical_date_or_run_after")
-                )
-                .where(DagRun.run_id == run_id)
-                .subquery()
+            dag_run_date_for_run_id = (
+                select(func.coalesce(DagRun.logical_date, DagRun.run_after))
+                .where(DagRun.run_id == run_id, DagRun.dag_id == cls.dag_id)
+                .correlate(cls)
+                .scalar_subquery()
             )
 
             query = query.where(
-                func.coalesce(DagRun.logical_date, DagRun.run_after) <= dr.c.logical_date_or_run_after
+                func.coalesce(DagRun.logical_date, DagRun.run_after) <= dag_run_date_for_run_id
             )
         else:
             query = query.where(cls.run_id == run_id)

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -65,13 +65,14 @@ def reset_db():
 
 @pytest.fixture
 def task_instance_factory(request, session: Session):
-    def func(*, dag_id, task_id, logical_date, run_after=None):
+    def func(*, dag_id, task_id, logical_date, run_after=None, run_id=None):
         sync_dag_to_db(DAG(dag_id=dag_id))
-        run_id = DagRun.generate_run_id(
-            run_type=DagRunType.SCHEDULED,
-            logical_date=logical_date,
-            run_after=run_after if run_after is not None else logical_date,
-        )
+        if run_id is None:
+            run_id = DagRun.generate_run_id(
+                run_type=DagRunType.SCHEDULED,
+                logical_date=logical_date,
+                run_after=run_after if run_after is not None else logical_date,
+            )
         interval = (logical_date, logical_date) if logical_date else None
         run = DagRun(
             dag_id=dag_id,
@@ -378,6 +379,46 @@ class TestXComGet:
             map(lambda j: json.dumps(j), [{"key2": "value2"}, {"key1": "value1"}])
         )
         assert [x.logical_date for x in stored_xcoms] == [ti2.logical_date, ti1.logical_date]
+
+    def test_xcom_get_many_from_prior_dates_scopes_run_id_to_dag(
+        self, session, task_instance_factory, push_simple_json_xcom
+    ):
+        shared_run_id = "manual__shared_run"
+        ti_earlier = task_instance_factory(
+            dag_id="dag_1",
+            task_id="task_1",
+            logical_date=timezone.datetime(2021, 12, 1, 4, 56),
+        )
+        ti_target = task_instance_factory(
+            dag_id="dag_1",
+            task_id="task_1",
+            logical_date=timezone.datetime(2021, 12, 3, 4, 56),
+            run_id=shared_run_id,
+        )
+        task_instance_factory(
+            dag_id="dag_2",
+            task_id="task_1",
+            logical_date=timezone.datetime(2021, 12, 2, 4, 56),
+            run_id=shared_run_id,
+        )
+
+        push_simple_json_xcom(ti=ti_earlier, key="xcom_1", value={"key": "dag_1_earlier"})
+        push_simple_json_xcom(ti=ti_target, key="xcom_1", value={"key": "dag_1_target"})
+
+        stored_xcoms = session.scalars(
+            XComModel.get_many(
+                run_id=shared_run_id,
+                key="xcom_1",
+                dag_ids="dag_1",
+                task_ids="task_1",
+                include_prior_dates=True,
+            )
+        ).all()
+
+        assert [x.value for x in stored_xcoms] == [
+            json.dumps({"key": "dag_1_target"}),
+            json.dumps({"key": "dag_1_earlier"}),
+        ]
 
     def test_xcom_get_invalid_key(self, session, task_instance):
         """Test that getting an XCom with an invalid key raises a ValueError."""


### PR DESCRIPTION
## Why
Currently, when we call `get_manys `in `XcomModel `with `include_prior_dates`, we will query only use `run_id`, but even different Dag has same `run_id`, so we have to use `dag_id `in query either

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
