### PR TITLE
Ensure that DB migrations run in a single connection.

### DIFF
--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1207,7 +1207,8 @@ def _run_upgradedb(
         # End the read-only transaction from _get_current_revision before
         # external DB manager migrations, which may run DDL that is blocked by
         # open transactions (e.g. CREATE INDEX CONCURRENTLY). The advisory lock
-        # is unaffected: it is session-level and held on a separate connection.
+        # from create_global_lock() is unaffected: it is session-level and held
+        # on a separate connection.
         work_session.rollback()
 
         if current_revision == source_heads[0] and not _SKIP_EXTERNAL_DB_MANAGERS_UPGRADE.get():

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1204,6 +1204,12 @@ def _run_upgradedb(
         with _configured_alembic_environment() as env:
             source_heads = env.script.get_heads()
 
+        # End the read-only transaction from _get_current_revision before
+        # external DB manager migrations, which may run DDL that is blocked by
+        # open transactions (e.g. CREATE INDEX CONCURRENTLY). The advisory lock
+        # is unaffected: it is session-level and held on a separate connection.
+        work_session.rollback()
+
         if current_revision == source_heads[0] and not _SKIP_EXTERNAL_DB_MANAGERS_UPGRADE.get():
             external_db_manager = RunDBManager()
             external_db_manager.upgradedb(work_session, use_migration_files=use_migration_files)


### PR DESCRIPTION
This was discovered by running with a custom External DB manager that had some
gnarly queries that ended up being locked behind this transaction.

`_single_connection_pool` replaces `settings.engine` with a
SingletonThreadPool engine. But `work_session` was created before that — it
still holds an internal reference to the old engine object.
_single_connection_pool has no way to rebind work_session.

So when _get_current_revision(session=work_session) runs on line 1203 — inside
the _single_connection_pool() block — it calls session.connection() which goes
through the old engine, not the SingletonThreadPool. The old engine's pool was
disposed and recreated empty by engine.dispose(), so it creates a brand new
connection. That connection is completely outside _single_connection_pool's
control.

_single_connection_pool guarantees one connection on the new engine. It can't
prevent work_session from creating connections on the old one. The name is a
bit of a lie — it's really "single connection pool for new code that uses
settings.engine", not "single connection total."

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
