### PR TITLE
fix: Parameterise key sorting in "Rendered Template" view

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -499,6 +499,17 @@ core:
       type: integer
       example: ~
       default: "4096"
+    sort_rendered_template_fields:
+      description: |
+        Whether to sort dictionary keys alphabetically when rendering template fields for display
+        in the "Rendered Template" view. When set to True (the default), dictionary keys are sorted
+        to ensure consistent ordering. Set to False to preserve the original key ordering as
+        defined by the operator, which can be useful for large nested context objects where
+        the original key order is meaningful.
+      version_added: 3.1.0
+      type: boolean
+      example: ~
+      default: "True"
     execution_api_server_url:
       description: |
         The url of the execution api server. Default is ``{BASE_URL}/execution/``

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -91,9 +91,9 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
         # and need to be converted to lists
         return template_field
     template_field = translate_tuples_to_lists(template_field)
-    # Sort dictionaries recursively to ensure consistent string representation
-    # This prevents hash inconsistencies when dict ordering varies
-    if isinstance(template_field, dict):
+    if isinstance(template_field, dict) and conf.getboolean(
+        "core", "sort_rendered_template_fields", fallback=True
+    ):
         template_field = sort_dict_recursively(template_field)
     serialized = str(template_field)
     if len(serialized) > max_length:


### PR DESCRIPTION
Closes #27026

## What this fixes

In `airflow/www/views.py` around line 1254, remove the hardcoded `sort_keys=True` from the Rendered Template JSON serialization and replace it with a configurable flag (Airflow config option or query parameter), so operators can preserve original template key ordering for large nested context objects.