### PR TITLE
Bump uv required-version floor to 0.11.7

### DIFF
--- a/dev/breeze/tests/test_environment_check.py
+++ b/dev/breeze/tests/test_environment_check.py
@@ -27,7 +27,7 @@ from airflow_breeze.utils.environment_check import check_uv_version
 # `# sync-uv-min-version` marker is auto-rewritten when required-version is bumped
 # manually. Tests that exercise the success path set both the mocked floor AND the
 # mocked "actual uv" to this value so the ok-case keeps passing after a bump.
-_MIN_UV = "0.9.17"  # sync-uv-min-version
+_MIN_UV = "0.11.7"  # sync-uv-min-version
 
 
 @mock.patch("airflow_breeze.utils.environment_check._read_required_uv_version")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1354,7 +1354,7 @@ leveldb = [
 # with AIRFLOW_UV_VERSION would force everyone to upgrade uv on every release. The
 # breeze/prek uv version checks read this value dynamically and tolerate a stale
 # floor; `scripts/ci/prek/upgrade_important_versions.py` deliberately skips it.
-required-version = ">=0.9.17"
+required-version = ">=0.11.7"
 no-build-isolation-package = ["sphinx-redoc"]
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
 exclude-newer = "4 days"


### PR DESCRIPTION
The contributor-facing minimum uv version (`[tool.uv] required-version`)
was `>=0.9.17`, while the project's CI/Docker images
(`AIRFLOW_UV_VERSION`) and `uv.lock` already pin to `0.11.7`.

Older uv versions normalize lockfile content differently (e.g. marker
rewrites in DNF expansion, `exclude-newer` timestamp drift), so
contributors running `uv lock` with their own older uv produce drift
in `uv.lock` unrelated to their actual changes.

Lifting the floor to `0.11.7` keeps everyone aligned with the
already-shipped CI version and avoids those incidental lockfile
diffs. The `# sync-uv-min-version` marker propagates the value
into the breeze test fixture automatically (one extra line in
`dev/breeze/tests/test_environment_check.py`).

`uv.lock` itself didn't need updating — uv was already at 0.11.7
in the lock.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)