### PR TITLE
Prepare airflow-ctl 0.1.4rc3 release

### DIFF
--- a/airflow-ctl/RELEASE_NOTES.rst
+++ b/airflow-ctl/RELEASE_NOTES.rst
@@ -15,6 +15,46 @@
     specific language governing permissions and limitations
     under the License.
 
+airflowctl 0.1.4 (2026-04-21)
+-----------------------------
+
+Significant Changes
+^^^^^^^^^^^^^^^^^^^
+
+- Add YAML-based help texts for auto-generated airflowctl commands (#65073)
+- Added plugins command to airflowctl (#64935)
+- Python 3.14 support (#63520)
+
+Bug Fixes
+^^^^^^^^^
+
+- Declare ``pyyaml`` as a runtime dependency so ``airflowctl`` starts without crashing on ``ModuleNotFoundError`` (#65489)
+- Fix ``airflowctl dagrun list`` crash when ``--state`` is omitted (#65608)
+- Prevent path traversal via ``AIRFLOW_CLI_ENVIRONMENT`` in airflowctl (#64618)
+- Fix ``is_alive`` default in ``airflowctl jobs list`` to show all jobs (#65065)
+- Fix CLI error handling and exit codes for failed commands (#65052)
+- Fix ``airflowctl connections import`` to return non-zero exit code on failure (#64416)
+- Fix ``airflowctl variables import`` to correctly handle falsy values (#64362)
+- Fix ``airflowctl version`` command prompting for keyring credentials (#63772)
+- Fix ``airflowctl`` boolean flags on Python 3.14 (#63587)
+- Allow ``null`` ``dag_run_conf`` in ``BackfillResponse`` serialization (#63259)
+
+Improvements
+^^^^^^^^^^^^
+
+- Use DAG form when materializing assets in airflowctl (#64211)
+- Mention Python 3.14 support in docs (#63950)
+
+Miscellaneous
+^^^^^^^^^^^^^
+
+- Cap ``httpx`` below 1.0 to avoid pulling the pre-release rewrite on ``--prerelease=allow`` installs (#65607)
+- Run non-provider mypy checks as regular prek static checks (#64780)
+- Add ``*.iml`` to ``.gitignore`` in all distributions (#63636)
+- Sync airflowctl from main to v3-2-test (#65069)
+- CI: Upgrade important CI environment (#64458, #65525)
+
+
 airflowctl 0.1.3 (2026-03-09)
 -----------------------------
 

--- a/airflow-ctl/src/airflowctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/__init__.py
@@ -19,4 +19,4 @@ from __future__ import annotations
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
Bump \`__version__\` to \`0.1.4\` and regenerate \`RELEASE_NOTES.rst\`, anchored to \`airflow-ctl/v0-1-test\`.

This is the first airflow-ctl release cut under the new dedicated branching strategy (#65574) — \`airflow-ctl/v0-1-test\` and \`airflow-ctl/v0-1-stable\` are anchored to core Airflow \`v3-2-stable\` (the minor airflow-ctl 0.1.x ships alongside).

## Changes from rc2

rc2 was cut from \`main\`, which at the time contained commits destined for the next core Airflow patch (3.2.2) that do not belong in the airflow-ctl 0.1.4 cut — most notably the \`get_task_instances\` cursor pagination and the \`is_backfillable\` DAG-response field (see #65497 for the rc2 testing thread).

rc3 therefore excludes those datamodel changes. On top of the rc2 contents, rc3 adds:

- **#65489** \`pyyaml\` declared as runtime dep (already in rc2 — retained here).
- **#65607** \`httpx<1.0\` cap so \`--prerelease=allow\` / \`--pre\` installs do not pull the ground-up API rewrite in \`1.0.dev*\`. Full migration tracked in #65609.
- **#65608** \`airflowctl dagrun list\` no longer crashes with "Invalid state: None" when \`--state\` is omitted.

## Files changed

- \`airflow-ctl/src/airflowctl/__init__.py\` — \`__version__\` bumped 0.1.3 → 0.1.4.
- \`airflow-ctl/RELEASE_NOTES.rst\` — new 0.1.4 section prepended (generated via \`breeze release-management generate-airflowctl-changelog\`, then hand-cleaned to match rc2's wording and drop non-user-visible sync commits / re-categorise the httpx cap as Miscellaneous since it is a dependency-management action rather than a user-visible behaviour fix).

## Release plan from here

Once this PR merges into \`airflow-ctl/v0-1-test\`:

1. Open sync PR \`airflow-ctl/v0-1-test\` → \`airflow-ctl/v0-1-stable\`.
2. After sync merges, tag \`airflow-ctl/0.1.4rc3\` on \`-stable\` HEAD.
3. Build \`.whl\` / \`.tar.gz\` / source tarball via \`breeze release-management prepare-airflow-ctl-distributions\` + \`prepare-tarball\`; sign; upload to SVN dev + PyPI; open testing-status issue; send vote email.

See \`dev/README_RELEASE_AIRFLOWCTL.md\` for the full process (updated in #65606 to branch from \`vX-Y-stable\` rather than \`vX-Y-test\`).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)