### PR TITLE
Include TI UUID in scheduler, DAG processor, triggerer, and worker logs

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -301,7 +301,14 @@ def _execute_callbacks(
     dagbag: DagBag, callback_requests: list[CallbackRequest], log: FilteringBoundLogger
 ) -> None:
     for request in callback_requests:
-        log.debug("Processing Callback Request", request=request.to_json())
+        if isinstance(request, (TaskCallbackRequest, EmailRequest)):
+            log.debug(
+                "Processing Callback Request",
+                request=request.to_json(),
+                ti_id=str(request.ti.id),
+            )
+        else:
+            log.debug("Processing Callback Request", request=request.to_json())
         with BundleVersionLock(
             bundle_name=request.bundle_name,
             bundle_version=request.bundle_version,
@@ -366,6 +373,7 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
             dag_id=request.ti.dag_id,
             task_id=request.ti.task_id,
             run_id=request.ti.run_id,
+            ti_id=str(request.ti.id),
         )
         return
 
@@ -415,11 +423,21 @@ def _execute_task_callbacks(dagbag: DagBag, request: TaskCallbackRequest, log: F
 
     for idx, callback in enumerate(callbacks):
         callback_repr = get_callback_representation(callback)
-        log.info("Executing Task callback at index %d: %s", idx, callback_repr)
+        log.info(
+            "Executing Task callback at index %d: %s (ti_id=%s)",
+            idx,
+            callback_repr,
+            request.ti.id,
+        )
         try:
             callback(context)
         except Exception:
-            log.exception("Error in callback at index %d: %s", idx, callback_repr)
+            log.exception(
+                "Error in callback at index %d: %s (ti_id=%s)",
+                idx,
+                callback_repr,
+                request.ti.id,
+            )
 
 
 def _execute_email_callbacks(dagbag: DagBag, request: EmailRequest, log: FilteringBoundLogger) -> None:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -964,17 +964,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 continue
             if not ti.dag_version_id:
                 self.log.warning(
-                    "TaskInstance %s (ti_id=%s) does not have a dag_version_id set, cannot be enqueued. "
+                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
                     "This would get unstuck and dag_version_id updated.",
                     ti,
-                    ti.id,
                 )
                 continue
 
             self.log.debug(
-                "Queueing workload for TI: %s ti_id=%s try_number=%d state=%s scheduler_job_id=%s executor=%s",
+                "Queueing workload for TI: %s try_number=%d state=%s scheduler_job_id=%s executor=%s",
                 ti,
-                ti.id,
                 ti.try_number,
                 ti.state,
                 self.job.id,
@@ -1251,12 +1249,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if ti.try_number != try_number:
                 cls.logger().warning(
                     "TI try_number mismatch: db_try_number=%d event_try_number=%d "
-                    "ti=%s ti_id=%s state=%s job_id=%s. "
+                    "ti=%s state=%s job_id=%s. "
                     "Another scheduler may have already modified this TI.",
                     ti.try_number,
                     try_number,
                     ti,
-                    ti.id,
                     ti.state,
                     job_id,
                 )
@@ -1264,7 +1261,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             if state in (TaskInstanceState.QUEUED, TaskInstanceState.RUNNING):
                 ti.external_executor_id = info
-                cls.logger().info("Setting external_executor_id for %s (ti_id=%s) to %s", ti, ti.id, info)
+                cls.logger().info("Setting external_executor_id for %s to %s", ti, info)
                 continue
 
             msg = (
@@ -1339,16 +1336,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     dag = scheduler_dag_bag.get_dag_for_run(dag_run=ti.dag_run, session=session)
                     if not dag:
                         cls.logger().error(
-                            "DAG '%s' for task instance %s (ti_id=%s) not found in serialized_dag table",
+                            "DAG '%s' for task instance %s not found in serialized_dag table",
                             ti.dag_id,
                             ti,
-                            ti.id,
                         )
                         raise DagNotFound(f"DAG '{ti.dag_id}' not found in serialized_dag table")
 
                     task = dag.get_task(ti.task_id)
                 except Exception:
-                    cls.logger().exception("Marking task instance %s (ti_id=%s) as %s", ti, ti.id, state)
+                    cls.logger().exception("Marking task instance %s as %s", ti, state)
                     ti.set_state(state)
                     continue
                 ti.task = task
@@ -1390,10 +1386,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Handle cleared tasks that were successfully terminated by executor
                 if ti.state == TaskInstanceState.RESTARTING and state == TaskInstanceState.SUCCESS:
                     cls.logger().info(
-                        "Task %s (ti_id=%s) was cleared and successfully terminated. "
-                        "Setting to scheduled for retry.",
+                        "Task %s was cleared and successfully terminated. Setting to scheduled for retry.",
                         ti,
-                        ti.id,
                     )
                     # Adjust max_tries to allow retry beyond normal limits (like clearing does)
                     ti.max_tries = ti.try_number + ti.task.retries
@@ -1403,9 +1397,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Send email notification request to DAG processor via DB
                 if task.email and (task.email_on_failure or task.email_on_retry):
                     cls.logger().info(
-                        "Sending email request for task %s (ti_id=%s) to DAG Processor",
+                        "Sending email request for task %s to DAG Processor",
                         ti,
-                        ti.id,
                     )
                     # Safely extract bundle info with fallback for legacy tasks
                     # (dag_version may be None after Airflow 2 → 3 migration).
@@ -2513,7 +2506,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         num_times_stuck = self._get_num_times_stuck_in_queued(ti, session)
         if num_times_stuck < self._num_stuck_queued_retries:
-            self.log.info("Task stuck in queued; will try to requeue. task_instance=%s ti_id=%s", ti, ti.id)
+            self.log.info("Task stuck in queued; will try to requeue. task_instance=%s", ti)
             session.add(
                 Log(
                     event=TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT,
@@ -2527,9 +2520,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self._reschedule_stuck_task(ti, session=session)
         else:
             self.log.info(
-                "Task requeue attempts exceeded max; marking failed. task_instance=%s ti_id=%s",
+                "Task requeue attempts exceeded max; marking failed. task_instance=%s",
                 ti,
-                ti.id,
             )
             msg = f"Task was requeued more than {self._num_stuck_queued_retries} times and will be failed."
             session.add(

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -964,14 +964,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 continue
             if not ti.dag_version_id:
                 self.log.warning(
-                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
+                    "TaskInstance %s (ti_id=%s) does not have a dag_version_id set, cannot be enqueued. "
                     "This would get unstuck and dag_version_id updated.",
                     ti,
+                    ti.id,
                 )
                 continue
 
             self.log.debug(
-                "Queueing workload for TI: %s id=%s try_number=%d state=%s scheduler_job_id=%s executor=%s",
+                "Queueing workload for TI: %s ti_id=%s try_number=%d state=%s scheduler_job_id=%s executor=%s",
                 ti,
                 ti.id,
                 ti.try_number,
@@ -1263,11 +1264,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             if state in (TaskInstanceState.QUEUED, TaskInstanceState.RUNNING):
                 ti.external_executor_id = info
-                cls.logger().info("Setting external_executor_id for %s to %s", ti, info)
+                cls.logger().info("Setting external_executor_id for %s (ti_id=%s) to %s", ti, ti.id, info)
                 continue
 
             msg = (
-                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, map_index=%s, "
+                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, map_index=%s, ti_id=%s, "
                 "run_start_date=%s, run_end_date=%s, "
                 "run_duration=%s, state=%s, executor=%s, executor_state=%s, try_number=%s, max_tries=%s, "
                 "pool=%s, queue=%s, priority_weight=%d, operator=%s, queued_dttm=%s, scheduled_dttm=%s,"
@@ -1279,6 +1280,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ti.task_id,
                 ti.run_id,
                 ti.map_index,
+                ti.id,
                 ti.start_date,
                 ti.end_date,
                 ti.duration,
@@ -1337,15 +1339,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     dag = scheduler_dag_bag.get_dag_for_run(dag_run=ti.dag_run, session=session)
                     if not dag:
                         cls.logger().error(
-                            "DAG '%s' for task instance %s not found in serialized_dag table",
+                            "DAG '%s' for task instance %s (ti_id=%s) not found in serialized_dag table",
                             ti.dag_id,
                             ti,
+                            ti.id,
                         )
                         raise DagNotFound(f"DAG '{ti.dag_id}' not found in serialized_dag table")
 
                     task = dag.get_task(ti.task_id)
                 except Exception:
-                    cls.logger().exception("Marking task instance %s as %s", ti, state)
+                    cls.logger().exception("Marking task instance %s (ti_id=%s) as %s", ti, ti.id, state)
                     ti.set_state(state)
                     continue
                 ti.task = task
@@ -1387,7 +1390,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Handle cleared tasks that were successfully terminated by executor
                 if ti.state == TaskInstanceState.RESTARTING and state == TaskInstanceState.SUCCESS:
                     cls.logger().info(
-                        "Task %s was cleared and successfully terminated. Setting to scheduled for retry.", ti
+                        "Task %s (ti_id=%s) was cleared and successfully terminated. "
+                        "Setting to scheduled for retry.",
+                        ti,
+                        ti.id,
                     )
                     # Adjust max_tries to allow retry beyond normal limits (like clearing does)
                     ti.max_tries = ti.try_number + ti.task.retries
@@ -1397,8 +1403,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Send email notification request to DAG processor via DB
                 if task.email and (task.email_on_failure or task.email_on_retry):
                     cls.logger().info(
-                        "Sending email request for task %s to DAG Processor",
+                        "Sending email request for task %s (ti_id=%s) to DAG Processor",
                         ti,
+                        ti.id,
                     )
                     # Safely extract bundle info with fallback for legacy tasks
                     # (dag_version may be None after Airflow 2 → 3 migration).
@@ -2506,7 +2513,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         num_times_stuck = self._get_num_times_stuck_in_queued(ti, session)
         if num_times_stuck < self._num_stuck_queued_retries:
-            self.log.info("Task stuck in queued; will try to requeue. task_instance=%s", ti)
+            self.log.info("Task stuck in queued; will try to requeue. task_instance=%s ti_id=%s", ti, ti.id)
             session.add(
                 Log(
                     event=TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT,
@@ -2520,8 +2527,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self._reschedule_stuck_task(ti, session=session)
         else:
             self.log.info(
-                "Task requeue attempts exceeded max; marking failed. task_instance=%s",
+                "Task requeue attempts exceeded max; marking failed. task_instance=%s ti_id=%s",
                 ti,
+                ti.id,
             )
             msg = f"Task was requeued more than {self._num_stuck_queued_retries} times and will be failed."
             session.add(

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1305,7 +1305,16 @@ class TriggerRunner:
 
             await greenback.ensure_portal()
 
-        bind_log_contextvars(trigger_id=trigger_id)
+        ti = trigger.task_instance
+        bind_log_contextvars(
+            trigger_id=trigger_id,
+            ti_id=str(ti.id) if ti else None,
+            dag_id=ti.dag_id if ti else None,
+            task_id=ti.task_id if ti else None,
+            run_id=ti.run_id if ti else None,
+            try_number=ti.try_number if ti else None,
+            map_index=ti.map_index if ti else None,
+        )
 
         name = self.triggers[trigger_id]["name"]
         self.log.info("trigger %s starting", name)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1097,7 +1097,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         prefix = f"<TaskInstance: {self.dag_id}.{self.task_id} {self.run_id} "
         if self.map_index != -1:
             prefix += f"map_index={self.map_index} "
-        return prefix + f"[{self.state}]>"
+        return prefix + f"[{self.state}] ti_id={self.id}>"
 
     def next_retry_datetime(self):
         """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -692,7 +692,7 @@ class TestSchedulerJob:
             bundle_name="dag_maker",
             bundle_version=None,
             msg=f"Executor {executor} reported that the task instance "
-            "<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued]> "
+            f"<TaskInstance: test_process_executor_events_with_callback.dummy_task test [queued] ti_id={ti1.id}> "
             "finished with state failed, but the task instance's state attribute is queued. "
             "Learn more: https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#task-state-changed-externally",
             context_from_server=mock.ANY,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1904,11 +1904,13 @@ class TestSchedulerJob:
         some_pool = Pool(pool="some_pool", slots=2, description="my pool", include_deferred=False)
         session.add(some_pool)
         session.commit()
+        cannot_run_ti_id = dr.task_instances[0].id
         with caplog.at_level(logging.WARNING):
             self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
             assert (
-                "Not executing <TaskInstance: "
-                "SchedulerJobTest.test_test_not_enough_pool_slots.cannot_run test [scheduled]>. "
+                f"Not executing <TaskInstance: "
+                f"SchedulerJobTest.test_test_not_enough_pool_slots.cannot_run test [scheduled] "
+                f"ti_id={cannot_run_ti_id}>. "
                 "Requested pool slots (4) are greater than total pool slots: '2' for pool: some_pool"
                 in caplog.text
             )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1904,7 +1904,7 @@ class TestSchedulerJob:
         some_pool = Pool(pool="some_pool", slots=2, description="my pool", include_deferred=False)
         session.add(some_pool)
         session.commit()
-        cannot_run_ti_id = dr.task_instances[0].id
+        cannot_run_ti_id = next(t for t in dr.task_instances if t.task_id == "cannot_run").id
         with caplog.at_level(logging.WARNING):
             self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
             assert (

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -38,6 +38,7 @@ import structlog
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import AwareDatetime, ConfigDict, Field, JsonValue, TypeAdapter
+from structlog.contextvars import bind_contextvars
 
 from airflow.dag_processing.bundles.base import BaseDagBundle, BundleVersionLock
 from airflow.dag_processing.bundles.manager import DagBundlesManager
@@ -924,6 +925,17 @@ def startup(msg: StartupDetails) -> tuple[RuntimeTaskInstance, Context, Logger]:
 
         setproctitle(f"airflow worker -- {msg.ti.id}")
 
+    # Bind TI identifiers so every subsequent log line from this worker process
+    # carries ti_id, enabling single-grep lifecycle reconstruction across components.
+    bind_contextvars(
+        ti_id=str(msg.ti.id),
+        dag_id=msg.ti.dag_id,
+        task_id=msg.ti.task_id,
+        run_id=msg.ti.run_id,
+        try_number=msg.ti.try_number,
+        map_index=msg.ti.map_index,
+    )
+
     try:
         get_listener_manager().hook.on_starting(component=TaskRunnerMarker())
     except Exception:
@@ -1170,8 +1182,6 @@ def _validate_task_inlets_and_outlets(*, ti: RuntimeTaskInstance, log: Logger) -
 def _defer_task(
     defer: TaskDeferred, ti: RuntimeTaskInstance, log: Logger
 ) -> tuple[ToSupervisor, TaskInstanceState]:
-    # TODO: Should we use structlog.bind_contextvars here for dag_id, task_id & run_id?
-
     log.info("Pausing task as DEFERRED. ", dag_id=ti.dag_id, task_id=ti.task_id, run_id=ti.run_id)
     classpath, trigger_kwargs = defer.trigger.serialize()
     queue: str | None = None


### PR DESCRIPTION
Engineers currently cannot grep a single `ti_id` and reconstruct a task's full lifecycle timeline. The Execution API binds `ti_id` to every log line via `bind_contextvars`, but scheduler, DAG processor, triggerer, and worker each emit it in some places and not others. This PR closes that gap.

## What changed

| Component | Change | Rationale |
|---|---|---|
| **Worker** (`task-sdk/.../task_runner.py`) | `bind_contextvars(ti_id=str(msg.ti.id), ...)` at the top of `startup()` | One worker process = one TI. No cross-task leak risk, so context binding is strictly correct and instruments every subsequent log line (including ones added in future changes). |
| **Triggerer** (`jobs/triggerer_job_runner.py:1308`) | Extend the existing `bind_log_contextvars(trigger_id=...)` to also bind `ti_id` + composite TI keys when `trigger.task_instance` is present | `run_trigger` runs inside `asyncio.create_task`, which snapshots the context at creation, so the binding stays scoped to that coroutine. |
| **Scheduler** (`jobs/scheduler_job_runner.py`) | Add `ti_id=%s` as a positional arg to eight TI-touching log calls across `_enqueue_task_instances_with_queued_state`, `process_executor_events`, and `_maybe_requeue_stuck_ti` | Explicit positional args (no `bind_contextvars`) because the scheduler is a long-running process and any unhandled exception mid-loop would leave a stale `ti_id` bound for the rest of the process lifetime, corrupting all subsequent log lines. Per-iteration `with bound_contextvars(...)` would be correct but re-indents ~200 lines of hot-path code. Positional args are both safer and less invasive. |
| **DAG processor** (`dag_processing/processor.py`) | Add `ti_id` to `_execute_callbacks` and `_execute_task_callbacks` log calls (kwarg where the call is pure-structlog style, `%-format` positional where the call is stdlib style) | Same reasoning as scheduler. |

## Design notes

- **Why not `bind_contextvars` everywhere?** The earlier draft of this PR did exactly that. But we found a contextvar leak: if any exception propagates out of the per-TI loop body, the post-loop `unbind_contextvars` is skipped and the last TI's `ti_id` stays bound for the remainder of the scheduler process. Because `merge_contextvars` is wired into the stdlib logging `foreign_pre_chain`, this taints every subsequent log line -- including ones that have nothing to do with that TI. Inverts the goal of the PR. Per-iteration `bound_contextvars` context manager is correct but requires re-indenting long loop bodies. For the scheduler and DAG processor, explicit positional `ti_id=%s` args are both safer and less invasive.
- **Why is it OK to bind in the worker?** A worker is a fresh process that runs exactly one TI. There is no cross-iteration or cross-TI state to leak into. The bind is strictly correct and instruments every log line for free.
- **Why is it OK to bind in the triggerer?** `run_trigger` is launched via `asyncio.create_task`, which copies the current `contextvars.Context` at task creation. Any contextvar bound inside the coroutine is scoped to that task and cannot leak into another trigger's coroutine or the triggerer's supervisor loop.
