### PR TITLE
Filter external dependency nodes by readable DAGs in structure_data endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -26,7 +26,7 @@ from airflow.api_fastapi.common.parameters import QueryIncludeDownstream, QueryI
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.structure import StructureDataResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import requires_access_dag
+from airflow.api_fastapi.core_api.security import ReadableDagsFilterDep, requires_access_dag
 from airflow.api_fastapi.core_api.services.ui.structure import (
     bind_output_assets_to_tasks,
     get_upstream_assets,
@@ -52,6 +52,7 @@ structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
 def structure_data(
     session: SessionDep,
     dag_id: str,
+    readable_dags_filter: ReadableDagsFilterDep,
     include_upstream: QueryIncludeUpstream = False,
     include_downstream: QueryIncludeDownstream = False,
     depth: int | None = None,
@@ -105,10 +106,21 @@ def structure_data(
         start_edges: list[dict] = []
         end_edges: list[dict] = []
 
+        readable_dag_ids = readable_dags_filter.value
         for dependency_dag_id, dependencies in sorted(SerializedDagModel.get_dag_dependencies().items()):
+            if readable_dag_ids is not None and dependency_dag_id not in readable_dag_ids:
+                continue
             for dependency in dependencies:
                 # Dependencies not related to `dag_id` are ignored
                 if dependency_dag_id != dag_id and dependency.target != dag_id:
+                    continue
+                # When target is a real DAG ID (not a type label), hide it
+                # if the caller cannot read that DAG.
+                if (
+                    readable_dag_ids is not None
+                    and dependency.target != dependency.dependency_type
+                    and dependency.target not in readable_dag_ids
+                ):
                     continue
 
                 # upstream assets are handled by the `get_upstream_assets` function.

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import copy
+from unittest import mock
 
 import pendulum
 import pytest
@@ -303,7 +304,7 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
-                6,
+                7,
             ),
             (
                 {
@@ -311,7 +312,7 @@ class TestStructureDataEndpoint:
                     "root": "unknown_task",
                 },
                 {"edges": [], "nodes": []},
-                6,
+                7,
             ),
             (
                 {
@@ -336,7 +337,7 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
-                6,
+                7,
             ),
             (
                 {"dag_id": DAG_ID_EXTERNAL_TRIGGER, "external_dependencies": True},
@@ -375,7 +376,7 @@ class TestStructureDataEndpoint:
                         },
                     ],
                 },
-                13,
+                14,
             ),
         ],
     )
@@ -572,7 +573,7 @@ class TestStructureDataEndpoint:
             ],
         }
 
-        with assert_queries_count(13):
+        with assert_queries_count(14):
             response = test_client.get("/structure/structure_data", params=params)
         assert response.status_code == 200
         assert response.json() == expected
@@ -684,6 +685,24 @@ class TestStructureDataEndpoint:
     def test_delete_dag_should_response_403(self, unauthorized_test_client):
         response = unauthorized_test_client.get("/structure/structure_data", params={"dag_id": DAG_ID})
         assert response.status_code == 403
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={DAG_ID_EXTERNAL_TRIGGER},
+    )
+    @pytest.mark.usefixtures("make_dags")
+    def test_external_deps_filters_unreadable_dags(self, _, test_client):
+        response = test_client.get(
+            "/structure/structure_data",
+            params={"dag_id": DAG_ID_EXTERNAL_TRIGGER, "external_dependencies": True},
+        )
+        assert response.status_code == 200
+        result = response.json()
+        node_ids = {node["id"] for node in result["nodes"]}
+        assert "trigger_dag_run_operator" in node_ids
+        assert not any(DAG_ID in nid for nid in node_ids if nid != "trigger_dag_run_operator")
+        edge_targets = {edge["target_id"] for edge in result["edges"]}
+        assert not any(DAG_ID in tid for tid in edge_targets)
 
     def test_should_return_404(self, test_client):
         response = test_client.get("/structure/structure_data", params={"dag_id": "not_existing"})


### PR DESCRIPTION
## Summary

The `/ui/structure/structure_data` endpoint, when called with
`external_dependencies=true`, returned dependency graph nodes for
linked DAGs without verifying that the caller had read permission
on those linked DAGs. This meant a user authorized for DAG A could
see that DAG B existed as an external dependency and learn its
trigger/sensor structure, even if they had no access to DAG B.

This change adds the `ReadableDagsFilterDep` (the same filter
already used by the `/ui/dependencies` endpoint) and skips any
dependency entry that references a DAG outside the caller's
readable set. Two filter levels:

1. **Outer loop** — skip the entire `dependency_dag_id` if it is not
   in the caller's readable DAGs.
2. **Inner loop** — when `dependency.target` is a real DAG ID (detected
   by `target != dependency_type`), skip if that target DAG is not
   readable.

## Test plan

- [x] Existing `test_structure.py` tests pass (admin user continues to
  see all external dependencies; query counts bumped +1 for the new
  `get_authorized_dag_ids` call)
- [x] New test: mock `get_authorized_dag_ids` to return only the
  requested DAG; call with `external_dependencies=true`; assert
  no nodes or edges from unreadable linked DAGs appear

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
