### PR TITLE
Fix scheduler UniqueViolation crash on downgrade from 3.2.0 to 3.1.x

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0107_3_2_0_add_partition_fields_to_dag.py
+++ b/airflow-core/src/airflow/migrations/versions/0107_3_2_0_add_partition_fields_to_dag.py
@@ -62,3 +62,15 @@ def downgrade():
             batch_op.drop_column("next_dagrun_partition_date")
         with op.batch_alter_table("dag_run", schema=None) as batch_op:
             batch_op.drop_column("partition_date")
+
+    # When downgrading from 3.2.0 to 3.1.x, the run_id generation semantics change:
+    # 3.2.0 generates run_id from run_after (data interval end),
+    # 3.1.x generates run_id from next_dagrun (logical date / data interval start).
+    # If next_dagrun/next_dagrun_create_after are left pointing at values set by 3.2.0,
+    # the 3.1.x scheduler will try to create runs with run_ids that already exist in
+    # dag_run, causing DB insert violation. Nulling these fields forces the 3.1.x
+    # scheduler to recalculate them from the last completed run using 3.1.x semantics.
+    op.execute(
+        "UPDATE dag SET next_dagrun = NULL, next_dagrun_create_after = NULL, "
+        "next_dagrun_data_interval_start = NULL, next_dagrun_data_interval_end = NULL"
+    )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What?
When downgrading from Airflow 3.2.0 to 3.1.x, the scheduler enters a crash loop due to `UniqueViolation` errors on the `dag_run` table, causing all DAG scheduling to stop.

### Current behaviour
Airflow 3.2.0 (related PR: https://github.com/apache/airflow/pull/59115) changed how run_id is generated for scheduled DAG runs:

- 3.1.x: `run_id = scheduled__<logical_date>`
- 3.2.0: `run_id = scheduled__<run_after>`

For a daily DAG, these timestamps differ by one interval. After downgrading to 3.1.x, `DagModel.next_dagrun` still holds a value set by 3.2.0. The 3.1.x scheduler uses that value to generate a run_id that already exists in dag_run (created by 3.2.0 with the new format) leading to DB insertion error.

This is made worse by the known session handling issue in _create_dag_runs_timetable (issue: https://github.com/apache/airflow/issues/59120): one UniqueViolation messed the entire SQLAlchemy session, causing errors to cascade to every other DAG in the same scheduler batch. The result is a full scheduler crash loop affecting all DAGs, not just the one with the collision.


### Proposed change
Add a data migration to the downgrade path of existing migration: 0107, so that on downgrade, we null out `next_dagrun`, `next_dagrun_create_after`, `next_dagrun_data_interval_start`, and `next_dagrun_data_interval_end` for all DAGs.

Nulling is intentional so that the scheduler as it already handles NULL can start recalculating these fields from the last completed run on its next cycle. After downgrade, the 3.1.x scheduler recalculates using 3.1.x semantics, generating run_ids that will not collide with existing runs.

### What does this mean for 3.2 -> 3.2.1? (assuming we make this into 3.2.2)

For 3.2 and 3.2.1:

- This fix is not in it
- Downgrade path is broken
- Anyone who upgraded to 3.2.0 and rolled back to 3.1.x will hit the crash loop


Anyone on these versions who needs to roll back to 3.1.x should manually run the sql workaround (null out the 4 fields) before starting the 3.1.x scheduler.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
