### PR TITLE
Handle undecryptable Variable values gracefully in Stable REST API

### DIFF
--- a/airflow-core/newsfragments/65452.bugfix.rst
+++ b/airflow-core/newsfragments/65452.bugfix.rst
@@ -1,1 +1,0 @@
-Return ``"value": null`` (HTTP 200) from ``GET /variables/{key}`` when the stored value cannot be decrypted, matching ``GET /variables`` instead of failing with HTTP 500.

--- a/airflow-core/newsfragments/65452.bugfix.rst
+++ b/airflow-core/newsfragments/65452.bugfix.rst
@@ -1,5 +1,1 @@
-``GET /variables/{variable_key}`` now returns ``"value": null`` when the stored
-value cannot be decrypted (for example after a Fernet key rotation or
-misconfiguration), matching the behavior of the list endpoint
-``GET /variables``. Previously the detail endpoint failed with HTTP 500 because
-the response schema declared ``value`` as a required string.
+Return ``"value": null`` (HTTP 200) from ``GET /variables/{key}`` when the stored value cannot be decrypted, matching ``GET /variables`` instead of failing with HTTP 500.

--- a/airflow-core/newsfragments/65452.bugfix.rst
+++ b/airflow-core/newsfragments/65452.bugfix.rst
@@ -1,0 +1,5 @@
+``GET /variables/{variable_key}`` now returns ``"value": null`` when the stored
+value cannot be decrypted (for example after a Fernet key rotation or
+misconfiguration), matching the behavior of the list endpoint
+``GET /variables``. Previously the detail endpoint failed with HTTP 500 because
+the response schema declared ``value`` as a required string.

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -33,12 +33,6 @@ class VariableResponse(BaseModel):
     """Variable serializer for responses."""
 
     key: str
-    # ``val`` is intentionally Optional. ``Variable.get_val`` returns ``None`` when
-    # the stored value cannot be decrypted (e.g. after a Fernet key rotation or
-    # misconfiguration). Declaring the field as nullable surfaces that state as
-    # ``"value": null`` in the response instead of raising HTTP 500 due to
-    # response-schema validation. This also matches the behavior of the list
-    # endpoint which has always returned ``null`` in the same scenario.
     val: str | None = Field(alias="value", default=None)
     description: str | None
     is_encrypted: bool
@@ -46,8 +40,6 @@ class VariableResponse(BaseModel):
 
     @model_validator(mode="after")
     def redact_val(self) -> Self:
-        # Skip redaction when decryption failed upstream; there is nothing to mask
-        # and ``None`` must be preserved so clients can detect the failure.
         if self.val is None:
             return self
         try:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -33,7 +33,7 @@ class VariableResponse(BaseModel):
     """Variable serializer for responses."""
 
     key: str
-    val: str = Field(alias="value")
+    val: str | None = Field(alias="value", default=None)
     description: str | None
     is_encrypted: bool
     team_name: str | None

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -33,6 +33,12 @@ class VariableResponse(BaseModel):
     """Variable serializer for responses."""
 
     key: str
+    # ``val`` is intentionally Optional. ``Variable.get_val`` returns ``None`` when
+    # the stored value cannot be decrypted (e.g. after a Fernet key rotation or
+    # misconfiguration). Declaring the field as nullable surfaces that state as
+    # ``"value": null`` in the response instead of raising HTTP 500 due to
+    # response-schema validation. This also matches the behavior of the list
+    # endpoint which has always returned ``null`` in the same scenario.
     val: str | None = Field(alias="value", default=None)
     description: str | None
     is_encrypted: bool
@@ -40,6 +46,8 @@ class VariableResponse(BaseModel):
 
     @model_validator(mode="after")
     def redact_val(self) -> Self:
+        # Skip redaction when decryption failed upstream; there is nothing to mask
+        # and ``None`` must be preserved so clients can detect the failure.
         if self.val is None:
             return self
         try:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -15074,7 +15074,9 @@ components:
           type: string
           title: Key
         value:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Value
         description:
           anyOf:
@@ -15092,7 +15094,6 @@ components:
       type: object
       required:
       - key
-      - value
       - description
       - is_encrypted
       - team_name

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -7073,7 +7073,14 @@ export const $VariableResponse = {
             title: 'Key'
         },
         value: {
-            type: 'string',
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Value'
         },
         description: {
@@ -7104,7 +7111,7 @@ export const $VariableResponse = {
         }
     },
     type: 'object',
