### PR TITLE
Improve airflow-ctl release automation: gh-token fallback and categorization

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3026,18 +3026,29 @@ def _build_changelog_content(
     improvements: list[str] = []
     misc: list[str] = []
 
+    # Strip leaked branch prefixes like "[main]" or "[v3-2-test]" from PR
+    # titles before both categorisation and output — these are maintenance
+    # artefacts that should not be user-visible in release notes.
+    branch_prefix = re.compile(r"^\s*\[(?:main|v\d+(?:-\d+)*-test)\]\s*", re.IGNORECASE)
+
     for pr_number in prs:
         if pr_number not in pr_titles:
             continue
-        title = pr_titles[pr_number]
+        title = branch_prefix.sub("", pr_titles[pr_number]).strip()
         entry = f"{title} (#{pr_number})"
         lower = title.lower()
-        if lower.startswith(("feat", "add", "allow")):
-            significant.append(entry)
-        elif lower.startswith("fix"):
-            bug_fixes.append(entry)
-        elif lower.startswith(("ci:", "build", "upgrade")):
+        if lower.startswith(("ci:", "ci ", "build", "upgrade", "bump")) or "cooldown" in lower:
+            # CI / build / dependency-bump items land in Miscellaneous. Check
+            # before the "add"/"feat"/"allow" branch below, because titles like
+            # "Add 4-day cooldown for uv dependency resolution" are CI and
+            # should not sneak into Significant Changes.
             misc.append(entry)
+        elif lower.startswith(("feat", "add", "allow")):
+            significant.append(entry)
+        elif lower.startswith("fix") or lower.startswith(("prevent ", "security:")):
+            # Security fixes (e.g. "Prevent path traversal …") are bug fixes,
+            # not improvements.
+            bug_fixes.append(entry)
         else:
             improvements.append(entry)
 
@@ -4323,6 +4334,7 @@ def generate_issue_content(
         excluded_prs = []
     prs = [pr for pr in change_prs if pr is not None and pr not in excluded_prs]
 
+    github_token = _get_github_token(github_token)
     g = Github(github_token)
     repo = g.get_repo("apache/airflow")
     pull_requests: dict[int, PullRequestOrIssue] = {}


### PR DESCRIPTION
Two related fixes to the breeze airflow-ctl release-management commands, both uncovered during the ``0.1.4rc1`` → ``0.1.4rc2`` release:

### 1. ``generate-issue-content-airflow-ctl`` (and helm-chart / core) now fall back to ``gh auth token``

``generate_airflowctl_changelog`` already called ``_get_github_token`` to fall back to the local ``gh`` CLI token when ``GITHUB_TOKEN`` was not exported, but the shared ``generate_issue_content`` helper (used by ``generate-issue-content-airflow-ctl``, ``generate-issue-content-helm-chart``, and ``generate-issue-content-core``) did not, so RMs had to prefix the command with ``GITHUB_TOKEN=$(gh auth token)`` or export the token manually. This PR moves the fallback into ``generate_issue_content`` so every non-provider issue-content command behaves the same as the changelog generator.

### 2. Changelog categorization in ``_build_changelog_content`` is less noisy

Observations from ``0.1.4`` that are fixed here:

- PR titles prefixed with ``[main]`` / ``[v3-2-test]`` (leaked branch markers from backports) previously landed verbatim in release notes *and* broke the keyword match (``[main] Upgrade CI`` did not match the ``upgrade`` keyword, so it landed in *Improvements* instead of *Miscellaneous*). Both the stripping and the categorisation are now applied after removing the prefix.
- CI / build / dependency-bump items are checked *before* the ``feat``/``add``/``allow`` branch, so titles like ``Add 4-day cooldown for uv dependency resolution`` land in *Miscellaneous* rather than *Significant Changes*.
- Security fixes (``Prevent path traversal …``, ``security: …``) are now categorised as *Bug Fixes* rather than *Improvements*.

RMs still do a manual review of the generated section — these changes just cut down the amount of hand-shuffling in the common cases. See the release doc (``dev/README_RELEASE_AIRFLOWCTL.md``) for the full review checklist.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)