### PR TITLE
Implement on_kill() trigger hook for Databricks triggers

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -84,6 +84,14 @@ class DatabricksExecutionTrigger(BaseTrigger):
             },
         )
 
+    async def on_kill(self) -> None:
+        """Cancel the Databricks run when the trigger is cancelled by a user action."""
+        if self.run_id:
+            from asgiref.sync import sync_to_async
+
+            self.log.info("Cancelling Databricks run %s.", self.run_id)
+            await sync_to_async(self.hook.cancel_run)(self.run_id)
+
     async def run(self):
         async with self.hook:
             while True:
@@ -166,6 +174,14 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
                 "retry_args": self.retry_args,
             },
         )
+
+    async def on_kill(self) -> None:
+        """Cancel the Databricks SQL statement when the trigger is cancelled by a user action."""
+        if self.statement_id:
+            from asgiref.sync import sync_to_async
+
+            self.log.info("Cancelling Databricks SQL statement %s.", self.statement_id)
+            await sync_to_async(self.hook.cancel_sql_statement)(self.statement_id)
 
     async def run(self):
         async with self.hook:

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -259,6 +259,12 @@ class TestDatabricksExecutionTrigger:
         mock_sleep.assert_called_once()
         mock_sleep.assert_called_with(POLLING_INTERVAL_SECONDS)
 
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.cancel_run")
+    async def test_on_kill_cancels_run(self, mock_cancel_run):
+        await self.trigger.on_kill()
+        mock_cancel_run.assert_called_once_with(RUN_ID)
+
 
 class TestDatabricksSQLStatementExecutionTrigger:
     @pytest.fixture(autouse=True)
@@ -361,3 +367,9 @@ class TestDatabricksSQLStatementExecutionTrigger:
             )
         mock_sleep.assert_called_once()
         mock_sleep.assert_called_with(POLLING_INTERVAL_SECONDS)
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.cancel_sql_statement")
+    async def test_on_kill_cancels_statement(self, mock_cancel_sql_statement):
+        await self.trigger.on_kill()
+        mock_cancel_sql_statement.assert_called_once_with(STATEMENT_ID)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Add on to: https://github.com/apache/airflow/pull/65590 for databricks.

### What

Implements the on_kill() hook for both Databricks trigger classes so that external runs are cancelled when a user explicitly kills a deferred task.

- DatabricksExecutionTrigger.on_kill() — calls hook.cancel_run(run_id) to cancel the Databricks job run
- DatabricksSQLStatementExecutionTrigger.on_kill() — calls hook.cancel_sql_statement(statement_id) to cancel the SQL statement

No compat guard needed here because the method is just defined on the trigger class. On Airflow < main (3.3) the triggerer never calls it, so it is a harmless no-op. On Airflow 3.3+ it gets invoked automatically by the triggerer.


### Why `sync_to_async`?

Because `DatabricksHook.cancel_run()` is a synchronous method and it uses the requests library under the hood, which is blocking.

`sync_to_async` wraps the blocking call and runs it in a thread pool executor, so it doesn't block the triggerer's event loop while the HTTP request to Databricks completes.


### Manual e2e test

1. Created a Databricks job backed by a notebook with `time.sleep(300)` to keep the run alive

<img width="2194" height="619" alt="image" src="https://github.com/user-attachments/assets/2b4c9743-c929-44f1-818f-6242803ae0e8" />


2. Triggered a DAG using DatabricksRunNowOperator with deferrable=True

DAG:
```python
from airflow.sdk import dag
from airflow.providers.databricks.operators.databricks import DatabricksRunNowOperator

JOB_ID = "638893296567432"


@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False, tags=["test"])
def test_databricks_on_kill():
    DatabricksRunNowOperator(
        task_id="run_databricks_job",
        job_id=JOB_ID,
        databricks_conn_id="my_db",
        deferrable=True,
    )


test_databricks_on_kill()
```

3. Waited for the task to enter deferred state (triggerer polling the run)

4. Marked the task as failed from UI

<img width="2491" height="951" alt="image" src="https://github.com/user-attachments/assets/7fa6912a-2b0c-4f0a-8087-be7513f340ab" />

5. You can see same job ID being cancelled on DBX

<img width="2547" height="990" alt="image" src="https://github.com/user-attachments/assets/1b594865-00c5-4444-a6fa-03e18c9c68f8" />



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
