### PR TITLE
Fix airflowctl dagrun list crash when --state is omitted

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -606,8 +606,8 @@ class DagRunOperations(BaseOperations):
 
     def list(
         self,
-        state: str,
-        limit: int,
+        state: str | None = None,
+        limit: int = 100,
         start_date: datetime.datetime | None = None,
         end_date: datetime.datetime | None = None,
         dag_id: str | None = None,
@@ -616,7 +616,7 @@ class DagRunOperations(BaseOperations):
         List dag runs (at most `limit` results).
 
         Args:
-            state: Filter dag runs by state
+            state: Filter dag runs by state (optional; no filter applied when omitted)
             start_date: Filter dag runs by start date (optional)
             end_date: Filter dag runs by end date (optional)
             limit: Limit the number of results returned
@@ -626,10 +626,9 @@ class DagRunOperations(BaseOperations):
         if not dag_id:
             dag_id = "~"
 
-        params: dict[str, Any] = {
-            "state": str(state),
-            "limit": limit,
-        }
+        params: dict[str, Any] = {"limit": limit}
+        if state is not None:
+            params["state"] = str(state)
         if start_date is not None:
             params["start_date"] = start_date.isoformat()
         if end_date is not None:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1139,6 +1139,20 @@ class TestDagRunOperations:
         )
         assert response == self.dag_run_collection_response
 
+    def test_list_without_state_does_not_send_state_param(self):
+        """`state` is optional: omitting it must not send ``state=None`` to the API."""
+        captured_params: dict[str, str] = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            captured_params.update(dict(request.url.params))
+            return httpx.Response(200, json=json.loads(self.dag_run_collection_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.list(limit=5)
+        assert response == self.dag_run_collection_response
+        assert "state" not in captured_params
+        assert captured_params["limit"] == "5"
+
 
 class TestJobsOperations:
     job_response = JobResponse(


### PR DESCRIPTION
\`DagRunOperations.list()\` required a non-None \`state\` and unconditionally
sent \`str(state)\` to the API. When the CLI omitted \`--state\`, argparse
passed \`None\` and the API received the literal string \`"None"\`, failing
with \`Invalid value for state. Valid values are queued, running, success, failed\`.

Make \`state\` optional (\`Optional[str] = None\`) and only include it in the
query string when provided. Give \`limit\` a sensible default (100) while
we are at it so the method works when called with no args. The
auto-generated \`airflowctl dagrun list\` command now accepts \`--state\` as
a true filter instead of a required flag.

Reported in #65497 (rc2 testing).

## Test plan
- [X] New unit test \`test_list_without_state_does_not_send_state_param\` asserts \`state\` is not present in the URL query params when omitted
- [X] Existing \`TestDagRunOperations\` suite continues to pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)