### PR TITLE
feat: Add rendered map_index template to OL events

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -841,6 +841,9 @@ class TaskInstanceInfo(InfoJsonEncodable):
     casts = {
         "log_url": lambda ti: getattr(ti, "log_url", None),
         "map_index": lambda ti: ti.map_index if getattr(ti, "map_index", -1) != -1 else None,
+        "rendered_map_index": lambda ti: (
+            getattr(ti, "rendered_map_index", None) if getattr(ti, "map_index", -1) != -1 else None
+        ),
         "dag_bundle_version": lambda ti: (
             ti.bundle_instance.version if hasattr(ti, "bundle_instance") else None
         ),

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -3035,10 +3035,21 @@ def test_taskinstance_info_af3():
     assert dict(TaskInstanceInfo(runtime_ti)) == {
         "log_url": runtime_ti.log_url,
         "map_index": 2,
+        "rendered_map_index": None,
         "try_number": 1,
         "dag_bundle_version": "bundle_version",
         "dag_bundle_name": "bundle_name",
     }
+
+    runtime_ti.rendered_map_index = "country=PL"
+    assert dict(TaskInstanceInfo(runtime_ti))["rendered_map_index"] == "country=PL"
+
+    # Should only be included if task is mapped
+    runtime_ti.map_index = -1
+    runtime_ti.rendered_map_index = None
+    result = dict(TaskInstanceInfo(runtime_ti))
+    assert result["map_index"] is None
+    assert result["rendered_map_index"] is None
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 test")
@@ -3055,6 +3066,7 @@ def test_taskinstance_info_af2():
     assert dict(TaskInstanceInfo(ti)) == {
         "duration": 12.345,
         "map_index": 2,
+        "rendered_map_index": None,
         "pool": "default_pool",
         "try_number": 0,
         "queued_dttm": "2024-06-01T00:00:00+00:00",
@@ -3062,6 +3074,19 @@ def test_taskinstance_info_af2():
         "dag_bundle_name": None,
         "dag_bundle_version": None,
     }
+
+    # Also tested manually that it works well on AF2, hard to test hybrid property so just mocking it here
+    with patch.object(TaskInstance, "rendered_map_index", "country=PL"):
+        assert dict(TaskInstanceInfo(ti))["rendered_map_index"] == "country=PL"
+
+    ti_unmapped = TaskInstance(
+        task=task_obj, run_id="task_instance_run_id", state=TaskInstanceState.RUNNING, map_index=-1
+    )
+    # Should only be included if task is mapped
+    with patch.object(TaskInstance, "rendered_map_index", "should-not-be-emitted"):
+        result = dict(TaskInstanceInfo(ti_unmapped))
+    assert result["map_index"] is None
+    assert result["rendered_map_index"] is None
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 3 test")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Adding rendered value of map_index_template to OL events. This can be useful to identify mapped tasks, not only by map_index, but also by human readable labels.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
