### PR TITLE
Fix mypy plugin loading after airflow_mypy distribution migration

### DIFF
--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -74,8 +74,8 @@ no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = false
 plugins = [
-    "airflow_mypy/plugin/decorators.py",
-    "airflow_mypy/plugin/outputs.py",
+    "airflow_mypy.plugins.decorators",
+    "airflow_mypy.plugins.outputs",
 ]
 pretty = true
 show_error_codes = true

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -111,6 +111,7 @@ dependencies = [
 "mypy" = [
     # Mypy dependencies
     # TODO: upgrade to newer versions of MyPy continuously as they are released
+    "apache-airflow-mypy",
     "mypy==1.20.1",
     "types-Deprecated>=1.2.9.20240311",
     "types-Markdown>=3.6.0.20240316",

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-18T06:49:19.884005625Z"
+exclude-newer = "2026-04-18T12:14:40.504930901Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -2106,6 +2106,7 @@ version = "0.1.0"
 source = { editable = "devel-common" }
 dependencies = [
     { name = "aioresponses" },
+    { name = "apache-airflow-mypy" },
     { name = "black" },
     { name = "coverage" },
     { name = "filelock" },
@@ -2159,6 +2160,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "apache-airflow-mypy" },
     { name = "beautifulsoup4" },
     { name = "blinker" },
     { name = "click" },
@@ -2212,6 +2214,7 @@ all = [
     { name = "types-toml" },
 ]
 basic = [
+    { name = "apache-airflow-mypy" },
     { name = "coverage" },
     { name = "ipdb" },
     { name = "mypy" },
@@ -2309,6 +2312,7 @@ duckdb = [
     { name = "duckdb" },
 ]
 mypy = [
+    { name = "apache-airflow-mypy" },
     { name = "mypy" },
     { name = "types-aiofiles" },
     { name = "types-cachetools" },
@@ -2331,6 +2335,7 @@ mypy = [
     { name = "types-toml" },
 ]
 no-doc = [
+    { name = "apache-airflow-mypy" },
     { name = "beautifulsoup4" },
     { name = "blinker" },
     { name = "click" },
@@ -2422,6 +2427,7 @@ requires-dist = [
     { name = "apache-airflow-devel-common", extras = ["coverage", "debuggers", "mypy", "pytest", "sqlalchemy"], marker = "extra == 'basic'", editable = "devel-common" },
     { name = "apache-airflow-devel-common", extras = ["coverage", "duckdb", "debuggers", "devscripts", "doc", "docs-gen", "mypy", "pytest", "sentry", "sqlalchemy"], marker = "extra == 'all'", editable = "devel-common" },
     { name = "apache-airflow-devel-common", extras = ["coverage", "duckdb", "debuggers", "devscripts", "mypy", "pytest", "sentry"], marker = "extra == 'no-doc'", editable = "devel-common" },
+    { name = "apache-airflow-mypy", marker = "extra == 'mypy'", editable = "dev/mypy" },
     { name = "astroid", marker = "extra == 'docs'", specifier = ">=4" },
     { name = "beautifulsoup4", marker = "extra == 'sentry'", specifier = ">=4.7.1" },
     { name = "black", specifier = ">=26.1.0" },
@@ -20178,8 +20184,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
After #61422 (\"Make Mypy plugins installable\") two mypy hooks broke
because the plugin references were not migrated consistently:

* `devel-common`'s `mypy` extra did not depend on `apache-airflow-mypy`,
  so any hook that pulls `apache-airflow-devel-common[mypy]`
  (`mypy-airflow-core`, `mypy-task-sdk`, `mypy-devel-common`, …) failed
  with `Error importing plugin "airflow_mypy.plugins.decorators":
  No module named 'airflow_mypy'`.
* `dev/pyproject.toml` referenced the plugins by file path with the
  wrong subpackage name (`airflow_mypy/plugin/decorators.py` — singular,
  path-style), so `mypy-dev` failed with `Can't find plugin
  "dev/airflow_mypy/plugin/decorators.py"`.

Adding `apache-airflow-mypy` to `devel-common`'s `mypy` extra and
switching `dev/pyproject.toml` to the module-style plugin names that
already work in the root `pyproject.toml` fixes both.

Verified locally:
- `prek run mypy-devel-common --all-files` — Passed
- `prek run mypy-dev --all-files` — Passed
- `prek run mypy-airflow-core` (one file) — Passed

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)