### PR TITLE
Custom Executor task retry ignores manual cancel

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -268,6 +268,15 @@ class AwsBatchExecutor(BaseExecutor):
         queue = job_info.queue
         exec_info = job_info.config
         failure_count = self.active_workers.failure_count_by_id(job_id=job.job_id)
+        if task_key not in self.running:
+            self.log.info(
+                "Airflow task %s is no longer in the running state (likely cancelled). "
+                "Not rescheduling failed job %s.",
+                task_key,
+                job.job_id,
+            )
+            self.active_workers.pop_by_id(job.job_id)
+            return
         if int(failure_count) < int(self.max_submit_job_attempts):
             self.log.warning(
                 "Airflow task %s failed due to %s. Failure %s out of %s occurred on %s. Rescheduling.",
@@ -315,6 +324,13 @@ class AwsBatchExecutor(BaseExecutor):
             exec_config = batch_job.executor_config
             attempt_number = batch_job.attempt_number
             failure_reason: str | None = None
+            if key not in self.running:
+                self.log.info(
+                    "Airflow task %s is no longer in the running state (likely cancelled). "
+                    "Not submitting pending job.",
+                    key,
+                )
+                continue
             if timezone.utcnow() < batch_job.next_attempt_time:
                 self.pending_jobs.append(batch_job)
                 continue
@@ -448,6 +464,29 @@ class AwsBatchExecutor(BaseExecutor):
             {"name": "AIRFLOW_IS_EXECUTOR_CONTAINER", "value": "true"}
         )
         return submit_job_api
+
+    def revoke_task(self, *, ti: TaskInstance):
+        """
+        Revoke a task instance from the executor.
+
+        Stop the running AWS Batch job (if any), and clean up internal data structures.
+        Does not change the task state in Airflow or add events to the event buffer.
+
+        :param ti: Task instance to revoke
+        """
+        self.running.discard(ti.key)
+        self.queued_tasks.pop(ti.key, None)
+
+        # Remove from pending jobs queue
+        self.pending_jobs = deque(job for job in self.pending_jobs if job.key != ti.key)
+
+        # Terminate the running Batch job if it exists
+        if ti.key in self.active_workers.key_to_id:
+            job_id = self.active_workers.pop_by_key(ti.key)
+            try:
+                self.batch.terminate_job(jobId=job_id, reason="Task was revoked by the Airflow scheduler")
+            except Exception:
+                self.log.exception("Failed to terminate Batch job %s for task %s", job_id, ti.key)
 
     def end(self, heartbeat_interval=10):
         """Wait for all currently running tasks to end and prevent any new jobs from running."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/utils.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/utils.py
@@ -117,7 +117,17 @@ class BatchJobCollection:
         del self.key_to_id[task_key]
         del self.id_to_key[job_id]
         del self.id_to_failure_counts[job_id]
+        del self.id_to_job_info[job_id]
         return task_key
+
+    def pop_by_key(self, task_key: TaskInstanceKey) -> str:
+        """Delete job from collection based off of Airflow Task Instance Key."""
+        job_id = self.key_to_id[task_key]
+        del self.key_to_id[task_key]
+        del self.id_to_key[job_id]
+        del self.id_to_failure_counts[job_id]
+        del self.id_to_job_info[job_id]
+        return job_id
 
     def failure_count_by_id(self, job_id: str) -> int:
         """Get the number of times a job has failed given a Batch Job Id."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -344,6 +344,15 @@ class AwsEcsExecutor(BaseExecutor):
         queue = task_info.queue
         exec_info = task_info.config
         failure_count = self.active_workers.failure_count_by_key(task_key)
