### PR TITLE
fix CI error: AttributeError: 'TaskInstance' object has no attribute 'run'

### DIFF
--- a/airflow-core/tests/unit/ti_deps/deps/test_mapped_task_upstream_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_mapped_task_upstream_dep.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.exceptions import AirflowFailException, AirflowSkipException
@@ -221,27 +222,39 @@ def test_step_by_step(
     assert sorted(schedulable_tis) == ["t1", "t2_a", "t3", "t4"]
     assert not finished_tis_states
 
-    # Run first schedulable task
-    schedulable_tis["t1"].run()
+    # Simulate running the first schedulable task: t1 returns [0]
+    schedulable_tis["t1"].state = SUCCESS
+    schedulable_tis["t1"].xcom_push(XCOM_RETURN_KEY, [0], session=session)
+    session.add(TaskMap.from_task_instance_xcom(schedulable_tis["t1"], [0]))
+    session.flush()
     schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
     assert sorted(schedulable_tis) == ["t2_a", "t3", "t4"]
     assert finished_tis_states == {"t1": SUCCESS}
 
-    # Run remaining schedulable tasks
+    # Simulate running remaining schedulable tasks
     if failure_mode == UPSTREAM_FAILED:
-        with pytest.raises(AirflowFailException):
-            schedulable_tis["t2_a"].run()
+        schedulable_tis["t2_a"].state = FAILED
+        session.flush()
         _one_scheduling_decision_iteration(dr, session)
     else:
-        schedulable_tis["t2_a"].run()
+        schedulable_tis["t2_a"].state = SUCCESS
+        session.flush()
         schedulable_tis, _ = _one_scheduling_decision_iteration(dr, session)
         if not failure_mode:
-            schedulable_tis["t2_b"].run()
+            schedulable_tis["t2_b"].state = SUCCESS
+            schedulable_tis["t2_b"].xcom_push(XCOM_RETURN_KEY, [1, 2], session=session)
+            session.add(TaskMap.from_task_instance_xcom(schedulable_tis["t2_b"], [1, 2]))
         else:
-            with pytest.raises(AirflowFailException):
-                schedulable_tis["t2_b"].run()
-    schedulable_tis["t3"].run()
-    schedulable_tis["t4"].run()
+            schedulable_tis["t2_b"].state = FAILED
+        session.flush()
+    if skip_upstream:
+        schedulable_tis["t3"].state = SKIPPED
+    else:
+        schedulable_tis["t3"].state = SUCCESS
+        schedulable_tis["t3"].xcom_push(XCOM_RETURN_KEY, [3, 4], session=session)
+        session.add(TaskMap.from_task_instance_xcom(schedulable_tis["t3"], [3, 4]))
+    schedulable_tis["t4"].state = SUCCESS
+    session.flush()
     _one_scheduling_decision_iteration(dr, session)
 
     # Test the mapped task upstream dependency checks
@@ -259,17 +272,21 @@ def test_step_by_step(
     assert finished_tis_states == expected_finished_tis_states
 
     if expect_passed:
-        # Run the m1 tasks
+        # Simulate running the m1 tasks; m2 mapping counts xcoms with map_index >= 0
         for i in range(4):
-            schedulable_tis[f"{mapped_task_1}_{i}"].run()
+            ti = schedulable_tis[f"{mapped_task_1}_{i}"]
+            ti.state = SUCCESS
+            ti.xcom_push(XCOM_RETURN_KEY, i, session=session)
             expected_finished_tis_states[f"{mapped_task_1}_{i}"] = SUCCESS
+        session.flush()
         schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
         assert sorted(schedulable_tis) == [f"{mapped_task_2}_{i}" for i in range(4)]
         assert finished_tis_states == expected_finished_tis_states
-        # Run the m2 tasks
+        # Simulate running the m2 tasks
         for i in range(4):
-            schedulable_tis[f"{mapped_task_2}_{i}"].run()
+            schedulable_tis[f"{mapped_task_2}_{i}"].state = SUCCESS
             expected_finished_tis_states[f"{mapped_task_2}_{i}"] = SUCCESS
+        session.flush()
         schedulable_tis, finished_tis_states = _one_scheduling_decision_iteration(dr, session)
         assert finished_tis_states == expected_finished_tis_states
         assert not schedulable_tis


### PR DESCRIPTION
My PR is blocked by this CI error. This test was missed during the TaskInstance.run() cleanup in #59835, and the failure was exposed by #65500 which stopped masking quarantined test results.  

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
