### PR TITLE
Add team_name support for pool creation in Airflow CLI and improve error messages

### DIFF
--- a/airflow-core/src/airflow/api/client/local_client.py
+++ b/airflow-core/src/airflow/api/client/local_client.py
@@ -78,12 +78,12 @@ class Client:
         pool = Pool.get_pool(pool_name=name)
         if not pool:
             raise PoolNotFound(f"Pool {name} not found")
-        return pool.pool, pool.slots, pool.description, pool.include_deferred
+        return pool.pool, pool.slots, pool.description, pool.include_deferred, pool.team_name
 
     def get_pools(self):
-        return [(p.pool, p.slots, p.description, p.include_deferred) for p in Pool.get_pools()]
+        return [(p.pool, p.slots, p.description, p.include_deferred, p.team_name) for p in Pool.get_pools()]
 
-    def create_pool(self, name, slots, description, include_deferred):
+    def create_pool(self, name, slots, description, include_deferred, team_name=None):
         if not (name and name.strip()):
             raise AirflowBadRequest("Pool name shouldn't be empty")
         pool_name_length = Pool.pool.property.columns[0].type.length
@@ -94,10 +94,14 @@ class Client:
         except ValueError:
             raise AirflowBadRequest(f"Bad value for `slots`: {slots}")
         pool = Pool.create_or_update_pool(
-            name=name, slots=slots, description=description, include_deferred=include_deferred
+            name=name,
+            slots=slots,
+            description=description,
+            include_deferred=include_deferred,
+            team_name=team_name,
         )
-        return pool.pool, pool.slots, pool.description
+        return pool.pool, pool.slots, pool.description, pool.include_deferred, pool.team_name
 
     def delete_pool(self, name):
         pool = Pool.delete_pool(name=name)
-        return pool.pool, pool.slots, pool.description
+        return pool.pool, pool.slots, pool.description, pool.include_deferred, pool.team_name

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -561,6 +561,11 @@ ARG_POOL_DESCRIPTION = Arg(("description",), help="Pool description")
 ARG_POOL_INCLUDE_DEFERRED = Arg(
     ("--include-deferred",), help="Include deferred tasks in calculations for Pool", action="store_true"
 )
+ARG_POOL_TEAM_NAME = Arg(
+    ("--team-name",),
+    help="Team name" if conf.getboolean("core", "multi_team", fallback=False) else argparse.SUPPRESS,
+)
+
 ARG_POOL_IMPORT = Arg(
     ("file",),
     metavar="FILEPATH",
@@ -575,6 +580,12 @@ ARG_POOL_IMPORT = Arg(
         ),
         " " * 4,
     ),
+)
+ARG_POOL_IMPORT_TEAM_NAME = Arg(
+    ("--team-name",),
+    help="Team name to be assigned to pools that don't have a 'team_name' key in the import file"
+    if conf.getboolean("core", "multi_team", fallback=False)
+    else argparse.SUPPRESS,
 )
 
 ARG_POOL_EXPORT = Arg(("file",), metavar="FILEPATH", help="Export all pools to JSON file")
@@ -1431,6 +1442,7 @@ POOLS_COMMANDS = (
             ARG_POOL_SLOTS,
             ARG_POOL_DESCRIPTION,
             ARG_POOL_INCLUDE_DEFERRED,
+            ARG_POOL_TEAM_NAME,
             ARG_OUTPUT,
             ARG_VERBOSE,
         ),
