### PR TITLE
airflow-ctl 0.1.4rc3: test to stable

### DIFF
--- a/airflow-ctl/RELEASE_NOTES.rst
+++ b/airflow-ctl/RELEASE_NOTES.rst
@@ -15,6 +15,46 @@
     specific language governing permissions and limitations
     under the License.
 
+airflowctl 0.1.4 (2026-04-21)
+-----------------------------
+
+Significant Changes
+^^^^^^^^^^^^^^^^^^^
+
+- Add YAML-based help texts for auto-generated airflowctl commands (#65073)
+- Added plugins command to airflowctl (#64935)
+- Python 3.14 support (#63520)
+
+Bug Fixes
+^^^^^^^^^
+
+- Declare ``pyyaml`` as a runtime dependency so ``airflowctl`` starts without crashing on ``ModuleNotFoundError`` (#65489)
+- Fix ``airflowctl dagrun list`` crash when ``--state`` is omitted (#65608)
+- Prevent path traversal via ``AIRFLOW_CLI_ENVIRONMENT`` in airflowctl (#64618)
+- Fix ``is_alive`` default in ``airflowctl jobs list`` to show all jobs (#65065)
+- Fix CLI error handling and exit codes for failed commands (#65052)
+- Fix ``airflowctl connections import`` to return non-zero exit code on failure (#64416)
+- Fix ``airflowctl variables import`` to correctly handle falsy values (#64362)
+- Fix ``airflowctl version`` command prompting for keyring credentials (#63772)
+- Fix ``airflowctl`` boolean flags on Python 3.14 (#63587)
+- Allow ``null`` ``dag_run_conf`` in ``BackfillResponse`` serialization (#63259)
+
+Improvements
+^^^^^^^^^^^^
+
+- Use DAG form when materializing assets in airflowctl (#64211)
+- Mention Python 3.14 support in docs (#63950)
+
+Miscellaneous
+^^^^^^^^^^^^^
+
+- Cap ``httpx`` below 1.0 to avoid pulling the pre-release rewrite on ``--prerelease=allow`` installs (#65607)
+- Run non-provider mypy checks as regular prek static checks (#64780)
+- Add ``*.iml`` to ``.gitignore`` in all distributions (#63636)
+- Sync airflowctl from main to v3-2-test (#65069)
+- CI: Upgrade important CI environment (#64458, #65525)
+
+
 airflowctl 0.1.3 (2026-03-09)
 -----------------------------
 

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -29,7 +29,9 @@ requires-python = ">=3.10,!=3.15"
 dependencies = [
     # TODO there could be still missing deps such as airflow-core
     "argcomplete>=1.10",
-    "httpx>=0.27.0",
+    # Remove the <1.0 cap after migrating to httpx 1.x (ground-up API rewrite — no HTTPStatusError etc.);
+    # tracked at https://github.com/apache/airflow/issues/65609
+    "httpx>=0.27.0,<1.0",
     "keyring>=25.7.0",
     "lazy-object-proxy>=1.2.0",
     "methodtools>=0.4.7",

--- a/airflow-ctl/pyproject.toml
+++ b/airflow-ctl/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "methodtools>=0.4.7",
     "platformdirs>=4.3.6",
     "pydantic>=2.11.0", # https://github.com/apache/airflow/issues/56482
+    "pyyaml>=6.0.3",
     "rich-argparse>=1.0.0",
     "structlog>=25.4.0",
     "uuid6>=2024.7.10",

--- a/airflow-ctl/src/airflowctl/__init__.py
+++ b/airflow-ctl/src/airflowctl/__init__.py
@@ -19,4 +19,4 @@ from __future__ import annotations
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -606,8 +606,8 @@ class DagRunOperations(BaseOperations):
 
     def list(
         self,
-        state: str,
-        limit: int,
+        state: str | None = None,
+        limit: int = 100,
         start_date: datetime.datetime | None = None,
         end_date: datetime.datetime | None = None,
         dag_id: str | None = None,
@@ -616,7 +616,7 @@ class DagRunOperations(BaseOperations):
         List dag runs (at most `limit` results).
 
         Args:
-            state: Filter dag runs by state
+            state: Filter dag runs by state (optional; no filter applied when omitted)
             start_date: Filter dag runs by start date (optional)
             end_date: Filter dag runs by end date (optional)
             limit: Limit the number of results returned
@@ -626,10 +626,9 @@ class DagRunOperations(BaseOperations):
         if not dag_id:
             dag_id = "~"
 
-        params: dict[str, Any] = {
-            "state": str(state),
-            "limit": limit,
-        }
+        params: dict[str, Any] = {"limit": limit}
+        if state is not None:
+            params["state"] = str(state)
         if start_date is not None:
             params["start_date"] = start_date.isoformat()
         if end_date is not None:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1135,6 +1135,20 @@ class TestDagRunOperations:
         )
         assert response == self.dag_run_collection_response
 
+    def test_list_without_state_does_not_send_state_param(self):
+        """`state` is optional: omitting it must not send ``state=None`` to the API."""
+        captured_params: dict[str, str] = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            captured_params.update(dict(request.url.params))
+            return httpx.Response(200, json=json.loads(self.dag_run_collection_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.list(limit=5)
+        assert response == self.dag_run_collection_response
+        assert "state" not in captured_params
+        assert captured_params["limit"] == "5"
+
 
 class TestJobsOperations:
     job_response = JobResponse(

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T19:13:06.968011Z"
+exclude-newer = "2026-04-17T18:29:18.615995929Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -101,9 +101,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -1961,6 +1961,7 @@ dependencies = [
     { name = "methodtools" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "rich-argparse" },
     { name = "structlog" },
     { name = "tabulate" },
@@ -1996,6 +1997,7 @@ requires-dist = [
     { name = "methodtools", specifier = ">=0.4.7" },
     { name = "platformdirs", specifier = ">=4.3.6" },
     { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich-argparse", specifier = ">=1.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tabulate", specifier = ">=0.9.0" },


### PR DESCRIPTION
Sync \`airflow-ctl/v0-1-test\` into \`airflow-ctl/v0-1-stable\` for the airflow-ctl 0.1.4rc3 release cut.

Commits being synced:

- **#65634** Prepare airflow-ctl 0.1.4rc3 release (version bump + release notes)
- **#65607** Cap airflow-ctl httpx dependency below 1.0
- **#65489** Fix airflow-ctl missing pyyaml runtime dependency (cherry-pick)
- **#65608** Fix airflowctl dagrun list crash when --state is omitted (cherry-pick)

After this merges, the rc3 tag will be cut from \`airflow-ctl/v0-1-stable\` HEAD.

Process reference: \`dev/README_RELEASE_AIRFLOWCTL.md\` § "Sync \`-test\` to \`-stable\` before the GA / patch RC".

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)