### PR TITLE
Fix log groups collapsing on auto-refresh in Logs view

### DIFF
--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -309,6 +309,7 @@ const Details = ({
       <Tabs
         size="lg"
         isLazy
+        lazyBehavior="keepMounted"
         height="100%"
         index={tabIndex}
         onChange={onChangeTab}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -25,7 +25,6 @@ interface Props {
   parsedLogs: string;
   wrap: boolean;
   tryNumber: number;
-  unfoldedGroups: Array<string>;
   setUnfoldedLogGroup: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
@@ -33,7 +32,6 @@ const LogBlock = ({
   parsedLogs,
   wrap,
   tryNumber,
-  unfoldedGroups,
   setUnfoldedLogGroup,
 }: Props) => {
   const [autoScroll, setAutoScroll] = useState(true);
@@ -74,10 +72,11 @@ const LogBlock = ({
         0,
         target.id.length - unfoldIdSuffix.length,
       );
-      // remember the folding state if logs re-loaded
-      unfoldedGroups.push(gId);
-      setUnfoldedLogGroup(unfoldedGroups);
-      // now do the folding
+      // Persist the unfolded state so it survives re-renders (auto-refresh).
+      // A new array is required for React to detect the state change.
+      setUnfoldedLogGroup((prev) => [...prev, gId]);
+      // Immediate DOM update so the user sees the change without waiting
+      // for the next render cycle.
       target.style.display = "none";
       if (target.nextElementSibling) {
         (target.nextElementSibling as HTMLElement).style.display = "inline";
@@ -87,12 +86,7 @@ const LogBlock = ({
         0,
         target.id.length - foldIdSuffix.length,
       );
-      // remember the folding state if logs re-loaded
-      if (unfoldedGroups.indexOf(gId) >= 0) {
-        unfoldedGroups.splice(unfoldedGroups.indexOf(gId), 1);
-      }
-      setUnfoldedLogGroup(unfoldedGroups);
-      // now do the folding
+      setUnfoldedLogGroup((prev) => prev.filter((id) => id !== gId));
       if (target.parentElement) {
         target.parentElement.style.display = "none";
         if (target.parentElement.previousSibling) {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -278,7 +278,6 @@ const Logs = ({
             parsedLogs={parsedLogs}
             wrap={wrap}
             tryNumber={selectedTryNumber}
-            unfoldedGroups={unfoldedLogGroups}
             setUnfoldedLogGroup={setUnfoldedLogGroup}
           />
         )


### PR DESCRIPTION
Fix log groups (::group::) auto-collapsing whenever the UI auto-refreshes
or the user scrolls the log area. 

1. `LogBlock.onClick` mutated the `unfoldedGroups` array in-place (`.push`,
   `.splice`) then passed the **same reference** to `setState`. React 19
   uses strict `Object.is` comparison — same reference means the state
   update is silently discarded, so `useMemo` never recalculates the
   parsed logs with the correct unfolded state.

2. Chakra UI `Tabs` with `isLazy` defaults to `lazyBehavior="unmount"`,
   which unmounts inactive tab panels. Any remount resets `useState([])`
   to empty, losing the unfolded groups entirely.

**Fix:**
- Use immutable state updates (`[...prev, gId]` / `prev.filter(...)`)
  so React detects the state change.
- Add `lazyBehavior="keepMounted"` to the Tabs so panels preserve state
  once rendered (still lazy on initial load).


### Before

https://github.com/user-attachments/assets/a5a77e5f-561a-4499-b687-66d40e7b83ab



### After

https://github.com/user-attachments/assets/18613e4c-f3ec-464d-abe9-a1159d1ae820



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)