### PR TITLE
Chart: Make Git-Sync DAG mount path configurable

### DIFF
--- a/chart/docs/manage-dag-files.rst
+++ b/chart/docs/manage-dag-files.rst
@@ -108,6 +108,10 @@ This option will always use running Git-Sync sidecar on every dag-processor, wor
 The Git-Sync sidecar containers will sync Dags from a git repository every configured number of
 seconds. If you are using the ``KubernetesExecutor``, Git-Sync will run as an init container on your worker pods.
 
+If you want the synced files to appear under a different directory name than ``repo`` inside the Dag mount path,
+set ``dags.gitSync.link`` in your ``values.yaml``. For example, ``link: myrepo`` will mount Dags under
+``$AIRFLOW_HOME/dags/myrepo`` instead of ``$AIRFLOW_HOME/dags/repo``.
+
 .. code-block:: bash
 
    helm upgrade --install airflow apache-airflow/airflow \

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -241,9 +241,9 @@ If release name contains chart name it will be used as a full name.
     - name: GITSYNC_ROOT
       value: "/git"
     - name: GIT_SYNC_DEST
-      value: "repo"
+      value: {{ default "repo" .Values.dags.gitSync.link | quote }}
     - name: GITSYNC_LINK
-      value: "repo"
+      value: {{ default "repo" .Values.dags.gitSync.link | quote }}
     - name: GIT_SYNC_ADD_USER
       value: "true"
     - name: GITSYNC_ADD_USER
@@ -590,13 +590,13 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{- define "airflow_dags" -}}
   {{- if .Values.dags.mountPath }}
     {{- if .Values.dags.gitSync.enabled }}
-      {{- printf "%s/repo/%s" .Values.dags.mountPath .Values.dags.gitSync.subPath }}
+      {{- printf "%s/%s/%s" .Values.dags.mountPath (default "repo" .Values.dags.gitSync.link) .Values.dags.gitSync.subPath }}
     {{- else }}
       {{- printf "%s" .Values.dags.mountPath }}
     {{- end }}
   {{- else }}
     {{- if .Values.dags.gitSync.enabled }}
-      {{- printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath }}
+      {{- printf "%s/dags/%s/%s" .Values.airflowHome (default "repo" .Values.dags.gitSync.link) .Values.dags.gitSync.subPath }}
     {{- else }}
       {{- printf "%s/dags" .Values.airflowHome }}
     {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -11908,6 +11908,11 @@
                             "type": "integer",
                             "default": 1
                         },
+                        "link": {
+                            "description": "Name of the directory where git-sync will create the symlink to the checked out repository. This allows customization of the DAG mount path structure.",
+                            "type": "string",
+                            "default": "repo"
+                        },
                         "maxFailures": {
                             "description": "The number of consecutive failures allowed before aborting.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4347,6 +4347,11 @@ dags:
     # Should be "" if dags are at repo root
     subPath: "tests/dags"
 
+    # Name of the directory where git-sync will create the symlink to the checked out repository.
+    # This allows customization of the DAG mount path structure.
+    # Default is "repo" for backward compatibility.
+    link: "repo"
+
     # If your repo needs a username/password, you can load them to a k8s secret
     #
     # credentialsSecret: git-credentials

--- a/helm-tests/tests/helm_tests/airflow_aux/test_configmap.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_configmap.py
@@ -183,6 +183,21 @@ metadata:
                 {"mountPath": "/opt/airflow/dags/custom", "persistence": {"enabled": True}},
                 "/opt/airflow/dags/custom",
             ),
+            (
+                # Test custom link name with default mountPath
+                {"gitSync": {"enabled": True, "link": "myrepo"}},
+                "/opt/airflow/dags/myrepo/tests/dags",
+            ),
+            (
+                # Test custom link with custom mountPath
+                {"mountPath": "/opt/airflow/dags/custom", "gitSync": {"enabled": True, "link": "customrepo"}},
+                "/opt/airflow/dags/custom/customrepo/tests/dags",
+            ),
+            (
+                # Test custom link with subPath
+                {"gitSync": {"enabled": True, "link": "myrepo", "subPath": "mysubPath"}},
+                "/opt/airflow/dags/myrepo/mysubPath",
+            ),
         ],
     )
     def test_expected_default_dag_folder(self, dag_values, expected_default_dag_folder):


### PR DESCRIPTION
This PR allows users to configure the Git Sync destination directory via `dags.gitSync.link` (defaulting to `"repo"` for backward compatibility).

### What changed

- Added `dags.gitSync.link` to values and schema.
- Updated sidecar environment variables and the `airflow_dags` helper to honor the custom link name.
- Updated documentation and release notes.

### Why

Currently Git-Sync forces the DAG path to be `/dags/repo/...`. This fix enables customization for users who need a different directory structure.

closes: #65589

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude(for research)
