### PR TITLE
Migrate EmrServerlessStartJobTrigger from CancelledError to on_kill()

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -470,6 +470,10 @@ class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):
                 )
             yield TriggerEvent({"status": "success", self.return_key: self.return_value})
         except asyncio.CancelledError:
+            # TODO: Remove this CancelledError handler once the minimum Airflow version
+            # supported by the provider is >= 3.3. In Airflow 3.3+, BaseTrigger.on_kill()
+            # handles cancellation instead. Keeping this for backward compatibility with
+            # older Airflow versions.
             if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
                 self.log.info(
                     "Task was cancelled. Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -494,7 +494,8 @@ class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):
             yield TriggerEvent({"status": "failure", "message": str(e)})
 
     async def on_kill(self) -> None:
-        """Cancel the EMR Serverless job when the trigger is cancelled by a user action.
+        """
+        Cancel the EMR Serverless job when the trigger is cancelled by a user action.
 
         This hook is available in Airflow 3.3+ via BaseTrigger.on_kill().
         For older Airflow versions, the CancelledError handler in run() provides

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -16,28 +16,16 @@
 # under the License.
 from __future__ import annotations
 
-import asyncio
 import sys
-from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
 
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
 from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
-from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
-from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.triggers.base import TriggerEvent
-from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm.session import Session
-
     from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
-
-if not AIRFLOW_V_3_0_PLUS:
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.utils.session import provide_session
 
 
 class EmrAddStepsTrigger(AwsBaseWaiterTrigger):
@@ -385,109 +373,18 @@ class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):
     def hook(self) -> AwsGenericHook:
         return EmrServerlessHook(self.aws_conn_id)
 
-    if not AIRFLOW_V_3_0_PLUS:
-
-        @provide_session
-        def get_task_instance(self, session: Session) -> TaskInstance:
-            """Get the task instance for the current trigger (Airflow 2.x compatibility)."""
-            from sqlalchemy import select
-
-            query = select(TaskInstance).where(
-                TaskInstance.dag_id == self.task_instance.dag_id,
-                TaskInstance.task_id == self.task_instance.task_id,
-                TaskInstance.run_id == self.task_instance.run_id,
-                TaskInstance.map_index == self.task_instance.map_index,
+    async def on_kill(self) -> None:
+        """Cancel the EMR Serverless job when the trigger is cancelled by a user action."""
+        if self.job_id and self.cancel_on_kill:
+            self.log.info(
+                "Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",
+                self.application_id,
+                self.job_id,
             )
-            task_instance = session.scalars(query).one_or_none()
-            if task_instance is None:
-                raise ValueError(
-                    f"TaskInstance with dag_id: {self.task_instance.dag_id}, "
-                    f"task_id: {self.task_instance.task_id}, "
-                    f"run_id: {self.task_instance.run_id} and "
-                    f"map_index: {self.task_instance.map_index} is not found"
-                )
-            return task_instance
-
-    async def get_task_state(self):
-        """Get the current state of the task instance (Airflow 3.x)."""
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-        task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
-            dag_id=self.task_instance.dag_id,
-            task_ids=[self.task_instance.task_id],
-            run_ids=[self.task_instance.run_id],
-            map_index=self.task_instance.map_index,
-        )
-        try:
-            task_state = task_states_response[self.task_instance.run_id][self.task_instance.task_id]
-        except Exception:
-            raise ValueError(
-                f"TaskInstance with dag_id: {self.task_instance.dag_id}, "
-                f"task_id: {self.task_instance.task_id}, "
-                f"run_id: {self.task_instance.run_id} and "
-                f"map_index: {self.task_instance.map_index} is not found"
+            await sync_to_async(self.hook().conn.cancel_job_run)(
+                applicationId=self.application_id, jobRunId=self.job_id
             )
-        return task_state
-
-    async def safe_to_cancel(self) -> bool:
-        """
-        Whether it is safe to cancel the EMR Serverless job.
-
-        Returns True if task is NOT DEFERRED (user-initiated cancellation).
-        Returns False if task is DEFERRED (triggerer restart - don't cancel job).
-        """
-        if AIRFLOW_V_3_0_PLUS:
-            task_state = await self.get_task_state()
-        else:
-            task_instance = self.get_task_instance()  # type: ignore[call-arg]
-            task_state = task_instance.state
-        return task_state != TaskInstanceState.DEFERRED
-
-    async def run(self) -> AsyncIterator[TriggerEvent]:
-        """
-        Run the trigger and wait for the job to complete.
-
-        If the task is cancelled while waiting, attempt to cancel the EMR Serverless job
-        if cancel_on_kill is enabled and it's safe to do so.
-        """
-        hook = self.hook()
-        try:
-            async with await hook.get_async_conn() as client:
-                waiter = hook.get_waiter(
-                    self.waiter_name,
-                    deferrable=True,
-                    client=client,
-                    config_overrides=self.waiter_config_overrides,
-                )
-                await async_wait(
-                    waiter,
-                    self.waiter_delay,
-                    self.attempts,
-                    self.waiter_args,
-                    self.failure_message,
-                    self.status_message,
-                    self.status_queries,
-                )
-            yield TriggerEvent({"status": "success", self.return_key: self.return_value})
-        except asyncio.CancelledError:
-            if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
-                self.log.info(
-                    "Task was cancelled. Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",
-                    self.application_id,
-                    self.job_id,
-                )
-                hook.conn.cancel_job_run(applicationId=self.application_id, jobRunId=self.job_id)
-                self.log.info("EMR Serverless job %s cancelled successfully.", self.job_id)
-            else:
-                self.log.info(
-                    "Trigger may have shutdown or cancel_on_kill is disabled. "
-                    "Skipping job cancellation. Application ID: %s, Job ID: %s",
-                    self.application_id,
-                    self.job_id,
-                )
-            raise
-        except Exception as e:
-            yield TriggerEvent({"status": "failure", "message": str(e)})
+            self.log.info("EMR Serverless job %s cancelled successfully.", self.job_id)
 
 
 class EmrServerlessDeleteApplicationTrigger(AwsBaseWaiterTrigger):

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -16,16 +16,28 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import sys
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from asgiref.sync import sync_to_async
 
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
 from airflow.providers.amazon.aws.triggers.base import AwsBaseWaiterTrigger
+from airflow.providers.amazon.aws.utils.waiter_with_logging import async_wait
+from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.triggers.base import TriggerEvent
+from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm.session import Session
+
     from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
+
+if not AIRFLOW_V_3_0_PLUS:
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.utils.session import provide_session
 
 
 class EmrAddStepsTrigger(AwsBaseWaiterTrigger):
@@ -373,8 +385,117 @@ class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):
     def hook(self) -> AwsGenericHook:
         return EmrServerlessHook(self.aws_conn_id)
 
