### PR TITLE
render cleanup RBAC only for KubernetesExecutor

### DIFF
--- a/chart/templates/rbac/pod-cleanup-role.yaml
+++ b/chart/templates/rbac/pod-cleanup-role.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Cleanup Role
 #################################
-{{- if and .Values.rbac.create .Values.cleanup.enabled }}
+{{- if and .Values.rbac.create .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/chart/templates/rbac/pod-cleanup-rolebinding.yaml
+++ b/chart/templates/rbac/pod-cleanup-rolebinding.yaml
@@ -20,7 +20,7 @@
 ################################
 ## Airflow Cleanup Role Binding
 #################################
-{{- if and .Values.rbac.create .Values.cleanup.enabled }}
+{{- if and .Values.rbac.create .Values.cleanup.enabled (contains "KubernetesExecutor" .Values.executor) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -483,6 +483,13 @@ class TestBaseChartTest:
                 (f"{release_name}-ingress", "Ingress", "airflow-ingress"),
             ]
 
+        cleanup_kubernetes_executor_only_objects = {
+            (f"{release_name}-airflow-cleanup", "ServiceAccount"),
+            (f"{release_name}-cleanup", "CronJob"),
+            (f"{release_name}-cleanup-role", "Role"),
+            (f"{release_name}-cleanup-rolebinding", "RoleBinding"),
+        }
+
         for k8s_object_name, kind, component in kind_names_tuples:
             expected_labels = {
                 "label1": "value1",
@@ -499,7 +506,10 @@ class TestBaseChartTest:
                 if executor == "CeleryExecutor,KubernetesExecutor":
                     expected_labels["executor"] = "CeleryExecutor-KubernetesExecutor"
 
-            if component and component == "airflow-cleanup-pods" and executor == "CeleryExecutor":
+            if (
+                executor == "CeleryExecutor"
+                and (k8s_object_name, kind) in cleanup_kubernetes_executor_only_objects
+            ):
                 assert (k8s_object_name, kind) not in kind_k8s_obj_labels_tuples
             else:
                 actual_labels = kind_k8s_obj_labels_tuples.pop((k8s_object_name, kind))

--- a/helm-tests/tests/helm_tests/security/test_rbac.py
+++ b/helm-tests/tests/helm_tests/security/test_rbac.py
@@ -281,6 +281,27 @@ class TestRBAC:
         )
         assert sorted(list_of_kind_names_tuples) == sorted(real_list_of_kind_names)
 
+    @pytest.mark.parametrize("executor", ["CeleryExecutor", "LocalExecutor"])
+    def test_cleanup_resources_require_kubernetes_executor(self, executor):
+        k8s_objects = render_chart(
+            "test-rbac",
+            values={
+                "airflowVersion": "3.0.0",
+                "fullnameOverride": "test-rbac",
+                "executor": executor,
+                "rbac": {"create": True},
+                "cleanup": {"enabled": True},
+            },
+            show_only=[
+                "templates/rbac/pod-cleanup-role.yaml",
+                "templates/rbac/pod-cleanup-rolebinding.yaml",
+                "templates/cleanup/cleanup-cronjob.yaml",
+                "templates/cleanup/cleanup-serviceaccount.yaml",
+            ],
+        )
+
+        assert not k8s_objects
+
     def test_service_account_custom_names(self):
         k8s_objects = render_chart(
             "test-rbac",


### PR DESCRIPTION
## Why
cleanup Role and `RoleBinding `were rendered whenever `cleanup.enabled` was true, even when cleanup CronJob and cleanup `ServiceAccount` were not rendered.
This created inconsistent chart output and unnecessary RBAC resources in non-KubernetesExecutor setups.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