@@ -1445,7 +1457,7 @@ POOLS_COMMANDS = (
         name="import",
         help="Import pools",
         func=lazy_load_command("airflow.cli.commands.pool_command.pool_import"),
-        args=(ARG_POOL_IMPORT, ARG_VERBOSE),
+        args=(ARG_POOL_IMPORT, ARG_POOL_IMPORT_TEAM_NAME, ARG_VERBOSE),
     ),
     ActionCommand(
         name="export",

--- a/airflow-core/src/airflow/cli/commands/pool_command.py
+++ b/airflow-core/src/airflow/cli/commands/pool_command.py
@@ -25,6 +25,7 @@ from json import JSONDecodeError
 
 from airflow.api.client import get_current_api_client
 from airflow.cli.simple_table import AirflowConsole
+from airflow.configuration import conf
 from airflow.exceptions import PoolNotFound
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import suppress_logs_and_warning
@@ -32,16 +33,18 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 
 
 def _show_pools(pools, output):
-    AirflowConsole().print_as(
-        data=pools,
-        output=output,
-        mapper=lambda x: {
+    def mapper(x):
+        row = {
             "pool": x[0],
             "slots": x[1],
             "description": x[2],
             "include_deferred": x[3],
-        },
-    )
+        }
+        if conf.getboolean("core", "multi_team", fallback=False):
+            row["team_name"] = x[4] if len(x) > 4 else None
+        return row
+
+    AirflowConsole().print_as(data=pools, output=output, mapper=mapper)
 
 
 @suppress_logs_and_warning
@@ -70,9 +73,20 @@ def pool_get(args):
 @providers_configuration_loaded
 def pool_set(args):
     """Create new pool with a given name and slots."""
+    team_name = getattr(args, "team_name", None)
+
+    if team_name and not conf.getboolean("core", "multi_team", fallback=False):
+        raise SystemExit(
+            "Error: team_name cannot be set when multi_team mode is disabled. Please contact your administrator."
+        )
+
     api_client = get_current_api_client()
     api_client.create_pool(
-        name=args.pool, slots=args.slots, description=args.description, include_deferred=args.include_deferred
+        name=args.pool,
+        slots=args.slots,
+        description=args.description,
+        include_deferred=args.include_deferred,
+        team_name=team_name,
     )
     print(f"Pool {args.pool} created")
 
@@ -97,7 +111,8 @@ def pool_import(args):
     """Import pools from the file."""
     if not os.path.exists(args.file):
         raise SystemExit(f"Missing pools file {args.file}")
-    pools, failed = pool_import_helper(args.file)
+    fallback_team_name = getattr(args, "team_name", None)
+    pools, failed = pool_import_helper(args.file, fallback_team_name)
     if failed:
         raise SystemExit(f"Failed to update pool(s): {', '.join(failed)}")
     print(f"Uploaded {len(pools)} pool(s)")
@@ -110,7 +125,7 @@ def pool_export(args):
     print(f"Exported {len(pools)} pools to {args.file}")
 
 
-def pool_import_helper(filepath):
+def pool_import_helper(filepath, fallback_team_name=None):
     """Help import pools from the json file."""
     api_client = get_current_api_client()
 
@@ -120,6 +135,20 @@ def pool_import_helper(filepath):
         pools_json = json.loads(data)
     except JSONDecodeError as e:
         raise SystemExit(f"Invalid json file: {e}")
+
+    if not conf.getboolean("core", "multi_team", fallback=False):
+        if fallback_team_name:
+            raise SystemExit(
+                "Error: team_name cannot be set when multi_team mode is disabled. Please contact your administrator. "
+            )
+
+        invalid = [k for k, v in pools_json.items() if isinstance(v, dict) and v.get("team_name") is not None]
+        if invalid:
+            raise SystemExit(
+                f"Error: team_name cannot be set when multi_team mode is disabled. Please contact your administrator. "
+                f"Pools with team_name set: {', '.join(invalid)}"
+            )
+
     pools = []
     failed = []
     for k, v in pools_json.items():
@@ -130,6 +159,7 @@ def pool_import_helper(filepath):
                     slots=v["slots"],
                     description=v["description"],
                     include_deferred=v.get("include_deferred", False),
+                    team_name=v.get("team_name", fallback_team_name),
                 )
             )
         else:
@@ -143,7 +173,13 @@ def pool_export_helper(filepath):
     pool_dict = {}
     pools = api_client.get_pools()
     for pool in pools:
