### PR TITLE
Fix chart image volume schema validation

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -12298,6 +12298,32 @@
             "type": "object",
             "additionalProperties": false
         },
+        "io.k8s.api.core.v1.AppArmorProfile": {
+            "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+            "properties": {
+                "localhostProfile": {
+                    "description": "localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is \"Localhost\".",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type indicates which kind of AppArmor profile will be applied. Valid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "x-kubernetes-unions": [
+                {
+                    "discriminator": "type",
+                    "fields-to-discriminateBy": {
+                        "localhostProfile": "LocalhostProfile"
+                    }
+                }
+            ],
+            "additionalProperties": false
+        },
         "io.k8s.api.core.v1.AzureDiskVolumeSource": {
             "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
             "properties": {
@@ -12397,14 +12423,16 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "drop": {
                     "description": "Removed capabilities",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -12418,7 +12446,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "path": {
                     "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -12507,7 +12536,7 @@
             "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
             "properties": {
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -12526,7 +12555,7 @@
                     "type": "string"
                 },
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -12549,10 +12578,11 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -12576,10 +12606,11 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -12598,14 +12629,16 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "command": {
                     "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "env": {
                     "description": "List of environment variables to set in the container. Cannot be updated.",
@@ -12613,6 +12646,10 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
                     },
                     "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "name"
+                    ],
+                    "x-kubernetes-list-type": "map",
                     "x-kubernetes-patch-merge-key": "name",
                     "x-kubernetes-patch-strategy": "merge"
                 },
@@ -12621,7 +12658,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "image": {
                     "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
@@ -12711,6 +12749,10 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
                     },
                     "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "devicePath"
+                    ],
+                    "x-kubernetes-list-type": "map",
                     "x-kubernetes-patch-merge-key": "devicePath",
                     "x-kubernetes-patch-strategy": "merge"
                 },
@@ -12720,6 +12762,10 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     },
                     "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "mountPath"
+                    ],
+                    "x-kubernetes-list-type": "map",
                     "x-kubernetes-patch-merge-key": "mountPath",
                     "x-kubernetes-patch-strategy": "merge"
                 },
@@ -12793,7 +12839,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -12804,7 +12851,7 @@
             "properties": {
                 "fieldRef": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
-                    "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported."
                 },
                 "mode": {
                     "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -12839,7 +12886,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -12943,7 +12991,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -12970,14 +13019,16 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "wwids": {
                     "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -13133,7 +13184,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "path": {
                     "description": "Path to access on the HTTP server.",
@@ -13181,13 +13233,17 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "ip": {
                     "description": "IP address of the host file entry.",
                     "type": "string"
                 }
             },
+            "required": [
+                "ip"
+            ],
             "type": "object",
             "additionalProperties": false
         },
@@ -13246,7 +13302,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "readOnly": {
                     "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
@@ -13266,6 +13323,21 @@
                 "iqn",
                 "lun"
             ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ImageVolumeSource": {
+            "description": "ImageVolumeSource represents a image volume resource.",
+            "properties": {
+                "pullPolicy": {
+                    "description": "Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                    "type": "string"
+                },
+                "reference": {
+                    "description": "Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                    "type": "string"
+                }
+            },
             "type": "object",
             "additionalProperties": false
         },
@@ -13384,7 +13456,7 @@
             "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
             "properties": {
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 }
             },
