### PR TITLE
Fix `get_team_name_dep` creating wasted async sessions when `multi_team=False`

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/security.py
@@ -74,10 +74,8 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.params import Security as SecurityParam
 from fastapi.routing import APIRoute
 from fastapi.security import HTTPBearer, SecurityScopes
-from sqlalchemy import select
 
 from airflow.api_fastapi.auth.tokens import JWTValidator
-from airflow.api_fastapi.common.db.common import AsyncSessionDep
 from airflow.api_fastapi.execution_api.datamodels.token import TIToken
 from airflow.api_fastapi.execution_api.deps import DepContainer
 
@@ -222,15 +220,19 @@ class ExecutionAPIRoute(APIRoute):
         self.allowed_token_types = frozenset(token_scopes) if token_scopes else frozenset({"execution"})
 
 
-async def get_team_name_dep(session: AsyncSessionDep, token=CurrentTIToken) -> str | None:
+async def get_team_name_dep(token=CurrentTIToken) -> str | None:
     """Return the team name associated to the task (if any)."""
     from airflow.configuration import conf
-    from airflow.models import DagModel, TaskInstance
-    from airflow.models.dagbundle import DagBundleModel
-    from airflow.models.team import Team
 
     if not conf.getboolean("core", "multi_team"):
         return None
+
+    from sqlalchemy import select
+
+    from airflow.models import DagModel, TaskInstance
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.models.team import Team
+    from airflow.utils.session import create_session_async
 
     stmt = (
         select(Team.name)
@@ -240,4 +242,5 @@ async def get_team_name_dep(session: AsyncSessionDep, token=CurrentTIToken) -> s
         .join(DagBundleModel.teams)
         .where(TaskInstance.id == token.id)
     )
-    return await session.scalar(stmt)
+    async with create_session_async() as session:
+        return await session.scalar(stmt)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
@@ -23,7 +24,12 @@ from fastapi import APIRouter, FastAPI, Request, Security
 from fastapi.testclient import TestClient
 
 from airflow.api_fastapi.execution_api.datamodels.token import TIToken
-from airflow.api_fastapi.execution_api.security import ExecutionAPIRoute, _jwt_bearer, require_auth
+from airflow.api_fastapi.execution_api.security import (
+    ExecutionAPIRoute,
+    _jwt_bearer,
+    get_team_name_dep,
+    require_auth,
+)
 
 
 class TestExecutionAPIRoute:
@@ -136,3 +142,21 @@ class TestTokenTypeScopeEnforcement:
         run = client.get(f"/task-instances/{self.TI_ID}/run", headers={"Authorization": "Bearer fake"})
         assert state.status_code == 200
         assert run.status_code == 200
+
+
+class TestGetTeamNameDep:
+    """Tests for get_team_name_dep avoiding unnecessary async sessions."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_without_session_when_multi_team_disabled(self):
+        """When multi_team=False, no async session should be created."""
+        token = MagicMock(spec=TIToken)
+
+        with (
+            patch("airflow.configuration.conf.getboolean", return_value=False),
+            patch("airflow.utils.session.create_session_async") as mock_create_session,
+        ):
+            result = await get_team_name_dep(token=token)
+
+        assert result is None
+        mock_create_session.assert_not_called()


### PR DESCRIPTION
`get_team_name_dep()` declared `AsyncSessionDep` as a FastAPI dependency parameter. FastAPI resolves all dependencies before calling the function, so an async database connection was checked out on every request -- even when `multi_team=False` (the default), where the function immediately returned `None` without using the session.

## How this path is hit

`get_team_name_dep` is a `Depends()` on these Execution API endpoints:

- `GET /connections/{connection_id}`
- `GET /variables/{key}`
- `PUT /variables/{key}`
- `DELETE /variables/{key}`

Every worker calls these endpoints during task execution whenever a DAG reads a Connection or Variable. At scale (hundreds of workers, frequent lookups), each request was paying for:

1. Async connection checkout from the pool
2. No-op commit round-trip to PostgreSQL
3. Connection return to the pool

All for a function that returns `None` on every single call when `multi_team=False`.

## Fix

Remove `AsyncSessionDep` from the function signature. When `multi_team=True`, create a short-lived session via `create_session_async()` (the same function `AsyncSessionDep` wraps internally). When `multi_team=False`, return `None` without touching the database.