### PR TITLE
Fix N+1 queries in trigger asset event submission

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -274,7 +274,11 @@ class Trigger(Base):
             handle_event_submit(event, task_instance=task_instance, session=session)
 
         # Send an event to assets
-        trigger = session.scalars(select(cls).where(cls.id == trigger_id)).one_or_none()
+        trigger = session.scalars(
+            select(cls)
+            .where(cls.id == trigger_id)
+            .options(selectinload(cls.asset_watchers).selectinload(AssetWatcherModel.asset))
+        ).one_or_none()
         if trigger is None:
             # Already deleted for some reason
             return

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -48,6 +48,7 @@ from airflow.triggers.base import (
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 
+from tests_common.test_utils.asserts import count_queries
 from tests_common.test_utils.config import conf_vars
 
 if TYPE_CHECKING:
@@ -219,6 +220,38 @@ def test_submit_event(mock_callback_handle_event, session, create_task_instance)
 
     # Check that the callback's handle_event was called
     mock_callback_handle_event.assert_called_once_with(event, session)
+
+
+@patch("airflow.models.trigger.AssetManager.register_asset_change")
+def test_submit_event_no_n_plus_one_for_assets(_, session):
+    """Ensure asset notifications do not trigger per-asset lazy-load queries."""
+
+    def _create_trigger_with_assets(asset_count: int) -> int:
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+
+        for i in range(asset_count):
+            asset = AssetModel(name=f"asset_{asset_count}_{i}")
+            asset.add_trigger(trigger, f"watcher_{i}")
+            session.add(asset)
+
+        session.commit()
+        session.expire_all()
+        return trigger.id
+
+    def _submit_event_query_count(trigger_id: int) -> int:
+        with count_queries(session=session) as query_result:
+            Trigger.submit_event(trigger_id, TriggerEvent("payload"), session=session)
+        return sum(query_result.values())
+
+    small_query_count = _submit_event_query_count(_create_trigger_with_assets(1))
+    larger_query_count = _submit_event_query_count(_create_trigger_with_assets(5))
+
+    assert larger_query_count - small_query_count < 3, (
+        f"Added 4 assets but query count increased by {larger_query_count - small_query_count} "
+        f"({small_query_count} -> {larger_query_count}), suggesting n+1 queries for trigger assets"
+    )
 
 
 def test_submit_failure(session, create_task_instance):

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -48,6 +48,7 @@ from airflow.triggers.base import (
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 
 if TYPE_CHECKING:
@@ -219,6 +220,27 @@ def test_submit_event(mock_callback_handle_event, session, create_task_instance)
 
     # Check that the callback's handle_event was called
     mock_callback_handle_event.assert_called_once_with(event, session)
+
+
+@pytest.mark.parametrize(("asset_count", "expected_query_count"), [(1, 6), (5, 6)])
+@patch("airflow.models.trigger.AssetManager.register_asset_change")
+def test_submit_event_no_n_plus_one_for_assets(_, session, asset_count, expected_query_count):
+    """Ensure asset notifications do not trigger per-asset lazy-load queries."""
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    session.flush()
+    trigger_id = trigger.id
+
+    for i in range(asset_count):
+        asset = AssetModel(name=f"asset_{asset_count}_{i}")
+        asset.add_trigger(trigger, f"watcher_{i}")
+        session.add(asset)
+
+    session.commit()
+    session.expire_all()
+
+    with assert_queries_count(expected_query_count, session=session):
+        Trigger.submit_event(trigger_id, TriggerEvent("payload"), session=session)
 
 
 def test_submit_failure(session, create_task_instance):


### PR DESCRIPTION
### Why

When a trigger submits an event for watched assets, Airflow needs to load the trigger's asset watchers and their related assets before registering asset changes. These relationships were previously loaded lazily, so a trigger watching multiple assets could issue extra queries per asset during event submission.

This adds unnecessary database overhead in the Triggerer path and can scale poorly for triggers that notify many assets. Loading the asset watcher graph up front keeps event submission query usage stable as the number of watched assets grows.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=953ac8e action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @henry3260** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~41 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->