### PR TITLE
Fix DAG version inflation caused by unstable DagParam repr

### DIFF
--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -71,21 +71,27 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
             return tuple(sort_dict_recursively(item) for item in obj)
         return obj
 
+    def handle_not_jsonable_object(obj: Any) -> Any:
+        try:
+            return obj.serialize()
+        except AttributeError:
+            if callable(obj):
+                full_qualified_name = qualname(obj, True)
+                return f"<callable {full_qualified_name}>"
+            return str(obj)
+
     max_length = conf.getint("core", "max_templated_field_length")
 
     if not is_jsonable(template_field):
-        try:
-            serialized = template_field.serialize()
-        except AttributeError:
-            if callable(template_field):
-                full_qualified_name = qualname(template_field, True)
-                serialized = f"<callable {full_qualified_name}>"
-            else:
-                serialized = str(template_field)
-        if len(serialized) > max_length:
-            rendered = redact(serialized, name)
+        if isinstance(template_field, (list, tuple)):
+            not_jsonable_serialized = [handle_not_jsonable_object(item) for item in template_field]
+        else:
+            not_jsonable_serialized = handle_not_jsonable_object(template_field)
+        if len(str(not_jsonable_serialized)) > max_length:
+            rendered = redact(not_jsonable_serialized, name)
             return truncate_rendered_value(str(rendered), max_length)
-        return serialized
+        return not_jsonable_serialized
+
     if not template_field and not isinstance(template_field, tuple):
         # Avoid unnecessary serialization steps for empty fields unless they are tuples
         # and need to be converted to lists
@@ -95,9 +101,9 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     # This prevents hash inconsistencies when dict ordering varies
     if isinstance(template_field, dict):
         template_field = sort_dict_recursively(template_field)
-    serialized = str(template_field)
-    if len(serialized) > max_length:
-        rendered = redact(serialized, name)
+    jsonable_serialized = str(template_field)
+    if len(jsonable_serialized) > max_length:
+        rendered = redact(jsonable_serialized, name)
         return truncate_rendered_value(str(rendered), max_length)
     return template_field
 

--- a/airflow-core/tests/unit/dags/test_dag_decorator_version.py
+++ b/airflow-core/tests/unit/dags/test_dag_decorator_version.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.sdk import dag, task, task_group
+
+
+@dag(
+    dag_id="TEST_DTM",
+    dag_display_name="TEST DTM",
+    schedule=None,
+    default_args={"owner": "airflow", "email": ""},
+    start_date=datetime(2024, 1, 25),
+)
+def dtm_test(
+    exponent: int = 2,
+):
+
+    @task
+    def get_data():
+        return [20, 100, 200, 222, 242, 272]
+
+    @task
+    def to_exp(number: int, exponent: int) -> float:
+        return number**exponent
+
+    @task
+    def trunc(number: float, digits: int) -> float:
+        return round(number / 22, digits)
+
+    @task
+    def save(number: list[float]):
+        for n in number:
+            print(f"Got number: {n}")
+
+    @task_group  # type: ignore[type-var]
+    def transform(number: int, exponent: int) -> float:
+        a = to_exp(number, exponent)
+        b = trunc(a, 2)
+        return b
+
+    data = get_data()
+    result = transform.partial(exponent=exponent).expand(number=data)
+    save(result)  # type: ignore[arg-type]
+
+
+instance = dtm_test()

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -114,6 +114,7 @@ from tests_common.test_utils.timetables import (
     cron_timetable,
     delta_timetable,
 )
+from unit.models import TEST_DAGS_FOLDER
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
@@ -701,6 +702,16 @@ class TestStringifiedDAGs:
         # Verify deserialized DAGs.
         for dag_id in stringified_dags:
             self.validate_deserialized_dag(stringified_dags[dag_id], dags[dag_id])