-        pool_dict[pool[0]] = {"slots": pool[1], "description": pool[2], "include_deferred": pool[3]}
+        pool_dict[pool[0]] = {
+            "slots": pool[1],
+            "description": pool[2],
+            "include_deferred": pool[3],
+        }
+        if conf.getboolean("core", "multi_team", fallback=False):
+            pool_dict[pool[0]]["team_name"] = pool[4] if len(pool) > 4 else None
     with open(filepath, "w") as poolfile:
         poolfile.write(json.dumps(pool_dict, sort_keys=True, indent=4))
     return pools

--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -25,6 +25,7 @@ from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, func, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from airflow._shared.observability.metrics.stats import normalize_name_for_stats
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.base import Base
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
@@ -128,20 +129,33 @@ class Pool(Base):
         slots: int,
         description: str,
         include_deferred: bool,
+        team_name: str | None = None,
         session: Session = NEW_SESSION,
     ) -> Pool:
         """Create a pool with given parameters or update it if it already exists."""
         if not name:
             raise ValueError("Pool name must not be empty")
 
+        if team_name and not conf.getboolean("core", "multi_team", fallback=False):
+            raise ValueError(
+                "Multi-team mode is not configured in the Airflow environment. To assign a team to a pool, multi-team mode must be enabled."
+            )
+
         pool = session.scalar(select(Pool).filter_by(pool=name))
         if pool is None:
-            pool = Pool(pool=name, slots=slots, description=description, include_deferred=include_deferred)
+            pool = Pool(
+                pool=name,
+                slots=slots,
+                description=description,
+                include_deferred=include_deferred,
+                team_name=team_name,
+            )
             session.add(pool)
         else:
             pool.slots = slots
             pool.description = description
             pool.include_deferred = include_deferred
+            pool.team_name = team_name
 
         session.commit()
         return pool

--- a/airflow-core/tests/unit/cli/commands/test_pool_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_pool_command.py
@@ -26,10 +26,23 @@ from airflow import models, settings
 from airflow.cli import cli_parser
 from airflow.cli.commands import pool_command
 from airflow.models import Pool
+from airflow.models.team import Team
 from airflow.settings import Session
 from airflow.utils.db import add_default_pool_if_not_exists
+from airflow.utils.session import provide_session
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_teams
 
 pytestmark = pytest.mark.db_test
+
+
+@provide_session
+def _create_teams(session) -> None:
+    session.add(Team(name="test_team"))
+    session.add(Team(name="team_one"))
+    session.add(Team(name="team_two"))
+    session.commit()
 
 
 class TestCliPools:
@@ -41,17 +54,21 @@ class TestCliPools:
         cls.session = Session
         cls._cleanup()
 
-    def tearDown(self):
+    def teardown_method(self):
         self._cleanup()
 
     @staticmethod
     def _cleanup(session=None):
         if session is None:
             session = Session()
+        clear_db_teams()
         session.execute(delete(Pool).where(Pool.pool != Pool.DEFAULT_POOL_NAME))
         session.commit()
         add_default_pool_if_not_exists()
         session.close()
+
+    def create_teams(self):
+        _create_teams(self.session)
 
     def test_pool_list(self, stdout_capture):
         pool_command.pool_set(self.parser.parse_args(["pools", "set", "foo", "1", "test"]))
