### PR TITLE
Fix grammatical error in AWS Identity Center docs

### DIFF
--- a/providers/amazon/docs/auth-manager/setup/identity-center.rst
+++ b/providers/amazon/docs/auth-manager/setup/identity-center.rst
@@ -30,7 +30,7 @@ Create resources
 ================
 
 The AWS auth manager needs two resources in AWS IAM Identity Center: an instance and an application.
-You can must create them manually.
+You must create them manually.
 
 Create the instance
 -------------------


### PR DESCRIPTION
Fixes a grammatical error in the AWS IAM Identity Center configuration documentation.

**Changes:**
- Corrected "You can must create them manually" to "You must create them manually"