### PR TITLE
Cap airflow-ctl httpx dependency below 1.0

### DIFF
--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -29,7 +29,9 @@ requires-python = ">=3.10,!=3.15"
 dependencies = [
     # TODO there could be still missing deps such as airflow-core
     "argcomplete>=1.10",
-    "httpx>=0.27.0",
+    # Remove the <1.0 cap after migrating to httpx 1.x (ground-up API rewrite — no HTTPStatusError etc.);
+    # tracked at https://github.com/apache/airflow/issues/65609
+    "httpx>=0.27.0,<1.0",
     "keyring>=25.7.0",
     "lazy-object-proxy>=1.2.0",
     "methodtools>=0.4.7",


### PR DESCRIPTION
httpx 1.0 (currently \`1.0.dev3\` on PyPI) is a ground-up API rewrite:
the entire exception hierarchy (\`HTTPStatusError\`, \`RequestError\`, \`ConnectError\`, \`ReadError\`, \`TimeoutException\`, ...) was removed and client/transport/auth interfaces were redesigned. airflow-ctl currently uses \`httpx.HTTPStatusError\`, \`httpx.ConnectError\`, \`AsyncClient\`, and \`Response.raise_for_status()\` throughout \`api/client.py\` and \`api/operations.py\`, so pre-release httpx 1.x breaks \`airflowctl\` at import-time (\`ModuleNotFoundError\` / \`AttributeError\`) and the tool fails to start.

Reported during 0.1.4rc2 testing in #65497 — user had to work around it with \`--with 'httpx==0.28.1'\` on install.

Cap to \`<1.0\` so \`uv tool install apache-airflow-ctl --prerelease=allow\` does not accidentally pull the rewrite. The cap carries a comment in \`airflow-ctl/pyproject.toml\` linking to the migration tracking issue so the reference survives after this PR merges.

The full migration to httpx 1.x is tracked in #65609.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)