### PR TITLE
Fix SQS CreateQueue type error by casting attributes to string

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/sqs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/sqs.py
@@ -52,7 +52,8 @@ class SqsHook(AwsBaseHook):
         :return: dict with the information about the queue.
         """
         self.log.debug("Creating SQS queue %s with attributes %s", queue_name, attributes)
-        result = self.get_conn().create_queue(QueueName=queue_name, Attributes=attributes or {})
+        safe_attributes = {k: str(v) for k, v in (attributes or {}).items()}
+        result = self.get_conn().create_queue(QueueName=queue_name, Attributes=safe_attributes or {})
         self.log.debug("Created SQS queue %s, response: %s", queue_name, result.get("QueueUrl"))
         return result
 

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sqs.py
@@ -145,6 +145,29 @@ class TestSqsHook:
         immediate_receive = hook.get_conn().receive_message(QueueUrl=self.queue_url, WaitTimeSeconds=0)
         assert "Messages" not in immediate_receive or len(immediate_receive.get("Messages", [])) == 0
 
+    def test_create_queue_with_int_attributes(self, hook):
+        """Test that int attribute values are internally cast to strings and queue creation succeeds."""
+        queue_name = "test-queue-int-casting"
+        # These are the int values that the casting logic (fixed in SqsHook) should handle.
+        attributes = {
+            "DelaySeconds": 10,
+            "MaximumMessageSize": 262144,
+        }
+
+        response = hook.create_queue(queue_name=queue_name, attributes=attributes)
+
+        assert "QueueUrl" in response
+        assert queue_name in response["QueueUrl"]
+
+        # Verify that the attributes were correctly cast and stored as strings in the SQS service (moto).
+        queue_attrs = hook.get_conn().get_queue_attributes(
+            QueueUrl=response["QueueUrl"], AttributeNames=["DelaySeconds", "MaximumMessageSize"]
+        )
+
+        # moto/boto3 returns values as strings; if these assertions pass, the casting logic is verified.
+        assert queue_attrs["Attributes"]["DelaySeconds"] == "10"
+        assert queue_attrs["Attributes"]["MaximumMessageSize"] == "262144"
+
 
 @pytest.mark.asyncio
 class TestAsyncSqsHook:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
When creating an SQS queue, AWS requires all attribute values to be strings. Currently, if a user passes an integer (e.g., VisibilityTimeout=30), it causes a `botocore.exceptions.ParamValidationError` or InvalidAttributeValue error in real AWS environments.

This PR ensures all attribute values are cast to strings before being passed to the boto3 client.

**Related Issue:**
closes: #65592

**Tests performed:**
Verified with a reproduction script in Breeze (Python 3.13) that integer values no longer trigger validation errors.

<img width="854" height="955" alt="스크린샷 2026-04-22 오후 5 55 45" src="https://github.com/user-attachments/assets/e5a7dc3f-f295-4b47-a47d-a058aa2cdce3" />


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Gemini)

Generated-by: Gemini following the guidelines

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
