### PR TITLE
fix: Service IPC sockets during dag bundle refresh to prevent child process blocking

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -29,6 +29,7 @@ import random
 import selectors
 import signal
 import sys
+import threading
 import time
 import zipfile
 from collections import defaultdict, deque
@@ -433,7 +434,12 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._queue_requested_files_for_parsing()
 
-            self._refresh_dag_bundles(known_files=known_files)
+            # Service IPC requests from child processes in a background thread while
+            # _refresh_dag_bundles runs. Without this, child processes calling Variable.get()
+            # block on socket.recv() until the parent finishes bundle refresh and reaches
+            # _service_processor_sockets() — which can take minutes with many DAG files.
+            with self._ipc_service_thread():
+                self._refresh_dag_bundles(known_files=known_files)
 
             if not self._file_queue:
                 # Generate more file paths to process if we processed all the files already. Note for this to
@@ -469,6 +475,28 @@ class DagFileProcessorManager(LoggingMixin):
                 poll_time = 1 - loop_duration
             else:
                 poll_time = 0.0
+
+    @contextlib.contextmanager
+    def _ipc_service_thread(self):
+        """Run _service_processor_sockets in a background thread until the context exits.
+
+        This ensures child parsing processes that make IPC calls (e.g. Variable.get())
+        get immediate responses instead of waiting for the main loop to reach
+        _service_processor_sockets().
+        """
+        stop_event = threading.Event()
+
+        def _service_loop():
+            while not stop_event.is_set():
+                self._service_processor_sockets(timeout=0.1)
+
+        thread = threading.Thread(target=_service_loop, daemon=True, name="ipc-service")
+        thread.start()
+        try:
+            yield
+        finally:
+            stop_event.set()
+            thread.join(timeout=5)
 
     def _service_processor_sockets(self, timeout: float | None = 1.0):
         """


### PR DESCRIPTION
## What

Service IPC sockets in a background thread during `_refresh_dag_bundles()` so child parsing processes don't block on `Variable.get()` / `Connection.get()` calls.

## Why

In `_run_parsing_loop()`, IPC is only serviced once per iteration via `_service_processor_sockets()`. While the main loop executes `_refresh_dag_bundles()` and other operations, child processes that call `Variable.get()` block on `socket.recv()` waiting for the parent to respond. With many DAG files and multiple parsing processes, this turns sub-second parses into multi-minute waits.

This is a regression from Airflow 2.x where `Variable.get()` was a direct DB query with no IPC dependency.

For comparison, `WatchedSubprocess._monitor_subprocess()` in the task execution path has a tight loop that continuously services IPC — the dag-processor lacks this.

## How

- Added a `_ipc_service_thread()` context manager that runs `_service_processor_sockets()` in a daemon thread with a 100ms poll interval
- Wrapped `_refresh_dag_bundles()` with this context manager — the longest-running phase where child processes are likely to be blocked
- Thread is automatically stopped when the context exits, before the main loop continues with its own `_service_processor_sockets()` call

The change is minimal and non-invasive — existing IPC servicing in the main loop is untouched.

Closes #65369

---

^ Add meaningful description above

Read the **[Pull Request Contribution Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{pr_number}.significant.md`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).