### PR TITLE
Move KubernetesPodTrigger pod cleanup from cleanup() to on_kill()

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -417,7 +417,7 @@ class KubernetesPodTrigger(BaseTrigger):
         Whether it is safe to delete the pod during trigger cleanup.
 
         Used only on Airflow < 3.3.0 where the triggerer does not invoke ``on_kill()`` for user kills.
-        Cancel is NOT safe when the task is still in DEFERRED state (triggerer restart).
+        Deletion is NOT safe when the task is still in DEFERRED state (triggerer restart).
         """
         task_state = await self.get_task_state()
         return task_state != TaskInstanceState.DEFERRED
@@ -426,11 +426,9 @@ class KubernetesPodTrigger(BaseTrigger):
         """
         Delete the pod when the trigger is cancelled by a user action.
 
-        On Airflow 3.3.0+ the triggerer invokes this for user-initiated kills. On older versions this
-        is a no-op; use ``cleanup()`` and ``safe_to_cancel()`` instead.
+        The triggerer invokes this for user-initiated kills on Airflow 3.3.0+ only; on older versions
+        use ``cleanup()`` and ``safe_to_cancel()`` instead.
         """
-        if not AIRFLOW_V_3_3_PLUS:
-            return
         if self._fired_event:
             self.log.debug("Skipping on_kill since an event has already been fired.")
             return

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -25,7 +25,6 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 import tenacity
-from asgiref.sync import sync_to_async
 
 from airflow.providers.cncf.kubernetes.exceptions import KubernetesApiPermissionError
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
@@ -36,21 +35,11 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchTimeoutException,
     PodPhase,
 )
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
-from airflow.providers.common.compat.sdk import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
-from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import V1Pod
     from pendulum import DateTime
-    from sqlalchemy.orm.session import Session
-
-if not AIRFLOW_V_3_0_PLUS:
-    from sqlalchemy import select
-
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.utils.session import provide_session
 
 
 class ContainerState(str, Enum):
@@ -361,88 +350,14 @@ class KubernetesPodTrigger(BaseTrigger):
     def pod_manager(self) -> AsyncPodManager:
         return AsyncPodManager(async_hook=self.hook)
 
-    if not AIRFLOW_V_3_0_PLUS:
-
-        @provide_session
-        def get_task_instance(self, session: Session) -> TaskInstance:
-            """Get the task instance for this trigger from the database (Airflow 2.x only)."""
-            task_instance = session.scalar(
-                select(TaskInstance).where(
-                    TaskInstance.dag_id == self.task_instance.dag_id,
-                    TaskInstance.task_id == self.task_instance.task_id,
-                    TaskInstance.run_id == self.task_instance.run_id,
-                    TaskInstance.map_index == self.task_instance.map_index,
-                )
-            )
-            if task_instance is None:
-                raise AirflowException(
-                    "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
-                    self.task_instance.dag_id,
-                    self.task_instance.task_id,
-                    self.task_instance.run_id,
-                    self.task_instance.map_index,
-                )
-            return task_instance
-
-    async def get_task_state(self):
-        """Get the current state of the task instance."""
-        if AIRFLOW_V_3_0_PLUS:
-            from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-            task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
-                dag_id=self.task_instance.dag_id,
-                task_ids=[self.task_instance.task_id],
-                run_ids=[self.task_instance.run_id],
-                map_index=self.task_instance.map_index,
-            )
-            try:
-                return task_states_response[self.task_instance.run_id][self.task_instance.task_id]
-            except KeyError:
-                raise AirflowException(
-                    "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
-                    self.task_instance.dag_id,
-                    self.task_instance.task_id,
-                    self.task_instance.run_id,
-                    self.task_instance.map_index,
-                )
-        else:
-            task_instance = await sync_to_async(self.get_task_instance)()  # type: ignore[call-arg]
-            return task_instance.state
-
-    async def safe_to_cancel(self) -> bool:
-        """
-        Whether it is safe to cancel the external job which is being executed by this trigger.
-
-        Cancel is NOT safe when the task is still in DEFERRED state, because it means the
-        triggerer is redistributing triggers and the trigger will be recreated on another triggerer.
-        Cancel IS safe when the task state has changed (e.g. user marked it as success/failed).
-        """
-        task_state = await self.get_task_state()
-        return task_state != TaskInstanceState.DEFERRED
-
-    async def cleanup(self) -> None:
-        """Clean up the pod when the trigger is cancelled."""
+    async def on_kill(self) -> None:
+        """Delete the pod when the trigger is cancelled by a user action (see BaseTrigger.on_kill)."""
         if self._fired_event:
-            self.log.debug("Skipping cleanup since an event has already been fired.")
+            self.log.debug("Skipping on_kill since an event has already been fired.")
             return
 
         if self.on_kill_action == OnKillAction.KEEP_POD:
-            self.log.debug("Skipping cleanup since on_kill_action is set to %r.", self.on_kill_action.value)
-            return
-
-        try:
-            safe = await self.safe_to_cancel()
-        except Exception:
-            self.log.warning(
-                "Could not determine task state during cleanup; skipping pod deletion to be safe.",
-                exc_info=True,
-            )
-            return
-
-        if not safe:
-            self.log.debug(
-                "Skipping cleanup since the task is still in deferred state (likely a triggerer restart)."
-            )
+            self.log.debug("Skipping on_kill since on_kill_action is set to %r.", self.on_kill_action.value)
             return
 
         self.log.info("Deleting pod %s in namespace %s.", self.pod_name, self.pod_namespace)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -455,6 +455,10 @@ class KubernetesPodTrigger(BaseTrigger):
         deleting pods on triggerer restart. On older Airflow versions, ``cleanup()`` still uses
         ``safe_to_cancel()`` because ``on_kill()`` is not wired for user kills.
         """