@@ -67,6 +84,24 @@ class TestCliPools:
         pool_command.pool_set(self.parser.parse_args(["pools", "set", "foo", "1", "test"]))
         assert self.session.scalar(select(func.count()).select_from(Pool)) == 2
 
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_pool_create_with_team(self):
+        self.create_teams()
+        pool_command.pool_set(
+            self.parser.parse_args(["pools", "set", "foo", "1", "test", "--team-name", "test_team"])
+        )
+        assert self.session.scalar(select(func.count()).select_from(Pool)) == 2
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_pool_create_rejects_team_name_when_multi_team_disabled(self):
+        with pytest.raises(
+            SystemExit,
+            match="Error: team_name cannot be set when multi_team mode is disabled. Please contact your administrator.",
+        ):
+            pool_command.pool_set(
+                self.parser.parse_args(["pools", "set", "foo", "1", "test", "--team-name", "test_team"])
+            )
+
     def test_pool_update_deferred(self):
         pool_command.pool_set(self.parser.parse_args(["pools", "set", "foo", "1", "test"]))
         assert self.session.scalar(select(Pool).where(Pool.pool == "foo")).include_deferred is False
@@ -81,6 +116,14 @@ class TestCliPools:
 
     def test_pool_get(self):
         pool_command.pool_set(self.parser.parse_args(["pools", "set", "foo", "1", "test"]))
+        pool_command.pool_get(self.parser.parse_args(["pools", "get", "foo"]))
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_pool_get_with_team(self):
+        self.create_teams()
+        pool_command.pool_set(
+            self.parser.parse_args(["pools", "set", "foo", "1", "test", "--team-name", "test_team"])
+        )
         pool_command.pool_get(self.parser.parse_args(["pools", "get", "foo"]))
 
     def test_pool_delete(self):
@@ -113,6 +156,65 @@ class TestCliPools:
                 self.parser.parse_args(["pools", "import", str(invalid_pool_import_file_path)])
             )
 
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_pool_import_rejects_team_name_when_multi_team_disabled(self, tmp_path):
+        pool_import_file_path = tmp_path / "pools_import.json"
+        pool_config_input = {
+            "team_one_pool": {
+                "description": "team one pool",
+                "slots": 1,
+                "include_deferred": True,
+                "team_name": "team_one",
+            },
+            "default_pool": {
+                "description": "Default pool",
+                "slots": 128,
+                "include_deferred": False,
+                "team_name": None,
+            },
+            "team_two_pool": {
+                "description": "team two pool",
+                "slots": 2,
+                "include_deferred": False,
+                "team_name": "team_two",
+            },
+        }
+        with open(pool_import_file_path, mode="w") as file:
+            json.dump(pool_config_input, file)
+
+        # Import json
+        with pytest.raises(
+            SystemExit,
+            match="Error: team_name cannot be set when multi_team mode is disabled. Please contact your administrator.",
+        ):
+            pool_command.pool_import(self.parser.parse_args(["pools", "import", str(pool_import_file_path)]))
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_pool_import_with_fallback_team_name(self, tmp_path):
+        self.create_teams()
+        pool_import_file_path = tmp_path / "pools_import.json"
+        pool_config_input = {
+            "team_one_pool": {"description": "team one pool", "slots": 1, "include_deferred": True},
+            "default_pool": {"description": "Default pool", "slots": 128, "include_deferred": False},
+            "team_two_pool": {
+                "description": "team two pool",
+                "slots": 2,
+                "include_deferred": False,
+                "team_name": "team_two",
+            },
+        }
+        with open(pool_import_file_path, mode="w") as file:
+            json.dump(pool_config_input, file)
+
+        # Import json
+        pool_command.pool_import(
+            self.parser.parse_args(["pools", "import", str(pool_import_file_path), "--team-name", "team_one"])
+        )
+
+        assert self.session.scalar(select(Pool).where(Pool.pool == "team_one_pool")).team_name == "team_one"
+        assert self.session.scalar(select(Pool).where(Pool.pool == "default_pool")).team_name == "team_one"
+        assert self.session.scalar(select(Pool).where(Pool.pool == "team_two_pool")).team_name == "team_two"
+
     def test_pool_import_backwards_compatibility(self, tmp_path):
         pool_import_file_path = tmp_path / "pools_import.json"
         pool_config_input = {
@@ -133,6 +235,44 @@ class TestCliPools:
             "foo": {"description": "foo_test", "slots": 1, "include_deferred": True},
             "default_pool": {"description": "Default pool", "slots": 128, "include_deferred": False},
             "baz": {"description": "baz_test", "slots": 2, "include_deferred": False},
+        }
+        with open(pool_import_file_path, mode="w") as file:
+            json.dump(pool_config_input, file)
+
+        # Import json
+        pool_command.pool_import(self.parser.parse_args(["pools", "import", str(pool_import_file_path)]))
+
+        # Export json
+        pool_command.pool_export(self.parser.parse_args(["pools", "export", str(pool_export_file_path)]))
+
+        with open(pool_export_file_path) as file:
+            pool_config_output = json.load(file)
+            assert pool_config_input == pool_config_output, "Input and output pool files are not same"
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_pool_import_export_with_team(self, tmp_path):
+        self.create_teams()
+        pool_import_file_path = tmp_path / "pools_import.json"
+        pool_export_file_path = tmp_path / "pools_export.json"
+        pool_config_input = {
+            "team_one_pool": {
+                "description": "team one pool",
+                "slots": 1,
+                "include_deferred": True,
+                "team_name": "team_one",
+            },
+            "default_pool": {
+                "description": "Default pool",
+                "slots": 128,
+                "include_deferred": False,
+                "team_name": None,
+            },
+            "team_two_pool": {
+                "description": "team two pool",
+                "slots": 2,
+                "include_deferred": False,
+                "team_name": "team_two",
+            },
         }
         with open(pool_import_file_path, mode="w") as file:
             json.dump(pool_config_input, file)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Description

