### PR TITLE
Strip userinfo from OpenSearch host URL before using it as task-log label

### DIFF
--- a/providers/elasticsearch/AGENTS.md
+++ b/providers/elasticsearch/AGENTS.md
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Elasticsearch Provider — Agent Instructions
+
+## Keep in sync with `providers/opensearch`
+
+OpenSearch was forked from Elasticsearch and the two providers share most of
+their task-log handler code and surface. File layouts mirror each other:
+
+| Elasticsearch                                   | OpenSearch                              |
+| ----------------------------------------------- | --------------------------------------- |
+| `log/es_task_handler.py`                        | `log/os_task_handler.py`                |
+| `log/es_response.py`                            | `log/os_response.py`                    |
+| `log/es_json_formatter.py`                      | `log/os_json_formatter.py`              |
+| `ElasticsearchTaskHandler`                      | `OpensearchTaskHandler`                 |
+| `ElasticsearchRemoteLogIO`                      | `OpensearchRemoteLogIO`                 |
+
+**When fixing a bug or changing behaviour here, check whether the equivalent
+change is needed in `providers/opensearch` (and vice-versa).** This applies
+especially to: task-log handler logic, log grouping / formatting, connection
+handling, URL/credential treatment, and response parsing. The two packages
+ship on independent release cadences, so the fix should usually land as two
+separate PRs on the same day.
+
+Legitimate reasons to diverge: upstream client API differences (`elasticsearch`
+vs `opensearchpy`), provider-specific features that only one side has, or
+changes gated on config that only exists in one provider.

--- a/providers/opensearch/AGENTS.md
+++ b/providers/opensearch/AGENTS.md
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# OpenSearch Provider — Agent Instructions
+
+## Keep in sync with `providers/elasticsearch`
+
+OpenSearch was forked from Elasticsearch and the two providers share most of
+their task-log handler code and surface. File layouts mirror each other:
+
+| OpenSearch                              | Elasticsearch                                   |
+| --------------------------------------- | ----------------------------------------------- |
+| `log/os_task_handler.py`                | `log/es_task_handler.py`                        |
+| `log/os_response.py`                    | `log/es_response.py`                            |
+| `log/os_json_formatter.py`              | `log/es_json_formatter.py`                      |
+| `OpensearchTaskHandler`                 | `ElasticsearchTaskHandler`                      |
+| `OpensearchRemoteLogIO`                 | `ElasticsearchRemoteLogIO`                      |
+
+**When fixing a bug or changing behaviour here, check whether the equivalent
+change is needed in `providers/elasticsearch` (and vice-versa).** This applies
+especially to: task-log handler logic, log grouping / formatting, connection
+handling, URL/credential treatment, and response parsing. The two packages
+ship on independent release cadences, so the fix should usually land as two
+separate PRs on the same day.
+
+Legitimate reasons to diverge: upstream client API differences (`opensearchpy`
+vs `elasticsearch`), provider-specific features that only one side has (e.g.
+`write_to_os`), or changes gated on config that only exists in one provider.

