### PR TITLE
fix(ui): avoid task endpoint requests for task-group routes

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Task/Task.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/Task.tsx
@@ -52,8 +52,8 @@ export const Task = () => {
     data: task,
     error,
     isLoading,
-  } = useTaskServiceGetTask({ dagId, taskId: groupId ?? taskId }, undefined, {
-    enabled: groupId === undefined,
+  } = useTaskServiceGetTask({ dagId, taskId: taskId ?? "" }, undefined, {
+    enabled: groupId === undefined && Boolean(taskId),
   });
 
   const { data: dagStructure } = useGridStructure({ limit: 1 });

--- a/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import { render } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,11 +95,9 @@ describe("Task page API behavior", () => {
       </Wrapper>,
     );
 
-    expect(useTaskServiceGetTask).toHaveBeenCalledWith(
-      { dagId: "example_dag", taskId: "" },
-      undefined,
-      { enabled: false },
-    );
+    expect(useTaskServiceGetTask).toHaveBeenCalledWith({ dagId: "example_dag", taskId: "" }, undefined, {
+      enabled: false,
+    });
     expect(useTaskServiceGetTask).toHaveBeenCalledTimes(1);
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
@@ -1,0 +1,149 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { Task } from "./Task";
+
+let mockParams: Record<string, string | undefined> = {
+  dagId: "example_dag",
+  groupId: "group_a",
+  runId: undefined,
+  taskId: undefined,
+};
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockParams,
+  };
+});
+
+vi.mock("openapi/queries", () => ({
+  useTaskServiceGetTask: vi.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("src/hooks/usePluginTabs", () => ({
+  usePluginTabs: () => [],
+}));
+
+vi.mock("src/hooks/useRequiredActionTabs", () => ({
+  useRequiredActionTabs: (_args: unknown, tabs: Array<unknown>) => ({ tabs }),
+}));
+
+vi.mock("src/layouts/Details/DetailsLayout", () => ({
+  DetailsLayout: ({ children }: { readonly children: unknown }) => <div>{children}</div>,
+}));
+
+vi.mock("src/queries/useGridStructure.ts", () => ({
+  useGridStructure: () => ({ data: undefined }),
+}));
+
+vi.mock("src/utils/groupTask", () => ({
+  getGroupTask: () => undefined,
+}));
+
+vi.mock("./Header", () => ({
+  Header: () => <div>Header</div>,
+}));
+
+vi.mock("./GroupTaskHeader", () => ({
+  GroupTaskHeader: () => <div>GroupTaskHeader</div>,
+}));
+
+const { useTaskServiceGetTask } = await import("openapi/queries");
+
+describe("Task page API behavior", () => {
+  beforeEach(vi.clearAllMocks);
+
+  it("does not issue task endpoint call for task-group route", () => {
+    mockParams = {
+      dagId: "example_dag",
+      groupId: "group_a",
+      runId: undefined,
+      taskId: undefined,
+    };
+
+    render(
+      <Wrapper>
+        <Task />
+      </Wrapper>,
+    );
+
+    expect(useTaskServiceGetTask).toHaveBeenCalledWith(
+      { dagId: "example_dag", taskId: "" },
+      undefined,
+      { enabled: false },
+    );
+    expect(useTaskServiceGetTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches task details on task route", () => {
+    mockParams = {
+      dagId: "example_dag",
+      groupId: undefined,
+      runId: undefined,
+      taskId: "task_a",
+    };
+
+    render(
+      <Wrapper>
+        <Task />
+      </Wrapper>,
+    );
+
+    expect(useTaskServiceGetTask).toHaveBeenCalledWith(
+      { dagId: "example_dag", taskId: "task_a" },
+      undefined,
+      { enabled: true },
+    );
+    expect(useTaskServiceGetTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps task query disabled when group and task params both exist", () => {
+    mockParams = {
+      dagId: "example_dag",
+      groupId: "group_a",
+      runId: undefined,
+      taskId: "task_a",
+    };
+
+    render(
+      <Wrapper>
+        <Task />
+      </Wrapper>,
+    );
+
+    expect(useTaskServiceGetTask).toHaveBeenCalledWith(
+      { dagId: "example_dag", taskId: "task_a" },
+      undefined,
+      { enabled: false },
+    );
+    expect(useTaskServiceGetTask).toHaveBeenCalledTimes(1);
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Task/TaskPage.test.tsx
@@ -18,6 +18,7 @@
  */
 
 import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
@@ -57,7 +58,7 @@ vi.mock("src/hooks/useRequiredActionTabs", () => ({
 }));
 
 vi.mock("src/layouts/Details/DetailsLayout", () => ({
-  DetailsLayout: ({ children }: { readonly children: unknown }) => <div>{children}</div>,
+  DetailsLayout: ({ children }: { readonly children: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock("src/queries/useGridStructure.ts", () => ({


### PR DESCRIPTION
## Summary
- Fix task page query params so group routes do not carry groupId into task endpoint params.
- Keep task query disabled unless this is a real task route with a task id.
- Add focused regression tests for group route, task route, and mixed-param edge case.

## Why
On group routes, selecting a task group could lead to invalid task endpoint behavior and blanking after 404. This keeps task endpoint calls strictly tied to task routes.

## Testing
- pnpm test src/pages/Task/TaskPage.test.tsx
- pnpm exec eslint src/pages/Task/Task.tsx src/pages/Task/TaskPage.test.tsx

Closes #65302