### PR TITLE
Fix connection schema field not saved for providers without field behaviour

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useConnectionTypeMeta.ts
@@ -78,7 +78,9 @@ const convertStandardFields = (
   defaultFields: StandardFieldSpec,
 ): StandardFieldSpec => {
   if (apiFields === null) {
-    return { ...defaultFields };
+    const { url_schema: urlSchema, ...rest } = defaultFields;
+
+    return { ...rest, schema: urlSchema ?? {} };
   }
 
   const result: StandardFieldSpec = {


### PR DESCRIPTION
Fixes the connection form's schema field being silently lost for providers that don't define `get_ui_field_behaviour()` (Oracle, and many others).

- **On create**: schema was never sent in the request, so it was stored as `None` and `get_uri` was malformed (missing `/{schema}` path segment)
- **On edit**: the stray `url_schema` key in the request body triggered a 422 from `StrictBaseModel(extra="forbid")`

## Root cause

`convertStandardFields` in `useConnectionTypeMeta.ts` has two branches:

| `apiFields` | Key in returned dict | Correct? |
|---|---|---|
| non-null | `schema` (remapped from `url_schema`) | Yes |
| null (no field behaviour) | `url_schema` (raw default key) | **No** |

`ConnectionStandardFields.tsx` iterates the keys and creates a react-hook-form `Controller` with `name={key}`. When the key was `url_schema` instead of `schema`, user input went to a phantom field -- the real `schema` stayed at its default `""`, which `useAddConnection.ts` converted to `undefined` (omitted from the request).

On edit, `useEditConnection.tsx` spreads `...requestBody` which included the rogue `url_schema` key, and the backend's `ConnectionBody(extra="forbid")` rejected it.

## Fix

Remap `url_schema` to `schema` in the null branch, matching the non-null path:

```typescript
if (apiFields === null) {
  const { url_schema: urlSchema, ...rest } = defaultFields;
  return { ...rest, schema: urlSchema ?? {} };
}
```

Affects every provider without `get_ui_field_behaviour()`. [Oracle is the reporter](https://github.com/apache/airflow/issues/65257), but the bug applied generically.

Closes: #65257