+    if not AIRFLOW_V_3_0_PLUS:
+
+        @provide_session
+        def get_task_instance(self, session: Session) -> TaskInstance:
+            """Get the task instance for the current trigger (Airflow 2.x compatibility)."""
+            from sqlalchemy import select
+
+            query = select(TaskInstance).where(
+                TaskInstance.dag_id == self.task_instance.dag_id,
+                TaskInstance.task_id == self.task_instance.task_id,
+                TaskInstance.run_id == self.task_instance.run_id,
+                TaskInstance.map_index == self.task_instance.map_index,
+            )
+            task_instance = session.scalars(query).one_or_none()
+            if task_instance is None:
+                raise ValueError(
+                    f"TaskInstance with dag_id: {self.task_instance.dag_id}, "
+                    f"task_id: {self.task_instance.task_id}, "
+                    f"run_id: {self.task_instance.run_id} and "
+                    f"map_index: {self.task_instance.map_index} is not found"
+                )
+            return task_instance
+
+    async def get_task_state(self):
+        """Get the current state of the task instance (Airflow 3.x)."""
+        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+        task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
+            dag_id=self.task_instance.dag_id,
+            task_ids=[self.task_instance.task_id],
+            run_ids=[self.task_instance.run_id],
+            map_index=self.task_instance.map_index,
+        )
+        try:
+            task_state = task_states_response[self.task_instance.run_id][self.task_instance.task_id]
+        except Exception:
+            raise ValueError(
+                f"TaskInstance with dag_id: {self.task_instance.dag_id}, "
+                f"task_id: {self.task_instance.task_id}, "
+                f"run_id: {self.task_instance.run_id} and "
+                f"map_index: {self.task_instance.map_index} is not found"
+            )
+        return task_state
+
+    async def safe_to_cancel(self) -> bool:
+        """
+        Whether it is safe to cancel the EMR Serverless job.
+
+        Returns True if task is NOT DEFERRED (user-initiated cancellation).
+        Returns False if task is DEFERRED (triggerer restart - don't cancel job).
+        """
+        if AIRFLOW_V_3_0_PLUS:
+            task_state = await self.get_task_state()
+        else:
+            task_instance = self.get_task_instance()  # type: ignore[call-arg]
+            task_state = task_instance.state
+        return task_state != TaskInstanceState.DEFERRED
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """
+        Run the trigger and wait for the job to complete.
+
+        If the task is cancelled while waiting, attempt to cancel the EMR Serverless job
+        if cancel_on_kill is enabled and it's safe to do so.
+        """
+        hook = self.hook()
+        try:
+            async with await hook.get_async_conn() as client:
+                waiter = hook.get_waiter(
+                    self.waiter_name,
+                    deferrable=True,
+                    client=client,
+                    config_overrides=self.waiter_config_overrides,
+                )
+                await async_wait(
+                    waiter,
+                    self.waiter_delay,
+                    self.attempts,
+                    self.waiter_args,
+                    self.failure_message,
+                    self.status_message,
+                    self.status_queries,
+                )
+            yield TriggerEvent({"status": "success", self.return_key: self.return_value})
+        except asyncio.CancelledError:
+            if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
+                self.log.info(
+                    "Task was cancelled. Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",
+                    self.application_id,
+                    self.job_id,
+                )
+                hook.conn.cancel_job_run(applicationId=self.application_id, jobRunId=self.job_id)
+                self.log.info("EMR Serverless job %s cancelled successfully.", self.job_id)
+            else:
+                self.log.info(
+                    "Trigger may have shutdown or cancel_on_kill is disabled. "
+                    "Skipping job cancellation. Application ID: %s, Job ID: %s",
+                    self.application_id,
+                    self.job_id,
+                )
+            raise
+        except Exception as e:
+            yield TriggerEvent({"status": "failure", "message": str(e)})
+
     async def on_kill(self) -> None:
