### PR TITLE
Remove explicit session.commit() from delete_xcom to align with request-scoped session handling

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -442,5 +442,4 @@ def delete_xcom(
         XComModel.map_index == map_index,
     )
     session.execute(query)
-    session.commit()
     return {"message": f"XCom with key: {key} successfully deleted."}


### PR DESCRIPTION
### Summary

Remove the explicit `session.commit()` call from `delete_xcom` to align with the request-scoped session handling pattern used across other API endpoints.

---

### Details

* The `delete_xcom` route previously called `session.commit()` directly after executing the delete query.
* Other API handlers in the same module rely on the session lifecycle managed by FastAPI dependencies and do not perform explicit commits.
* This change removes the explicit commit to keep behavior consistent across endpoints and avoid premature transaction finalization within the handler.

---

### Why this change

* Ensures consistent session handling across all execution API routes
* Avoids committing within the handler when session lifecycle is externally managed
* Keeps the endpoint behavior aligned with existing patterns in the codebase

---

### Impact

* No change to API interface or response format
* No change to query logic or execution flow
* Transaction handling remains managed by the surrounding request lifecycle

---

### Testing

* Existing tests continue to pass
* No additional tests introduced, as this change aligns behavior with existing endpoints rather than introducing new functionality

---

### Notes

* This change is intentionally minimal and scoped to a single line removal
* Follows existing patterns in the same file for session usage

---

##### Was generative AI tooling used to co-author this PR?

* [ ] Yes (please specify the tool below)
