### PR TITLE
Handle supervisor remote log upload failures gracefully

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1097,8 +1097,11 @@ class ActivitySubprocess(WatchedSubprocess):
         """
         from airflow.sdk.log import upload_to_remote
 
-        with _remote_logging_conn(self.client):
-            upload_to_remote(self.process_log, self.ti)
+        try:
+            with _remote_logging_conn(self.client):
+                upload_to_remote(self.process_log, self.ti)
+        except Exception:
+            log.exception("Failed to upload remote logs", ti_id=self.id, pid=self.pid)
 
     def _monitor_subprocess(self):
         """

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1101,7 +1101,7 @@ class ActivitySubprocess(WatchedSubprocess):
             with _remote_logging_conn(self.client):
                 upload_to_remote(self.process_log, self.ti)
         except Exception:
-            log.exception("Failed to upload remote logs", ti_id=self.id, pid=self.pid)
+            self.process_log.exception("Failed to upload remote logs", ti_id=self.id, pid=self.pid)
 
     def _monitor_subprocess(self):
         """

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2915,6 +2915,38 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
                 assert connection_available["conn_uri"] is not None, "Connection URI was None during upload"
 
 
+@pytest.mark.parametrize("captured_logs", [logging.ERROR], indirect=True)
+def test_log_upload_failures_are_non_fatal(captured_logs, mocker):
+    proc = ActivitySubprocess(
+        process_log=mocker.MagicMock(),
+        id=TI_ID,
+        pid=12345,
+        stdin=mocker.MagicMock(),
+        client=mocker.MagicMock(),
+        process=mocker.MagicMock(),
+    )
+    proc.ti = mocker.MagicMock()
+
+    mocker.patch("airflow.sdk.execution_time.supervisor._remote_logging_conn", return_value=nullcontext())
+    upload_to_remote = mocker.patch(
+        "airflow.sdk.log.upload_to_remote", side_effect=RuntimeError("upload failed")
+    )
+
+    proc._upload_logs()
+
+    upload_to_remote.assert_called_once_with(proc.process_log, proc.ti)
+    assert {
+        "event": "Failed to upload remote logs",
+        "level": "error",
+        "logger": "supervisor",
+        "ti_id": TI_ID,
+        "pid": 12345,
+        "timestamp": mocker.ANY,
+        "loc": mocker.ANY,
+        "exc_info": mocker.ANY,
+    } in captured_logs
+
+
 def test_remote_logging_conn_sets_process_context(monkeypatch, mocker):
     """
     Test that _remote_logging_conn sets _AIRFLOW_PROCESS_CONTEXT=client.

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -2915,8 +2915,7 @@ def test_remote_logging_conn(remote_logging, remote_conn, expected_env, monkeypa
                 assert connection_available["conn_uri"] is not None, "Connection URI was None during upload"
 
 
-@pytest.mark.parametrize("captured_logs", [logging.ERROR], indirect=True)
-def test_log_upload_failures_are_non_fatal(captured_logs, mocker):
+def test_log_upload_failures_are_non_fatal(mocker):
     proc = ActivitySubprocess(
         process_log=mocker.MagicMock(),
         id=TI_ID,
@@ -2927,24 +2926,18 @@ def test_log_upload_failures_are_non_fatal(captured_logs, mocker):
     )
     proc.ti = mocker.MagicMock()
 
-    mocker.patch("airflow.sdk.execution_time.supervisor._remote_logging_conn", return_value=nullcontext())
-    upload_to_remote = mocker.patch(
-        "airflow.sdk.log.upload_to_remote", side_effect=RuntimeError("upload failed")
+    mocker.patch(
+        "airflow.sdk.execution_time.supervisor._remote_logging_conn",
+        side_effect=RuntimeError("upload failed"),
     )
 
     proc._upload_logs()
 
-    upload_to_remote.assert_called_once_with(proc.process_log, proc.ti)
-    assert {
-        "event": "Failed to upload remote logs",
-        "level": "error",
-        "logger": "supervisor",
-        "ti_id": TI_ID,
-        "pid": 12345,
-        "timestamp": mocker.ANY,
-        "loc": mocker.ANY,
-        "exc_info": mocker.ANY,
-    } in captured_logs
+    proc.process_log.exception.assert_called_once_with(
+        "Failed to upload remote logs",
+        ti_id=TI_ID,
+        pid=12345,
+    )
 
 
 def test_remote_logging_conn_sets_process_context(monkeypatch, mocker):


### PR DESCRIPTION
Prevent remote log upload errors from crashing task supervisor shutdown. Catch upload exceptions in the supervisor, log the failure with task context, and keep task completion behavior intact.
