### PR TITLE
Add dag_bundle_config_file configuration setting

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3087,6 +3087,15 @@ dag_processor:
       example: "/tmp/some-place"
       default: ~
 
+    dag_bundle_config_file:
+      description: |
+        String path to json file with Dag bundle configuration.
+        For more details see ``[dag_processor] dag_bundle_config_list``.
+      version_added: ~
+      type: string
+      example: "/opt/airflow/config/dag_bundles.json"
+      default: ~
+
     dag_bundle_config_list:
       description: |
         List of backend configs.  Must supply name, classpath, and kwargs for each backend.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3124,6 +3124,15 @@ dag_processor:
       example: "/tmp/some-place"
       default: ~
 
+    dag_bundle_config_file:
+      description: |
+        String path to json file with Dag bundle configuration.
+        For more details see ``[dag_processor] dag_bundle_config_list``.
+      version_added: ~
+      type: string
+      example: "/opt/airflow/config/dag_bundles.json"
+      default: ~
+
     dag_bundle_config_list:
       description: |
         List of backend configs.  Must supply name, classpath, and kwargs for each backend.

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import os
 import warnings
@@ -241,7 +242,13 @@ class DagBundlesManager(LoggingMixin):
         if self._bundle_config:
             return
 
-        config_list = conf.getjson("dag_processor", "dag_bundle_config_list")
+        bundle_config_file = conf.get("dag_processor", "dag_bundle_config_file", fallback=None)
+        if bundle_config_file and os.path.exists(bundle_config_file):
+            with open(bundle_config_file) as f:
+                config_list = json.load(f)
+            self.log.info("Loading bundle config from %s", bundle_config_file)
+        else:
+            config_list = conf.getjson("dag_processor", "dag_bundle_config_list")
         if not config_list:
             return
         if not isinstance(config_list, list):

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import os
 import warnings
@@ -274,7 +275,13 @@ class DagBundlesManager(LoggingMixin):
         if self._bundle_config:
             return
 
-        config_list = conf.getjson("dag_processor", "dag_bundle_config_list")
+        bundle_config_file = conf.get("dag_processor", "dag_bundle_config_file", fallback=None)
+        if bundle_config_file and os.path.exists(bundle_config_file):
+            with open(bundle_config_file) as f:
+                config_list = json.load(f)
+            self.log.info("Loading bundle config from %s", bundle_config_file)
+        else:
+            config_list = conf.getjson("dag_processor", "dag_bundle_config_list")
         if not config_list:
             return
         if not isinstance(config_list, list):

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -42,6 +42,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import OperationalError
 from uuid6 import uuid7
 
+from airflow._shared.module_loading import import_string
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.dag_processing.bundles.base import BaseDagBundle
@@ -2215,6 +2216,31 @@ class TestDagFileProcessorManager:
         assert dag_model.task_outlet_asset_references == [
             TaskOutletAssetReference(asset_id=mock.ANY, dag_id="dag_with_skip_task", task_id="skip_task")
         ]
+
+    def test_loading_bundle_config_from_file(self, tmp_path):
+        config = [
+            {
+                "name": "bundleone",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": "/dev/null", "refresh_interval": 0},
+            },
+            {
+                "name": "bundletwo",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": "/dev/null", "refresh_interval": 300},
+            },
+        ]
+        config_file = tmp_path / "bundle_config.json"
+
+        with open(config_file, "w") as f:
+            json.dump(config, f)
+
+        with conf_vars({("dag_processor", "dag_bundle_config_file"): str(config_file)}):
+            bm = DagBundlesManager()
+            for bundle in config:
+                assert bundle["name"] in bm._bundle_config
+                assert import_string(bundle["classpath"]) == bm._bundle_config[bundle["name"]].bundle_class
+                assert bundle["kwargs"] == bm._bundle_config[bundle["name"]].kwargs
 
     def test_bundles_are_refreshed(self):
         """

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -42,6 +42,7 @@ from sqlalchemy import func, select
 from sqlalchemy.exc import OperationalError
 from uuid6 import uuid7
 
+from airflow._shared.module_loading import import_string
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.dag_processing.bundles.base import BaseDagBundle
@@ -2523,6 +2524,31 @@ class TestDagFileProcessorManager:
         assert dag_model.task_outlet_asset_references == [
             TaskOutletAssetReference(asset_id=mock.ANY, dag_id="dag_with_skip_task", task_id="skip_task")
         ]
+
+    def test_loading_bundle_config_from_file(self, tmp_path):
+        config = [
+            {
+                "name": "bundleone",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": "/dev/null", "refresh_interval": 0},
+            },
+            {
+                "name": "bundletwo",
+                "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
+                "kwargs": {"path": "/dev/null", "refresh_interval": 300},
+            },
+        ]
+        config_file = tmp_path / "bundle_config.json"
+
+        with open(config_file, "w") as f:
+            json.dump(config, f)
+
+        with conf_vars({("dag_processor", "dag_bundle_config_file"): str(config_file)}):
+            bm = DagBundlesManager()
+            for bundle in config:
+                assert bundle["name"] in bm._bundle_config
+                assert import_string(bundle["classpath"]) == bm._bundle_config[bundle["name"]].bundle_class
+                assert bundle["kwargs"] == bm._bundle_config[bundle["name"]].kwargs
 
     def test_bundles_are_refreshed(self):
         """


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Add dag_bundle_config_file setting
---
Add `dag_bundle_config_file` setting to allow loading dag bundle config from a json file instead of from an inline string. Multi team configurations for large organisations can become more cumbersome, and so moving the config to a separate file enables better management of large bundle configs. This also allows the dag bundle config to be managed separately from the airflow config in a more intuitive way.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->
- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---