### PR TITLE
Lazy-load Alembic in db_manager imports

### DIFF
--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -55,6 +55,14 @@ def _get_alembic_command():
     return command
 
 
+class _AlembicCommandProxy:
+    def __getattr__(self, name):
+        return getattr(_get_alembic_command(), name)
+
+
+command = _AlembicCommandProxy()
+
+
 class BaseDBManager(LoggingMixin):
     """Abstract Base DB manager for external DBs."""
 
@@ -131,7 +139,7 @@ class BaseDBManager(LoggingMixin):
         engine = self.session.get_bind().engine
         self.metadata.create_all(engine)
         config = self.get_alembic_config()
-        _get_alembic_command().stamp(config, "head")
+        command.stamp(config, "head")
         self.log.info("%s tables have been created from the ORM", self.__class__.__name__)
 
     def drop_tables(self, connection):
@@ -185,7 +193,7 @@ class BaseDBManager(LoggingMixin):
             return
 
         config = self.get_alembic_config()
-        _get_alembic_command().upgrade(config, revision=to_revision or "heads", sql=show_sql_only)
+        command.upgrade(config, revision=to_revision or "heads", sql=show_sql_only)
         self.log.info("Migrated the %s database", self.__class__.__name__)
 
     def downgrade(self, to_revision, from_revision=None, show_sql_only=False):

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -20,7 +20,6 @@ import inspect as _inspect
 import os
 from typing import TYPE_CHECKING
 
-from alembic import command
 from sqlalchemy import inspect
 
 from airflow import settings
@@ -48,6 +47,12 @@ def _callable_accepts_use_migration_files(callable_) -> bool:
     return any(
         parameter.kind == _inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
     )
+
+
+def _get_alembic_command():
+    from alembic import command
+
+    return command
 
 
 class BaseDBManager(LoggingMixin):
@@ -126,7 +131,7 @@ class BaseDBManager(LoggingMixin):
         engine = self.session.get_bind().engine
         self.metadata.create_all(engine)
         config = self.get_alembic_config()
-        command.stamp(config, "head")
+        _get_alembic_command().stamp(config, "head")
         self.log.info("%s tables have been created from the ORM", self.__class__.__name__)
 
     def drop_tables(self, connection):
@@ -180,7 +185,7 @@ class BaseDBManager(LoggingMixin):
             return
 
         config = self.get_alembic_config()
-        command.upgrade(config, revision=to_revision or "heads", sql=show_sql_only)
+        _get_alembic_command().upgrade(config, revision=to_revision or "heads", sql=show_sql_only)
         self.log.info("Migrated the %s database", self.__class__.__name__)
 
     def downgrade(self, to_revision, from_revision=None, show_sql_only=False):

--- a/airflow-core/tests/unit/utils/test_db_manager.py
+++ b/airflow-core/tests/unit/utils/test_db_manager.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import importlib
+import subprocess
 import sys
 from contextlib import nullcontext
 from unittest import mock
@@ -100,21 +100,26 @@ def _create_run_db_manager(*managers):
 
 class TestBaseDBManager:
     def test_importing_db_manager_does_not_eagerly_import_alembic(self):
-        original_db_manager_module = sys.modules.get("airflow.utils.db_manager")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys\n"
+                    "import airflow.utils.db_manager as module\n"
+                    "assert hasattr(module, 'RunDBManager')\n"
+                    "alembic_modules = sorted(\n"
+                    "    name for name in sys.modules if name == 'alembic' or name.startswith('alembic.')\n"
+                    ")\n"
+                    "assert not alembic_modules, alembic_modules\n"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-        try:
-            sys.modules.pop("airflow.utils.db_manager", None)
-            for module_name in list(sys.modules):
-                if module_name == "alembic" or module_name.startswith("alembic."):
-                    sys.modules.pop(module_name)
-
-            module = importlib.import_module("airflow.utils.db_manager")
-
-            assert hasattr(module, "RunDBManager")
-            assert not any(name == "alembic" or name.startswith("alembic.") for name in sys.modules)
-        finally:
-            if original_db_manager_module is not None:
-                sys.modules["airflow.utils.db_manager"] = original_db_manager_module
+        assert result.returncode == 0, result.stderr or result.stdout
 
     @mock.patch.object(BaseDBManager, "get_alembic_config")
     @mock.patch.object(BaseDBManager, "get_current_revision")

--- a/airflow-core/tests/unit/utils/test_db_manager.py
+++ b/airflow-core/tests/unit/utils/test_db_manager.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
 from contextlib import nullcontext
 from unittest import mock
 
@@ -97,6 +99,23 @@ def _create_run_db_manager(*managers):
 
 
 class TestBaseDBManager:
+    def test_importing_db_manager_does_not_eagerly_import_alembic(self):
+        original_db_manager_module = sys.modules.get("airflow.utils.db_manager")
+
+        try:
+            sys.modules.pop("airflow.utils.db_manager", None)
+            for module_name in list(sys.modules):
+                if module_name == "alembic" or module_name.startswith("alembic."):
+                    sys.modules.pop(module_name)
+
+            module = importlib.import_module("airflow.utils.db_manager")
+
+            assert hasattr(module, "RunDBManager")
+            assert not any(name == "alembic" or name.startswith("alembic.") for name in sys.modules)
+        finally:
+            if original_db_manager_module is not None:
+                sys.modules["airflow.utils.db_manager"] = original_db_manager_module
+
     @mock.patch.object(BaseDBManager, "get_alembic_config")
     @mock.patch.object(BaseDBManager, "get_current_revision")
     @mock.patch.object(BaseDBManager, "create_db_from_orm")


### PR DESCRIPTION
## What this PR does

Avoids eagerly importing Alembic when `airflow.utils.db` / `airflow.utils.db_manager` are imported.

Today, `airflow.utils.db_manager` imports `from alembic import command` at module import time. Because `airflow.utils.db` imports `RunDBManager`, that path loads Alembic during a normal import and emits the noisy `alembic.runtime.plugins` INFO lines like:

```text
setup plugin alembic.autogenerate.schemas
setup plugin alembic.autogenerate.tables
setup plugin alembic.autogenerate.types
setup plugin alembic.autogenerate.constraints
setup plugin alembic.autogenerate.defaults
setup plugin alembic.autogenerate.comments
```

This PR defers importing `alembic.command` until the DB migration operations actually need it.

## Why

This keeps normal Airflow imports quiet without suppressing logs globally and without changing Alembic behavior during real migration operations.

To preserve existing test and patching behavior, `airflow.utils.db_manager.command` remains available via a lazy proxy.

## Related issue

Closes #65652

## Testing

- `ruff check airflow-core/src/airflow/utils/db_manager.py airflow-core/tests/unit/utils/test_db_manager.py`
- Breeze Python `3.10` container:
  - `python -m pytest airflow-core/tests/unit/utils/test_db_manager.py -q`
  - `python -m pytest providers/edge3/tests/unit/edge3/models/test_db.py -q`
- Verified the original repro is clean in Breeze:
  - `import airflow.utils.db_manager`
  - `import airflow.utils.db`

## Gen-AI disclosure

This PR was prepared with assistance from generative AI tools. I reviewed the generated changes, validated the behavior locally, and take responsibility for the final code and testing.
