### PR TITLE
Add is_docker_available helper for silent Docker checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -1017,6 +1017,28 @@ def _is_backend_container_unhealthy(project_name: str, backend: str) -> bool:
 
     return False
 
+def is_docker_available() -> bool:
+    """
+    Check whether Docker is installed and running on the host.
+
+    Returns True if ``docker info`` exits successfully, False otherwise.
+    Unlike :func:`check_docker_is_running`, this function does not print
+    any console output or call ``sys.exit`` — it is safe to call as a
+    simple boolean guard.
+    """
+    try:
+        response = run_command(
+            ["docker", "info"],
+            no_output_dump_on_exception=True,
+            capture_output=True,
+            check=False,
+            text=True,
+            quiet=True,
+        )
+        return response.returncode == 0
+    except FileNotFoundError:
+        # docker binary is not installed
+        return False
 
 def is_docker_rootless() -> bool:
     try:


### PR DESCRIPTION
What does this PR do?

Adds is_docker_available() to dev/breeze/src/airflow_breeze/utils/docker_command_utils.py.

The existing check_docker_is_running() prints console output and calls sys.exit(1) on failure, making it unsuitable as a silent boolean guard.

The new helper returns True/False without side effects, following the same pattern as is_docker_rootless().

Handles three cases:

* Docker running → True
* Docker installed but not running → False
* Docker not installed → False (via FileNotFoundError)

Was generative AI tooling used to co-author this PR?

* [yes ] Yes

Checklist

* No newsfragment needed (internal Breeze utility, not user-facing)
* No docs update needed