### PR TITLE
Fix airflow-ctl release guide verification commands

### DIFF
--- a/dev/README_RELEASE_AIRFLOWCTL.md
+++ b/dev/README_RELEASE_AIRFLOWCTL.md
@@ -652,6 +652,7 @@ cd "${AIRFLOW_REPO_ROOT}"
 Choose the tag you used for release:
 
 ```shell
+cd "${AIRFLOW_REPO_ROOT}"
 git fetch apache --tags --force
 git checkout airflow-ctl/${VERSION_RC}
 ```
@@ -717,7 +718,7 @@ tar -xzf /tmp/apache-rat-0.18-bin.tar.gz -C /tmp
 Unpack the release source archive (the `<package + version>-source.tar.gz` file) to a folder
 
 ```shell script
-rm -rf /tmp/apache/airflow-src && mkdir -p /tmp/apache-airflow-src && tar -xzf ${PATH_TO_AIRFLOW_SVN}/${VERSION_RC}/apache_airflow*-source.tar.gz --strip-components 1 -C /tmp/apache-airflow-src
+rm -rf /tmp/apache-airflow-src && mkdir -p /tmp/apache-airflow-src && tar -xzf ${PATH_TO_AIRFLOW_SVN}/airflow-ctl/${VERSION_RC}/apache_airflow*-source.tar.gz --strip-components 1 -C /tmp/apache-airflow-src
 ```
 
 Run the check:


### PR DESCRIPTION
Fix the airflow-ctl release guide in the PMC verification section.

This updates the reproducible-build instructions to:
- return to the Airflow repo before fetching tags and checking out the release tag
- use the correct temporary extraction directory path
- include the missing `airflow-ctl` path segment when unpacking the source release from SVN

This is a docs-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (GPT-5.4)

Generated-by: GitHub Copilot (GPT-5.4) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
