### PR TITLE
Fix FAB password hashing to respect FAB_PASSWORD_HASH_METHOD config

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -549,6 +549,10 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         jwt_manager.init_app(current_app)
         jwt_manager.user_lookup_loader(self.load_user_jwt)
 
+    def _hash_password(self, password: str) -> str:
+        method = current_app.config.get("FAB_PASSWORD_HASH_METHOD", "scrypt")
+        return generate_password_hash(password, method=method)
+
     def reset_password(self, userid: int, password: str) -> bool:
         """
         Change/Reset a user's password for auth db.
@@ -561,7 +565,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         user = self.get_user_by_id(userid)
         if not user:
             return False
-        user.password = generate_password_hash(password)
+        user.password = self._hash_password(password)
         self.reset_user_sessions(user)
         return self.update_user(user)
 
@@ -1404,7 +1408,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             if hashed_password:
                 user.password = hashed_password
             else:
-                user.password = generate_password_hash(password)
+                user.password = self._hash_password(password)
             self.session.commit()
             log.info(const.LOGMSG_INF_SEC_ADD_USER, username)
 
@@ -1448,7 +1452,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         if hashed_password:
             register_user.password = hashed_password
         else:
-            register_user.password = generate_password_hash(password)
+            register_user.password = self._hash_password(password)
         register_user.registration_hash = str(uuid.uuid1())
         try:
             self.session.add(register_user)

--- a/providers/fab/tests/unit/fab/auth_manager/test_security.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_security.py
@@ -1208,3 +1208,61 @@ def test_users_can_be_found(app, security_manager, session, caplog):
     assert len(users) == 1 + prior_user_count
     delete_user(app, "Test_cbf")
     assert "Error adding new user to database" in caplog.text
+
+
+OVERRIDE_STRING = "airflow.providers.fab.auth_manager.security_manager.override.{}"
+
+
+@mock.patch(OVERRIDE_STRING.format("generate_password_hash"))
+def test_hash_password_uses_fab_password_hash_method(mock_hash, app, security_manager):
+    """_hash_password must forward FAB_PASSWORD_HASH_METHOD from app config to generate_password_hash."""
+    with app.test_request_context():
+        with mock.patch.dict(app.config, {"FAB_PASSWORD_HASH_METHOD": "pbkdf2:sha256"}):
+            security_manager._hash_password("mypassword")
+            mock_hash.assert_called_once_with("mypassword", method="pbkdf2:sha256")
+
+
+@mock.patch(OVERRIDE_STRING.format("generate_password_hash"))
+def test_hash_password_defaults_to_scrypt_when_config_absent(mock_hash, app, security_manager):
+    """_hash_password falls back to scrypt when FAB_PASSWORD_HASH_METHOD is not in config."""
+    with app.test_request_context():
+        with mock.patch.dict(app.config, {}, clear=False) as cfg:
+            cfg.pop("FAB_PASSWORD_HASH_METHOD", None)
+            security_manager._hash_password("mypassword")
+            mock_hash.assert_called_once_with("mypassword", method="scrypt")
+
+
+def test_reset_password_uses_configured_hash_method(app, security_manager):
+    """reset_password must use FAB_PASSWORD_HASH_METHOD, not werkzeug's default."""
+    try:
+        user = create_user(app, "hash_method_reset_test")
+        with app.test_request_context():
+            with mock.patch.dict(app.config, {"FAB_PASSWORD_HASH_METHOD": "pbkdf2:sha256"}):
+                with mock.patch(
+                    OVERRIDE_STRING.format("generate_password_hash"), return_value="hashed_pw"
+                ) as mock_hash:
+                    security_manager.reset_password(user.id, "newpassword")
+                mock_hash.assert_called_with("newpassword", method="pbkdf2:sha256")
+    finally:
+        delete_user(app, "hash_method_reset_test")
+
+
+@mock.patch(OVERRIDE_STRING.format("generate_password_hash"))
+def test_add_user_uses_configured_hash_method(mock_hash, app, security_manager):
+    """add_user must use FAB_PASSWORD_HASH_METHOD, not werkzeug's default."""
+    mock_hash.return_value = "hashed_pw"
+    with app.test_request_context():
+        with mock.patch.dict(app.config, {"FAB_PASSWORD_HASH_METHOD": "pbkdf2:sha256"}):
+            role = security_manager.find_role("Admin")
+            try:
+                security_manager.add_user(
+                    username="hash_method_add_test",
+                    first_name="Hash",
+                    last_name="Test",
+                    email="hash_method_add_test@example.com",
+                    role=role,
+                    password="plaintext",
+                )
+                mock_hash.assert_called_with("plaintext", method="pbkdf2:sha256")
+            finally:
+                delete_user(app, "hash_method_add_test")


### PR DESCRIPTION
## Description

`FabAirflowSecurityManagerOverride` contains three bare `generate_password_hash(password)` calls in `reset_password`, `add_user`, and `add_register_user` that ignore the `FAB_PASSWORD_HASH_METHOD` key in the Flask app config. On FIPS-compliant systems, operators set this config to an approved algorithm (e.g. `pbkdf2:sha256`) but the hardcoded calls bypass it, causing authentication failures.

The fix introduces a `_hash_password()` helper that reads `FAB_PASSWORD_HASH_METHOD` from `current_app.config` (defaulting to `scrypt`) and replaces all three call sites.

Fixes #65728

## Changes

- `providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py`: Add `_hash_password(password)` helper; replace 3 bare `generate_password_hash(password)` calls in `reset_password`, `add_user`, and `add_register_user`.
- `providers/fab/tests/unit/fab/auth_manager/test_security.py`: Add 4 tests covering helper config-forwarding, scrypt fallback, and both callers.

## Root Cause

```python
# Before — method hardcoded to werkzeug default, ignores FAB_PASSWORD_HASH_METHOD
user.password = generate_password_hash(password)

# After — reads FAB_PASSWORD_HASH_METHOD from app config
def _hash_password(self, password: str) -> str:
    method = current_app.config.get("FAB_PASSWORD_HASH_METHOD", "scrypt")
    return generate_password_hash(password, method=method)

user.password = self._hash_password(password)
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes Claude

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