+        if task_key not in self.running:
+            self.log.info(
+                "Airflow task %s is no longer in the running state (likely cancelled). "
+                "Not rescheduling failed ECS task %s.",
+                task_key,
+                task_arn,
+            )
+            self.active_workers.pop_by_key(task_key)
+            return
         if int(failure_count) < int(self.max_run_task_attempts):
             self.log.warning(
                 "Airflow task %s failed due to %s. Failure %s out of %s occurred on %s. Rescheduling.",
@@ -392,6 +401,13 @@ class AwsEcsExecutor(BaseExecutor):
             exec_config = ecs_task.executor_config
             attempt_number = ecs_task.attempt_number
             failure_reasons = []
+            if task_key not in self.running:
+                self.log.info(
+                    "Airflow task %s is no longer in the running state (likely cancelled). "
+                    "Not submitting pending ECS task.",
+                    task_key,
+                )
+                continue
             if timezone.utcnow() < ecs_task.next_attempt_time:
                 self.pending_tasks.append(ecs_task)
                 continue
@@ -511,6 +527,34 @@ class AwsEcsExecutor(BaseExecutor):
         self.pending_tasks.append(
             EcsQueuedTask(key, command, queue, executor_config or {}, 1, timezone.utcnow())
         )
+
+    def revoke_task(self, *, ti: TaskInstance):
+        """
+        Revoke a task instance from the executor.
+
+        Stop the running ECS task (if any), and clean up internal data structures.
+        Does not change the task state in Airflow or add events to the event buffer.
+
+        :param ti: Task instance to revoke
+        """
+        self.running.discard(ti.key)
+        self.queued_tasks.pop(ti.key, None)
+
+        # Remove from pending tasks queue
+        self.pending_tasks = deque(task for task in self.pending_tasks if task.key != ti.key)
+
+        # Stop the running ECS task if it exists
+        if ti.key in self.active_workers.key_to_arn:
+            task_arn = self.active_workers.key_to_arn[ti.key]
+            self.active_workers.pop_by_key(ti.key)
+            try:
+                self.ecs.stop_task(
+                    cluster=self.cluster,
+                    task=task_arn,
+                    reason="Task was revoked by the Airflow scheduler",
+                )
+            except Exception:
+                self.log.exception("Failed to stop ECS task %s for task %s", task_arn, ti.key)
 
     def end(self, heartbeat_interval=10):
         """Wait for all currently running tasks to end, and don't launch any tasks."""

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -42,7 +42,7 @@ from airflow.providers.amazon.aws.executors.batch.utils import (
     CONFIG_GROUP_NAME,
     AllBatchConfigKeys,
 )
-from airflow.providers.common.compat.sdk import AirflowException, conf
+from airflow.providers.common.compat.sdk import AirflowException, conf, timezone
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.state import State
 from airflow.version import version as airflow_version_str
@@ -196,6 +196,7 @@ class TestAwsBatchExecutor:
         mock_executor.batch.submit_job.return_value = {"jobId": MOCK_JOB_ID, "jobName": "some-job-name"}
 
         mock_executor.execute_async(airflow_key, airflow_cmd)
+        mock_executor.running.add(airflow_key)
         assert len(mock_executor.pending_jobs) == 1
         mock_executor.attempt_submit_jobs()
         mock_executor.batch.submit_job.assert_called_once()
@@ -295,6 +296,7 @@ class TestAwsBatchExecutor:
         }
         mock_executor.execute_async(airflow_key, airflow_cmd1)
         mock_executor.execute_async(airflow_key, airflow_cmd2)
+        mock_executor.running.add(airflow_key)
         assert len(mock_executor.pending_jobs) == 2
 
         mock_executor.batch.submit_job.side_effect = responses
@@ -362,6 +364,7 @@ class TestAwsBatchExecutor:
         }
         mock_executor.execute_async(airflow_key, airflow_cmd1)
         mock_executor.execute_async(airflow_key, airflow_cmd2)
+        mock_executor.running.add(airflow_key)
         assert len(mock_executor.pending_jobs) == 2
 
         mock_executor.batch.submit_job.side_effect = failures
@@ -383,11 +386,14 @@ class TestAwsBatchExecutor:
         mock_executor.attempt_submit_jobs()
         if VersionInfo.parse(str(airflow_version)) >= (2, 10, 0):
             events = [(x.event, x.task_id, x.try_number) for x in mock_executor._task_event_logs]
-            assert events == [("batch job submit failure", "b", 1)] * 2
+            # Only one event because after the first job with this key is failed,
+            # the key is removed from self.running and the second job is skipped.
+            assert events == [("batch job submit failure", "b", 1)]
 
     def test_attempt_submit_jobs_failure(self, mock_executor):
         mock_executor.batch.submit_job.side_effect = NoCredentialsError()
         mock_executor.execute_async("airflow_key", "airflow_cmd")
