### PR TITLE
fix(connection-model): RFC3896 `conn_type` warning (#63167)

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -228,9 +228,11 @@ class Connection(Base, LoggingMixin):
             raise AirflowException("Invalid connection string.")
         host_with_protocol = schemes_count_in_uri == 2
         uri_parts = urlsplit(uri)
-        conn_type = uri_parts.scheme
-        self.conn_type = self._normalize_conn_type(conn_type)
-        rest_of_the_url = uri.replace(f"{conn_type}://", ("" if host_with_protocol else "//"))
+        self._prenormalized_conn_type = uri_parts.scheme
+        self.conn_type = self._normalize_conn_type(self._prenormalized_conn_type)
+        rest_of_the_url = uri.replace(
+            f"{self._prenormalized_conn_type}://", ("" if host_with_protocol else "//")
+        )
         if host_with_protocol:
             uri_splits = rest_of_the_url.split("://", 1)
             if "@" in uri_splits[0] or ":" in uri_splits[0]:
@@ -273,10 +275,11 @@ class Connection(Base, LoggingMixin):
 
         Note that the URI returned by this method is **not** SQLAlchemy-compatible, if you need a SQLAlchemy-compatible URI, use the :attr:`~airflow.providers.common.sql.hooks.sql.DbApiHook.sqlalchemy_url`
         """
-        if self.conn_type and "_" in self.conn_type:
+        conn_type = getattr(self, "_prenormalized_conn_type", self.conn_type) or ""
+        if "_" in conn_type:
             self.log.warning(
                 "Connection schemes (type: %s) shall not contain '_' according to RFC3986.",
-                self.conn_type,
+                conn_type,
             )
 
         if self.conn_type:

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
+from structlog.testing import capture_logs
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models import Connection
@@ -269,6 +270,55 @@ class TestConnection:
     )
     def test_get_uri(self, connection, expected_uri):
         assert connection.get_uri() == expected_uri
+
+    @pytest.mark.parametrize(
+        ("connection", "expected_warned"),
+        [
+            (Connection(conn_id="test-uri-1", uri="google-cloud-platform://testlogin:testpassword@"), False),
+            (Connection(conn_id="test-uri-2", uri="amazon://test:test@"), False),
+            (
+                Connection(
+                    conn_id="test-non-uri-1",
+                    conn_type="google-cloud-platform",
+                    login="testlogin",
+                    password="testpassword",
+                ),
+                False,
+            ),
+            (
+                Connection(
+                    conn_id="test-non-uri-2",
+                    conn_type="google_cloud_platform",
+                    login="testlogin",
+                    password="testpassword",
+                ),
+                True,
+            ),
+            (
+                Connection(
+                    conn_id="test-non-uri-3", conn_type="amazon", login="testlogin", password="testpassword"
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_get_uri_conn_type_warning(self, connection: Connection, expected_warned: bool):
+        with capture_logs() as captured_logs:
+            connection.get_uri()
+        conn_type_warnings = list(
+            filter(
+                lambda captured_log: (
+                    captured_log["log_level"] == "warning" and "RFC3986" in captured_log["event"]
+                ),
+                captured_logs,
+            )
+        )
+        if expected_warned:
+            assert conn_type_warnings, f"RFC3986 warning expected for connection '{connection.conn_id}'."
+        else:
+            assert not conn_type_warnings, (
+                f"RFC3986 warning not expected for connection '{connection.conn_id}'."
+            )
 
     @pytest.mark.parametrize(
         ("connection", "expected_conn_id"),


### PR DESCRIPTION
Backport of https://github.com/apache/airflow/pull/63167
(cherry picked from commit 06c75db1ec759abb6c3417eb05f84bcc323d0695)


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
