### PR TITLE
airflow-ctl: pull provider workspace deps so local mypy resolves cross-project types

### DIFF
--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -145,6 +145,14 @@ docs = [
 dev = [
     "apache-airflow-ctl[dev]",
     "apache-airflow-devel-common",
+    # Installed so that mypy (which follows imports across the workspace via
+    # [tool.mypy].mypy_path in the root pyproject.toml) can resolve types in
+    # airflow-core, task-sdk, and provider source trees referenced from
+    # airflow-ctl's generated datamodels. Without these the local prek hook
+    # ``mypy-airflow-ctl`` fails on macOS while the CI image passes. Match
+    # the pattern used by task-sdk's dev group.
+    "apache-airflow-providers-common-sql",
+    "apache-airflow-providers-standard",
 ]
 codegen = [
     "datamodel-code-generator[http]==0.33.0",
@@ -217,3 +225,5 @@ required-version = ">=0.6.3"
 
 [tool.uv.sources]
 apache-airflow-devel-common = { workspace = true }
+apache-airflow-providers-common-sql = { workspace = true }
+apache-airflow-providers-standard = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-15T13:08:58.648422Z"
+exclude-newer = "2026-04-15T16:17:41.541638Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -1975,6 +1975,8 @@ codegen = [
 dev = [
     { name = "apache-airflow-ctl", extra = ["dev"] },
     { name = "apache-airflow-devel-common" },
+    { name = "apache-airflow-providers-common-sql" },
+    { name = "apache-airflow-providers-standard" },
 ]
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
@@ -2007,6 +2009,8 @@ codegen = [
 dev = [
     { name = "apache-airflow-ctl", extras = ["dev"], editable = "airflow-ctl" },
     { name = "apache-airflow-devel-common", editable = "devel-common" },
+    { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
+    { name = "apache-airflow-providers-standard", editable = "providers/standard" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
 


### PR DESCRIPTION
Local ``prek run mypy-airflow-ctl --all-files`` (and the equivalent direct ``uv run --frozen --project airflow-ctl ... mypy`` command documented in ``CLAUDE.md``) fails on macOS with ~29 errors in ``airflow-core``, ``task-sdk``, and ``providers/common/sql`` files that mypy follows via ``[tool.mypy].mypy_path``. The same hook passes cleanly in the CI docker image because the image has the full workspace installed.

Root cause: ``uv sync --frozen --project airflow-ctl`` installs only airflow-ctl's immediate deps, but mypy — per the root ``[tool.mypy].mypy_path`` that points at every workspace project — follows imports from airflow-ctl's generated datamodels into task-sdk/airflow-core source, and then into runtime deps like ``msgspec`` that only get installed via the providers/task-sdk dev groups.

This PR adds ``apache-airflow-providers-common-sql`` and ``apache-airflow-providers-standard`` to airflow-ctl's ``[dependency-groups].dev`` (and to ``[tool.uv.sources]`` as workspace members), mirroring what ``task-sdk/pyproject.toml`` already does. Those two providers transitively pull in ``msgspec`` and enough of the airflow-core/task-sdk graph that mypy's workspace-following succeeds locally.

Verified locally: ``prek run mypy-airflow-ctl --all-files`` now reports ``Passed``.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)