### PR TITLE
Widen BaseExecutor method signatures to accept WorkloadKey

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -35,12 +35,11 @@ from airflow.executors import workloads
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.workloads.callback import ExecuteCallback
 from airflow.executors.workloads.task import ExecuteTask
+from airflow.executors.workloads.types import state_class_for_key
 from airflow.models import Log
 from airflow.models.callback import CallbackKey
-from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.observability.metrics import stats_utils
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.state import CallbackState, TaskInstanceState
 
 PARALLELISM: int = conf.getint("core", "PARALLELISM")
 
@@ -79,6 +78,7 @@ if TYPE_CHECKING:
     from airflow.executors.workloads import ExecutorWorkload
     from airflow.executors.workloads.types import WorkloadKey, WorkloadState
     from airflow.models.taskinstance import TaskInstance
+    from airflow.models.taskinstancekey import TaskInstanceKey
 
     # Event_buffer dict value type
     # Tuple of: state, info
@@ -86,12 +86,6 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
-
-
-def _state_class_for_key(key: WorkloadKey) -> type[TaskInstanceState] | type[CallbackState]:
-    if isinstance(key, TaskInstanceKey):
-        return TaskInstanceState
-    return CallbackState
 
 
 @dataclass
@@ -461,7 +455,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, _state_class_for_key(key).FAILED, info)
+        self.change_state(key, state_class_for_key(key).FAILED, info)
 
     def success(self, key: WorkloadKey, info=None) -> None:
         """
@@ -470,7 +464,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, _state_class_for_key(key).SUCCESS, info)
+        self.change_state(key, state_class_for_key(key).SUCCESS, info)
 
     def queued(self, key: WorkloadKey, info=None) -> None:
         """
@@ -479,7 +473,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, _state_class_for_key(key).QUEUED, info)
+        self.change_state(key, state_class_for_key(key).QUEUED, info)
 
     def running_state(self, key: WorkloadKey, info=None) -> None:
         """
@@ -488,7 +482,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, _state_class_for_key(key).RUNNING, info, remove_running=False)
+        self.change_state(key, state_class_for_key(key).RUNNING, info, remove_running=False)
 
     def get_event_buffer(self, dag_ids=None) -> dict[WorkloadKey, EventBufferValueType]:
         """

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -240,8 +240,11 @@ class BaseExecutor(LoggingMixin):
     def start(self):  # pragma: no cover
         """Executors may need to get things started."""
 
-    def log_task_event(self, *, event: str, extra: str, ti_key: TaskInstanceKey):
+    def log_task_event(self, *, event: str, extra: str, ti_key: WorkloadKey):
         """Add an event to the log table."""
+        if isinstance(ti_key, CallbackKey):
+            self.log.debug("Skipping log_task_event for callback key %s (event=%s)", ti_key, event)
+            return
         self._task_event_logs.append(Log(event=event, task_instance=ti_key, extra=extra))
 
     def queue_workload(self, workload: ExecutorWorkload, session: Session) -> None:
@@ -429,7 +432,7 @@ class BaseExecutor(LoggingMixin):
     # it die". It is possible for the task itself to finish with success, but the state of the task to be set
     # to FAILED. By using TaskInstanceState enum here it confuses matters!
     def change_state(
-        self, key: TaskInstanceKey, state: TaskInstanceState, info=None, remove_running=True
+        self, key: WorkloadKey, state: TaskInstanceState, info=None, remove_running=True
     ) -> None:
         """
         Change state of the task.
@@ -447,7 +450,7 @@ class BaseExecutor(LoggingMixin):
                 self.log.debug("Could not find key: %s", key)
         self.event_buffer[key] = state, info
 
-    def fail(self, key: TaskInstanceKey, info=None) -> None:
+    def fail(self, key: WorkloadKey, info=None) -> None:
         """
         Set fail state for the event.
 
@@ -456,7 +459,7 @@ class BaseExecutor(LoggingMixin):
         """
         self.change_state(key, TaskInstanceState.FAILED, info)
 
-    def success(self, key: TaskInstanceKey, info=None) -> None:
+    def success(self, key: WorkloadKey, info=None) -> None:
         """
         Set success state for the event.
 
@@ -465,7 +468,7 @@ class BaseExecutor(LoggingMixin):
         """
         self.change_state(key, TaskInstanceState.SUCCESS, info)
 
-    def queued(self, key: TaskInstanceKey, info=None) -> None:
+    def queued(self, key: WorkloadKey, info=None) -> None:
         """
         Set queued state for the event.
 
@@ -474,7 +477,7 @@ class BaseExecutor(LoggingMixin):
         """
         self.change_state(key, TaskInstanceState.QUEUED, info)
 
-    def running_state(self, key: TaskInstanceKey, info=None) -> None:
+    def running_state(self, key: WorkloadKey, info=None) -> None:
         """
         Set running state for the event.
 

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -37,9 +37,10 @@ from airflow.executors.workloads.callback import ExecuteCallback
 from airflow.executors.workloads.task import ExecuteTask
 from airflow.models import Log
 from airflow.models.callback import CallbackKey
