### PR TITLE
Add opt-in Presidio input_guard for outbound LLM PII sanitization

### DIFF
--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -37,6 +37,7 @@
     Connection types <connections/pydantic_ai>
     MCP connection <connections/mcp>
     Hooks <hooks/pydantic_ai>
+    Privacy guard <privacy>
     Toolsets <toolsets>
     Operators <operators/index>
     HITL Review <hitl_review>

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -98,6 +98,30 @@ data back. The result is serialized via ``model_dump()`` for XCom.
     :start-after: [START howto_decorator_agent_structured]
     :end-before: [END howto_decorator_agent_structured]
 
+Input Guard
+-----------
+
+Set ``input_guard`` to sanitize model-bound prompts, message history, tool
+results returned to the model, and system instructions with Presidio:
+
+.. code-block:: python
+
+    AgentOperator(
+        task_id="analyze_customer",
+        llm_conn_id="pydanticai_default",
+        prompt="Investigate alice@example.com and 4111 1111 1111 1111",
+        toolsets=[SQLToolset(db_conn_id="postgres_default")],
+        input_guard={
+            "enabled": True,
+            "mode": "replace",
+            "entities": ("EMAIL_ADDRESS", "CREDIT_CARD"),
+        },
+    )
+
+This first iteration sanitizes **outbound model input only**. Raw values may
+still exist in Airflow-local artifacts such as HITL state, XComs, DEBUG logs,
+and durable cache files. See :doc:`../privacy`.
+
 
 Chaining with Downstream Tasks
 -------------------------------
@@ -230,6 +254,7 @@ Parameters
   every tool call is logged in real time. Default ``True``.
 - ``agent_params``: Additional keyword arguments passed to the pydantic-ai
   ``Agent`` constructor (e.g. ``retries``, ``model_settings``).
+- ``input_guard``: Optional Presidio-based outbound text sanitization config.
 - ``durable``: When ``True``, enables step-level caching of model responses and
   tool results via ObjectStorage. On retry, cached steps are replayed instead of
   re-executing expensive LLM calls. Requires the ``[common.ai] durable_cache_path``

--- a/providers/common/ai/docs/operators/llm.rst
+++ b/providers/common/ai/docs/operators/llm.rst
@@ -61,6 +61,29 @@ via ``agent_params`` — for example, ``retries``, ``model_settings``, or ``tool
 See the `pydantic-ai Agent docs <https://ai.pydantic.dev/api/agent/>`__ for
 the full list of supported parameters.
 
+Input Guard
+-----------
+
+Set ``input_guard`` to sanitize model-bound text with Presidio before the
+request is sent to the LLM:
+
+.. code-block:: python
+
+    LLMOperator(
+        task_id="summarize",
+        llm_conn_id="pydanticai_default",
+        prompt="Email alice@example.com about card 4111 1111 1111 1111",
+        input_guard={
+            "enabled": True,
+            "mode": "replace",
+            "entities": ("EMAIL_ADDRESS", "CREDIT_CARD"),
+        },
+    )
+
+This first iteration sanitizes text sent to the model only. It does not yet
+redact approval, XCom, or log artifacts stored inside Airflow. See
+:doc:`../privacy`.
+
 .. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_llm.py
     :language: python
     :start-after: [START howto_operator_llm_agent_params]
@@ -132,6 +155,9 @@ Parameters
   for structured output.
 - ``agent_params``: Additional keyword arguments passed to the pydantic-ai ``Agent``
   constructor (e.g. ``retries``, ``model_settings``, ``tools``). Supports Jinja templating.
+- ``input_guard``: Optional Presidio-based outbound text sanitization config.
+  Supports ``enabled``, ``entities``, ``mode``, ``score_threshold``, and
+  ``attachment_policy``.
 - ``require_approval``: If ``True``, the task defers after generating output and waits
   for human review.  Default ``False``.
 - ``approval_timeout``: Maximum time to wait for a review (``timedelta``).  ``None``

--- a/providers/common/ai/docs/operators/llm_file_analysis.rst
+++ b/providers/common/ai/docs/operators/llm_file_analysis.rst
@@ -83,6 +83,34 @@ back from the LLM instead of a plain string:
     :start-after: [START howto_operator_llm_file_analysis_structured]
     :end-before: [END howto_operator_llm_file_analysis_structured]
 
+Input Guard
+-----------
+
+Set ``input_guard`` to sanitize the prompt text and normalized file text before
+the request is sent to the model:
+
+.. code-block:: python
+
+    LLMFileAnalysisOperator(
+        task_id="scan_logs",
+        llm_conn_id="pydanticai_default",
+        file_path="file:///tmp/logs",
+        prompt="Find incidents involving alice@example.com",
+        input_guard={
+            "enabled": True,
+            "mode": "replace",
+            "entities": ("EMAIL_ADDRESS",),
+        },
+    )
+
+When input guarding is enabled, binary multimodal attachments are rejected by
+default because Presidio only sanitizes text. Set
+``attachment_policy="allow_unmodified"`` only if you are comfortable sending
+the binary payload unchanged.
+
+Like the other AI operators, v1 only sanitizes model-bound text. Local Airflow
+artifacts such as XCom or logs are not yet redacted. See :doc:`../privacy`.
+
 TaskFlow Decorator
 ------------------
 
@@ -123,6 +151,7 @@ Parameters
   ``BaseModel`` for structured output.
 - ``agent_params``: Additional keyword arguments passed to the pydantic-ai
   ``Agent`` constructor (e.g. ``retries``, ``model_settings``).
+- ``input_guard``: Optional Presidio-based outbound text sanitization config.
 
 Supported Formats
 -----------------

