### PR TITLE
Skip S3 folder-marker keys in S3ToGCSOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -206,12 +206,41 @@ class S3ToGCSOperator(S3ListOperator):
         gcs_bucket, _ = _parse_gcs_url(self.dest_gcs)
         return [f"gs://{gcs_bucket}/{self.s3_to_gcs_object(s3_object=k)}" for k in s3_keys]
 
+    @staticmethod
+    def _strip_overlapping_folder_markers(keys: list[str]) -> tuple[list[str], list[str]]:
+        """
+        Drop trailing-slash keys that are strict prefixes of other listed keys.
+
+        Treated as S3 directory markers. A lone trailing-slash key with no overlap
+        (e.g. ``lonely/``) is preserved, and a non-slash key that happens to be a
+        strict prefix of another (e.g. ``abc`` of ``abcdef``) is also preserved.
+        Returns ``(kept, dropped)``.
+        """
+        if not keys:
+            return [], []
+        ordered = sorted(set(keys))
+        kept: list[str] = []
+        dropped: list[str] = []
+        for current, nxt in zip(ordered, ordered[1:]):
+            if current.endswith("/") and nxt.startswith(current):
+                dropped.append(current)
+            else:
+                kept.append(current)
+        kept.append(ordered[-1])
+        return kept, dropped
+
     def _get_files(self, context: Context, gcs_hook: GCSHook) -> list[str]:
         # use the super method to list all the files in an S3 bucket/key
         s3_objects = super().execute(context)
 
-        # Skip S3 folder-marker keys (``.../``); they overlap sibling keys in Storage Transfer includePrefixes.
-        s3_objects = [obj for obj in s3_objects if not obj.endswith("/")]
+        s3_objects, dropped_overlap_keys = self._strip_overlapping_folder_markers(s3_objects)
+        if dropped_overlap_keys:
+            self.log.info(
+                "Skipping %s S3 folder-marker key(s) overlapping listed objects "
+                "(omitted from transfer and XCom output): %s",
+                len(dropped_overlap_keys),
+                dropped_overlap_keys,
+            )
 
         if not self.replace:
             s3_objects = self.exclude_existing_objects(s3_objects=s3_objects, gcs_hook=gcs_hook)

--- a/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/s3_to_gcs.py
@@ -210,6 +210,9 @@ class S3ToGCSOperator(S3ListOperator):
         # use the super method to list all the files in an S3 bucket/key
         s3_objects = super().execute(context)
 
+        # Skip S3 folder-marker keys (``.../``); they overlap sibling keys in Storage Transfer includePrefixes.
+        s3_objects = [obj for obj in s3_objects if not obj.endswith("/")]
+
         if not self.replace:
             s3_objects = self.exclude_existing_objects(s3_objects=s3_objects, gcs_hook=gcs_hook)
 

--- a/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
@@ -551,6 +551,24 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
         mock_create_transfer_job.assert_called()
         assert job_names == expected_job_names
 
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_execute_skips_s3_folder_markers(self, gcs_mock_hook, s3_mock_hook):
+        """Keys ending with ``/`` are omitted (S3 folder markers; break deferrable includePrefixes)."""
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            return_gcs_uris=True,
+        )
+        operator.hook = mock.MagicMock()
+        operator.hook.list_keys.return_value = ["test/", "test/airflow.png"]
+
+        assert operator.execute(context={}) == [f"gs://{GCS_BUCKET}/{GCS_PREFIX}test/airflow.png"]
+
     @mock.patch(
         "airflow.providers.google.cloud.transfers.s3_to_gcs.S3ToGCSOperator.log", new_callable=PropertyMock
     )

--- a/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_s3_to_gcs.py
@@ -551,10 +551,40 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
         mock_create_transfer_job.assert_called()
         assert job_names == expected_job_names
 
