### PR TITLE
fix: prevent webhook_endpoint extra field from being sent as HTTP header in DiscordWebhookHook

### DIFF
--- a/providers/discord/newsfragments/65398.bugfix.rst
+++ b/providers/discord/newsfragments/65398.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``DiscordWebhookHook`` sending ``webhook_endpoint`` as an HTTP header causing ``400 Bad Request`` from Discord after Airflow 3.2 updated ``HttpHook`` to inject connection extra fields as headers.

--- a/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
+++ b/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
@@ -218,6 +218,19 @@ class DiscordWebhookHook(HttpHook):
             conn = self.get_connection(http_conn_id)
         return self.handler.get_webhook_endpoint(conn, webhook_endpoint)
 
+    def get_conn(self, headers: dict[Any, Any] | None = None, extra_options: dict[str, Any] | None = None):
+        """Override to prevent webhook_endpoint from being sent as an HTTP header."""
+        if not self.http_conn_id:
+            return super().get_conn(headers=headers, extra_options=extra_options)
+        conn = self.get_connection(self.http_conn_id)
+        original_extra = conn.extra
+        try:
+            cleaned = {k: v for k, v in conn.extra_dejson.items() if k != "webhook_endpoint"}
+            conn.extra = json.dumps(cleaned) if cleaned else None
+            return super().get_conn(headers=headers, extra_options=extra_options)
+        finally:
+            conn.extra = original_extra
+
     def execute(self) -> None:
         """Execute the Discord webhook call."""
         proxies = {}


### PR DESCRIPTION
When using DiscordWebhookHook with a connection that stores webhook_endpoint in the extra field, Airflow 3.2 now injects remaining connection extra fields as HTTP request headers via HttpHook.get_conn(). This causes Discord to
reject the request with 400 Bad Request because webhook_endpoint is not a valid HTTP header.

The fix overrides get_conn in DiscordWebhookHook to remove webhook_endpoint from the connection's extra fields before HttpHook processes them. Since webhook_endpoint is used to build the request URL, not as an HTTP header,
it should never be sent to Discord. The original extra is restored in a finally block to avoid any side effects.

Closes #65279

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---