### PR TITLE
Use compat timezone helpers in sensor and trigger of SFTP provider

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/sensors/sftp.py
@@ -26,10 +26,15 @@ from typing import TYPE_CHECKING, Any
 
 from paramiko.sftp import SFTP_NO_SUCH_FILE
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator, PokeReturnValue, conf
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    BaseSensorOperator,
+    PokeReturnValue,
+    conf,
+    timezone,
+)
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.providers.sftp.triggers.sftp import SFTPTrigger
-from airflow.utils.timezone import convert_to_utc, parse
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -119,9 +124,9 @@ class SFTPSensor(BaseSensorOperator):
                     continue
 
                 if isinstance(self.newer_than, str):
-                    self.newer_than = parse(self.newer_than)
-                _mod_time = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
-                _newer_than = convert_to_utc(self.newer_than)
+                    self.newer_than = timezone.parse(self.newer_than)
+                _mod_time = timezone.convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
+                _newer_than = timezone.convert_to_utc(self.newer_than)
                 if _newer_than <= _mod_time:
                     files_found.append(actual_file_present)
                     self.log.info(

--- a/providers/sftp/src/airflow/providers/sftp/triggers/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/triggers/sftp.py
@@ -24,10 +24,9 @@ from typing import Any
 
 from dateutil.parser import parse as parse_date
 
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, timezone
 from airflow.providers.sftp.hooks.sftp import SFTPHookAsync
 from airflow.triggers.base import BaseTrigger, TriggerEvent
-from airflow.utils.timezone import convert_to_utc
 
 
 class SFTPTrigger(BaseTrigger):
@@ -87,7 +86,7 @@ class SFTPTrigger(BaseTrigger):
 
         if isinstance(self.newer_than, str):
             self.newer_than = parse_date(self.newer_than)
-        _newer_than = convert_to_utc(self.newer_than) if self.newer_than else None
+        _newer_than = timezone.convert_to_utc(self.newer_than) if self.newer_than else None
         while True:
             try:
                 if self.file_pattern:
@@ -102,7 +101,9 @@ class SFTPTrigger(BaseTrigger):
                             mod_time = datetime.fromtimestamp(float(file.attrs.mtime)).strftime(
                                 "%Y%m%d%H%M%S"
                             )
-                            mod_time_utc = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
+                            mod_time_utc = timezone.convert_to_utc(
+                                datetime.strptime(mod_time, "%Y%m%d%H%M%S")
+                            )
                             if _newer_than <= mod_time_utc:
                                 files_sensed.append(file.filename)
                         else:
@@ -118,7 +119,7 @@ class SFTPTrigger(BaseTrigger):
                 else:
                     mod_time = await hook.get_mod_time(self.path)
                     if _newer_than:
-                        mod_time_utc = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
+                        mod_time_utc = timezone.convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
                         if _newer_than <= mod_time_utc:
                             yield TriggerEvent({"status": "success", "message": f"Sensed file: {self.path}"})
                             return

--- a/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
@@ -29,7 +29,11 @@ from pendulum import datetime as pendulum_datetime, timezone
 
 from airflow.providers.common.compat.sdk import AirflowException, PokeReturnValue
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
-from airflow.utils.deprecation_tools import DeprecatedImportWarning
+
+try:
+    from airflow.utils.deprecation_tools import DeprecatedImportWarning
+except ImportError:
+    DeprecatedImportWarning = DeprecationWarning
 
 # Ignore missing args provided by default_args
 # mypy: disable-error-code="arg-type"

--- a/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
@@ -30,10 +30,13 @@ from pendulum import datetime as pendulum_datetime, timezone
 from airflow.providers.common.compat.sdk import AirflowException, PokeReturnValue
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
 
+WARNING_CATEGORY: type[Warning]
 try:
     from airflow.utils.deprecation_tools import DeprecatedImportWarning
 except ImportError:
-    DeprecatedImportWarning = DeprecationWarning
+    WARNING_CATEGORY = DeprecationWarning
+else:
+    WARNING_CATEGORY = DeprecatedImportWarning
 
 # Ignore missing args provided by default_args
 # mypy: disable-error-code="arg-type"
@@ -48,7 +51,7 @@ class TestSFTPSensor:
             importlib.reload(sftp_sensor_module)
 
         assert not any(
-            issubclass(warning.category, DeprecatedImportWarning)
+            issubclass(warning.category, WARNING_CATEGORY)
             and "airflow.utils.timezone" in str(warning.message)
             for warning in captured_warnings
         )

--- a/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/sensors/test_sftp.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import warnings
 from datetime import datetime, timezone as stdlib_timezone
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -25,15 +27,28 @@ import pytest
 from paramiko.sftp import SFTP_FAILURE
 from pendulum import datetime as pendulum_datetime, timezone
 
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, PokeReturnValue
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
-from airflow.sensors.base import PokeReturnValue
+from airflow.utils.deprecation_tools import DeprecatedImportWarning
 
 # Ignore missing args provided by default_args
 # mypy: disable-error-code="arg-type"
 
 
 class TestSFTPSensor:
+    def test_no_timezone_deprecated_import_warning_on_module_reload(self):
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            import airflow.providers.sftp.sensors.sftp as sftp_sensor_module
+
+            importlib.reload(sftp_sensor_module)
+
+        assert not any(
+            issubclass(warning.category, DeprecatedImportWarning)
+            and "airflow.utils.timezone" in str(warning.message)
+            for warning in captured_warnings
+        )
+
     @patch("airflow.providers.sftp.sensors.sftp.SFTPHook")
     def test_file_present(self, sftp_hook_mock):
         sftp_hook_mock.return_value.isfile.return_value = True

--- a/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
@@ -29,7 +29,11 @@ from asyncssh.sftp import SFTPAttrs, SFTPName
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.sftp.triggers.sftp import SFTPTrigger
 from airflow.triggers.base import TriggerEvent
-from airflow.utils.deprecation_tools import DeprecatedImportWarning
+
+try:
+    from airflow.utils.deprecation_tools import DeprecatedImportWarning
+except ImportError:
+    DeprecatedImportWarning = DeprecationWarning
 
 
 class TestSFTPTrigger:

--- a/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
@@ -30,10 +30,13 @@ from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.sftp.triggers.sftp import SFTPTrigger
 from airflow.triggers.base import TriggerEvent
 
+WARNING_CATEGORY: type[Warning]
 try:
     from airflow.utils.deprecation_tools import DeprecatedImportWarning
 except ImportError:
-    DeprecatedImportWarning = DeprecationWarning
+    WARNING_CATEGORY = DeprecationWarning
+else:
+    WARNING_CATEGORY = DeprecatedImportWarning
 
 
 class TestSFTPTrigger:
@@ -45,7 +48,7 @@ class TestSFTPTrigger:
             importlib.reload(sftp_trigger_module)
 
         assert not any(
-            issubclass(warning.category, DeprecatedImportWarning)
+            issubclass(warning.category, WARNING_CATEGORY)
             and "airflow.utils.timezone" in str(warning.message)
             for warning in captured_warnings
         )

--- a/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/triggers/test_sftp.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import importlib
 import time
+import warnings
 from unittest import mock
 
 import pytest
@@ -27,9 +29,23 @@ from asyncssh.sftp import SFTPAttrs, SFTPName
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.sftp.triggers.sftp import SFTPTrigger
 from airflow.triggers.base import TriggerEvent
+from airflow.utils.deprecation_tools import DeprecatedImportWarning
 
 
 class TestSFTPTrigger:
+    def test_no_timezone_deprecated_import_warning_on_module_reload(self):
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter("always")
+            import airflow.providers.sftp.triggers.sftp as sftp_trigger_module
+
+            importlib.reload(sftp_trigger_module)
+
+        assert not any(
+            issubclass(warning.category, DeprecatedImportWarning)
+            and "airflow.utils.timezone" in str(warning.message)
+            for warning in captured_warnings
+        )
+
     def test_sftp_trigger_serialization(self):
         """
         Asserts that the SFTPTrigger correctly serializes its arguments and classpath.


### PR DESCRIPTION
This updates the SFTP sensor and trigger modules to use the providers compat timezone import instead of deprecated timezone imports.

Behavior is unchanged: newer_than parsing and UTC comparisons follow the same logic as before. The PR also adds regression tests to ensure importing these SFTP modules does not raise deprecated timezone import warnings.

Closes: #65419

What I tested:
- breeze run pytest providers/sftp/tests/unit/sftp/sensors/test_sftp.py providers/sftp/tests/unit/sftp/triggers/test_sftp.py -xvs
- breeze run pytest providers/sftp/tests/unit/sftp/decorators/sensors/test_sftp.py -xvs