### PR TITLE
Breeze: ensure generated Dockerfile.pmc upgrades uv to required floor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -245,6 +245,7 @@ repos:
         files: >
           (?x)
           ^pyproject\.toml$|
+          ^dev/breeze/src/airflow_breeze/utils/check_release_files\.py$|
           ^dev/breeze/tests/test_environment_check\.py$
         require_serial: true
       - id: check-distribution-gitignore

--- a/dev/breeze/src/airflow_breeze/utils/check_release_files.py
+++ b/dev/breeze/src/airflow_breeze/utils/check_release_files.py
@@ -22,13 +22,23 @@ from pathlib import Path
 
 from airflow_breeze.utils.console import get_console
 
-PROVIDERS_DOCKER = """\
+# Must satisfy the `[tool.uv] required-version` floor in the root pyproject.toml
+# that gets COPY'd into the PMC image. Kept in lockstep with that floor by the
+# `sync-uv-min-version-markers` prek hook.
+_PROVIDERS_DOCKER_UV_MIN_VERSION = "0.11.7"  # sync-uv-min-version
+
+PROVIDERS_DOCKER = f"""\
 FROM ghcr.io/apache/airflow/main/ci/python3.10
 RUN cd airflow-core; uv sync --no-sources
 
 # Install providers with providers pre-releases allowed
 COPY pyproject.toml .
-{}
+# The CI image may ship an older uv than the copied pyproject.toml's
+# `[tool.uv] required-version` floor; `uv pip install` would then refuse with
+# a version-pin error. Upgrade uv first so the install step works regardless
+# of when the CI image was last rebuilt.
+RUN pip install --upgrade 'uv>={_PROVIDERS_DOCKER_UV_MIN_VERSION}'
+{{}}
 """
 
 AIRFLOW_DOCKER = """\

--- a/dev/breeze/tests/test_check_release_files.py
+++ b/dev/breeze/tests/test_check_release_files.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from airflow_breeze.utils.check_release_files import (
+    PROVIDERS_DOCKER,
     check_airflow_ctl_release,
     check_airflow_release,
     check_providers,
@@ -220,3 +221,35 @@ def test_check_python_client_release_fail():
         "apache_airflow_client-2.5.0.tar.gz.sha512",
         "apache_airflow_python_client-2.5.0-source.tar.gz.asc",
     ]
+
+
+def test_providers_docker_upgrades_uv_before_install():
+    """The generated Dockerfile.pmc must upgrade uv to satisfy the copied
+    pyproject.toml's [tool.uv] required-version floor before `uv pip install`
+    runs, otherwise the install step fails with a version-pin error when the
+    CI image ships an older uv.
+    """
+    install_cmd = "RUN uv pip install --pre --system 'apache-airflow-providers-amazon==9.26.0rc1'"
+    rendered = PROVIDERS_DOCKER.format(install_cmd)
+
+    assert "pip install --upgrade 'uv>=" in rendered
+    upgrade_idx = rendered.index("pip install --upgrade 'uv>=")
+    install_idx = rendered.index(install_cmd)
+    assert upgrade_idx < install_idx, "uv upgrade must precede uv pip install"
+
+
+def test_providers_docker_uv_version_matches_required_version():
+    """The hard-coded uv floor in PROVIDERS_DOCKER must equal the current
+    [tool.uv] required-version from the root pyproject.toml. The
+    `sync-uv-min-version-markers` prek hook enforces this at commit time;
+    this test is a belt-and-braces guard for accidental drift.
+    """
+    from airflow_breeze.utils.check_release_files import _PROVIDERS_DOCKER_UV_MIN_VERSION
+    from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH
+
+    pyproject = (AIRFLOW_ROOT_PATH / "pyproject.toml").read_text()
+    import re
+
+    match = re.search(r'required-version\s*=\s*"\s*>=\s*([0-9]+(?:\.[0-9]+){0,2})\s*"', pyproject)
+    assert match, "Could not find [tool.uv] required-version in root pyproject.toml"
+    assert match.group(1) == _PROVIDERS_DOCKER_UV_MIN_VERSION


### PR DESCRIPTION
`breeze release-management check-release-files providers` generates a
`Dockerfile.pmc` that copies the root `pyproject.toml` into the CI image
and then runs `uv pip install`. If the CI image ships an older uv than
`[tool.uv] required-version`, the install step fails with:

```
error: Required uv version `>=X.Y.Z` does not match the running
version `A.B.C`. Update `uv` by running `uv self update`.
```

This is reproducible today: the current `ghcr.io/apache/airflow/main/ci/python3.10`
image ships uv `0.11.6`, the pin is `>=0.11.7`, and so every PMC
`Dockerfile.pmc` install attempt breaks out of the box.

## Fix

- Inject `RUN pip install --upgrade 'uv>=X.Y.Z'` before `uv pip install`
  in `PROVIDERS_DOCKER`. The install step now works regardless of when
  the CI image was last rebuilt.
- Put the floor in a `_PROVIDERS_DOCKER_UV_MIN_VERSION` constant with
  the existing `# sync-uv-min-version` marker, and add
  `check_release_files.py` to the `sync-uv-min-version-markers` prek
  hook's file list. When someone bumps `[tool.uv] required-version`,
  the hook rewrites this constant on the next commit.
- Two new tests guard the change: (1) the rendered `PROVIDERS_DOCKER`
  contains the uv upgrade step and it precedes `uv pip install`;
  (2) the hard-coded floor matches the current `required-version` from
  the root `pyproject.toml` (belt-and-braces — the hook enforces this
  at commit time, the test catches accidental drift).

Not auto-syncing with `AIRFLOW_UV_VERSION` on purpose — per the comment
next to `required-version`, that value intentionally stays decoupled
and is managed via `upgrade_important_versions.py`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7

Generated-by: Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)