### PR TITLE
Use monotonic clock for prek command timing

### DIFF
--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -90,9 +90,9 @@ def run_command(*args, **kwargs) -> None:
         print("#" * min(len(text), 200), file=sys.stderr)
         print(text, file=sys.stderr)
         print("#" * min(len(text), 200), file=sys.stderr)
-    time_start = time.time()
+    time_start = time.monotonic()
     subprocess.check_call(*args, **kwargs)
-    time_end = time.time()
+    time_end = time.monotonic()
     if console:
         console.print(f"[green]After {text}[/]")
         console.print(f"[green]Command finished in {time_end - time_start:.2f} seconds[/]")


### PR DESCRIPTION
Replace` time.time()` with `time.monotonic()` for reliable duration measurement.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
