### PR TITLE
fix frame mismatch in triggerer

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -877,7 +877,7 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
         from asgiref.sync import async_to_sync
 
         with self._thread_lock:
-            return async_to_sync(self.asend)(msg)
+            return async_to_sync(self._asend)(msg)
 
     async def _aread_frame(self):
         try:
@@ -899,14 +899,20 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
             raise RuntimeError(f"Response read out of order! Got {frame.id=}, {expect_id=}")
         return self._from_frame(frame)
 
-    async def asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
+    async def _asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
         frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
         bytes = frame.as_bytes()
+        self._async_writer.write(bytes)
+        return await self._aget_response(frame.id)
 
+    async def asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
         async with self._async_lock:
-            self._async_writer.write(bytes)
-
-            return await self._aget_response(frame.id)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._thread_lock.acquire)
+            try:
+                return await self._asend(msg)
+            finally:
+                self._thread_lock.release()
 
 
 class TriggerRunner:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -870,7 +870,7 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
     def _read_frame(self):
         from asgiref.sync import async_to_sync
 
-        with self._lock_sync(): 
+        with self._lock_sync():
             return async_to_sync(self._aread_frame)()
 
     def send(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
@@ -908,6 +908,7 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
         bytes = frame.as_bytes()
         self._async_writer.write(bytes)
         return await self._aget_response(frame.id)
+
 
 class TriggerRunner:
     """

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -870,14 +870,18 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
     def _read_frame(self):
         from asgiref.sync import async_to_sync
 
-        with self._thread_lock:
+        with self._lock_sync(): 
             return async_to_sync(self._aread_frame)()
 
     def send(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
         from asgiref.sync import async_to_sync
 
-        with self._thread_lock:
+        with self._lock_sync():
             return async_to_sync(self._asend)(msg)
+
+    async def asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
+        async with self._lock_async():
+            return await self._asend(msg)
 
     async def _aread_frame(self):
         try:
@@ -904,16 +908,6 @@ class TriggerCommsDecoder(CommsDecoder[ToTriggerRunner, ToTriggerSupervisor]):
         bytes = frame.as_bytes()
         self._async_writer.write(bytes)
         return await self._aget_response(frame.id)
-
-    async def asend(self, msg: ToTriggerSupervisor) -> ToTriggerRunner | None:
-        async with self._async_lock:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._thread_lock.acquire)
-            try:
-                return await self._asend(msg)
-            finally:
-                self._thread_lock.release()
-
 
 class TriggerRunner:
     """

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1597,7 +1597,7 @@ class TestTriggerCommsDecoder:
 
             req = decoder.resp_decoder.decode(data)  # This is a _RequestFrame
             # Deserialize the TriggerStateChanges request body
-            changes = messages.TriggerStateChanges(**req.body)
+            messages.TriggerStateChanges(**req.body)
 
             # Prepare the TriggerStateSync response
             resp = messages.TriggerStateSync(to_create=[], to_cancel=set())
@@ -1667,5 +1667,5 @@ class TestTriggerCommsDecoder:
         await writer.wait_closed()
         r.close()
 
-        for idx, result in enumerate(results):
+        for _idx, result in enumerate(results):
             assert isinstance(result, messages.TriggerStateSync)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1597,6 +1597,7 @@ class TestTriggerCommsDecoder:
 
             req = decoder.resp_decoder.decode(data)  # This is a _RequestFrame
             # Deserialize the TriggerStateChanges request body
+            assert req.body is not None, "Expected a non-None body in the test frame"
             messages.TriggerStateChanges(**req.body)
 
             # Prepare the TriggerStateSync response

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -20,13 +20,16 @@ from __future__ import annotations
 import asyncio
 import datetime
 import itertools
+import msgspec
 import os
 import selectors
+import structlog
 import time
+import threading
 import typing
 import uuid
 from collections.abc import AsyncIterator
-from socket import socket
+from socket import socket, socketpair
 from typing import TYPE_CHECKING, Any
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -67,7 +70,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseHook, BaseOperator
-from airflow.sdk.execution_time.comms import ToSupervisor, ToTask
+from airflow.sdk.execution_time.comms import ToSupervisor, ToTask, _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.triggers.testing import FailureTrigger, SuccessTrigger
@@ -1538,3 +1541,131 @@ class TestMakeTriggerSpan:
         assert attrs["airflow.trigger.name"] == "OnlyTrigger"
         assert "airflow.dag_id" not in attrs
         assert "airflow.task_id" not in attrs
+
+class TestTriggerCommsDecoder:
+    """Tests for the low‑level TriggerCommsDecoder socket communication."""
+
+    @pytest.mark.asyncio
+    async def test_recv_trigger_message(self):
+        r, w = socketpair()
+        r.setblocking(False)
+        w.setblocking(False)
+
+        # Create asyncio reader/writer for the decoder side (using socket r)
+        reader, writer = await asyncio.open_connection(sock=r)
+
+        # Pass the socket explicitly to avoid ENOTSOCK (fd 0 is not a socket)
+        decoder = TriggerCommsDecoder(
+            socket=r,
+            async_reader=reader,
+            async_writer=writer,
+            log=None,
+        )
+
+        # Prepare a TriggerStateSync response frame, send it on the other socket (w)
+        sync = messages.TriggerStateSync(to_create=[], to_cancel=set())
+        frame = _RequestFrame(id=0, body=sync.model_dump())
+        data = msgspec.msgpack.encode(frame)
+        loop = asyncio.get_running_loop()
+        await loop.sock_sendall(w, len(data).to_bytes(4, "big") + data)
+
+        # Use async internal methods to avoid AsyncToSync in an async context
+        resp_frame = await decoder._aread_frame()
+        msg = decoder._from_frame(resp_frame)
+        assert isinstance(msg, messages.TriggerStateSync)
+        assert msg.to_create == []
+        assert msg.to_cancel == set()
+
+        writer.close()
+        await writer.wait_closed()
+
+    async def _run_trigger_comms_server(
+        self, w_sock: socket, num_requests: int, decoder: TriggerCommsDecoder
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        for _ in range(num_requests):
+            len_bytes = await loop.sock_recv(w_sock, 4)
+            length = int.from_bytes(len_bytes, "big")
+            data = bytearray()
+            while len(data) < length:
+                chunk = await loop.sock_recv(w_sock, length - len(data))
+                if not chunk:
+                    break
+                data.extend(chunk)
+
+            req = decoder.resp_decoder.decode(data)   # This is a _RequestFrame
+            # Deserialize the TriggerStateChanges request body
+            changes = messages.TriggerStateChanges(**req.body)
+
+            # Prepare the TriggerStateSync response
+            resp = messages.TriggerStateSync(to_create=[], to_cancel=set())
+            resp_frame = _RequestFrame(id=req.id, body=resp.model_dump())
+            resp_bytes = msgspec.msgpack.encode(resp_frame)
+            await loop.sock_sendall(w_sock, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
+        w_sock.close()
+
+    @pytest.mark.asyncio
+    async def test_asend_basic(self):
+        r, w = socketpair()
+        r.setblocking(False)
+        w.setblocking(False)
+
+        reader, writer = await asyncio.open_connection(sock=r)
+        decoder = TriggerCommsDecoder(
+            socket=r,
+            async_reader=reader,
+            async_writer=writer,
+            log=structlog.get_logger(),
+        )
+
+        server_task = asyncio.create_task(
+            self._run_trigger_comms_server(w, 1, decoder)
+        )
+
+        msg = messages.TriggerStateChanges(events=None, finished=None, failures=None)
+        result = await decoder.asend(msg)
+
+        assert isinstance(result, messages.TriggerStateSync)
+        assert result.to_create == []
+        assert result.to_cancel == set()
+
+        await server_task
+        writer.close()
+        await writer.wait_closed()
+        r.close()
+
+    @pytest.mark.asyncio
+    async def test_asend_concurrent_safety(self):
+        r, w = socketpair()
+        r.setblocking(False)
+        w.setblocking(False)
+
+        reader, writer = await asyncio.open_connection(sock=r)
+        decoder = TriggerCommsDecoder(
+            socket=r,
+            async_reader=reader,
+            async_writer=writer,
+            log=structlog.get_logger(),
+        )
+
+        num_requests = 5
+        server_task = asyncio.create_task(
+            self._run_trigger_comms_server(w, num_requests, decoder)
+        )
+
+        async def make_request(idx: int):
+            msg = messages.TriggerStateChanges(
+                events=[(idx, TriggerEvent(payload={"index": idx}))],
+                finished=None,
+                failures=None,
+            )
+            return await decoder.asend(msg)
+
+        results = await asyncio.gather(*(make_request(i) for i in range(num_requests)))
+        await server_task
+        writer.close()
+        await writer.wait_closed()
+        r.close()
+
+        for idx, result in enumerate(results):
+            assert isinstance(result, messages.TriggerStateSync)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1547,6 +1547,7 @@ class TestTriggerCommsDecoder:
 
     @pytest.mark.asyncio
     async def test_recv_trigger_message(self):
+        """Verify low-level receiving of a TriggerStateSync message through the TriggerCommsDecoder."""
         r, w = socketpair()
         r.setblocking(False)
         w.setblocking(False)
@@ -1582,6 +1583,7 @@ class TestTriggerCommsDecoder:
     async def _run_trigger_comms_server(
         self, w_sock: socket, num_requests: int, decoder: TriggerCommsDecoder
     ) -> None:
+        """Mock server that receives ``TriggerStateChanges`` requests and replies with ``TriggerStateSync`` responses."""
         loop = asyncio.get_running_loop()
         for _ in range(num_requests):
             len_bytes = await loop.sock_recv(w_sock, 4)
@@ -1606,6 +1608,7 @@ class TestTriggerCommsDecoder:
 
     @pytest.mark.asyncio
     async def test_asend_basic(self):
+        """Test basic async send of a ``TriggerStateChanges`` message and receiving of a ``TriggerStateSync`` response."""
         r, w = socketpair()
         r.setblocking(False)
         w.setblocking(False)
@@ -1634,6 +1637,7 @@ class TestTriggerCommsDecoder:
 
     @pytest.mark.asyncio
     async def test_asend_concurrent_safety(self):
+        """Ensure that multiple concurrent ``asend()`` calls to the ``TriggerCommsDecoder`` are serialised correctly and each receives its proper response."""
         r, w = socketpair()
         r.setblocking(False)
         w.setblocking(False)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -20,12 +20,9 @@ from __future__ import annotations
 import asyncio
 import datetime
 import itertools
-import msgspec
 import os
 import selectors
-import structlog
 import time
-import threading
 import typing
 import uuid
 from collections.abc import AsyncIterator
@@ -34,8 +31,10 @@ from typing import TYPE_CHECKING, Any
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
+import msgspec
 import pendulum
 import pytest
+import structlog
 from asgiref.sync import sync_to_async
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -70,7 +69,7 @@ from airflow.providers.standard.operators.python import PythonOperator
 from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseHook, BaseOperator
-from airflow.sdk.execution_time.comms import ToSupervisor, ToTask, _RequestFrame, _ResponseFrame
+from airflow.sdk.execution_time.comms import ToSupervisor, ToTask, _RequestFrame
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.triggers.testing import FailureTrigger, SuccessTrigger
@@ -1542,6 +1541,7 @@ class TestMakeTriggerSpan:
         assert "airflow.dag_id" not in attrs
         assert "airflow.task_id" not in attrs
 
+
 class TestTriggerCommsDecoder:
     """Tests for the low‑level TriggerCommsDecoder socket communication."""
 
@@ -1593,7 +1593,7 @@ class TestTriggerCommsDecoder:
                     break
                 data.extend(chunk)
 
-            req = decoder.resp_decoder.decode(data)   # This is a _RequestFrame
+            req = decoder.resp_decoder.decode(data)  # This is a _RequestFrame
             # Deserialize the TriggerStateChanges request body
             changes = messages.TriggerStateChanges(**req.body)
 
@@ -1618,9 +1618,7 @@ class TestTriggerCommsDecoder:
             log=structlog.get_logger(),
         )
 
-        server_task = asyncio.create_task(
-            self._run_trigger_comms_server(w, 1, decoder)
-        )
+        server_task = asyncio.create_task(self._run_trigger_comms_server(w, 1, decoder))
 
         msg = messages.TriggerStateChanges(events=None, finished=None, failures=None)
         result = await decoder.asend(msg)
@@ -1649,9 +1647,7 @@ class TestTriggerCommsDecoder:
         )
 
         num_requests = 5
-        server_task = asyncio.create_task(
-            self._run_trigger_comms_server(w, num_requests, decoder)
-        )
+        server_task = asyncio.create_task(self._run_trigger_comms_server(w, num_requests, decoder))
 
         async def make_request(idx: int):
             msg = messages.TriggerStateChanges(

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -218,12 +218,13 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
     def send(self, msg: SendMsgType) -> ReceiveMsgType | None:
         """Send a request to the parent and block until the response is received."""
-        frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
-        frame_bytes = frame.as_bytes()
 
         # We must make sure sockets aren't intermixed between sync and async calls,
         # thus we need a dual locking mechanism to ensure that.
         with self._lock_sync():
+            frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
+            frame_bytes = frame.as_bytes()
+
             self.socket.sendall(frame_bytes)
             if isinstance(msg, ResendLoggingFD):
                 if recv_fds is None:
@@ -247,13 +248,13 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
         Uses async lock for coroutine safety and thread lock for socket safety.
         """
-        frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
-        frame_bytes = frame.as_bytes()
 
         async with self._lock_async():
-            # Acquire the threading lock without blocking the event loop
-            loop = asyncio.get_running_loop()
+            frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
+            frame_bytes = frame.as_bytes()
+
             # Async write to socket
+            loop = asyncio.get_running_loop()
             await loop.sock_sendall(self.socket, frame_bytes)
 
             if isinstance(msg, ResendLoggingFD):

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -58,6 +58,7 @@ from pathlib import Path
 from socket import socket
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Generic, Literal, TypeVar, overload
 from uuid import UUID
+from contextlib import asynccontextmanager, contextmanager
 
 import attrs
 import msgspec
@@ -193,6 +194,28 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
     # Async lock for async operations
     _async_lock: asyncio.Lock = attrs.field(factory=asyncio.Lock, repr=False)
 
+    @contextmanager
+    def _lock_sync(self):
+        """Acquire the thread lock for synchronous operations."""
+        with self._thread_lock:
+            yield
+
+    @asynccontextmanager
+    async def _lock_async(self):
+        """
+        Acquire both the async lock and the thread lock for asynchronous operations.
+
+        The thread lock is acquired via a thread executor so the event loop
+        is not blocked while waiting for other holders.
+        """
+        async with self._async_lock:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._thread_lock.acquire)
+            try:
+                yield
+            finally:
+                self._thread_lock.release()
+
     def send(self, msg: SendMsgType) -> ReceiveMsgType | None:
         """Send a request to the parent and block until the response is received."""
         frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
@@ -200,7 +223,7 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
         # We must make sure sockets aren't intermixed between sync and async calls,
         # thus we need a dual locking mechanism to ensure that.
-        with self._thread_lock:
+        with self._lock_sync():
             self.socket.sendall(frame_bytes)
             if isinstance(msg, ResendLoggingFD):
                 if recv_fds is None:
@@ -227,30 +250,26 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
         frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
         frame_bytes = frame.as_bytes()
 
-        async with self._async_lock:
+        async with self._lock_async():
             # Acquire the threading lock without blocking the event loop
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._thread_lock.acquire)
-            try:
-                # Async write to socket
-                await loop.sock_sendall(self.socket, frame_bytes)
+            # Async write to socket
+            await loop.sock_sendall(self.socket, frame_bytes)
 
-                if isinstance(msg, ResendLoggingFD):
-                    if recv_fds is None:
-                        return None
-                    # Blocking read in a thread
-                    frame, fds = await asyncio.to_thread(self._read_frame, maxfds=1)
-                    resp = self._from_frame(frame)
-                    if TYPE_CHECKING:
-                        assert isinstance(resp, SentFDs)
-                    resp.fds = fds
-                    return resp  # type: ignore[return-value]
+            if isinstance(msg, ResendLoggingFD):
+                if recv_fds is None:
+                    return None
+                # Blocking read in a thread
+                frame, fds = await asyncio.to_thread(self._read_frame, maxfds=1)
+                resp = self._from_frame(frame)
+                if TYPE_CHECKING:
+                    assert isinstance(resp, SentFDs)
+                resp.fds = fds
+                return resp  # type: ignore[return-value]
 
-                # Normal blocking read in a thread
-                frame = await asyncio.to_thread(self._read_frame)
-                return self._from_frame(frame)
-            finally:
-                self._thread_lock.release()
+            # Normal blocking read in a thread
+            frame = await asyncio.to_thread(self._read_frame)
+            return self._from_frame(frame)
 
     @overload
     def _read_frame(self, maxfds: None = None) -> _ResponseFrame: ...

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -52,13 +52,13 @@ import asyncio
 import itertools
 import threading
 from collections.abc import Iterator
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from socket import socket
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Generic, Literal, TypeVar, overload
 from uuid import UUID
-from contextlib import asynccontextmanager, contextmanager
 
 import attrs
 import msgspec

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -218,7 +218,6 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
     def send(self, msg: SendMsgType) -> ReceiveMsgType | None:
         """Send a request to the parent and block until the response is received."""
-
         # We must make sure sockets aren't intermixed between sync and async calls,
         # thus we need a dual locking mechanism to ensure that.
         with self._lock_sync():
@@ -248,7 +247,6 @@ class CommsDecoder(Generic[ReceiveMsgType, SendMsgType]):
 
         Uses async lock for coroutine safety and thread lock for socket safety.
         """
-
         async with self._lock_async():
             frame = _RequestFrame(id=next(self.id_counter), body=msg.model_dump())
             frame_bytes = frame.as_bytes()

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -210,7 +210,7 @@ class TestCommsDecoder:
                     break
                 data.extend(chunk)
             req = decoder.resp_decoder.decode(data)
-            assert req.body is not None
+            assert req.body is not None, "Expected a non-None body in the test frame"
             key = req.body["key"]
             resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
             resp_frame = _ResponseFrame(req.id, resp, None)

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -242,7 +242,7 @@ class TestCommsDecoder:
     async def test_asend_concurrent_safety(self):
         """Multiple concurrent asend calls must not interleave and must each receive the correct response."""
         r, w = socketpair()
-        r.setblocking(False)  # <-- required for asyncio
+        r.setblocking(False)
         w.setblocking(False)
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
         num_requests = 5

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -196,6 +196,7 @@ class TestCommsDecoder:
             assert results[idx].key == f"key{idx}", f"Out-of-order or missing response for thread {idx}"
             assert results[idx].value == f"value{idx}", f"Incorrect value for thread {idx}"
 
+    @staticmethod
     async def _variable_server_side(w_sock, num_requests: int, decoder: CommsDecoder) -> None:
         """Handle ``num_requests`` GetVariable frames, responding with VariableResult."""
         loop = asyncio.get_running_loop()

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -196,6 +196,26 @@ class TestCommsDecoder:
             assert results[idx].key == f"key{idx}", f"Out-of-order or missing response for thread {idx}"
             assert results[idx].value == f"value{idx}", f"Incorrect value for thread {idx}"
 
+    async def _variable_server_side(w_sock, num_requests: int, decoder: CommsDecoder) -> None:
+        """Handle ``num_requests`` GetVariable frames, responding with VariableResult."""
+        loop = asyncio.get_running_loop()
+        for _ in range(num_requests):
+            len_bytes = await loop.sock_recv(w_sock, 4)
+            length = int.from_bytes(len_bytes, "big")
+            data = bytearray()
+            while len(data) < length:
+                chunk = await loop.sock_recv(w_sock, length - len(data))
+                if not chunk:
+                    break
+                data.extend(chunk)
+            req = decoder.resp_decoder.decode(data)
+            key = req.body["key"]
+            resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
+            resp_frame = _ResponseFrame(req.id, resp, None)
+            resp_bytes = msgspec.msgpack.encode(resp_frame)
+            await loop.sock_sendall(w_sock, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
+        w_sock.close()
+
     @pytest.mark.asyncio
     async def test_asend_basic(self):
         """Verify a single async request‑response cycle via asend."""
@@ -204,27 +224,7 @@ class TestCommsDecoder:
         w.setblocking(False)
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
 
-        async def server():
-            loop = asyncio.get_running_loop()
-            # read length
-            len_bytes = await loop.sock_recv(w, 4)
-            length = int.from_bytes(len_bytes, "big")
-            data = bytearray()
-            while len(data) < length:
-                chunk = await loop.sock_recv(w, length - len(data))
-                if not chunk:
-                    break
-                data.extend(chunk)
-            req = decoder.resp_decoder.decode(data)
-            # build a VariableResult matching the request
-            key = req.body["key"]
-            resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
-            resp_frame = _ResponseFrame(req.id, resp, None)
-            resp_bytes = msgspec.msgpack.encode(resp_frame)
-            await loop.sock_sendall(w, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
-            w.close()  # signal EOF for clean shutdown
-
-        server_task = asyncio.create_task(server())
+        server_task = asyncio.create_task(TestCommsDecoder._variable_server_side(w, 1, decoder))
 
         msg = GetVariable(key="basic_key")
         result = await decoder.asend(msg)
@@ -245,27 +245,7 @@ class TestCommsDecoder:
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
         num_requests = 5
 
-        async def server():
-            loop = asyncio.get_running_loop()
-            for _ in range(num_requests):
-                # read one frame
-                len_bytes = await loop.sock_recv(w, 4)
-                length = int.from_bytes(len_bytes, "big")
-                data = bytearray()
-                while len(data) < length:
-                    chunk = await loop.sock_recv(w, length - len(data))
-                    if not chunk:
-                        break
-                    data.extend(chunk)
-                req = decoder.resp_decoder.decode(data)
-                key = req.body["key"]
-                resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
-                resp_frame = _ResponseFrame(req.id, resp, None)
-                resp_bytes = msgspec.msgpack.encode(resp_frame)
-                await loop.sock_sendall(w, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
-            w.close()
-
-        server_task = asyncio.create_task(server())
+        server_task = asyncio.create_task(TestCommsDecoder._variable_server_side(w, num_requests, decoder))
 
         async def make_request(idx: int) -> VariableResult:
             msg = GetVariable(key=f"key{idx}")

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -220,7 +220,7 @@ class TestCommsDecoder:
     async def test_asend_basic(self):
         """Verify a single async request‑response cycle via asend."""
         r, w = socketpair()
-        r.setblocking(False)   # <-- required for asyncio
+        r.setblocking(False)  # <-- required for asyncio
         w.setblocking(False)
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
 
@@ -240,7 +240,7 @@ class TestCommsDecoder:
     async def test_asend_concurrent_safety(self):
         """Multiple concurrent asend calls must not interleave and must each receive the correct response."""
         r, w = socketpair()
-        r.setblocking(False)   # <-- required for asyncio
+        r.setblocking(False)  # <-- required for asyncio
         w.setblocking(False)
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
         num_requests = 5

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -210,6 +210,7 @@ class TestCommsDecoder:
                     break
                 data.extend(chunk)
             req = decoder.resp_decoder.decode(data)
+            assert req.body is not None
             key = req.body["key"]
             resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
             resp_frame = _ResponseFrame(req.id, resp, None)

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -222,7 +222,7 @@ class TestCommsDecoder:
     async def test_asend_basic(self):
         """Verify a single async request‑response cycle via asend."""
         r, w = socketpair()
-        r.setblocking(False)  # <-- required for asyncio
+        r.setblocking(False)
         w.setblocking(False)
         decoder = CommsDecoder(socket=r, log=structlog.get_logger())
 

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import uuid
 from socket import socketpair
@@ -29,6 +30,7 @@ from airflow.sdk import timezone
 from airflow.sdk.execution_time.comms import (
     BundleInfo,
     CommsDecoder,
+    GetVariable,
     MaskSecret,
     StartupDetails,
     VariableResult,
@@ -193,3 +195,87 @@ class TestCommsDecoder:
             assert errors[idx] is None, f"Thread {idx} error: {errors[idx]}"
             assert results[idx].key == f"key{idx}", f"Out-of-order or missing response for thread {idx}"
             assert results[idx].value == f"value{idx}", f"Incorrect value for thread {idx}"
+
+    @pytest.mark.asyncio
+    async def test_asend_basic(self):
+        """Verify a single async request‑response cycle via asend."""
+        r, w = socketpair()
+        r.setblocking(False)   # <-- required for asyncio
+        w.setblocking(False)
+        decoder = CommsDecoder(socket=r, log=structlog.get_logger())
+
+        async def server():
+            loop = asyncio.get_running_loop()
+            # read length
+            len_bytes = await loop.sock_recv(w, 4)
+            length = int.from_bytes(len_bytes, "big")
+            data = bytearray()
+            while len(data) < length:
+                chunk = await loop.sock_recv(w, length - len(data))
+                if not chunk:
+                    break
+                data.extend(chunk)
+            req = decoder.resp_decoder.decode(data)
+            # build a VariableResult matching the request
+            key = req.body["key"]
+            resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
+            resp_frame = _ResponseFrame(req.id, resp, None)
+            resp_bytes = msgspec.msgpack.encode(resp_frame)
+            await loop.sock_sendall(w, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
+            w.close()  # signal EOF for clean shutdown
+
+        server_task = asyncio.create_task(server())
+
+        msg = GetVariable(key="basic_key")
+        result = await decoder.asend(msg)
+
+        assert isinstance(result, VariableResult)
+        assert result.key == "basic_key"
+        assert result.value == "value_basic_key"
+
+        await server_task
+        r.close()  # clean up the read end
+
+    @pytest.mark.asyncio
+    async def test_asend_concurrent_safety(self):
+        """Multiple concurrent asend calls must not interleave and must each receive the correct response."""
+        r, w = socketpair()
+        r.setblocking(False)   # <-- required for asyncio
+        w.setblocking(False)
+        decoder = CommsDecoder(socket=r, log=structlog.get_logger())
+        num_requests = 5
+
+        async def server():
+            loop = asyncio.get_running_loop()
+            for _ in range(num_requests):
+                # read one frame
+                len_bytes = await loop.sock_recv(w, 4)
+                length = int.from_bytes(len_bytes, "big")
+                data = bytearray()
+                while len(data) < length:
+                    chunk = await loop.sock_recv(w, length - len(data))
+                    if not chunk:
+                        break
+                    data.extend(chunk)
+                req = decoder.resp_decoder.decode(data)
+                key = req.body["key"]
+                resp = {"type": "VariableResult", "key": key, "value": f"value_{key}"}
+                resp_frame = _ResponseFrame(req.id, resp, None)
+                resp_bytes = msgspec.msgpack.encode(resp_frame)
+                await loop.sock_sendall(w, len(resp_bytes).to_bytes(4, "big") + resp_bytes)
+            w.close()
+
+        server_task = asyncio.create_task(server())
+
+        async def make_request(idx: int) -> VariableResult:
+            msg = GetVariable(key=f"key{idx}")
+            return await decoder.asend(msg)
+
+        # Start all requests concurrently
+        results = await asyncio.gather(*[make_request(i) for i in range(num_requests)])
+        await server_task
+        r.close()
+
+        for idx, result in enumerate(results):
+            assert result.key == f"key{idx}"
+            assert result.value == f"value_key{idx}"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Fix for triggerers crashing due to frame mismatch. It happens when using Kafka assets for scheduling Dags.
* Added _lock_sync and _lock_async context managers in base CommsDecoder class
* Using _lock_sync and _lock_async in TriggerCommsDecoder
* Frame counter is protected by locks
* Added tests

* related: #64620

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