+        # TODO: Remove this Airflow < 3.3 cleanup branch (early return, ``safe_to_cancel``, and
+        # related tests) once the minimum Airflow version supported by this provider is >= 3.3.
+        # In Airflow 3.3+, ``BaseTrigger.on_kill()`` handles user-initiated kills; keeping the
+        # legacy path for backward compatibility with older Airflow versions.
         if AIRFLOW_V_3_3_PLUS:
             return
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 import tenacity
+from asgiref.sync import sync_to_async
 
 from airflow.providers.cncf.kubernetes.exceptions import KubernetesApiPermissionError
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
@@ -35,11 +36,24 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchTimeoutException,
     PodPhase,
 )
+from airflow.providers.cncf.kubernetes.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
+from airflow.providers.common.compat.sdk import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import V1Pod
     from pendulum import DateTime
+    from sqlalchemy.orm.session import Session
+
+if not AIRFLOW_V_3_0_PLUS:
+    from sqlalchemy import select
+
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.utils.session import provide_session
 
 
 class ContainerState(str, Enum):
@@ -350,14 +364,123 @@ class KubernetesPodTrigger(BaseTrigger):
     def pod_manager(self) -> AsyncPodManager:
         return AsyncPodManager(async_hook=self.hook)
 
+    if not AIRFLOW_V_3_0_PLUS:
+
+        @provide_session
+        def get_task_instance(self, session: Session) -> TaskInstance:
+            """Get the task instance for this trigger from the database (Airflow 2.x only)."""
+            task_instance = session.scalar(
+                select(TaskInstance).where(
+                    TaskInstance.dag_id == self.task_instance.dag_id,
+                    TaskInstance.task_id == self.task_instance.task_id,
+                    TaskInstance.run_id == self.task_instance.run_id,
+                    TaskInstance.map_index == self.task_instance.map_index,
+                )
+            )
+            if task_instance is None:
+                raise AirflowException(
+                    "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
+                    self.task_instance.dag_id,
+                    self.task_instance.task_id,
+                    self.task_instance.run_id,
+                    self.task_instance.map_index,
+                )
+            return task_instance
+
+    async def get_task_state(self):
+        """Get the current state of the task instance."""
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+            task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
+                dag_id=self.task_instance.dag_id,
+                task_ids=[self.task_instance.task_id],
+                run_ids=[self.task_instance.run_id],
+                map_index=self.task_instance.map_index,
+            )
+            try:
+                return task_states_response[self.task_instance.run_id][self.task_instance.task_id]
+            except KeyError:
+                raise AirflowException(
+                    "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
+                    self.task_instance.dag_id,
+                    self.task_instance.task_id,
+                    self.task_instance.run_id,
+                    self.task_instance.map_index,
+                )
+        else:
+            task_instance = await sync_to_async(self.get_task_instance)()  # type: ignore[call-arg]
+            return task_instance.state
+
+    async def safe_to_cancel(self) -> bool:
+        """
+        Whether it is safe to delete the pod during trigger cleanup.
+
+        Used only on Airflow < 3.3.0 where the triggerer does not invoke ``on_kill()`` for user kills.
+        Cancel is NOT safe when the task is still in DEFERRED state (triggerer restart).
+        """
+        task_state = await self.get_task_state()
+        return task_state != TaskInstanceState.DEFERRED
+
     async def on_kill(self) -> None:
