### PR TITLE
Bump sphinx-airflow-theme from 0.3.5 to 0.3.7 for polished dark mode

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "docutils>=0.21",
     "pagefind>=1.5.0",
     "pagefind-bin>=1.5.0",
-    "sphinx-airflow-theme@https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.5-py3-none-any.whl",
+    "sphinx-airflow-theme@https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.7-py3-none-any.whl",
     "sphinx-argparse>=0.4.0",
     "sphinx-autoapi>=3.8.0",
     "sphinx-autobuild>=2024.10.2",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T06:47:57.670501027Z"
+exclude-newer = "2026-04-12T00:57:13.706449Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -92,9 +92,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -854,7 +854,7 @@ wheels = [
 
 [[package]]
 name = "apache-airflow"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow-core" },
@@ -1717,7 +1717,7 @@ requires-dist = [
 
 [[package]]
 name = "apache-airflow-core"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "airflow-core" }
 dependencies = [
     { name = "a2wsgi" },
@@ -2428,7 +2428,7 @@ requires-dist = [
     { name = "semver", marker = "extra == 'devscripts'", specifier = ">=3.0.2" },
     { name = "setuptools", marker = "extra == 'docs'", specifier = "<82.0.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
-    { name = "sphinx-airflow-theme", marker = "extra == 'docs'", url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.5-py3-none-any.whl" },
+    { name = "sphinx-airflow-theme", marker = "extra == 'docs'", url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.7-py3-none-any.whl" },
     { name = "sphinx-argparse", marker = "extra == 'docs'", specifier = ">=0.4.0" },
     { name = "sphinx-autoapi", marker = "extra == 'docs'", specifier = ">=3.8.0" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2024.10.2" },
@@ -19961,8 +19961,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -20430,15 +20430,15 @@ wheels = [
 
 [[package]]
 name = "sphinx-airflow-theme"
-version = "0.3.5"
-source = { url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.5-py3-none-any.whl" }
+version = "0.3.7"
+source = { url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.7-py3-none-any.whl" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
-    { url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.5-py3-none-any.whl", hash = "sha256:f3c2cd9eb6d791b041e414801e5c71d7df4cf70c8d33518f3cdd66d48a85eee4" },
+    { url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.7-py3-none-any.whl", hash = "sha256:75300d893e57fef5bbe1c1aa4ac356e7d0feeb0c7c697687be0172fd591658d5" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
Bumps `sphinx-airflow-theme` from 0.3.5 to 0.3.7, picking up changes from apache/airflow-site#1501 & https://github.com/apache/airflow-site/pull/1502:

**Before**:

<img width="1714" height="844" alt="image" src="https://github.com/user-attachments/assets/03f0a165-d49e-4ab6-923f-bd546b02b5d7" />


**After**:

<img width="1710" height="848" alt="image" src="https://github.com/user-attachments/assets/fe6d59b1-15c3-419a-a569-0917ebc5c12a" />

---

- Deep navy-black dark mode palette (`#0f1117` body bg, `#38bdf8` cyan accent) inspired by the registry site
- Compact navbar (30px → 14px vertical padding)
- Replaced ~20 hardcoded dark-mode hex values with CSS variables across navbar, code blocks, sidebar, and TOC
- Dark mode treatment for the search form
- Global SVG fill fix for icons using hardcoded `fill="#51504f"` (invisible on dark backgrounds)
- Removed stale Airflow Summit banner padding offsets
- Moved inline color declarations from `globaltoc.html` into the SCSS system