### PR TITLE
Notify #internal-airflow-ci-cd when update constraints workflow fails

### DIFF
--- a/.github/workflows/update-constraints-on-push.yml
+++ b/.github/workflows/update-constraints-on-push.yml
@@ -150,3 +150,27 @@ jobs:
       - name: "Push changes"
         working-directory: "constraints"
         run: git push
+
+  notify-on-failure:
+    name: "Notify on failure"
+    runs-on: ["ubuntu-22.04"]
+    needs: [build-info, build-ci-images, generate-constraints, update-constraints]
+    if: failure()
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - name: "Send Slack notification"
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ env.SLACK_BOT_TOKEN }}
+          # yamllint disable rule:line-length
+          payload: |
+            channel: "internal-airflow-ci-cd"
+            text: "🚨 Update constraints workflow failed on branch *${{ github.ref_name }}*\n\n*Details:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "🚨 Update constraints workflow failed on *${{ github.ref_name }}*\n\n*Details:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+          # yamllint enable rule:line-length

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-cohere>=1.4.0"
 ]
 "common.ai" = [
-    "apache-airflow-providers-common-ai>=0.1.0" # Set from local provider pyproject.toml
+    "apache-airflow-providers-common-ai>=0.1.0"
 ]
 "common.compat" = [
     "apache-airflow-providers-common-compat>=1.2.1"
@@ -424,7 +424,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-cloudant>=4.0.1",
     "apache-airflow-providers-cncf-kubernetes>=9.0.0",
     "apache-airflow-providers-cohere>=1.4.0",
-    "apache-airflow-providers-common-ai>=0.1.0", # Set from local provider pyproject.toml
+    "apache-airflow-providers-common-ai>=0.1.0",
     "apache-airflow-providers-common-compat>=1.2.1",
     "apache-airflow-providers-common-io>=1.4.2",
     "apache-airflow-providers-common-messaging>=2.0.0", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py


### PR DESCRIPTION
Adds a `notify-on-failure` job to `update-constraints-on-push.yml` that posts to the `#internal-airflow-ci-cd` Slack channel whenever any upstream job in the workflow fails. The job depends on all upstream jobs and only runs when `failure()` is true, using the same `slackapi/slack-github-action` pattern already used in `ci-notification.yml`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)