### PR TITLE
Fix graph view not auto-refreshing task states during DAG run

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.test.tsx
@@ -1,0 +1,147 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDagRunServiceGetDagRun } from "openapi/queries";
+import { useGridTiSummariesStream } from "src/queries/useGridTISummaries.ts";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { Graph } from "./Graph";
+
+let mockParams: Record<string, string> = { dagId: "test_dag" };
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockParams,
+    useSearchParams: () => [new URLSearchParams()],
+  };
+});
+
+vi.mock("openapi/queries", () => ({
+  useDagRunServiceGetDagRun: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useStructureServiceStructureData: vi.fn(() => ({ data: { edges: [], nodes: [] } })),
+}));
+
+vi.mock("src/queries/useDependencyGraph", () => ({
+  useDependencyGraph: vi.fn(() => ({ data: { edges: [], nodes: [] } })),
+}));
+
+vi.mock("src/components/Graph/useGraphLayout", () => ({
+  useGraphLayout: vi.fn(() => ({ data: { edges: [], nodes: [] } })),
+}));
+
+vi.mock("src/queries/useGridTISummaries.ts", () => ({
+  useGridTiSummariesStream: vi.fn(() => ({ summariesByRunId: new Map() })),
+}));
+
+vi.mock("src/hooks/useSelectedVersion", () => ({
+  default: vi.fn(() => 1),
+}));
+
+vi.mock("src/context/openGroups", () => ({
+  useOpenGroups: vi.fn(() => ({ allGroupIds: [], openGroupIds: [], setAllGroupIds: vi.fn() })),
+}));
+
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual("@xyflow/react");
+
+  return {
+    ...actual,
+    ReactFlow: vi.fn(() => null),
+    useReactFlow: vi.fn(() => ({ fitView: vi.fn(), getZoom: vi.fn() })),
+  };
+});
+
+const mockDagRun = {
+  bundle_version: null,
+  conf: null,
+  dag_display_name: "test_dag",
+  dag_id: "test_dag",
+  dag_versions: [],
+  end_date: null,
+  has_missed_deadline: false,
+  logical_date: null,
+  note: null,
+  partition_key: null,
+  queued_at: null,
+  run_after: "2025-01-01T00:00:00Z",
+  run_id: "run_1",
+  run_type: "manual" as const,
+  start_date: "2025-01-01T00:00:01Z",
+  state: "running" as const,
+  triggered_by: "ui" as const,
+  triggering_user_name: null,
+};
+
+describe("Graph", () => {
+  it("passes states to useGridTiSummariesStream when a runId is present", () => {
+    mockParams = { dagId: "test_dag", runId: "run_1" };
+    vi.mocked(useDagRunServiceGetDagRun).mockReturnValue({
+      data: mockDagRun,
+      isLoading: false,
+    } as ReturnType<typeof useDagRunServiceGetDagRun>);
+
+    render(<Graph />, { wrapper: Wrapper });
+
+    expect(vi.mocked(useGridTiSummariesStream)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runIds: ["run_1"],
+        states: ["running"],
+      }),
+    );
+  });
+
+  it("passes undefined states while dag run is still loading", () => {
+    mockParams = { dagId: "test_dag", runId: "run_1" };
+    vi.mocked(useDagRunServiceGetDagRun).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useDagRunServiceGetDagRun>);
+
+    render(<Graph />, { wrapper: Wrapper });
+
+    expect(vi.mocked(useGridTiSummariesStream)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runIds: ["run_1"],
+        states: undefined,
+      }),
+    );
+  });
+
+  it("passes undefined states to useGridTiSummariesStream when there is no runId", () => {
+    mockParams = { dagId: "test_dag" };
+    vi.mocked(useDagRunServiceGetDagRun).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useDagRunServiceGetDagRun>);
+
+    render(<Graph />, { wrapper: Wrapper });
+
+    expect(vi.mocked(useGridTiSummariesStream)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runIds: [],
+        states: undefined,
+      }),
+    );
+  });
+});

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -23,7 +23,7 @@ import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
-import { useStructureServiceStructureData } from "openapi/queries";
+import { useDagRunServiceGetDagRun, useStructureServiceStructureData } from "openapi/queries";
 import { DownloadButton } from "src/components/Graph/DownloadButton";
 import { edgeTypes, nodeTypes } from "src/components/Graph/graphTypes";
 import type { CustomNodeProps } from "src/components/Graph/reactflowUtils";
@@ -134,7 +134,15 @@ export const Graph = () => {
     versionNumber: selectedVersion,
   });
 
-  const { summariesByRunId } = useGridTiSummariesStream({ dagId, runIds: runId ? [runId] : [] });
+  const { data: dagRun } = useDagRunServiceGetDagRun({ dagId, dagRunId: runId }, undefined, {
+    enabled: Boolean(runId),
+  });
+
+  const { summariesByRunId } = useGridTiSummariesStream({
+    dagId,
+    runIds: runId ? [runId] : [],
+    states: dagRun ? [dagRun.state] : undefined,
+  });
   const gridTISummaries = runId ? summariesByRunId.get(runId) : undefined;
 
   // Add task instances to the node data but without having to recalculate how the graph is laid out


### PR DESCRIPTION
Graph view does not refresh task statuses while tasks are running

Before:
<img width="1652" height="938" alt="image" src="https://github.com/user-attachments/assets/df17748a-8fd8-4823-b5de-4722f2dba7a3" />

After:
<img width="1659" height="829" alt="image" src="https://github.com/user-attachments/assets/eefdfa8e-861d-40fb-85cd-9a5502aff705" />



### Root cause
`Graph.tsx` calls `useGridTiSummariesStream` without the `states` prop:
```ts
// Before
useGridTiSummariesStream({ dagId, runIds: runId ? [runId] : [] });
```

Inside useGridTiSummariesStream, the auto-refresh interval only starts when hasActiveRuns is true:

const hasActiveRuns = states?.some((state) => isStatePending(state)) ?? false;
Without states, this is always false → the setInterval never fires → after the initial stream completes the graph freezes.

Grid.tsx already passes states correctly — Graph was missing it.

Fix
Fetch the current dag run state via useDagRunServiceGetDagRun (already cached by React Query — no extra network cost) and pass it as states:

// After
```
const { data: dagRun } = useDagRunServiceGetDagRun(
  { dagId, dagRunId: runId },
  undefined,
  { enabled: Boolean(runId) },
);
useGridTiSummariesStream({
  dagId,
  runIds: runId ? [runId] : [],
  states: dagRun ? [dagRun.state] : undefined,
});
```
Tests
Added Graph.test.tsx with two cases:

Verifies states is forwarded when a runId is present and the run is active
Verifies states is undefined when no runId is present
* closes: https://github.com/apache/airflow/issues/65517

-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
