### PR TITLE
Fix e2e flaky in AssetDetailPage and ConnectionsPage tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/AssetDetailPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/AssetDetailPage.ts
@@ -30,7 +30,13 @@ export class AssetDetailPage extends BasePage {
   }
 
   public async clickOnAsset(name: string): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (res) => /\/api\/v2\/assets\/\d+(\?|$)/.test(res.url()) && res.ok(),
+      { timeout: 15_000 },
+    );
+
     await this.page.getByRole("link", { exact: true, name }).click();
+    await responsePromise;
   }
 
   public getHeading(name: string): Locator {
@@ -64,6 +70,7 @@ export class AssetDetailPage extends BasePage {
     const button = statContainer.getByRole("button").first();
 
     await expect(button).toBeVisible();
+    await expect(button).toBeEnabled();
     await expect(button).toHaveText(/^[1-9]/);
 
     const text = await button.textContent();

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
@@ -147,11 +147,12 @@ export class ConnectionsPage extends BasePage {
     await expect(deleteButton).toBeVisible({ timeout: 10_000 });
     await expect(deleteButton).toBeEnabled({ timeout: 5000 });
 
-    await expect(async () => {
-      await deleteButton.click({ timeout: 5000 });
-      await expect(this.confirmDeleteButton).toBeVisible({ timeout: 5000 });
-    }).toPass({ intervals: [2000], timeout: 30_000 });
+    // Extended timeout: on resource-constrained CI runners, WebKit can take
+    // longer than the default 10s to release the previous dialog's backdrop
+    // pointer-events after close.
+    await deleteButton.click({ timeout: 30_000 });
 
+    await expect(this.confirmDeleteButton).toBeVisible({ timeout: 10_000 });
     await expect(this.confirmDeleteButton).toBeEnabled({ timeout: 5000 });
     await this.confirmDeleteButton.click();
 
@@ -304,17 +305,17 @@ export class ConnectionsPage extends BasePage {
   public async saveConnection(): Promise<void> {
     await expect(this.saveButton).toBeVisible({ timeout: 10_000 });
     await expect(this.saveButton).toBeEnabled({ timeout: 5000 });
+
+    const responsePromise = this.page.waitForResponse(
+      (response) =>
+        /\/api\/v2\/connections(\/[^/]+)?(\?|$)/.test(response.url()) &&
+        ["PATCH", "POST"].includes(response.request().method()) &&
+        response.ok(),
+      { timeout: 15_000 },
+    );
+
     await this.saveButton.click();
-
-    await Promise.race([
-      this.page.waitForURL("**/connections", { timeout: 10_000 }),
-      this.successAlert.waitFor({ state: "visible", timeout: 30_000 }),
-    ]);
-
-    // Ensure the dialog is fully closed before proceeding.
-    // Ark UI may leave the backdrop element in the DOM with data-state="closed",
-    // but it is non-interactive (pointer-events: none) and does not block clicks.
-    await expect(this.connectionForm).toBeHidden({ timeout: 10_000 });
+    await responsePromise;
   }
 
   public async searchConnections(searchTerm: string): Promise<void> {

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/asset.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/asset.spec.ts
@@ -71,7 +71,7 @@ test.describe("Assets Page", () => {
       .toBe(true);
   });
 
-  test.fixme("verify asset details and dependencies", async ({ assetDetailPage }) => {
+  test("verify asset details and dependencies", async ({ assetDetailPage }) => {
     const assetName = testConfig.asset.name;
 
     await assetDetailPage.goto();

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
@@ -191,7 +191,7 @@ test.describe("Connections Page - CRUD Operations", () => {
     expect(stillExists).toBeTruthy();
   });
 
-  test.fixme("should delete a connection", async () => {
+  test("should delete a connection", async () => {
     test.setTimeout(120_000);
 
     // Create a temporary connection for deletion test


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

Re-enables two e2e tests that were previously marked as `test.fixme` in #65487 by stabilizing them using Playwright-native synchronization. No UI changes.

## Problem
In CI (Linux WebKit), Ark UI dialog/popover occasionally leaves residual state longer than expected, which can block subsequent clicks.  
This is due to lingering UI artifacts (e.g. backdrop pointer-events, stat-card layout) exceeding the default 10s action timeout.

The issue is specific to the resource-constrained CI runner (2 parallel workers) and is not reproducible on macOS Safari.

## Changes

* ConnectionsPage
  * Replaced UI-based completion checks (URL change, toast, dialog closed) with `waitForResponse` on `/api/v2/connections`
  * Increased delete button click timeout to 30s to handle CI slowness.  
* AssetDetailPage
  * Added `waitForResponse` for the asset detail API to ensure all data is loaded before proceeding.
  * Added `toBeEnabled()` pre-check  
  * Replaced with standard `click()` for proper actionability

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
