### PR TITLE
Fix triggerer supervisor missing server context for secrets backend

### DIFF
--- a/airflow-core/newsfragments/65739.bugfix.rst
+++ b/airflow-core/newsfragments/65739.bugfix.rst
@@ -1,0 +1,1 @@
+Triggerer supervisor now marks itself as a server context so remote-log handlers (e.g. WasbTaskHandler) can read connections from the metastore when shipping per-trigger logs to remote storage.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -206,6 +206,9 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             sys.exit(os.EX_SOFTWARE)
 
     def _execute(self) -> int | None:
+        # Mark this as a server context for secrets backend detection
+        os.environ["_AIRFLOW_PROCESS_CONTEXT"] = "server"
+
         self.log.info("Starting the triggerer")
         self.register_signals()
         stats_factory = stats_utils.get_stats_factory(Stats)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1366,6 +1366,35 @@ class TestTriggererJobRunner:
         call_kwargs = stats_init_mock.call_args.kwargs
         assert "factory" in call_kwargs
 
+    @patch("airflow.jobs.triggerer_job_runner.Stats.initialize")
+    @patch.object(TriggerRunnerSupervisor, "start")
+    def test_execute_marks_process_context_as_server(
+        self, mock_supervisor_start, _stats_init_mock, monkeypatch, session
+    ):
+        """
+        _execute() must set _AIRFLOW_PROCESS_CONTEXT=server so that connection
+        lookups in the supervisor process (e.g. remote log shipping for
+        trigger logs) use the metastore-backed secrets chain instead of the
+        env-vars-only fallback chain.
+        """
+        monkeypatch.delenv("_AIRFLOW_PROCESS_CONTEXT", raising=False)
+        assert "_AIRFLOW_PROCESS_CONTEXT" not in os.environ
+
+        mock_supervisor = MagicMock()
+        mock_supervisor._exit_code = 0  # let _execute return without re-raising
+        mock_supervisor_start.return_value = mock_supervisor
+
+        job = Job()
+        session.add(job)
+        session.flush()
+
+        job_runner = TriggererJobRunner(job)
+
+        with patch.object(job_runner, "register_signals"):
+            job_runner._execute()
+
+        assert os.environ.get("_AIRFLOW_PROCESS_CONTEXT") == "server"
+
 
 class TestTriggererMessageTypes:
     def test_message_types_in_triggerer(self):


### PR DESCRIPTION
<!--
Fix for #65729: triggerer supervisor unable to ship logs to remote Azure blob connection.
-->

When a trigger finishes, `TriggerRunnerSupervisor._handle_request` calls `factory.upload_to_remote()` in the supervisor (main) process to ship the per-trigger log file to the configured remote storage. The call path is:

```
WasbRemoteLogIO.write
  -> WasbHook.load_string -> WasbHook.upload -> WasbHook._get_blob_client
    -> WasbHook.blob_service_client -> WasbHook.get_conn
      -> Hook.get_connection -> Connection.get -> _get_connection
```

`_get_connection` picks secrets backends via `ensure_secrets_backend_loaded()`, which auto-detects context:

1. `SUPERVISOR_COMMS` set -> worker client chain
2. `_AIRFLOW_PROCESS_CONTEXT=server` -> server chain (includes `MetastoreBackend`)
3. fallback -> **only** `EnvironmentVariablesBackend`

The triggerer supervisor process sets neither marker, so it falls into the fallback chain and cannot see connections stored only in the metastore — regardless of provider. The user in #65729 reports this with WASB, but the same bug hits S3/GCS/etc. The result is `AirflowNotFoundException: The conn_id '<id>' isn't defined` and the per-trigger log (`attempt=1.log.trigger.<id>.log`) is never uploaded.

`SchedulerJobRunner._execute`, `DagFileProcessorManager.run` and `airflow.api_fastapi.main` already set `_AIRFLOW_PROCESS_CONTEXT=server` for the same reason. The triggerer was simply missing from that list.

## What this PR does

- In `TriggererJobRunner._execute()`, set `_AIRFLOW_PROCESS_CONTEXT=server` before doing anything else. Identical pattern and comment as scheduler.
- Add a regression test `test_execute_marks_process_context_as_server` in `airflow-core/tests/unit/jobs/test_triggerer_job.py` asserting the env var is set after `_execute()` runs.

## Why the trigger subprocess is unaffected

The async trigger subprocess inherits this env var from the parent, but its `TriggerRunner.arun()` first calls `await self.init_comms()`, which sets `task_runner.SUPERVISOR_COMMS` before any trigger code runs. `ensure_secrets_backend_loaded()` checks `SUPERVISOR_COMMS` before the env var, so the subprocess still uses the correct client chain. No trigger-side behaviour changes.

## Verification

Reproduced on both Linux (Ubuntu 22.04) and Windows by driving `WasbRemoteLogIO.write` in the supervisor context with a metastore-backed fake connection and `BlobServiceClient` stub:

```
Before fix: AirflowNotFoundException: The conn_id `logs_to_azure_blob` isn't defined
            (identical stack trace to issue #65729)
After  fix: BlobServiceClient instantiated -> upload proceeds
```

Full `test_triggerer_job.py` (37 tests) and `task-sdk/tests/.../test_secrets.py::TestContextDetection` (3 tests) pass after the change.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

closes: #65729