+        mock_executor.running.add("airflow_key")
         assert len(mock_executor.pending_jobs) == 1
         with pytest.raises(NoCredentialsError, match="Unable to locate credentials"):
             mock_executor.attempt_submit_jobs()
@@ -413,6 +419,7 @@ class TestAwsBatchExecutor:
 
         mock_executor.execute_async(airflow_keys[0], airflow_cmds[0])
         mock_executor.execute_async(airflow_keys[1], airflow_cmds[1])
+        mock_executor.running.update(airflow_keys)
         assert len(mock_executor.pending_jobs) == 2
         jobs = [
             {
@@ -483,6 +490,7 @@ class TestAwsBatchExecutor:
 
     def test_sync_client_error(self, mock_executor, caplog):
         mock_executor.execute_async("airflow_key", "airflow_cmd")
+        mock_executor.running.add("airflow_key")
         assert len(mock_executor.pending_jobs) == 1
         mock_resp = {
             "Error": {
@@ -668,6 +676,7 @@ class TestAwsBatchExecutor:
             exec_config={},
             attempt_number=attempt_number,
         )
+        executor.running.add(airflow_key)
 
         after_batch_job = {
             "jobName": "some-job-queue",
@@ -749,6 +758,149 @@ class TestAwsBatchExecutor:
             assert submit_kwargs["jobQueue"] == "some-job-queue"
             assert submit_kwargs["jobDefinition"] == "some-job-def"
             assert submit_kwargs["jobName"] == "some-job-name"
+
+    @mock.patch.object(batch_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
+    def test_failed_job_not_retried_when_cancelled(self, _, mock_executor, caplog):
+        """When a task is removed from self.running (e.g. user cancelled it), the executor
+        should not reschedule the failed job."""
+        airflow_key = "CancelledTaskKey"
+        mock_executor.execute_async(airflow_key, ["cmd1", "cmd2"])
+        mock_executor.running.add(airflow_key)
+
+        mock_executor.batch.submit_job.return_value = {"jobId": "job-cancel-1"}
+        mock_executor.attempt_submit_jobs()
+
+        assert len(mock_executor.active_workers) == 1
+        assert len(mock_executor.pending_jobs) == 0
+
+        # Simulate the scheduler removing the task from running (user cancelled)
+        mock_executor.running.discard(airflow_key)
+
+        # Now simulate the job failing in AWS
+        mock_executor.batch.describe_jobs.return_value = {
+            "jobs": [
+                {
+                    "jobName": "job-cancel-1",
+                    "jobId": "job-cancel-1",
+                    "status": "FAILED",
+                    "statusReason": "Container exited with non-zero code",
+                }
+            ]
+        }
+        mock_executor.sync_running_jobs()
+
+        # Task should NOT be rescheduled
+        assert len(mock_executor.pending_jobs) == 0
+        assert len(mock_executor.active_workers) == 0
+        assert "no longer in the running state" in caplog.text
+
+    def test_pending_job_not_submitted_when_cancelled(self, mock_executor):
+        """When a task is removed from self.running while it's in the pending queue,
+        the executor should discard it instead of submitting."""
+        airflow_key = "CancelledPendingKey"
+        mock_executor.execute_async(airflow_key, ["cmd1", "cmd2"])
+        mock_executor.running.add(airflow_key)
+
+        assert len(mock_executor.pending_jobs) == 1
+
+        # Simulate the scheduler removing the task from running (user cancelled)
+        mock_executor.running.discard(airflow_key)
+
+        mock_executor.attempt_submit_jobs()
+
+        # Job should not have been submitted
+        mock_executor.batch.submit_job.assert_not_called()
+        assert len(mock_executor.pending_jobs) == 0
+        assert len(mock_executor.active_workers) == 0
+
+    def test_revoke_task_running_job(self, mock_executor):
+        """Test that revoke_task terminates a running Batch job and cleans up internal state."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.active_workers.add_job(
+            job_id="revoke-job-1",
+            airflow_task_key=airflow_key,
+            airflow_cmd=["cmd"],
+            queue="queue",
+            exec_config={},
+            attempt_number=1,
+        )
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        mock_executor.revoke_task(ti=ti)
+
+        mock_executor.batch.terminate_job.assert_called_once_with(
+            jobId="revoke-job-1", reason="Task was revoked by the Airflow scheduler"
+        )
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.active_workers) == 0
+
+    def test_revoke_task_pending_job(self, mock_executor):
+        """Test that revoke_task removes a pending job from the queue."""
+        from airflow.providers.amazon.aws.executors.batch.utils import BatchQueuedJob
+
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.pending_jobs.append(
+            BatchQueuedJob(
+                key=airflow_key,
+                command=["cmd"],
+                queue="queue",
+                executor_config={},
+                attempt_number=1,
+                next_attempt_time=timezone.utcnow(),
+            )
+        )
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.pending_jobs) == 0
+        # No Batch job to terminate since it was only pending
+        mock_executor.batch.terminate_job.assert_not_called()
+
+    def test_revoke_task_not_found(self, mock_executor):
+        """Test that revoke_task handles gracefully when the task is not in any internal structure."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        # Should not raise
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        mock_executor.batch.terminate_job.assert_not_called()
+
+    def test_revoke_task_terminate_api_failure(self, mock_executor, caplog):
+        """Test that revoke_task handles API failures gracefully."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.active_workers.add_job(
+            job_id="revoke-fail-job",
+            airflow_task_key=airflow_key,
+            airflow_cmd=["cmd"],
+            queue="queue",
+            exec_config={},
+            attempt_number=1,
+        )
+        mock_executor.running.add(airflow_key)
+        mock_executor.batch.terminate_job.side_effect = Exception("API Error")
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        # Should not raise
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.active_workers) == 0
+        assert "Failed to terminate Batch job" in caplog.text
 
 
 class TestBatchExecutorConfig:

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_utils.py
@@ -206,9 +206,8 @@ class TestBatchJobCollection:
         assert len(self.collection) == 0
         assert self.job_id1 not in self.collection.id_to_key
         assert self.key1 not in self.collection.key_to_id
-        # id_to_job_info is NOT removed by pop_by_id in the current implementation.
-        assert self.job_id1 in self.collection.id_to_job_info
-        assert self.collection.id_to_job_info[self.job_id1].cmd == self.cmd1
+        # id_to_job_info is now also cleaned up by pop_by_id.
+        assert self.job_id1 not in self.collection.id_to_job_info
         # id_to_failure_counts is a defaultdict, so accessing a removed key returns 0.
         assert self.collection.id_to_failure_counts[self.job_id1] == 0
 

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -401,6 +401,7 @@ class TestAwsEcsExecutor:
 
         assert len(mock_executor.pending_tasks) == 0
         mock_executor.execute_async(airflow_key, mock_cmd)
+        mock_executor.running.add(airflow_key)
         assert len(mock_executor.pending_tasks) == 1
 
         mock_executor.attempt_task_runs()
@@ -520,6 +521,7 @@ class TestAwsEcsExecutor:
         }
         mock_executor.ecs.run_task.side_effect = [run_task_exception, run_task_exception, run_task_success]
         mock_executor.execute_async(mock_airflow_key, mock_cmd)
+        mock_executor.running.add(mock_airflow_key)
         expected_retry_count = 2
 
         # Fail 2 times
@@ -540,6 +542,7 @@ class TestAwsEcsExecutor:
         """Test what happens when ECS refuses to execute a task and throws an exception"""
         mock_executor.ecs.run_task.side_effect = Exception("Test exception")
         mock_executor.execute_async(mock_airflow_key, mock_cmd)
+        mock_executor.running.add(mock_airflow_key)
 
         # No matter what, don't schedule until run_task becomes successful.
         for _ in range(int(mock_executor.max_run_task_attempts) * 2):
@@ -557,6 +560,7 @@ class TestAwsEcsExecutor:
         }
 
         mock_executor.execute_async(mock_airflow_key, mock_cmd)
+        mock_executor.running.add(mock_airflow_key)
 
         # No matter what, don't schedule until run_task becomes successful.
         for _ in range(int(mock_executor.max_run_task_attempts) * 2):
@@ -585,6 +589,7 @@ class TestAwsEcsExecutor:
 
         mock_executor.execute_async(airflow_keys[0], commands[0])
         mock_executor.execute_async(airflow_keys[1], commands[1])
+        mock_executor.running.update(airflow_keys)
 
         assert len(mock_executor.pending_tasks) == 2
         assert len(mock_executor.active_workers.get_all_arns()) == 0
@@ -653,6 +658,7 @@ class TestAwsEcsExecutor:
 
         mock_executor.execute_async(airflow_keys[0], airflow_commands[0])
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
+        mock_executor.running.update(airflow_keys)
 
         assert len(mock_executor.pending_tasks) == 2
 
@@ -672,6 +678,7 @@ class TestAwsEcsExecutor:
         airflow_keys[1] = mock.Mock(spec=tuple)
         airflow_commands[1] = _generate_mock_cmd()
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
+        mock_executor.running.add(airflow_keys[1])
 
         assert len(mock_executor.pending_tasks) == 2
         # assert that the order of pending tasks is preserved i.e. the first task is 1st etc.
@@ -715,6 +722,7 @@ class TestAwsEcsExecutor:
 
         mock_executor.execute_async(airflow_keys[0], airflow_commands[0])
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
+        mock_executor.running.update(airflow_keys)
         assert len(mock_executor.pending_tasks) == 2
         caplog.set_level("WARNING")
 
@@ -882,6 +890,7 @@ class TestAwsEcsExecutor:
         mock_executor._calculate_next_attempt_time = MagicMock(return_value=utcnow())
         task_key = mock_airflow_key()
         mock_executor.execute_async(task_key, mock_cmd)
+        mock_executor.running.add(task_key)
         for _ in range(2):
             assert len(mock_executor.pending_tasks) == 1
             keys = [task.key for task in mock_executor.pending_tasks]
@@ -957,6 +966,7 @@ class TestAwsEcsExecutor:
         """Test what happens when ECS sync fails for certain tasks repeatedly."""
         airflow_key = "test-key"
         mock_executor.execute_async(airflow_key, mock_cmd)
+        mock_executor.running.add(airflow_key)
         assert len(mock_executor.pending_tasks) == 1
 
         run_task_ret_val = {
@@ -1148,7 +1158,9 @@ class TestAwsEcsExecutor:
     @staticmethod
     def _add_mock_task(executor: AwsEcsExecutor, arn: str, state=TaskInstanceState.RUNNING):
         task = mock_task(arn, state)
-        executor.active_workers.add_task(task, mock.Mock(spec=tuple), mock_queue, mock_cmd, mock_config, 1)  # type:ignore[arg-type]
+        task_key = mock.Mock(spec=tuple)
+        executor.active_workers.add_task(task, task_key, mock_queue, mock_cmd, mock_config, 1)  # type:ignore[arg-type]
+        executor.running.add(task_key)
 
     def _sync_mock_with_call_counts(self, sync_func: Callable):
         """Mock won't work here, because we actually want to call the 'sync' func."""
@@ -1321,6 +1333,153 @@ class TestAwsEcsExecutor:
         assert len(orphaned_tasks) - 1 == len(mock_executor.active_workers)
         # The remaining one task is unable to be adopted.
         assert len(not_adopted_tasks) == 1
+
+    @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
+    def test_failed_task_not_retried_when_cancelled(self, _, mock_executor, mock_cmd, caplog):
+        """When a task is removed from self.running (e.g. user cancelled it), the executor
+        should not reschedule the failed ECS task."""
+        airflow_key = "CancelledTaskKey"
+        mock_executor.execute_async(airflow_key, mock_cmd)
+        mock_executor.running.add(airflow_key)
+
+        mock_executor.ecs.run_task.return_value = {
+            "tasks": [
+                {
+                    "taskArn": ARN1,
+                    "lastStatus": "",
+                    "desiredStatus": "",
+                    "containers": [{"name": "some-ecs-container"}],
+                }
+            ],
+            "failures": [],
+        }
+        mock_executor.attempt_task_runs()
+
+        assert len(mock_executor.active_workers) == 1
+        assert len(mock_executor.pending_tasks) == 0
+
+        # Simulate the scheduler removing the task from running (user cancelled)
+        mock_executor.running.discard(airflow_key)
+
+        # Now simulate the task failing in AWS
+        mock_executor.ecs.describe_tasks.return_value = {
+            "tasks": [],
+            "failures": [{"arn": ARN1, "reason": "Task failed"}],
+        }
+        mock_executor.sync_running_tasks()
+
+        # Task should NOT be rescheduled
+        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.active_workers) == 0
+        assert "no longer in the running state" in caplog.text
+
+    def test_pending_task_not_submitted_when_cancelled(self, mock_executor, mock_cmd):
+        """When a task is removed from self.running while it's in the pending queue,
+        the executor should discard it instead of submitting."""
+        airflow_key = "CancelledPendingKey"
+        mock_executor.execute_async(airflow_key, mock_cmd)
+        mock_executor.running.add(airflow_key)
+
+        assert len(mock_executor.pending_tasks) == 1
+
+        # Simulate the scheduler removing the task from running (user cancelled)
+        mock_executor.running.discard(airflow_key)
+
+        mock_executor.attempt_task_runs()
+
+        # Task should not have been submitted
+        mock_executor.ecs.run_task.assert_not_called()
+        assert len(mock_executor.pending_tasks) == 0
+        assert len(mock_executor.active_workers) == 0
+
+    def test_revoke_task_running_task(self, mock_executor):
+        """Test that revoke_task stops a running ECS task and cleans up internal state."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        ecs_task = EcsExecutorTask(
+            task_arn="revoke-arn-1",
+            last_status="RUNNING",
+            desired_status="RUNNING",
+            containers=[{"name": "some-ecs-container"}],
+        )
+        mock_executor.active_workers.add_task(ecs_task, airflow_key, "queue", ["cmd"], {}, 1)
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        mock_executor.revoke_task(ti=ti)
+
+        mock_executor.ecs.stop_task.assert_called_once_with(
+            cluster=mock_executor.cluster,
+            task="revoke-arn-1",
+            reason="Task was revoked by the Airflow scheduler",
+        )
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.active_workers) == 0
+
+    def test_revoke_task_pending_task(self, mock_executor):
+        """Test that revoke_task removes a pending task from the queue."""
+        from airflow.providers.amazon.aws.executors.ecs.utils import EcsQueuedTask
+
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.pending_tasks.append(
+            EcsQueuedTask(
+                key=airflow_key,
+                command=["cmd"],
+                queue="queue",
+                executor_config={},
+                attempt_number=1,
+                next_attempt_time=utcnow(),
+            )
+        )
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.pending_tasks) == 0
+        # No ECS task to stop since it was only pending
+        mock_executor.ecs.stop_task.assert_not_called()
+
+    def test_revoke_task_not_found(self, mock_executor):
+        """Test that revoke_task handles gracefully when the task is not in any internal structure."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        mock_executor.running.add(airflow_key)
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        # Should not raise
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        mock_executor.ecs.stop_task.assert_not_called()
+
+    def test_revoke_task_stop_api_failure(self, mock_executor, caplog):
+        """Test that revoke_task handles API failures gracefully."""
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1)
+        ecs_task = EcsExecutorTask(
+            task_arn="revoke-fail-arn",
+            last_status="RUNNING",
+            desired_status="RUNNING",
+            containers=[{"name": "some-ecs-container"}],
+        )
+        mock_executor.active_workers.add_task(ecs_task, airflow_key, "queue", ["cmd"], {}, 1)
+        mock_executor.running.add(airflow_key)
+        mock_executor.ecs.stop_task.side_effect = Exception("API Error")
+
+        ti = mock.Mock(spec=TaskInstance)
+        ti.key = airflow_key
+
+        # Should not raise
+        mock_executor.revoke_task(ti=ti)
+
+        assert airflow_key not in mock_executor.running
+        assert len(mock_executor.active_workers) == 0
+        assert "Failed to stop ECS task" in caplog.text
 
 
 class TestEcsExecutorConfig:


### PR DESCRIPTION
@o-nikolas - Check this out when you get time.   It's a bug report from back in May 2024.   What do you think?

```
Steps to reproduce:
- Use either the Batch or ECS Executor
- Run a DAG that will fail in the container
 - Easy way is to change the dag_id locally, so that airflow cannot find the dag we tell it to run
- When you see the message saying the task failed 1 out of 3 attempts, cancel the task in the UI
- The task will be marked as failed in the UI, but the Executor will continue to reattempt the task until it fails all 3 times
```

Creating as a draft until I get your thoughts.  100% done using Kiro's "spec-driven coding" feature
