### PR TITLE
Add default GO_VERSION for pgbouncer-exporter Dockerfile

### DIFF
--- a/chart/dockerfiles/pgbouncer-exporter/Dockerfile
+++ b/chart/dockerfiles/pgbouncer-exporter/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG ALPINE_VERSION="3.23"
-ARG GO_VERSION
+ARG GO_VERSION="1.23.7"
 
 FROM golang:${GO_VERSION} AS builder
 


### PR DESCRIPTION
Adds a default value (`1.23.7`) for the `GO_VERSION` ARG in `chart/dockerfiles/pgbouncer-exporter/Dockerfile`, matching `EXPECTED_GO_VERSION` in `build_and_push.sh`. This allows the Dockerfile to be built standalone without having to pass `--build-arg GO_VERSION=...`, while the build script continues to pass it explicitly.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)