### PR TITLE
Preload source_aliases in process_executor_events

### DIFF
--- a/airflow-core/newsfragments/65422.bugfix.rst
+++ b/airflow-core/newsfragments/65422.bugfix.rst
@@ -1,0 +1,1 @@
+Fix scheduler crash on asset-triggered DagRuns by eager-loading ``AssetEvent.source_aliases`` in ``SchedulerJobRunner.process_executor_events``.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1231,12 +1231,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
         if filter_for_tis is None:
             return len(event_buffer)
-        asset_loader, _ = _eager_load_dag_run_for_validation()
+        asset_loader, alias_loader = _eager_load_dag_run_for_validation()
         query = (
             select(TI)
             .where(filter_for_tis)
             .options(selectinload(TI.dag_model))
             .options(asset_loader)
+            .options(alias_loader)
             .options(joinedload(TI.dag_run).selectinload(DagRun.created_dag_version))
             .options(joinedload(TI.dag_version))
         )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -849,11 +849,15 @@ class TestSchedulerJob:
         Test that _process_executor_events handles asset events without DetachedInstanceError.
 
         Regression test for scheduler crashes when task callbacks are built with
-        consumed_asset_events that weren't eager-loaded.
+        consumed_asset_events that weren't eager-loaded. Exercises both
+        ``AssetEvent.asset`` and ``AssetEvent.source_aliases`` so that missing
+        either loader option on the TI query surfaces as a ``DetachedInstanceError``
+        when the callback's ``DRDataModel`` is built.
         """
         asset1 = Asset(uri="test://asset1", name="test_asset_executor", group="test_group")
         asset_model = AssetModel(name=asset1.name, uri=asset1.uri, group=asset1.group)
-        session.add(asset_model)
+        asset_alias = AssetAliasModel(name="test_alias_executor", group="test_group")
+        session.add_all([asset_model, asset_alias])
         session.flush()
 
         with dag_maker(dag_id="test_executor_events_with_assets", schedule=[asset1], fileloc="/test_path1/"):
@@ -865,7 +869,9 @@ class TestSchedulerJob:
 
         dr = dag_maker.create_dagrun()
 
-        # Create asset event and attach to dag run
+        # Create asset event with an attached source alias so the lazy-loaded
+        # AssetEvent.source_aliases relationship is non-empty and must be
+        # eager-loaded to survive a detached ORM instance in the callback.
         asset_event = AssetEvent(
             asset_id=asset_model.id,
             source_task_id="upstream_task",
@@ -873,6 +879,7 @@ class TestSchedulerJob:
             source_run_id="upstream_run",
             source_map_index=-1,
         )
+        asset_event.source_aliases.append(asset_alias)
         session.add(asset_event)
         session.flush()
         dr.consumed_asset_events.append(asset_event)
@@ -896,12 +903,14 @@ class TestSchedulerJob:
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.FAILED
 
-        # Verify callback was created with asset event data
+        # Verify callback was created with asset event data including aliases
         self.job_runner.executor.callback_sink.send.assert_called_once()
         callback_request = self.job_runner.executor.callback_sink.send.call_args.args[0]
         assert callback_request.context_from_server is not None
-        assert len(callback_request.context_from_server.dag_run.consumed_asset_events) == 1
-        assert callback_request.context_from_server.dag_run.consumed_asset_events[0].asset.uri == asset1.uri
+        events = callback_request.context_from_server.dag_run.consumed_asset_events
+        assert len(events) == 1
+        assert events[0].asset.uri == asset1.uri
+        assert [alias.name for alias in events[0].source_aliases] == [asset_alias.name]
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_schedule_dag_run_with_asset_event(self, session: Session, dag_maker: DagMaker):


### PR DESCRIPTION
### Summary

`SchedulerJobRunner.process_executor_events` builds a `DRDataModel` for the failing task via `DRDataModel.model_validate(ti.dag_run, from_attributes=True)`. Pydantic walks `DagRun.consumed_asset_events`, and for each `AssetEvent` it descends into both `asset` and `source_aliases`.

PR #56916 (included in 3.2.0) added the helper `_eager_load_dag_run_for_validation` to preload those relationships. Its docstring example applies both loaders, and the other call site in `_adopt_or_reset_orphaned_tasks` applies both. The `process_executor_events` site only applies the first one:

```python
asset_loader, _ = _eager_load_dag_run_for_validation()
query = (
    select(TI)
    .where(filter_for_tis)
    .options(selectinload(TI.dag_model))
    .options(asset_loader)
    # alias_loader is missing
    ...
)
```

As a result, when the Celery/Kubernetes executor reports a failed-while-queued event for an asset-triggered DagRun whose consumed `AssetEvent` has a non-empty `source_aliases`, SQLAlchemy detaches the `AssetEvent` instance by the time pydantic walks it, and `source_aliases` hits a lazy loader without a session:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for DagRun
consumed_asset_events.0.source_aliases
  Error extracting attribute: DetachedInstanceError: Parent instance
  <AssetEvent at 0x...> is not bound to a Session; lazy load operation
  of attribute 'source_aliases' cannot proceed
```

The exception escapes `_run_scheduler_loop`, the scheduler process exits, which orphans in-flight task instances. The next scheduler's `_adopt_or_reset_orphaned_tasks` picks them up, their adoption replays the same validation path, and the crash repeats.

### Change

Apply the `alias_loader` alongside `asset_loader` at this call site. One extra `selectinload` is issued when the batch contains asset-triggered DagRuns with populated `source_aliases`; zero runtime impact for DAGs without asset events.

### Test

The existing regression test `test_process_executor_events_with_asset_events` created an `AssetEvent` with no aliases, so it didn't stress the missing loader. Extended to attach an `AssetAliasModel` to the event and to assert that the alias survives into the callback payload:

```python
events = callback_request.context_from_server.dag_run.consumed_asset_events
assert len(events) == 1
assert events[0].asset.uri == asset1.uri
assert [alias.name for alias in events[0].source_aliases] == [asset_alias.name]
```

<!--- closes: -->
<!--- related: #56916 -->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.