### PR TITLE
Fix memory growth from pathlib sys.intern in long-running processes

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -60,6 +60,36 @@ JWT_PATTERN = re.compile(r"eyJ[\.A-Za-z0-9-_]*")
 LEVEL_TO_FILTERING_LOGGER: dict[int, type[Logger]] = {}
 
 
+class _PatchedPath(Path):
+    """
+    Backport of Python 3.14's ``PurePath._parse_path`` without ``sys.intern``.
+
+    The ``sys.intern`` call in the stock ``_parse_path`` causes memory
+    to grow unboundedly in long-running processes. Upstream removed it
+    in Python 3.14 (https://github.com/python/cpython/issues/119518);
+    this class applies the same fix for earlier versions.
+    """
+
+    @classmethod
+    def _parse_path(cls, path: str) -> tuple[str, str, list[str]]:
+        if not path:
+            return "", "", []
+        sep = os.path.sep
+        altsep = os.path.altsep
+        if altsep:
+            path = path.replace(altsep, sep)
+        drv, root, rel = os.path.splitroot(path)
+        if not root and drv.startswith(sep) and not drv.endswith(sep):
+            drv_parts = drv.split(sep)
+            if len(drv_parts) == 4 and drv_parts[2] not in "?.":
+                # e.g. //server/share
+                root = sep
+            elif len(drv_parts) == 6:
+                # e.g. //?/unc/server/share
+                root = sep
+        return drv, root, [x for x in rel.split(sep) if x and x != "."]
+
+
 def _make_airflow_structlogger(min_level):
     # This uses https://github.com/hynek/structlog/blob/2f0cc42d/src/structlog/_native.py#L126
     # as inspiration
