### PR TITLE
fix(fab): use naming_convention for 02ca36b0235b batch_alter_table on SQLite

### DIFF
--- a/providers/fab/src/airflow/providers/fab/migrations/versions/0001_3_5_0_fix_fab_db_inconsistencies.py
+++ b/providers/fab/src/airflow/providers/fab/migrations/versions/0001_3_5_0_fix_fab_db_inconsistencies.py
@@ -39,6 +39,15 @@ branch_labels = None
 depends_on = None
 fab_version = "3.5.0"
 
+# SQLite reflects inline FK/UQ constraints without names, which makes
+# batch_op.drop_constraint(...) fail with "No such constraint". Passing this
+# naming convention to batch_alter_table tells alembic to synthesize names
+# for reflected unnamed constraints that match what batch_op.f() produces.
+_naming_convention = {
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "uq": "%(table_name)s_%(column_0_N_name)s_uq",
+}
+
 
 def _mysql_run_procedure(procedure_name: str, body: str) -> str:
     return f"""
@@ -238,7 +247,9 @@ def upgrade() -> None:
         op.execute(sa.text(_mysql_create_idx_permission_view_id_if_not_exists()))
         op.execute(sa.text(_mysql_create_idx_role_id_if_not_exists()))
 
-    with op.batch_alter_table("ab_permission_view_role", schema=None) as batch_op:
+    with op.batch_alter_table(
+        "ab_permission_view_role", schema=None, naming_convention=_naming_convention
+    ) as batch_op:
         batch_op.drop_constraint(batch_op.f("ab_permission_view_role_role_id_fkey"), type_="foreignkey")
         batch_op.drop_constraint(
             batch_op.f("ab_permission_view_role_permission_view_id_fkey"), type_="foreignkey"
@@ -274,7 +285,7 @@ def upgrade() -> None:
     with op.batch_alter_table("ab_register_user", schema=None) as batch_op:
         batch_op.create_unique_constraint(batch_op.f("ab_register_user_email_uq"), ["email"])
 
-    with op.batch_alter_table("ab_user_role", schema=None) as batch_op:
+    with op.batch_alter_table("ab_user_role", schema=None, naming_convention=_naming_convention) as batch_op:
         batch_op.drop_constraint(batch_op.f("ab_user_role_role_id_fkey"), type_="foreignkey")
         batch_op.drop_constraint(batch_op.f("ab_user_role_user_id_fkey"), type_="foreignkey")
         batch_op.create_foreign_key(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## What

Pass a `naming_convention` to the two `batch_alter_table` blocks in migration `02ca36b0235b` that drop FKs on `ab_permission_view_role` and `ab_user_role`.

## Why
flask-appbuilder 5.2.0 defines these tables with unnamed inline FK/UQ constraints. On SQLite they reflect as `name=None`, so `batch_op.drop_constraint(batch_op.f("..._fkey"))` raises `ValueError: No such constraint`. The convention lets alembic synthesize names matching `batch_op.f()` during reflection. MySQL/Postgres use direct `ALTER TABLE` DDL and are unaffected.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude (Opus 4.7)] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