+from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.observability.metrics import stats_utils
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.state import TaskInstanceState
+from airflow.utils.state import CallbackState, TaskInstanceState
 
 PARALLELISM: int = conf.getint("core", "PARALLELISM")
 
@@ -76,9 +77,8 @@ if TYPE_CHECKING:
     from airflow.configuration import AirflowConfigParser
     from airflow.executors.executor_utils import ExecutorName
     from airflow.executors.workloads import ExecutorWorkload
-    from airflow.executors.workloads.types import WorkloadKey
+    from airflow.executors.workloads.types import WorkloadKey, WorkloadState
     from airflow.models.taskinstance import TaskInstance
-    from airflow.models.taskinstancekey import TaskInstanceKey
 
     # Event_buffer dict value type
     # Tuple of: state, info
@@ -86,6 +86,12 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+def _state_class_for_key(key: WorkloadKey) -> type[TaskInstanceState] | type[CallbackState]:
+    if isinstance(key, TaskInstanceKey):
+        return TaskInstanceState
+    return CallbackState
 
 
 @dataclass
@@ -431,9 +437,7 @@ class BaseExecutor(LoggingMixin):
     # TODO: This should not be using `TaskInstanceState` here, this is just "did the process complete, or did
     # it die". It is possible for the task itself to finish with success, but the state of the task to be set
     # to FAILED. By using TaskInstanceState enum here it confuses matters!
-    def change_state(
-        self, key: WorkloadKey, state: TaskInstanceState, info=None, remove_running=True
-    ) -> None:
+    def change_state(self, key: WorkloadKey, state: WorkloadState, info=None, remove_running=True) -> None:
         """
         Change state of the task.
 
@@ -457,7 +461,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, TaskInstanceState.FAILED, info)
+        self.change_state(key, _state_class_for_key(key).FAILED, info)
 
     def success(self, key: WorkloadKey, info=None) -> None:
         """
@@ -466,7 +470,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, TaskInstanceState.SUCCESS, info)
+        self.change_state(key, _state_class_for_key(key).SUCCESS, info)
 
     def queued(self, key: WorkloadKey, info=None) -> None:
         """
@@ -475,7 +479,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, TaskInstanceState.QUEUED, info)
+        self.change_state(key, _state_class_for_key(key).QUEUED, info)
 
     def running_state(self, key: WorkloadKey, info=None) -> None:
         """
@@ -484,7 +488,7 @@ class BaseExecutor(LoggingMixin):
         :param info: Executor information for the task instance
         :param key: Unique key for the task instance
         """
-        self.change_state(key, TaskInstanceState.RUNNING, info, remove_running=False)
+        self.change_state(key, _state_class_for_key(key).RUNNING, info, remove_running=False)
 
     def get_event_buffer(self, dag_ids=None) -> dict[WorkloadKey, EventBufferValueType]:
         """

--- a/airflow-core/src/airflow/executors/workloads/types.py
+++ b/airflow-core/src/airflow/executors/workloads/types.py
@@ -22,11 +22,11 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from airflow.models.callback import ExecutorCallback
 from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstancekey import TaskInstanceKey
+from airflow.utils.state import CallbackState, TaskInstanceState
 
 if TYPE_CHECKING:
     from airflow.models.callback import CallbackKey
-    from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.utils.state import CallbackState, TaskInstanceState
 
     # Type aliases for workload keys and states (used by executor layer)
     WorkloadKey: TypeAlias = TaskInstanceKey | CallbackKey
@@ -38,3 +38,9 @@ if TYPE_CHECKING:
 # Type alias for scheduler workloads (ORM models that can be routed to executors)
 # Must be outside TYPE_CHECKING for use in function signatures
 SchedulerWorkload: TypeAlias = TaskInstance | ExecutorCallback
+
+
+def state_class_for_key(key: WorkloadKey) -> type[TaskInstanceState] | type[CallbackState]:
+    if isinstance(key, TaskInstanceKey):
+        return TaskInstanceState
+    return CallbackState

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -41,7 +41,7 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.sdk import BaseOperator
 from airflow.sdk.execution_time.callback_supervisor import execute_callback
 from airflow.serialization.definitions.baseoperator import SerializedBaseOperator
-from airflow.utils.state import State, TaskInstanceState
+from airflow.utils.state import CallbackState, State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.markers import skip_if_force_lowest_dependencies_marker
@@ -110,6 +110,17 @@ def test_log_task_event_branches_on_key_type():
     callback_key = str(UUID("00000000-0000-0000-0000-000000000001"))
     executor.log_task_event(event="callback_event", extra="extra", ti_key=callback_key)
     assert len(executor._task_event_logs) == 1
