### PR TITLE
Fix GenAIGenerativeModelHook ignoring Airflow connection credentials

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/gen_ai.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gen_ai.py
@@ -73,6 +73,7 @@ class GenAIGenerativeModelHook(GoogleBaseHook):
             vertexai=True,
             project=project_id,
             location=location,
+            credentials=self.get_credentials(),
         )
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/providers/google/tests/unit/google/cloud/hooks/test_gen_ai.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gen_ai.py
@@ -134,6 +134,21 @@ class TestGenAIGenerativeModelHookWithDefaultProjectId:
             self.hook = GenAIGenerativeModelHook(gcp_conn_id=TEST_GCP_CONN_ID)
             self.hook.get_credentials = self.dummy_get_credentials
 
+    @mock.patch("google.genai.Client")
+    def test_get_genai_client_passes_connection_credentials(self, mock_client) -> None:
+        """get_genai_client must pass Airflow connection credentials to genai.Client, not fall back to ADC."""
+        mock_credentials = mock.Mock()
+        self.hook.get_credentials = mock.Mock(return_value=mock_credentials)
+
+        self.hook.get_genai_client(project_id=GCP_PROJECT, location=GCP_LOCATION)
+
+        mock_client.assert_called_once_with(
+            vertexai=True,
+            project=GCP_PROJECT,
+            location=GCP_LOCATION,
+            credentials=mock_credentials,
+        )
+
     @mock.patch(GENERATIVE_MODEL_STRING.format("GenAIGenerativeModelHook.get_genai_client"))
     def test_text_embedding_model_get_embeddings(self, mock_get_client) -> None:
         client_mock = mock_get_client.return_value


### PR DESCRIPTION
## Description

`GenAIGenerativeModelHook.get_genai_client()` constructs a `genai.Client` without passing credentials, causing it to fall back to Application Default Credentials (ADC) even when `gcp_conn_id` is set to an explicit service-account connection. Users in environments without ADC (e.g. Docker containers, on-premise) receive `DefaultCredentialsError` at runtime.

The fix passes `self.get_credentials()` to `genai.Client`, which is the same pattern used by every other Google provider hook (GCS, BigQuery, Vertex AI, etc.).

Fixes #65709

## Changes

- `providers/google/src/airflow/providers/google/cloud/hooks/gen_ai.py`: Pass `credentials=self.get_credentials()` to `genai.Client` in `GenAIGenerativeModelHook.get_genai_client()`.
- `providers/google/tests/unit/google/cloud/hooks/test_gen_ai.py`: Add `test_get_genai_client_passes_connection_credentials` to assert credentials from the connection are forwarded to the client.

## Root Cause

```python
# Before — credentials omitted, ADC used regardless of gcp_conn_id
def get_genai_client(self, project_id: str, location: str):
    return genai.Client(
        vertexai=True,
        project=project_id,
        location=location,
    )

# After — honours the configured Airflow connection
def get_genai_client(self, project_id: str, location: str):
    return genai.Client(
        vertexai=True,
        project=project_id,
        location=location,
        credentials=self.get_credentials(),
    )
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes Claude

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.