### PR TITLE
Breeze: fail fast when building provider sdists from a git worktree

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1158,6 +1158,10 @@ def prepare_provider_distributions(
     version_suffix: str,
 ):
     perform_environment_checks()
+    # Workaround for pypa/flit#798 (fix PR pypa/flit#799) plus the Breeze
+    # Docker-mount case. Remove this call and the helper it invokes once
+    # the conditions in the tracking issue are met:
+    # https://github.com/apache/airflow/issues/65772
     check_flit_worktree_compatibility(distribution_format)
     fix_ownership_using_docker()
     cleanup_python_generated_files()

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -112,6 +112,7 @@ from airflow_breeze.prepare_providers.provider_distributions import (
     PrepareReleasePackageTagExistException,
     PrepareReleasePackageWrongSetupException,
     build_provider_distribution,
+    check_flit_worktree_compatibility,
     cleanup_build_remnants,
     get_packages_list_to_act_on,
     move_built_distributions_and_cleanup,
@@ -1157,6 +1158,7 @@ def prepare_provider_distributions(
     version_suffix: str,
 ):
     perform_environment_checks()
+    check_flit_worktree_compatibility(distribution_format)
     fix_ownership_using_docker()
     cleanup_python_generated_files()
     console_print("\n[info]Cleaning generated _api folders from docs directories")

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
@@ -33,9 +33,47 @@ from airflow_breeze.utils.packages import (
     get_removed_provider_ids,
     tag_exists_for_provider,
 )
-from airflow_breeze.utils.path_utils import AIRFLOW_DIST_PATH
+from airflow_breeze.utils.path_utils import AIRFLOW_DIST_PATH, AIRFLOW_ROOT_PATH
 from airflow_breeze.utils.run_utils import run_command
 from airflow_breeze.utils.version_utils import is_local_package_version
+
+
+def check_flit_worktree_compatibility(distribution_format: str) -> None:
+    """Refuse to build provider sdists from a git worktree.
+
+    flit's ``--use-vcs`` relies on ``flit.vcs.identify_vcs`` which checks
+    ``(p / ".git").is_dir()``. Inside a ``git worktree add`` directory ``.git``
+    is a *file* (``gitdir: ...`` pointer), not a directory, so VCS detection
+    silently fails and flit falls back to a minimal sdist that omits
+    ``docs/``, ``tests/``, ``provider.yaml`` and other tracked files. The
+    resulting sdists differ from the released ones and fail reproducibility
+    checks, with no warning from flit itself.
+
+    This only affects sdist builds for providers that use the ``flit_core``
+    build backend. Wheels are unaffected, and providers that use ``hatchling``
+    with an explicit ``[tool.hatch.build.targets.sdist]`` ``include`` list are
+    also unaffected. Upstream flit tracking:
+    https://github.com/pypa/flit/blob/main/flit/vcs/__init__.py (``identify_vcs``).
+    """
+    if distribution_format == "wheel":
+        return
+    git_marker = AIRFLOW_ROOT_PATH / ".git"
+    if git_marker.is_file():
+        console_print(
+            "\n[error]Cannot build provider sdists from a git worktree.[/]\n\n"
+            "[warning]flit's `--use-vcs` does not recognise git worktrees "
+            "(flit.vcs.identify_vcs uses `.git.is_dir()`, but in a worktree "
+            "`.git` is a file). flit silently falls back to a minimal sdist "
+            "that omits docs/, tests/, provider.yaml and other tracked files, "
+            "so the resulting packages fail reproducibility checks against "
+            "the released sdists on dist.apache.org.[/]\n\n"
+            "[info]Until flit is fixed, run this command from a plain "
+            "`git checkout` (not a `git worktree add ...` directory). "
+            "If you only need wheels, pass `--distribution-format wheel` — "
+            "wheels are built from `pyproject.toml` metadata and are not "
+            "affected by this bug.[/]\n"
+        )
+        sys.exit(1)
 
 
 class PrepareReleasePackageTagExistException(Exception):

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
@@ -66,8 +66,14 @@ def check_flit_worktree_compatibility(distribution_format: str) -> None:
     ``[tool.hatch.build.targets.sdist]`` ``include`` list are also
     unaffected.
 
-    Remove this check once upstream flit handles worktrees correctly *and*
-    Airflow pins to a flit release that contains the fix.
+    Upstream flit tracking:
+
+    - Issue: https://github.com/pypa/flit/issues/798
+    - Fix PR: https://github.com/pypa/flit/pull/799
+
+    Airflow-side follow-up (remove this workaround when both conditions in
+    the tracking issue are met):
+    https://github.com/apache/airflow/issues/65772
     """
     if distribution_format == "wheel":
         return

--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_distributions.py
@@ -39,41 +39,104 @@ from airflow_breeze.utils.version_utils import is_local_package_version
 
 
 def check_flit_worktree_compatibility(distribution_format: str) -> None:
-    """Refuse to build provider sdists from a git worktree.
+    """Refuse to build provider sdists when VCS detection will silently break.
 
-    flit's ``--use-vcs`` relies on ``flit.vcs.identify_vcs`` which checks
-    ``(p / ".git").is_dir()``. Inside a ``git worktree add`` directory ``.git``
-    is a *file* (``gitdir: ...`` pointer), not a directory, so VCS detection
-    silently fails and flit falls back to a minimal sdist that omits
-    ``docs/``, ``tests/``, ``provider.yaml`` and other tracked files. The
-    resulting sdists differ from the released ones and fail reproducibility
-    checks, with no warning from flit itself.
+    Provider sdists are built with ``flit --use-vcs``. flit identifies the VCS
+    via ``flit.vcs.identify_vcs``, which checks ``(p / ".git").is_dir()``.
+    That check fails in two related scenarios, both of which produce a
+    broken sdist with no warning from flit:
 
-    This only affects sdist builds for providers that use the ``flit_core``
-    build backend. Wheels are unaffected, and providers that use ``hatchling``
-    with an explicit ``[tool.hatch.build.targets.sdist]`` ``include`` list are
-    also unaffected. Upstream flit tracking:
-    https://github.com/pypa/flit/blob/main/flit/vcs/__init__.py (``identify_vcs``).
+    1. **Plain git worktree on the host.** Inside a ``git worktree add ...``
+       directory ``.git`` is a regular file containing a ``gitdir: <path>``
+       pointer, not a directory. ``is_dir()`` returns False, ``identify_vcs``
+       returns ``None``, and flit falls back to a non-VCS sdist that omits
+       tracked files like ``docs/``, ``tests/`` and ``provider.yaml``. The
+       resulting packages fail reproducibility checks against the released
+       sdists on dist.apache.org.
+    2. **Breeze Docker builds with a worktree mounted.** When the build runs
+       inside Breeze's container, only the worktree directory is
+       bind-mounted. The absolute ``gitdir:`` path baked into ``.git``
+       points somewhere on the host (``<main_repo>/.git/worktrees/<name>``)
+       that does not exist inside the container, so even if flit recognised
+       worktrees, ``git ls-files`` would fail or misbehave.
+
+    Wheels are built from ``pyproject.toml`` metadata and are unaffected, so
+    this check is a no-op for ``--distribution-format wheel``. Providers
+    that use ``hatchling`` with an explicit
+    ``[tool.hatch.build.targets.sdist]`` ``include`` list are also
+    unaffected.
+
+    Remove this check once upstream flit handles worktrees correctly *and*
+    Airflow pins to a flit release that contains the fix.
     """
     if distribution_format == "wheel":
         return
+
     git_marker = AIRFLOW_ROOT_PATH / ".git"
-    if git_marker.is_file():
+    if not git_marker.is_file():
+        # Regular .git directory (or missing entirely) — flit's VCS detection
+        # works correctly, nothing to do.
+        return
+
+    # .git is a file — typical in a git worktree (or submodule). Parse the
+    # pointer so we can give a precise error for each failure mode, and so
+    # we detect the Breeze-in-Docker case where the target is unreachable.
+    try:
+        content = git_marker.read_text(encoding="utf-8").strip()
+    except OSError as err:
         console_print(
-            "\n[error]Cannot build provider sdists from a git worktree.[/]\n\n"
-            "[warning]flit's `--use-vcs` does not recognise git worktrees "
-            "(flit.vcs.identify_vcs uses `.git.is_dir()`, but in a worktree "
-            "`.git` is a file). flit silently falls back to a minimal sdist "
-            "that omits docs/, tests/, provider.yaml and other tracked files, "
-            "so the resulting packages fail reproducibility checks against "
-            "the released sdists on dist.apache.org.[/]\n\n"
-            "[info]Until flit is fixed, run this command from a plain "
-            "`git checkout` (not a `git worktree add ...` directory). "
-            "If you only need wheels, pass `--distribution-format wheel` — "
-            "wheels are built from `pyproject.toml` metadata and are not "
-            "affected by this bug.[/]\n"
+            f"\n[error]Cannot read {git_marker}: {err}.[/]\n"
+            "[info]Run this command from a plain `git checkout`, or pass "
+            "`--distribution-format wheel` (wheels are unaffected).[/]\n"
         )
         sys.exit(1)
+
+    if not content.startswith("gitdir:"):
+        console_print(
+            f"\n[error]Unexpected `.git` file format at {git_marker}.[/]\n\n"
+            f"[warning]Expected a `gitdir: <path>` pointer (git worktree or "
+            f"submodule), got:\n  {content!r}[/]\n\n"
+            "[info]Run this command from a plain `git checkout`, or pass "
+            "`--distribution-format wheel` (wheels are unaffected).[/]\n"
+        )
+        sys.exit(1)
+
+    gitdir = Path(content[len("gitdir:") :].strip())
+    if not gitdir.exists():
+        console_print(
+            "\n[error]Cannot build provider sdists: git worktree pointer "
+            "targets a missing gitdir.[/]\n\n"
+            f"[warning]The `.git` file at `{git_marker}` points to "
+            f"`{gitdir}`, but that directory does not exist from here.[/]\n\n"
+            "[info]This typically happens when Breeze runs the build inside "
+            "Docker: only the worktree directory is bind-mounted into the "
+            "container, so the main repo's `.git/worktrees/<name>` folder "
+            "that the pointer references is not reachable. flit then either "
+            "fails outright or silently produces an incomplete sdist that "
+            "omits tracked files.[/]\n\n"
+            "[info]Run this command from a plain `git checkout` (not a "
+            "`git worktree add ...` directory), or pass "
+            "`--distribution-format wheel` — wheels don't need VCS metadata "
+            "and are unaffected.[/]\n"
+        )
+        sys.exit(1)
+
+    # Healthy worktree on the host. flit's `.is_dir()` check still misses it,
+    # so we refuse sdist builds here too.
+    console_print(
+        "\n[error]Cannot build provider sdists from a git worktree.[/]\n\n"
+        "[warning]flit's `--use-vcs` does not recognise git worktrees "
+        "(flit.vcs.identify_vcs uses `.git.is_dir()`, but in a worktree "
+        "`.git` is a file). flit silently falls back to a minimal sdist "
+        "that omits docs/, tests/, provider.yaml and other tracked files, "
+        "so the resulting packages fail reproducibility checks against "
+        "the released sdists on dist.apache.org.[/]\n\n"
+        "[info]Run this command from a plain `git checkout` (not a "
+        "`git worktree add ...` directory). If you only need wheels, pass "
+        "`--distribution-format wheel` — wheels are built from "
+        "`pyproject.toml` metadata and are not affected by this bug.[/]\n"
+    )
+    sys.exit(1)
 
 
 class PrepareReleasePackageTagExistException(Exception):

--- a/dev/breeze/tests/test_provider_distributions.py
+++ b/dev/breeze/tests/test_provider_distributions.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from airflow_breeze.prepare_providers import provider_distributions
+from airflow_breeze.prepare_providers.provider_distributions import (
+    check_flit_worktree_compatibility,
+)
+
+
+@pytest.fixture
+def worktree_root(tmp_path: Path) -> Path:
+    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/foo\n")
+    return tmp_path
+
+
+@pytest.fixture
+def plain_checkout_root(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def test_worktree_blocks_sdist_build(worktree_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
+        with pytest.raises(SystemExit) as exc_info:
+            check_flit_worktree_compatibility("sdist")
+        assert exc_info.value.code == 1
+
+
+def test_worktree_blocks_both_format_build(worktree_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
+        with pytest.raises(SystemExit) as exc_info:
+            check_flit_worktree_compatibility("both")
+        assert exc_info.value.code == 1
+
+
+def test_worktree_allows_wheel_build(worktree_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
+        check_flit_worktree_compatibility("wheel")
+
+
+def test_plain_checkout_allows_sdist_build(plain_checkout_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", plain_checkout_root):
+        check_flit_worktree_compatibility("sdist")
+        check_flit_worktree_compatibility("both")
+        check_flit_worktree_compatibility("wheel")

--- a/dev/breeze/tests/test_provider_distributions.py
+++ b/dev/breeze/tests/test_provider_distributions.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -26,10 +27,43 @@ from airflow_breeze.prepare_providers.provider_distributions import (
     check_flit_worktree_compatibility,
 )
 
+# Rich output is wrapped to the terminal width and peppered with ANSI escapes;
+# strip both when asserting on message contents.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(out: str, err: str) -> str:
+    return " ".join(_ANSI_RE.sub("", out + err).split())
+
 
 @pytest.fixture
-def worktree_root(tmp_path: Path) -> Path:
-    (tmp_path / ".git").write_text("gitdir: /elsewhere/.git/worktrees/foo\n")
+def healthy_worktree_root(tmp_path: Path) -> Path:
+    """A worktree whose `gitdir:` pointer targets a real directory."""
+    gitdir = tmp_path / "main_repo" / ".git" / "worktrees" / "feature"
+    gitdir.mkdir(parents=True)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {gitdir}\n")
+    return worktree
+
+
+@pytest.fixture
+def broken_worktree_root(tmp_path: Path) -> Path:
+    """A worktree whose `gitdir:` pointer targets a path that does not exist.
+
+    This is the Breeze-in-Docker shape: the worktree directory is mounted
+    into the container but the absolute `gitdir:` path is not.
+    """
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /nonexistent/main/.git/worktrees/feature\n")
+    return worktree
+
+
+@pytest.fixture
+def malformed_git_file_root(tmp_path: Path) -> Path:
+    """`.git` is a file but the content is not a `gitdir:` pointer."""
+    (tmp_path / ".git").write_text("this is not a git pointer\n")
     return tmp_path
 
 
@@ -39,26 +73,54 @@ def plain_checkout_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_worktree_blocks_sdist_build(worktree_root: Path) -> None:
-    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
+@pytest.mark.parametrize("dist_format", ["sdist", "both"])
+def test_healthy_worktree_blocks_sdist_build(healthy_worktree_root: Path, dist_format: str) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", healthy_worktree_root):
         with pytest.raises(SystemExit) as exc_info:
-            check_flit_worktree_compatibility("sdist")
+            check_flit_worktree_compatibility(dist_format)
         assert exc_info.value.code == 1
 
 
-def test_worktree_blocks_both_format_build(worktree_root: Path) -> None:
-    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
-        with pytest.raises(SystemExit) as exc_info:
-            check_flit_worktree_compatibility("both")
-        assert exc_info.value.code == 1
-
-
-def test_worktree_allows_wheel_build(worktree_root: Path) -> None:
-    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", worktree_root):
+def test_healthy_worktree_allows_wheel_build(healthy_worktree_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", healthy_worktree_root):
         check_flit_worktree_compatibility("wheel")
 
 
-def test_plain_checkout_allows_sdist_build(plain_checkout_root: Path) -> None:
+@pytest.mark.parametrize("dist_format", ["sdist", "both"])
+def test_broken_gitdir_pointer_exits_with_docker_hint(
+    broken_worktree_root: Path, capsys: pytest.CaptureFixture[str], dist_format: str
+) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", broken_worktree_root):
+        with pytest.raises(SystemExit) as exc_info:
+            check_flit_worktree_compatibility(dist_format)
+        assert exc_info.value.code == 1
+    # The Docker-specific message must surface — the broken pointer is the
+    # signal we use to tell the user that this is the container-mount case.
+    captured = capsys.readouterr()
+    output = _plain(captured.out, captured.err)
+    assert "Docker" in output
+    assert "does not exist" in output
+
+
+def test_broken_gitdir_still_allows_wheel_build(broken_worktree_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", broken_worktree_root):
+        check_flit_worktree_compatibility("wheel")
+
+
+@pytest.mark.parametrize("dist_format", ["sdist", "both"])
+def test_malformed_git_file_exits(malformed_git_file_root: Path, dist_format: str) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", malformed_git_file_root):
+        with pytest.raises(SystemExit) as exc_info:
+            check_flit_worktree_compatibility(dist_format)
+        assert exc_info.value.code == 1
+
+
+def test_malformed_git_file_allows_wheel_build(malformed_git_file_root: Path) -> None:
+    with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", malformed_git_file_root):
+        check_flit_worktree_compatibility("wheel")
+
+
+def test_plain_checkout_allows_all_formats(plain_checkout_root: Path) -> None:
     with patch.object(provider_distributions, "AIRFLOW_ROOT_PATH", plain_checkout_root):
         check_flit_worktree_compatibility("sdist")
         check_flit_worktree_compatibility("both")


### PR DESCRIPTION
`breeze release-management prepare-provider-distributions` now exits
early with a clear error if it is run from a context where flit's VCS
detection would silently produce a broken sdist.

## Scope of the check

Two related failure modes are guarded:

1. **Plain git worktree on the host.** `flit --use-vcs` (used to build
   most provider sdists) relies on `flit.vcs.identify_vcs`, which
   checks `(p / ".git").is_dir()`. In a worktree `.git` is a file
   (`gitdir:` pointer), not a directory, so flit silently falls back to
   a minimal sdist that omits `docs/`, `tests/`, `provider.yaml` and
   other tracked files. The resulting packages differ from released
   sdists on dist.apache.org and fail reproducibility checks — with no
   warning from flit.
2. **Breeze Docker builds from a worktree.** Even once flit is fixed,
   when the build runs inside Breeze's container only the worktree
   directory is bind-mounted. The absolute `gitdir:` pointer inside
   `.git` references the main repo's `.git/worktrees/<name>` folder on
   the host, which is not reachable from the container. `git ls-files`
   then fails or misbehaves and the sdist is again incomplete.

The check parses `.git` and branches on the failure mode:

| Situation | Outcome |
|---|---|
| `.git` is a directory (plain checkout) | pass |
| `.git` file with `gitdir:` pointing at an existing directory (host worktree) | exit 1, explain flit bug and workarounds |
| `.git` file with `gitdir:` pointing at a missing directory (Docker mount) | exit 1, explain the bind-mount case |
| `.git` file with unexpected content | exit 1, print the content and suggest plain checkout |
| `--distribution-format wheel` | pass regardless — wheels don't need VCS metadata |

## Context

Discovered during PMC verification of the 2026-04-21 provider RC run
from a worktree: all 47 wheels matched byte-for-byte, the 3 providers
that use hatchling with explicit `[tool.hatch.build.targets.sdist]`
includes matched, but all 20 flit-based sdists diverged. Wheels are
unaffected.

## Upstream and tracking

- Upstream flit bug filed: https://github.com/pypa/flit/issues/798
- Fix PR opened against `pypa/flit`: https://github.com/pypa/flit/pull/799
- Airflow tracking issue for removing this check: #65772

The tracking issue's conditions (flit fix released **and** Airflow
constraints pin to it, plus the Docker-mount story resolved) must both
be met before `check_flit_worktree_compatibility` is removed. The code
carries the tracking-issue URL at the call site and in the helper's
docstring per `CLAUDE.md`.

## Test plan

- [x] `uv run --project dev/breeze pytest dev/breeze/tests/test_provider_distributions.py` — 10 passed
- [x] Tests cover: plain checkout, healthy host worktree, broken gitdir (Docker case), malformed `.git` file, wheel-only bypass — each across `sdist`, `both`, and `wheel` distribution formats as applicable
- [x] `prek run --from-ref main --stage pre-commit` — all applicable hooks pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7

Generated-by: Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)