### PR TITLE
fix: FAB 3.6.0 cookie creation issue with string pattern on bytes

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/session.py
+++ b/providers/fab/src/airflow/providers/fab/www/session.py
@@ -25,14 +25,14 @@ from flask_session.sqlalchemy import SqlAlchemySessionInterface
 
 class _LazySafeSerializer:
     def dumps(self, session_dict):
-        encoder = msgspec.msgpack.Encoder(
-            enc_hook=lambda obj: str(obj) if isinstance(obj, LazyString) else obj
-        )
-        return encoder.encode(dict(session_dict))
+        encoder = msgspec.json.Encoder(enc_hook=lambda obj: str(obj) if isinstance(obj, LazyString) else obj)
+        return encoder.encode(dict(session_dict)).decode("utf-8")
 
     def loads(self, data):
-        decoder = msgspec.msgpack.Decoder()
-        return decoder.decode(data)
+        try:
+            return msgspec.json.Decoder().decode(data)
+        except Exception:
+            return msgspec.msgpack.Decoder().decode(data)
 
     # optional old API
     encode = dumps


### PR DESCRIPTION
Closes #64921

## What this fixes

In `airflow/providers/fab/www/session.py`, the session save mechanism passes bytes to Werkzeug's `dump_cookie` function, which expects a string value, causing a `TypeError: cannot use a string pattern on a bytes-like object`. The fix is to decode the bytes cookie value to a UTF-8 string before passing it to Werkzeug's cookie-setting logic, likely a one-line `.decode('utf-8')` call at the serialization boundary.