### PR TITLE
Set JWT refresh cookie Secure flag when request is HTTPS

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
@@ -62,7 +62,7 @@ class JWTRefreshMiddleware(BaseHTTPMiddleware):
 
             if new_token is not None:
                 cookie_path = get_cookie_path()
-                secure = bool(conf.get("api", "ssl_cert", fallback=""))
+                secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
                 response.set_cookie(
                     COOKIE_NAME_JWT_TOKEN,
                     new_token,

--- a/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
@@ -131,6 +131,51 @@ class TestJWTRefreshMiddleware:
         set_cookie_headers = response.headers.get("set-cookie", "")
         assert f"{COOKIE_NAME_JWT_TOKEN}=new_token" in set_cookie_headers
 
+    @pytest.mark.parametrize(
+        ("scheme", "ssl_cert", "expected_secure"),
+        [
+            pytest.param("https", "", True, id="https-no-local-ssl-cert"),
+            pytest.param("http", "/etc/ssl/cert.pem", True, id="http-with-local-ssl-cert"),
+            pytest.param("https", "/etc/ssl/cert.pem", True, id="https-with-local-ssl-cert"),
+            pytest.param("http", "", False, id="http-no-local-ssl-cert"),
+        ],
+    )
+    @patch("airflow.api_fastapi.auth.middlewares.refresh_token.get_auth_manager")
+    @patch("airflow.api_fastapi.auth.middlewares.refresh_token.resolve_user_from_token")
+    @patch("airflow.api_fastapi.auth.middlewares.refresh_token.conf")
+    @pytest.mark.asyncio
+    async def test_dispatch_cookie_secure_flag(
+        self,
+        mock_conf,
+        mock_resolve_user_from_token,
+        mock_get_auth_manager,
+        middleware,
+        mock_request,
+        mock_user,
+        scheme,
+        ssl_cert,
+        expected_secure,
+    ):
+        """The cookie Secure flag must follow the request scheme as well as the local ssl_cert."""
+        refreshed_user = MagicMock(spec=BaseUser)
+        mock_request.cookies = {COOKIE_NAME_JWT_TOKEN: "valid_token"}
+        mock_request.base_url = MagicMock(scheme=scheme)
+        mock_resolve_user_from_token.return_value = mock_user
+        mock_auth_manager = MagicMock()
+        mock_get_auth_manager.return_value = mock_auth_manager
+        mock_auth_manager.refresh_user.return_value = refreshed_user
+        mock_auth_manager.generate_jwt.return_value = "new_token"
+        mock_conf.get.return_value = ssl_cert
+
+        call_next = AsyncMock(return_value=Response())
+        response = await middleware.dispatch(mock_request, call_next)
+
+        set_cookie_headers = response.headers.get("set-cookie", "")
+        if expected_secure:
+            assert "Secure" in set_cookie_headers
+        else:
+            assert "Secure" not in set_cookie_headers
+
     @patch("airflow.api_fastapi.auth.middlewares.refresh_token.get_cookie_path", return_value="/team-a/")
     @patch("airflow.api_fastapi.auth.middlewares.refresh_token.get_auth_manager")
     @patch("airflow.api_fastapi.auth.middlewares.refresh_token.resolve_user_from_token")


### PR DESCRIPTION
## Summary

`JWTRefreshMiddleware` set the JWT refresh cookie's `Secure` flag based solely on whether `api.ssl_cert` was configured locally. In deployments where TLS is terminated at a reverse proxy and the Airflow process itself has no SSL certificate, this evaluated to `False` and the cookie was sent without the `Secure` flag even when the incoming request was already HTTPS.

Every other cookie-setting location in the codebase uses the same pattern:

```python
secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
```

…at `core_api/routes/public/auth.py:68`, `auth/managers/simple/routes/login.py:92`, `providers/fab/.../login.py:106`, `providers/keycloak/.../login.py:158`, and documented in `auth-manager/index.rst:168`. This PR brings `JWTRefreshMiddleware` in line.

## Test plan

- [x] New parametrized test `test_dispatch_cookie_secure_flag` covers all 4 combinations of `scheme` × `ssl_cert` and asserts the `Secure` cookie attribute is set exactly when it should be
- [x] Existing 7 tests in `test_refresh_token.py` continue to pass
- [x] Total: 11/11 pass

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.6 (1M context)

Generated-by: Claude Opus 4.6 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
