### PR TITLE
Fix branch operator not skipping tasks inside TaskGroups

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/branch.py
+++ b/providers/standard/src/airflow/providers/standard/operators/branch.py
@@ -62,13 +62,33 @@ class BranchMixIn(SkipMixin):
             branches_to_execute = [branches_to_execute]
 
         for branch in branches_to_execute:
-            if branch in dag.task_group_dict:
-                tg = dag.task_group_dict[branch]
+            resolved = self._resolve_branch_id(task, dag, branch)
+            if resolved in dag.task_group_dict:
+                tg = dag.task_group_dict[resolved]
                 root_ids = [root.task_id for root in tg.roots]
                 self.log.info("Expanding task group %s into %s", tg.group_id, root_ids)
                 yield from root_ids
             else:
-                yield branch
+                yield resolved
+
+    def _resolve_branch_id(self, task, dag, branch: str) -> str:
+        """
+        Resolve a branch id, allowing relative ids when called from inside a task group.
+
+        If ``branch`` matches a task or task group id as-is, return it unchanged.
+        Otherwise, if the caller is inside a prefixed task group, try resolving
+        ``branch`` as ``"{group_id}.{branch}"`` so a branch inside group ``g``
+        can return ``"path_a"`` instead of ``"g.path_a"``.
+        """
+        if branch in dag.task_group_dict or branch in dag.task_dict:
+            return branch
+        tg = getattr(task, "task_group", None)
+        if tg is not None and tg.group_id and tg.prefix_group_id:
+            candidate = f"{tg.group_id}.{branch}"
+            if candidate in dag.task_group_dict or candidate in dag.task_dict:
+                self.log.info("Resolving relative branch %r as %r", branch, candidate)
+                return candidate
+        return branch
 
 
 class BaseBranchOperator(BaseOperator, BranchMixIn):

--- a/providers/standard/tests/unit/standard/operators/test_branch_operator.py
+++ b/providers/standard/tests/unit/standard/operators/test_branch_operator.py
@@ -358,3 +358,49 @@ class TestBranchOperator:
                     assert ti.state == State.NONE
                 else:
                     raise Exception
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="TaskGroup branching via SDK requires Airflow 3+")
+    @pytest.mark.parametrize(
+        "branch_return",
+        [
+            pytest.param("g.path_a", id="absolute-task-id"),
+            pytest.param("path_a", id="relative-task-id"),
+        ],
+    )
+    def test_branch_inside_task_group(self, dag_maker, branch_return):
+        """Branch inside a TaskGroup must skip non-selected siblings, whether the branch
+        callable returns the fully-qualified task id ("g.path_a") or the id relative to
+        the enclosing group ("path_a"). Regression test for branching inside TaskGroups."""
+
+        class ChoosePath(BaseBranchOperator):
+            def choose_branch(self, context):
+                return branch_return
+
+        dag_id = f"branch_in_task_group_{branch_return.replace('.', '_')}"
+        with dag_maker(
+            dag_id,
+            default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
+            schedule=INTERVAL,
+            serialized=True,
+        ):
+            with TaskGroup(group_id="g"):
+                choose = ChoosePath(task_id="choose")
+                path_a = EmptyOperator(task_id="path_a")
+                path_b = EmptyOperator(task_id="path_b")
+                choose >> [path_a, path_b]
+
+        dr = dag_maker.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            logical_date=DEFAULT_DATE,
+            data_interval=DataInterval(DEFAULT_DATE, DEFAULT_DATE),
+            triggered_by=DagRunTriggeredByType.TEST,
+        )
+        dag_maker.run_ti("g.choose", dr)
+
+        states = {
+            ti.task_id: ti.state for ti in dag_maker.session.scalars(select(TI).where(TI.dag_id == dag_id))
+        }
+        assert states["g.choose"] == State.SUCCESS
+        assert states["g.path_a"] is None
+        assert states["g.path_b"] == State.SKIPPED

--- a/task-sdk/src/airflow/sdk/bases/branch.py
+++ b/task-sdk/src/airflow/sdk/bases/branch.py
@@ -61,13 +61,33 @@ class BranchMixIn(SkipMixin):
             branches_to_execute = [branches_to_execute]
 
         for branch in branches_to_execute:
-            if branch in dag.task_group_dict:
-                tg = dag.task_group_dict[branch]
+            resolved = self._resolve_branch_id(task, dag, branch)
+            if resolved in dag.task_group_dict:
+                tg = dag.task_group_dict[resolved]
                 root_ids = [root.task_id for root in tg.roots]
                 self.log.info("Expanding task group %s into %s", tg.group_id, root_ids)
                 yield from root_ids
             else:
-                yield branch
+                yield resolved
+
+    def _resolve_branch_id(self, task, dag, branch: str) -> str:
+        """
+        Resolve a branch id, allowing relative ids when called from inside a task group.
+
+        If ``branch`` matches a task or task group id as-is, return it unchanged.
+        Otherwise, if the caller is inside a prefixed task group, try resolving
+        ``branch`` as ``"{group_id}.{branch}"`` so a branch inside group ``g``
+        can return ``"path_a"`` instead of ``"g.path_a"``.
+        """
+        if branch in dag.task_group_dict or branch in dag.task_dict:
+            return branch
+        tg = getattr(task, "task_group", None)
+        if tg is not None and tg.group_id and tg.prefix_group_id:
+            candidate = f"{tg.group_id}.{branch}"
+            if candidate in dag.task_group_dict or candidate in dag.task_dict:
+                self.log.info("Resolving relative branch %r as %r", branch, candidate)
+                return candidate
+        return branch
 
 
 class BaseBranchOperator(BaseOperator, BranchMixIn):

--- a/task-sdk/tests/task_sdk/bases/test_branch.py
+++ b/task-sdk/tests/task_sdk/bases/test_branch.py
@@ -61,10 +61,12 @@ class TestBranchMixIn:
 
         mock_task = MagicMock(spec=BaseOperator)
         mock_task.downstream_list = [downstream1, downstream2]
+        mock_task.task_group = None
         mock_dag = MagicMock(spec=DAG)
         mock_dag.task_ids = ["branch", "down1", "down2"]
         mock_dag.get_task.return_value = downstream1
         mock_dag.task_group_dict = {}
+        mock_dag.task_dict = {"branch": mock_task, "down1": downstream1, "down2": downstream2}
         mock_task.dag = mock_dag
 
         ti = Mock(spec=RuntimeTaskInstanceProtocol, map_index=-1, task=mock_task)
@@ -101,13 +103,37 @@ class TestBranchMixIn:
 
         mock_dag = MagicMock(spec=DAG)
         mock_dag.task_group_dict = {}
+        mock_dag.task_dict = {"regular_task": object()}
         mock_task = MagicMock(spec=BaseOperator)
+        mock_task.task_group = None
         mock_task.dag = mock_dag
 
         ti = Mock(spec=RuntimeTaskInstanceProtocol, task=mock_task)
 
         result = list(mixin._expand_task_group_roots(ti, "regular_task"))
         assert result == ["regular_task"]
+
+    def test_expand_task_group_roots_resolves_relative_id_inside_group(self):
+        """Inside a prefixed task group, a relative branch id should resolve to the
+        fully-qualified id (e.g. "path_a" -> "g.path_a")."""
+        mixin = BranchMixIn()
+
+        mock_tg = MagicMock(spec=TaskGroup)
+        mock_tg.group_id = "g"
+        mock_tg.prefix_group_id = True
+
+        mock_dag = MagicMock(spec=DAG)
+        mock_dag.task_group_dict = {"g": mock_tg}
+        mock_dag.task_dict = {"g.choose": object(), "g.path_a": object()}
+        mock_task = MagicMock(spec=BaseOperator)
+        mock_task.task_group = mock_tg
+        mock_task.dag = mock_dag
+
+        ti = Mock(spec=RuntimeTaskInstanceProtocol, task=mock_task)
+
+        assert list(mixin._expand_task_group_roots(ti, "path_a")) == ["g.path_a"]
+        # Absolute ids still pass through.
+        assert list(mixin._expand_task_group_roots(ti, "g.path_a")) == ["g.path_a"]
 
 
 class TestBaseBranchOperator:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Branch operators inside TaskGroups now correctly skip non-selected sibling tasks when returning relative task IDs. Previously, a branch callable inside group "g" that returned "path_a" would fail to skip sibling task "path_b" because the branching logic only recognized fully-qualified IDs like "g.path_a".

This fix allows branch callables to return either:
- Relative IDs: `"path_a"` (more intuitive)
- Absolute IDs: `"g.path_a"` (backward compatible)

Both formats now work correctly, preventing unnecessary task execution and resource waste in production environments (particularly KubernetesExecutor where each task starts a pod).

**Changes:**
- Added `_resolve_branch_id()` method to resolve relative task IDs within TaskGroups
- Applied fix to both `task-sdk` and `providers/standard` distributions
- Added regression tests covering both relative and absolute ID formats
- Added unit tests for the resolution logic

**Testing:**
- New parametrized integration test: `test_branch_inside_task_group`
- New unit test: `test_expand_task_group_roots_resolves_relative_id_inside_group`
- All existing branch operator tests pass

closes: #65745 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes — Claude Code
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