-        """Delete the pod when the trigger is cancelled by a user action (see BaseTrigger.on_kill)."""
+        """
+        Delete the pod when the trigger is cancelled by a user action.
+
+        On Airflow 3.3.0+ the triggerer invokes this for user-initiated kills. On older versions this
+        is a no-op; use ``cleanup()`` and ``safe_to_cancel()`` instead.
+        """
+        if not AIRFLOW_V_3_3_PLUS:
+            return
         if self._fired_event:
             self.log.debug("Skipping on_kill since an event has already been fired.")
             return
 
         if self.on_kill_action == OnKillAction.KEEP_POD:
             self.log.debug("Skipping on_kill since on_kill_action is set to %r.", self.on_kill_action.value)
+            return
+
+        self.log.info("Deleting pod %s in namespace %s.", self.pod_name, self.pod_namespace)
+        try:
+            await self.hook.delete_pod(
+                name=self.pod_name,
+                namespace=self.pod_namespace,
+                grace_period_seconds=self.termination_grace_period,
+            )
+        except Exception:
+            self.log.exception("Unexpected error while deleting pod %s", self.pod_name)
+
+    async def cleanup(self) -> None:
+        """
+        Clean up the pod when the trigger exits.
+
+        On Airflow 3.3.0+ pod deletion on user kill is handled in ``on_kill()`` only; this avoids
+        deleting pods on triggerer restart. On older Airflow versions, ``cleanup()`` still uses
+        ``safe_to_cancel()`` because ``on_kill()`` is not wired for user kills.
+        """
+        if AIRFLOW_V_3_3_PLUS:
+            return
+
+        if self._fired_event:
+            self.log.debug("Skipping cleanup since an event has already been fired.")
+            return
+
+        if self.on_kill_action == OnKillAction.KEEP_POD:
+            self.log.debug("Skipping cleanup since on_kill_action is set to %r.", self.on_kill_action.value)
+            return
+
+        try:
+            safe = await self.safe_to_cancel()
+        except Exception:
+            self.log.warning(
+                "Could not determine task state during cleanup; skipping pod deletion to be safe.",
+                exc_info=True,
+            )
+            return
+
+        if not safe:
+            self.log.debug(
+                "Skipping cleanup since the task is still in deferred state (likely a triggerer restart)."
+            )
             return
 
         self.log.info("Deleting pod %s in namespace %s.", self.pod_name, self.pod_namespace)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/version_compat.py
