### PR TITLE
Stop dumping full Click context dict in update-breeze-cmd-output hook

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/setup_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/setup_commands.py
@@ -48,7 +48,7 @@ from airflow_breeze.commands.main_command import main
 from airflow_breeze.utils.cache import check_if_cache_exists, delete_cache, touch_cache_file
 from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.confirm import STANDARD_TIMEOUT, Answer, user_confirm
-from airflow_breeze.utils.console import console_print, get_stderr_console
+from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.docker_command_utils import VOLUMES_FOR_SELECTED_MOUNTS
 from airflow_breeze.utils.path_utils import (
@@ -352,8 +352,6 @@ def get_command_hash_dict() -> dict[str, str]:
     hashes: dict[str, str] = {}
     with Context(main) as ctx:
         the_context_dict = ctx.to_info_dict()
-        if get_verbose():
-            get_stderr_console().print(the_context_dict)
         commands_dict = the_context_dict["command"]["commands"]
         options = rich_click.rich_click.OPTION_GROUPS
         for command in sorted(commands_dict.keys()):


### PR DESCRIPTION
The `update-breeze-cmd-output` prek hook calls `breeze setup
regenerate-command-images`, which printed the entire Click context
dict (60K+ lines) when `VERBOSE` was set in the environment. CI runs
prek with `VERBOSE=true`, so a failure of this hook drowned the
actual error message under that dump.

Example failure with the noise:
https://github.com/apache/airflow/actions/runs/24765956624/job/72462411984?pr=65660

The dump was a leftover developer debug print and provided no
actionable information for diagnosing why the hook failed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)