--- a/providers/opensearch/docs/changelog.rst
+++ b/providers/opensearch/docs/changelog.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+When the ``[opensearch] host`` config embeds credentials
+(``https://user:password@opensearch.example.com:9200``), the log-source
+label shown in task logs is now the host URL with the ``user:password@``
+portion stripped. Previously the full URL (including credentials) could
+appear as a dictionary key in the task-log output when log-hits did not
+carry a ``host`` field. The OpenSearch client is still connected using
+the full URL, so authentication is unaffected.
+
 1.9.0
 .....
 

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -197,6 +197,28 @@ def _create_opensearch_client(
     )
 
 
+def _strip_userinfo(url: str) -> str:
+    """
+    Return ``url`` with any ``user:password@`` userinfo removed.
+
+    The OpenSearch ``[opensearch] host`` config commonly embeds
+    credentials (``https://user:password@opensearch.example.com:9200``).
+    This value is reused as a display label for log-source grouping, so
+    the credentials would otherwise end up in task logs. Anything that
+    is not a valid URL is returned unchanged.
+    """
+    try:
+        parsed = urlparse(url)
+    except (TypeError, ValueError):
+        return url
+    if not parsed.hostname or (not parsed.username and not parsed.password):
+        return url
+    netloc = parsed.hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return parsed._replace(netloc=netloc).geturl()
+
+
 def _render_log_id(
     log_id_template: str, ti: TaskInstance | TaskInstanceKey | RuntimeTI, try_number: int
 ) -> str:
@@ -713,8 +735,9 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
 
     def _group_logs_by_host(self, response: OpensearchResponse) -> dict[str, list[Hit]]:
         grouped_logs = defaultdict(list)
+        host_fallback = _strip_userinfo(self.host)
         for hit in response:
-            key = getattr_nested(hit, self.host_field, None) or self.host
+            key = getattr_nested(hit, self.host_field, None) or host_fallback
             grouped_logs[key].append(hit)
         return grouped_logs
 
@@ -937,8 +960,9 @@ class OpensearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
     def _group_logs_by_host(self, response: OpensearchResponse) -> dict[str, list[Hit]]:
         grouped_logs = defaultdict(list)
+        host_fallback = _strip_userinfo(self.host)
         for hit in response:
-            key = getattr_nested(hit, self.host_field, None) or self.host
+            key = getattr_nested(hit, self.host_field, None) or host_fallback
             grouped_logs[key].append(hit)
         return grouped_logs
 

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -38,6 +38,7 @@ from airflow.providers.opensearch.log.os_task_handler import (
     _build_log_fields,
     _format_error_detail,
     _render_log_id,
+    _strip_userinfo,
     get_os_kwargs_from_config,
     getattr_nested,
 )
@@ -221,6 +222,21 @@ class TestOpensearchTaskHandler:
                 OpensearchTaskHandler.format_url(host)
         else:
             assert OpensearchTaskHandler.format_url(host) == expected
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("https://user:pass@opensearch.example.com:9200", "https://opensearch.example.com:9200"),
+            ("http://USER:PASS@opensearch.example.com", "http://opensearch.example.com"),
+            ("https://opensearch.example.com:9200", "https://opensearch.example.com:9200"),
+            ("http://localhost:9200", "http://localhost:9200"),
+            ("https://user@opensearch.example.com", "https://opensearch.example.com"),
+            ("not-a-url", "not-a-url"),
+            ("", ""),
+        ],
+    )
+    def test_strip_userinfo(self, host, expected):
+        assert _strip_userinfo(host) == expected
 
     def test_client(self):
         assert isinstance(self.os_task_handler.client, opensearchpy.OpenSearch)


### PR DESCRIPTION
Follow-up to #65349 (thanks @Owen-CH-Leung for [catching this](https://github.com/apache/airflow/pull/65349#issuecomment-4264676160)). OpenSearch's task-log handler has the same credential-leak as Elasticsearch did: `_group_logs_by_host` falls back to the raw `[opensearch] host` config value as the log-source label, so a host URL containing `user:password@...` appears as a dictionary key in task-log output.

Applies the same `_strip_userinfo` helper used in `providers/elasticsearch`. The OpenSearch client itself still connects using the full unredacted URL, so authentication is unaffected. Both `_group_logs_by_host` sites (`OpensearchTaskHandler` and `OpensearchRemoteLogIO`) are patched.

Also adds `AGENTS.md` to both `providers/opensearch` and `providers/elasticsearch` noting that the two providers are forks and that most task-log-handler fixes should be cross-applied, so this kind of cross-provider miss is easier to avoid next time.

## Test plan

- [X] New `test_strip_userinfo` parametrized across 7 input URL shapes (with userinfo, without userinfo, username-only, non-URL, empty) — all pass
- [X] Full existing `test_os_task_handler.py` non-db suite continues to pass (42/42)

## Changelog

Added a redaction note above the latest version header in `providers/opensearch/docs/changelog.rst` (mirrors the ES PR).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)