### PR TITLE
fix(amazon): Support AWS China region endpoints in RedshiftSQLHook OpenLineage identifier parsing

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -285,6 +285,10 @@ class RedshiftSQLHook(DbApiHook):
         parts = hostname.split(".")
         if hostname.endswith("amazonaws.com") and len(parts) == 6:
             return f"{parts[0]}.{parts[2]}"
+        # AWS China regions use the amazonaws.com.cn endpoint suffix
+        # e.g. my-cluster.id.cn-north-1.redshift.amazonaws.com.cn (7 parts vs 6 for global)
+        if hostname.endswith("amazonaws.com.cn") and len(parts) == 7:
+            return f"{parts[0]}.{parts[2]}"
         self.log.debug(
             """Could not parse identifier from hostname '%s'.
             You are probably using IP to connect to Redshift cluster.

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
@@ -297,6 +297,18 @@ class TestRedshiftSQLHookConn:
                 {},
                 "1.2.3.4",
             ),
+            # test with AWS China region endpoint (provisioned cluster)
+            (
+                "cluster_identifier_from_host.id.cn-north-1.redshift.amazonaws.com.cn",
+                {"iam": True},
+                "cluster_identifier_from_host.cn-north-1",
+            ),
+            # test with AWS China region endpoint (serverless)
+            (
+                "workgroup-name.account-id.cn-northwest-1.redshift-serverless.amazonaws.com.cn",
+                {"iam": True},
+                "workgroup-name.cn-northwest-1",
+            ),
         ],
     )
     def test_get_openlineage_redshift_authority_part(


### PR DESCRIPTION
## What

Fix `_get_identifier_from_hostname` in `RedshiftSQLHook` to correctly parse AWS China region endpoints (`amazonaws.com.cn`).

## Why

AWS China regions (cn-north-1, cn-northwest-1) use a different endpoint suffix than global regions:

| Region | Endpoint format | Parts |
|--------|----------------|-------|
| Global | `my-cluster.id.us-east-1.redshift.amazonaws.com` | 6 |
| China | `my-cluster.id.cn-north-1.redshift.amazonaws.com.cn` | 7 |

The existing code only checks `hostname.endswith("amazonaws.com") and len(parts) == 6`, which fails for China endpoints. This causes the OpenLineage authority to fall back to the raw hostname instead of the expected `cluster_identifier.region_name` format.

Affects both provisioned clusters and Redshift Serverless workgroups in China regions.

## How

Added a check for `amazonaws.com.cn` with `len(parts) == 7`, using the same parsing logic (`parts[0].parts[2]`) since the cluster identifier and region are at the same positions.

## Testing

Added two parametrized test cases covering:
- Provisioned cluster in cn-north-1
- Redshift Serverless workgroup in cn-northwest-1

Verified with a real Redshift Serverless endpoint in cn-north-1:
`airflow-test.029295324148.cn-north-1.redshift-serverless.amazonaws.com.cn`