### PR TITLE
Add documentation for team-based asset event filtering

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -402,6 +402,53 @@ As mentioned in :ref:`Fetching information from previously emitted asset events<
             events = inlet_events[AssetAlias("example-alias")]
             last_row_count = events[-1].extra["row_count"]
 
+.. _asset_allow_producer_teams:
+
+Cross-team asset event filtering with ``allow_producer_teams``
+--------------------------------------------------------------
+
+.. versionadded:: 3.3.0
+
+When :doc:`Multi-Team mode </core-concepts/multi-team>` is enabled, asset events are filtered by team
+membership. By default, a consuming Dag only receives asset events produced by Dags within the same team
+or by global (teamless) Dags. This prevents unintended cross-team triggers.
+
+To allow specific other teams to produce events that trigger your Dag, use the ``allow_producer_teams`` parameter
+on the ``Asset`` definition:
+
+.. code-block:: python
+
+    from airflow.sdk import Asset
+
+    shared_data = Asset(
+        name="my_data",
+        uri="s3://bucket/shared/data.csv",
+        allow_producer_teams=["team_analytics", "team_ml"],
+    )
+
+In this example, asset events produced by Dags belonging to ``team_analytics`` or ``team_ml`` will be
+accepted by any consuming Dag that schedules on ``shared_data``, in addition to events from the consuming
+Dag's own team.
+
+Default behavior
+~~~~~~~~~~~~~~~~
+
+When ``allow_producer_teams`` is not specified (or set to an empty list), the default same-team filtering applies.
+The rules depend on whether the producer and consumer have a team association:
+
+- **Both have the same team**: The event is always delivered.
+- **Producer has a team, consumer has a different team**: The event is blocked (unless the
+  producer's team is in the asset's ``allow_producer_teams``).
+- **Producer has no team (global Dag)**: The event is delivered to all consumers, regardless of
+  the consumer's team. Global Dags act as shared infrastructure that any team can depend on.
+- **Consumer has no team (global Dag)**: The consumer accepts events from any source,
+  regardless of the producer's team. Teamless consumers act as shared infrastructure that any
+  team can feed into.
+- **Neither has a team**: The event is delivered (both are global).
+
+When Multi-Team mode is disabled, ``allow_producer_teams`` is ignored and all asset events are delivered to all
+consuming Dags, preserving backward compatibility.
+
 Asset partitions
 ----------------
 

--- a/airflow-core/docs/core-concepts/multi-team.rst
+++ b/airflow-core/docs/core-concepts/multi-team.rst
@@ -503,16 +503,130 @@ When Multi-Team mode is enabled, the scheduler performs additional logic to dete
     teams share the same metadata database and common Airflow infrastructure. For absolutely strict security
     requirements, consider separate Airflow deployments.
 
-Architecture
-------------
+.. _multi-team-asset-event-filtering:
 
-The following diagram shows a Multi-Team Airflow deployment with resource isolation between teams.
+Team-Based Asset Event Filtering
+---------------------------------
 
-The components in blue are the shared components and those in green are the team components (note the green shadow box
-indicating more than one team is present in the architecture).
+When Multi-Team mode is enabled, asset events are filtered by team membership before they trigger
+downstream Dag runs. This prevents asset events produced by one team's Dags from unintentionally
+triggering Dag runs for a different team.
 
-.. image:: /img/multi_team_arch_diagram.png
-   :alt: Multi-Team Airflow Architecture showing resource isolation between teams
+Default Behavior
+^^^^^^^^^^^^^^^^
+
+By default, a consuming Dag only receives asset events from producers within the same team or from Dags with no team association, i.e. global Dags.
+
+Cross-Team Opt-In with ``allow_producer_teams``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To allow specific teams to produce events that trigger consumers on a given asset from another team, use the
+``allow_producer_teams`` parameter on the ``Asset`` definition:
+
+.. code-block:: python
+
+    from airflow.sdk import Asset
+
+    shared_data = Asset(
+        name="shared_data",
+        uri="s3://bucket/shared/data.csv",
+        allow_producer_teams=["team_analytics", "team_ml"],
+    )
+
+With this configuration, asset events from ``team_analytics`` or ``team_ml`` will be accepted by any
+consuming Dag that schedules on ``shared_data``, in addition to events from the consumer's own team.
+
+See :ref:`Cross-team asset event filtering with allow_producer_teams <asset_allow_producer_teams>` in the Assets
+documentation for usage details and validation rules.
+
+Behavioral Rules
+^^^^^^^^^^^^^^^^
+
+The following table describes the complete filtering logic:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 15 25
+
+   * - Producer
+     - Consumer
+     - ``allow_producer_teams``
+     - Result
+     - Reason
+   * - Team A (DAG)
+     - Team A
+     - (any)
+     - ✅ Allowed
+     - Same team
+   * - Team A (DAG)
+     - Team B
+     - ``[]``
+     - ❌ Blocked
+     - Different team, no opt-in
+   * - Team A (DAG)
+     - Team B
+     - ``["team_a"]``
+     - ✅ Allowed
+     - Cross-team opt-in
+   * - (no team, DAG)
+     - Team B
+     - (any)
+     - ✅ Allowed
+     - Global producer
+   * - Team A (DAG)
+     - (no team)
+     - (any)
+     - ✅ Allowed
+     - Teamless consumer accepts events from any DAG producer
+   * - (no team, DAG)
+     - (no team)
+     - (any)
+     - ✅ Allowed
+     - Both global
+   * - Team A (API)
+     - Team A
+     - (any)
+     - ✅ Allowed
+     - Same team
+   * - Team A (API)
+     - Team B
+     - ``["team_a"]``
+     - ✅ Allowed
+     - Cross-team opt-in
+   * - Team A (API)
+     - (no team)
+     - (any)
+     - ✅ Allowed
+     - Teamless consumer accepts events from any source
+   * - (no team, API)
+     - Team B
+     - (any)
+     - ❌ Blocked
+     - Teamless API user cannot trigger team-bound consumer
+   * - (no team, API)
+     - (no team)
+     - (any)
+     - ✅ Allowed
+     - Both global
+
+Key rules:
+
+- **Same team**: Always allowed.
+- **Global (teamless) DAG producer**: Triggers all consumers regardless of team.
+- **Teamless API user**: Can only trigger teamless consumers. Unlike a teamless DAG — which is
+  deployed by a platform operator and intentionally shared — an API user without a team has no
+  verified team affiliation, so their events are restricted to teamless consumers to
+  prevent unscoped access to team-bound pipelines.
+- **Teamless consumer**: Accepts events from any source (DAG or API), regardless of team.
+- **Cross-team via** ``allow_producer_teams``: Allowed when the producer's team is listed in the asset's ``allow_producer_teams``.
+- **Multi-Team disabled**: All filtering is skipped; existing behavior is preserved.
+
+API-Triggered Events
+^^^^^^^^^^^^^^^^^^^^
+
+When a user creates an asset event via the REST API, the user's team is resolved from the auth manager.
+The same filtering rules apply, with one distinction: a teamless API user can only trigger teamless
+consumers, whereas a teamless DAG producer is treated as global and can trigger any consumer.
 
 Important Considerations
 ------------------------
@@ -535,3 +649,14 @@ Global Uniqueness of Identifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dag IDs, Variable keys, and Connection IDs must be unique across the entire Airflow deployment**, regardless of which team owns them. This is similar to how S3 bucket names are globally unique across all AWS accounts. You should establish naming conventions within your organization to avoid naming conflicts (e.g. prefix identifiers with the team name)
+
+Architecture
+------------
+
+The following diagram shows a Multi-Team Airflow deployment with resource isolation between teams.
+
+The components in blue are the shared components and those in green are the team components (note the green shadow box
+indicating more than one team is present in the architecture).
+
+.. image:: /img/multi_team_arch_diagram.png
+   :alt: Multi-Team Airflow Architecture showing resource isolation between teams

--- a/airflow-core/src/airflow/example_dags/example_asset_allow_teams.py
+++ b/airflow-core/src/airflow/example_dags/example_asset_allow_teams.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG demonstrating cross-team asset triggering with ``allow_producer_teams``.
+
+When Multi-Team mode is enabled (``[core] multi_team = True``), asset events are filtered by team
+membership. By default, a consuming DAG only receives events from DAGs within the same team.
+
+Usage:
+    - ``team_analytics_producer`` (belonging to ``team_analytics``) produces events on ``shared_data``.
+    - ``team_ml_consumer`` (belonging to ``team_ml``) consumes ``shared_data``.
+    - Because ``shared_data`` has ``allow_producer_teams=["team_analytics"]``, events from ``team_analytics``
+      are accepted by ``team_ml_consumer``.
+    - Without ``allow_producer_teams``, the cross-team event would be blocked.
+"""
+
+from __future__ import annotations
+
+import pendulum
+
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk import DAG, Asset
+
+# [START asset_allow_producer_teams]
+# Define an asset that accepts events from team_analytics in addition to the consumer's own team.
+shared_data = Asset(
+    name="shared_data",
+    uri="s3://data-lake/shared/output.csv",
+    allow_producer_teams=["team_analytics"],
+)
+
+# Producer DAG — belongs to team_analytics (via its DAG bundle configuration).
+# When this DAG's task completes, it emits an asset event for shared_data.
+with DAG(
+    dag_id="team_analytics_producer",
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
+    schedule="@daily",
+    catchup=False,
+    tags=["team_analytics", "produces", "asset-scheduled", "allow-teams"],
+) as producer_dag:
+    BashOperator(
+        task_id="produce_shared_data",
+        outlets=[shared_data],
+        bash_command="echo 'Producing shared data for cross-team consumption'",
+    )
+
+# Consumer DAG — belongs to team_ml (via its DAG bundle configuration).
+# This DAG is triggered when shared_data is updated. Because shared_data has
+# allow_producer_teams=["team_analytics"], events from team_analytics are accepted.
+with DAG(
+    dag_id="team_ml_consumer",
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
+    schedule=[shared_data],
+    catchup=False,
+    tags=["team_ml", "consumes", "asset-scheduled", "allow-teams"],
+) as consumer_dag:
+    BashOperator(
+        task_id="consume_shared_data",
+        bash_command="echo 'Consuming shared data from team_analytics'",
+    )
+# [END asset_allow_producer_teams]

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1636,6 +1636,7 @@ tbuild
 TCP
 tcp
 tdload
+teamless
 teardown
 teardowns
 templatable
@@ -1746,6 +1747,7 @@ unpaused
 unpausing
 unpredicted
 unsanitized
+unscoped
 untestable
 untransformed
 untrusted


### PR DESCRIPTION
Create documentation for the new feature team-based asset event filtering as described in [AIP-67](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=294816378#AIP67MultiteamdeploymentofAirflowcomponents-Datasettriggeringaccesscontrol).

You can also see the generated documentation as PDF here:

[Asset Definitions](https://github.com/user-attachments/assets/395acda0-506b-45f8-b139-698c51806933)
[Multi-Team](https://github.com/user-attachments/assets/717dc32b-492c-4fad-ad9c-0d0011793216)

Here is the description of the feature as described in the AIP:
> While any DAG can produce events that are related to any data assets, the DAGs consuming the data assets will - by default - only receive events that are triggered in the same team or by an API call from a user that is recognized to belong to the same team by Auth Manager. DAG authors could specify a list of teams that should additionally be allowed to trigger the DAG (joined by the URI of the Data Asset) by adding a new asset parameter and the triggering will happend. Also this AIP depends on AIP-73 - Expanded Data Awareness - and the exact approach will piggiback on deailed implementation of Data ASsets. `allow_triggering_by_teams = [ "team1", "team2" ]`

I'll leave this PR open in draft while working on the feature. The goal is to merge this PR once the feature is implemented.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Kiro (Claude)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
