### PR TITLE
fix(task-sdk): respect default parameter in xcom_pull when map_indexes is not set

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -540,8 +540,11 @@ class RuntimeTaskInstance(TaskInstance):
                     dag_id=dag_id,
                     include_prior_dates=include_prior_dates,
                 )
-                xcoms.append(None) if values is None else xcoms.extend(values)
-            # For a single task pulling from an unmapped task, return a single value
+                if values is None:
+                    xcoms.append(default)
+                else:
+                    xcoms.extend(values)
+            # For single task pulling from unmapped task, return single value
             if single_task_requested and len(xcoms) == 1:
                 return xcoms[0]
             return xcoms

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -419,7 +419,7 @@ class RuntimeTaskInstance(TaskInstance):
                 )
 
                 if values is None:
-                    xcoms.append(None)
+                    xcoms.append(default)
                 else:
                     xcoms.extend(values)
             # For single task pulling from unmapped task, return single value


### PR DESCRIPTION
## Summary

In `RuntimeTaskInstance.xcom_pull()`, when `map_indexes` is not specified (the default NOTSET path), the code always appends `None` to the result list when no XCom is found, ignoring the caller-provided `default` parameter.

The explicit `map_indexes` branch (below) correctly uses `default`. This fix aligns the non-map_indexes path with that behavior.

**Before:** `ti.xcom_pull(task_ids="t", key="k", default="fallback")` returns `None` when no XCom exists.
**After:** Returns `"fallback"` as expected per the docstring.

Fixes #64295

<!-- pr-triage-fold: triaged=2026-07-02T17:38:30Z head=c00c3a4 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @armorbreak001** · by `@potiuk` · 2026-07-02 17:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - This PR has **merge conflicts with `main`**. Please rebase onto the latest `main` and resolve them.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->