--- a/providers/common/ai/docs/privacy.rst
+++ b/providers/common/ai/docs/privacy.rst
@@ -1,0 +1,134 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Privacy Guard
+=============
+
+The ``common.ai`` provider can sanitize model-bound text with
+`Microsoft Presidio <https://github.com/microsoft/presidio>`__ before that text
+is sent to the LLM.
+
+This feature is configured per task via the ``input_guard`` parameter on
+``LLMOperator``, ``AgentOperator``, and ``LLMFileAnalysisOperator`` (and the
+matching TaskFlow decorators).
+
+What v1 protects
+----------------
+
+When ``input_guard={"enabled": True}`` is set, the provider sanitizes:
+
+- the prompt and message history sent to the model
+- system instructions passed to the pydantic-ai ``Agent``
+- normalized text extracted by ``LLMFileAnalysisOperator``
+
+The provider uses Presidio's analyzer and anonymizer to detect entities and
+apply one of four operator modes:
+
+- ``redact``
+- ``mask``
+- ``replace``
+- ``hash``
+
+Logging sanitized previews
+--------------------------
+
+To help validate a DAG in a real environment, the input guard can log the
+**sanitized** outbound text after Presidio has transformed it.
+
+Enable it with:
+
+.. code-block:: python
+
+    input_guard = {
+        "enabled": True,
+        "mode": "replace",
+        "log_sanitized_text": True,
+        "log_preview_chars": 240,
+    }
+
+When enabled, task logs include lines similar to:
+
+.. code-block:: text
+
+    Input guard sanitized outbound instructions: mode=replace, entities=EMAIL_ADDRESS:1, preview='...'
+    Input guard sanitized outbound message[0].parts[0]: mode=replace, entities=CREDIT_CARD:1, EMAIL_ADDRESS:1, preview='...'
+
+Only the sanitized preview is logged. The raw pre-sanitized text is not logged
+by the input guard itself.
+
+What v1 does **not** protect
+----------------------------
+
+This first iteration only sanitizes **text sent to the model**.
+
+It does **not** sanitize Airflow-local copies of the same data. In particular,
+raw values may still appear in:
+
+- Human-in-the-Loop approval state
+- HITL review XCom payloads
+- task logs, especially at DEBUG level
+- durable execution cache files
+
+Local artifact redaction is planned for a later iteration.
+
+Multimodal attachments
+----------------------
+
+Presidio sanitizes text, not binary attachments.
+
+When ``input_guard`` is enabled, ``LLMFileAnalysisOperator`` rejects PNG, JPG,
+JPEG, and PDF attachments by default if they would be sent as ``BinaryContent``.
+To bypass this behavior, set:
+
+.. code-block:: python
+
+    input_guard = {
+        "enabled": True,
+        "attachment_policy": "allow_unmodified",
+    }
+
+Use that mode carefully: the binary payload is sent to the model unchanged.
+
+Example
+-------
+
+.. code-block:: python
+
+    from airflow.providers.common.ai.operators.llm import LLMOperator
+
+    LLMOperator(
+        task_id="summarize_ticket",
+        llm_conn_id="pydanticai_default",
+        prompt="Customer email is alice@example.com and card is 4111 1111 1111 1111",
+        input_guard={
+            "enabled": True,
+            "mode": "replace",
+            "entities": ("EMAIL_ADDRESS", "CREDIT_CARD"),
+        },
+    )
+
+See ``airflow.providers.common.ai.example_dags.example_llm_input_guard`` for
+runnable operator, agent, and file-analysis examples covering all four
+anonymization modes plus sanitized-preview logging.
+
+Limitations
+-----------
+
+- Presidio may miss sensitive values or produce false positives.
+- This is a privacy guardrail for model input, not an access-control mechanism.
+- Tools can still access sensitive data locally before the sanitized text is
+  prepared for the model.

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -75,6 +75,10 @@ dependencies = [
 # The optional dependencies should be modified in place in the generated file
 # Any change in the dependencies is preserved when the file is regenerated
 [project.optional-dependencies]
+"presidio" = [
+    "presidio-analyzer>=2.2.360",
+    "presidio-anonymizer>=2.2.360",
+]
 "anthropic" = ["pydantic-ai-slim[anthropic]"]
 "bedrock" = ["pydantic-ai-slim[bedrock]"]
 "google" = ["pydantic-ai-slim[google]"]
@@ -107,7 +111,9 @@ dev = [
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "sqlglot>=30.0.0",
     "pydantic-ai-slim[mcp]",
-    "apache-airflow-providers-common-sql[datafusion]"
+    "apache-airflow-providers-common-sql[datafusion]",
+    "presidio-analyzer>=2.2.360",
+    "presidio-anonymizer>=2.2.360",
 ]
 
 # To build docs:

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_input_guard.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llm_input_guard.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example DAGs demonstrating input_guard variants and sanitized-preview logging."""
+
+from __future__ import annotations
+
+from airflow.providers.common.ai.operators.agent import AgentOperator
+from airflow.providers.common.ai.operators.llm import LLMOperator
+from airflow.providers.common.ai.operators.llm_file_analysis import LLMFileAnalysisOperator
+from airflow.providers.common.compat.sdk import dag
+
+_PROMPT_WITH_PII = (
+    "Customer Jane Doe can be reached at jane.doe@example.com, phone 555-123-4567, "
+    "card 4111 1111 1111 1111, and SSN 123-45-6789. Summarize the support issue without "
+    "exposing sensitive values."
+)
+
+_SYSTEM_PROMPT_WITH_PII = (
+    "You are a support analyst. Internal escalation contact is agent.owner@example.com. "
+    "Keep the response concise."
+)
+
+_BASE_INPUT_GUARD = {
+    "enabled": True,
+    "entities": ("EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD", "US_SSN"),
+    "log_sanitized_text": True,
+    "log_preview_chars": 240,
+}
+
+
+# [START howto_operator_llm_input_guard_modes]
+@dag
+def example_llm_input_guard_modes():
+    """Run the same prompt with each Presidio anonymization mode."""
+
+    LLMOperator(
+        task_id="replace_sensitive_values",
+        prompt=_PROMPT_WITH_PII,
+        llm_conn_id="pydanticai_default",
+        system_prompt=_SYSTEM_PROMPT_WITH_PII,
+        input_guard={**_BASE_INPUT_GUARD, "mode": "replace"},
+    )
+
+    LLMOperator(
+        task_id="mask_sensitive_values",
+        prompt=_PROMPT_WITH_PII,
+        llm_conn_id="pydanticai_default",
+        system_prompt=_SYSTEM_PROMPT_WITH_PII,
+        input_guard={**_BASE_INPUT_GUARD, "mode": "mask"},
+    )
+
+    LLMOperator(
+        task_id="redact_sensitive_values",
+        prompt=_PROMPT_WITH_PII,
+        llm_conn_id="pydanticai_default",
+        system_prompt=_SYSTEM_PROMPT_WITH_PII,
+        input_guard={**_BASE_INPUT_GUARD, "mode": "redact"},
+    )
+
+    LLMOperator(
+        task_id="hash_sensitive_values",
+        prompt=_PROMPT_WITH_PII,
+        llm_conn_id="pydanticai_default",
+        system_prompt=_SYSTEM_PROMPT_WITH_PII,
+        input_guard={**_BASE_INPUT_GUARD, "mode": "hash"},
+    )
+
+
+# [END howto_operator_llm_input_guard_modes]
+
+example_llm_input_guard_modes()
+
+
+# [START howto_operator_agent_input_guard]
+@dag
+def example_agent_input_guard():
+    """AgentOperator example showing sanitized previews in the task log."""
+
+    AgentOperator(
+        task_id="support_agent_with_input_guard",
+        prompt=_PROMPT_WITH_PII,
+        llm_conn_id="pydanticai_default",
+        system_prompt=_SYSTEM_PROMPT_WITH_PII,
+        input_guard={**_BASE_INPUT_GUARD, "mode": "replace"},
+    )
+
+
+# [END howto_operator_agent_input_guard]
+
+example_agent_input_guard()
+
+
+# [START howto_operator_llm_file_analysis_input_guard]
+@dag
+def example_llm_file_analysis_input_guard():
+    """File-analysis example that sanitizes prompt text and normalized file text."""
+
+    LLMFileAnalysisOperator(
+        task_id="analyze_masked_ticket_export",
+        prompt=(
+            "Review this support export. A customer message may mention jane.doe@example.com, "
+            "555-123-4567, and 4111 1111 1111 1111. Summarize the findings safely."
+        ),
+        llm_conn_id="pydanticai_default",
+        file_path="s3://support/tickets/2024-01-15/",
+        file_conn_id="aws_default",
+        input_guard={**_BASE_INPUT_GUARD, "mode": "replace"},
+    )
+
+
+# [END howto_operator_llm_file_analysis_input_guard]
+
+example_llm_file_analysis_input_guard()

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
@@ -22,6 +22,9 @@ from pydantic_ai import Agent
 from pydantic_ai.models import infer_model
 from pydantic_ai.providers import infer_provider, infer_provider_class
 
+from airflow.providers.common.ai.privacy.config import InputGuardConfig
+from airflow.providers.common.ai.privacy.history import build_history_processor
+from airflow.providers.common.ai.privacy.presidio_guard import PresidioInputGuard
 from airflow.providers.common.compat.sdk import BaseHook
 
 OutputT = TypeVar("OutputT")
@@ -180,15 +183,35 @@ class PydanticAIHook(BaseHook):
     def create_agent(self, *, instructions: str, **agent_kwargs) -> Agent[None, str]: ...
 
     def create_agent(
-        self, output_type: type[Any] = str, *, instructions: str, **agent_kwargs
+        self,
+        output_type: type[Any] = str,
+        *,
+        instructions: str,
+        input_guard: InputGuardConfig | dict[str, Any] | None = None,
+        **agent_kwargs,
     ) -> Agent[None, Any]:
         """
         Create a pydantic-ai Agent configured with this hook's model.
 
         :param output_type: The expected output type from the agent (default: ``str``).
         :param instructions: System-level instructions for the agent.
+        :param input_guard: Optional outbound input-sanitization configuration.
         :param agent_kwargs: Additional keyword arguments passed to the Agent constructor.
         """
+        config = InputGuardConfig.from_value(input_guard)
+        if config.enabled:
+            instructions = PresidioInputGuard(config, logger=self.log).sanitize_text(
+                instructions,
+                source="instructions",
+            )
+            # Prepend so guarding runs before any user-supplied history processors.
+            # Explicit None is treated as empty (caller may pass history_processors=None).
+            existing = agent_kwargs.pop("history_processors", None) or []
+            agent_kwargs["history_processors"] = [
+                build_history_processor(config, logger=self.log),
+                *existing,
+            ]
+
         return Agent(self.get_conn(), output_type=output_type, instructions=instructions, **agent_kwargs)
 
     def test_connection(self) -> tuple[bool, str]:

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from airflow.providers.common.ai.durable.step_counter import DurableStepCounter
     from airflow.providers.common.ai.durable.storage import DurableStorage
+    from airflow.providers.common.ai.privacy.config import InputGuardConfig
     from airflow.providers.common.compat.sdk import TaskInstanceKey
     from airflow.sdk import Context
 
@@ -147,6 +148,7 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         toolsets: list[AbstractToolset] | None = None,
         enable_tool_logging: bool = True,
         agent_params: dict[str, Any] | None = None,
+        input_guard: InputGuardConfig | dict[str, Any] | None = None,
         durable: bool = False,
         # Agent feedback parameters
         enable_hitl_review: bool = False,
@@ -165,6 +167,7 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         self.toolsets = toolsets
         self.enable_tool_logging = enable_tool_logging
         self.agent_params = agent_params or {}
+        self.input_guard = input_guard
 
         self.durable = durable
 
@@ -201,6 +204,8 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             if self.enable_tool_logging:
                 toolsets = wrap_toolsets_for_logging(toolsets, self.log)
             extra_kwargs["toolsets"] = toolsets
+        if self.input_guard is not None:
+            extra_kwargs["input_guard"] = self.input_guard
         return self.llm_hook.create_agent(
             output_type=self.output_type,
             instructions=self.system_prompt,

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
@@ -33,6 +33,7 @@ from airflow.providers.common.compat.sdk import BaseOperator
 if TYPE_CHECKING:
     from pydantic_ai import Agent
 
+    from airflow.providers.common.ai.privacy.config import InputGuardConfig
     from airflow.sdk import Context
 
 
@@ -83,6 +84,7 @@ class LLMOperator(BaseOperator, LLMApprovalMixin):
         system_prompt: str = "",
         output_type: type = str,
         agent_params: dict[str, Any] | None = None,
+        input_guard: InputGuardConfig | dict[str, Any] | None = None,
         require_approval: bool = False,
         approval_timeout: timedelta | None = None,
         allow_modifications: bool = False,
@@ -95,6 +97,7 @@ class LLMOperator(BaseOperator, LLMApprovalMixin):
         self.system_prompt = system_prompt
         self.output_type = output_type
         self.agent_params = agent_params or {}
+        self.input_guard = input_guard
         self.require_approval = require_approval
         self.approval_timeout = approval_timeout
         self.allow_modifications = allow_modifications
@@ -114,10 +117,24 @@ class LLMOperator(BaseOperator, LLMApprovalMixin):
         }
         return PydanticAIHook.get_hook(self.llm_conn_id, hook_params=hook_params)
 
-    def execute(self, context: Context) -> Any:
-        agent: Agent[None, Any] = self.llm_hook.create_agent(
-            output_type=self.output_type, instructions=self.system_prompt, **self.agent_params
+    def _create_agent(
+        self,
+        *,
+        output_type: type[Any] | None = None,
+        instructions: str | None = None,
+        **agent_kwargs: Any,
+    ) -> Agent[None, Any]:
+        """Create the pydantic-ai Agent with optional outbound input guarding."""
+        if self.input_guard is not None:
+            agent_kwargs["input_guard"] = self.input_guard
+        return self.llm_hook.create_agent(
+            output_type=output_type or self.output_type,
+            instructions=instructions if instructions is not None else self.system_prompt,
+            **agent_kwargs,
         )
+
+    def execute(self, context: Context) -> Any:
+        agent = self._create_agent(**self.agent_params)
         result = agent.run_sync(self.prompt)
         log_run_summary(self.log, result)
         output = result.output

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
@@ -76,11 +76,7 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
         )
         output_type = list[downstream_tasks_enum] if self.allow_multiple_branches else downstream_tasks_enum
 
-        agent = self.llm_hook.create_agent(
-            output_type=output_type,
-            instructions=self.system_prompt,
-            **self.agent_params,
-        )
+        agent = self._create_agent(output_type=output_type, **self.agent_params)
         result = agent.run_sync(self.prompt)
         log_run_summary(self.log, result)
         output = result.output

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
@@ -24,12 +24,11 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from airflow.providers.common.ai.operators.llm import LLMOperator
+from airflow.providers.common.ai.privacy.history import sanitize_file_content
 from airflow.providers.common.ai.utils.file_analysis import build_file_analysis_request
 from airflow.providers.common.ai.utils.logging import log_run_summary
 
 if TYPE_CHECKING:
-    from pydantic_ai import Agent
-
     from airflow.sdk import Context
 
 
@@ -116,6 +115,10 @@ class LLMFileAnalysisOperator(LLMOperator):
             max_text_chars=self.max_text_chars,
             sample_rows=self.sample_rows,
         )
+        if self.input_guard is not None:
+            request.user_content = sanitize_file_content(
+                request.user_content, self.input_guard, logger=self.log
+            )
         self.log.info(
             "Calling model for file analysis: files=%s, attachments=%s, text_files=%s, total_size_bytes=%s, "
             "omitted_files=%s, text_truncated=%s, multi_modal=%s, sample_rows=%s",
@@ -129,11 +132,7 @@ class LLMFileAnalysisOperator(LLMOperator):
             self.sample_rows,
         )
         self.log.debug("Resolved file analysis paths: %s", request.resolved_paths)
-        agent: Agent[None, Any] = self.llm_hook.create_agent(
-            output_type=self.output_type,
-            instructions=self._build_system_prompt(),
-            **self.agent_params,
-        )
+        agent = self._create_agent(instructions=self._build_system_prompt(), **self.agent_params)
         result = agent.run_sync(request.user_content)
         log_run_summary(self.log, result)
         output = result.output

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
@@ -303,7 +303,7 @@ class LLMSchemaCompareOperator(LLMOperator):
 
         full_system_prompt = self._build_system_prompt(schema_context)
 
-        agent = self.llm_hook.create_agent(
+        agent = self._create_agent(
             output_type=SchemaCompareResult,
             instructions=full_system_prompt,
             **self.agent_params,

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -144,9 +144,7 @@ class LLMSQLQueryOperator(LLMOperator):
 
         full_system_prompt = self._build_system_prompt(schema_info)
 
-        agent = self.llm_hook.create_agent(
-            output_type=str, instructions=full_system_prompt, **self.agent_params
-        )
+        agent = self._create_agent(output_type=str, instructions=full_system_prompt, **self.agent_params)
         result = agent.run_sync(self.prompt)
         log_run_summary(self.log, result)
         sql = self._strip_llm_output(result.output)

--- a/providers/common/ai/src/airflow/providers/common/ai/privacy/__init__.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/privacy/__init__.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Privacy helpers for sanitizing LLM-bound content."""
+
+from __future__ import annotations
+
+from airflow.providers.common.ai.privacy.config import InputGuardConfig
+from airflow.providers.common.ai.privacy.exceptions import InputGuardAttachmentError, InputGuardError
+from airflow.providers.common.ai.privacy.history import (
+    build_history_processor,
+    sanitize_file_content,
+    sanitize_user_content,
+)
+from airflow.providers.common.ai.privacy.presidio_guard import PresidioInputGuard
+
+__all__ = [
+    "InputGuardAttachmentError",
+    "InputGuardConfig",
+    "InputGuardError",
+    "PresidioInputGuard",
+    "build_history_processor",
+    "sanitize_file_content",
+    "sanitize_user_content",
+]

--- a/providers/common/ai/src/airflow/providers/common/ai/privacy/config.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/privacy/config.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Configuration for LLM input guarding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from airflow.providers.common.ai.privacy.exceptions import InputGuardError
+
+InputGuardMode = Literal["redact", "mask", "replace", "hash"]
+AttachmentPolicy = Literal["reject", "allow_unmodified"]
+
+
+@dataclass(slots=True)
+class InputGuardConfig:
+    """Runtime configuration for outbound LLM input sanitization."""
+
+    enabled: bool = False
+    language: str = "en"
+    entities: tuple[str, ...] | None = None
+    mode: InputGuardMode = "replace"
+    replace_value_template: str = "<{entity_type}>"
+    mask_char: str = "*"
+    mask_from_end: bool = False
+    score_threshold: float | None = None
+    attachment_policy: AttachmentPolicy = "reject"
+    log_sanitized_text: bool = False
+    log_preview_chars: int = 200
+
+    @classmethod
+    def from_value(cls, value: InputGuardConfig | dict[str, Any] | None) -> InputGuardConfig:
+        """Normalize supported config inputs into an InputGuardConfig."""
+        if value is None:
+            return cls()
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            raise InputGuardError("input_guard must be a dict or InputGuardConfig instance.")
+        try:
+            entities = value.get("entities")
+            if entities is not None:
+                value = {**value, "entities": tuple(entities)}
+            return cls(**value)
+        except TypeError as exc:
+            raise InputGuardError(f"Invalid input_guard configuration: {exc}") from exc

--- a/providers/common/ai/src/airflow/providers/common/ai/privacy/exceptions.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/privacy/exceptions.py
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Exceptions raised by common.ai privacy helpers."""
+
+from __future__ import annotations
+
+# Shared message used wherever binary multimodal attachments are rejected.
+ATTACHMENT_REJECTION_MSG = (
+    "input_guard cannot sanitize binary multimodal attachments. "
+    "Disable multimodal inputs or set attachment_policy='allow_unmodified'."
+)
+
+
+class InputGuardError(ValueError):
+    """Base error for invalid or unsupported input-guard behavior."""
+
+
+class InputGuardAttachmentError(InputGuardError):
+    """Raised when guarded multimodal attachments are not allowed."""

--- a/providers/common/ai/src/airflow/providers/common/ai/privacy/history.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/privacy/history.py
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Pydantic AI history processors backed by Presidio."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from pydantic_ai.messages import BinaryContent
+
+from airflow.providers.common.ai.privacy.exceptions import ATTACHMENT_REJECTION_MSG, InputGuardAttachmentError
+from airflow.providers.common.ai.privacy.presidio_guard import PresidioInputGuard
+
+if TYPE_CHECKING:
+    import logging
+
+    from airflow.providers.common.ai.privacy.config import InputGuardConfig
+
+
+def sanitize_user_content(
+    content: Any,
+    *,
+    guard: PresidioInputGuard,
+    config: InputGuardConfig,
+    source: str = "content",
+) -> Any:
+    """Sanitize supported user-content payloads while respecting attachment policy."""
+    if isinstance(content, BinaryContent):
+        if config.attachment_policy == "reject":
+            raise InputGuardAttachmentError(ATTACHMENT_REJECTION_MSG)
+        return content
+    if isinstance(content, str):
+        return guard.sanitize_text(content, source=source)
+    if isinstance(content, list):
+        return [
+            sanitize_user_content(item, guard=guard, config=config, source=f"{source}[{i}]")
+            for i, item in enumerate(content)
+        ]
+    if isinstance(content, tuple):
+        return tuple(
+            sanitize_user_content(item, guard=guard, config=config, source=f"{source}[{i}]")
+            for i, item in enumerate(content)
+        )
+    if isinstance(content, dict):
+        return {
+            key: sanitize_user_content(value, guard=guard, config=config, source=f"{source}.{key}")
+            for key, value in content.items()
+        }
+    # Non-text, non-container types (int, float, …) pass through unchanged.
+    return content
+
+
+def contains_binary_content(content: Any) -> bool:
+    """Return True when user content includes at least one binary attachment."""
+    if isinstance(content, BinaryContent):
+        return True
+    if isinstance(content, list | tuple):
+        return any(contains_binary_content(item) for item in content)
+    if isinstance(content, dict):
+        return any(contains_binary_content(value) for value in content.values())
+    return False
+
+
+def sanitize_file_content(
+    user_content: Any,
+    input_guard: InputGuardConfig | dict[str, Any] | None,
+    logger: logging.Logger | None = None,
+) -> Any:
+    """
+    Sanitize file-analysis content using the given guard configuration.
+
+    Performs an early binary-attachment check before invoking the guard so that
+    multimodal attachments are rejected before any LLM call is made.
+
+    :param user_content: The prompt/content payload built from the analysed files.
+    :param input_guard: Guard configuration as an ``InputGuardConfig`` or raw dict.
+    :param logger: Logger to use for sanitization summaries.
+    :return: Sanitized content, or the original content when guarding is disabled.
+    """
+    from airflow.providers.common.ai.privacy.config import InputGuardConfig as _Config
+
+    config = _Config.from_value(input_guard)
+    if not config.enabled:
+        return user_content
+    if config.attachment_policy == "reject" and contains_binary_content(user_content):
+        raise InputGuardAttachmentError(ATTACHMENT_REJECTION_MSG)
+    guard = PresidioInputGuard(config, logger=logger)
+    return sanitize_user_content(
+        user_content, guard=guard, config=config, source="file_analysis.user_content"
+    )
+
+
+def build_history_processor(config: InputGuardConfig, logger: logging.Logger | None = None):
+    """Build a Pydantic AI history processor that sanitizes outbound content."""
+    guard = PresidioInputGuard(config, logger=logger)
+
+    def _processor(messages: list[Any]) -> list[Any]:
+        sanitized_messages: list[Any] = []
+        for message_index, message in enumerate(messages):
+            parts = getattr(message, "parts", None)
+            if parts is None:
+                sanitized_messages.append(message)
+                continue
+
+            new_parts = []
+            changed = False
+            for part_index, part in enumerate(parts):
+                content = getattr(part, "content", None)
+                if content is None:
+                    new_parts.append(part)
+                    continue
+                sanitized_content = sanitize_user_content(
+                    content,
+                    guard=guard,
+                    config=config,
+                    source=f"message[{message_index}].parts[{part_index}]",
+                )
+                if sanitized_content == content:
+                    new_parts.append(part)
+                    continue
+                changed = True
+                # pydantic-ai messages are always dataclasses; replace() is safe.
+                new_parts.append(replace(part, content=sanitized_content))
+
+            if not changed:
+                sanitized_messages.append(message)
+                continue
+
+            sanitized_messages.append(replace(message, parts=new_parts))
+        return sanitized_messages
+
+    return _processor

--- a/providers/common/ai/src/airflow/providers/common/ai/privacy/presidio_guard.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/privacy/presidio_guard.py
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Presidio-backed sanitization helpers for model-bound text."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+if TYPE_CHECKING:
+    import logging
+
+    from airflow.providers.common.ai.privacy.config import InputGuardConfig
+
+# Masks up to this many characters per detected entity, effectively masking all practical PII.
+_MAX_MASK_CHARS = 10_000
+
+
+@lru_cache(maxsize=1)
+def _create_presidio_engines() -> tuple[Any, Any]:
+    """Create and cache shared Presidio engines for the provider process."""
+    try:
+        from presidio_analyzer import AnalyzerEngine
+        from presidio_anonymizer import AnonymizerEngine
+    except ImportError as exc:
+        raise AirflowOptionalProviderFeatureException(
+            "input_guard requires the presidio extra: "
+            "pip install apache-airflow-providers-common-ai[presidio]"
+        ) from exc
+
+    return AnalyzerEngine(), AnonymizerEngine()
+
+
+class PresidioInputGuard:
+    """Sanitize outbound strings and JSON-like payloads with Presidio."""
+
+    def __init__(self, config: InputGuardConfig, logger: logging.Logger | None = None) -> None:
+        self.config = config
+        self.logger = logger
+        self._analyzer, self._anonymizer = _create_presidio_engines()
+
+    def sanitize_text(self, text: str, *, source: str = "text") -> str:
+        """Analyze and anonymize one text blob."""
+        if not text:
+            return text
+
+        analyze_kwargs: dict[str, Any] = {
+            "text": text,
+            "language": self.config.language,
+        }
+        if self.config.entities:
+            analyze_kwargs["entities"] = list(self.config.entities)
+        if self.config.score_threshold is not None:
+            analyze_kwargs["score_threshold"] = self.config.score_threshold
+
+        results = self._analyzer.analyze(**analyze_kwargs)
+        if not results:
+            return text
+
+        sanitized_text = self._anonymizer.anonymize(
+            text=text,
+            analyzer_results=results,
+            operators=self._build_operators(results),
+        ).text
+        self._log_sanitization(results=results, sanitized_text=sanitized_text, source=source)
+        return sanitized_text
+
+    def sanitize_value(self, value: Any, *, source: str = "value") -> Any:
+        """Recursively sanitize text in JSON-like tool payloads."""
+        if isinstance(value, str):
+            return self.sanitize_text(value, source=source)
+        if isinstance(value, Mapping):
+            return {
+                key: self.sanitize_value(subvalue, source=f"{source}.{key}")
+                for key, subvalue in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                self.sanitize_value(item, source=f"{source}[{index}]") for index, item in enumerate(value)
+            ]
+        if isinstance(value, tuple):
+            return tuple(
+                self.sanitize_value(item, source=f"{source}[{index}]") for index, item in enumerate(value)
+            )
+        return value
+
+    def _build_operators(self, results: Sequence[Any]) -> dict[str, Any]:
+        from presidio_anonymizer.entities import OperatorConfig
+
+        if self.config.mode == "redact":
+            return {"DEFAULT": OperatorConfig("redact", {})}
+        if self.config.mode == "hash":
+            return {"DEFAULT": OperatorConfig("hash", {})}
+        if self.config.mode == "mask":
+            return {
+                "DEFAULT": OperatorConfig(
+                    "mask",
+                    {
+                        "masking_char": self.config.mask_char,
+                        "chars_to_mask": _MAX_MASK_CHARS,
+                        "from_end": self.config.mask_from_end,
+                    },
+                )
+            }
+
+        operators: dict[str, Any] = {}
+        for result in results:
+            entity_type = getattr(result, "entity_type", "PII")
+            operators[entity_type] = OperatorConfig(
+                "replace",
+                {"new_value": self.config.replace_value_template.format(entity_type=entity_type)},
+            )
+        operators.setdefault("DEFAULT", OperatorConfig("replace", {"new_value": "<PII>"}))
+        return operators
+
+    def _log_sanitization(self, *, results: Sequence[Any], sanitized_text: str, source: str) -> None:
+        """Emit privacy-safe logs for sanitized outbound content."""
+        if self.logger is None:
+            return
+
+        entity_counts = Counter(getattr(result, "entity_type", "PII") for result in results)
+        entity_summary = ", ".join(
+            f"{entity_type}:{count}" for entity_type, count in sorted(entity_counts.items())
+        )
+
+        if self.config.log_sanitized_text:
+            preview = sanitized_text
+            if len(preview) > self.config.log_preview_chars:
+                preview = preview[: self.config.log_preview_chars] + "..."
+            self.logger.info(
+                "Input guard sanitized outbound %s: mode=%s, entities=%s, preview=%r",
+                source,
+                self.config.mode,
+                entity_summary,
+                preview,
+            )
+            return
+
+        self.logger.info(
+            "Input guard sanitized outbound %s: mode=%s, entities=%s",
+            source,
+            self.config.mode,
+            entity_summary,
+        )

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -241,6 +242,116 @@ class TestPydanticAIHookCreateAgent:
             instructions="Be helpful.",
             retries=3,
         )
+
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_model", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.Agent", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.build_history_processor", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.PresidioInputGuard", autospec=True)
+    def test_create_agent_with_input_guard_sanitizes_instructions_and_sets_history_processor(
+        self,
+        mock_guard_cls,
+        mock_build_history_processor,
+        mock_agent_cls,
+        mock_infer_model,
+    ):
+        mock_model = MagicMock(spec=Model)
+        mock_infer_model.return_value = mock_model
+        mock_guard = mock_guard_cls.return_value
+        mock_guard.sanitize_text.return_value = "Sanitized instructions"
+        processor = MagicMock()
+        mock_build_history_processor.return_value = processor
+
+        hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
+        conn = Connection(conn_id="test_conn", conn_type="pydanticai")
+        with patch.object(hook, "get_connection", return_value=conn):
+            hook.create_agent(
+                instructions="My email is alice@example.com",
+                input_guard={"enabled": True},
+            )
+
+        mock_guard_cls.assert_called_once()
+        assert mock_guard_cls.call_args.kwargs == {"logger": hook.log}
+        assert mock_guard_cls.call_args.args[0].enabled is True
+        mock_guard.sanitize_text.assert_called_once_with(
+            "My email is alice@example.com",
+            source="instructions",
+        )
+        mock_build_history_processor.assert_called_once()
+        assert mock_build_history_processor.call_args.kwargs == {"logger": hook.log}
+        assert mock_build_history_processor.call_args.args[0].enabled is True
+        mock_agent_cls.assert_called_once_with(
+            mock_model,
+            output_type=str,
+            instructions="Sanitized instructions",
+            history_processors=[processor],
+        )
+
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.infer_model", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.Agent", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.build_history_processor", autospec=True)
+    @patch("airflow.providers.common.ai.hooks.pydantic_ai.PresidioInputGuard", autospec=True)
+    def test_create_agent_prepends_history_processor_to_user_supplied_processors(
+        self,
+        mock_guard_cls,
+        mock_build_history_processor,
+        mock_agent_cls,
+        mock_infer_model,
+    ):
+        mock_model = MagicMock(spec=Model)
+        mock_infer_model.return_value = mock_model
+        mock_guard_cls.return_value.sanitize_text.return_value = "sanitized"
+        processor = MagicMock()
+        mock_build_history_processor.return_value = processor
+        user_processor = MagicMock()
+
+        hook = PydanticAIHook(llm_conn_id="test_conn", model_id="openai:gpt-5.3")
+        conn = Connection(conn_id="test_conn", conn_type="pydanticai")
+        with patch.object(hook, "get_connection", return_value=conn):
+            hook.create_agent(
+                instructions="Be helpful.",
+                input_guard={"enabled": True},
+                history_processors=[user_processor],
+            )
+
+        mock_build_history_processor.assert_called_once()
+        assert mock_build_history_processor.call_args.kwargs == {"logger": hook.log}
+        assert mock_build_history_processor.call_args.args[0].enabled is True
+        mock_agent_cls.assert_called_once_with(
+            mock_model,
+            output_type=str,
+            instructions="sanitized",
+            history_processors=[processor, user_processor],
+        )
+
+
+@dataclass
+class _FakePart:
+    content: str
+
+
+@dataclass
+class _FakeMessage:
+    parts: list[_FakePart]
+
+
+class TestHistoryProcessor:
+    @patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", autospec=True)
+    def test_build_history_processor_sanitizes_message_content(self, mock_guard_cls):
+        from airflow.providers.common.ai.privacy.config import InputGuardConfig
+        from airflow.providers.common.ai.privacy.history import build_history_processor
+
+        mock_guard = mock_guard_cls.return_value
+        mock_guard.sanitize_text.side_effect = lambda text, source="text": text.replace(
+            "alice@example.com", "<EMAIL_ADDRESS>"
+        )
+
+        processor = build_history_processor(InputGuardConfig(enabled=True))
+        messages = [_FakeMessage(parts=[_FakePart(content="Email alice@example.com now")])]
+
+        sanitized = processor(messages)
+
+        assert sanitized[0].parts[0].content == "Email <EMAIL_ADDRESS> now"
+        assert messages[0].parts[0].content == "Email alice@example.com now"
 
 
 class TestPydanticAIHookTestConnection:

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -191,6 +191,21 @@ class TestAgentOperatorExecute:
 
         mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": "openai:gpt-5"})
 
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_forwards_input_guard(self, mock_hook_cls):
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="my_llm",
+            input_guard={"enabled": True},
+        )
+        op.execute(context=MagicMock())
+
+        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        assert create_call[1]["input_guard"] == {"enabled": True}
+
     @pytest.mark.skipif(
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
     )

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm.py
@@ -96,6 +96,27 @@ class TestLLMOperator:
             model_settings={"temperature": 0.9},
         )
 
+    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+    def test_execute_forwards_input_guard(self, mock_hook_cls):
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_agent.run_sync.return_value = _make_mock_run_result("guarded")
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+
+        op = LLMOperator(
+            task_id="test",
+            prompt="Send with masking",
+            llm_conn_id="my_llm",
+            input_guard={"enabled": True},
+        )
+        result = op.execute(context=MagicMock())
+
+        assert result == "guarded"
+        mock_hook_cls.get_hook.return_value.create_agent.assert_called_once_with(
+            output_type=str,
+            instructions="",
+            input_guard={"enabled": True},
+        )
+
 
 def _make_context(ti_id=None):
     ti_id = ti_id or uuid4()

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
@@ -22,8 +22,10 @@ from uuid import uuid4
 
 import pytest
 from pydantic import BaseModel
+from pydantic_ai.messages import BinaryContent
 
 from airflow.providers.common.ai.operators.llm_file_analysis import LLMFileAnalysisOperator
+from airflow.providers.common.ai.privacy.exceptions import InputGuardAttachmentError
 from airflow.providers.common.ai.utils.file_analysis import FileAnalysisRequest
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
@@ -152,6 +154,35 @@ class TestLLMFileAnalysisOperator:
                 sample_rows=0,
             )
         mock_build_request.assert_not_called()
+
+    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+    @patch(
+        "airflow.providers.common.ai.operators.llm_file_analysis.build_file_analysis_request", autospec=True
+    )
+    def test_execute_rejects_binary_attachments_when_input_guard_is_enabled(
+        self, mock_build_request, mock_hook_cls
+    ):
+        mock_build_request.return_value = FileAnalysisRequest(
+            user_content=[
+                "prepared prompt",
+                BinaryContent(data=b"image-bytes", media_type="image/png"),
+            ],
+            resolved_paths=["/tmp/app.png"],
+            total_size_bytes=10,
+        )
+
+        op = LLMFileAnalysisOperator(
+            task_id="test",
+            prompt="Inspect image",
+            llm_conn_id="my_llm",
+            file_path="/tmp/app.png",
+            input_guard={"enabled": True},
+        )
+
+        with pytest.raises(InputGuardAttachmentError, match="cannot sanitize binary multimodal attachments"):
+            op.execute(context={})
+
+        mock_hook_cls.get_hook.return_value.create_agent.assert_not_called()
 
 
 @pytest.mark.skipif(

--- a/providers/common/ai/tests/unit/common/ai/privacy/__init__.py
+++ b/providers/common/ai/tests/unit/common/ai/privacy/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/common/ai/tests/unit/common/ai/privacy/test_presidio_guard.py
+++ b/providers/common/ai/tests/unit/common/ai/privacy/test_presidio_guard.py
@@ -1,0 +1,494 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airflow.providers.common.ai.privacy.config import InputGuardConfig
+from airflow.providers.common.ai.privacy.exceptions import (
+    ATTACHMENT_REJECTION_MSG,
+    InputGuardAttachmentError,
+    InputGuardError,
+)
+from airflow.providers.common.ai.privacy.history import (
+    build_history_processor,
+    contains_binary_content,
+    sanitize_file_content,
+    sanitize_user_content,
+)
+from airflow.providers.common.ai.privacy.presidio_guard import PresidioInputGuard, _create_presidio_engines
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engines(analyzer_results=None, anonymized_text="<REDACTED>"):
+    """Return (analyzer_mock, anonymizer_mock) pre-configured for a single analyze call."""
+    analyzer = MagicMock()
+    analyzer.analyze.return_value = analyzer_results or []
+    anonymizer = MagicMock()
+    anonymizer.anonymize.return_value = SimpleNamespace(text=anonymized_text)
+    return analyzer, anonymizer
+
+
+def _patch_modules(analyzer, anonymizer):
+    """Return a dict for use with patch.dict(sys.modules, ...)."""
+    return {
+        "presidio_analyzer": SimpleNamespace(AnalyzerEngine=MagicMock(return_value=analyzer)),
+        "presidio_anonymizer": SimpleNamespace(AnonymizerEngine=MagicMock(return_value=anonymizer)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# InputGuardConfig
+# ---------------------------------------------------------------------------
+
+
+class TestInputGuardConfig:
+    def test_from_value_none_returns_disabled_default(self):
+        cfg = InputGuardConfig.from_value(None)
+        assert cfg.enabled is False
+
+    def test_from_value_passthrough_config_instance(self):
+        original = InputGuardConfig(enabled=True, mode="redact")
+        assert InputGuardConfig.from_value(original) is original
+
+    def test_from_value_dict_converts_entities_to_tuple(self):
+        cfg = InputGuardConfig.from_value({"enabled": True, "entities": ["EMAIL_ADDRESS", "PHONE_NUMBER"]})
+        assert cfg.enabled is True
+        assert cfg.entities == ("EMAIL_ADDRESS", "PHONE_NUMBER")
+
+    def test_from_value_invalid_type_raises(self):
+        with pytest.raises(InputGuardError, match="input_guard must be a dict"):
+            InputGuardConfig.from_value("not-a-dict")  # type: ignore[arg-type]
+
+    def test_from_value_unknown_key_raises(self):
+        with pytest.raises(InputGuardError, match="Invalid input_guard configuration"):
+            InputGuardConfig.from_value({"enabled": True, "unknown_key": "x"})
+
+    def test_mask_from_end_default_is_false(self):
+        """Masking should preserve trailing characters (e.g. last 4 of a card) by default."""
+        assert InputGuardConfig().mask_from_end is False
+
+
+# ---------------------------------------------------------------------------
+# PresidioInputGuard — logging
+# ---------------------------------------------------------------------------
+
+
+class TestPresidioInputGuardLogging:
+    def setup_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def teardown_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def test_sanitize_text_logs_sanitized_preview_when_enabled(self):
+        analyzer, anonymizer = _make_engines(
+            analyzer_results=[
+                SimpleNamespace(entity_type="EMAIL_ADDRESS"),
+                SimpleNamespace(entity_type="CREDIT_CARD"),
+            ],
+            anonymized_text="Email is <EMAIL_ADDRESS> and card is <CREDIT_CARD>",
+        )
+        logger = MagicMock()
+
+        with patch.dict(sys.modules, _patch_modules(analyzer, anonymizer)):
+            guard = PresidioInputGuard(
+                InputGuardConfig(enabled=True, log_sanitized_text=True, log_preview_chars=80),
+                logger=logger,
+            )
+            with patch.object(guard, "_build_operators", return_value={}):
+                sanitized = guard.sanitize_text(
+                    "Email is jane@example.com and card is 4111 1111 1111 1111",
+                    source="prompt",
+                )
+
+        assert sanitized == "Email is <EMAIL_ADDRESS> and card is <CREDIT_CARD>"
+        logger.info.assert_called_once_with(
+            "Input guard sanitized outbound %s: mode=%s, entities=%s, preview=%r",
+            "prompt",
+            "replace",
+            "CREDIT_CARD:1, EMAIL_ADDRESS:1",
+            "Email is <EMAIL_ADDRESS> and card is <CREDIT_CARD>",
+        )
+
+    def test_sanitize_text_logs_summary_when_preview_logging_disabled(self):
+        analyzer, anonymizer = _make_engines(
+            analyzer_results=[SimpleNamespace(entity_type="PHONE_NUMBER")],
+            anonymized_text="Call <PHONE_NUMBER>",
+        )
+        logger = MagicMock()
+
+        with patch.dict(sys.modules, _patch_modules(analyzer, anonymizer)):
+            guard = PresidioInputGuard(InputGuardConfig(enabled=True), logger=logger)
+            with patch.object(guard, "_build_operators", return_value={}):
+                guard.sanitize_text("Call 555-123-4567", source="instructions")
+
+        logger.info.assert_called_once_with(
+            "Input guard sanitized outbound %s: mode=%s, entities=%s",
+            "instructions",
+            "replace",
+            "PHONE_NUMBER:1",
+        )
+
+    def test_no_log_when_no_entities_detected(self):
+        analyzer, anonymizer = _make_engines(analyzer_results=[])
+        logger = MagicMock()
+
+        with patch.dict(sys.modules, _patch_modules(analyzer, anonymizer)):
+            guard = PresidioInputGuard(InputGuardConfig(enabled=True), logger=logger)
+            result = guard.sanitize_text("no pii here", source="prompt")
+
+        assert result == "no pii here"
+        logger.info.assert_not_called()
+
+    def test_engines_are_cached_across_guard_instances(self):
+        analyzer_cls = MagicMock(return_value=MagicMock())
+        anonymizer_cls = MagicMock(return_value=MagicMock())
+
+        with patch.dict(
+            sys.modules,
+            {
+                "presidio_analyzer": SimpleNamespace(AnalyzerEngine=analyzer_cls),
+                "presidio_anonymizer": SimpleNamespace(AnonymizerEngine=anonymizer_cls),
+            },
+        ):
+            PresidioInputGuard(InputGuardConfig(enabled=True))
+            PresidioInputGuard(InputGuardConfig(enabled=True))
+
+        analyzer_cls.assert_called_once_with()
+        anonymizer_cls.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# PresidioInputGuard — modes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOperators:
+    def setup_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def teardown_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def _make_guard(self, mode):
+        analyzer_cls = MagicMock(return_value=MagicMock())
+        anonymizer_cls = MagicMock(return_value=MagicMock())
+        with patch.dict(
+            sys.modules,
+            {
+                "presidio_analyzer": SimpleNamespace(AnalyzerEngine=analyzer_cls),
+                "presidio_anonymizer": SimpleNamespace(AnonymizerEngine=anonymizer_cls),
+            },
+        ):
+            return PresidioInputGuard(InputGuardConfig(enabled=True, mode=mode))
+
+    def test_redact_mode_builds_single_default_operator(self):
+
+        guard = self._make_guard("redact")
+        results = [SimpleNamespace(entity_type="EMAIL_ADDRESS")]
+        ops = guard._build_operators(results)
+        assert set(ops) == {"DEFAULT"}
+        assert ops["DEFAULT"].operator_name == "redact"
+
+    def test_hash_mode_builds_single_default_operator(self):
+        guard = self._make_guard("hash")
+        ops = guard._build_operators([SimpleNamespace(entity_type="PHONE_NUMBER")])
+        assert set(ops) == {"DEFAULT"}
+        assert ops["DEFAULT"].operator_name == "hash"
+
+    def test_mask_mode_includes_mask_char_and_max_chars(self):
+        from airflow.providers.common.ai.privacy.presidio_guard import _MAX_MASK_CHARS
+
+        guard = self._make_guard("mask")
+        ops = guard._build_operators([SimpleNamespace(entity_type="US_SSN")])
+        assert ops["DEFAULT"].operator_name == "mask"
+        params = ops["DEFAULT"].params
+        assert params["masking_char"] == "*"
+        assert params["chars_to_mask"] == _MAX_MASK_CHARS
+        assert params["from_end"] is False  # mask_from_end default is False
+
+    def test_replace_mode_uses_entity_type_template(self):
+        guard = self._make_guard("replace")
+        results = [SimpleNamespace(entity_type="EMAIL_ADDRESS")]
+        ops = guard._build_operators(results)
+        assert "EMAIL_ADDRESS" in ops
+        assert ops["EMAIL_ADDRESS"].params["new_value"] == "<EMAIL_ADDRESS>"
+
+    def test_replace_mode_has_default_fallback(self):
+        guard = self._make_guard("replace")
+        ops = guard._build_operators([SimpleNamespace(entity_type="EMAIL_ADDRESS")])
+        assert "DEFAULT" in ops
+        assert ops["DEFAULT"].params["new_value"] == "<PII>"
+
+
+# ---------------------------------------------------------------------------
+# sanitize_user_content
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeUserContent:
+    def _guard(self, sanitized="<EMAIL>"):
+        g = MagicMock(spec=PresidioInputGuard)
+        g.sanitize_text.side_effect = lambda text, source: sanitized if "@" in text else text
+        return g
+
+    def test_plain_string_delegates_to_guard(self):
+        guard = self._guard("<EMAIL>")
+        config = InputGuardConfig(enabled=True)
+        result = sanitize_user_content("user@example.com", guard=guard, config=config)
+        assert result == "<EMAIL>"
+        guard.sanitize_text.assert_called_once()
+
+    def test_list_is_sanitized_recursively(self):
+        guard = self._guard("<EMAIL>")
+        config = InputGuardConfig(enabled=True)
+        result = sanitize_user_content(["user@example.com", "safe text"], guard=guard, config=config)
+        assert result == ["<EMAIL>", "safe text"]
+
+    def test_tuple_is_sanitized_recursively(self):
+        guard = self._guard("<EMAIL>")
+        config = InputGuardConfig(enabled=True)
+        result = sanitize_user_content(("user@example.com",), guard=guard, config=config)
+        assert result == ("<EMAIL>",)
+
+    def test_dict_is_sanitized_recursively(self):
+        guard = self._guard("<EMAIL>")
+        config = InputGuardConfig(enabled=True)
+        result = sanitize_user_content(
+            {"email": "user@example.com", "other": "safe"}, guard=guard, config=config
+        )
+        assert result == {"email": "<EMAIL>", "other": "safe"}
+
+    def test_non_text_value_passes_through(self):
+        guard = MagicMock(spec=PresidioInputGuard)
+        config = InputGuardConfig(enabled=True)
+        result = sanitize_user_content(42, guard=guard, config=config)
+        assert result == 42
+        guard.sanitize_text.assert_not_called()
+
+    def test_binary_content_reject_raises(self):
+        from pydantic_ai.messages import BinaryContent
+
+        guard = MagicMock(spec=PresidioInputGuard)
+        config = InputGuardConfig(enabled=True, attachment_policy="reject")
+        binary = BinaryContent(data=b"...", media_type="image/png")
+        with pytest.raises(InputGuardAttachmentError, match=ATTACHMENT_REJECTION_MSG):
+            sanitize_user_content(binary, guard=guard, config=config)
+
+    def test_binary_content_allow_unmodified_passes_through(self):
+        from pydantic_ai.messages import BinaryContent
+
+        guard = MagicMock(spec=PresidioInputGuard)
+        config = InputGuardConfig(enabled=True, attachment_policy="allow_unmodified")
+        binary = BinaryContent(data=b"...", media_type="image/png")
+        result = sanitize_user_content(binary, guard=guard, config=config)
+        assert result is binary
+
+    def test_binary_inside_list_is_rejected(self):
+        from pydantic_ai.messages import BinaryContent
+
+        guard = MagicMock(spec=PresidioInputGuard)
+        config = InputGuardConfig(enabled=True, attachment_policy="reject")
+        binary = BinaryContent(data=b"...", media_type="image/png")
+        with pytest.raises(InputGuardAttachmentError):
+            sanitize_user_content(["text", binary], guard=guard, config=config)
+
+
+# ---------------------------------------------------------------------------
+# contains_binary_content
+# ---------------------------------------------------------------------------
+
+
+class TestContainsBinaryContent:
+    def test_plain_string_returns_false(self):
+        assert contains_binary_content("hello") is False
+
+    def test_binary_content_returns_true(self):
+        from pydantic_ai.messages import BinaryContent
+
+        assert contains_binary_content(BinaryContent(data=b"x", media_type="image/png")) is True
+
+    def test_list_with_binary_returns_true(self):
+        from pydantic_ai.messages import BinaryContent
+
+        assert contains_binary_content(["text", BinaryContent(data=b"x", media_type="image/png")]) is True
+
+    def test_nested_dict_with_binary_returns_true(self):
+        from pydantic_ai.messages import BinaryContent
+
+        assert contains_binary_content({"a": BinaryContent(data=b"x", media_type="image/png")}) is True
+
+    def test_plain_dict_returns_false(self):
+        assert contains_binary_content({"key": "value"}) is False
+
+
+# ---------------------------------------------------------------------------
+# build_history_processor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHistoryProcessor:
+    def setup_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def teardown_method(self):
+        _create_presidio_engines.cache_clear()
+
+    def _make_processor(self, sanitized_text="<PII>"):
+        """Return a history processor backed by a mocked guard."""
+        analyzer_cls = MagicMock(return_value=MagicMock())
+        anonymizer_cls = MagicMock(return_value=MagicMock())
+        with patch.dict(
+            sys.modules,
+            {
+                "presidio_analyzer": SimpleNamespace(AnalyzerEngine=analyzer_cls),
+                "presidio_anonymizer": SimpleNamespace(AnonymizerEngine=anonymizer_cls),
+            },
+        ):
+            config = InputGuardConfig(enabled=True)
+            processor = build_history_processor(config)
+
+        # Patch the guard inside the closure after creation.
+        guard = MagicMock(spec=PresidioInputGuard)
+        guard.sanitize_text.side_effect = lambda text, source: sanitized_text if text else text
+        # Re-inject guard by rebuilding with our mock — easier via direct patch below.
+        return processor, guard, config
+
+    def test_messages_without_parts_pass_through(self):
+        config = InputGuardConfig(enabled=True)
+        guard = MagicMock(spec=PresidioInputGuard)
+        guard.sanitize_text.return_value = "<PII>"
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            processor = build_history_processor(config)
+
+        msg = SimpleNamespace()  # no .parts attribute
+        assert processor([msg]) == [msg]
+
+    def test_unchanged_messages_are_returned_as_is(self):
+        config = InputGuardConfig(enabled=True)
+        guard = MagicMock(spec=PresidioInputGuard)
+        # sanitize_text returns same text — no change
+        guard.sanitize_text.side_effect = lambda text, source: text
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            processor = build_history_processor(config)
+
+        @dataclass
+        class Part:
+            content: str
+
+        @dataclass
+        class Message:
+            parts: list
+
+        msg = Message(parts=[Part(content="hello")])
+        result = processor([msg])
+        assert result[0] is msg  # identity — not reconstructed
+
+    def test_changed_part_rebuilds_message_via_replace(self):
+        config = InputGuardConfig(enabled=True)
+        guard = MagicMock(spec=PresidioInputGuard)
+        guard.sanitize_text.return_value = "<EMAIL>"
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            processor = build_history_processor(config)
+
+        @dataclass
+        class Part:
+            content: str
+
+        @dataclass
+        class Message:
+            parts: list
+
+        original_msg = Message(parts=[Part(content="user@example.com")])
+        result = processor([original_msg])
+        assert result[0] is not original_msg
+        assert result[0].parts[0].content == "<EMAIL>"
+
+    def test_part_without_content_attr_is_kept(self):
+        config = InputGuardConfig(enabled=True)
+        guard = MagicMock(spec=PresidioInputGuard)
+        guard.sanitize_text.return_value = "<PII>"
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            processor = build_history_processor(config)
+
+        @dataclass
+        class ToolCallPart:
+            tool_name: str  # no .content
+
+        @dataclass
+        class Message:
+            parts: list
+
+        msg = Message(parts=[ToolCallPart(tool_name="search")])
+        result = processor([msg])
+        assert result[0] is msg
+
+
+# ---------------------------------------------------------------------------
+# sanitize_file_content
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFileContent:
+    def test_disabled_guard_returns_content_unchanged(self):
+        result = sanitize_file_content("sensitive text", {"enabled": False})
+        assert result == "sensitive text"
+
+    def test_none_guard_returns_content_unchanged(self):
+        result = sanitize_file_content("sensitive text", None)
+        assert result == "sensitive text"
+
+    def test_enabled_guard_sanitizes_text(self):
+        guard = MagicMock(spec=PresidioInputGuard)
+        guard.sanitize_text.return_value = "<EMAIL>"
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            result = sanitize_file_content("user@example.com", {"enabled": True})
+
+        assert result == "<EMAIL>"
+
+    def test_binary_reject_policy_raises_before_guard(self):
+        from pydantic_ai.messages import BinaryContent
+
+        binary = BinaryContent(data=b"...", media_type="image/png")
+        with pytest.raises(InputGuardAttachmentError, match=ATTACHMENT_REJECTION_MSG):
+            sanitize_file_content(binary, {"enabled": True, "attachment_policy": "reject"})
+
+    def test_binary_allow_unmodified_passes_through(self):
+        from pydantic_ai.messages import BinaryContent
+
+        guard = MagicMock(spec=PresidioInputGuard)
+        # sanitize_text won't be called for BinaryContent
+        binary = BinaryContent(data=b"...", media_type="image/png")
+
+        with patch("airflow.providers.common.ai.privacy.history.PresidioInputGuard", return_value=guard):
+            result = sanitize_file_content(binary, {"enabled": True, "attachment_policy": "allow_unmodified"})
+
+        assert result is binary


### PR DESCRIPTION
## Summary

Adds an opt-in `input_guard` parameter to `LLMOperator`, `AgentOperator`, and
`LLMFileAnalysisOperator` that uses Microsoft Presidio to sanitize PII and
other sensitive entities in text before it is sent to the model.

### What it does

- **Sanitizes** user prompt text, system instructions, and multi-turn message
  history (via pydantic-ai `history_processors`) before each model call
- **Sanitizes** normalized file content in `LLMFileAnalysisOperator`
- **Supports four Presidio modes**: `replace` (default), `mask`, `redact`, `hash`
- **Rejects binary multimodal attachments** by default when guarding is enabled;
  opt out with `attachment_policy="allow_unmodified"`
- **Logs sanitization summaries** (entity types and counts) at INFO; optionally
  logs a truncated sanitized preview with `log_sanitized_text=True`

### Usage

```python
LLMOperator(
    task_id="safe_call",
    prompt="Customer Jane Doe, jane@example.com, card 4111 1111 1111 1111",
    llm_conn_id="pydanticai_default",
    input_guard={
        "enabled": True,
        "entities": ["EMAIL_ADDRESS", "CREDIT_CARD", "PHONE_NUMBER"],
        "mode": "replace",
    },
)

```
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
- gpt codex

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
