### PR TITLE
Add Registry link to docs navbar

### DIFF
--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -147,6 +147,7 @@ def get_html_theme_options():
             {"href": "/community/", "text": "Community"},
             {"href": "/meetups/", "text": "Meetups"},
             {"href": "/docs/", "text": "Documentation"},
+            {"href": "/registry/", "text": "Registry"},
             {"href": "/use-cases/", "text": "Use Cases"},
             {"href": "/announcements/", "text": "Announcements"},
             {"href": "/blog/", "text": "Blog"},


### PR DESCRIPTION
- Add Registry link to the docs navbar, between Documentation and Use Cases

The `sphinx_airflow_theme` already includes Registry in its default `navbar_links`, but the docs override `navbar_links` in `get_html_theme_options()` so the theme default never applies. This adds it to the explicit list.