@@ -35,10 +35,12 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
 ]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -31,9 +31,10 @@ from pendulum import DateTime
 
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.state import TaskInstanceState
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -31,11 +31,11 @@ from pendulum import DateTime
 
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.state import TaskInstanceState
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
-POD_TRIGGER_MODULE = "airflow.providers.cncf.kubernetes.triggers.pod"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"
 POD_NAME = "test-pod-name"
 NAMESPACE = "default"
@@ -560,9 +560,12 @@ class TestKubernetesPodTrigger:
             await trigger._get_pod()
         assert mock_hook.get_pod.call_count == call_count
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="Triggerer invokes on_kill for user kills only on Airflow 3.3+",
+    )
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_does_not_delete_when_fired_event(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -577,9 +580,12 @@ class TestKubernetesPodTrigger:
         await trigger.on_kill()
         mock_hook.delete_pod.assert_not_called()
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="Triggerer invokes on_kill for user kills only on Airflow 3.3+",
+    )
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_does_not_delete_when_on_kill_action_keep_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -593,9 +599,12 @@ class TestKubernetesPodTrigger:
         await trigger.on_kill()
         mock_hook.delete_pod.assert_not_called()
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="Triggerer invokes on_kill for user kills only on Airflow 3.3+",
+    )
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_deletes_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -614,9 +623,12 @@ class TestKubernetesPodTrigger:
             grace_period_seconds=None,
         )
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="Triggerer invokes on_kill for user kills only on Airflow 3.3+",
+    )
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_deletes_pod_even_when_on_finish_action_keep_pod(self, mock_hook):
         """on_finish_action is not consulted during kill -- on_kill_action is the sole control."""
         trigger = KubernetesPodTrigger(
@@ -636,25 +648,11 @@ class TestKubernetesPodTrigger:
             grace_period_seconds=None,
         )
 
+    @pytest.mark.skipif(
+        AIRFLOW_V_3_3_PLUS,
+        reason="Legacy cleanup path runs only on Airflow < 3.3",
+    )
     @pytest.mark.asyncio
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
-    @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_on_kill_noop_before_airflow_3_3(self, mock_hook):
-        """on_kill is not wired for user kills on Airflow < 3.3.0."""
-        trigger = KubernetesPodTrigger(
-            pod_name=POD_NAME,
-            pod_namespace=NAMESPACE,
-            base_container_name=BASE_CONTAINER_NAME,
-            trigger_start_time=TRIGGER_START_TIME,
-            schedule_timeout=STARTUP_TIMEOUT_SECS,
-            on_kill_action="delete_pod",
-            on_finish_action="delete_pod",
-        )
-        await trigger.on_kill()
-        mock_hook.delete_pod.assert_not_called()
-
-    @pytest.mark.asyncio
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
     @mock.patch(f"{TRIGGER_PATH}.hook")
     async def test_cleanup_does_not_delete_during_triggerer_restart(self, mock_hook):
         trigger = KubernetesPodTrigger(
@@ -670,8 +668,11 @@ class TestKubernetesPodTrigger:
             await trigger.cleanup()
         mock_hook.delete_pod.assert_not_called()
 
+    @pytest.mark.skipif(
+        AIRFLOW_V_3_3_PLUS,
+        reason="Legacy cleanup path runs only on Airflow < 3.3",
+    )
     @pytest.mark.asyncio
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
     @mock.patch(f"{TRIGGER_PATH}.hook")
     async def test_cleanup_deletes_pod_when_safe_to_cancel(self, mock_hook):
         trigger = KubernetesPodTrigger(
@@ -692,8 +693,11 @@ class TestKubernetesPodTrigger:
             grace_period_seconds=None,
         )
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_3_PLUS,
+        reason="cleanup skips pod deletion only on Airflow 3.3+",
+    )
     @pytest.mark.asyncio
