### PR TITLE
Allow accessing a Dag's members via `[]`

### DIFF
--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -37,6 +37,7 @@ try:
         AirflowOptionalProviderFeatureException as AirflowOptionalProviderFeatureException,
         AirflowRescheduleException as AirflowRescheduleException,
         AirflowTimetableInvalid as AirflowTimetableInvalid,
+        TaskItemNotFound as TaskItemNotFound,
         TaskNotFound as TaskNotFound,
     )
 except ModuleNotFoundError:
@@ -53,6 +54,12 @@ except ModuleNotFoundError:
 
     class TaskNotFound(AirflowException):  # type: ignore[no-redef]
         """Raise when a Task is not available in the system."""
+
+    class TaskItemNotFound(TaskNotFound, KeyError):  # type: ignore[no-redef]
+        """Raise when attempting to access an invalid task using [] notation."""
+
+        def __str__(self) -> str:
+            return str(self.args[0]) if self.args else ""
 
     class AirflowRescheduleException(AirflowException):  # type: ignore[no-redef]
         """

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -37,7 +37,7 @@ try:
         AirflowOptionalProviderFeatureException as AirflowOptionalProviderFeatureException,
         AirflowRescheduleException as AirflowRescheduleException,
         AirflowTimetableInvalid as AirflowTimetableInvalid,
-        TaskItemNotFound as TaskItemNotFound,
+        NodeNotFound as NodeNotFound,
         TaskNotFound as TaskNotFound,
     )
 except ModuleNotFoundError:
@@ -55,8 +55,8 @@ except ModuleNotFoundError:
     class TaskNotFound(AirflowException):  # type: ignore[no-redef]
         """Raise when a Task is not available in the system."""
 
-    class TaskItemNotFound(TaskNotFound, KeyError):  # type: ignore[no-redef]
-        """Raise when attempting to access an invalid task using [] notation."""
+    class NodeNotFound(TaskNotFound, KeyError):  # type: ignore[no-redef]
+        """Raise when attempting to access an invalid node (task or task group) using [] notation."""
 
         def __str__(self) -> str:
             return str(self.args[0]) if self.args else ""

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -32,7 +32,7 @@ from sqlalchemy import func, or_, select, tuple_
 
 from airflow._shared.timezones.timezone import coerce_datetime
 from airflow.configuration import conf as airflow_conf
-from airflow.exceptions import AirflowException, TaskItemNotFound, TaskNotFound
+from airflow.exceptions import AirflowException, NodeNotFound, TaskNotFound
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
@@ -252,7 +252,7 @@ class SerializedDAG:
             return node
         if (tg := self.task_group_dict.get(node_id)) is not None:
             return tg
-        raise TaskItemNotFound(f"Task or group {node_id!r} not found")
+        raise NodeNotFound(f"Task or group {node_id!r} not found")
 
     @property
     def task_group_dict(self):

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -246,12 +246,13 @@ class SerializedDAG:
             return self.task_dict[task_id]
         raise TaskNotFound(f"Task {task_id} not found")
 
-    def __getitem__(self, task_id: str) -> SerializedOperator:
-        """Return a task by its fully-qualified task_id."""
-        try:
-            return self.get_task(task_id)
-        except TaskNotFound:
-            raise TaskItemNotFound(f"Task {task_id!r} not found")
+    def __getitem__(self, node_id: str) -> SerializedOperator | SerializedTaskGroup:
+        """Return a task or task group by its fully-qualified ID."""
+        if (node := self.task_dict.get(node_id)) is not None:
+            return node
+        if (tg := self.task_group_dict.get(node_id)) is not None:
+            return tg
+        raise TaskItemNotFound(f"Task or group {node_id!r} not found")
 
     @property
     def task_group_dict(self):

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -32,7 +32,7 @@ from sqlalchemy import func, or_, select, tuple_
 
 from airflow._shared.timezones.timezone import coerce_datetime
 from airflow.configuration import conf as airflow_conf
-from airflow.exceptions import AirflowException, TaskNotFound
+from airflow.exceptions import AirflowException, TaskItemNotFound, TaskNotFound
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
@@ -245,6 +245,13 @@ class SerializedDAG:
         if task_id in self.task_dict:
             return self.task_dict[task_id]
         raise TaskNotFound(f"Task {task_id} not found")
+
+    def __getitem__(self, task_id: str) -> SerializedOperator:
+        """Return a task by its fully-qualified task_id."""
+        try:
+            return self.get_task(task_id)
+        except TaskNotFound:
+            raise TaskItemNotFound(f"Task {task_id!r} not found")
 
     @property
     def task_group_dict(self):

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1053,15 +1053,15 @@ def test_serialized_dag_getitem_returns_task(dag_maker):
 
 
 @pytest.mark.db_test
-def test_serialized_dag_getitem_missing_raises_task_item_not_found(dag_maker):
-    from airflow.exceptions import TaskItemNotFound
+def test_serialized_dag_getitem_missing_raises_node_not_found(dag_maker):
+    from airflow.exceptions import NodeNotFound
 
     with dag_maker() as dag:
         BashOperator(task_id="my_task", bash_command="echo 1")
 
     ser_dict = DagSerialization.to_dict(dag)
     ser_dag = DagSerialization.from_dict(ser_dict)
-    with pytest.raises(TaskItemNotFound):
+    with pytest.raises(NodeNotFound):
         ser_dag["nonexistent"]
 
 

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1074,3 +1074,17 @@ def test_serialized_dag_getitem_missing_is_key_error(dag_maker):
     ser_dag = DagSerialization.from_dict(ser_dict)
     with pytest.raises(KeyError):
         ser_dag["nonexistent"]
+
+
+@pytest.mark.db_test
+def test_serialized_dag_getitem_returns_task_group(dag_maker):
+    from airflow.serialization.definitions.dag import SerializedDAG
+
+    with dag_maker() as dag:
+        with TaskGroup(group_id="section") as tg:
+            BashOperator(task_id="t", bash_command="echo 1")
+
+    ser_dict = DagSerialization.to_dict(dag)
+    ser_dag = DagSerialization.from_dict(ser_dict)
+    assert isinstance(ser_dag, SerializedDAG)
+    assert ser_dag["section"].group_id == tg.group_id

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1037,3 +1037,40 @@ class TestKubernetesImportAvoidance:
         result = _has_kubernetes()
 
         assert result is True
+
+
+@pytest.mark.db_test
+def test_serialized_dag_getitem_returns_task(dag_maker):
+    from airflow.serialization.definitions.dag import SerializedDAG
+
+    with dag_maker() as dag:
+        BashOperator(task_id="my_task", bash_command="echo 1")
+
+    ser_dict = DagSerialization.to_dict(dag)
+    ser_dag = DagSerialization.from_dict(ser_dict)
+    assert isinstance(ser_dag, SerializedDAG)
+    assert ser_dag["my_task"].task_id == "my_task"
+
+
+@pytest.mark.db_test
+def test_serialized_dag_getitem_missing_raises_task_item_not_found(dag_maker):
+    from airflow.exceptions import TaskItemNotFound
+
+    with dag_maker() as dag:
+        BashOperator(task_id="my_task", bash_command="echo 1")
+
+    ser_dict = DagSerialization.to_dict(dag)
+    ser_dag = DagSerialization.from_dict(ser_dict)
+    with pytest.raises(TaskItemNotFound):
+        ser_dag["nonexistent"]
+
+
+@pytest.mark.db_test
+def test_serialized_dag_getitem_missing_is_key_error(dag_maker):
+    with dag_maker() as dag:
+        BashOperator(task_id="my_task", bash_command="echo 1")
+
+    ser_dict = DagSerialization.to_dict(dag)
+    ser_dag = DagSerialization.from_dict(ser_dict)
+    with pytest.raises(KeyError):
+        ser_dag["nonexistent"]

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -57,6 +57,7 @@ from airflow.sdk.exceptions import (
     FailFastDagInvalidTriggerRule,
     ParamValidationError,
     RemovedInAirflow4Warning,
+    TaskItemNotFound,
     TaskNotFound,
 )
 
@@ -1031,6 +1032,13 @@ class DAG:
         if task_id in self.task_dict:
             return self.task_dict[task_id]
         raise TaskNotFound(f"Task {task_id} not found")
+
+    def __getitem__(self, task_id: str) -> Operator:
+        """Return a task by its fully-qualified task_id. Use TaskGroup.__getitem__ to access groups."""
+        try:
+            return self.get_task(task_id)
+        except TaskNotFound:
+            raise TaskItemNotFound(f"Task {task_id!r} not found")
 
     @property
     def task(self) -> TaskDecoratorCollection:

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -43,7 +43,7 @@ from airflow import settings
 from airflow.sdk import TaskInstanceState, TriggerRule, XComArg
 from airflow.sdk.bases.operator import BaseOperator
 from airflow.sdk.bases.timetable import BaseTimetable
-from airflow.sdk.definitions._internal.node import validate_key
+from airflow.sdk.definitions._internal.node import DAGNode, validate_key
 from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet, is_arg_set
 from airflow.sdk.definitions.asset import AssetAll, BaseAsset
 from airflow.sdk.definitions.context import Context
@@ -1033,12 +1033,13 @@ class DAG:
             return self.task_dict[task_id]
         raise TaskNotFound(f"Task {task_id} not found")
 
-    def __getitem__(self, task_id: str) -> Operator:
-        """Return a task by its fully-qualified task_id. Use TaskGroup.__getitem__ to access groups."""
-        try:
-            return self.get_task(task_id)
-        except TaskNotFound:
-            raise TaskItemNotFound(f"Task {task_id!r} not found")
+    def __getitem__(self, node_id: str) -> DAGNode:
+        """Return a task or task group by its fully-qualified ID."""
+        if (node := self.task_dict.get(node_id)) is not None:
+            return node
+        if (tg := self.task_group_dict.get(node_id)) is not None:
+            return tg
+        raise TaskItemNotFound(f"Task or group {node_id!r} not found")
 
     @property
     def task(self) -> TaskDecoratorCollection:

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -55,9 +55,9 @@ from airflow.sdk.exceptions import (
     AirflowDagCycleException,
     DuplicateTaskIdFound,
     FailFastDagInvalidTriggerRule,
+    NodeNotFound,
     ParamValidationError,
     RemovedInAirflow4Warning,
-    TaskItemNotFound,
     TaskNotFound,
 )
 
@@ -1039,7 +1039,7 @@ class DAG:
             return node
         if (tg := self.task_group_dict.get(node_id)) is not None:
             return tg
-        raise TaskItemNotFound(f"Task or group {node_id!r} not found")
+        raise NodeNotFound(f"Task or group {node_id!r} not found")
 
     @property
     def task(self) -> TaskDecoratorCollection:

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -33,8 +33,8 @@ from airflow.sdk.definitions._internal.node import DAGNode, validate_group_key
 from airflow.sdk.exceptions import (
     AirflowDagCycleException,
     DuplicateTaskIdFound,
+    NodeNotFound,
     TaskAlreadyInTaskGroup,
-    TaskItemNotFound,
 )
 
 if TYPE_CHECKING:
@@ -497,7 +497,7 @@ class TaskGroup(DAGNode):
         try:
             return self.get_child_by_label(label)
         except KeyError:
-            raise TaskItemNotFound(f"Task {label!r} not found")
+            raise NodeNotFound(f"Task {label!r} not found")
 
     def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
         """Serialize task group; required by DagNode."""

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -34,6 +34,7 @@ from airflow.sdk.exceptions import (
     AirflowDagCycleException,
     DuplicateTaskIdFound,
     TaskAlreadyInTaskGroup,
+    TaskItemNotFound,
 )
 
 if TYPE_CHECKING:
@@ -140,10 +141,6 @@ class TaskGroup(DAGNode):
     def _validate_dag(self, _attr, dag):
         if not dag:
             raise RuntimeError("TaskGroup can only be used inside a dag")
-
-    def __getitem__(self, key: str) -> DAGNode:
-        """Return a child node by label via ``tg[label]`` syntax. See `get_child_by_label`."""
-        return self.get_child_by_label(key)
 
     def __attrs_post_init__(self):
         # TODO: If attrs supported init only args we could use that here
@@ -495,6 +492,12 @@ class TaskGroup(DAGNode):
     def get_child_by_label(self, label: str) -> DAGNode:
         """Get a child task/TaskGroup by its label (i.e. task_id/group_id without the group_id prefix)."""
         return self.children[self.child_id(label)]
+
+    def __getitem__(self, label: str) -> DAGNode:
+        try:
+            return self.get_child_by_label(label)
+        except KeyError:
+            raise TaskItemNotFound(f"Task {label!r} not found")
 
     def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
         """Serialize task group; required by DagNode."""

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -330,6 +330,13 @@ class TaskNotFound(AirflowException):
     """Raise when a Task is not available in the system."""
 
 
+class TaskItemNotFound(TaskNotFound, KeyError):
+    """Raise when attempting to access an invalid task using [] notation."""
+
+    def __str__(self) -> str:
+        return str(self.args[0]) if self.args else ""
+
+
 class TaskAlreadyRunningError(AirflowException):
     """Raised when a task is already running on another worker."""
 

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -330,8 +330,8 @@ class TaskNotFound(AirflowException):
     """Raise when a Task is not available in the system."""
 
 
-class TaskItemNotFound(TaskNotFound, KeyError):
-    """Raise when attempting to access an invalid task using [] notation."""
+class NodeNotFound(TaskNotFound, KeyError):
+    """Raise when attempting to access an invalid node (task or task group) using [] notation."""
 
     def __str__(self) -> str:
         return str(self.args[0]) if self.args else ""

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -950,6 +950,27 @@ class TestDagGetItem:
             op = DoNothingOperator(task_id="my_task")
         assert dag["my_task"] is op
 
+    def test_getitem_returns_task_group(self):
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with dag:
+            with TaskGroup(group_id="section") as tg:
+                DoNothingOperator(task_id="t")
+        assert dag["section"] is tg
+
+    def test_getitem_nested_task_by_qualified_id(self):
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with dag:
+            with TaskGroup(group_id="section"):
+                op = DoNothingOperator(task_id="t")
+        assert dag["section.t"] is op
+
+    def test_getitem_nested_task_via_chained_access(self):
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with dag:
+            with TaskGroup(group_id="section"):
+                op = DoNothingOperator(task_id="t")
+        assert dag["section"]["t"] is op
+
     def test_getitem_missing_raises_task_item_not_found(self):
         from airflow.sdk.exceptions import TaskItemNotFound
 

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -971,11 +971,11 @@ class TestDagGetItem:
                 op = DoNothingOperator(task_id="t")
         assert dag["section"]["t"] is op
 
-    def test_getitem_missing_raises_task_item_not_found(self):
-        from airflow.sdk.exceptions import TaskItemNotFound
+    def test_getitem_missing_raises_node_not_found(self):
+        from airflow.sdk.exceptions import NodeNotFound
 
         dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
-        with pytest.raises(TaskItemNotFound):
+        with pytest.raises(NodeNotFound):
             dag["nonexistent"]
 
     def test_getitem_missing_is_key_error(self):

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -941,3 +941,23 @@ class TestCycleTester:
                 op1 >> Label("label") >> op2
 
         assert not dag.check_cycle()
+
+
+class TestDagGetItem:
+    def test_getitem_returns_task(self):
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with dag:
+            op = DoNothingOperator(task_id="my_task")
+        assert dag["my_task"] is op
+
+    def test_getitem_missing_raises_task_item_not_found(self):
+        from airflow.sdk.exceptions import TaskItemNotFound
+
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with pytest.raises(TaskItemNotFound):
+            dag["nonexistent"]
+
+    def test_getitem_missing_is_key_error(self):
+        dag = DAG("test_dag", schedule=None, start_date=DEFAULT_DATE)
+        with pytest.raises(KeyError):
+            dag["nonexistent"]

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -243,9 +243,9 @@ def test_taskgroup_getitem_returns_child_by_label(prefix: bool):
     assert group1["subgroup"] == subgroup
     assert group1["subgroup"]["task2"] == task2
 
-    from airflow.sdk.exceptions import TaskItemNotFound
+    from airflow.sdk.exceptions import NodeNotFound
 
-    with pytest.raises(TaskItemNotFound):
+    with pytest.raises(NodeNotFound):
         group1["nonexistent"]
 
 
@@ -934,17 +934,17 @@ def test_build_task_group_with_operators():
 
 
 class TestTaskGroupGetItem:
-    def test_getitem_missing_raises_task_item_not_found(self):
+    def test_getitem_missing_raises_node_not_found(self):
         import pendulum
 
-        from airflow.sdk.exceptions import TaskItemNotFound
+        from airflow.sdk.exceptions import NodeNotFound
 
         start = pendulum.datetime(2016, 1, 1)
         with DAG("test_dag", schedule=None, start_date=start):
             with TaskGroup(group_id="section") as tg:
                 pass
 
-        with pytest.raises(TaskItemNotFound):
+        with pytest.raises(NodeNotFound):
             tg["nonexistent"]
 
     def test_getitem_missing_is_key_error(self):

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -243,8 +243,9 @@ def test_taskgroup_getitem_returns_child_by_label(prefix: bool):
     assert group1["subgroup"] == subgroup
     assert group1["subgroup"]["task2"] == task2
 
-    # Missing label raises KeyError
-    with pytest.raises(KeyError):
+    from airflow.sdk.exceptions import TaskItemNotFound
+
+    with pytest.raises(TaskItemNotFound):
         group1["nonexistent"]
 
 
@@ -930,3 +931,29 @@ def test_build_task_group_with_operators():
     # Testing Tasks downstream
     assert dag.task_dict["task_start"].downstream_task_ids == {"section_1.task_1"}
     assert dag.task_dict["section_1.task_3"].downstream_task_ids == {"task_end"}
+
+
+class TestTaskGroupGetItem:
+    def test_getitem_missing_raises_task_item_not_found(self):
+        import pendulum
+
+        from airflow.sdk.exceptions import TaskItemNotFound
+
+        start = pendulum.datetime(2016, 1, 1)
+        with DAG("test_dag", schedule=None, start_date=start):
+            with TaskGroup(group_id="section") as tg:
+                pass
+
+        with pytest.raises(TaskItemNotFound):
+            tg["nonexistent"]
+
+    def test_getitem_missing_is_key_error(self):
+        import pendulum
+
+        start = pendulum.datetime(2016, 1, 1)
+        with DAG("test_dag", schedule=None, start_date=start):
+            with TaskGroup(group_id="section") as tg:
+                pass
+
+        with pytest.raises(KeyError):
+            tg["nonexistent"]

--- a/task-sdk/tests/task_sdk/test_exceptions.py
+++ b/task-sdk/tests/task_sdk/test_exceptions.py
@@ -18,26 +18,26 @@ from __future__ import annotations
 
 import pytest
 
-from airflow.sdk.exceptions import TaskItemNotFound, TaskNotFound
+from airflow.sdk.exceptions import NodeNotFound, TaskNotFound
 
 
-def test_task_item_not_found_is_subclass_of_task_not_found():
-    assert issubclass(TaskItemNotFound, TaskNotFound)
+def test_node_not_found_is_subclass_of_task_not_found():
+    assert issubclass(NodeNotFound, TaskNotFound)
 
 
-def test_task_item_not_found_is_subclass_of_key_error():
-    assert issubclass(TaskItemNotFound, KeyError)
+def test_node_not_found_is_subclass_of_key_error():
+    assert issubclass(NodeNotFound, KeyError)
 
 
-def test_task_item_not_found_caught_as_key_error():
+def test_node_not_found_caught_as_key_error():
     with pytest.raises(KeyError):
-        raise TaskItemNotFound("missing_task")
+        raise NodeNotFound("missing_task")
 
 
-def test_task_item_not_found_caught_as_task_not_found():
+def test_node_not_found_caught_as_task_not_found():
     with pytest.raises(TaskNotFound):
-        raise TaskItemNotFound("missing_task")
+        raise NodeNotFound("missing_task")
 
 
-def test_task_item_not_found_str_suppresses_key_error_repr():
-    assert str(TaskItemNotFound("missing")) == "missing"
+def test_node_not_found_str_suppresses_key_error_repr():
+    assert str(NodeNotFound("missing")) == "missing"

--- a/task-sdk/tests/task_sdk/test_exceptions.py
+++ b/task-sdk/tests/task_sdk/test_exceptions.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.sdk.exceptions import TaskItemNotFound, TaskNotFound
+
+
+def test_task_item_not_found_is_subclass_of_task_not_found():
+    assert issubclass(TaskItemNotFound, TaskNotFound)
+
+
+def test_task_item_not_found_is_subclass_of_key_error():
+    assert issubclass(TaskItemNotFound, KeyError)
+
+
+def test_task_item_not_found_caught_as_key_error():
+    with pytest.raises(KeyError):
+        raise TaskItemNotFound("missing_task")
+
+
+def test_task_item_not_found_caught_as_task_not_found():
+    with pytest.raises(TaskNotFound):
+        raise TaskItemNotFound("missing_task")
+
+
+def test_task_item_not_found_str_suppresses_key_error_repr():
+    assert str(TaskItemNotFound("missing")) == "missing"


### PR DESCRIPTION
related: #64430


## Summary

- Add `dag[id]` subscript syntax to `DAG` and `SerializedDAG` for accessing any node (task or task group) by its fully-qualified ID.
- Update `TaskGroup.__getitem__` to raise `TaskItemNotFound` (instead of a raw `KeyError`) on a miss, so callers can catch either `KeyError` or `TaskNotFound`.
- Introduce `TaskItemNotFound(TaskNotFound, KeyError)` as a new exception in `airflow.sdk.exceptions` (and re-export it from `airflow.exceptions`) — a `KeyError` subtype that also satisfies `TaskNotFound`, giving callers flexibility without breaking existing `KeyError` handlers.

## Details

| Component | Change |
|-----------|--------|
| `task-sdk/src/airflow/sdk/exceptions.py` | Add `TaskItemNotFound(TaskNotFound, KeyError)` |
| `airflow-core/src/airflow/exceptions.py` | Re-export `TaskItemNotFound`; add fallback stub |
| `task-sdk/src/airflow/sdk/definitions/dag.py` | Add `DAG.__getitem__`: checks `task_dict` then `task_group_dict`, returns `DAGNode` |
| `task-sdk/src/airflow/sdk/definitions/taskgroup.py` | Update `TaskGroup.__getitem__` to re-raise `KeyError` as `TaskItemNotFound` |
| `airflow-core/src/airflow/serialization/definitions/dag.py` | Add `SerializedDAG.__getitem__`: same lookup logic, returns `SerializedOperator \| SerializedTaskGroup` |

## Usage

```python
with DAG("my_dag", ...) as dag:
    with TaskGroup("section") as tg:
        t = BashOperator(task_id="my_task", bash_command="echo 1")

# Access a top-level task
assert dag["my_task"] is t           # hypothetical top-level task

# Access a grouped task by fully-qualified ID
assert dag["section.my_task"] is t

# Access the task group itself
assert dag["section"] is tg

# Chain subscripts (DAG returns TaskGroup, TaskGroup returns child by label)
assert dag["section"]["my_task"] is t

# All misses raise TaskItemNotFound (catchable as KeyError or TaskNotFound)
dag["nonexistent"]   # raises TaskItemNotFound
```

## Two access patterns for nested nodes

`dag[id]` supports two equivalent ways to reach a task inside a group:

| Pattern | Mechanism |
|---------|-----------|
| `dag["section.my_task"]` | Direct flat lookup in `task_dict` — O(1) |
| `dag["section"]["my_task"]` | `dag["section"]` returns the `TaskGroup`; `tg["my_task"]` resolves by label |

Both are tested. The flat lookup is marginally cheaper; the chained form is more readable when the group is already in scope.

## `TaskItemNotFound` exception hierarchy

```
KeyError
└── TaskItemNotFound
      └── (also) TaskNotFound ← AirflowException
```

Callers can catch it as `KeyError` (existing dict-style handlers), `TaskNotFound` (Airflow task-lookup handlers), or `TaskItemNotFound` (subscript-specific handlers).

The fallback stub in `airflow.exceptions` (active when `airflow.sdk` is not installed) mirrors the same `__str__` override so `str(exc)` never includes the extra quotes that `KeyError.__str__` adds.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
