### PR TITLE
Scope backport-to-v3-2-test label to PRs targeting main

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -348,17 +348,22 @@ labelPRBasedOnFilePath:
     - .readthedocs.yml
 
   # This should be copy of the "area:dev-tools" above minus contributing docs and some files that should
-  # only make sense in main - it should be updated when we switch maintenance branch
+  # only make sense in main - it should be updated when we switch maintenance branch.
+  # Scoped to PRs targeting `main` only — a PR opened directly against v3-2-test
+  # does not need a backport-to-v3-2-test label.
   backport-to-v3-2-test:
-    - scripts/**/*
-    - dev/**/*
-    - .github/**/*
-    - Dockerfile.ci
-    - yamllint-config.yml
-    - .dockerignore
-    - .hadolint.yaml
-    - .pre-commit-config.yaml
-    - .rat-excludes
+    paths:
+      - scripts/**/*
+      - dev/**/*
+      - .github/**/*
+      - Dockerfile.ci
+      - yamllint-config.yml
+      - .dockerignore
+      - .hadolint.yaml
+      - .pre-commit-config.yaml
+      - .rat-excludes
+    targetBranchFilter:
+      - ^main$
 
   kind:documentation:
     - airflow-core/docs/**/*

--- a/scripts/ci/prek/boring_cyborg.py
+++ b/scripts/ci/prek/boring_cyborg.py
@@ -46,8 +46,14 @@ if CONFIG_KEY not in cyborg_config:
     raise SystemExit(f"Missing section {CONFIG_KEY}")
 
 errors = []
-# Check if all patterns in the cyborg config are existing in the repository
-for label, patterns in cyborg_config[CONFIG_KEY].items():
+# Each label rule is either a list of glob patterns (legacy form) or an object
+# with `paths` and an optional `targetBranchFilter` (see kaxil/boring-cyborg#112).
+# Only the glob patterns in `paths` need to exist in the repository.
+for label, rule in cyborg_config[CONFIG_KEY].items():
+    if isinstance(rule, dict):
+        patterns = rule.get("paths", [])
+    else:
+        patterns = rule
     for pattern in patterns:
         try:
             next(Path(AIRFLOW_ROOT_PATH).glob(pattern))


### PR DESCRIPTION
Uses the per-rule `targetBranchFilter` added in [kaxil/boring-cyborg#112](https://github.com/kaxil/boring-cyborg/pull/112) so the `backport-to-v3-2-test` label is only applied to PRs whose base branch is `main`. A PR opened directly against `v3-2-test` does not need a backport label for itself.

Also teaches the `check-boring-cyborg-configuration` prek hook about the new `{paths, targetBranchFilter}` object form for label rules so it no longer treats those keys as unused patterns.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)