### PR TITLE
Protect airflow-ctl/v0-1-stable and wire up backport label

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -162,6 +162,11 @@ github:
       required_linear_history: true
       required_conversation_resolution: true
       required_signatures: false
+    airflow-ctl/v0-1-stable:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_linear_history: true
+      required_signatures: false
   collaborators:
     # Max 10 collaborators allowed
     # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#assigning-the-github-triage-role-to-external-collaborators

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -365,6 +365,15 @@ labelPRBasedOnFilePath:
     targetBranchFilter:
       - ^main$
 
+  # Apply to PRs touching airflow-ctl code so the release manager notices when a
+  # fix should land on the airflow-ctl/v0-1-test maintenance branch.
+  # Scoped to PRs targeting `main` only.
+  backport-to-airflow-ctl-v0-1-test:
+    paths:
+      - airflow-ctl/**/*
+    targetBranchFilter:
+      - ^main$
+
   kind:documentation:
     - airflow-core/docs/**/*
     - chart/docs/**/*


### PR DESCRIPTION
Adds the \`airflow-ctl/v0-1-stable\` release branch to \`.asf.yaml\` so Apache INFRA protects it — merges require a reviewed PR and linear history — matching the protection on core \`vX-Y-stable\` branches. The companion \`airflow-ctl/v0-1-test\` branch is intentionally left unprotected so the release manager can push cherry-picks and sync-PR merge commits directly.

Wires \`backport-to-airflow-ctl-v0-1-test\` into \`.github/boring-cyborg.yml\` for PRs targeting \`main\` that touch \`airflow-ctl/**/*\`, the same pattern as the existing \`backport-to-vX-Y-test\` labels.

The matching GitHub label has been created already (\`gh label create backport-to-airflow-ctl-v0-1-test --color 0e8a16\`).

Part of the airflow-ctl 0.1.4rc3 release prep following the new branching strategy from #65574.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)