+
+
+def test_state_methods_pick_callback_state_for_callback_key():
+    executor = BaseExecutor()
+    callback_key = str(UUID("00000000-0000-0000-0000-000000000002"))
+
+    executor.fail(callback_key)
+    assert executor.event_buffer[callback_key] == (CallbackState.FAILED, None)
+
+    executor.success(callback_key)
+    assert executor.event_buffer[callback_key] == (CallbackState.SUCCESS, None)
 
 
 def test_fail_and_success():

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -100,6 +100,18 @@ def test_get_event_buffer():
     assert len(executor.event_buffer) == 0
 
 
+def test_log_task_event_branches_on_key_type():
+    executor = BaseExecutor()
+    ti_key = TaskInstanceKey("my_dag", "my_task", timezone.utcnow(), 1)
+
+    executor.log_task_event(event="task_event", extra="extra", ti_key=ti_key)
+    assert len(executor._task_event_logs) == 1
+
+    callback_key = str(UUID("00000000-0000-0000-0000-000000000001"))
+    executor.log_task_event(event="callback_event", extra="extra", ti_key=callback_key)
+    assert len(executor._task_event_logs) == 1
+
+
 def test_fail_and_success():
     executor = BaseExecutor()
 

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -112,15 +112,22 @@ def test_log_task_event_branches_on_key_type():
     assert len(executor._task_event_logs) == 1
 
 
-def test_state_methods_pick_callback_state_for_callback_key():
+@pytest.mark.parametrize(
+    ("method_name", "expected_state"),
+    [
+        ("fail", CallbackState.FAILED),
+        ("success", CallbackState.SUCCESS),
+        ("queued", CallbackState.QUEUED),
+        ("running_state", CallbackState.RUNNING),
+    ],
+)
+def test_state_methods_pick_callback_state_for_callback_key(method_name, expected_state):
     executor = BaseExecutor()
     callback_key = str(UUID("00000000-0000-0000-0000-000000000002"))
 
-    executor.fail(callback_key)
-    assert executor.event_buffer[callback_key] == (CallbackState.FAILED, None)
+    getattr(executor, method_name)(callback_key)
 
-    executor.success(callback_key)
-    assert executor.event_buffer[callback_key] == (CallbackState.SUCCESS, None)
+    assert executor.event_buffer[callback_key] == (expected_state, None)
 
 
 def test_fail_and_success():

--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -40,6 +40,7 @@ AIRFLOW_V_3_1_3_PLUS = get_base_airflow_version_tuple() >= (3, 1, 3)
 AIRFLOW_V_3_1_7_PLUS = get_base_airflow_version_tuple() >= (3, 1, 7)
 AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import PokeReturnValue, timezone
@@ -61,6 +62,7 @@ __all__ = [
     "AIRFLOW_V_3_0_1",
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
     "NOTSET",
     "XCOM_RETURN_KEY",
     "ArgNotSet",

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -64,11 +64,16 @@ if TYPE_CHECKING:
     from airflow.providers.celery.executors.celery_executor_utils import TaskTuple, WorkloadInCelery
 
     if AIRFLOW_V_3_2_PLUS:
-        from airflow.executors.workloads.types import WorkloadKey as _WorkloadKey
+        from airflow.executors.workloads.types import (
+            WorkloadKey as _WorkloadKey,
+            WorkloadState as _WorkloadState,
+        )
 
         WorkloadKey: TypeAlias = _WorkloadKey
+        WorkloadState: TypeAlias = _WorkloadState
     else:
         WorkloadKey: TypeAlias = TaskInstanceKey  # type: ignore[no-redef, misc]
+        WorkloadState: TypeAlias = TaskInstanceState  # type: ignore[no-redef, misc]
 
 
 # PEP562
@@ -277,9 +282,7 @@ class CeleryExecutor(BaseExecutor):
             if state:
                 self.update_task_state(cast("TaskInstanceKey", key), state, info)
 
-    def change_state(
-        self, key: WorkloadKey, state: TaskInstanceState, info=None, remove_running=True
-    ) -> None:
+    def change_state(self, key: WorkloadKey, state: WorkloadState, info=None, remove_running=True) -> None:
         super().change_state(key, state, info, remove_running=remove_running)
         self.workloads.pop(key, None)
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -278,7 +278,7 @@ class CeleryExecutor(BaseExecutor):
                 self.update_task_state(cast("TaskInstanceKey", key), state, info)
 
     def change_state(
-        self, key: TaskInstanceKey, state: TaskInstanceState, info=None, remove_running=True
+        self, key: WorkloadKey, state: TaskInstanceState, info=None, remove_running=True
     ) -> None:
         super().change_state(key, state, info, remove_running=remove_running)
         self.workloads.pop(key, None)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

## Summary

Widens BaseExecutor method signatures from `TaskInstanceKey` to  `WorkloadKey` (union of `TaskInstanceKey | CallbackKey`) so executors can signal state transitions for both task and callback workloads.                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                              

Unblocks follow-up work on callback-aware executors.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
