### PR TITLE
Fix REST API pools: serialize unlimited open_slots as -1 instead of inf

### DIFF
--- a/airflow/api_connexion/schemas/pool_schema.py
+++ b/airflow/api_connexion/schemas/pool_schema.py
@@ -71,7 +71,8 @@ class PoolSchema(SQLAlchemySchema):
 
     @staticmethod
     def get_open_slots(obj: Pool) -> int:
-        """Return the open slots of the pool.
+        """
+        Return the open slots of the pool.
 
         Unlimited pools (``slots == -1``) use ``float('inf')`` internally; the REST API
         schema requires an integer, so we serialize that as ``-1`` (same convention as

--- a/airflow/api_connexion/schemas/pool_schema.py
+++ b/airflow/api_connexion/schemas/pool_schema.py
@@ -70,9 +70,17 @@ class PoolSchema(SQLAlchemySchema):
         return obj.deferred_slots()
 
     @staticmethod
-    def get_open_slots(obj: Pool) -> float:
-        """Return the open slots of the pool."""
-        return obj.open_slots()
+    def get_open_slots(obj: Pool) -> int:
+        """Return the open slots of the pool.
+
+        Unlimited pools (``slots == -1``) use ``float('inf')`` internally; the REST API
+        schema requires an integer, so we serialize that as ``-1`` (same convention as
+        ``slots`` for unlimited).
+        """
+        open_slots = obj.open_slots()
+        if isinstance(open_slots, float) and open_slots == float("inf"):
+            return -1
+        return int(open_slots)
 
 
 class PoolCollection(NamedTuple):

--- a/tests/api_connexion/schemas/test_pool_schemas.py
+++ b/tests/api_connexion/schemas/test_pool_schemas.py
@@ -54,6 +54,17 @@ class TestPoolSchema:
         }
 
     @provide_session
+    def test_serialize_unlimited_pool_open_slots_as_minus_one(self, session):
+        """Unlimited pools must not serialize open_slots as inf (OpenAPI integer)."""
+        pool_model = Pool(pool="unlimited_pool", slots=-1, include_deferred=False)
+        session.add(pool_model)
+        session.commit()
+        pool_instance = session.query(Pool).filter(Pool.pool == pool_model.pool).first()
+        serialized_pool = pool_schema.dump(pool_instance)
+        assert serialized_pool["slots"] == -1
+        assert serialized_pool["open_slots"] == -1
+
+    @provide_session
     def test_deserialize(self, session):
         pool_dict = {"name": "test_pool", "slots": 3, "include_deferred": True}
         deserialized_pool = pool_schema.load(pool_dict, session=session)

--- a/tests/api_connexion/schemas/test_pool_schemas.py
+++ b/tests/api_connexion/schemas/test_pool_schemas.py
@@ -33,36 +33,37 @@ class TestPoolSchema:
     def teardown_method(self) -> None:
         clear_db_pools()
 
+    @pytest.mark.parametrize(
+        ("pool_name", "slots", "expected_open_slots"),
+        [
+            pytest.param("test_pool", 2, 2, id="finite_slots"),
+            pytest.param("unlimited_pool", -1, -1, id="unlimited_slots_serialized_as_minus_one"),
+        ],
+    )
     @provide_session
-    def test_serialize(self, session):
-        pool_model = Pool(pool="test_pool", slots=2, include_deferred=False)
+    def test_serialize(self, pool_name, slots, expected_open_slots, session):
+        """Pools must serialize open_slots as an integer.
+
+        Unlimited pools (``slots == -1``) must not leak ``inf`` into the JSON
+        response since the OpenAPI schema declares ``open_slots`` as an integer.
+        """
+        pool_model = Pool(pool=pool_name, slots=slots, include_deferred=False)
         session.add(pool_model)
         session.commit()
         pool_instance = session.query(Pool).filter(Pool.pool == pool_model.pool).first()
         serialized_pool = pool_schema.dump(pool_instance)
         assert serialized_pool == {
-            "name": "test_pool",
-            "slots": 2,
+            "name": pool_name,
+            "slots": slots,
             "occupied_slots": 0,
             "running_slots": 0,
             "queued_slots": 0,
             "scheduled_slots": 0,
             "deferred_slots": 0,
-            "open_slots": 2,
+            "open_slots": expected_open_slots,
             "description": None,
             "include_deferred": False,
         }
-
-    @provide_session
-    def test_serialize_unlimited_pool_open_slots_as_minus_one(self, session):
-        """Unlimited pools must not serialize open_slots as inf (OpenAPI integer)."""
-        pool_model = Pool(pool="unlimited_pool", slots=-1, include_deferred=False)
-        session.add(pool_model)
-        session.commit()
-        pool_instance = session.query(Pool).filter(Pool.pool == pool_model.pool).first()
-        serialized_pool = pool_schema.dump(pool_instance)
-        assert serialized_pool["slots"] == -1
-        assert serialized_pool["open_slots"] == -1
 
     @provide_session
     def test_deserialize(self, session):


### PR DESCRIPTION
For pools with unlimited capacity (slots == -1), Pool.open_slots() returns float("inf"). The Connexion v1 REST API schema defines open_slots as an integer, so the serialized response failed OpenAPI validation and clients saw HTTP 500 with a message that inf is not an integer.

This change updates PoolSchema.get_open_slots so unlimited pools expose open_slots as -1, aligned with how unlimited capacity is already represented via slots: -1. A regression test ensures serialization never emits inf for such pools.

**Files changed**

- airflow/api_connexion/schemas/pool_schema.py — map inf to -1 when dumping open_slots; return type is int.
- tests/api_connexion/schemas/test_pool_schemas.py — test for a pool with slots=-1 expecting open_slots=-1.


Related issue
close:  #65377 