+
+    @conf_vars({("core", "load_examples"): "false"})
+    def test_reserialize_should_make_equal_hash_with_dag_processor(self):
+        dagbag1 = DagBag(TEST_DAGS_FOLDER / "test_dag_decorator_version.py")
+        result1 = DagSerialization.to_dict(next(iter(dagbag1.dags.values())))
+
+        dagbag2 = DagBag(TEST_DAGS_FOLDER / "test_dag_decorator_version.py")
+        result2 = DagSerialization.to_dict(next(iter(dagbag2.dags.values())))
+
+        assert json.dumps(result1) == json.dumps(result2)
 
     @skip_if_force_lowest_dependencies_marker
     @pytest.mark.db_test

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -82,6 +82,7 @@ from airflow.serialization.json_schema import load_dag_schema_dict
 from airflow.serialization.serialized_objects import (
     BaseSerialization,
     DagSerialization,
+    LazyDeserializedDAG,
     OperatorSerialization,
     _XComRef,
 )
@@ -706,12 +707,12 @@ class TestStringifiedDAGs:
     @conf_vars({("core", "load_examples"): "false"})
     def test_reserialize_should_make_equal_hash_with_dag_processor(self):
         dagbag1 = DagBag(TEST_DAGS_FOLDER / "test_dag_decorator_version.py")
-        result1 = DagSerialization.to_dict(next(iter(dagbag1.dags.values())))
+        hash_result1 = LazyDeserializedDAG.from_dag(next(iter(dagbag1.dags.values()))).hash
 
         dagbag2 = DagBag(TEST_DAGS_FOLDER / "test_dag_decorator_version.py")
-        result2 = DagSerialization.to_dict(next(iter(dagbag2.dags.values())))
+        hash_result2 = LazyDeserializedDAG.from_dag(next(iter(dagbag2.dags.values()))).hash
 
-        assert json.dumps(result1) == json.dumps(result2)
+        assert hash_result1 == hash_result2
 
     @skip_if_force_lowest_dependencies_marker
     @pytest.mark.db_test

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -359,6 +359,22 @@ class DagParam(ResolveMixin):
 
         return cls(current_dag=current_dag, name=data["name"], default=data["default"])
 
+    def __repr__(self) -> str:
+        return json.dumps(
+            {
+                "dag_id": self.current_dag.dag_id,
+                "name": self._name,
+            }
+        )
+
+    def __str__(self) -> str:
+        return json.dumps(
+            {
+                "dag_id": self.current_dag.dag_id,
+                "name": self._name,
+            }
+        )
+
 
 def process_params(
     dag: DAG,

--- a/task-sdk/src/airflow/sdk/definitions/param.py
+++ b/task-sdk/src/airflow/sdk/definitions/param.py
@@ -359,22 +359,6 @@ class DagParam(ResolveMixin):
 
         return cls(current_dag=current_dag, name=data["name"], default=data["default"])
 
-    def __repr__(self) -> str:
-        return json.dumps(
-            {
-                "dag_id": self.current_dag.dag_id,
-                "name": self._name,
-            }
-        )
-
-    def __str__(self) -> str:
-        return json.dumps(
-            {
-                "dag_id": self.current_dag.dag_id,
-                "name": self._name,
-            }
-        )
-
 
 def process_params(
     dag: DAG,


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/65674

In `serailized_dag`, `op_args` of task_id `transform.to_exp` is changed in every parsing, because `DagParam` has no stringfy function
```
"op_args": "(MappedArgument(_input=DictOfListsExpandInput(value={'number': XComArg(<Task(_PythonDecoratedOperator): get_data>)}), _key='number'), <airflow.sdk.definitions.param.DagParam object at 0xf96d2cd44a60>)",
``` 

The `template_field` ends up as a tuple, but since it contains an object type, `is_jsonable` returns False. Because tuple has no serialize path, execution falls into [this logic](https://github.com/wjddn279/airflow/blob/main/airflow-core/src/airflow/serialization/helpers.py#L84), and the plain string conversion embeds the raw object representation (including its id), which is highly likely to cause Dag inflation.

I means the logic needs to be modified to handle the case not `is_jsonable` but list, tuple, dict type like this https://github.com/apache/airflow/pull/63871

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
