### PR TITLE
[v3-2-test] Remove gunicorn upper bound now that 25.2.0 is released with the fix

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -195,12 +195,7 @@ dependencies = [
     "memray>=1.19.0",
 ]
 "gunicorn" = [
-    # Temporary upper bound due to Gunicorn 25.1.0 control-socket deadlock
-    # seen in the Airflow API server path (preload + fork).
-    # Upstream tracking:
-    # - https://github.com/benoitc/gunicorn/issues/3529
-    # - https://github.com/benoitc/gunicorn/pull/3520
-    "gunicorn>=23.0.0,<25.1.0",
+    "gunicorn>=23.0.0,!=25.1.0",
 ]
 "otel" = [
     "opentelemetry-exporter-prometheus>=0.47b0",

--- a/uv.lock
+++ b/uv.lock
@@ -1870,7 +1870,7 @@ requires-dist = [
     { name = "greenback", marker = "extra == 'async'", specifier = ">=1.2.1" },
     { name = "greenlet", marker = "python_full_version >= '3.14' and extra == 'async'", specifier = ">=3.3.2" },
     { name = "greenlet", marker = "python_full_version < '3.14' and extra == 'async'", specifier = ">=3.1.0" },
-    { name = "gunicorn", marker = "extra == 'gunicorn'", specifier = ">=23.0.0,<25.1.0" },
+    { name = "gunicorn", marker = "extra == 'gunicorn'", specifier = ">=23.0.0,!=25.1.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.12'", specifier = ">=6.5" },
     { name = "importlib-metadata", marker = "python_full_version >= '3.12'", specifier = ">=7.0" },


### PR DESCRIPTION
Backport of https://github.com/apache/airflow/pull/64193

(cherry picked from commit 8eb89dbad1836b76ff2165e64fd69c3d1460ce6d)
---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
