### PR TITLE
Add apache-airflow-mypy to devel-common mypy dependency group

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -111,6 +111,7 @@ dependencies = [
 "mypy" = [
     # Mypy dependencies
     # TODO: upgrade to newer versions of MyPy continuously as they are released
+    "apache-airflow-mypy",
     "mypy==1.20.1",
     "types-Deprecated>=1.2.9.20240311",
     "types-Markdown>=3.6.0.20240316",


### PR DESCRIPTION
PR #61422 (merged Apr 22, 2026) changed the root `pyproject.toml` mypy plugin references from file-path form to module form:

```toml
plugins = [
    "airflow_mypy.plugins.decorators",
    "airflow_mypy.plugins.outputs",
]
```

Module-form plugins require the package to be importable in the mypy venv. The mypy hooks for `airflow-core`, `task-sdk`, and all other non-provider, non-scripts distributions build their venv by running:

```
uv sync --frozen --project devel-common --group mypy
```

But `devel-common`'s `mypy` dependency group did not include `apache-airflow-mypy` (which lives in `dev/mypy/`). As a result, all those mypy hooks fail immediately with:

```
Error importing plugin "airflow_mypy.plugins.decorators": No module named 'airflow_mypy'
```

This was discovered during the provider release process (#65614) when rebasing onto today's `main` after #61422 landed.

**Fix:** add `apache-airflow-mypy` to the `mypy` optional-extra in `devel-common/pyproject.toml` so it is installed into every affected mypy hook venv.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (Claude Sonnet 4.6)

Generated-by: GitHub Copilot (Claude Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)