-    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     @mock.patch(f"{TRIGGER_PATH}.hook")
     async def test_cleanup_noop_on_airflow_3_3_plus(self, mock_hook):
         """On Airflow 3.3.0+, cleanup does not delete pods (on_kill handles user kill)."""
@@ -735,6 +739,10 @@ class TestKubernetesPodTrigger:
         )
         assert await trigger.safe_to_cancel() is False
 
+    @pytest.mark.skipif(
+        AIRFLOW_V_3_3_PLUS,
+        reason="Legacy cleanup path runs only on Airflow < 3.3",
+    )
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
     async def test_cleanup_skips_deletion_when_safe_to_cancel_raises(self, mock_hook):
@@ -747,11 +755,10 @@ class TestKubernetesPodTrigger:
             on_kill_action="delete_pod",
             on_finish_action="delete_pod",
         )
-        with mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False):
-            with mock.patch(
-                f"{TRIGGER_PATH}.safe_to_cancel",
-                new_callable=mock.AsyncMock,
-                side_effect=Exception("API down"),
-            ):
-                await trigger.cleanup()
+        with mock.patch(
+            f"{TRIGGER_PATH}.safe_to_cancel",
+            new_callable=mock.AsyncMock,
+            side_effect=Exception("API down"),
+        ):
+            await trigger.cleanup()
         mock_hook.delete_pod.assert_not_called()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -32,7 +32,6 @@ from pendulum import DateTime
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
 from airflow.triggers.base import TriggerEvent
-from airflow.utils.state import TaskInstanceState
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"
@@ -561,7 +560,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_does_not_delete_when_fired_event(self, mock_hook):
+    async def test_on_kill_does_not_delete_when_fired_event(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
             pod_namespace=NAMESPACE,
@@ -572,12 +571,12 @@ class TestKubernetesPodTrigger:
             on_finish_action="delete_pod",
         )
         trigger._fired_event = True
-        await trigger.cleanup()
+        await trigger.on_kill()
         mock_hook.delete_pod.assert_not_called()
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_does_not_delete_when_on_kill_action_keep_pod(self, mock_hook):
+    async def test_on_kill_does_not_delete_when_on_kill_action_keep_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
             pod_namespace=NAMESPACE,
@@ -587,29 +586,12 @@ class TestKubernetesPodTrigger:
             on_kill_action="keep_pod",
             on_finish_action="delete_pod",
         )
-        await trigger.cleanup()
+        await trigger.on_kill()
         mock_hook.delete_pod.assert_not_called()
 
     @pytest.mark.asyncio
-    @mock.patch(f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, return_value=False)
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_does_not_delete_during_triggerer_restart(self, mock_hook, mock_safe):
-        trigger = KubernetesPodTrigger(
-            pod_name=POD_NAME,
-            pod_namespace=NAMESPACE,
-            base_container_name=BASE_CONTAINER_NAME,
-            trigger_start_time=TRIGGER_START_TIME,
-            schedule_timeout=STARTUP_TIMEOUT_SECS,
-            on_kill_action="delete_pod",
-            on_finish_action="delete_pod",
-        )
-        await trigger.cleanup()
-        mock_hook.delete_pod.assert_not_called()
-
-    @pytest.mark.asyncio
-    @mock.patch(f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, return_value=True)
-    @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_deletes_pod_on_manual_mark(self, mock_hook, mock_safe):
+    async def test_on_kill_deletes_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
             pod_namespace=NAMESPACE,
@@ -620,7 +602,7 @@ class TestKubernetesPodTrigger:
             on_finish_action="delete_pod",
         )
         mock_hook.delete_pod = mock.AsyncMock()
-        await trigger.cleanup()
+        await trigger.on_kill()
         mock_hook.delete_pod.assert_called_once_with(
             name=POD_NAME,
             namespace=NAMESPACE,
@@ -628,9 +610,8 @@ class TestKubernetesPodTrigger:
         )
 
     @pytest.mark.asyncio
