### PR TITLE
fix(ui): avoid false unused plural keys in translation completeness checker

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ui_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ui_commands.py
@@ -150,10 +150,12 @@ def expand_plural_keys(keys: set[str], lang: str, en_key_to_value: dict[str, str
     """
     For a set of keys, expand plural bases to include required suffixes for the language.
 
-    When en_key_to_value is provided, only expand a base to all plural forms when at least
-    one of the English values for that base contains {{count}}. Keys without {{count}}
-    (e.g. fixed "1 Error") are not expanded, so locales are not required to have
-    unused forms like error_other when the source only has error_one.
+    When en_key_to_value is provided, expand a plural base if either:
+    - one of the English values for that base contains {{count}}, or
+    - English defines multiple plural forms for that base (for example *_one and *_other).
+
+    This prevents falsely marking locale-specific plural keys as unused when count drives
+    plural selection but is not interpolated in the English string itself.
     """
     console = get_console()
     suffixes = PLURAL_SUFFIXES.get(lang)
@@ -174,7 +176,9 @@ def expand_plural_keys(keys: set[str], lang: str, en_key_to_value: dict[str, str
         if en_key_to_value is not None:
             en_keys_for_base = [k for k in keys if get_plural_base(k, suffixes) == base]
             any_has_count = any(COUNT_PLACEHOLDER in en_key_to_value.get(k, "") for k in en_keys_for_base)
-            if not any_has_count:
+            has_multiple_en_plural_forms = len(en_keys_for_base) > 1
+
+            if not any_has_count and not has_multiple_en_plural_forms:
                 continue
         for suffix in suffixes:
             expanded.add(base + suffix)

--- a/dev/breeze/tests/test_ui_commands.py
+++ b/dev/breeze/tests/test_ui_commands.py
@@ -80,6 +80,17 @@ class TestPluralHandling:
         assert "warning_few" in expanded
         assert "warning_many" in expanded
 
+    def test_expand_plural_keys_expands_when_en_has_multiple_plural_forms(self):
+        # Even without {{count}} in EN values, plural selection is still active when
+        # EN defines multiple plural forms for the same base key.
+        keys = {"dagRun_one", "dagRun_other"}
+        en_key_to_value = {"dagRun_one": "Dag Run", "dagRun_other": "Dag Runs"}
+        expanded = expand_plural_keys(keys, "pl", en_key_to_value)
+        assert "dagRun_one" in expanded
+        assert "dagRun_other" in expanded
+        assert "dagRun_few" in expanded
+        assert "dagRun_many" in expanded
+
 
 class TestFlattenKeys:
     def test_flatten_simple_dict(self):
@@ -222,6 +233,46 @@ class TestCompareKeys:
 
             # EN base has no {{count}}, so error_other is not required and is unused
             assert "dagWarnings.error_other" in summary["test.json"].unused_keys.get("de", [])
+        finally:
+            ui_commands.LOCALES_DIR = original_locales_dir
+
+    def test_compare_keys_multi_plural_without_count_is_not_unused(self, tmp_path):
+        """When EN defines multiple plural forms, locale plural forms should not be marked unused."""
+        en_dir = tmp_path / "en"
+        en_dir.mkdir()
+        pl_dir = tmp_path / "pl"
+        pl_dir.mkdir()
+
+        # EN has plural variants but no explicit {{count}} interpolation in values.
+        # Plural routing is still active and locale-specific forms should be treated as required.
+        en_data = {"dagWarnings": {"error_one": "Error", "error_other": "Errors"}}
+        pl_data = {
+            "dagWarnings": {
+                "error_one": "Błąd",
+                "error_few": "Błędy",
+                "error_many": "Błędów",
+                "error_other": "Błędy",
+            }
+        }
+
+        (en_dir / "test.json").write_text(json.dumps(en_data))
+        (pl_dir / "test.json").write_text(json.dumps(pl_data))
+
+        import airflow_breeze.commands.ui_commands as ui_commands
+
+        original_locales_dir = ui_commands.LOCALES_DIR
+        ui_commands.LOCALES_DIR = tmp_path
+
+        try:
+            locale_files = [
+                LocaleFiles(locale="en", files=["test.json"]),
+                LocaleFiles(locale="pl", files=["test.json"]),
+            ]
+            summary, _ = compare_keys(locale_files)
+
+            # Previously these could be falsely flagged as unused.
+            assert "dagWarnings.error_few" not in summary["test.json"].unused_keys.get("pl", [])
+            assert "dagWarnings.error_many" not in summary["test.json"].unused_keys.get("pl", [])
         finally:
             ui_commands.LOCALES_DIR = original_locales_dir
 


### PR DESCRIPTION
## Summary
- Fix `check-translation-completeness` so plural keys are expanded not only when EN contains `{{count}}`, but also when EN already has multiple plural forms for the same base (for example `_one` + `_other`).
- This avoids false "unused" reports for locale-specific plural forms in languages like Polish.
- Added focused tests for both the helper behavior and compare flow regression.

## Why
Issue #65229 reports that language-specific plural forms can be marked as unused even when plural routing is active.

## Tests
- `uv run ruff format dev/breeze/src/airflow_breeze/commands/ui_commands.py dev/breeze/tests/test_ui_commands.py`
- `uv run ruff check --fix dev/breeze/src/airflow_breeze/commands/ui_commands.py dev/breeze/tests/test_ui_commands.py`
- `uv run --project dev/breeze pytest dev/breeze/tests/test_ui_commands.py -xvs`

Closes #65229