### PR TITLE
[v3-2-test] Add missing Polish translations to reach 100% coverage

### DIFF
--- a/.github/skills/airflow-translations/locales/pl.md
+++ b/.github/skills/airflow-translations/locales/pl.md
@@ -147,6 +147,25 @@ Preserve all `{{variable}}` placeholders. Adjust word order for natural Polish:
 "title": "Usuń {{liczba}} połączeń"  // variable name translated
 ```
 
+## Terminology Glossary
+
+Preferred wording for specific UI terms. Apply these to new translations and
+prefer them when reviewing existing ones.
+
+| English / context | Preferred Polish | Avoid |
+|---|---|---|
+| Consuming Asset (asset consumed by a Dag run) | **Zabierający zasób** | ~~Konsumujący zasób~~ |
+| Bulk clear / delete / update (toaster and button labels) | **grupowy / grupowego / grupowej / grupowe …** | ~~masowy / masowego / masowej / masowe~~ |
+| Deactivated (Dag header status) | **Deaktywowany** / Deaktywowana / Deaktywowane | ~~Dezaktywowany~~ |
+
+Notes:
+
+- For "bulk <verb>" always use "grupowy" with the grammatical form that
+  matches the noun — e.g. "żądanie grupowego wyczyszczenia", "żądanie
+  grupowej aktualizacji". Never use "masowy".
+- "Deactivated" / "Deaktywowany" must agree in gender with the noun it
+  describes (e.g. neuter "zadanie" → "Deaktywowane").
+
 ## Terminology Reference
 
 The established Polish translations are defined in the existing locale files.

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -128,7 +128,8 @@
       "includeDeferred": "Uwzględnij odroczone",
       "nameMaxLength": "Nazwa może zawierać maksymalnie 256 znaków",
       "nameRequired": "Nazwa jest wymagana",
-      "slots": "Miejsca"
+      "slots": "Miejsca",
+      "slotsHelperText": "Użyj -1 dla nieograniczonej liczby miejsc."
     },
     "noPoolsFound": "Nie znaleziono pul",
     "pool_few": "Pule",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -115,6 +115,12 @@
     "notFound": "Nie znaleziono strony",
     "title": "Błąd"
   },
+  "errors": {
+    "forbidden": {
+      "description": "Nie masz uprawnień do wykonania tej akcji.",
+      "title": "Dostęp zabroniony"
+    }
+  },
   "expand": {
     "collapse": "Zwiń",
     "expand": "Rozwiń",
@@ -140,6 +146,7 @@
     "selectDateRange": "Wybierz zakres dat",
     "startTime": "Czas rozpoczęcia"
   },
+  "generateToken": "Wygeneruj token",
   "logicalDate": "Data logiczna",
   "logout": "Wyloguj",
   "logoutConfirmation": "Zamierzasz wylogować się z aplikacji.",
@@ -187,6 +194,7 @@
   "reset": "Resetuj",
   "runId": "Identyfikator wykonania",
   "runTypes": {
+    "asset_materialization": "Materializacja zasobu",
     "asset_triggered": "Uruchomiony przez zasób",
     "backfill": "Wypełnienie wsteczne",
     "manual": "Ręcznie",
@@ -316,10 +324,10 @@
   },
   "toaster": {
     "bulkDelete": {
-      "error": "Nie udało się wykonać żądania masowego usunięcia {{resourceName}}",
+      "error": "Nie udało się wykonać żądania grupowego usunięcia {{resourceName}}",
       "success": {
         "description": "Pomyślnie usunięto {{count}} {{resourceName}}. Klucze: {{keys}}",
-        "title": "Wysłano żądanie masowego usunięcia {{resourceName}}"
+        "title": "Wysłano żądanie grupowego usunięcia {{resourceName}}"
       }
     },
     "create": {
@@ -350,6 +358,18 @@
         "title": "Wysłano żądanie aktualizacji {{resourceName}}"
       }
     }
+  },
+  "tokenGeneration": {
+    "apiToken": "Token API",
+    "cliToken": "Token CLI",
+    "errorDescription": "Podczas generowania tokenu wystąpił błąd. Spróbuj ponownie.",
+    "errorTitle": "Nie udało się wygenerować tokenu",
+    "generate": "Wygeneruj",
+    "selectType": "Wybierz typ tokenu do wygenerowania.",
+    "title": "Wygeneruj token",
+    "tokenExpiresIn": "Ten token wygasa za {{duration}}.",
+    "tokenGenerated": "Twój token został wygenerowany.",
+    "tokenShownOnce": "Ten token zostanie wyświetlony tylko raz. Skopiuj go teraz."
   },
   "total": "Wszystkie {{state}}",
   "triggered": "Uruchomiony",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -47,10 +47,7 @@
     "invalidJson": "Nieprawidłowy format JSON: {{errorMessage}}"
   },
   "dagWarnings": {
-    "error_few": "Błędy",
-    "error_many": "Błędów",
     "error_one": "Błąd",
-    "error_other": "Błedy",
     "errorAndWarning": "1 Błąd i {{warningText}}",
     "warning_few": "{{count}} Ostrzeżenia",
     "warning_many": "{{count}} Ostrzeżeń",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -45,12 +45,16 @@
     "buttons": {
       "resetToLatest": "Przywróć do najnowszego",
       "toggleGroup": "Przełącz grupę"
-    }
+    },
+    "runTypeLegend": "Legenda typów wykonań"
   },
   "header": {
     "buttons": {
       "advanced": "Zaawansowane",
       "dagDocs": "Dokumentacja Daga"
+    },
+    "status": {
+      "deactivated": "Deaktywowany"
     }
   },
   "logs": {


### PR DESCRIPTION
Backports the Polish translation coverage work from the main-branch PR
to \`v3-2-test\`, scoped to the subset of keys that exist on 3.2.

## Summary

- Fills the 17 Polish translation keys reported as missing by
  \`breeze ui check-translation-completeness --language pl\` —
  \`pools.form.slotsHelperText\` (admin), \`errors.forbidden\`,
  \`generateToken\`, \`runTypes.asset_materialization\`, the
  \`tokenGeneration\` object (common), and \`grid.runTypeLegend\` /
  \`header.status.deactivated\` (dag).
- Updates the two pre-existing \`bulkDelete\` toaster messages in
  \`common.json\` to use "grupowego" per the terminology glossary.
- Backports the Polish terminology glossary section in
  \`.github/skills/airflow-translations/locales/pl.md\` ("Zabierający"
  not "Konsumujący", "grupowy" not "masowy", "Deaktywowany" not
  "Dezaktywowany").
- Drops the unused \`dagWarnings.error_few/many/other\` PL entries —
  the EN source only has \`error_one\`, so there are no plural forms
  to translate there (the #65270 fix correctly flags them).

After this change the checker reports 100% coverage (880/880), with
0 missing and 0 unused keys.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)