### PR TITLE
Fix Airflow 3 task log access with NetworkPolicies

### DIFF
--- a/chart/templates/scheduler/scheduler-networkpolicy.yaml
+++ b/chart/templates/scheduler/scheduler-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: airflow
-          component: scheduler
+          component: api-server
           release: {{ .Release.Name }}
     ports:
     - protocol: TCP

--- a/chart/templates/triggerer/triggerer-networkpolicy.yaml
+++ b/chart/templates/triggerer/triggerer-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: triggerer
+          component: api-server
     ports:
     - protocol: TCP
       port: {{ .Values.ports.triggererLogs }}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -64,7 +64,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: webserver
+          component: api-server
     ports:
     - protocol: TCP
       port: {{ .Values.ports.workerLogs }}

--- a/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
@@ -1005,6 +1005,20 @@ class TestSchedulerNetworkPolicy:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    def test_should_allow_api_server_to_read_scheduler_logs(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "networkPolicies": {"enabled": True},
+            },
+            show_only=["templates/scheduler/scheduler-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
 
 class TestSchedulerLogGroomer(LogGroomerTestBase):
     """Scheduler log groomer."""

--- a/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
@@ -778,6 +778,23 @@ class TestTriggererServiceAccount:
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 
 
+class TestTriggererNetworkPolicy:
+    """Tests triggerer network policy."""
+
+    def test_should_allow_api_server_to_read_triggerer_logs(self):
+        docs = render_chart(
+            values={
+                "networkPolicies": {"enabled": True},
+            },
+            show_only=["templates/triggerer/triggerer-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
+
 class TestTriggererLogGroomer(LogGroomerTestBase):
     """Triggerer log groomer."""
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2682,6 +2682,21 @@ class TestWorkerNetworkPolicy:
         assert labels["test_label"] == "test_label_value"
         assert "key" not in labels
 
+    @pytest.mark.parametrize("executor", ["CeleryExecutor", "CeleryExecutor,KubernetesExecutor"])
+    def test_should_allow_api_server_to_read_worker_logs(self, executor):
+        docs = render_chart(
+            values={
+                "networkPolicies": {"enabled": True},
+                "executor": executor,
+            },
+            show_only=["templates/workers/worker-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
 
 class TestWorkerService:
     """Tests worker service."""


### PR DESCRIPTION
## Why

In Airflow 3, task logs are fetched through the API server rather than the webserver.

The Helm chart still allowed ingress to the scheduler, triggerer, and worker log-serving ports only from pods labeled `component: webserver`. When `networkPolicies.enabled=true`, this can block the API server from reaching those log endpoints and break task log access in Airflow 3.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
