### PR TITLE
Fix cleanup pod lifecycle hooks not being applied

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -27,6 +27,7 @@
 {{- $topologySpreadConstraints := or .Values.cleanup.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "airflowPodSecurityContext" (list .Values.cleanup .Values) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list .Values.cleanup .Values) }}
+{{- $containerLifecycleHooks := or .Values.cleanup.containerLifecycleHooks .Values.containerLifecycleHooks }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -92,6 +93,9 @@ spec:
               image: {{ template "airflow_image" . }}
               imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
               securityContext: {{ $containerSecurityContext | nindent 16 }}
+              {{- if $containerLifecycleHooks }}
+              lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 16 }}
+              {{- end }}
               {{- if .Values.cleanup.command }}
               command: {{ tpl (toYaml .Values.cleanup.command) . | nindent 16 }}
               {{- end }}

--- a/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_cleanup_pods.py
@@ -228,6 +228,50 @@ class TestCleanupPods:
             "exec airflow kubernetes cleanup-pods --namespace=default",
         ]
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            pytest.param(
+                {
+                    "cleanup": {
+                        "enabled": True,
+                        "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                    },
+                },
+                id="component",
+            ),
+            pytest.param(
+                {
+                    "cleanup": {"enabled": True},
+                    "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                },
+                id="global-fallback",
+            ),
+            pytest.param(
+                {
+                    "cleanup": {
+                        "enabled": True,
+                        "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                    },
+                    "containerLifecycleHooks": {"postStart": {"exec": {"command": ["echo", "global"]}}},
+                },
+                id="component-overrides-global",
+            ),
+        ],
+    )
+    def test_should_render_container_lifecycle_hooks(self, values):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                **values,
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        assert jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].lifecycle", docs[0]) == {
+            "preStop": {"exec": {"command": ["echo", "cleanup"]}}
+        }
+
     def test_should_add_extraEnvs(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
## Why

The chart already exposes `cleanup.containerLifecycleHooks` in `values.yaml`, but the cleanup CronJob template never used that value. In practice, this means users can configure the option but it has no effect.

This change fixes that mismatch between chart values and template behavio.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
