### PR TITLE
[v3-2-test] Add dev/sync_fork.sh helper to sync fork branches with upstream (#65550)

### DIFF
--- a/contributing-docs/10_working_with_git.rst
+++ b/contributing-docs/10_working_with_git.rst
@@ -75,6 +75,38 @@ way to sync your fork in GitHub's web UI with the `Fetch upstream feature
 This will force-push the ``main`` branch from ``apache/airflow`` to the ``main`` branch
 in your fork. Note that in case you modified the main in your fork, you might loose those changes.
 
+Syncing multiple branches with the helper script
+------------------------------------------------
+
+If you also backport to the current release branch (for example ``v3-2-test``) you usually
+want to keep more than one branch of your fork in sync with upstream. The
+``dev/sync_fork.sh`` helper does that in one go — it fetches ``upstream`` and force-pushes
+each listed branch from ``upstream/<branch>`` directly to ``origin/<branch>`` without
+touching your local working tree or checked-out branch.
+
+.. warning::
+
+   The script uses ``git push --force`` and will **overwrite** the listed branches
+   on your fork. By default it targets ``main`` and the current release branch
+   (currently ``v3-2-test``). Any commits you have on those branches in your fork
+   that are not in upstream will be lost. If you keep work on those branches,
+   commit it to a different branch first.
+
+Assumes your remotes are named ``upstream`` (for ``apache/airflow``) and ``origin``
+(for your fork). Override with the ``UPSTREAM_REMOTE`` and ``ORIGIN_REMOTE``
+environment variables if yours are named differently.
+
+.. code-block:: console
+
+    # Sync the default branches (main and the current release branch)
+    ./dev/sync_fork.sh
+
+    # Sync only main
+    ./dev/sync_fork.sh main
+
+    # Sync a specific set of branches
+    ./dev/sync_fork.sh main v3-2-test v3-1-test
+
 
 How to rebase PR
 ================

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -475,6 +475,22 @@ uv tool install -e ./dev/breeze
   with minimum version for the next version of Airflow will be added in the future.
 - Check `Apache Airflow is tested with` (stable version) in `README.md` has the same tested versions as in the tip of
   the stable branch in `dev/breeze/src/airflow_breeze/global_constants.py`
+- Create `backport-to-vX-Y-test` label:
+
+    ```shell script
+    gh label create 'backport-to-vX-Y-test' --repo apache/airflow --description 'Backport to vX-Y-test' --color 0e8a16
+    ```
+
+- Update `.github/boring-cyborg.yml` and add `backport-to-vX-Y-test` auto-assignment for the new branch.
+- Update the `DEFAULT_BRANCHES` list in `dev/sync_fork.sh` to replace the previous `vX-Y-test` entry
+  with the newly cut `vX-Y-test` branch so contributors using the helper sync the current release branch
+  by default.
+- Update `.github/` configuration on `main` to add the new `vX-Y-test` branch (you can use the
+  `uv run dev/update_github_branch_config.py X Y` helper script for this). The following files need updating:
+  - `.github/dependabot.yml` — add `target-branch: vX-Y-test` entries for github-actions, pip, and npm ecosystems.
+  - `.github/workflows/milestone-tag-assistant.yml` — add `vX-Y-test` to the push branches list.
+  - `.github/workflows/basic-tests.yml` — update the release-management dry-run commands to test the new version.
+  - `.github/workflows/ci-notification.yml` — switch the `workflow-status` matrix branch to the new branch.
 - Commit the above changes with the message `Update version to ${VERSION}`.
 - Build the release notes:
 

--- a/dev/sync_fork.sh
+++ b/dev/sync_fork.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Sync branches on your fork with the upstream Apache Airflow repository.
+#
+# Force-pushes the named branches from <upstream>/<branch> directly to
+# <origin>/<branch>. Does not touch your local working tree or checked-out
+# branch.
+#
+# WARNING: this OVERWRITES the listed branches on your fork. Any commits you
+# have on those branches in your fork that are not in upstream will be lost.
+#
+# Usage:
+#   dev/sync_fork.sh [branch ...]
+#
+# Examples:
+#   dev/sync_fork.sh                          # sync the default branches
+#   dev/sync_fork.sh main                     # sync only main
+#   dev/sync_fork.sh main v3-2-test v3-1-test # sync several branches
+#
+# The upstream and origin remote names default to "upstream" and "origin" and
+# can be overridden via the UPSTREAM_REMOTE and ORIGIN_REMOTE env vars.
+#
+# NOTE FOR RELEASE MANAGERS: when a new vX-Y-test branch is cut, update the
+# DEFAULT_BRANCHES list below to include it (and drop branches that are no
+# longer maintained).
+set -euo pipefail
+
+UPSTREAM="${UPSTREAM_REMOTE:-upstream}"
+ORIGIN="${ORIGIN_REMOTE:-origin}"
+DEFAULT_BRANCHES=(main v3-2-test)
+
+if [[ $# -gt 0 ]]; then
+    BRANCHES=("$@")
+else
+    BRANCHES=("${DEFAULT_BRANCHES[@]}")
+fi
+
+echo "Fetching ${UPSTREAM}..."
+git fetch --prune "${UPSTREAM}"
+
+for branch in "${BRANCHES[@]}"; do
+    echo "Syncing ${branch}: ${UPSTREAM}/${branch} -> ${ORIGIN}/${branch}"
+    git push --force "${ORIGIN}" "refs/remotes/${UPSTREAM}/${branch}:refs/heads/${branch}"
+done
+
+echo "Done."


### PR DESCRIPTION
Backport of #65550 to v3-2-test.

Gives contributors a one-liner to force-update multiple branches on
their fork from the corresponding upstream branches without switching
local checkouts. Defaults to `main` and the current release branch.

Conflict resolved in `dev/README_RELEASE_AIRFLOW.md` — the cherry-pick adds a new documentation block about backport label creation and `.github/` configuration for cutting new release branches; that block did not exist on v3-2-test and was accepted as-is (pure addition).

(cherry picked from commit de62575750619b442d0567a43848b645f53935d4)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)