### PR TITLE
Fix unnecessary gc.freeze() calls in LocalExecutor when no workers spawn

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -225,7 +225,7 @@ class LocalExecutor(BaseExecutor):
             assert p.pid  # Since we've called start
         self.workers[p.pid] = p
 
-    def _spawn_workers_with_gc_freeze(self, spawn_number):
+    def _spawn_workers_with_gc_freeze(self, spawn_number: int):
         """
         Freeze the GC before forking worker process and unfreeze it after forking.
 
@@ -236,6 +236,10 @@ class LocalExecutor(BaseExecutor):
 
         Ref: https://docs.python.org/3/library/gc.html#gc.freeze
         """
+        if spawn_number <= 0:
+            # Early return to avoid an unnecessary gc.freeze/unfreeze cycle.
+            return
+
         import gc
 
         gc.freeze()

--- a/airflow-core/tests/unit/executors/test_local_executor_check_workers.py
+++ b/airflow-core/tests/unit/executors/test_local_executor_check_workers.py
@@ -16,7 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import gc
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -115,6 +116,19 @@ def test_no_spawn_if_parallelism_reached(setup_executor):
     executor.workers = {1: proc1, 2: proc2}
     executor._check_workers()
     executor._spawn_worker.assert_not_called()
+
+
+@patch.object(gc, "freeze")
+def test_no_gc_freeze_when_nothing_to_spawn(mock_freeze, setup_executor):
+    executor = setup_executor
+    executor.parallelism = 1
+    executor._unread_messages.value = 1
+    executor.activity_queue.empty.return_value = False
+    proc1 = MagicMock()
+    proc1.is_alive.return_value = True
+    executor.workers = {1: proc1}
+    executor._check_workers()
+    mock_freeze.assert_not_called()
 
 
 def test_spawn_worker_when_we_have_parallelism_left(setup_executor):


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/58365

Fixes an issue in local_executor where the `_check_workers` method could pass 0 as the spawn_number argument, causing the `gc.freeze / gc.unfreeze` cycle to run even when no worker was actually being spawned.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