@@ -717,8 +747,8 @@ def init_log_folder(directory: str | os.PathLike[str], new_folder_permissions: i
     sure that the same group is set as default group for both - impersonated user and main airflow
     user.
     """
-    directory = Path(directory)
-    for parent in reversed(Path(directory).parents):
+    directory = _PatchedPath(directory)
+    for parent in reversed(_PatchedPath(directory).parents):
         parent.mkdir(mode=new_folder_permissions, exist_ok=True)
     directory.mkdir(mode=new_folder_permissions, exist_ok=True)
 
@@ -737,7 +767,7 @@ def init_log_file(
 
     See above ``init_log_folder`` method for more detailed explanation.
     """
-    full_path = Path(base_log_folder, local_relative_path)
+    full_path = _PatchedPath(base_log_folder, local_relative_path)
     init_log_folder(full_path.parent, new_folder_permissions)
 
     try:

--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -60,34 +60,42 @@ JWT_PATTERN = re.compile(r"eyJ[\.A-Za-z0-9-_]*")
 LEVEL_TO_FILTERING_LOGGER: dict[int, type[Logger]] = {}
 
 
-class _PatchedPath(Path):
-    """
-    Backport of Python 3.14's ``PurePath._parse_path`` without ``sys.intern``.
+# ``_parse_path`` was introduced in Python 3.12; older versions use a different
+# parsing path (``_flavour.parse_parts``) that does not call ``sys.intern``,
+# so the patch is neither necessary nor applicable there.
+if (3, 12) <= sys.version_info < (3, 14):
 
-    The ``sys.intern`` call in the stock ``_parse_path`` causes memory
-    to grow unboundedly in long-running processes. Upstream removed it
-    in Python 3.14 (https://github.com/python/cpython/issues/119518);
-    this class applies the same fix for earlier versions.
-    """
+    class _PatchedPath(Path):
+        """
+        Backport of Python 3.14's ``PurePath._parse_path`` without ``sys.intern``.
 
-    @classmethod
-    def _parse_path(cls, path: str) -> tuple[str, str, list[str]]:
-        if not path:
-            return "", "", []
-        sep = os.path.sep
-        altsep = os.path.altsep
-        if altsep:
-            path = path.replace(altsep, sep)
-        drv, root, rel = os.path.splitroot(path)
-        if not root and drv.startswith(sep) and not drv.endswith(sep):
-            drv_parts = drv.split(sep)
-            if len(drv_parts) == 4 and drv_parts[2] not in "?.":
-                # e.g. //server/share
-                root = sep
-            elif len(drv_parts) == 6:
-                # e.g. //?/unc/server/share
-                root = sep
-        return drv, root, [x for x in rel.split(sep) if x and x != "."]
+        The ``sys.intern`` call in the stock ``_parse_path`` causes memory
+        to grow unboundedly in long-running processes. Upstream removed it
+        in Python 3.14 (https://github.com/python/cpython/issues/119518);
+        this class applies the same fix for earlier versions.
+        """
+
+        @classmethod
+        def _parse_path(cls, path: str) -> tuple[str, str, list[str]]:
+            if not path:
+                return "", "", []
+            sep = os.path.sep
+            altsep = os.path.altsep
+            if altsep:
+                path = path.replace(altsep, sep)
+            drv, root, rel = os.path.splitroot(path)
+            if not root and drv.startswith(sep) and not drv.endswith(sep):
+                drv_parts = drv.split(sep)
+                if len(drv_parts) == 4 and drv_parts[2] not in "?.":
+                    # e.g. //server/share
+                    root = sep
+                elif len(drv_parts) == 6:
+                    # e.g. //?/unc/server/share
+                    root = sep
+            return drv, root, [x for x in rel.split(sep) if x and x != "."]
+
+else:
+    _PatchedPath = Path  # type: ignore[misc, assignment]
 
 
 def _make_airflow_structlogger(min_level):

--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -62,8 +62,11 @@ LEVEL_TO_FILTERING_LOGGER: dict[int, type[Logger]] = {}
 
 # ``_parse_path`` was introduced in Python 3.12; older versions use a different
 # parsing path (``_flavour.parse_parts``) that does not call ``sys.intern``,
-# so the patch is neither necessary nor applicable there.
-if (3, 12) <= sys.version_info < (3, 14):
+# so the patch is neither necessary nor applicable there. Python 3.14 removed
+# the ``sys.intern`` call upstream, so the patch is unnecessary there too.
+if sys.version_info < (3, 12) or sys.version_info >= (3, 14):
+    _PatchedPath = Path  # type: ignore[misc, assignment]
+else:
 
     class _PatchedPath(Path):
         """
@@ -93,9 +96,6 @@ if (3, 12) <= sys.version_info < (3, 14):
                     # e.g. //?/unc/server/share
                     root = sep
             return drv, root, [x for x in rel.split(sep) if x and x != "."]
-
-else:
-    _PatchedPath = Path  # type: ignore[misc, assignment]
 
 
 def _make_airflow_structlogger(min_level):


### PR DESCRIPTION
### Problem?
After patching for https://github.com/apache/airflow/pull/65121, I found the memory growth in `parsed = [sys.intern(str(x)) for x in rel.split(sep) if x and x != '.']` statement in python Path library.
[memray-flamegraph-output-2026-04-12.13.14.12.556546.html](https://github.com/user-attachments/files/26998263/memray-flamegraph-output-2026-04-12.13.14.12.556546.html)


### Cause?
`pathlib.PurePath._parse_path` calls `sys.intern` on every path component. In long-running Airflow processes (scheduler, dag-processor, triggerer, workers) each task run produces log paths containing unique identifiers (dag_id, run_id, task_id, try_number), and those interned components accumulate in the interpreter's intern dict for the lifetime of the process. 

### Solution?

The exactly same issue was reported in python issue (https://github.com/python/cpython/issues/119518). Python 3.14 removes the interning call from _parse_path entirely (https://github.com/python/cpython/pull/123356), but Airflow supports earlier versions. This PR backports the 3.14 parsing logic as a small Path subclass (_PatchedPath) and routes log-folder/log-file initialization through it, so path components can be garbage-collected as ordinary mortal strings.

After applying this change and https://github.com/apache/airflow/pull/65121, I confirmed that all memory leaks under the local executor are gone. This improvement should also carry over to other components that rely on logging (e.g. dag-processor, celery executor).
[memray-flamegraph-output-2026-04-17 08:12:02.069120.html](https://github.com/user-attachments/files/26998430/memray-flamegraph-output-2026-04-17.08.12.02.069120.html)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
