### PR TITLE
fix(amazon): correct AWS China SQS regex to use amazonaws.com.cn

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/queues/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/queues/sqs.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from airflow.triggers.base import BaseEventTrigger
 
 # [START queue_regexp]
-QUEUE_REGEXP = r"^https://sqs\.[^.]+\.(amazonaws\.com|amazonaws\.cn)/[0-9]+/.+"
+QUEUE_REGEXP = r"^https://sqs\.[^.]+\.amazonaws\.com(\.cn)?/[0-9]+/.+"
 # [END queue_regexp]
 
 

--- a/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/queues/test_sqs.py
@@ -40,10 +40,10 @@ def test_message_sqs_queue_matches():
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/123456789012")
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/123456789012/")
     assert not provider.queue_matches("https://sqs.us-east-1.amazonaws.com/")
-    # AWS China regions (cn-north-1, cn-northwest-1)
-    assert provider.queue_matches("https://sqs.cn-north-1.amazonaws.cn/123456789012/my-queue")
-    assert provider.queue_matches("https://sqs.cn-northwest-1.amazonaws.cn/123456789012/my-queue")
-    assert not provider.queue_matches("https://sqs.cn-north-1.amazonaws.cn/123456789012")
+    # AWS China regions use the amazonaws.com.cn endpoint suffix
+    assert provider.queue_matches("https://sqs.cn-north-1.amazonaws.com.cn/123456789012/my-queue")
+    assert provider.queue_matches("https://sqs.cn-northwest-1.amazonaws.com.cn/123456789012/my-queue")
+    assert not provider.queue_matches("https://sqs.cn-north-1.amazonaws.com.cn/123456789012")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up to #65173. As [reported by @crazy-canux](https://github.com/apache/airflow/issues/65128#issuecomment-4249555812), AWS China regions use the endpoint suffix \`amazonaws.com.cn\`, not \`amazonaws.cn\`. The regex shipped in #65173 fails to match real AWS China SQS URLs like:

\`\`\`
https://sqs.cn-northwest-1.amazonaws.com.cn/123456/my-sqs
\`\`\`

This PR updates the regex to accept the optional \`.cn\` suffix on \`amazonaws.com\`, and updates the tests to use the correct endpoint.

Reopens / properly fixes #65128.