### PR TITLE
Fix DEFAULT_LOGGING_CONFIG use right kwargs

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -370,4 +370,4 @@ if REMOTE_LOGGING:
             "section 'elasticsearch' if you are using Elasticsearch. In the other case, "
             "'remote_base_log_folder' option in the 'logging' section."
         )
-    DEFAULT_LOGGING_CONFIG["handlers"]["task"].update(remote_task_handler_kwargs)
+    DEFAULT_LOGGING_CONFIG["handlers"]["task"].update(_handler_kwargs)

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -54,6 +54,7 @@ def test_remote_task_handler_kwargs_not_leaked_to_local_task_handler(
     remote_base, remote_io_path, restore_local_settings
 ):
     """Verify remote_task_handler_kwargs are passed to RemoteLogIO and not leaked to FileTaskHandler."""
+    pytest.importorskip(remote_io_path.rsplit(".", 1)[0])
     user_kwargs = {"remote_base": "ignored", "custom_key": "v"}
     with (
         mock.patch(remote_io_path) as mock_remote_io,

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import importlib
+import json
+from unittest import mock
+
+import pytest
+
+from airflow.config_templates import airflow_local_settings
+
+from tests_common.test_utils.config import conf_vars
+
+
+@pytest.fixture
+def restore_local_settings():
+    yield
+    importlib.reload(airflow_local_settings)
+
+
+@pytest.mark.parametrize(
+    "remote_base, remote_io_path",
+    [
+        ("s3://bucket/path", "airflow.providers.amazon.aws.log.s3_task_handler.S3RemoteLogIO"),
+        ("wasb-logs", "airflow.providers.microsoft.azure.log.wasb_task_handler.WasbRemoteLogIO"),
+        ("gs://bucket/path", "airflow.providers.google.cloud.log.gcs_task_handler.GCSRemoteLogIO"),
+        (
+            "cloudwatch://arn:aws:logs:us-east-1:0:log-group:foo",
+            "airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudWatchRemoteLogIO",
+        ),
+        ("oss://bucket/path", "airflow.providers.alibaba.cloud.log.oss_task_handler.OSSRemoteLogIO"),
+        ("hdfs://host/path", "airflow.providers.apache.hdfs.log.hdfs_task_handler.HdfsRemoteLogIO"),
+    ],
+    ids=["s3", "wasb", "gcs", "cloudwatch", "oss", "hdfs"],
+)
+def test_remote_task_handler_kwargs_not_leaked_to_local_task_handler(
+    remote_base, remote_io_path, restore_local_settings
+):
+    """Verify remote_task_handler_kwargs are passed to RemoteLogIO and not leaked to FileTaskHandler."""
+    user_kwargs = {"remote_base": "ignored", "custom_key": "v"}
+    with (
+        mock.patch(remote_io_path) as mock_remote_io,
+        conf_vars(
+            {
+                ("logging", "remote_logging"): "True",
+                ("logging", "remote_base_log_folder"): remote_base,
+                ("logging", "remote_task_handler_kwargs"): json.dumps(user_kwargs),
+            }
+        ),
+    ):
+        importlib.reload(airflow_local_settings)
+        task_cfg = airflow_local_settings.DEFAULT_LOGGING_CONFIG["handlers"]["task"]
+        for k in user_kwargs:
+            assert k not in task_cfg, f"{k!r} leaked into task handler for {remote_base}"
+
+        # Verify kwargs were passed to REMOTE_TASK_LOG
+        for k, v in user_kwargs.items():
+            assert mock_remote_io.call_args.kwargs[k] == v

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -36,7 +36,7 @@ def restore_local_settings():
 
 
 @pytest.mark.parametrize(
-    "remote_base, remote_io_path",
+    ("remote_base", "remote_io_path"),
     [
         ("s3://bucket/path", "airflow.providers.amazon.aws.log.s3_task_handler.S3RemoteLogIO"),
         ("wasb-logs", "airflow.providers.microsoft.azure.log.wasb_task_handler.WasbRemoteLogIO"),


### PR DESCRIPTION
# Overview

During testing for the Airflow 3.2.1 release, we found a logging configuration issue while setting up a Wasp remote logger.

The following error is raised at startup:

```
Unable to load the config, contains a configuration error.                                                                                                                                                                                   
Traceback (most recent call last):                                                                                                                                                                                                           
  File "/usr/python/lib/python3.12/logging/config.py", line 608, in configure                                                                                                                                                                
    handler = self.configure_handler(handlers[name])                                                                                                                                                                                         
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                         
  File "/usr/python/lib/python3.12/logging/config.py", line 876, in configure_handler                                                                                                                                                        
    result = factory(**kwargs)                                                                                                                                                                                                               
             ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                               
TypeError: FileTaskHandler.__init__() got an unexpected keyword argument 'remote_base' 
```

After investigating the root cause we found that PR https://github.com/apache/airflow/pull/64832 introduced a new _handler_kwargs variable which "replace" the usage of the remote_task_handler_kwargs variable. 

However, near the end of the file, DEFAULT_LOGGING_CONFIG is still initialized using remote_task_handler_kwargs instead of _handler_kwargs.


# Details of change:

* Initialize DEFAULT_LOGGING_CONFIG["handlers"]["task"] using the correct handler kwargs so the task handler receives matching parameters.
 