### PR TITLE
Fix airflow-ctl missing pyyaml runtime dependency

### DIFF
--- a/airflow-ctl/RELEASE_NOTES.rst
+++ b/airflow-ctl/RELEASE_NOTES.rst
@@ -29,6 +29,7 @@ Significant Changes
 Bug Fixes
 ^^^^^^^^^
 
+- Declare ``pyyaml`` as a runtime dependency so ``airflowctl`` starts without crashing on ``ModuleNotFoundError``
 - Prevent path traversal via AIRFLOW_CLI_ENVIRONMENT in airflowctl (#64618)
 - Fix ``is_alive`` default in ``airflowctl jobs list`` to show all jobs (#65065)
 - Fix CLI error handling and exit codes for failed commands (#65052)

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "methodtools>=0.4.7",
     "platformdirs>=4.3.6",
     "pydantic>=2.11.0", # https://github.com/apache/airflow/issues/56482
+    "pyyaml>=6.0.3",
     "rich-argparse>=1.0.0",
     "structlog>=25.4.0",
     "uuid6>=2024.7.10",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-13T06:48:54.989850866Z"
+exclude-newer = "2026-04-15T13:08:58.648422Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -92,9 +92,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -1954,6 +1954,7 @@ dependencies = [
     { name = "methodtools" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "rich-argparse" },
     { name = "structlog" },
     { name = "tabulate" },
@@ -1989,6 +1990,7 @@ requires-dist = [
     { name = "methodtools", specifier = ">=0.4.7" },
     { name = "platformdirs", specifier = ">=4.3.6" },
     { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich-argparse", specifier = ">=1.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
@@ -19963,8 +19965,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
PR #65073 added ``import yaml`` at module scope in ``airflow-ctl/src/airflowctl/ctl/cli_config.py`` (and ``airflowctl/ctl/utils/yaml.py``) without declaring ``pyyaml`` as a runtime dependency in ``airflow-ctl/pyproject.toml``.

As a result, a fresh ``pip install apache-airflow-ctl`` followed by any ``airflowctl`` invocation crashes with ``ModuleNotFoundError: No module named 'yaml'``. Caught during ``airflow-ctl 0.1.4rc1`` release-candidate pre-upload sanity checks.

This PR adds ``pyyaml>=6.0.3`` to ``dependencies`` (matching the pin used in ``airflow-core``) and regenerates ``uv.lock``. Also notes the fix in the 0.1.4 Bug Fixes section of ``airflow-ctl/RELEASE_NOTES.rst``.

Blocks ``airflow-ctl 0.1.4`` — ``0.1.4rc2`` will be cut from the merged commit.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)