-        """Cancel the EMR Serverless job when the trigger is cancelled by a user action."""
+        """Cancel the EMR Serverless job when the trigger is cancelled by a user action.
+
+        This hook is available in Airflow 3.3+ via BaseTrigger.on_kill().
+        For older Airflow versions, the CancelledError handler in run() provides
+        the same cancellation behavior.
+        """
         if self.job_id and self.cancel_on_kill:
             self.log.info(
                 "Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import sys
 from unittest import mock
 
@@ -290,11 +291,15 @@ class TestEmrServerlessStartJobTrigger:
         assert kwargs["cancel_on_kill"] is False
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn", new_callable=mock.PropertyMock)
-    async def test_on_kill_cancels_job(self, mock_conn):
-        """Test that on_kill() cancels the EMR Serverless job when cancel_on_kill=True."""
-        mock_cancel = mock.MagicMock()
-        mock_conn.return_value.cancel_job_run = mock_cancel
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
+    async def test_emr_serverless_trigger_cancellation(self, mock_safe_to_cancel, mock_async_wait):
+        """
+        Test that EmrServerlessStartJobTrigger cancels the job when task is killed
+        and safe_to_cancel returns True.
+        """
+        mock_safe_to_cancel.return_value = True
+        mock_async_wait.side_effect = asyncio.CancelledError()
 
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
@@ -305,13 +310,124 @@ class TestEmrServerlessStartJobTrigger:
             cancel_on_kill=True,
         )
 
-        await trigger.on_kill()
+        mock_hook = mock.MagicMock()
+        mock_hook.get_waiter.return_value = mock.MagicMock()
+        mock_hook.conn.cancel_job_run.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
-        mock_cancel.assert_called_once_with(applicationId="test_app", jobRunId="test_job")
+        mock_client = mock.MagicMock()
+        mock_async_cm = mock.MagicMock()
+        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
+        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
+
+        with mock.patch.object(trigger, "hook", return_value=mock_hook):
+            with pytest.raises(asyncio.CancelledError):
+                async for _ in trigger.run():
+                    pass
+
+        mock_hook.conn.cancel_job_run.assert_called_once_with(applicationId="test_app", jobRunId="test_job")
 
     @pytest.mark.asyncio
