### PR TITLE
Remove stray ellipsis from Plugin Management Interface docs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -173,8 +173,6 @@ Plugin Management Interface
 Airflow 3.1 introduces a Plugin Management Interface, available under *Admin → Plugins* in the Airflow UI.
 This page allows you to view installed plugins.
 
-...
-
 External Views
 --------------
 


### PR DESCRIPTION
The "Plugin Management Interface" section in `plugins.rst` contains a stray `...` on its own line.
This renders as literal text (`…`) on the published documentation and serves no purpose. This PR removes it.

closes: #65713

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)