+    @pytest.mark.parametrize(
+        ("keys", "expected_kept", "expected_dropped"),
+        [
+            # Empty / single / no-overlap listings keep everything as is.
+            ([], [], []),
+            (["a"], ["a"], []),
+            (["a", "b"], ["a", "b"], []),
+            # Non-slash prefix overlaps must NOT be treated as folder markers.
+            (["a", "ax"], ["a", "ax"], []),
+            (["a", "ax", "ay"], ["a", "ax", "ay"], []),
+            (["abc", "abcdef"], ["abc", "abcdef"], []),
+            # Slash-suffixed keys overlapping a sibling are folder markers and dropped.
+            (["foo/", "foo/bar.txt"], ["foo/bar.txt"], ["foo/"]),
+            (
+                ["data/", "data/sub/", "data/sub/file.txt"],
+                ["data/sub/file.txt"],
+                ["data/", "data/sub/"],
+            ),
+            # A lone trailing-slash key with no overlap is a real object and stays.
+            (["lonely/"], ["lonely/"], []),
+            (["lonely/", "report.csv"], ["lonely/", "report.csv"], []),
+        ],
+    )
+    def test_strip_overlapping_folder_markers(self, keys, expected_kept, expected_dropped):
+        """Folder-marker detection: requires both strict-prefix overlap AND trailing slash."""
+        kept, dropped = S3ToGCSOperator._strip_overlapping_folder_markers(keys)
+        assert kept == expected_kept
+        assert dropped == expected_dropped
+
     @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
     @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
-    def test_execute_skips_s3_folder_markers(self, gcs_mock_hook, s3_mock_hook):
-        """Keys ending with ``/`` are omitted (S3 folder markers; break deferrable includePrefixes)."""
+    def test_execute_skips_overlapping_folder_markers_in_deferrable_xcom(self, mock_gcs_hook, mock_s3_hook):
+        """Deferrable: overlapping folder markers are dropped from both STS transfer and XCom output."""
+        mock_gcs_hook.project_id = PROJECT_ID
         operator = S3ToGCSOperator(
             task_id=TASK_ID,
             bucket=S3_BUCKET,
@@ -562,12 +592,121 @@ class TestS3ToGoogleCloudStorageOperatorDeferrable:
             delimiter=S3_DELIMITER,
             gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX,
+            deferrable=True,
+            replace=True,
             return_gcs_uris=True,
         )
         operator.hook = mock.MagicMock()
-        operator.hook.list_keys.return_value = ["test/", "test/airflow.png"]
+        operator.hook.list_keys.return_value = ["foo/", "foo/bar.txt", "lonely/"]
 
