### PR TITLE
Fix constraints diff status handling in ci_diff_constraints script

### DIFF
--- a/scripts/ci/constraints/ci_diff_constraints.sh
+++ b/scripts/ci/constraints/ci_diff_constraints.sh
@@ -17,4 +17,17 @@
 # under the License.
 cp -v ./files/constraints-*/constraints*.txt constraints/
 cd constraints || exit 1
-git diff --color --exit-code --ignore-matching-lines="^#.*" || echo "No changes in constraints"
+
+set +e
+git diff --color --exit-code --ignore-matching-lines="^#.*"
+diff_status=$?
+set -e
+
+if [[ ${diff_status} -eq 0 ]]; then
+echo "No changes in constraints"
+elif [[ ${diff_status} -eq 1 ]]; then
+echo "Changes detected in constraints, proceeding..."
+else
+echo "Failed to diff constraints"
+exit "${diff_status}"
+fi


### PR DESCRIPTION
## Why
The constraints diff step currently treats non-zero` git diff` results as a normal success path, which can cause misleading output and hide real failures.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