-    @mock.patch(f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, return_value=True)
     @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_deletes_pod_even_when_on_finish_action_keep_pod(self, mock_hook, mock_safe):
+    async def test_on_kill_deletes_pod_even_when_on_finish_action_keep_pod(self, mock_hook):
         """on_finish_action is not consulted during kill -- on_kill_action is the sole control."""
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -642,56 +623,9 @@ class TestKubernetesPodTrigger:
             on_finish_action="keep_pod",
         )
         mock_hook.delete_pod = mock.AsyncMock()
-        await trigger.cleanup()
+        await trigger.on_kill()
         mock_hook.delete_pod.assert_called_once_with(
             name=POD_NAME,
             namespace=NAMESPACE,
             grace_period_seconds=None,
         )
-
-    @pytest.mark.asyncio
-    @mock.patch(f"{TRIGGER_PATH}.get_task_state", new_callable=mock.AsyncMock)
-    async def test_safe_to_cancel_returns_true_when_task_not_deferred(self, mock_get_state):
-        """safe_to_cancel should return True when the task is no longer DEFERRED (e.g. user marked success)."""
-        mock_get_state.return_value = TaskInstanceState.SUCCESS
-        trigger = KubernetesPodTrigger(
-            pod_name=POD_NAME,
-            pod_namespace=NAMESPACE,
-            base_container_name=BASE_CONTAINER_NAME,
-            trigger_start_time=TRIGGER_START_TIME,
-            schedule_timeout=STARTUP_TIMEOUT_SECS,
-        )
-        assert await trigger.safe_to_cancel() is True
-
-    @pytest.mark.asyncio
-    @mock.patch(f"{TRIGGER_PATH}.get_task_state", new_callable=mock.AsyncMock)
-    async def test_safe_to_cancel_returns_false_when_task_still_deferred(self, mock_get_state):
-        """safe_to_cancel should return False when the task is still DEFERRED (triggerer restart)."""
-        mock_get_state.return_value = TaskInstanceState.DEFERRED
-        trigger = KubernetesPodTrigger(
-            pod_name=POD_NAME,
-            pod_namespace=NAMESPACE,
-            base_container_name=BASE_CONTAINER_NAME,
-            trigger_start_time=TRIGGER_START_TIME,
-            schedule_timeout=STARTUP_TIMEOUT_SECS,
-        )
-        assert await trigger.safe_to_cancel() is False
-
-    @pytest.mark.asyncio
-    @mock.patch(
-        f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, side_effect=Exception("API down")
-    )
-    @mock.patch(f"{TRIGGER_PATH}.hook")
-    async def test_cleanup_skips_deletion_when_safe_to_cancel_raises(self, mock_hook, mock_safe):
-        """When safe_to_cancel() raises, cleanup should skip pod deletion (fail-safe)."""
-        trigger = KubernetesPodTrigger(
-            pod_name=POD_NAME,
-            pod_namespace=NAMESPACE,
-            base_container_name=BASE_CONTAINER_NAME,
-            trigger_start_time=TRIGGER_START_TIME,
-            schedule_timeout=STARTUP_TIMEOUT_SECS,
-            on_kill_action="delete_pod",
-            on_finish_action="delete_pod",
-        )
-        await trigger.cleanup()
-        mock_hook.delete_pod.assert_not_called()

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -32,8 +32,10 @@ from pendulum import DateTime
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
 from airflow.triggers.base import TriggerEvent
+from airflow.utils.state import TaskInstanceState
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
+POD_TRIGGER_MODULE = "airflow.providers.cncf.kubernetes.triggers.pod"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"
 POD_NAME = "test-pod-name"
 NAMESPACE = "default"
