### PR TITLE
Split constraint update workflow: stable branches always, main on uv.lock change

### DIFF
--- a/.github/workflows/update-constraints-on-push-stable.yml
+++ b/.github/workflows/update-constraints-on-push-stable.yml
@@ -16,14 +16,11 @@
 # under the License.
 #
 ---
-name: Update constraints on push for main (only when uv.lock changes)
+name: Update constraints on push for stable branch (always)
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - main
-      - v[0-9]+-[0-9]+-test
-    paths:
-      - 'uv.lock'
+      - v[0-9]+-[0-9]+-stable
 permissions:
   contents: read
 


### PR DESCRIPTION
Split the constraint update workflow into two flows so that stable branches refresh constraints on every push, while `main` and `v*-test` keep the existing `uv.lock`-only trigger.

- New `update-constraints-on-push-stable.yml` runs on `v[0-9]+-[0-9]+-stable` and always regenerates and pushes constraints (no path filter).
- `update-constraints-on-push.yml` is renamed accordingly and now only listens on `main` and `v*-test`, still gated on `uv.lock` changes.

Constraints on stable branches reflect the last successful CI run for the released line, so they should be refreshed whenever any change lands — not gated on `uv.lock` churn. Main/test continue to regenerate only when dependencies actually change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)