### PR TITLE
fix false-green applyCustomEnv check for database cleanup

### DIFF
--- a/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
@@ -281,22 +281,23 @@ class TestDatabaseCleanup:
         docs = render_chart(
             values={
                 "env": all_containers_envs,
-                "applyCustomEnv": custom_envs_enabled,
                 "databaseCleanup": {
                     "enabled": True,
+                    "applyCustomEnv": custom_envs_enabled,
                     "env": cleanup_envs,
                 },
             },
             show_only=["templates/database-cleanup/database-cleanup-cronjob.yaml"],
         )
+        envs = jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].env", docs[0])
+
         if cleanup_envs:
-            assert cleanup_envs[0] in jmespath.search(
-                "spec.jobTemplate.spec.template.spec.containers[0].env", docs[0]
-            )
+            assert cleanup_envs[0] in envs
         if all_containers_envs:
-            assert all_containers_envs[0] in jmespath.search(
-                "spec.jobTemplate.spec.template.spec.containers[0].env", docs[0]
-            )
+            if custom_envs_enabled:
+                assert all_containers_envs[0] in envs
+            else:
+                assert all_containers_envs[0] not in envs
 
     @pytest.mark.parametrize("command", [None, ["custom", "command"]])
     @pytest.mark.parametrize("args", [None, ["custom", "args"]])

--- a/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
@@ -255,22 +255,23 @@ class TestDatabaseCleanup:
         docs = render_chart(
             values={
                 "env": all_containers_envs,
-                "applyCustomEnv": custom_envs_enabled,
                 "databaseCleanup": {
                     "enabled": True,
+                    "applyCustomEnv": custom_envs_enabled,
                     "env": cleanup_envs,
                 },
             },
             show_only=["templates/database-cleanup/database-cleanup-cronjob.yaml"],
         )
+        envs = jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].env", docs[0])
+
         if cleanup_envs:
-            assert cleanup_envs[0] in jmespath.search(
-                "spec.jobTemplate.spec.template.spec.containers[0].env", docs[0]
-            )
+            assert cleanup_envs[0] in envs
         if all_containers_envs:
-            assert all_containers_envs[0] in jmespath.search(
-                "spec.jobTemplate.spec.template.spec.containers[0].env", docs[0]
-            )
+            if custom_envs_enabled:
+                assert all_containers_envs[0] in envs
+            else:
+                assert all_containers_envs[0] not in envs
 
     @pytest.mark.parametrize("command", [None, ["custom", "command"]])
     @pytest.mark.parametrize("args", [None, ["custom", "args"]])


### PR DESCRIPTION
## Why
The database cleanup template reads `databaseCleanup.applyCustomEnv`, but the test was toggling a top-level `applyCustomEnv `key.
That means the branch in the template was not actually controlled by the test input.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