-    required: ['key', 'value', 'description', 'is_encrypted', 'team_name'],
+    required: ['key', 'description', 'is_encrypted', 'team_name'],
     title: 'VariableResponse',
     description: 'Variable serializer for responses.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1720,7 +1720,7 @@ export type VariableCollectionResponse = {
  */
 export type VariableResponse = {
     key: string;
-    value: string;
+    value?: string | null;
     description: string | null;
     is_encrypted: boolean;
     team_name: string | null;

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/EditVariableButton.tsx
@@ -50,7 +50,7 @@ const EditVariableButton = ({ disabled, variable }: Props) => {
     description: variable.description ?? "",
     key: variable.key,
     team_name: variable.team_name ?? "",
-    value: formatValue(variable.value),
+    value: formatValue(variable.value ?? ""),
   };
   const { editVariable, error, isPending, setError } = useEditVariable(initialVariableValue, {
     onSuccessConfirm: onClose,

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -94,9 +94,9 @@ const getColumns = ({
       cell: ({ row }) => (
         <Box minWidth={0} overflowWrap="anywhere" wordBreak="break-word">
           <TrimText
-            charLimit={open ? row.original.value.length : undefined}
+            charLimit={open ? (row.original.value?.length ?? 0) : undefined}
             showTooltip
-            text={row.original.value}
+            text={row.original.value ?? null}
           />
         </Box>
       ),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -254,6 +254,31 @@ class TestGetVariable(TestVariableEndpoint):
         body = response.json()
         assert f"The Variable with key: `{TEST_VARIABLE_KEY}` was not found" == body["detail"]
 
+    def test_get_should_respond_200_with_null_value_when_decryption_fails(self, test_client, session):
+        """
+        Regression test for https://github.com/apache/airflow/pull/65452.
+
+        If the stored value cannot be decrypted (for example after a Fernet key
+        rotation) ``Variable.get_val`` returns ``None``. The endpoint must then
+        respond with HTTP 200 and ``"value": null`` instead of failing with an
+        HTTP 500 caused by response-schema validation.
+        """
+        self.create_variables()
+        with mock.patch(
+            "airflow.models.variable.Variable.get_val", return_value=None
+        ):
+            response = test_client.get(f"/variables/{TEST_VARIABLE_KEY}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {
+            "key": TEST_VARIABLE_KEY,
+            "value": None,
+            "description": TEST_VARIABLE_DESCRIPTION,
+            "is_encrypted": True,
+            "team_name": None,
+        }
+
 
 class TestGetVariables(TestVariableEndpoint):
     @pytest.mark.enable_redact

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -263,10 +263,11 @@ class TestGetVariable(TestVariableEndpoint):
         respond with HTTP 200 and ``"value": null`` instead of failing with an
         HTTP 500 caused by response-schema validation.
         """
+        from cryptography.fernet import InvalidToken
+
         self.create_variables()
-        with mock.patch(
-            "airflow.models.variable.Variable.get_val", return_value=None
-        ):
+        with mock.patch("airflow.models.variable.get_fernet") as mock_get_fernet:
+            mock_get_fernet.return_value.decrypt.side_effect = InvalidToken
             response = test_client.get(f"/variables/{TEST_VARIABLE_KEY}")
 
         assert response.status_code == 200

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -994,7 +994,7 @@ class VariableResponse(BaseModel):
     """
 
     key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
+    value: Annotated[str | None, Field(title="Value")] = None
     description: Annotated[str | None, Field(title="Description")] = None
     is_encrypted: Annotated[bool, Field(title="Is Encrypted")]
     team_name: Annotated[str | None, Field(title="Team Name")] = None


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0 -->
**Fix Variables API returning 500 for undecryptable values**

**What is the problem?**
When a Fernet key is rotated or misconfigured, previously stored encrypted Variable values may become undecryptable.

**Calling:**
GET /api/v1/variables/{key}
result in a 500 Internal Server Error with a schema validation message

**While calling list varibales**
GET /api/v2/variables 
returns the variables successfully, but with values as null when decryption fails.

**List api output:**
{
"total_entries": 1,
"variables": [
{
"description": "Testing variable use",
"key": "Testing",
"value": null
}
]
}

**GET variable Response:**
{
"detail": "None is not of type 'string'\n\nFailed validating 'type' in schema['allOf'][1]['properties']['value']:\n{'type': 'string'}\n\nOn instance['value']:\n None",
"status": 500,
"title": "Response body does not conform to specification",
"type": "https://airflow.apache.org/docs/apache-airflow/3.2.0/stable-rest-api-ref.html#section/Errors/Unknown"
}

This occurs because the decrypted value becomes None, which violates the OpenAPI schema expecting a string and inconsistent and confusing API behavior.  

**Expected output:**
{
"description": "Testing variable use",
"key": "Testing",
"value": null
}

**Why is this change needed?**

- A 500 error is misleading since this is a predictable scenario (Fernet mismatch)
- The API response violates schema validation
- Leads to inconsistent and confusing API behavior
- Impacts API consumers relying on stable responses

**What is changed?**
The value field in the Variables API response schema has been updated to handle undecryptable values safely:
- **Before:**
   val: str = Field(alias="value")
- **After**
   val: str | None = Field(alias="value", default=None)

**Why this change?**
- Previously, the field strictly required a string
- When Fernet decryption failed, the value became None
- This caused schema validation errors → 500 Internal Server Error

Related issue
open: #65391