@@ -13423,7 +13495,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
@@ -13441,7 +13514,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "required": [
@@ -13467,7 +13541,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "required": [
@@ -13485,14 +13560,16 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "matchFields": {
                     "description": "A list of node selector requirements by node's fields.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -13526,7 +13603,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "dataSource": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
@@ -13549,7 +13627,7 @@
                     "type": "string"
                 },
                 "volumeAttributesClassName": {
-                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                     "type": "string"
                 },
                 "volumeMode": {
@@ -13626,14 +13704,16 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                     "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -13647,7 +13727,7 @@
                     "description": "A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods."
                 },
                 "matchLabelKeys": {
-                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. Also, MatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                     "items": {
                         "type": "string"
                     },
@@ -13655,7 +13735,7 @@
                     "x-kubernetes-list-type": "atomic"
                 },
                 "mismatchLabelKeys": {
-                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector. Also, MismatchLabelKeys cannot be set when LabelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                     "items": {
                         "type": "string"
                     },
@@ -13671,7 +13751,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "topologyKey": {
                     "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
@@ -13692,14 +13773,16 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                     "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -13708,6 +13791,10 @@
         "io.k8s.api.core.v1.PodSecurityContext": {
             "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
             "properties": {
+                "appArmorProfile": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+                    "description": "appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
+                },
                 "fsGroup": {
                     "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
                     "format": "int64",
@@ -13740,19 +13827,25 @@
                     "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
                 },
                 "supplementalGroups": {
-                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.",
+                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID and fsGroup (if specified).  If the SupplementalGroupsPolicy feature is enabled, the supplementalGroupsPolicy field determines whether these are in addition to or instead of any group memberships defined in the container image. If unspecified, no additional groups are added, though group memberships defined in the container image may still be used, depending on the supplementalGroupsPolicy field. Note that this field cannot be set when spec.os.name is windows.",
                     "items": {
                         "format": "int64",
                         "type": "integer"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                    "description": "Defines how supplemental groups of the first container processes are calculated. Valid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used. (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled and the container runtime must implement support for this feature. Note that this field cannot be set when spec.os.name is windows.",
+                    "type": "string"
                 },
                 "sysctls": {
                     "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
@@ -13866,11 +13959,12 @@
                     "type": "integer"
                 },
                 "sources": {
-                    "description": "sources is the list of volume projections",
+                    "description": "sources is the list of volume projections. Each entry in this list handles one source.",
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "type": "object",
@@ -13931,7 +14025,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "pool": {
                     "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -13962,6 +14057,10 @@
             "properties": {
                 "name": {
                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                    "type": "string"
+                },
+                "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.",
                     "type": "string"
                 }
             },
@@ -14131,7 +14230,7 @@
             "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
             "properties": {
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -14150,7 +14249,7 @@
                     "type": "string"
                 },
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -14173,10 +14272,11 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "name": {
-                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                 },
                 "optional": {
@@ -14200,7 +14300,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "optional": {
                     "description": "optional field specify whether the Secret or its keys must be defined",
@@ -14221,6 +14322,10 @@
                     "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
                     "type": "boolean"
                 },
+                "appArmorProfile": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
+                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows."
+                },
                 "capabilities": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
                     "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows."
@@ -14230,7 +14335,7 @@
                     "type": "boolean"
                 },
                 "procMount": {
-                    "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                    "description": "procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
                     "type": "string"
                 },
                 "readOnlyRootFilesystem": {
@@ -14418,7 +14523,7 @@
                     "type": "integer"
                 },
                 "minDomains": {
-                    "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.\n\nThis is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
+                    "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.",
                     "format": "int32",
                     "type": "integer"
                 },
@@ -14568,6 +14673,10 @@
                     "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
                     "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
                 },
+                "image": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ImageVolumeSource",
+                    "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath). The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type."
+                },
                 "iscsi": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
                     "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md"
@@ -14654,7 +14763,7 @@
                     "type": "string"
                 },
                 "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).",
                     "type": "string"
                 },
                 "name": {
@@ -14664,6 +14773,10 @@
                 "readOnly": {
                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
                     "type": "boolean"
+                },
+                "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled recursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
                 },
                 "subPath": {
                     "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
@@ -14682,7 +14795,7 @@
             "additionalProperties": false
         },
         "io.k8s.api.core.v1.VolumeProjection": {
-            "description": "Projection that may be projected along with other supported volume types",
+            "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
             "properties": {
                 "clusterTrustBundle": {
                     "$ref": "#/definitions/io.k8s.api.core.v1.ClusterTrustBundleProjection",
@@ -14810,7 +14923,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "required": [
@@ -14880,7 +14994,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "matchLabels": {
                     "additionalProperties": {
@@ -14910,7 +15025,8 @@
                     "items": {
                         "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 }
             },
             "required": [
@@ -14984,6 +15100,7 @@
                         "type": "string"
                     },
                     "type": "array",
+                    "x-kubernetes-list-type": "set",
                     "x-kubernetes-patch-strategy": "merge"
                 },
                 "generateName": {
@@ -15007,7 +15124,8 @@
                     "items": {
                         "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                 },
                 "name": {
                     "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
@@ -15023,6 +15141,10 @@
                         "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
                     },
                     "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "uid"
+                    ],
+                    "x-kubernetes-list-type": "map",
                     "x-kubernetes-patch-merge-key": "uid",
                     "x-kubernetes-patch-strategy": "merge"
                 },

--- a/scripts/ci/prek/vendor_k8s_json_schema.py
+++ b/scripts/ci/prek/vendor_k8s_json_schema.py
@@ -32,7 +32,7 @@ from common_prek_utils import AIRFLOW_ROOT_PATH
 
 K8S_DEFINITIONS = (
     "https://raw.githubusercontent.com/yannh/kubernetes-json-schema"
-    "/master/v1.29.0-standalone-strict/_definitions.json"
+    "/master/v1.31.0-standalone-strict/_definitions.json"
 )
 VALUES_SCHEMA_FILE = AIRFLOW_ROOT_PATH / "chart/values.schema.json"
 


### PR DESCRIPTION
Fix Helm chart validation for Kubernetes Image Volumes in extraVolumes by bumping the vendored Kubernetes schema to v1.31 and regenerating chart/values.schema.json. This restores validation for Volume.image on Kubernetes 1.31+.

closes: #65394

Validation: chart-specific schema checks passed locally.

Was generative AI tooling used to co-author this PR?
Yes — Claude (For pr description)