This PR adds support to create pools with teams assigned to them when multi\_team is enabled and raises an error when team\_name is provided when multi\_team is disabled following the behaviour of the API.

It adds two unique "--team-name" arguments for both the set and import Pool commands along with support to display team_name values in other commands.

- When used with the set command it will create a pool with the provided team_name assigned to it.
- When used with the import command it will assign all pools without a team_name key provided in the JSON file the one provided as an argument.

This same functionality still needs to be added to the connections and variables CLI. I will be adding these in subsequent PRs once this is merged. I will also follow up with a doc change after that.

## Motivation

In the case of the Pools CLI it does not currently support adding Pools with a team_name which differs from the Airflow API which has support for this. This PR adds a more consistent experience between both.

## Behaviour

**When multi_team is disabled:**

<img width="821" height="300" alt="Import Help" src="https://github.com/user-attachments/assets/8cde0383-0631-48e2-ad23-3c00d6af1c29" />
<br>
<img width="1262" height="155" alt="Import JSON" src="https://github.com/user-attachments/assets/ac8e78d1-3d5b-483c-a2b5-816e00825f74" />
<br>
<img width="960" height="212" alt="List" src="https://github.com/user-attachments/assets/da4621c1-9ad5-4040-ab13-5cee769a2dfe" />
<br>

**When multi_team is enabled:**

<img width="915" height="340" alt="Import Help" src="https://github.com/user-attachments/assets/d0657de3-16a3-4356-b995-628f220e8aa1" />
<br>
<img width="980" height="232" alt="List" src="https://github.com/user-attachments/assets/e374a86a-9174-416f-8285-6e38bca00300" />

## Tests

- Added tests under airflow-core/tests/unit/cli/commands/test_pool_command.py for each respective API file to validate the error behaviour when submitting a request with team\-name and multi\-team mode disabled and enabled.

## Questions

When --team-name is provided to the import command, it only applies to pools where team_name is absent from the JSON. If a pool already has team_name set to any value (including None/null), the JSON value takes precedence and the argument is ignored. Is this the right behaviour or should I implement one of the alternatives?

- team-name acts as an override for all pools without a team_name (including None/null)
- team-name acts as a strict override for all pools in the JSON
- team-name is removed from the import command entirely

The motivation for the current approach is to make it easier to bulk-import legacy pool JSON files into a multi-team environment without modifying the files themselves.

related: #62251, #63994 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Google Antigravity)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
