### PR TITLE
Sync local virtualenv before mypy and freeze uv.lock prek hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1007,12 +1007,14 @@ repos:
         pass_filenames: false
         files: ^dev/breeze/src/airflow_breeze/global_constants\.py$
         require_serial: true
-        # This is a fast regular hook that runs when any pyproject.toml changes
-        # It runs locally and usually will not result in modifying the lock unnecessarily
-        # Unless there is a conflict and uv will determine that the lock needs to be updated to resolve it
+        # This is a fast regular hook that runs when any pyproject.toml changes.
+        # It runs locally with `--frozen` so the lock is only verified against pyproject.toml,
+        # never silently rewritten during a commit. If a pyproject.toml change makes the lock
+        # stale, the hook fails and the contributor must run `uv lock` explicitly and commit
+        # the refreshed uv.lock — which keeps lock updates intentional and reviewable.
       - id: update-uv-lock
         name: Update uv.lock
-        entry: uv lock
+        entry: uv lock --frozen
         language: system
         files: >
           (?x)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 - **Run other suites of tests** `breeze testing <test_group>` (test groups: `airflow-ctl-tests`, `docker-compose-tests`, `task-sdk-tests`)
 - **Run scripts tests:** `uv run --project scripts pytest scripts/tests/ -xvs`
 - **Run Airflow CLI:** `breeze run airflow dags list`
-- **Type-check (non-providers):** `uv run --project <PROJECT> --with "apache-airflow-devel-common[mypy]" mypy path/to/code`
+- **Type-check (non-providers):** first run `uv sync --frozen --project <PROJECT>` to align the local virtualenv with `uv.lock` (the dependency set CI uses), then `uv run --frozen --project <PROJECT> --with "apache-airflow-devel-common[mypy]" mypy path/to/code`
 - **Type-check (providers):** `breeze run mypy path/to/code`
 - **Lint with ruff only:** `prek run ruff --from-ref <target_branch>`
 - **Format with ruff only:** `prek run ruff-format --from-ref <target_branch>`

--- a/contributing-docs/08_static_code_checks.rst
+++ b/contributing-docs/08_static_code_checks.rst
@@ -287,7 +287,16 @@ For **non-provider projects** (airflow-core, task-sdk, airflow-ctl, dev, scripts
 runs locally using the ``uv`` virtualenv — no breeze CI image is needed. These checks run as regular
 prek hooks in the ``pre-commit`` stage, checking whole directories at once. This means they run both
 as part of local commits and as part of regular static checks in CI (not as separate mypy CI jobs).
-You can also run mypy directly. Use ``--frozen`` to avoid updating ``uv.lock``:
+
+Before running mypy directly (or via the ``mypy-*`` prek hooks), synchronize your local virtualenv
+with ``uv.lock`` so it matches the dependency set CI uses — otherwise mypy may pick up a different
+set of installed packages than CI and produce results that diverge from CI:
+
+.. code-block:: bash
+
+  uv sync --frozen --project <PROJECT>
+
+Then run mypy directly. Use ``--frozen`` so ``uv`` does not update ``uv.lock``:
 
 .. code-block:: bash
 

--- a/scripts/ci/prek/mypy_local_folder.py
+++ b/scripts/ci/prek/mypy_local_folder.py
@@ -186,7 +186,33 @@ if CI:
         },
     )
 else:
-    # Locally, run via uv with --frozen to not update the lock file.
+    # Locally, first synchronize the project's virtualenv with uv.lock so that mypy runs
+    # against the same dependency set CI uses. Without this, the local .venv can drift from
+    # uv.lock (e.g. after switching branches or installing extras) and mypy results would
+    # diverge from CI. --frozen ensures uv.lock itself is not updated.
+    sync_cmd = ["uv", "sync", "--frozen", "--project", project]
+    if console:
+        console.print(f"[magenta]Syncing virtualenv for project {project}: {' '.join(sync_cmd)}[/]")
+    else:
+        print(f"Syncing virtualenv for project {project}: {' '.join(sync_cmd)}")
+    sync_result = subprocess.run(
+        sync_cmd,
+        cwd=str(AIRFLOW_ROOT_PATH),
+        check=False,
+        env={**os.environ, "TERM": "ansi"},
+    )
+    if sync_result.returncode != 0:
+        msg = (
+            f"`uv sync --frozen --project {project}` failed. Fix the sync error before running mypy — "
+            "otherwise the local virtualenv may not match uv.lock and mypy results will diverge from CI.\n"
+        )
+        if console:
+            console.print(f"[red]{msg}")
+        else:
+            print(msg)
+        sys.exit(sync_result.returncode)
+
+    # Then run mypy via uv with --frozen to not update the lock file.
     cmd = [
         "uv",
         "run",
@@ -211,8 +237,9 @@ if result.returncode != 0:
     msg = (
         "Mypy check failed. You can run mypy locally with:\n"
         f"  prek run mypy-{mypy_folders[0]} --all-files\n"
-        "Or directly with:\n"
-        f'  uv run --project {project} --with "apache-airflow-devel-common[mypy]" mypy <files>\n'
+        "Or directly (first sync the virtualenv to match CI's dependency set):\n"
+        f"  uv sync --frozen --project {project}\n"
+        f'  uv run --frozen --project {project} --with "apache-airflow-devel-common[mypy]" mypy <files>\n'
         "You can also clear the mypy cache with:\n"
         "  breeze down --cleanup-mypy-cache\n"
     )


### PR DESCRIPTION
Align local mypy runs with CI by syncing the project virtualenv to
`uv.lock` before mypy executes, and prevent the `update-uv-lock` prek
hook from silently rewriting `uv.lock` during a commit.

## Changes

- **`scripts/ci/prek/mypy_local_folder.py`**: before running mypy
  locally, the hook now runs `uv sync --frozen --project <project>` so
  the local `.venv` matches the dependency set CI uses. If the sync
  fails, mypy is not invoked and the hook exits with a clear error.
  The failure message points at the same two-step command
  (`uv sync --frozen` + `uv run --frozen ... mypy`).
- **`.pre-commit-config.yaml`**: the `update-uv-lock` hook now runs
  `uv lock --frozen` instead of `uv lock`. A pyproject.toml change
  that would touch `uv.lock` now fails the hook, forcing contributors
  to run `uv lock` explicitly and commit the refreshed lock — keeping
  lock updates intentional and reviewable.
- **`AGENTS.md`** and **`contributing-docs/08_static_code_checks.rst`**:
  updated the type-check / mypy instructions to document the
  `uv sync --frozen --project <PROJECT>` prerequisite and explain why
  (otherwise mypy results can diverge from CI).

## Motivation

Running mypy locally without syncing the project venv produces
results that can silently drift from CI, because the local `.venv`
may contain different package versions than `uv.lock` (e.g. after
switching branches, installing extras, or running `uv run` with
different projects). Forcing a `--frozen` sync before mypy makes
local results reproducible and consistent with CI.

Likewise, allowing `uv lock` (without `--frozen`) to silently
rewrite `uv.lock` from a commit hook means lock changes can sneak
into unrelated commits. Failing fast lets contributors decide
when and how to regenerate the lock.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)