### PR TITLE
Fix DiscordWebhookHook leaking webhook_endpoint as HTTP header

### DIFF
--- a/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
+++ b/providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py
@@ -27,6 +27,8 @@ from airflow.providers.common.compat.connection import get_async_connection
 from airflow.providers.http.hooks.http import HttpAsyncHook, HttpHook
 
 if TYPE_CHECKING:
+    from requests import Session
+
     from airflow.providers.common.compat.sdk import Connection
     from airflow.providers.discord.notifications.embed import Embed
 
@@ -217,6 +219,14 @@ class DiscordWebhookHook(HttpHook):
         if not webhook_endpoint and http_conn_id:
             conn = self.get_connection(http_conn_id)
         return self.handler.get_webhook_endpoint(conn, webhook_endpoint)
+
+    def get_conn(
+        self, headers: dict[Any, Any] | None = None, extra_options: dict[str, Any] | None = None
+    ) -> Session:
+        session = super().get_conn(headers=headers, extra_options=extra_options)
+        # HttpHook promotes leftover extra fields to headers; strip the Discord-specific one.
+        session.headers.pop("webhook_endpoint", None)
+        return session
 
     def execute(self) -> None:
         """Execute the Discord webhook call."""

--- a/providers/discord/tests/unit/discord/hooks/test_discord_webhook.py
+++ b/providers/discord/tests/unit/discord/hooks/test_discord_webhook.py
@@ -204,6 +204,12 @@ class TestDiscordWebhookHook:
         # Then
         assert webhook_endpoint == expected_webhook_endpoint
 
+    def test_get_conn_does_not_leak_webhook_endpoint_as_header(self):
+        """webhook_endpoint in connection extra must not be sent as an HTTP header to Discord."""
+        hook = DiscordWebhookHook(http_conn_id="default-discord-webhook")
+        session = hook.get_conn()
+        assert "webhook_endpoint" not in session.headers
+
 
 class TestDiscordWebhookAsyncHook:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

`DiscordWebhookHook` stores `webhook_endpoint` in the connection's `extra` field (e.g. `{"webhook_endpoint": "webhooks/{id}/{token}"}`). `HttpHook._configure_session_from_extra` promotes all unrecognised extra fields to session headers after extracting known options (proxies, timeout, verify, etc.). As a result, every request to Discord included a spurious `webhook_endpoint` header, which Discord rejects with `400 Bad Request`.

The bug was introduced when `HttpHook` started treating leftover `extra` fields as headers (for generic HTTP auth/session customisation). The Discord hook needs to suppress this for its own connection-specific field.

Fixes #65279

## Changes

- `providers/discord/src/airflow/providers/discord/hooks/discord_webhook.py`: Override `get_conn()` in `DiscordWebhookHook` to pop `webhook_endpoint` from session headers after the parent builds the session.
- `providers/discord/tests/unit/discord/hooks/test_discord_webhook.py`: Add `test_get_conn_does_not_leak_webhook_endpoint_as_header` to assert the header is absent from the session.

## Root Cause

```python
# HttpHook._configure_session_from_extra (http/hooks/http.py)
# After popping stream/cert/proxies/timeout/verify/etc., remaining extra fields
# are added as session headers — including webhook_endpoint from Discord connections.
session.headers.update(conn_extra_options)   # ← sends webhook_endpoint to Discord → 400

# Fix in DiscordWebhookHook
def get_conn(self, headers=None, extra_options=None):
    session = super().get_conn(headers=headers, extra_options=extra_options)
    # webhook_endpoint is a Discord connection field, not an HTTP header.
    session.headers.pop("webhook_endpoint", None)
    return session
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes Claude

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.