### PR TITLE
Fix flaky Stackdriver test timeout caused by leaked watchtower handler

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import logging
 import textwrap
 import time
@@ -60,6 +61,26 @@ def get_time_str(time_in_milliseconds):
 def logmock():
     with mock_aws():
         yield
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_cloudwatch_handlers():
+    # Watchtower's CloudWatchLogHandler spawns a queue worker thread that keeps
+    # the handler alive even after the test fixture tears down, so it stays
+    # registered in logging._handlerList. Several tests here never call close()
+    # or mock watchtower.CloudWatchLogHandler.close, leaking the handler across
+    # tests. When a later test in the same xdist worker calls
+    # logging.config.dictConfig (e.g. settings.configure_logging()), its
+    # _clearExistingHandlers path runs close() on the leaked handler and blocks
+    # up to FLUSH_TIMEOUT waiting for an undrainable queue — mock_aws is gone.
+    # Closing here while mock_aws is still active drains cleanly.
+    yield
+    for handler_ref in logging._handlerList[:]:
+        handler = handler_ref()
+        if handler is not None and isinstance(handler, CloudWatchLogHandler):
+            with contextlib.suppress(Exception):
+                handler.close()
+            logging._removeHandlerRef(handler_ref)
 
 
 # We only test this directly on Airflow 3


### PR DESCRIPTION
Under xdist, tests from `providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py` and `providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py` can land on the same worker. The Amazon tests create `watchtower.CloudWatchLogHandler` instances whose `use_queues=True` worker thread keeps them registered in `logging._handlerList` well after the test ends (several tests never call `close()` or mock out `watchtower.CloudWatchLogHandler.close`).

Later, the Stackdriver test's `settings.configure_logging()` runs `logging.config.dictConfig()` → `_clearExistingHandlers()` → `logging.shutdown()`, which calls `close()` on the leaked watchtower handler and blocks up to `FLUSH_TIMEOUT` (60s) waiting for a queue that can never drain — `mock_aws` from the Amazon tests has already exited. pytest-timeout then fails the Stackdriver test.

Observed in [this run](https://github.com/apache/airflow/actions/runs/24626125745/job/72005911434): `test_should_use_configured_log_name` timed out on `gw0` with the close stack hanging inside `watchtower/__init__.py:537`.

This PR adds an autouse fixture in the Amazon CloudWatch test module that closes and deregisters any remaining `CloudWatchLogHandler` after each test, while `mock_aws` is still active so the queue drains cleanly.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7, 1M context)

Generated-by: Claude Code (Opus 4.7, 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)