### PR TITLE
Add team_name attribute to DAG for multi-team context support

### DIFF
--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -165,6 +165,7 @@
       "properties": {
         "params": { "$ref": "#/definitions/params" },
         "dag_id": { "type": "string" },
+        "team_name": { "type": ["string", "null"] },
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
         "owner_links": { "type": "object" },

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -439,6 +439,10 @@ class DAG:
         default=None,
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
     )
+    team_name: str | None = attrs.field(
+        default=None,
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+    )
     default_args: dict[str, Any] = attrs.field(
         factory=dict, validator=attrs.validators.instance_of(dict), converter=dict_copy
     )
@@ -1551,6 +1555,7 @@ if TYPE_CHECKING:
         dag_id: str = "",
         *,
         description: str | None = None,
+        team_name: str | None = None,
         schedule: ScheduleArg = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -803,6 +803,9 @@ def set_current_context(context: Context) -> Generator[Context, None, None]:
     This method should be called once per Task execution, before calling operator.execute.
     """
     _CURRENT_CONTEXT.append(context)
+
+    context["team_name"] = getattr(context.get("dag", None), "team_name", None)
+    
     try:
         yield context
     finally:


### PR DESCRIPTION
Closes: #65465

### Description

This PR adds support for a new `team_name` attribute on DAGs to enable multi-team context handling in Airflow.

### Changes

- Added `team_name` field to the DAG class
- Extended the `@dag` decorator to accept `team_name`
- Injected `team_name` into runtime context (`context["team_name"]`)
- Updated DAG serialization schema to include `team_name`

### Use Case / Motivation

This feature enables:

- Team-level policies in `airflow_local_settings.py`
- Jinja templating support:
  - `{{ team_name }}`
  - `{{ dag.team_name }}`
  - `{{ ti.team_name }}`
- Team-based log partitioning and access control

This is useful in multi-team environments where DAG ownership and execution policies depend on team identity.

### Example

```python
@dag(dag_id="example_dag", team_name="data_team")
def my_dag():
    ...