### PR TITLE
Extract seams for Dag processor callback fetching to allow DB-to-API swap

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -642,13 +642,13 @@ class DagFileProcessorManager(LoggingMixin):
                 return False
         return True
 
-    def _add_callback_to_queue(self, request: CallbackRequest):
+    def _add_callback_to_queue(self, request: CallbackRequest) -> None:
         self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
         bundle = self.resolve_callback_bundle(request)
         if bundle is None:
-            return None
+            return
         if not self.initialize_callback_bundle(request, bundle):
-            return None
+            return
 
         file_info = DagFileInfo(
             rel_path=Path(request.filepath),

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -180,18 +180,6 @@ class _StubSelector(selectors.BaseSelector):
     def get_map(self): ...
 
 
-class CallbackBundleUnavailable(Exception):
-    """
-    Raised when the bundle required by a callback request cannot be prepared.
-
-    Used as a control-flow signal between the callback seam methods
-    (:meth:`DagFileProcessorManager.resolve_callback_bundle`,
-    :meth:`DagFileProcessorManager.initialize_callback_bundle`) and their caller.
-    Overrides that source callbacks from an API should raise this to signal the
-    caller to skip the callback.
-    """
-
-
 @attrs.define(kw_only=True)
 class DagFileProcessorManager(LoggingMixin):
     """
@@ -622,45 +610,35 @@ class DagFileProcessorManager(LoggingMixin):
             guard.commit()
         return callback_queue
 
-    def resolve_callback_bundle(self, request: CallbackRequest) -> BaseDagBundle:
+    def prepare_callback_bundle(self, request: CallbackRequest) -> BaseDagBundle | None:
         """
-        Resolve the bundle required to execute a callback request.
+        Return the bundle to run the callback against, or ``None`` to skip the callback.
 
-        Raises :class:`CallbackBundleUnavailable` if the bundle cannot be resolved.
+        Default implementation looks the bundle up via :class:`DagBundlesManager` and, for
+        versioned requests on bundles that support versioning, calls ``bundle.initialize()``.
         Override to source the bundle from an API.
         """
         try:
-            return DagBundlesManager().get_bundle(name=request.bundle_name, version=request.bundle_version)
-        except ValueError as e:
+            bundle = DagBundlesManager().get_bundle(name=request.bundle_name, version=request.bundle_version)
+        except ValueError:
             self.log.error("Bundle %s no longer configured, skipping callback", request.bundle_name)
-            raise CallbackBundleUnavailable(f"Bundle {request.bundle_name!r} no longer configured") from e
-
-    def initialize_callback_bundle(self, request: CallbackRequest, bundle: BaseDagBundle) -> None:
-        """
-        Prepare ``bundle`` so the callback can run against it.
-
-        Raises :class:`CallbackBundleUnavailable` if preparation fails and the callback should
-        be skipped. Override to change how bundles are materialized (for example, via an API).
-        """
+            return None
         if bundle.supports_versioning and request.bundle_version:
             try:
                 bundle.initialize()
-            except Exception as e:
+            except Exception:
                 self.log.exception(
                     "Error initializing bundle %s version %s for callback, skipping",
                     request.bundle_name,
                     request.bundle_version,
                 )
-                raise CallbackBundleUnavailable(
-                    f"Failed to initialize bundle {request.bundle_name!r} version {request.bundle_version!r}"
-                ) from e
+                return None
+        return bundle
 
     def _add_callback_to_queue(self, request: CallbackRequest) -> None:
         self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
-        try:
-            bundle = self.resolve_callback_bundle(request)
-            self.initialize_callback_bundle(request, bundle)
-        except CallbackBundleUnavailable:
+        bundle = self.prepare_callback_bundle(request)
+        if bundle is None:
             return
 
         file_info = DagFileInfo(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -582,7 +582,7 @@ class DagFileProcessorManager(LoggingMixin):
         self,
         session: Session = NEW_SESSION,
     ) -> list[CallbackRequest]:
-        """Fetch callbacks from the metadata database."""
+        """Fetch callbacks from database and add them to the internal queue for execution."""
         self.log.debug("Fetching callbacks from the database.")
 
         callback_queue: list[CallbackRequest] = []

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -180,6 +180,18 @@ class _StubSelector(selectors.BaseSelector):
     def get_map(self): ...
 
 
+class CallbackBundleUnavailable(Exception):
+    """
+    Raised when the bundle required by a callback request cannot be prepared.
+
+    Used as a control-flow signal between the callback seam methods
+    (:meth:`DagFileProcessorManager.resolve_callback_bundle`,
+    :meth:`DagFileProcessorManager.initialize_callback_bundle`) and their caller.
+    Overrides that source callbacks from an API should raise this to signal the
+    caller to skip the callback.
+    """
+
+
 @attrs.define(kw_only=True)
 class DagFileProcessorManager(LoggingMixin):
     """
@@ -610,44 +622,45 @@ class DagFileProcessorManager(LoggingMixin):
             guard.commit()
         return callback_queue
 
-    def resolve_callback_bundle(self, request: CallbackRequest) -> BaseDagBundle | None:
+    def resolve_callback_bundle(self, request: CallbackRequest) -> BaseDagBundle:
         """
         Resolve the bundle required to execute a callback request.
 
-        Returns ``None`` if the bundle is no longer configured.
+        Raises :class:`CallbackBundleUnavailable` if the bundle cannot be resolved.
+        Override to source the bundle from an API.
         """
         try:
             return DagBundlesManager().get_bundle(name=request.bundle_name, version=request.bundle_version)
-        except ValueError:
+        except ValueError as e:
             self.log.error("Bundle %s no longer configured, skipping callback", request.bundle_name)
-            return None
+            raise CallbackBundleUnavailable(f"Bundle {request.bundle_name!r} no longer configured") from e
 
-    def initialize_callback_bundle(self, request: CallbackRequest, bundle: BaseDagBundle) -> bool:
+    def initialize_callback_bundle(self, request: CallbackRequest, bundle: BaseDagBundle) -> None:
         """
         Prepare ``bundle`` so the callback can run against it.
 
-        Returns ``True`` when the callback can proceed (either initialization succeeded or was not
-        required), ``False`` when preparation failed and the callback should be skipped. Override
-        to change how bundles are materialized (for example, via an API).
+        Raises :class:`CallbackBundleUnavailable` if preparation fails and the callback should
+        be skipped. Override to change how bundles are materialized (for example, via an API).
         """
         if bundle.supports_versioning and request.bundle_version:
             try:
                 bundle.initialize()
-            except Exception:
+            except Exception as e:
                 self.log.exception(
                     "Error initializing bundle %s version %s for callback, skipping",
                     request.bundle_name,
                     request.bundle_version,
                 )
-                return False
-        return True
+                raise CallbackBundleUnavailable(
+                    f"Failed to initialize bundle {request.bundle_name!r} version {request.bundle_version!r}"
+                ) from e
 
     def _add_callback_to_queue(self, request: CallbackRequest) -> None:
         self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
-        bundle = self.resolve_callback_bundle(request)
-        if bundle is None:
-            return
-        if not self.initialize_callback_bundle(request, bundle):
+        try:
+            bundle = self.resolve_callback_bundle(request)
+            self.initialize_callback_bundle(request, bundle)
+        except CallbackBundleUnavailable:
             return
 
         file_info = DagFileInfo(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -574,11 +574,11 @@ class DagFileProcessorManager(LoggingMixin):
 
         Default implementation reads from the metadata DB; override to source callbacks from an API.
         """
-        return self._fetch_callbacks()
+        return self._fetch_callbacks_from_db()
 
     @provide_session
     @retry_db_transaction
-    def _fetch_callbacks(
+    def _fetch_callbacks_from_db(
         self,
         session: Session = NEW_SESSION,
     ) -> list[CallbackRequest]:

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -471,7 +471,7 @@ class DagFileProcessorManager(LoggingMixin):
 
             self._collect_results()
 
-            for callback in self._fetch_callbacks():
+            for callback in self.fetch_callbacks():
                 self._add_callback_to_queue(callback)
             self._scan_stale_dags()
             self._cleanup_stale_bundle_versions()
@@ -568,13 +568,21 @@ class DagFileProcessorManager(LoggingMixin):
             session.delete(request)
         return files
 
+    def fetch_callbacks(self) -> list[CallbackRequest]:
+        """
+        Fetch and claim callbacks for this manager's bundles.
+
+        Default implementation reads from the metadata DB; override to source callbacks from an API.
+        """
+        return self._fetch_callbacks()
+
     @provide_session
     @retry_db_transaction
     def _fetch_callbacks(
         self,
         session: Session = NEW_SESSION,
     ) -> list[CallbackRequest]:
-        """Fetch callbacks from database and add them to the internal queue for execution."""
+        """Fetch callbacks from the metadata database."""
         self.log.debug("Fetching callbacks from the database.")
 
         callback_queue: list[CallbackRequest] = []
@@ -602,14 +610,26 @@ class DagFileProcessorManager(LoggingMixin):
             guard.commit()
         return callback_queue
 
-    def _add_callback_to_queue(self, request: CallbackRequest):
-        self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
+    def resolve_callback_bundle(self, request: CallbackRequest) -> BaseDagBundle | None:
+        """
+        Resolve the bundle required to execute a callback request.
+
+        Returns ``None`` if the bundle is no longer configured.
+        """
         try:
-            bundle = DagBundlesManager().get_bundle(name=request.bundle_name, version=request.bundle_version)
+            return DagBundlesManager().get_bundle(name=request.bundle_name, version=request.bundle_version)
         except ValueError:
-            # Bundle no longer configured
             self.log.error("Bundle %s no longer configured, skipping callback", request.bundle_name)
             return None
+
+    def initialize_callback_bundle(self, request: CallbackRequest, bundle: BaseDagBundle) -> bool:
+        """
+        Prepare ``bundle`` so the callback can run against it.
+
+        Returns ``True`` when the callback can proceed (either initialization succeeded or was not
+        required), ``False`` when preparation failed and the callback should be skipped. Override
+        to change how bundles are materialized (for example, via an API).
+        """
         if bundle.supports_versioning and request.bundle_version:
             try:
                 bundle.initialize()
@@ -619,7 +639,16 @@ class DagFileProcessorManager(LoggingMixin):
                     request.bundle_name,
                     request.bundle_version,
                 )
-                return None
+                return False
+        return True
+
+    def _add_callback_to_queue(self, request: CallbackRequest):
+        self.log.debug("Queuing %s CallbackRequest: %s", type(request).__name__, request)
+        bundle = self.resolve_callback_bundle(request)
+        if bundle is None:
+            return None
+        if not self.initialize_callback_bundle(request, bundle):
+            return None
 
         file_info = DagFileInfo(
             rel_path=Path(request.filepath),

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -48,7 +48,6 @@ from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import DagBag
 from airflow.dag_processing.manager import (
     BundleState,
-    CallbackBundleUnavailable,
     DagFileInfo,
     DagFileProcessorManager,
     DagFileStat,
@@ -1565,9 +1564,10 @@ class TestDagFileProcessorManager:
             assert dag2_path not in manager._callback_to_execute
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
-    def test_resolve_callback_bundle(self, mock_bundle_manager):
+    def test_prepare_callback_bundle_initializes_versioned_bundle(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         bundle = MagicMock(spec=BaseDagBundle)
+        bundle.supports_versioning = True
         mock_bundle_manager.return_value.get_bundle.return_value = bundle
 
         request = DagCallbackRequest(
@@ -1580,13 +1580,51 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        assert manager.resolve_callback_bundle(request) is bundle
-        mock_bundle_manager.return_value.get_bundle.assert_called_once_with(
-            name="testing", version="some_commit_hash"
-        )
+        assert manager.prepare_callback_bundle(request) is bundle
+        bundle.initialize.assert_called_once()
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
-    def test_resolve_callback_bundle_raises_for_unconfigured_bundle(self, mock_bundle_manager):
+    def test_prepare_callback_bundle_skips_initialize_for_unversioned_request(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock(spec=BaseDagBundle)
+        bundle.supports_versioning = True
+        mock_bundle_manager.return_value.get_bundle.return_value = bundle
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version=None,
+            msg=None,
+        )
+
+        assert manager.prepare_callback_bundle(request) is bundle
+        bundle.initialize.assert_not_called()
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_prepare_callback_bundle_skips_initialize_for_non_versioning_bundle(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock(spec=BaseDagBundle)
+        bundle.supports_versioning = False
+        mock_bundle_manager.return_value.get_bundle.return_value = bundle
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        assert manager.prepare_callback_bundle(request) is bundle
+        bundle.initialize.assert_not_called()
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_prepare_callback_bundle_returns_none_when_unconfigured(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         mock_bundle_manager.return_value.get_bundle.side_effect = ValueError("missing bundle")
 
@@ -1600,31 +1638,15 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        with pytest.raises(CallbackBundleUnavailable, match="no longer configured"):
-            manager.resolve_callback_bundle(request)
+        assert manager.prepare_callback_bundle(request) is None
 
-    def test_initialize_callback_bundle_skips_unversioned_callback(self):
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_prepare_callback_bundle_returns_none_when_initialize_fails(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
-
-        request = DagCallbackRequest(
-            filepath="file1.py",
-            dag_id="dag1",
-            run_id="run1",
-            is_failure_callback=False,
-            bundle_name="testing",
-            bundle_version=None,
-            msg=None,
-        )
-
-        manager.initialize_callback_bundle(request, bundle)
-        bundle.initialize.assert_not_called()
-
-    def test_initialize_callback_bundle_skips_non_versioned_bundle(self):
-        manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock(spec=BaseDagBundle)
-        bundle.supports_versioning = False
+        bundle.initialize.side_effect = RuntimeError("clone failed")
+        mock_bundle_manager.return_value.get_bundle.return_value = bundle
 
         request = DagCallbackRequest(
             filepath="file1.py",
@@ -1636,11 +1658,11 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        manager.initialize_callback_bundle(request, bundle)
-        bundle.initialize.assert_not_called()
+        assert manager.prepare_callback_bundle(request) is None
+        bundle.initialize.assert_called_once()
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
-    def test_add_callback_initializes_versioned_bundle(self, mock_bundle_manager):
+    def test_add_callback_queues_file_info_on_success(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
@@ -1660,26 +1682,11 @@ class TestDagFileProcessorManager:
         manager._add_callback_to_queue(request)
 
         bundle.initialize.assert_called_once()
-
-    def test_initialize_callback_bundle_raises_when_initialization_fails(self):
-        manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock(spec=BaseDagBundle)
-        bundle.supports_versioning = True
-        bundle.initialize.side_effect = RuntimeError("clone failed")
-
-        request = DagCallbackRequest(
-            filepath="file1.py",
-            dag_id="dag1",
-            run_id="run1",
-            is_failure_callback=False,
-            bundle_name="testing",
-            bundle_version="some_commit_hash",
-            msg=None,
-        )
-
-        with pytest.raises(CallbackBundleUnavailable, match="Failed to initialize bundle"):
-            manager.initialize_callback_bundle(request, bundle)
-        bundle.initialize.assert_called_once()
+        assert manager._callback_to_execute
+        [(file_info, requests)] = manager._callback_to_execute.items()
+        assert file_info.rel_path == Path("file1.py")
+        assert file_info.bundle_name == "testing"
+        assert requests == [request]
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
     def test_add_callback_skips_when_bundle_init_fails(self, mock_bundle_manager):
@@ -1722,6 +1729,13 @@ class TestDagFileProcessorManager:
         manager._add_callback_to_queue(request)
 
         assert not manager._callback_to_execute
+
+    def test_fetch_callbacks_delegates_to_private_method(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        expected: list = [mock.sentinel.callback]
+        with mock.patch.object(manager, "_fetch_callbacks", return_value=expected) as private:
+            assert manager.fetch_callbacks() is expected
+        private.assert_called_once_with()
 
     def test_dag_with_assets(self, session, configure_testing_dag_bundle):
         """'Integration' test to ensure that the assets get parsed and stored correctly for parsed dags."""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1281,7 +1281,7 @@ class TestDagFileProcessorManager:
 
     @conf_vars({("core", "load_examples"): "False"})
     def test_fetch_callbacks_from_database(self, configure_testing_dag_bundle):
-        """Test _fetch_callbacks returns callbacks ordered by priority_weight desc."""
+        """Test _fetch_callbacks_from_db returns callbacks ordered by priority_weight desc."""
 
         dag_filepath = TEST_DAG_FOLDER / "test_on_failure_callback_dag.py"
 
@@ -1311,7 +1311,7 @@ class TestDagFileProcessorManager:
             manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
 
             with create_session() as session:
-                callbacks = manager._fetch_callbacks(session=session)
+                callbacks = manager._fetch_callbacks_from_db(session=session)
 
                 # Should return callbacks ordered by priority_weight desc (highest first)
                 assert callbacks[0].run_id == "123"
@@ -1385,7 +1385,7 @@ class TestDagFileProcessorManager:
             manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
 
             with create_session() as session:
-                callbacks = manager._fetch_callbacks(session=session)
+                callbacks = manager._fetch_callbacks_from_db(session=session)
 
                 # Only the matching callback should be returned
                 assert [c.run_id for c in callbacks] == ["match"]
@@ -1441,7 +1441,7 @@ class TestDagFileProcessorManager:
             manager._dag_bundles = list(DagBundlesManager().get_all_dag_bundles())
 
             with create_session() as session:
-                callbacks = manager._fetch_callbacks(session=session)
+                callbacks = manager._fetch_callbacks_from_db(session=session)
 
                 assert [c.run_id for c in callbacks] == ["match"]
 
@@ -1733,7 +1733,7 @@ class TestDagFileProcessorManager:
     def test_fetch_callbacks_delegates_to_private_method(self):
         manager = DagFileProcessorManager(max_runs=1)
         expected: list = [mock.sentinel.callback]
-        with mock.patch.object(manager, "_fetch_callbacks", return_value=expected) as private:
+        with mock.patch.object(manager, "_fetch_callbacks_from_db", return_value=expected) as private:
             assert manager.fetch_callbacks() is expected
         private.assert_called_once_with()
 

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1326,7 +1326,7 @@ class TestDagFileProcessorManager:
         }
     )
     def test_fetch_callbacks_from_database_max_per_loop(self, tmp_path, configure_testing_dag_bundle):
-        """Test DagFileProcessorManager._fetch_callbacks method"""
+        """Test DagFileProcessorManager.fetch_callbacks method."""
         dag_filepath = TEST_DAG_FOLDER / "test_on_failure_callback_dag.py"
 
         with create_session() as session:
@@ -1564,6 +1564,80 @@ class TestDagFileProcessorManager:
             assert dag2_path not in manager._callback_to_execute
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_resolve_callback_bundle(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        mock_bundle_manager.return_value.get_bundle.return_value = bundle
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        assert manager.resolve_callback_bundle(request) is bundle
+        mock_bundle_manager.return_value.get_bundle.assert_called_once_with(
+            name="testing", version="some_commit_hash"
+        )
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_resolve_callback_bundle_returns_none_for_unconfigured_bundle(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        mock_bundle_manager.return_value.get_bundle.side_effect = ValueError("missing bundle")
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        assert manager.resolve_callback_bundle(request) is None
+
+    def test_initialize_callback_bundle_skips_unversioned_callback(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        bundle.supports_versioning = True
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version=None,
+            msg=None,
+        )
+
+        assert manager.initialize_callback_bundle(request, bundle) is True
+        bundle.initialize.assert_not_called()
+
+    def test_initialize_callback_bundle_skips_non_versioned_bundle(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        bundle.supports_versioning = False
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        assert manager.initialize_callback_bundle(request, bundle) is True
+        bundle.initialize.assert_not_called()
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
     def test_add_callback_initializes_versioned_bundle(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         bundle = MagicMock()
@@ -1583,6 +1657,25 @@ class TestDagFileProcessorManager:
 
         manager._add_callback_to_queue(request)
 
+        bundle.initialize.assert_called_once()
+
+    def test_initialize_callback_bundle_returns_false_when_initialization_fails(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle = MagicMock()
+        bundle.supports_versioning = True
+        bundle.initialize.side_effect = Exception("clone failed")
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        assert manager.initialize_callback_bundle(request, bundle) is False
         bundle.initialize.assert_called_once()
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1566,7 +1566,7 @@ class TestDagFileProcessorManager:
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
     def test_resolve_callback_bundle(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         mock_bundle_manager.return_value.get_bundle.return_value = bundle
 
         request = DagCallbackRequest(
@@ -1603,7 +1603,7 @@ class TestDagFileProcessorManager:
 
     def test_initialize_callback_bundle_skips_unversioned_callback(self):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
 
         request = DagCallbackRequest(
@@ -1621,7 +1621,7 @@ class TestDagFileProcessorManager:
 
     def test_initialize_callback_bundle_skips_non_versioned_bundle(self):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = False
 
         request = DagCallbackRequest(
@@ -1640,7 +1640,7 @@ class TestDagFileProcessorManager:
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
     def test_add_callback_initializes_versioned_bundle(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
         bundle.path = Path("/tmp/bundle")
         mock_bundle_manager.return_value.get_bundle.return_value = bundle
@@ -1661,7 +1661,7 @@ class TestDagFileProcessorManager:
 
     def test_initialize_callback_bundle_returns_false_when_initialization_fails(self):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
         bundle.initialize.side_effect = Exception("clone failed")
 
@@ -1681,7 +1681,7 @@ class TestDagFileProcessorManager:
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
     def test_add_callback_skips_when_bundle_init_fails(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
-        bundle = MagicMock()
+        bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
         bundle.initialize.side_effect = Exception("clone failed")
         mock_bundle_manager.return_value.get_bundle.return_value = bundle

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -48,6 +48,7 @@ from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import DagBag
 from airflow.dag_processing.manager import (
     BundleState,
+    CallbackBundleUnavailable,
     DagFileInfo,
     DagFileProcessorManager,
     DagFileStat,
@@ -1585,7 +1586,7 @@ class TestDagFileProcessorManager:
         )
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
-    def test_resolve_callback_bundle_returns_none_for_unconfigured_bundle(self, mock_bundle_manager):
+    def test_resolve_callback_bundle_raises_for_unconfigured_bundle(self, mock_bundle_manager):
         manager = DagFileProcessorManager(max_runs=1)
         mock_bundle_manager.return_value.get_bundle.side_effect = ValueError("missing bundle")
 
@@ -1599,7 +1600,8 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        assert manager.resolve_callback_bundle(request) is None
+        with pytest.raises(CallbackBundleUnavailable, match="no longer configured"):
+            manager.resolve_callback_bundle(request)
 
     def test_initialize_callback_bundle_skips_unversioned_callback(self):
         manager = DagFileProcessorManager(max_runs=1)
@@ -1616,7 +1618,7 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        assert manager.initialize_callback_bundle(request, bundle) is True
+        manager.initialize_callback_bundle(request, bundle)
         bundle.initialize.assert_not_called()
 
     def test_initialize_callback_bundle_skips_non_versioned_bundle(self):
@@ -1634,7 +1636,7 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        assert manager.initialize_callback_bundle(request, bundle) is True
+        manager.initialize_callback_bundle(request, bundle)
         bundle.initialize.assert_not_called()
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
@@ -1659,11 +1661,11 @@ class TestDagFileProcessorManager:
 
         bundle.initialize.assert_called_once()
 
-    def test_initialize_callback_bundle_returns_false_when_initialization_fails(self):
+    def test_initialize_callback_bundle_raises_when_initialization_fails(self):
         manager = DagFileProcessorManager(max_runs=1)
         bundle = MagicMock(spec=BaseDagBundle)
         bundle.supports_versioning = True
-        bundle.initialize.side_effect = Exception("clone failed")
+        bundle.initialize.side_effect = RuntimeError("clone failed")
 
         request = DagCallbackRequest(
             filepath="file1.py",
@@ -1675,7 +1677,8 @@ class TestDagFileProcessorManager:
             msg=None,
         )
 
-        assert manager.initialize_callback_bundle(request, bundle) is False
+        with pytest.raises(CallbackBundleUnavailable, match="Failed to initialize bundle"):
+            manager.initialize_callback_bundle(request, bundle)
         bundle.initialize.assert_called_once()
 
     @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
@@ -1699,7 +1702,26 @@ class TestDagFileProcessorManager:
         manager._add_callback_to_queue(request)
 
         bundle.initialize.assert_called_once()
-        assert len(manager._callback_to_execute) == 0
+        assert not manager._callback_to_execute
+
+    @mock.patch("airflow.dag_processing.manager.DagBundlesManager")
+    def test_add_callback_skips_when_bundle_unconfigured(self, mock_bundle_manager):
+        manager = DagFileProcessorManager(max_runs=1)
+        mock_bundle_manager.return_value.get_bundle.side_effect = ValueError("missing bundle")
+
+        request = DagCallbackRequest(
+            filepath="file1.py",
+            dag_id="dag1",
+            run_id="run1",
+            is_failure_callback=False,
+            bundle_name="testing",
+            bundle_version="some_commit_hash",
+            msg=None,
+        )
+
+        manager._add_callback_to_queue(request)
+
+        assert not manager._callback_to_execute
 
     def test_dag_with_assets(self, session, configure_testing_dag_bundle):
         """'Integration' test to ensure that the assets get parsed and stored correctly for parsed dags."""


### PR DESCRIPTION
Introduce two seams in `DagFileProcessorManager` callback handling so metadata-DB access can later be swapped for API calls:

- `fetch_callbacks()` — the outer seam; default delegates to the DB-backed `_fetch_callbacks()`.
- `prepare_callback_bundle(request) -> BaseDagBundle | None` — resolves the bundle for a callback request and, for versioned requests on bundles that support versioning, calls `bundle.initialize()`. Returns `None` to signal the callback should be skipped (bundle no longer configured, or initialization failed).

`_add_callback_to_queue` checks the returned bundle and skips on `None`. No behavior change for the default DB-backed flow — log messages and skip semantics are preserved.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)
Generated-by: claude opus 4.7