-    async def test_on_kill_does_not_cancel_when_disabled(self):
-        """Test that on_kill() does NOT cancel the job when cancel_on_kill=False."""
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
+    async def test_emr_serverless_trigger_no_cancellation_when_unsafe(
+        self, mock_safe_to_cancel, mock_async_wait
+    ):
+        """
+        Test that EmrServerlessStartJobTrigger does NOT cancel the job when
+        safe_to_cancel returns False (e.g., triggerer shutdown).
+        """
+        mock_safe_to_cancel.return_value = False
+        mock_async_wait.side_effect = asyncio.CancelledError()
+
+        trigger = EmrServerlessStartJobTrigger(
+            application_id="test_app",
+            job_id="test_job",
+            waiter_delay=30,
+            waiter_max_attempts=60,
+            aws_conn_id="aws_default",
+            cancel_on_kill=True,
+        )
+
+        mock_hook = mock.MagicMock()
+        mock_hook.get_waiter.return_value = mock.MagicMock()
+
+        mock_client = mock.MagicMock()
+        mock_async_cm = mock.MagicMock()
+        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
+        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
+
+        with mock.patch.object(trigger, "hook", return_value=mock_hook):
+            with pytest.raises(asyncio.CancelledError):
+                async for _ in trigger.run():
+                    pass
+
+        mock_hook.conn.cancel_job_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
+    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
+    async def test_emr_serverless_trigger_no_cancellation_when_disabled(
+        self, mock_safe_to_cancel, mock_async_wait
+    ):
+        """
+        Test that EmrServerlessStartJobTrigger does NOT cancel the job when
+        cancel_on_kill=False.
+        """
+        mock_safe_to_cancel.return_value = True
+        mock_async_wait.side_effect = asyncio.CancelledError()
+
+        trigger = EmrServerlessStartJobTrigger(
+            application_id="test_app",
+            job_id="test_job",
+            waiter_delay=30,
+            waiter_max_attempts=60,
+            aws_conn_id="aws_default",
+            cancel_on_kill=False,  # Disabled
+        )
+
+        mock_hook = mock.MagicMock()
+        mock_hook.get_waiter.return_value = mock.MagicMock()
+
+        mock_client = mock.MagicMock()
+        mock_async_cm = mock.MagicMock()
+        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
+        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
+        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
+
+        with mock.patch.object(trigger, "hook", return_value=mock_hook):
+            with pytest.raises(asyncio.CancelledError):
+                async for _ in trigger.run():
+                    pass
+
+        mock_hook.conn.cancel_job_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_kill_cancels_job(self):
+        """Test that on_kill() cancels the EMR Serverless job via the hook."""
+        trigger = EmrServerlessStartJobTrigger(
+            application_id="test_app",
+            job_id="test_job",
+            waiter_delay=30,
+            waiter_max_attempts=60,
+            aws_conn_id="aws_default",
+            cancel_on_kill=True,
+        )
+
+        mock_hook = mock.MagicMock()
+        mock_hook.conn.cancel_job_run.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+        with mock.patch.object(trigger, "hook", return_value=mock_hook):
+            await trigger.on_kill()
+
+        mock_hook.conn.cancel_job_run.assert_called_once_with(
+            applicationId="test_app", jobRunId="test_job"
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_kill_skips_when_cancel_disabled(self):
+        """Test that on_kill() does nothing when cancel_on_kill=False."""
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
             job_id="test_job",
@@ -329,8 +445,8 @@ class TestEmrServerlessStartJobTrigger:
         mock_hook.conn.cancel_job_run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_on_kill_does_not_cancel_when_no_job_id(self):
-        """Test that on_kill() does NOT cancel when job_id is None."""
+    async def test_on_kill_skips_when_no_job_id(self):
+        """Test that on_kill() does nothing when job_id is None."""
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
             job_id=None,

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -421,9 +421,7 @@ class TestEmrServerlessStartJobTrigger:
         with mock.patch.object(trigger, "hook", return_value=mock_hook):
             await trigger.on_kill()
 
-        mock_hook.conn.cancel_job_run.assert_called_once_with(
-            applicationId="test_app", jobRunId="test_job"
-        )
+        mock_hook.conn.cancel_job_run.assert_called_once_with(applicationId="test_app", jobRunId="test_job")
 
     @pytest.mark.asyncio
     async def test_on_kill_skips_when_cancel_disabled(self):

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_emr.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import asyncio
 import sys
 from unittest import mock
 
@@ -291,15 +290,11 @@ class TestEmrServerlessStartJobTrigger:
         assert kwargs["cancel_on_kill"] is False
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
-    async def test_emr_serverless_trigger_cancellation(self, mock_safe_to_cancel, mock_async_wait):
-        """
-        Test that EmrServerlessStartJobTrigger cancels the job when task is killed
-        and safe_to_cancel returns True.
-        """
-        mock_safe_to_cancel.return_value = True
-        mock_async_wait.side_effect = asyncio.CancelledError()
+    @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn", new_callable=mock.PropertyMock)
+    async def test_on_kill_cancels_job(self, mock_conn):
+        """Test that on_kill() cancels the EMR Serverless job when cancel_on_kill=True."""
+        mock_cancel = mock.MagicMock()
+        mock_conn.return_value.cancel_job_run = mock_cancel
 
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
@@ -310,96 +305,45 @@ class TestEmrServerlessStartJobTrigger:
             cancel_on_kill=True,
         )
 
-        mock_hook = mock.MagicMock()
-        mock_hook.get_waiter.return_value = mock.MagicMock()
-        mock_hook.conn.cancel_job_run.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+        await trigger.on_kill()
 
