### PR TITLE
Fix `mypy-scripts` and `check-distribution-gitignore` hooks

### DIFF
--- a/scripts/ci/prek/check_distribution_gitignore.py
+++ b/scripts/ci/prek/check_distribution_gitignore.py
@@ -40,7 +40,7 @@ errors: list[str] = []
 for pyproject_path in sorted(AIRFLOW_ROOT_PATH.rglob("pyproject.toml")):
     relative = pyproject_path.relative_to(AIRFLOW_ROOT_PATH)
     # Skip directories that are not part of the source tree
-    if any(part.startswith(".") or part in ("out", "node_modules") for part in relative.parts):
+    if any(part.startswith(".") or part in ("out", "node_modules", "files") for part in relative.parts):
         continue
     dist_dir = pyproject_path.parent
     gitignore_path = dist_dir / ".gitignore"

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "apache-airflow-devel-common",
 ]
 mypy = [
+    "apache-airflow-core",
     "apache-airflow-devel-common[mypy]",
 ]
 


### PR DESCRIPTION
## Summary

Fixes two issues affecting the `mypy-scripts` and `check-distribution-gitignore` static check:

1. **Add apache-airflow-core to scripts mypy dependencies** - The scripts package imports from airflow (e.g., `from airflow import __version__`), but `apache-airflow-core` wasn't listed in the mypy dependency group, causing mypy type resolution failures.
2. **Exclude files dir from distribution gitignore check** - Updates the gitignore check to exclude the files directory. When installing gcloud using `install_gcloud`, it creates a directory with a `.gitignore` file within `/files/opt/google-cloud/sdk` - which seems that I did once and now it affects.

## Test plan

- Run `prek run mypy-scripts --all-files` to verify the mypy-scripts hook passes
- Run `prek run --from-ref main --stage pre-commit` to verify all pre-commit checks pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Haiku 4.5

Generated-by: Claude Haiku 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)