### PR TITLE
Fix Google provider test failures without werkzeug

### DIFF
--- a/providers/google/tests/conftest.py
+++ b/providers/google/tests/conftest.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 
 import importlib.metadata
 
-import werkzeug
+try:
+    import werkzeug
+except ModuleNotFoundError:
+    werkzeug = None
 
 pytest_plugins = "tests_common.pytest_plugin"
 
 # Flask 2.2.x test client reads werkzeug.__version__ which Werkzeug 3.x removed.
 # Connexion 2.x used to pin Werkzeug<3, but connexion is now removed from FAB provider.
-if not hasattr(werkzeug, "__version__"):
+if werkzeug is not None and not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = importlib.metadata.version("werkzeug")


### PR DESCRIPTION
Make werkzeug import optional in Google provider test conftest to fix test collection failures when werkzeug is not installed, when running locally with `uv run` (not inside breeze).

## Background

The werkzeug import was added to Google provider's test conftest during the FAB connexion-to-FastAPI migration (PR #62664, commit f4fd68fb15 on March 6, 2026), but it's not actually needed for most Google provider tests.

- **FAB provider**: Legitimately needs werkzeug (5+ test files use Flask test client) ✅
- **Google provider**: Only 1 test file (`test_google_openid.py`) uses Flask test client ❌

The hard import was causing test collection failures for the other 99%+ of Google provider tests when werkzeug wasn't installed, even though they don't need it.

## Changes

- Changed werkzeug import from hard import to optional try/except
- Added None check before accessing werkzeug attributes
- Maintains backward compatibility: tests that need werkzeug still work when it's available

## Notes

- werkzeug was never part of Google provider in Airflow 2.X era
- This unnecessary hard dependency was introduced as a blanket change appropriate for FAB provider but not for Google provider
- FAB provider conftest correctly keeps werkzeug as a hard import (it genuinely needs it)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot

Generated-by: GitHub Copilot following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)