-        mock_client = mock.MagicMock()
-        mock_async_cm = mock.MagicMock()
-        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
-        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
-        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
-
-        with mock.patch.object(trigger, "hook", return_value=mock_hook):
-            with pytest.raises(asyncio.CancelledError):
-                async for _ in trigger.run():
-                    pass
-
-        mock_hook.conn.cancel_job_run.assert_called_once_with(applicationId="test_app", jobRunId="test_job")
+        mock_cancel.assert_called_once_with(applicationId="test_app", jobRunId="test_job")
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
-    async def test_emr_serverless_trigger_no_cancellation_when_unsafe(
-        self, mock_safe_to_cancel, mock_async_wait
-    ):
-        """
-        Test that EmrServerlessStartJobTrigger does NOT cancel the job when
-        safe_to_cancel returns False (e.g., triggerer shutdown).
-        """
-        mock_safe_to_cancel.return_value = False
-        mock_async_wait.side_effect = asyncio.CancelledError()
-
+    async def test_on_kill_does_not_cancel_when_disabled(self):
+        """Test that on_kill() does NOT cancel the job when cancel_on_kill=False."""
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
             job_id="test_job",
             waiter_delay=30,
             waiter_max_attempts=60,
             aws_conn_id="aws_default",
-            cancel_on_kill=True,
+            cancel_on_kill=False,
         )
 
         mock_hook = mock.MagicMock()
-        mock_hook.get_waiter.return_value = mock.MagicMock()
-
-        mock_client = mock.MagicMock()
-        mock_async_cm = mock.MagicMock()
-        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
-        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
-        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
 
         with mock.patch.object(trigger, "hook", return_value=mock_hook):
-            with pytest.raises(asyncio.CancelledError):
-                async for _ in trigger.run():
-                    pass
+            await trigger.on_kill()
 
         mock_hook.conn.cancel_job_run.assert_not_called()
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.async_wait")
-    @mock.patch("airflow.providers.amazon.aws.triggers.emr.EmrServerlessStartJobTrigger.safe_to_cancel")
-    async def test_emr_serverless_trigger_no_cancellation_when_disabled(
-        self, mock_safe_to_cancel, mock_async_wait
-    ):
-        """
-        Test that EmrServerlessStartJobTrigger does NOT cancel the job when
-        cancel_on_kill=False.
-        """
-        mock_safe_to_cancel.return_value = True
-        mock_async_wait.side_effect = asyncio.CancelledError()
-
+    async def test_on_kill_does_not_cancel_when_no_job_id(self):
+        """Test that on_kill() does NOT cancel when job_id is None."""
         trigger = EmrServerlessStartJobTrigger(
             application_id="test_app",
-            job_id="test_job",
+            job_id=None,
             waiter_delay=30,
             waiter_max_attempts=60,
             aws_conn_id="aws_default",
-            cancel_on_kill=False,  # Disabled
+            cancel_on_kill=True,
         )
 
         mock_hook = mock.MagicMock()
-        mock_hook.get_waiter.return_value = mock.MagicMock()
-
-        mock_client = mock.MagicMock()
-        mock_async_cm = mock.MagicMock()
-        mock_async_cm.__aenter__ = mock.AsyncMock(return_value=mock_client)
-        mock_async_cm.__aexit__ = mock.AsyncMock(return_value=None)
-        mock_hook.get_async_conn = mock.AsyncMock(return_value=mock_async_cm)
 
         with mock.patch.object(trigger, "hook", return_value=mock_hook):
-            with pytest.raises(asyncio.CancelledError):
-                async for _ in trigger.run():
-                    pass
+            await trigger.on_kill()
 
         mock_hook.conn.cancel_job_run.assert_not_called()
 


### PR DESCRIPTION
Migrate `EmrServerlessStartJobTrigger` from the old `asyncio.CancelledError` catch pattern to the new `BaseTrigger.on_kill()` hook (added via #65590).

**Changes:**
- Add `async on_kill()` method that cancels the EMR Serverless job only on user-initiated task kills
- Remove the `CancelledError` handler from `run()`, letting the parent class `AwsBaseWaiterTrigger.run()` handle the standard waiter flow
- Remove `safe_to_cancel()`, `get_task_instance()`, `get_task_state()` which are no longer needed (`on_kill` only fires on user kills)
- Clean up unused imports (`asyncio`, `AIRFLOW_V_3_0_PLUS`, `TaskInstanceState`, etc.)
- Update tests to directly verify `on_kill()` behavior

Follows the same pattern as the Databricks trigger migration in #65590.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #65733

-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Gemini

Generated-by: Gemini following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
