### PR TITLE
Fix flaky K8s xcom tests on ARM hitting 120s pod-start timeout

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
+++ b/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: base
-      image: perl
+      image: ubuntu
       command: ["/bin/bash"]
       args: ["-c", 'echo {\"hello\" : \"world\"} | cat > /airflow/xcom/return.json']
   restartPolicy: Never

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -51,6 +51,12 @@ from tests_common.test_utils.taskinstance import create_task_instance
 HOOK_CLASS = "airflow.providers.cncf.kubernetes.operators.pod.KubernetesHook"
 POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
 
+# Longer than the operator's 120s default to absorb the first-pull latency of
+# the xcom sidecar image (alpine) on ARM runners with a cold containerd cache.
+# Whichever xcom test runs first has to pay that cost; giving all of them the
+# same budget keeps the tests order-independent.
+XCOM_STARTUP_TIMEOUT_SECONDS = 300
+
 
 def create_context(task) -> Context:
     from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -709,6 +715,7 @@ class TestKubernetesPodOperatorSystem:
             task_id=str(uuid4()),
             in_cluster=False,
             do_xcom_push=True,
+            startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS,
         )
         context = create_context(k)
         assert k.execute(context) == expected
@@ -753,6 +760,7 @@ class TestKubernetesPodOperatorSystem:
             labels=self.labels,
             pod_template_file=basic_pod_template.as_posix(),
             do_xcom_push=True,
+            startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS,
         )
 
         context = create_context(k)
@@ -775,6 +783,7 @@ class TestKubernetesPodOperatorSystem:
             in_cluster=False,
             pod_template_file=basic_pod_template.as_posix(),
             do_xcom_push=True,
+            startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS,
         )
 
         context = create_context(k)
@@ -814,6 +823,7 @@ class TestKubernetesPodOperatorSystem:
             pod_template_file=basic_pod_template.as_posix(),
             full_pod_spec=pod_spec,
             do_xcom_push=True,
+            startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS,
         )
 
         context = create_context(k)
@@ -842,7 +852,7 @@ class TestKubernetesPodOperatorSystem:
                 containers=[
                     k8s.V1Container(
                         name="base",
-                        image="perl",
+                        image="ubuntu",
                         command=["/bin/bash"],
                         args=["-c", 'echo {\\"hello\\" : \\"world\\"} | cat > /airflow/xcom/return.json'],
                         env=[k8s.V1EnvVar(name="env_name", value="value")],
@@ -858,7 +868,7 @@ class TestKubernetesPodOperatorSystem:
             full_pod_spec=pod_spec,
             do_xcom_push=True,
             on_finish_action=OnFinishAction.KEEP_POD,
-            startup_timeout_seconds=30,
+            startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS,
         )
 
         context = create_context(k)


### PR DESCRIPTION
## Summary

On ARM CI runners with a cold containerd cache, the first K8s system test that needs to pull a new image can exceed `KubernetesPodOperator`'s default `startup_timeout_seconds=120`, producing a `PodLaunchTimeoutException` that surfaces as a generic `AirflowException: Pod ... returned a failure`.

Observed in apache/airflow actions run [24716106401](https://github.com/apache/airflow/actions/runs/24716106401), job [72301089157](https://github.com/apache/airflow/actions/runs/24716106401/job/72301089157) (`K8S System:CeleryExecutor-3.12-v1.32.8-false`, ARM): both failing tests took exactly ~120s, matching the default; pod events showed `Pulling image "alpine" ...` with no `Successfully pulled` inside the 120s window.

Two small changes in `kubernetes-tests/` only — no production code touched.

### 1. `basic_pod.yaml` / `test_full_pod_spec`: `perl` → `ubuntu`

The pod template just runs `/bin/bash -c 'echo {"hello":"world"} > /airflow/xcom/return.json'`. Any image with bash works, and `ubuntu` is already warmed by earlier tests in the suite — eliminates the `perl` image pull entirely.

### 2. `startup_timeout_seconds=XCOM_STARTUP_TIMEOUT_SECONDS` (300s) on every real-cluster `do_xcom_push=True` test

Since pytest ordering isn't guaranteed, whichever xcom test runs first has to absorb the one-time `alpine` sidecar pull. Bumping the budget on all of them keeps the suite order-independent. A module-level constant with an inline comment documents the reasoning.

The operator's production default of 120s is **unchanged** — this is a test-side robustness tweak only.

## Test plan

- [ ] Next scheduled `ci-amd-arm.yml` run (or a manual rerun of the job above) shows the `K8S System:CeleryExecutor-3.12-v1.32.8-false` job passing.
- [ ] Existing K8s system tests on AMD runners continue to pass (they already ran in ~5s per test, so raising the max budget is a no-op for them).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)