### PR TITLE
Add test coverage for per-set queue in default KEDA query in Helm chart

### DIFF
--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1633,6 +1633,7 @@ class TestWorkerSets:
 
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == "test"
 
+    @pytest.mark.parametrize("parent_path", ["deprecated", "modern"])
     @pytest.mark.parametrize("enable_default", [False, True])
     @pytest.mark.parametrize(
         ("queue", "expected_in_query"),
@@ -1641,22 +1642,28 @@ class TestWorkerSets:
             ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
         ],
     )
-    def test_overwrite_queue_keda_query(self, enable_default, queue, expected_in_query):
+    def test_overwrite_queue_keda_query(self, parent_path, enable_default, queue, expected_in_query):
+        parent_keda = {"enabled": True, "pollingInterval": 10}
+        celery = {
+            "enableDefault": enable_default,
+            "sets": [{"name": "worker-set", "queue": queue}],
+        }
+        if parent_path == "deprecated":
+            workers_values = {"keda": parent_keda, "celery": celery}
+        else:
+            celery["keda"] = parent_keda
+            workers_values = {"celery": celery}
+
         docs = render_chart(
             name="test",
-            values={
-                "workers": {
-                    "celery": {
-                        "keda": {"enabled": True},
-                        "enableDefault": enable_default,
-                        "sets": [{"name": "worker-set", "queue": queue}],
-                    },
-                },
-            },
+            values={"workers": workers_values},
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
 
         assert len(docs) == (2 if enable_default else 1)
+        for doc in docs:
+            assert jmespath.search("spec.pollingInterval", doc) == 10
+
         by_name = {d["metadata"]["name"]: d for d in docs}
         set_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker-worker-set"])
         assert expected_in_query in set_query

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1634,6 +1634,33 @@ class TestWorkerSets:
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == "test"
 
     @pytest.mark.parametrize(
+        ("queue", "expected_in_query"),
+        [
+            ("cpu", "queue IN ('cpu')"),
+            ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
+        ],
+    )
+    def test_per_set_queue_renders_in_default_keda_query(self, queue, expected_in_query):
+        docs = render_chart(
+            name="test",
+            values={
+                "workers": {
+                    "celery": {
+                        "keda": {"enabled": True},
+                        "enableDefault": False,
+                        "sets": [{"name": "worker-set", "queue": queue}],
+                    },
+                },
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+        )
+
+        assert len(docs) == 1
+        query = jmespath.search("spec.triggers[0].metadata.query", docs[0])
+        assert expected_in_query in query
+        assert "queue IN ('default')" not in query
+
+    @pytest.mark.parametrize(
         "workers_values",
         [
             {

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1633,6 +1633,7 @@ class TestWorkerSets:
 
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == "test"
 
+    @pytest.mark.parametrize("enable_default", [False, True])
     @pytest.mark.parametrize(
         ("queue", "expected_in_query"),
         [
@@ -1640,14 +1641,14 @@ class TestWorkerSets:
             ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
         ],
     )
-    def test_overwrite_queue_keda_query(self, queue, expected_in_query):
+    def test_overwrite_queue_keda_query(self, enable_default, queue, expected_in_query):
         docs = render_chart(
             name="test",
             values={
                 "workers": {
                     "celery": {
                         "keda": {"enabled": True},
-                        "enableDefault": False,
+                        "enableDefault": enable_default,
                         "sets": [{"name": "worker-set", "queue": queue}],
                     },
                 },
@@ -1655,10 +1656,15 @@ class TestWorkerSets:
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
 
-        assert len(docs) == 1
-        query = jmespath.search("spec.triggers[0].metadata.query", docs[0])
-        assert expected_in_query in query
-        assert "queue IN ('default')" not in query
+        assert len(docs) == (2 if enable_default else 1)
+        by_name = {d["metadata"]["name"]: d for d in docs}
+        set_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker-worker-set"])
+        assert expected_in_query in set_query
+        assert "queue IN ('default')" not in set_query
+        if enable_default:
+            default_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker"])
+            assert "queue IN ('default')" in default_query
+            assert expected_in_query not in default_query
 
     @pytest.mark.parametrize(
         "workers_values",

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1640,7 +1640,7 @@ class TestWorkerSets:
             ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
         ],
     )
-    def test_per_set_queue_renders_in_default_keda_query(self, queue, expected_in_query):
+    def test_overwrite_queue_keda_query(self, queue, expected_in_query):
         docs = render_chart(
             name="test",
             values={

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1695,36 +1695,6 @@ class TestWorkerSets:
         "workers_values",
         [
             {
-                "keda": {"enabled": True, "pollingInterval": 10},
-                "celery": {
-                    "enableDefault": True,
-                    "sets": [{"name": "worker-set"}],
-                },
-            },
-            {
-                "celery": {
-                    "keda": {"enabled": True, "pollingInterval": 10},
-                    "enableDefault": True,
-                    "sets": [{"name": "worker-set"}],
-                },
-            },
-        ],
-    )
-    def test_overwrite_parent_keda_propagates_to_sets(self, workers_values):
-        docs = render_chart(
-            name="test",
-            values={"workers": workers_values},
-            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
-        )
-
-        assert len(docs) == 2
-        for doc in docs:
-            assert jmespath.search("spec.pollingInterval", doc) == 10
-
-    @pytest.mark.parametrize(
-        "workers_values",
-        [
-            {
                 "keda": {"usePgbouncer": False},
                 "celery": {
                     "enableDefault": False,

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker_sets.py
@@ -1633,8 +1633,6 @@ class TestWorkerSets:
 
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == "test"
 
-    @pytest.mark.parametrize("parent_path", ["deprecated", "modern"])
-    @pytest.mark.parametrize("enable_default", [False, True])
     @pytest.mark.parametrize(
         ("queue", "expected_in_query"),
         [
@@ -1642,36 +1640,86 @@ class TestWorkerSets:
             ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
         ],
     )
-    def test_overwrite_queue_keda_query(self, parent_path, enable_default, queue, expected_in_query):
-        parent_keda = {"enabled": True, "pollingInterval": 10}
-        celery = {
-            "enableDefault": enable_default,
-            "sets": [{"name": "worker-set", "queue": queue}],
-        }
-        if parent_path == "deprecated":
-            workers_values = {"keda": parent_keda, "celery": celery}
-        else:
-            celery["keda"] = parent_keda
-            workers_values = {"celery": celery}
+    def test_overwrite_queue_keda_query(self, queue, expected_in_query):
+        docs = render_chart(
+            name="test",
+            values={
+                "workers": {
+                    "celery": {
+                        "keda": {"enabled": True},
+                        "enableDefault": False,
+                        "sets": [{"name": "worker-set", "queue": queue}],
+                    },
+                },
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+        )
 
+        assert len(docs) == 1
+        query = jmespath.search("spec.triggers[0].metadata.query", docs[0])
+        assert expected_in_query in query
+        assert "queue IN ('default')" not in query
+
+    @pytest.mark.parametrize(
+        ("queue", "expected_in_query"),
+        [
+            ("cpu", "queue IN ('cpu')"),
+            ("highcpu,highmem", "queue IN ('highcpu','highmem')"),
+        ],
+    )
+    def test_overwrite_queue_keda_query_with_default(self, queue, expected_in_query):
+        docs = render_chart(
+            name="test",
+            values={
+                "workers": {
+                    "celery": {
+                        "keda": {"enabled": True},
+                        "enableDefault": True,
+                        "sets": [{"name": "worker-set", "queue": queue}],
+                    },
+                },
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+        )
+
+        assert len(docs) == 2
+        by_name = {d["metadata"]["name"]: d for d in docs}
+        set_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker-worker-set"])
+        default_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker"])
+        assert expected_in_query in set_query
+        assert "queue IN ('default')" not in set_query
+        assert "queue IN ('default')" in default_query
+        assert expected_in_query not in default_query
+
+    @pytest.mark.parametrize(
+        "workers_values",
+        [
+            {
+                "keda": {"enabled": True, "pollingInterval": 10},
+                "celery": {
+                    "enableDefault": True,
+                    "sets": [{"name": "worker-set"}],
+                },
+            },
+            {
+                "celery": {
+                    "keda": {"enabled": True, "pollingInterval": 10},
+                    "enableDefault": True,
+                    "sets": [{"name": "worker-set"}],
+                },
+            },
+        ],
+    )
+    def test_overwrite_parent_keda_propagates_to_sets(self, workers_values):
         docs = render_chart(
             name="test",
             values={"workers": workers_values},
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
 
-        assert len(docs) == (2 if enable_default else 1)
+        assert len(docs) == 2
         for doc in docs:
             assert jmespath.search("spec.pollingInterval", doc) == 10
-
-        by_name = {d["metadata"]["name"]: d for d in docs}
-        set_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker-worker-set"])
-        assert expected_in_query in set_query
-        assert "queue IN ('default')" not in set_query
-        if enable_default:
-            default_query = jmespath.search("spec.triggers[0].metadata.query", by_name["test-worker"])
-            assert "queue IN ('default')" in default_query
-            assert expected_in_query not in default_query
 
     @pytest.mark.parametrize(
         "workers_values",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Adds test coverage for the case where a `workers.celery.sets` entry overrides `queue` without overriding `keda.query`

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude for exploring existing tests.

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---
