### PR TITLE
Fix publish-docs Update Provider Registry job for non-provider distributions

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -176,7 +176,7 @@ jobs:
                 PROVIDER_ID="${pkg#apache-airflow-providers-}"
                 REGISTRY_PROVIDERS="${REGISTRY_PROVIDERS:+${REGISTRY_PROVIDERS} }${PROVIDER_ID}"
                 ;;
-              apache-airflow|all-providers|apache-airflow-providers|helm-chart|docker-stack)
+              apache-airflow|all-providers|apache-airflow-providers|helm-chart|docker-stack|apache-airflow-ctl|apache-airflow-task-sdk)
                 # Not a provider package, skip
                 ;;
               *)


### PR DESCRIPTION
Triggering the ``Publish Docs to S3`` workflow with ``apache-airflow-ctl`` (or ``apache-airflow-task-sdk``) has the docs publishing succeed but the downstream ``Update Provider Registry / Build & Publish Registry`` job fail with:

```
ERROR: provider 'apache-airflow-ctl' not found in provider.yaml files
```

Observed on run https://github.com/apache/airflow/actions/runs/24630652716 while publishing docs for ``airflow-ctl/0.1.4rc2``.

### Cause

``publish-docs-to-s3.yml`` computes the registry-update list in the ``build-info`` job. The ``case`` statement that filters out non-provider packages (``apache-airflow``, ``all-providers``, ``apache-airflow-providers``, ``helm-chart``, ``docker-stack``) did not include ``apache-airflow-ctl`` or ``apache-airflow-task-sdk``, so those names fell through to the default branch and were added to ``REGISTRY_PROVIDERS``. The downstream ``registry-build.yml`` workflow then called ``dev/registry/extract_parameters.py --provider apache-airflow-ctl``, which exits 1 because airflow-ctl is not a provider.

### Fix

Extend the skip list to include ``apache-airflow-ctl`` and ``apache-airflow-task-sdk`` so the registry-update job is correctly skipped for these distributions (matching the existing behaviour for ``apache-airflow`` and ``helm-chart``).

Docs publishing itself is unaffected — this change only stops surfacing a red check on every airflow-ctl / task-sdk docs publish.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)