-        assert operator.execute(context={}) == [f"gs://{GCS_BUCKET}/{GCS_PREFIX}test/airflow.png"]
+        with mock.patch.object(operator, "submit_transfer_jobs") as mock_submit_transfer_jobs:
+            mock_submit_transfer_jobs.return_value = [TRANSFER_JOB_ID_0]
+            with pytest.raises(TaskDeferred) as exception_info:
+                operator.execute(context={})
+
+        # ``foo/`` is a strict prefix of ``foo/bar.txt`` and is treated as a folder marker, so it
+        # is omitted from the STS transfer, the trigger payload, and the XCom return. ``lonely/``
+        # has no overlap and is preserved everywhere.
+        expected_keys = ["foo/bar.txt", "lonely/"]
+        mock_submit_transfer_jobs.assert_called_once()
+        assert mock_submit_transfer_jobs.call_args.kwargs["files"] == expected_keys
+        assert exception_info.value.trigger.files == expected_keys
+
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_execute_skips_overlapping_folder_markers_in_non_deferrable_xcom(
+        self, mock_gcs_hook, mock_s3_hook
+    ):
+        """Non-deferrable: overlapping folder markers are dropped from per-object transfer and XCom."""
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            replace=True,
+            return_gcs_uris=True,
+        )
+        operator.hook = mock.MagicMock()
+        operator.hook.list_keys.return_value = ["data/snapshot/", "data/snapshot/file.txt"]
+
+        with mock.patch.object(operator, "transfer_files") as mock_transfer_files:
+            result = operator.execute(context={})
+
+        # ``data/snapshot/`` is a strict prefix of ``data/snapshot/file.txt`` so it's treated as a
+        # folder marker and skipped. Only the real object is transferred and reported via XCom.
+        mock_transfer_files.assert_called_once()
+        assert mock_transfer_files.call_args.args[0] == ["data/snapshot/file.txt"]
+        assert result == [f"gs://{GCS_BUCKET}/{GCS_PREFIX}data/snapshot/file.txt"]
+
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_execute_keeps_real_slash_suffixed_keys(self, mock_gcs_hook, mock_s3_hook):
+        """Real S3 objects whose keys end with ``/`` and have no sibling overlap survive.
+
+        Regression for the reviewer's concern: S3 permits trailing-slash object names, so a lone
+        ``key/`` with no other listed key under that prefix is *not* a folder marker and must keep
+        its place in both the transfer call and the XCom payload.
+        """
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            replace=True,
+            return_gcs_uris=True,
+        )
+        operator.hook = mock.MagicMock()
+        operator.hook.list_keys.return_value = ["lonely/", "report.csv"]
+
+        with mock.patch.object(operator, "transfer_files") as mock_transfer_files:
+            result = operator.execute(context={})
+
+        mock_transfer_files.assert_called_once()
+        assert sorted(mock_transfer_files.call_args.args[0]) == ["lonely/", "report.csv"]
+        assert sorted(result) == sorted(
+            [
+                f"gs://{GCS_BUCKET}/{GCS_PREFIX}lonely/",
+                f"gs://{GCS_BUCKET}/{GCS_PREFIX}report.csv",
+            ]
+        )
+
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.S3Hook")
+    @mock.patch("airflow.providers.google.cloud.transfers.s3_to_gcs.GCSHook")
+    def test_execute_keeps_non_slash_prefix_overlaps(self, mock_gcs_hook, mock_s3_hook):
+        """Non-slash keys that happen to be a strict prefix of another key are NOT folder markers.
+
+        Folder-marker detection requires both a strict-prefix overlap AND a trailing slash. Random
+        prefix relationships between regular object keys (e.g. opaque keys sharing a binary prefix)
+        must be left alone in both the transfer path and the XCom output.
+        """
+        operator = S3ToGCSOperator(
+            task_id=TASK_ID,
+            bucket=S3_BUCKET,
+            prefix=S3_PREFIX,
+            delimiter=S3_DELIMITER,
+            gcp_conn_id=GCS_CONN_ID,
+            dest_gcs=GCS_PATH_PREFIX,
+            replace=True,
+            return_gcs_uris=True,
+        )
+        operator.hook = mock.MagicMock()
+        operator.hook.list_keys.return_value = ["abc", "abcdef"]
+
+        with mock.patch.object(operator, "transfer_files") as mock_transfer_files:
+            result = operator.execute(context={})
+
+        mock_transfer_files.assert_called_once()
+        assert sorted(mock_transfer_files.call_args.args[0]) == ["abc", "abcdef"]
+        assert sorted(result) == sorted(
+            [
+                f"gs://{GCS_BUCKET}/{GCS_PREFIX}abc",
+                f"gs://{GCS_BUCKET}/{GCS_PREFIX}abcdef",
+            ]
+        )
 
     @mock.patch(
         "airflow.providers.google.cloud.transfers.s3_to_gcs.S3ToGCSOperator.log", new_callable=PropertyMock


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

`S3ToGCSOperator` now drops S3 keys that end with `/`.

## Problem
1. Listing objects for a given bucket and prefix (e.g. folder_name/) can return trailing-`/` keys. Previously they were included in execute's return value and XCom (`gs://…/folder_name/`).
2. With deferrable=True, that list is sent to Storage Transfer as includePrefixes. A key like `folder_name/` is a strict prefix of keys such as `folder_name/file.txt`, which the API rejects with HTTP 400 (overlapping include prefixes).

## Solution
- Omit keys ending with `/` from the list used for transfer and for execute.
- This matches typical S3 folder placeholders; ordinary data object keys rarely end with `/`.

## Screenshots
### Before
Trailing `/` in XCom
<img width="1024" height="302" alt="image" src="https://github.com/user-attachments/assets/5187be7c-fd27-4a8a-b8c3-283ac83b4ea2" />

Deferrable / Storage Transfer includePrefixes error
<img width="1038" height="332" alt="image" src="https://github.com/user-attachments/assets/70041802-167f-42a9-86f4-660e45a7fd3f" />

### After
No trailing `/` in XCom
<img width="1169" height="344" alt="image" src="https://github.com/user-attachments/assets/b9d3252d-6958-46a3-a53b-90db75a0894b" />

Deferrable run succeeds
<img width="1174" height="242" alt="image" src="https://github.com/user-attachments/assets/ccd83fad-2bd8-459a-b03b-287ba3e41893" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Cursor

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