@@ -560,6 +562,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_does_not_delete_when_fired_event(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -576,6 +579,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_does_not_delete_when_on_kill_action_keep_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -591,6 +595,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_deletes_pod(self, mock_hook):
         trigger = KubernetesPodTrigger(
             pod_name=POD_NAME,
@@ -611,6 +616,7 @@ class TestKubernetesPodTrigger:
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.hook")
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
     async def test_on_kill_deletes_pod_even_when_on_finish_action_keep_pod(self, mock_hook):
         """on_finish_action is not consulted during kill -- on_kill_action is the sole control."""
         trigger = KubernetesPodTrigger(
@@ -629,3 +635,123 @@ class TestKubernetesPodTrigger:
             namespace=NAMESPACE,
             grace_period_seconds=None,
         )
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test_on_kill_noop_before_airflow_3_3(self, mock_hook):
+        """on_kill is not wired for user kills on Airflow < 3.3.0."""
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            on_kill_action="delete_pod",
+            on_finish_action="delete_pod",
+        )
+        await trigger.on_kill()
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test_cleanup_does_not_delete_during_triggerer_restart(self, mock_hook):
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            on_kill_action="delete_pod",
+            on_finish_action="delete_pod",
+        )
+        with mock.patch(f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, return_value=False):
+            await trigger.cleanup()
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False)
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test_cleanup_deletes_pod_when_safe_to_cancel(self, mock_hook):
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            on_kill_action="delete_pod",
+            on_finish_action="delete_pod",
+        )
+        mock_hook.delete_pod = mock.AsyncMock()
+        with mock.patch(f"{TRIGGER_PATH}.safe_to_cancel", new_callable=mock.AsyncMock, return_value=True):
+            await trigger.cleanup()
+        mock_hook.delete_pod.assert_called_once_with(
+            name=POD_NAME,
+            namespace=NAMESPACE,
+            grace_period_seconds=None,
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", True)
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test_cleanup_noop_on_airflow_3_3_plus(self, mock_hook):
+        """On Airflow 3.3.0+, cleanup does not delete pods (on_kill handles user kill)."""
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            on_kill_action="delete_pod",
+            on_finish_action="delete_pod",
+        )
+        await trigger.cleanup()
+        mock_hook.delete_pod.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}.get_task_state", new_callable=mock.AsyncMock)
+    async def test_safe_to_cancel_returns_true_when_task_not_deferred(self, mock_get_state):
+        mock_get_state.return_value = TaskInstanceState.SUCCESS
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+        )
+        assert await trigger.safe_to_cancel() is True
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}.get_task_state", new_callable=mock.AsyncMock)
+    async def test_safe_to_cancel_returns_false_when_task_still_deferred(self, mock_get_state):
+        mock_get_state.return_value = TaskInstanceState.DEFERRED
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+        )
+        assert await trigger.safe_to_cancel() is False
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}.hook")
+    async def test_cleanup_skips_deletion_when_safe_to_cancel_raises(self, mock_hook):
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+            on_kill_action="delete_pod",
+            on_finish_action="delete_pod",
+        )
+        with mock.patch(f"{POD_TRIGGER_MODULE}.AIRFLOW_V_3_3_PLUS", False):
+            with mock.patch(
+                f"{TRIGGER_PATH}.safe_to_cancel",
+                new_callable=mock.AsyncMock,
+                side_effect=Exception("API down"),
+            ):
+                await trigger.cleanup()
+        mock_hook.delete_pod.assert_not_called()


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

`KubernetesPodTrigger` now cancels external work only through `BaseTrigger.on_kill()` instead of the previous `cleanup()` path that used `safe_to_cancel()` to distinguish user kills from triggerer restarts. Pod deletion on user-initiated kill is unchanged in intent: it still respects `_fired_event`, `on_kill_action`, and `termination_grace_period`; triggerer shutdown or redistribution no longer goes through pod-deletion logic in this trigger.

Unit tests were updated to assert `on_kill` behavior instead of `cleanup` / `safe_to_cancel`.

related: #65733

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Cursor (GPT-based agent)

<!--
Generated-by: Cursor (GPT-based agent) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.