### PR TITLE
Add AIP-to-user-stories skill for generating recipe playbooks from AIPs

### DIFF
--- a/.claude/skills/aip-user-stories
+++ b/.claude/skills/aip-user-stories
@@ -1,0 +1,1 @@
+../../.github/skills/aip-user-stories

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,6 +174,7 @@ Dockerfile.ci @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @ja
 /airflow-core/src/airflow/api_fastapi/execution_api/AGENTS.md @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin @Dev-iL @jason810496 @shahar1 @choo121600
 /providers/AGENTS.md @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin @Dev-iL @jason810496 @shahar1 @choo121600
 /.github/skills/ @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin @Dev-iL @jason810496 @shahar1 @choo121600
+/.claude/skills/ @potiuk @kaxil @jscheffl @amoghrajesh @ashb @sjyangkevin @Dev-iL @jason810496 @shahar1 @choo121600
 
 # RMs on release documents
 /dev/README_RELEASE_*.md @potiuk @jscheffl @vincbeck @shahar1 @jedcunningham @bugraoz93

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -2,6 +2,8 @@
 applyTo: "**"
 excludeAgent: "coding-agent"
 ---
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
 
 # Airflow Code Review Instructions
 

--- a/.github/skills/aip-user-stories/SKILL.md
+++ b/.github/skills/aip-user-stories/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: aip-user-stories
+description: Generate verified recipe playbooks from AIPs with PR implementations (post mode), or speculative user stories from AIPs without implementations (pre mode). Use when the user provides an AIP URL or AIP content, optionally with PR URLs and file paths.
+when_to_use: Trigger when the user mentions aip user stories, aip playbook, aip recipes, generate recipes from AIP, user stories for AIP, AIP guide, AIP how-to.
+allowed-tools: Bash(gh pr view *) Bash(gh pr diff *) Read WebFetch(domain:cwiki.apache.org) WebFetch(domain:github.com)
+argument-hint: <AIP-URL-or-pasted-content> [<PR-URL>...] [<file>...]
+license: Apache-2.0
+---
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# AIP-to-User-Stories Playbook
+
+## Invocation
+
+```
+/aip-user-stories <AIP-URL-or-pasted-content> [<PR-URL>...] [<file>...]
+```
+
+If no arguments: print this usage synopsis and stop.
+
+## Mode Detection
+
+An argument starting with `https://cwiki.apache.org/confluence/` is the AIP URL. Arguments starting with `https://github.com/apache/airflow/pull/` are PR URLs. Other arguments are local file paths.
+
+- **PR URLs present → post-implementation mode**: generates verified recipe playbooks from actual code.
+- **No PR URLs → pre-implementation mode**: generates speculative user stories to help AIP authors validate design.
+
+PR URLs signal post mode and serve as **discovery hints** — starting points for finding the implementation in the codebase. They are not an exhaustive list of all PRs for the feature, and the skill must explore beyond the supplied PRs to find the full implementation.
+
+## AIP Number
+
+Extract the AIP number from the URL path (e.g., `AIP-76` from a URL containing `/aip-76` or `/AIP-76`). If the number cannot be determined from the URL or pasted content, ask the user.
+
+## Output Path
+
+Write the final playbook to `.claude/aip-{number}.md` where `{number}` is the extracted AIP number. If the file already exists, ask the user before overwriting.
+
+---
+
+## Post-Implementation Mode
+
+Source of truth: the **actual implementation** in the codebase and PRs — not the AIP specification. When the AIP proposes APIs that differ from what was implemented, the playbook follows the implementation.
+
+### Phase 1 — Parse
+
+Separate arguments into:
+
+- **AIP source**: a URL to fetch, or pasted content already in the conversation.
+- **PR URLs**: GitHub pull request URLs (one or more).
+- **File paths**: local files (example Dags, source files, tests).
+
+AIP content can come from a URL (fetched via WebFetch) or pasted directly by the user — both are equally valid input paths. If a URL fetch returns empty or garbled content, tell the user and ask them to paste the AIP content instead.
+
+At least one PR URL is required in post mode. If none are provided but the mode was forced, ask for PR URLs.
+
+### Phase 2 — Fetch & Discover
+
+Retrieve initial sources:
+
+- AIP content (from URL or already pasted).
+- PR diffs and metadata via `gh pr view <number> --json title,body,files` and `gh pr diff <number>`.
+- Local files specified as arguments.
+
+Then use the PRs as **discovery seeds**: identify which modules, packages, and files the PRs touch, and explore outward from there:
+
+- Read the touched files in their current state (not just the diff) to understand the full implementation.
+- Follow imports, base classes, and related modules to find connected implementation code.
+- Search for related example Dags, test files, and documentation that may not appear in the PR diffs.
+- Grep for key class names, function names, and configuration keys from the AIP to find implementation spread across files the PRs didn't touch.
+
+The PRs are a starting point, not a boundary. Code may have been implemented in other PRs, refactored since the PR merged, or spread across modules the PR didn't directly modify.
+
+### Phase 3 — Analyze
+
+Cross-reference AIP features against the **codebase** (not the PRs):
+
+- Which AIP features are implemented (found in the current codebase)?
+- Which AIP features are NOT implemented (proposed in AIP but absent from the codebase)?
+- What patterns exist in tests and example Dags that demonstrate usage?
+
+### Version Detection
+
+Search PR diffs for `versionadded::` or `.. versionadded::` directives. If found, use that version. If not found, ask the user for the target Airflow version.
+
+### Phase 4 — Propose
+
+Present a numbered list of recipe candidates, grouped by concept:
+
+```
+**[Concept Group Name]**
+1. Recipe Title — one-sentence description of what the user accomplishes
+2. Recipe Title — one-sentence description
+...
+```
+
+Each recipe maps to one distinct use case — a specific problem the user solves with this feature. If two API classes serve the same use case, combine them. If one class serves multiple use cases, split them.
+
+For AIP features not found in the implementation, list them separately under **Not Yet Implemented** and ask the user: include with placeholder code, or skip?
+
+Wait for user approval before generating.
+
+### Phase 5 — Generate
+
+For each approved recipe, produce content following the template in `references/playbook-template.md`.
+
+**Code block tiers:**
+
+1. **Verified** — the pattern exists in the codebase (source, example Dags, or tests). Use the code directly. No markers.
+2. **Adapted** — combines verified components in a new way (e.g., using a verified mapper with a different asset). Clean code, with a brief note below the block: *"Adapted from [source file path]"*.
+3. **Unverified** — no codebase evidence for this pattern. Use placeholders:
+
+   ```python
+   # TODO: Implement [description]
+   # See: [reference or AIP section]
+   ...
+   ```
+
+Verification sources: source code under `airflow-core/src/`, example Dags, and test files.
+
+### Phase 6 — Assemble
+
+Combine the overview and recipes into a playbook following the template structure. Write to `.claude/aip-{number}.md`.
+
+If the user chose to skip unimplemented AIP features during the Propose phase, add a brief "Not Yet Implemented" section at the end listing them with one-line descriptions. Omit this section if all features were covered.
+
+---
+
+## Pre-Implementation Mode
+
+Source of truth: the **AIP specification** itself. No implementation exists to verify against.
+
+If file paths are provided, warn that they will be ignored (no implementation to reference).
+
+### Phase 1 — Parse
+
+Extract the AIP source: a URL to fetch, or pasted content. File path arguments are ignored with a warning.
+
+AIP content can come from a URL or pasted directly — both are equally valid.
+
+```
+URL-based:  /aip-user-stories https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-76
+Paste-based: /aip-user-stories (then paste AIP content when prompted)
+```
+
+### Phase 2 — Fetch
+
+Retrieve AIP content from URL or accept pasted content. If a URL fetch returns empty or garbled content, ask the user to paste the AIP content.
+
+Ask the user for the target Airflow version (no PR to extract `versionadded` from).
+
+### Phase 3 — Analyze
+
+Extract from the AIP:
+
+- Proposed features, APIs, and configuration options.
+- Use cases described or implied.
+- Code examples provided in the AIP itself.
+
+No code verification — nothing is implemented yet.
+
+### Phase 4 — Propose
+
+Present a numbered list of user story candidates, grouped by concept:
+
+```
+**[Concept Group Name]**
+1. Story Title — one-sentence description of the user goal
+2. Story Title — one-sentence description
+...
+```
+
+Wait for user approval before generating.
+
+### Phase 5 — Generate
+
+For each approved story, produce content following the template in `references/playbook-template.md` (pre-mode section).
+
+ALL code blocks must be marked as speculative:
+
+```python
+# PROPOSED API — not yet implemented
+```
+
+Base speculative code on the AIP's own code examples and proposed API as closely as possible.
+
+Each story must include **open design questions** that probe:
+
+- **API ergonomics** — Is this easy to use correctly and hard to misuse?
+- **Edge cases** — What happens with unusual inputs, empty partitions, or unexpected configurations?
+- **Compatibility** — How does this interact with existing Airflow patterns (catchup, backfill, dynamic task mapping, sensors, XCom)?
+- **Implementation feasibility** — What constraints or complexities has the AIP not addressed?
+
+Questions must be specific to the story's use case. Generic questions ("what about error handling?") do not count.
+
+### Phase 6 — Assemble
+
+Combine the overview and user stories into a document following the template structure. Write to `.claude/aip-{number}.md`.
+
+---
+
+## Gotchas
+
+- **Confluence pages often return partial or JavaScript-rendered content via WebFetch.** If the fetched AIP content looks incomplete (missing sections, garbled HTML), ask the user to paste the content. Don't generate from partial input.
+- **PR diffs can show intermediate code that was later revised.** When multiple commits exist in a PR, prefer the final state of files (use `gh pr view` with `--json files` and read the current branch/merged code) over the raw diff, which may include since-reverted changes. More broadly, always prefer the current codebase state over PR diffs — PRs are discovery aids, not the source of truth.
+- **AIP terminology drifts from implementation.** AIPs are written before (or during) implementation. Class names, parameter names, and module paths in the AIP frequently differ from what was actually merged. Always verify names against the codebase, not the AIP text.
+- **Test files reveal use cases that examples miss.** Example Dags tend to show the happy path. Test files (especially parametrized tests) expose edge cases, error conditions, and alternative configurations that make better recipes.
+- **An AIP feature listed as "implemented" in the AIP may not be in the PR.** AIPs track overall status, not per-PR scope. Cross-reference each feature against actual PR code, not the AIP's status section.

--- a/.github/skills/aip-user-stories/references/playbook-template.md
+++ b/.github/skills/aip-user-stories/references/playbook-template.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# {AIP Title} — Playbook
+
+> **Airflow version:** {version}
+> **Required packages:** {packages, if any beyond core}
+
+## Prerequisites
+
+{Version requirements, installation steps for provider packages if needed, configuration prerequisites.}
+
+## Overview
+
+{2-3 paragraphs drawn from the AIP motivation section. What problem does this feature solve? What was the previous state? What changes for the user? Written for a practitioner, not a committee.}
+
+---
+
+## Recipes (Post-Implementation Mode)
+
+{Repeat this section for each recipe.}
+
+### {Recipe Title}
+
+**Goal:** {One sentence — what the user accomplishes with this recipe.}
+
+**Prerequisites:** {Anything specific to this recipe beyond the global prerequisites — a provider package, a configuration flag, an external service.}
+
+```python
+{Code block — verified, adapted, or placeholder per the three-tier system.}
+```
+
+{If adapted, note below the block: *"Adapted from [source file path]"*}
+
+{Explanation: WHY this pattern works, not line-by-line narration. What makes this the right approach for this use case.}
+
+---
+
+## User Stories (Pre-Implementation Mode)
+
+{Repeat this section for each user story.}
+
+### {Story Title}
+
+**Goal:** {One sentence — the user's objective.}
+
+```python
+# PROPOSED API — not yet implemented
+{Speculative code based on the AIP's proposed API.}
+```
+
+{Brief explanation of what this code would accomplish and why the AIP proposes this approach.}
+
+**Open Design Questions:**
+
+- {Specific question about API ergonomics for this use case}
+- {Specific question about edge cases relevant to this story}
+- {Specific question about compatibility with existing Airflow patterns}
+- {Specific question about implementation feasibility or constraints}
+
+---
+
+## Not Yet Implemented
+
+{Include only if the user chose to skip unimplemented features during the Propose phase. List each skipped feature with a one-line description. Omit this entire section if all features were covered.}
+
+- **{Feature name}** — {one-line description from AIP}

--- a/.github/skills/maintainer-review/SKILL.md
+++ b/.github/skills/maintainer-review/SKILL.md
@@ -1,36 +1,22 @@
 ---
 name: maintainer-review
 description: |
-  Walk a maintainer through deep code review of open pull
-  requests on `apache/airflow` (or another target repo). The
-  default working list — referred to throughout the docs as
-  **"my reviews"** — is the union of five signals on the
-  authenticated maintainer: PRs where review is requested
-  from them, PRs that touch files they recently modified, PRs
-  whose changed files they own per `CODEOWNERS`, PRs that
-  `@`-mention them, and PRs they already submitted a real
-  review on (triage comments do not count). Filters can narrow
-  by area label, collaborator status, or to a single PR. For
-  each PR the skill reads the diff, applies the project's
-  review criteria
+  Walk a maintainer through deep code review of open pull requests on `apache/airflow` (or another target repo). The
+  default working list — referred to throughout the docs as **"my reviews"** — is the union of five signals on the
+  authenticated maintainer: PRs where review is requested from them, PRs that touch files they recently modified, PRs
+  whose changed files they own per `CODEOWNERS`, PRs that `@`-mention them, and PRs they already submitted a real
+  review on (triage comments do not count). Filters can narrow by area label, collaborator status, or to a single PR.
+  For each PR the skill reads the diff, applies the project's review criteria
   ([.github/instructions/code-review.instructions.md](../../../.github/instructions/code-review.instructions.md)
-  and [AGENTS.md](../../../AGENTS.md)), runs any
-  locally-configured adversarial reviewer (e.g. the OpenAI
-  Codex plugin), surfaces findings, drafts an
-  `approve` / `request-changes` / `comment` review with
-  inline comments proposed by default, and — on the
-  maintainer's confirmation — posts it via the
-  `addPullRequestReview` mutation. This is the deep-review
-  counterpart to the triage skill.
+  and [AGENTS.md](../../../AGENTS.md)), runs any locally-configured adversarial reviewer (e.g. the OpenAI
+  Codex plugin), surfaces findings, drafts an `approve` / `request-changes` / `comment` review with
+  inline comments proposed by default, and — on the maintainer's confirmation — posts it via the
+  `addPullRequestReview` mutation. This is the deep-review counterpart to the triage skill.
 when_to_use: |
-  Invoke when a maintainer says "review my PRs", "go through
-  the PRs assigned to me", "review my queue", "review the
-  area:scheduler PRs", "review PR NNN", "do my review pass",
-  or any variation on "look over the code on PRs I'm
-  responsible for, one at a time." Distinct from `pr-triage`,
-  which decides *whether* to engage with a PR. This skill is
-  invoked **after** triage has produced PRs marked `ready for
-  maintainer review` (or any other curated selector) and a
+  Invoke when a maintainer says "review my PRs", "go through the PRs assigned to me", "review my queue", "review the
+  area:scheduler PRs", "review PR NNN", "do my review pass", or any variation on "look over the code on PRs I'm
+  responsible for, one at a time." Distinct from `pr-triage`, which decides *whether* to engage with a PR. This skill is
+  invoked **after** triage has produced PRs marked `ready for maintainer review` (or any other curated selector) and a
   human reviewer is doing the actual code review.
 license: Apache-2.0
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ ENV/
 .claude/*
 !.claude/skills/
 .claude/skills/*
+!.claude/skills/aip-user-stories
 !.claude/skills/pr-stats
 !.claude/skills/pr-triage
 !.claude/skills/maintainer-review

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,6 +176,8 @@ repos:
           - "||"
           - --license-filepath
           - scripts/ci/license-templates/SHORT_LICENSE.md
+          - --detect-license-in-X-top-lines
+          - '30'
           - --fuzzy-match-generates-todo
         files:
           (?x)
@@ -186,12 +188,7 @@ repos:
           ^(?:.*/)?SKILL\.md$
         exclude:
           (?x)
-          ^scripts/ci/license-templates/|
-          ^\.github/instructions/|
-          ^\.github/skills/airflow-translations/SKILL\.md$|
-          ^\.github/skills/pr-stats/SKILL\.md$|
-          ^\.github/skills/pr-triage/SKILL\.md$|
-          ^\.github/skills/maintainer-review/SKILL\.md$
+          ^scripts/ci/license-templates/
       - id: insert-license
         name: Add license for all other files
         args:
@@ -289,6 +286,9 @@ repos:
         alias: blacken-docs
         additional_dependencies:
          - 'black==26.1.0'
+        exclude: >
+          (?x)
+          ^\.github/skills/aip-user-stories
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:

--- a/uv.lock
+++ b/uv.lock
@@ -736,15 +736,17 @@ wheels = [
 
 [[package]]
 name = "alibabacloud-adb20211201"
-version = "3.7.1"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "alibabacloud-endpoint-util" },
+    { name = "alibabacloud-openapi-util" },
     { name = "alibabacloud-tea-openapi" },
-    { name = "darabonba-core" },
+    { name = "alibabacloud-tea-util" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/94/6e7ea4ccea9b6d09d65746bd3a1170957fc4f3b5aecf6cf7f81a65888c35/alibabacloud_adb20211201-3.7.1.tar.gz", hash = "sha256:8e3c66440510065382f51d9b4bed24c3fa6415de6a8a0132eb8492a046a9b88b", size = 295517, upload-time = "2026-01-06T18:41:22.685Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/df/8af8a3d58ec53110da00421014f3d2faa40077882e2de5c1af2fe28f9d88/alibabacloud_adb20211201-3.7.0.tar.gz", hash = "sha256:1f741121c7de28ee481ea1cbbd19bc8564e9afbdf353887dc515652052d1294e", size = 241247, upload-time = "2025-12-16T17:32:34.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/0f/28d3b3dac73366cb7a2374bb2f2a910d20a5bda26f7908e61723ee2c72b8/alibabacloud_adb20211201-3.7.1-py3-none-any.whl", hash = "sha256:1e5a538ef59c075a707ae8ef659fdb06f0bbdb262d249d8027858d20134964d3", size = 841309, upload-time = "2026-01-06T18:41:21.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/72/edbecddc5284e42186e9c8cac4f362e0187ebd6eb7f0f79aa16f11d016a0/alibabacloud_adb20211201-3.7.0-py3-none-any.whl", hash = "sha256:08e9a3ccc00f12973c8739823f49b9fe2175f1029c9b55885ceb9d158018eb26", size = 242860, upload-time = "2025-12-16T17:32:33.403Z" },
 ]
 
 [[package]]
@@ -769,6 +771,12 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a0/87/1d7019d23891897cb076b2f7e3c81ab3c2ba91de3bb067196f675d60d34c/alibabacloud-credentials-api-1.0.0.tar.gz", hash = "sha256:8c340038d904f0218d7214a8f4088c31912bfcf279af2cbc7d9be4897a97dd2f", size = 2330, upload-time = "2025-01-13T05:53:04.931Z" }
 
 [[package]]
+name = "alibabacloud-endpoint-util"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/7d/8cc92a95c920e344835b005af6ea45a0db98763ad6ad19299d26892e6c8d/alibabacloud_endpoint_util-0.0.4.tar.gz", hash = "sha256:a593eb8ddd8168d5dc2216cd33111b144f9189fcd6e9ca20e48f358a739bbf90", size = 2813, upload-time = "2025-06-12T07:20:52.572Z" }
+
+[[package]]
 name = "alibabacloud-gateway-spi"
 version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -776,6 +784,19 @@ dependencies = [
     { name = "alibabacloud-credentials" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/98/d7111245f17935bf72ee9bea60bbbeff2bc42cdfe24d2544db52bc517e1a/alibabacloud_gateway_spi-0.0.3.tar.gz", hash = "sha256:10d1c53a3fc5f87915fbd6b4985b98338a776e9b44a0263f56643c5048223b8b", size = 4249, upload-time = "2025-02-23T16:29:54.222Z" }
+
+[[package]]
+name = "alibabacloud-openapi-util"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-tea-util" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/51/be5802851a4ed20ac2c6db50ac8354a6e431e93db6e714ca39b50983626f/alibabacloud_openapi_util-0.2.4.tar.gz", hash = "sha256:87022b9dcb7593a601f7a40ca698227ac3ccb776b58cb7b06b8dc7f510995c34", size = 7981, upload-time = "2026-01-15T08:05:03.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/46/9b217343648b366eb93447f5d93116e09a61956005794aed5ef95a2e9e2e/alibabacloud_openapi_util-0.2.4-py3-none-any.whl", hash = "sha256:a2474f230b5965ae9a8c286e0dc86132a887928d02d20b8182656cf6b1b6c5bd", size = 7661, upload-time = "2026-01-15T08:05:01.374Z" },
+]
 
 [[package]]
 name = "alibabacloud-oss-v2"
@@ -802,19 +823,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/9a/7d/b22cb9a0d4f396ee0
 
 [[package]]
 name = "alibabacloud-tea-openapi"
-version = "0.4.4"
+version = "0.3.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alibabacloud-credentials" },
     { name = "alibabacloud-gateway-spi" },
+    { name = "alibabacloud-openapi-util" },
     { name = "alibabacloud-tea-util" },
-    { name = "cryptography" },
-    { name = "darabonba-core" },
+    { name = "alibabacloud-tea-xml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/93/138bcdc8fc596add73e37cf2073798f285284d1240bda9ee02f9384fc6be/alibabacloud_tea_openapi-0.4.4.tar.gz", hash = "sha256:1b0917bc03cd49417da64945e92731716d53e2eb8707b235f54e45b7473221ce", size = 21960, upload-time = "2026-03-26T10:16:16.792Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/5a/6bfc4506438c1809c486f66217ad11eab78157192b3d5707b4e2f4212f6c/alibabacloud_tea_openapi-0.4.4-py3-none-any.whl", hash = "sha256:cea6bc1fe35b0319a8752cb99eb0ecb0dab7ca1a71b99c12970ba0867410995f", size = 26236, upload-time = "2026-03-26T10:16:15.861Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/09/be/f594e79625e5ccfcfe7f12d7d70709a3c59e920878469c998886211c850d/alibabacloud_tea_openapi-0.3.16.tar.gz", hash = "sha256:6bffed8278597592e67860156f424bde4173a6599d7b6039fb640a3612bae292", size = 13087, upload-time = "2025-07-04T09:30:10.689Z" }
 
 [[package]]
 name = "alibabacloud-tea-util"
@@ -827,6 +845,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/e9/ee/ea90be94ad781a505
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/9e/c394b4e2104766fb28a1e44e3ed36e4c7773b4d05c868e482be99d5635c9/alibabacloud_tea_util-0.3.14-py3-none-any.whl", hash = "sha256:10d3e5c340d8f7ec69dd27345eb2fc5a1dab07875742525edf07bbe86db93bfe", size = 6697, upload-time = "2025-11-19T06:01:07.355Z" },
 ]
+
+[[package]]
+name = "alibabacloud-tea-xml"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-tea" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/eb/5e82e419c3061823f3feae9b5681588762929dc4da0176667297c2784c1a/alibabacloud_tea_xml-0.0.3.tar.gz", hash = "sha256:979cb51fadf43de77f41c69fc69c12529728919f849723eb0cd24eb7b048a90c", size = 3466, upload-time = "2025-07-01T08:04:55.144Z" }
 
 [[package]]
 name = "amqp"
@@ -7911,6 +7938,7 @@ name = "apache-airflow-registry-tools"
 version = "0.0.1"
 source = { editable = "dev/registry" }
 dependencies = [
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -7923,6 +7951,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
@@ -10456,62 +10485,62 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/928c9ce0d120a40a81aa99e3ba383e87337b9ac9ef9f6db02e4d7822424d/cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7", size = 3909893, upload-time = "2026-04-24T19:54:38.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/d691e284750df5d9569f2b1ce4a00a71e1d79566da83b2b3e5549c84917f/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe", size = 4587867, upload-time = "2026-04-24T19:54:40.619Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d6/1b90f1a4e453009730b4545286f0b39bb348d805c11181fc31544e4f9a65/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475", size = 4627192, upload-time = "2026-04-24T19:54:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9c/51f28c3550276bcf35660703ba0ab829a90b88be8cd98a71ef23c2413913/cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8", size = 3698916, upload-time = "2026-04-24T19:54:49.782Z" },
 ]
 
 [[package]]
@@ -10524,19 +10553,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/df/e9c2720d32c5de985ce64d5dedf883b52c26ff5e9aa2ba2becea00098320/curlify-3.0.0.tar.gz", hash = "sha256:7b488ff3c924dba3433a1cc74044c0942da21f0a97fa26c3138319ba640ca412", size = 3668, upload-time = "2025-05-25T11:50:00.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/f8/912ebddbff8ea603d4c90fa31557096f927b17efd30a166ce7ac1242910a/curlify-3.0.0-py3-none-any.whl", hash = "sha256:52060c0eb7a656b7bde6b668c32f337bed4d736ce230755767e3ada56a09c338", size = 3580, upload-time = "2025-05-25T11:49:59.335Z" },
-]
-
-[[package]]
-name = "darabonba-core"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "alibabacloud-tea" },
-    { name = "requests" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/d3/a7daaee544c904548e665829b51a9fa2572acb82c73ad787a8ff90273002/darabonba_core-1.0.5-py3-none-any.whl", hash = "sha256:671ab8dbc4edc2a8f88013da71646839bb8914f1259efc069353243ef52ea27c", size = 24580, upload-time = "2025-12-12T07:53:59.494Z" },
 ]
 
 [[package]]
@@ -14192,7 +14208,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.24.1"
+version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -14200,9 +14216,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/6e/35174c1d3f30560848c82d3c233c01420e047d70925c897a4d6e932b4898/jsonschema-4.24.1.tar.gz", hash = "sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d", size = 356635, upload-time = "2025-07-17T14:40:01.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/7f/ea48ffb58f9791f9d97ccb35e42fea1ebc81c67ce36dc4b8b2eee60e8661/jsonschema-4.24.1-py3-none-any.whl", hash = "sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627", size = 89060, upload-time = "2025-07-17T14:39:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
 [[package]]
@@ -16024,36 +16040,36 @@ wheels = [
 
 [[package]]
 name = "nh3"
-version = "0.3.4"
+version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/86/f8d3a7c9bd1bbaa181f6312c757e0b74d25f71ecf84ea3c0dc5e0f01840d/nh3-0.3.4.tar.gz", hash = "sha256:96709a379997c1b28c8974146ca660b0dcd3794f4f6d50c1ea549bab39ac6ade", size = 19520, upload-time = "2026-03-25T10:57:30.789Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8", size = 20743, upload-time = "2026-04-25T10:44:16.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/5e/c400663d14be2216bc084ed2befc871b7b12563f85d40904f2a4bf0dd2b7/nh3-0.3.4-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8b61058f34c2105d44d2a4d4241bacf603a1ef5c143b08766bbd0cf23830118f", size = 1417991, upload-time = "2026-03-25T10:56:59.13Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f5/109526f5002ec41322ac8cafd50f0f154bae0c26b9607c0fcb708bdca8ec/nh3-0.3.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:554cc2bab281758e94d770c3fb0bf2d8be5fb403ef6b2e8841dd7c1615df7a0f", size = 790566, upload-time = "2026-03-25T10:57:00.445Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/66/38950f2b4b316ffd82ee51ed8f9143d1f56fdd620312cacc91613b77b3e7/nh3-0.3.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dbe76feaa44e2ef9436f345016012a591550e77818876a8de5c8bc2a248e08df", size = 837538, upload-time = "2026-03-25T10:57:01.848Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9f/9d6da970e9524fe360ea02a2082856390c2c8ba540409d1be6e5851887b3/nh3-0.3.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:87dac8d611b4a478400e0821a13b35770e88c266582f065e7249d6a37b0f86e8", size = 1012154, upload-time = "2026-03-25T10:57:03.592Z" },
-    { url = "https://files.pythonhosted.org/packages/54/92/7c85c33c241e9dd51dda115bd3f765e940446588cdaaca62ef8edffe675f/nh3-0.3.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8d697e19f2995b337f648204848ac3a528eaafffc39e7ce4ac6b7a2fbe6c84af", size = 1092516, upload-time = "2026-03-25T10:57:04.726Z" },
-    { url = "https://files.pythonhosted.org/packages/16/0f/597842bdb2890999a3faa2f3fcb02db8aa6ad09320d3d843ff6d0a1f737b/nh3-0.3.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:7cae217f031809321db962cd7e092bda8d4e95a87f78c0226628fa6c2ea8ebc5", size = 1053793, upload-time = "2026-03-25T10:57:06.171Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/32/669da65147bc10746d2e1d7a8a3dbfbffe0315f419e74b559e2ee3471a01/nh3-0.3.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:07999b998bf89692738f15c0eac76a416382932f855709e0b7488b595c30ec89", size = 1035975, upload-time = "2026-03-25T10:57:07.292Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7e/9e97a8b3c5161c79b4bf21cc54e9334860a52cc54ede15bf2239ef494b73/nh3-0.3.4-cp314-cp314t-win32.whl", hash = "sha256:ca90397c8d36c1535bf1988b2bed006597337843a164c7ec269dc8813f37536b", size = 600419, upload-time = "2026-03-25T10:57:08.342Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c7/6849d8d4295d3997d148eacb2d4b1c9faada4895ee3c1b1e12e72f4611e2/nh3-0.3.4-cp314-cp314t-win_amd64.whl", hash = "sha256:41e46b3499918ab6128b6421677b316e79869d0c140da24069d220a94f4e72d1", size = 613342, upload-time = "2026-03-25T10:57:09.593Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/0e/14a3f510f36c20b922c123a2730f071f938d006fb513aacfd46d6cbc03a7/nh3-0.3.4-cp314-cp314t-win_arm64.whl", hash = "sha256:80b955d802bf365bd42e09f6c3d64567dce777d20e97968d94b3e9d9e99b265e", size = 607025, upload-time = "2026-03-25T10:57:10.959Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/57/a97955bc95960cfb1f0517043d60a121f4ba93fde252d4d9ffd3c2a9eead/nh3-0.3.4-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d8bebcb20ab4b91858385cd98fe58046ec4a624275b45ef9b976475604f45b49", size = 1439519, upload-time = "2026-03-25T10:57:12.019Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/60/c9a33361da8cde7c7760f091cd10467bc470634e4eea31c8bb70935b00a4/nh3-0.3.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d825722a1e8cbc87d7ca1e47ffb1d2a6cf343ad4c1b8465becf7cadcabcdfd0", size = 833798, upload-time = "2026-03-25T10:57:13.264Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/19/9487790780b8c94eacca37866c1270b747a4af8e244d43b3b550fddbbf62/nh3-0.3.4-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aa8b43e68c26b68069a3b6cef09de166d1d7fa140cf8d77e409a46cbf742e44", size = 820414, upload-time = "2026-03-25T10:57:14.236Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b4/c6a340dd321d20b1e4a663307032741da045685c87403926c43656f6f5ec/nh3-0.3.4-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f5f214618ad5eff4f2a6b13a8d4da4d9e7f37c569d90a13fb9f0caaf7d04fe21", size = 1061531, upload-time = "2026-03-25T10:57:15.384Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/49/f6b4b474e0032e4bcbb7174b44e4cf6915670e09c62421deb06ccfcb88b8/nh3-0.3.4-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3390e4333883673a684ce16c1716b481e91782d6f56dec5c85fed9feedb23382", size = 1021889, upload-time = "2026-03-25T10:57:16.454Z" },
-    { url = "https://files.pythonhosted.org/packages/43/da/e52a6941746d1f974752af3fc8591f1dbcdcf7fd8c726c7d99f444ba820e/nh3-0.3.4-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18a2e44ccb29cbb45071b8f3f2dab9ebfb41a6516f328f91f1f1fd18196239a4", size = 912965, upload-time = "2026-03-25T10:57:17.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b7/ec1cbc6b297a808c513f59f501656389623fc09ad6a58c640851289c7854/nh3-0.3.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0961a27dc2057c38d0364cb05880e1997ae1c80220cbc847db63213720b8f304", size = 804975, upload-time = "2026-03-25T10:57:18.994Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/56/b1275aa2c6510191eed76178da4626b0900402439cb9f27d6b9bf7c6d5e9/nh3-0.3.4-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:9337517edb7c10228252cce2898e20fb3d77e32ffaccbb3c66897927d74215a0", size = 833400, upload-time = "2026-03-25T10:57:20.086Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a5/5d574ffa3c6e49a5364d1b25ebad165501c055340056671493beb467a15e/nh3-0.3.4-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d866701affe67a5171b916b5c076e767a74c6a9efb7fb2006eb8d3c5f9a293d5", size = 854277, upload-time = "2026-03-25T10:57:21.433Z" },
-    { url = "https://files.pythonhosted.org/packages/79/36/8aeb2ab21517cefa212db109e41024e02650716cb42bf293d0a88437a92d/nh3-0.3.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:47d749d99ae005ab19517224140b280dd56e77b33afb82f9b600e106d0458003", size = 1022021, upload-time = "2026-03-25T10:57:22.433Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/95/9fd860997685e64abe2d5a995ca2eb5004c0fb6d6585429612a7871548b9/nh3-0.3.4-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f987cb56458323405e8e5ea827e1befcf141ffa0c0ac797d6d02e6b646056d9a", size = 1103526, upload-time = "2026-03-25T10:57:23.487Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0d/df545070614c1007f0109bb004230226c9000e7857c9785583ec25cda9d7/nh3-0.3.4-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:883d5a6d6ee8078c4afc8e96e022fe579c4c265775ff6ee21e39b8c542cabab3", size = 1068050, upload-time = "2026-03-25T10:57:24.624Z" },
-    { url = "https://files.pythonhosted.org/packages/94/d5/17b016df52df052f714c53be71df26a1943551d9931e9383b92c998b88f8/nh3-0.3.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:75643c22f5092d8e209f766ee8108c400bc1e44760fc94d2d638eb138d18f853", size = 1046037, upload-time = "2026-03-25T10:57:25.799Z" },
-    { url = "https://files.pythonhosted.org/packages/51/39/49f737907e6ab2b4ca71855d3bd63dd7958862e9c8b94fb4e5b18ccf6988/nh3-0.3.4-cp38-abi3-win32.whl", hash = "sha256:72e4e9ca1c4bd41b4a28b0190edc2e21e3f71496acd36a0162858e1a28db3d7e", size = 609542, upload-time = "2026-03-25T10:57:27.112Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4f/af8e9071d7464575a7316831938237ffc9d92d27f163dbdd964b1309cd9b/nh3-0.3.4-cp38-abi3-win_amd64.whl", hash = "sha256:c10b1f0c741e257a5cb2978d6bac86e7c784ab20572724b20c6402c2e24bce75", size = 624244, upload-time = "2026-03-25T10:57:28.302Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0c/37695d6b0168f6714b5c492331636a9e6123d6ec22d25876c68d06eab1b8/nh3-0.3.4-cp38-abi3-win_arm64.whl", hash = "sha256:43ad4eedee7e049b9069bc015b7b095d320ed6d167ecec111f877de1540656e9", size = 616649, upload-time = "2026-03-25T10:57:29.623Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b0/8587ac42a9627ab88e7e221601f1dfccbf4db80b2a29222ea63266dc9abc/nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a", size = 1420126, upload-time = "2026-04-25T10:43:39.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/1dbc4d0c43f12e8c1784ede17eaee6f061d4fbe5505757c65c49b2ceab95/nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263", size = 793943, upload-time = "2026-04-25T10:43:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9f/d6758d7a14ee964bf439cc35ae4fa24a763a93399c8ef6f22bd11d532d29/nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9", size = 841150, upload-time = "2026-04-25T10:43:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/d5d1ae8374612c98f390e1ea7c610fa6c9716259a03bbf4d15b269f40073/nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588", size = 1008415, upload-time = "2026-04-25T10:43:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d13a9c3fd2d9c131a2a281737380e9379eb0f8c33fea24c2b923aaafbb15/nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd", size = 1092706, upload-time = "2026-04-25T10:43:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/57/2f3add7f8680fcc896afa6a675cb2bab09982853ee8af40bad621f6b61c4/nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17", size = 1048346, upload-time = "2026-04-25T10:43:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c3/2f9e4ffa82863074d1361bfe949bc46393d91b3411579dfbbd090b24cac5/nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29", size = 1029038, upload-time = "2026-04-25T10:43:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/2804deb3f3315184c9cae41702e293c87524b5a21f766b07d7fe3ffbcfbb/nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88", size = 603263, upload-time = "2026-04-25T10:43:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/f6685248b49f7548fc9a8c335ab3a52f68610b72e8a61576447151e4e2e6/nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f", size = 616866, upload-time = "2026-04-25T10:43:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/d8c9018635d4acfefde6b68470daa510eed715a350cbaa2f928ba0609f81/nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79", size = 602566, upload-time = "2026-04-25T10:43:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101", size = 1442393, upload-time = "2026-04-25T10:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878", size = 837722, upload-time = "2026-04-25T10:43:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/d4e06e28c5ad1c4b065f89737d02631bd49f1660b6ebcf17a87ffcd201da/nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93", size = 822872, upload-time = "2026-04-25T10:43:56.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/50659255213f241ec5797ae7427464c969397373e83b3659372b341ae869/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3", size = 1100031, upload-time = "2026-04-25T10:43:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7a/a12ae77593b2fcf3be25df7bc1c01967d0de448bdb4b6c7ec80fe4f5a74f/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4", size = 1057669, upload-time = "2026-04-25T10:43:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/5647dc04c0233192a3956fc91708822b21403a06508cacf78083c68e7bf0/nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b", size = 914795, upload-time = "2026-04-25T10:44:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1", size = 806976, upload-time = "2026-04-25T10:44:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/85/01/26761e1dc2b848e65a62c19e5d39ad446283287cd4afddc89f364ab86bc9/nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc", size = 834904, upload-time = "2026-04-25T10:44:03.454Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/0766113e679540ac1edc1b82b1295aecd321eeb75d6fead70109a838b6ee/nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b", size = 857159, upload-time = "2026-04-25T10:44:05.003Z" },
+    { url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4", size = 1018600, upload-time = "2026-04-25T10:44:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/d9c59c1b49669fcb7bababa55df82385f029ad5c2651f583c3a1141cfdd1/nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d", size = 1103530, upload-time = "2026-04-25T10:44:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/cdd210bfb8d9d43fb02fc3c868336b9955934d8e15e66eb1d15a147b8af0/nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad", size = 1061754, upload-time = "2026-04-25T10:44:09.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9", size = 1040938, upload-time = "2026-04-25T10:44:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/fc2f9ed208a3801a319f59b5fea03cdc20cf3bd8af14be930d3a8de01224/nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f", size = 611445, upload-time = "2026-04-25T10:44:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30", size = 626502, upload-time = "2026-04-25T10:44:13.682Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7c/19cd0671d1ba2762fb388fc149697d20d0568ccfeef833b11280a619e526/nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b", size = 611069, upload-time = "2026-04-25T10:44:14.934Z" },
 ]
 
 [[package]]
@@ -16278,7 +16294,7 @@ wheels = [
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.8.4"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
@@ -16288,9 +16304,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/de/0199b15f5dde3ca61df6e6b3987420bfd424db077998f0162e8ffe12e4f5/openapi_spec_validator-0.8.4.tar.gz", hash = "sha256:8bb324b9b08b9b368b1359dec14610c60a8f3a3dd63237184eb04456d4546f49", size = 1756847, upload-time = "2026-03-01T15:48:19.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/3f/aa0c1150627b4e683ae5673486b7d5cf2623a8821601863ee389e430965a/openapi_spec_validator-0.8.5.tar.gz", hash = "sha256:93b04ef5321d5866b2502371123d86333e5c1444f051d323e02525d9e83c7622", size = 1756845, upload-time = "2026-04-24T15:25:21.334Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/70/52310f9ece5f4eb02e0b31d538b51f729169517767a8d0100a25db31d67f/openapi_spec_validator-0.8.4-py3-none-any.whl", hash = "sha256:cf905117063d7c4d495c8a5a167a1f2a8006da6ffa8ba234a7ed0d0f11454d51", size = 50330, upload-time = "2026-03-01T15:48:17.668Z" },
+    { url = "https://files.pythonhosted.org/packages/64/96/d7dfe1cc0be2df22d7a97ffb0f8bb00b10d92749aa6e64ffa7cc9a041580/openapi_spec_validator-0.8.5-py3-none-any.whl", hash = "sha256:3669106361856934153991e30714616a294865a33f6411a4c25d1dc2d08cfbc2", size = 50334, upload-time = "2026-04-24T15:25:19.65Z" },
 ]
 
 [[package]]
@@ -16698,11 +16714,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -17671,17 +17687,17 @@ wheels = [
 
 [[package]]
 name = "py-spy"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/e2/ff811a367028b87e86714945bb9ecb5c1cc69114a8039a67b3a862cef921/py_spy-0.4.1.tar.gz", hash = "sha256:e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4", size = 244726, upload-time = "2025-07-31T19:33:25.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/d8/5b71371f50cf153b1307e5a11ac8a4ce4d85651dae946bd7e9a064146545/py_spy-0.4.2.tar.gz", hash = "sha256:90e600b27bb6bb40479637baca5a5b4bc2ba3395c93d889e672315d93042c4ae", size = 286374, upload-time = "2026-04-24T22:08:54.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/e3/3a32500d845bdd94f6a2b4ed6244982f42ec2bc64602ea8fcfe900678ae7/py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc", size = 3682508, upload-time = "2025-07-31T19:33:13.753Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/bf/e4d280e9e0bec71d39fc646654097027d4bbe8e04af18fb68e49afcff404/py_spy-0.4.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c", size = 1796395, upload-time = "2025-07-31T19:33:15.325Z" },
-    { url = "https://files.pythonhosted.org/packages/df/79/9ed50bb0a9de63ed023aa2db8b6265b04a7760d98c61eb54def6a5fddb68/py_spy-0.4.1-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee776b9d512a011d1ad3907ed53ae32ce2f3d9ff3e1782236554e22103b5c084", size = 2034938, upload-time = "2025-07-31T19:33:17.194Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a5/36862e3eea59f729dfb70ee6f9e14b051d8ddce1aa7e70e0b81d9fe18536/py_spy-0.4.1-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:532d3525538254d1859b49de1fbe9744df6b8865657c9f0e444bf36ce3f19226", size = 2658968, upload-time = "2025-07-31T19:33:18.916Z" },
-    { url = "https://files.pythonhosted.org/packages/08/f8/9ea0b586b065a623f591e5e7961282ec944b5fbbdca33186c7c0296645b3/py_spy-0.4.1-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4972c21890b6814017e39ac233c22572c4a61fd874524ebc5ccab0f2237aee0a", size = 2147541, upload-time = "2025-07-31T19:33:20.565Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fb/bc7f639aed026bca6e7beb1e33f6951e16b7d315594e7635a4f7d21d63f4/py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29", size = 2763338, upload-time = "2025-07-31T19:33:22.202Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/da/fcc9a9fcd4ca946ff402cff20348e838b051d69f50f5d1f5dca4cd3c5eb8/py_spy-0.4.1-py2.py3-none-win_amd64.whl", hash = "sha256:d92e522bd40e9bf7d87c204033ce5bb5c828fca45fa28d970f58d71128069fdc", size = 1818784, upload-time = "2025-07-31T19:33:23.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/21/ec030145a0c7992bd4b9eafb2f06f56358b3a5339eab4a16534baf3c69aa/py_spy-0.4.2-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1ccf688393105111684435f035bc14ec3f22117dd2b85b2414612cf27a22755a", size = 3743992, upload-time = "2026-04-24T22:08:45.438Z" },
+    { url = "https://files.pythonhosted.org/packages/50/80/de5fd27243c2be03692ecd317bf0dbe24b4c6f78f689ce111e7277a7cb09/py_spy-0.4.2-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0e6f6810ccf0fc5e64e85e0182a5b626c4496eec01b14fb8755154b363a4831", size = 1859057, upload-time = "2026-04-24T22:08:46.946Z" },
+    { url = "https://files.pythonhosted.org/packages/89/23/3eb4c23c684ebd667674ce1d076ae855e0621d1d9bd5e052aa3f7982f757/py_spy-0.4.2-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:142887e984a4e541071c99a4401ff8c3770f255d329dbd0f64e8c1dd51882cce", size = 2828136, upload-time = "2026-04-24T22:08:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/6314152cf9ad3310ebacbf2c47b5ed858086530f8e12b1a665725ca5e0f4/py_spy-0.4.2-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1c6d9b0e2379ead5bf792df43f4cf36153aa79e6dda4fb8ac7740cf8017110", size = 2857707, upload-time = "2026-04-24T22:08:49.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1f/0960a129d504728d28a51dbd5a04ce94031eb75bac676341da7aefdd8232/py_spy-0.4.2-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24720573f95230653b457671a1dcc3c5a381fcf4e92677761e328a430ad251b2", size = 2301852, upload-time = "2026-04-24T22:08:51.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/dd7d3c763a00b7b965e25a5eab0acd1a345dbaf0f45fffe595278873a1c0/py_spy-0.4.2-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aeb0323409199c785f730645e9f4bb7a7b9ca2c481f2c331a55642b5d13fa52f", size = 2936518, upload-time = "2026-04-24T22:08:52.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ed/1409cdb557e558a6c98003ab12fdd4284699e158c167c187cb0f124eea4c/py_spy-0.4.2-py2.py3-none-win_amd64.whl", hash = "sha256:8b06a353c177677e4e1701b288d8c58e2f8d4208ee81a8048d9f72ba800918f8", size = 1894002, upload-time = "2026-04-24T22:08:53.811Z" },
 ]
 
 [[package]]
@@ -17866,7 +17882,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.86.1"
+version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -17878,9 +17894,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/47/891272d6d9028a860953dc21e0d8d4e47966c1a28099770230dfef711898/pydantic_ai_slim-1.86.1.tar.gz", hash = "sha256:3d502df00581bdd8b26ac5d6c6c220c426e7e7c256fee0d921c3e80897a08ee5", size = 567573, upload-time = "2026-04-24T00:46:07.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/f9/76c7943f208b09b320dc65a000689929df6a5d3b143d56b48deade6db486/pydantic_ai_slim-1.87.0.tar.gz", hash = "sha256:25822985ca21d6f2995310da915080fc3f75763aec82e815a3388257b06d6b84", size = 573802, upload-time = "2026-04-25T01:09:21.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/72/b8ff24a16adf017c5013f0a981eea3c6057aadf434d1d23523dc8903232b/pydantic_ai_slim-1.86.1-py3-none-any.whl", hash = "sha256:1e9d3b61b351dd5222a6050596f80b22c064cf40bf7c89845f66578df57648e7", size = 724714, upload-time = "2026-04-24T00:46:00.294Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/90/810dbc478bf063677cf56babc4404f2f0c59794017a5022ac93345a26d75/pydantic_ai_slim-1.87.0-py3-none-any.whl", hash = "sha256:6a9b4f9bcac3709ef47f3b3cda70446c002eb55901038a50d6224ee6743fe31a", size = 732159, upload-time = "2026-04-25T01:09:13.025Z" },
 ]
 
 [package.optional-dependencies]
@@ -18032,7 +18048,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.86.1"
+version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -18040,9 +18056,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/90/6c2c934ba5a4ebefb33127b36adcda2914e58c1fe28c0af49aa8894806b8/pydantic_graph-1.86.1.tar.gz", hash = "sha256:d3c45bc0b782f526cc995f9826e9665888e26ab15ea783a82826a09ca9f5f930", size = 59238, upload-time = "2026-04-24T00:46:10.187Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/fa/b2306c6dbb06e4dfe6ce6b7c5a28b82bee536d965e1dd1800b49c386b389/pydantic_graph-1.87.0.tar.gz", hash = "sha256:0f44848f8e83908ce372491c32ef349dfaf05e29f39fade0bae9309ab4f015cd", size = 59251, upload-time = "2026-04-25T01:09:23.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/e5/c5dd495026e67fe88f37a73447fa83a928d4d6c29429795e2301b7526e7d/pydantic_graph-1.86.1-py3-none-any.whl", hash = "sha256:fbd41ade2dcf53409ab2ae9d55dd6ebb0f3ac26ccfa10a2c211c7473f57707cd", size = 73065, upload-time = "2026-04-24T00:46:03.845Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9a/e99edfa37527ee04c14db7fc4b8da3f8e9c913f91c541a4b2d08438b461e/pydantic_graph-1.87.0-py3-none-any.whl", hash = "sha256:fd39e4e852808e36163474fe2af48e88a046b5e5e00596730f33c17d2429b7d2", size = 73063, upload-time = "2026-04-25T01:09:16.493Z" },
 ]
 
 [[package]]
@@ -18510,15 +18526,15 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "26.0.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a8/26d36401e3ab8eed9030ad33f381da7856fcfad5691780fccd1b019718fc/pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b", size = 186181, upload-time = "2026-04-24T20:23:48.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece", size = 58109, upload-time = "2026-04-24T20:23:46.273Z" },
 ]
 
 [[package]]
@@ -18564,82 +18580,82 @@ wheels = [
 
 [[package]]
 name = "pyroaring"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/71/134bcaf93d8734051ecbc164dabe695645849249e0fb24209b2dd88e8147/pyroaring-1.0.4.tar.gz", hash = "sha256:99d4217bdfeedc91b82efcec940175a9f9a9137c6476faf7ce5d9c9dd889c8e6", size = 189155, upload-time = "2026-03-19T13:57:27.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/46/a50510d080f8cb089303ec0f7cd80736b2949ca3d148f48f1cc90c49e345/pyroaring-1.1.0.tar.gz", hash = "sha256:f02e4021397ae02a139defdc6813b9942ab163de90affddd4ce4efbac299f619", size = 200298, upload-time = "2026-04-24T21:29:25.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/b3/5a910bcad7295a7198619540a4d879e447e5e0bf391a18f26e4f6bbd86d0/pyroaring-1.0.4-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1c5f78aeccf2ce4580cd373f50c20b3e6279a594d6fb827266dbceede9dd8c92", size = 320196, upload-time = "2026-03-19T13:55:31.771Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/66/e9d05f2e6d496d60cc7264a64d73d342bd099f164a7cdf2d57386bed4cce/pyroaring-1.0.4-cp310-cp310-macosx_14_0_universal2.whl", hash = "sha256:c0e7768e2143b842f5833857bbcd0ba28b0022028654ca5be395b7320b548460", size = 681634, upload-time = "2026-03-19T13:55:33.049Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/52/4e3f4dfd44edb425e43d4a4400308c564750b7f538fb625ca74c05e334fd/pyroaring-1.0.4-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:7497ea5124523bae7c05726e38faa9fe2f6e64c2423f96f0e4a00078d8c1b9db", size = 360359, upload-time = "2026-03-19T13:55:34.557Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/1e/31e5ea70966af4af507efd1c44240df5f09db73b6a04bdcb582377b9d870/pyroaring-1.0.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:827e7ecfa57a0f6e1cfd2449eabbc04fabcc16e4b3ad0f59f7a2d08f5d2fd063", size = 1885434, upload-time = "2026-03-19T13:55:35.668Z" },
-    { url = "https://files.pythonhosted.org/packages/81/e1/98bc17b321e6c838edb64c166e8661341b05539bde815e0198a34f56ccba/pyroaring-1.0.4-cp310-cp310-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d3125ddc6e9e9dd58663db2db67c5ef12ac76d7a7e1882cf82581cd2307ac82b", size = 1751735, upload-time = "2026-03-19T13:55:37.194Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4e/a7d94c948450ab8f63a400d1f5cad61c2135c2b52d060865075027b296db/pyroaring-1.0.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6633a7a91df7aea8340e348408b4eb92a2cd89eae0f99e9b42b1d6eb6a1c9673", size = 2078662, upload-time = "2026-03-19T13:55:38.553Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e9/e3da53c33de08e5be4e6fd5f6444d490bb631d0b0c13bc5f753eeab5c376/pyroaring-1.0.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fcee7f9cd9dcce96e057ae78b7deef0eced728b7452dcf2781b366bd69db3432", size = 2809536, upload-time = "2026-03-19T13:55:40.135Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/30/2249294290890dfdbb9d8537e5b322cd3386f716f62dafcccde1aa33edd3/pyroaring-1.0.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:dfabce5b120dd50dc46d11066ec111732d19a4f99e5a7720271dbab5b13bb692", size = 2610604, upload-time = "2026-03-19T13:55:41.485Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/71/368c5b35af66fea64bf4fcb461d55857de4ff484aa3f4ff55ce2f1c2e24e/pyroaring-1.0.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a92af0bf8ad040b513ef8867fda2669708a1b81325295c55cb4e8cc3a835321a", size = 3052109, upload-time = "2026-03-19T13:55:43.193Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/79/556ac6b249e2c73dc2fb224baab9ecb497217d711b848c8a9a42a5b5c921/pyroaring-1.0.4-cp310-cp310-win32.whl", hash = "sha256:49a354fdd9359a11c2da5a70d5c202ee339a4328d2c57679acf642e577202b87", size = 202780, upload-time = "2026-03-19T13:55:44.817Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ce/d68e2485e3b87e650535be76ed6344b663f41ad723d11a60405e375c8d7a/pyroaring-1.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:387001bcaa1653c6770eb8dd88f6427cbcef882c2ab8a812949dd8d98d09d545", size = 252209, upload-time = "2026-03-19T13:55:46.087Z" },
-    { url = "https://files.pythonhosted.org/packages/14/65/1c29ad4ac8986c0f89ed76ff3ca5c83ca8aeed268594796dec25554bb3f5/pyroaring-1.0.4-cp310-cp310-win_arm64.whl", hash = "sha256:a7553a23a806033ee93f5bd50f7c963d713a26ebecd55f173d24404a8673317d", size = 216508, upload-time = "2026-03-19T13:55:47.463Z" },
-    { url = "https://files.pythonhosted.org/packages/84/1c/f96ef38332d29015ef5285c0f6117b5644ccd9930334038740aed1df0a09/pyroaring-1.0.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8e1b2a9f6f6c08e971098867186bfd23fd08afd899db318cc9ed602913b1fc54", size = 319867, upload-time = "2026-03-19T13:55:48.492Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a5/0759a5b55fe4ea0ef322a134117dc2a706ac76e6dcd1706b1de4c5af66a3/pyroaring-1.0.4-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:8a202294c7bfd19c2d08e95e03e486859b351a6f1daf0d69197bd8d355d4044a", size = 680818, upload-time = "2026-03-19T13:55:49.696Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/47/f681a3fe58f1ca2712c33b1003e40b3716d0eab267abf8e6ae57b19c9245/pyroaring-1.0.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:f8157345c01f633f759fc47133a076d3307f85d0246dd17986127fd1e2c349d0", size = 359867, upload-time = "2026-03-19T13:55:51.053Z" },
-    { url = "https://files.pythonhosted.org/packages/58/6f/bdcf4b8ba51f921bc5184feb07985dcb32b0aacb78d7003d153e0883afb1/pyroaring-1.0.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:969c24580c9c16daa8e36eb76729d8c59c76250890dc6acdae9adb4d41107c4b", size = 1951858, upload-time = "2026-03-19T13:55:52.413Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/40/3475ba1a455df6ff617e9babbe998b8973483266384cd5ff4072914228da/pyroaring-1.0.4-cp311-cp311-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2984402d7c003923dc2e9b3e05676417f1de66ec31e4988d4b54c0a6008fe269", size = 1797084, upload-time = "2026-03-19T13:55:53.685Z" },
-    { url = "https://files.pythonhosted.org/packages/50/5a/e4426481a29099095dd56b1685a78039456f36cc4afedd55a09b9c137ac3/pyroaring-1.0.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d85f85aa2f56a5dde9c8d97cbfaf80dfe9c7212171f7f263043d0800b44cee3a", size = 2145587, upload-time = "2026-03-19T13:55:55.026Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/05/8d14ebe27b888433b61f5a9af8e99b368e58370102449299fecea4501d3a/pyroaring-1.0.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0b69e8799062acf859b13f5369c0976a6033211e72c51f8b7bc817925cab193f", size = 2875499, upload-time = "2026-03-19T13:55:56.847Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/4fd95a78f6de7dd5c39db8c34905e9fc7a538218abcec76a141d425779e7/pyroaring-1.0.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0333b18734475c531977e7a9027fc5753d7cac836f2475198f630ecefbbfd764", size = 2667086, upload-time = "2026-03-19T13:55:58.431Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ff/53af720a9b65858344dcd0765f57df9900ce5c1020038d33d2bbff78203f/pyroaring-1.0.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0736ee92f8781570d5be22a4f43238937676518a18487b1efafca67a63a89099", size = 3116570, upload-time = "2026-03-19T13:55:59.683Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/b7/f278f468acea40f8d3989c803cbb40ee222a86892abdacfe1e882788e292/pyroaring-1.0.4-cp311-cp311-win32.whl", hash = "sha256:76bdac16f535154322ca734cf51d96fa8f8d5a2f8d009a24affba0036f74f677", size = 201943, upload-time = "2026-03-19T13:56:00.905Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c4/4567fa392b4cc5407471b0c1aa8263674dd0611cd51012daf58ada694d4e/pyroaring-1.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:910c177c3ff77db0d306119963583be85a98870d396472b5a0153babc8b7fcf7", size = 253022, upload-time = "2026-03-19T13:56:02.124Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5b/1676f27f95ebadfa3a221c146ee941db0e91dcd08d1ee21c45106f9e329a/pyroaring-1.0.4-cp311-cp311-win_arm64.whl", hash = "sha256:c2e909a436ef22b9ba9f7dbc0e88fb684ced3bc6d5192b8315fe5ba180796b34", size = 216497, upload-time = "2026-03-19T13:56:03.547Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a7/9f4977405d3a3fa02cf575951f03a9cda4c01efbe27a19230addee06acc2/pyroaring-1.0.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:924ee997ff1a0f2a184e39e153e9f77e0b928fe908d0aef63d03204c3ed90586", size = 322060, upload-time = "2026-03-19T13:56:04.94Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e9/32fd7125aea82a3d1d29b755edbc7bb531907638c68a5bcc767d20c2be4a/pyroaring-1.0.4-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:b7a527279cc378e893a543a2271d71321b57d21733915a5a14e587532e29265a", size = 685716, upload-time = "2026-03-19T13:56:06.431Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b3/6b78bd9d743c053fb3b0485a6b1f487e6a658123f06013bee55610b02120/pyroaring-1.0.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:d73979e1a3a6de2b7039dd9a545afa23f3b33f8b6f90a825390a34253d097f96", size = 363373, upload-time = "2026-03-19T13:56:07.707Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ff/188c16cdd75d841e50d2779ff7b5d1c5c915a6f23006ef3ab3680f48faca/pyroaring-1.0.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dab3d8577b143c64c1c1659b4d1c69d7fec5baa0d0c0181cdddf6b84f43af00a", size = 1914865, upload-time = "2026-03-19T13:56:09.22Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/12/ae7b4fa3682190597cbfb252be570358c5bc55f46f6b05db3fde66dfacc1/pyroaring-1.0.4-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:dcc7d0133f46163b5390dd151e3305bd47289f7710c6e5444f38453d55b15d1c", size = 1742423, upload-time = "2026-03-19T13:56:10.422Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/25/966ea0a9d857ac3f2af1eaebdbfd56e627507b890f8ff7752c32e8e57b57/pyroaring-1.0.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a8b8448c2f7af3b40f17dde23b6739f3b19cf8b24db6f817c549c870d50aae3", size = 2130698, upload-time = "2026-03-19T13:56:12.039Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/0d0320925cf8bc1fcb53db182359bd673bf6b434f31c6cc69e4f5312c55f/pyroaring-1.0.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:13ccc488cfe6a227945586090397f299fd40c1a0dc1ed25e8e58a4d068c1ed46", size = 2822746, upload-time = "2026-03-19T13:56:13.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/98/a5f6d619098e307baf71b14a4df955914e8092f459d19daf80fbbd651fa1/pyroaring-1.0.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:dd89ebb7496325fb1b3dbe290dad35bc4da8722b5e3afd2a71b1d6e8ad981725", size = 2657370, upload-time = "2026-03-19T13:56:14.848Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/4d8beb31e4f648326b9b39c8f056fc1cb41422ef4e2be17cb15432c7fd40/pyroaring-1.0.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06b15bc8e0c272c3bee0c8adc29130178cd792ad99af64d7d7a1eb3069a1e0b8", size = 3088618, upload-time = "2026-03-19T13:56:16.625Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/95e223db5e60a6def8abcc2a8ebc4c71df23148a602310973c9a6964e3c5/pyroaring-1.0.4-cp312-cp312-win32.whl", hash = "sha256:4dca094f1d0e18901fa3f6b8866fa14a0f9640b22f41f5fc278c20e15e70efee", size = 202455, upload-time = "2026-03-19T13:56:18.124Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2c/5e41a91822c3bbc735382939d354e2c10bae453b18fe5a133f7fdbb33ce9/pyroaring-1.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:63ab0dcb24933fc9d4ca8c9fa0440f7e177183975990f756a42cddad22fd66db", size = 257479, upload-time = "2026-03-19T13:56:19.25Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/d7/7bc58e807e7d6739f4f5c45964a35927e1ff7f591e3943372097d29a00a7/pyroaring-1.0.4-cp312-cp312-win_arm64.whl", hash = "sha256:226079645dd4098d3619ae5fc19bf9abfd2187a74aba94a8768443e637d406fa", size = 215516, upload-time = "2026-03-19T13:56:20.286Z" },
-    { url = "https://files.pythonhosted.org/packages/45/d2/bd78613ecab5dcc17631de0de019b16470f1974e88cfb577caf131083661/pyroaring-1.0.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4171902a88df936564f39cce05e36ff5d363e122575d5cf575163917be9ec91c", size = 321192, upload-time = "2026-03-19T13:56:21.605Z" },
-    { url = "https://files.pythonhosted.org/packages/be/25/9c1c57743c2bb400d09e29f174b5369054e2700343b04dce36bdb55702e3/pyroaring-1.0.4-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:cbbe3fd3baef0bf04e149031aff44485757173370c5ce326ccb5269e131377ed", size = 684346, upload-time = "2026-03-19T13:56:22.996Z" },
-    { url = "https://files.pythonhosted.org/packages/36/10/3c8cdc657b7ca4f30f51e385980b205bf1b1f04cad12c856a34db380bc5a/pyroaring-1.0.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:f38ca8a8b43f6a12d606bf68d9c0348620bca29b97d315d545caa3f0a1179902", size = 362544, upload-time = "2026-03-19T13:56:24.068Z" },
-    { url = "https://files.pythonhosted.org/packages/86/46/3c6177117baa1896f38818767db1cd43130b32afc8b63a7be2a0c18faab6/pyroaring-1.0.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ef35040b1bc4bb686b4206f4a4de748f6209fa578cafdf177ca3bb67f7bd552", size = 1914120, upload-time = "2026-03-19T13:56:25.545Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/84/61176b1fdda1cde8572fc66fd88c1169f72fcace6b443bd8113df075b940/pyroaring-1.0.4-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:15c7f8b4bfc66c005723218500af414466a52e5cd419dbdd3a899307303b4322", size = 1741664, upload-time = "2026-03-19T13:56:27.369Z" },
-    { url = "https://files.pythonhosted.org/packages/48/8c/fc091d54a09f549c6fb860302676f2b3ca79ffbda23f298e59bdba693989/pyroaring-1.0.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbed00fb4c4f2ba0446e159f025beebb12c2f12dd34827551eb239438044fdb9", size = 2107765, upload-time = "2026-03-19T13:56:28.605Z" },
-    { url = "https://files.pythonhosted.org/packages/95/d4/864caa6719c3c229767a1cc6c32f707c0f7a67dbe19c3be595c7f43dec4d/pyroaring-1.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79af77dfb872da8a908514628b3f6bbcd2151bf31aeafebe2527e8d6fb786c97", size = 2819767, upload-time = "2026-03-19T13:56:30.216Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/67/7b0c91ea00d0c3e447c7507d8e9f26d94cad1f3c24c86088840d9fc490d2/pyroaring-1.0.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:15b0b92b4dcdb636ecd0a2104ef3be6b5288f85642dd16d7d631152948c3856e", size = 2651293, upload-time = "2026-03-19T13:56:31.856Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/aa/1c3746750c8c9b972d421fc6eae27fc21109a5cc26b89b7d5f8d104a613d/pyroaring-1.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:68f18b8fffee671996a4ba450f015a89281f7b7516ccc70b1398f20f46858536", size = 3070775, upload-time = "2026-03-19T13:56:33.878Z" },
-    { url = "https://files.pythonhosted.org/packages/05/da/a527a6141ea8839bee27869b92584f05120e1fc47cd572e313ddf5fd9f56/pyroaring-1.0.4-cp313-cp313-win32.whl", hash = "sha256:9be9df4a9ec671fdef22581e8ac9110ca8c47c5724e90ce825d54813de8ac3d3", size = 202501, upload-time = "2026-03-19T13:56:35.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/b1/4ab2b78ab46dd4312e68013f997b4e771ed91c6acb65a00bbeafe7ea3fe4/pyroaring-1.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:048b915bacfc8e4d05de4fe6c2d7f7dd9d4c7a200b3b23dc1589226ca2526b41", size = 257129, upload-time = "2026-03-19T13:56:36.746Z" },
-    { url = "https://files.pythonhosted.org/packages/70/73/ba128b5bafe10f7098217f257a11b1f5ecb50947e3800101a13124562d0f/pyroaring-1.0.4-cp313-cp313-win_arm64.whl", hash = "sha256:645af7435e9ad31a7aa6891b55797fe904c9c579fc5993b7fd59605f593188b9", size = 215209, upload-time = "2026-03-19T13:56:37.785Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/d9/64ae48d0d7d7e8352ab894a2d38b111db87499af2d2fa98464b395a1ab86/pyroaring-1.0.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d0b14587e4ea67b7c7e16293bd934929ac1a7cced34aed11caab15466b24b8d4", size = 322966, upload-time = "2026-03-19T13:56:38.926Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ee/573e103a721feb22b9299c65d71bfc24872ddc487a84b61407a45750cd4d/pyroaring-1.0.4-cp314-cp314-macosx_14_0_universal2.whl", hash = "sha256:55ae44a958017ef5d355c80a1b20ecd5cf8cd796ea26c9e34ef606a2f65f49de", size = 686037, upload-time = "2026-03-19T13:56:40.148Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/00/0c16fcd126e1cac0280ab1f44bcac8603ecca124c36cf5c523698abe628d/pyroaring-1.0.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:316f89f7961972d07b7ed71f32335fe1b47d143b3dca1c35d58c48299f687750", size = 363100, upload-time = "2026-03-19T13:56:42.184Z" },
-    { url = "https://files.pythonhosted.org/packages/51/5d/1bc58754e2c747b06ff380467a2d38b63542856bbf681b4472fa3f9e2346/pyroaring-1.0.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:edd767e6263fa17feae959519ee3d9bdbd0c5f03b55f89ecdff9d7136886e8f6", size = 1913082, upload-time = "2026-03-19T13:56:43.334Z" },
-    { url = "https://files.pythonhosted.org/packages/23/21/8f75c12cab6e0af84464e8d8aff14bc46daa72d8d28c1fa966ba5f296705/pyroaring-1.0.4-cp314-cp314-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2fc84c41de2b1370d57fea076f12246e6ab9333499ba6e8c74a5ea32168d357a", size = 1734580, upload-time = "2026-03-19T13:56:44.572Z" },
-    { url = "https://files.pythonhosted.org/packages/32/30/aa3b93bbb13c9d122e6d95cebedcd3479366cee9d78094f5207b9da0642e/pyroaring-1.0.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:abcb5083a80453ff59757882510c41e895b20c3326a37e3f683993953ae6ed1c", size = 2097410, upload-time = "2026-03-19T13:56:46.158Z" },
-    { url = "https://files.pythonhosted.org/packages/74/ff/75e3a99ebc63ba2be3a484bd7b0e191209f4b5cbbcb094a057779cef4ac5/pyroaring-1.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:078ee25ed3fda098032d7f30a603f836b538e5e7e5717d8dee29b42de4547250", size = 2823136, upload-time = "2026-03-19T13:56:47.479Z" },
-    { url = "https://files.pythonhosted.org/packages/78/1d/85d398b50f4e4c47ee88e65d172d07a4bc2f2d981ca4b366e5c83b67f38c/pyroaring-1.0.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ed967ec4ef3b9de7ef3f7c0cf3a850b599111479654d0b7962f12acea77b24ce", size = 2635231, upload-time = "2026-03-19T13:56:48.927Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/33/db0761c3120a65e8b2e0ee3d75b645674c532c65c22396a219f707bf963d/pyroaring-1.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2f617e66633428659193736bc568a0462f2966ab14229ec936ebb490647caa67", size = 3059892, upload-time = "2026-03-19T13:56:50.415Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/2b/4d73d056a73f65af4a58e8c691adcbcf563dd220d21f4285ebcc7d10509c/pyroaring-1.0.4-cp314-cp314-win32.whl", hash = "sha256:f0239d70d5d83227fa43a43b332bf707c6cafa7e28c14889d1602fc872934f02", size = 207536, upload-time = "2026-03-19T13:56:52.335Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8e/bc8b4704742debc21b4f4eebb5de8fc7d9e3ce8643b7d65c5c519eff5e42/pyroaring-1.0.4-cp314-cp314-win_amd64.whl", hash = "sha256:06f080c8dc42af32f66f11afdc603d5bf965d9239ad8d7773f0bae0d28a4e22f", size = 264935, upload-time = "2026-03-19T13:56:53.364Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2e/f9146436ecf3cf5af8c581f69ebbf03dd3d1561c7b8fe39679b50a3c37b9/pyroaring-1.0.4-cp314-cp314-win_arm64.whl", hash = "sha256:9ef52a2a1b3e6ccb3daac2dd5e8178349846d05f8cc1d0c05c551f73927cf0b4", size = 223530, upload-time = "2026-03-19T13:56:54.463Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/a9/f0a925c0d857d23830fa1a12452d0976f8ba245f2e4a9f019243b6d6f0c4/pyroaring-1.0.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:91e615d6a5e114ce9297650fabd48bf1f01655cfd5bd9cb41b9b1dc0ff840e06", size = 335434, upload-time = "2026-03-19T13:56:55.548Z" },
-    { url = "https://files.pythonhosted.org/packages/66/36/0c06caab704ed4573e5e4f24e5f4a99c6c9c03f24a53d0f73970517dceff/pyroaring-1.0.4-cp314-cp314t-macosx_14_0_universal2.whl", hash = "sha256:d943aebe18f017e3a37acdf8eced5b37bd9b5d5fcde8d581936ec6732b72f3c7", size = 707199, upload-time = "2026-03-19T13:56:56.622Z" },
-    { url = "https://files.pythonhosted.org/packages/07/4a/0fdd0bead1a3889cc6bd0dccbc168df5a4c9fc635e40a95f13426246c7c3/pyroaring-1.0.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:01f990499a4f34a666702da16080b6a94b990c5dc5cd7f2b1f6f92a7184b94ed", size = 372204, upload-time = "2026-03-19T13:56:57.762Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/8a/78cfd7c35c1e6a82bbca8e3f57f123273168b892ab92daf5138a3717e57d/pyroaring-1.0.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:236c5fb377d942c0911c7f7b1d929e192ad0165f07dca0957fa4b8ec607b4a8d", size = 1962093, upload-time = "2026-03-19T13:56:59.36Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f7/12f5dc15217f9d018b0b76dafb89db49833c14d58e49a0a16779b7b231ea/pyroaring-1.0.4-cp314-cp314t-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:84925878cff40ce1f5a99de0fc5b49b7cf6a6276ae5046ae80bc2ae9b5b83d83", size = 1751588, upload-time = "2026-03-19T13:57:01.097Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/84/7291e0a04af887f58ecd58a304dae2f979a8393ad7cd18059a744a16053b/pyroaring-1.0.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4ce889a06603931a03195b90dc11f03cfb6849c4d8504168e7325da06ce95ee", size = 2130851, upload-time = "2026-03-19T13:57:02.38Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/23/56d4dba6fa2aae5c862f1c46d9f8c8d53f7c3ade95e327db7e430913ef8a/pyroaring-1.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f8285cb12c7181cd29c9807f624d729c0db7bbf6f96fe7c25aba719225f85051", size = 2853020, upload-time = "2026-03-19T13:57:03.663Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/25/9a3e61e85ce1e670fe3fbaac2a56eb0c8c8aa6ac3a945f5f734bf5851b7f/pyroaring-1.0.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:731e1f64292ee0e99cf43ef9d052c75c06f4c6dda752a6a21d062726bb077a2b", size = 2645177, upload-time = "2026-03-19T13:57:05.263Z" },
-    { url = "https://files.pythonhosted.org/packages/25/43/f57f8696c050dd8b642522e9ab775987c8fec7a61ab2a0899776c7f82036/pyroaring-1.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4035852113b720f72872741be8f9760c0d2dd1640f0bc598ece7ff7ca226a3a0", size = 3087856, upload-time = "2026-03-19T13:57:06.531Z" },
-    { url = "https://files.pythonhosted.org/packages/74/3a/0a9d837478912ce51d1583bc4352818e8933252207d05d3021e91103e084/pyroaring-1.0.4-cp314-cp314t-win32.whl", hash = "sha256:f9a111e668f026849a22a7e4cab628e41e48bb87bd2a9aea72bca75edcd7a6f2", size = 234160, upload-time = "2026-03-19T13:57:07.848Z" },
-    { url = "https://files.pythonhosted.org/packages/50/9d/bcd304935f20ce5f9ecb2837df69516be657e144da350a73a1899985aa38/pyroaring-1.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:92fdad43421ad2e076639f7a0d9ee815713b98bfe07dd9107ef3ea91ff0f3b37", size = 298468, upload-time = "2026-03-19T13:57:08.94Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/4d/bd52a55dcef5cde4d0dda8c80000463c6929c7faba2466d9fa58fd0d48f8/pyroaring-1.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:c291428f148450e0609d5b1201b81e8248b3262770e51fc4c89768529ee36df0", size = 234175, upload-time = "2026-03-19T13:57:10.071Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b0/ab1c3b9227aadc326138cbbb973549399ece103d35b8c11952405a252a4d/pyroaring-1.1.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:19c9bb8b32f17fe63e54e78f88a7a67fe2dca352bf79d7d3b43f0a901db5ea3b", size = 332486, upload-time = "2026-04-24T21:27:35.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/02/a3a916ac9b6de70ac8696f767eb3487c41ca37b7f991216abbebe528045c/pyroaring-1.1.0-cp310-cp310-macosx_14_0_universal2.whl", hash = "sha256:212f471da113eba24a0fedbd1ef078bfed34b792e8f48dba3f7301f1bca2678a", size = 707625, upload-time = "2026-04-24T21:27:36.809Z" },
+    { url = "https://files.pythonhosted.org/packages/22/53/e845f27b6e6e23cb322f834fcf871e27e4e2e9284360d63e68bfcf9088dd/pyroaring-1.1.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a31276323fdd355505883162f1dca4d7acc3d6ec2159c85ddef863f1fe9e8f05", size = 382766, upload-time = "2026-04-24T21:27:38.337Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d3/4c9439ff556091d93c591ac466ab526991fa8745c1a15e9ca49081f215da/pyroaring-1.1.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55c9d0b708a65308eaa95c53d9de56a2b4425812395f6e57a4d9ad8efb081bf9", size = 1970617, upload-time = "2026-04-24T21:27:39.722Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4a/568684cc6d5294f0ec183bacf38f5a27b2c37908d0e0ac6f4423ae7c7c5f/pyroaring-1.1.0-cp310-cp310-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5599b691e5e993f7fdd9880429d1c485eae03dc392ba5b2dbe2eef0434bea1a5", size = 1853502, upload-time = "2026-04-24T21:27:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f0/82c4335651ae243eed411daa8e5acc1c62179a3e90350e4785c487e643a7/pyroaring-1.1.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8376c62e60a49e8fe51ffce569f74beed6e53fb58e5d6739f954c8c51ec0bec3", size = 2171600, upload-time = "2026-04-24T21:27:42.79Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b6/e6859ba41ad4c421248c2baaa4aa6c434369991200c4809cd389a4b1688f/pyroaring-1.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cc998e81748b72659802a7b434b39292308a5f4ab8dd4bf4739d65de1d4ed2bf", size = 2887912, upload-time = "2026-04-24T21:27:43.864Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c2/3f31ebc60ab094c1f2ff72f60aa0b5650d49c7653b5b575648cfb22b5441/pyroaring-1.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:fe0b9f0baf190663df37571cbb8a77370e7bd3a66068276d48f813c53ceba530", size = 2691997, upload-time = "2026-04-24T21:27:44.996Z" },
+    { url = "https://files.pythonhosted.org/packages/00/6e/c1d09230ebe0088ca011be2879e7c2f956cbdbc530c6427f6d046658b1df/pyroaring-1.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:83815b3a4cb9c3b17096c70833373610d5c93e89c134548cf43436c90326bfb3", size = 3143377, upload-time = "2026-04-24T21:27:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/fa/665ad8ce092e24b4d3b1f5e34b032d73c6a3f4792f229a70b702cd050408/pyroaring-1.1.0-cp310-cp310-win32.whl", hash = "sha256:e9caf67c0c05d27bab0d88cf193e73023f624c6714f1ff807c7d4b135b19d36a", size = 210064, upload-time = "2026-04-24T21:27:47.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/802d6edca2dfdca841ecaafb1d60c05657f2d3948b7b78eb892cf8195dac/pyroaring-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:a6343249ce9401dd90c3b934fd9a4a618b6fc455f27a9aa11d198eebd4743137", size = 259507, upload-time = "2026-04-24T21:27:48.788Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/4c/b57b59a7d7f913eb6d1ce2578fbd82a3209805a33a673f562ca1035839c1/pyroaring-1.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:8f5194c0544b08e56e108dad096c468c67f8ac60eec42763aed36ccbd3565346", size = 217549, upload-time = "2026-04-24T21:27:50.129Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/aa/574f153feb89856010092c33cafe4a52f4da8cea19d441cbc4cbcb8ccb1f/pyroaring-1.1.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:462b0952277d3100a90ae890ae641d3fb3561b10cfea542e02468f0bef7700a5", size = 332142, upload-time = "2026-04-24T21:27:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/938a9fbdd41699ac9419ca922fcf80eb58c0c62aa34539aa540abaee9a63/pyroaring-1.1.0-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:9cf8608c9d6cb6bff9c624744f7a2ba8ab12276f097a07930490fe0e2219e9be", size = 706441, upload-time = "2026-04-24T21:27:52.226Z" },
+    { url = "https://files.pythonhosted.org/packages/06/06/5120acc9918223ccb647dfadb430da1ec08d7ada818469ad3a2f1574b8c7/pyroaring-1.1.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:44a9f9719ed18e86627286f90057f9b7e22f6ba1d952c9793f9600b5c14e8680", size = 382003, upload-time = "2026-04-24T21:27:53.322Z" },
+    { url = "https://files.pythonhosted.org/packages/88/73/adc7951e0d4e65ab7a84fa5562bc28ba2dcc6f461a9156edc0d5aefda7f6/pyroaring-1.1.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c14fc6bd65e5624f76b90297b081222261476978f795f60d48745553617ddceb", size = 2034493, upload-time = "2026-04-24T21:27:54.739Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/28/992f2f2ef573b54559ed4bc62b5cf0ea095a59173521cfbe78dfefcc08ad/pyroaring-1.1.0-cp311-cp311-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:01212da3752d6486adcca98c9d353f8fb8e36513e05062cdd0feebc4211dbe70", size = 1901479, upload-time = "2026-04-24T21:27:57.115Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4b/38bded4ca17af6359c1766c25e942435332d26e2cb3321d9d081546b75f8/pyroaring-1.1.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:100585f438b293112e2c52e45a442835837c8a0267dd1e513bafec35628f8ecb", size = 2235338, upload-time = "2026-04-24T21:27:58.66Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ff/8e7da41468a33fc9d0fbee949e8f3f734930b5173020a478686558388f31/pyroaring-1.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:532e53191d8dd29dedfc5202cbb45632f7df751b207a7f6d6860fb7067c7fe11", size = 2951300, upload-time = "2026-04-24T21:28:00.12Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a8/f8a4b55b0817aac3caf6b3b51f2e93cf152f32784949919512bd38feb0f6/pyroaring-1.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:731a7a9e050758986d5757eea10f9ccb08f9c3ef514ce0335f4a90e126f81131", size = 2752747, upload-time = "2026-04-24T21:28:01.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/26/b5a29c0f38c581ac290245150d4d14b627f110eac208f3569d5d8739c78f/pyroaring-1.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e9864e19109e76111befc75d799d334e7365eb4189607aa734053c12e7840fa5", size = 3203933, upload-time = "2026-04-24T21:28:02.595Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/2b3661d9a9e12dac02d2c3ef4545bd2236fcd964ba8fdd96e308ca621153/pyroaring-1.1.0-cp311-cp311-win32.whl", hash = "sha256:7caf95de39ce869ea0978068521cf6faa7350574fd1734ad6c63e5ed8cd06baa", size = 209205, upload-time = "2026-04-24T21:28:03.811Z" },
+    { url = "https://files.pythonhosted.org/packages/be/1f/416a8cf29738d2e8c552fcaff7951c2a9a3bac0faffbb88b888287665834/pyroaring-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:a23cd023985b5f2ba23e84e1fadaeacde3c8a59e1d2adb3fe782e99db1e22387", size = 260338, upload-time = "2026-04-24T21:28:04.752Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/0d/fd3f57014e98ffd20a3db7fc07157be8abb6cc5a356ccb20e1ea2493c397/pyroaring-1.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:a98d1147fe1d3195053b67b474bccc0be5021506765d27f613a943c8c99f9e4c", size = 217570, upload-time = "2026-04-24T21:28:06.126Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e9/d8dcccfdac1657e6a53b6ade0c0c71d59244316810c82537a5d634f8b7fd/pyroaring-1.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:fdf484d26016e0c016f23f2b635d2899daec034565fdcc062ed6b10f3b26a3f4", size = 334166, upload-time = "2026-04-24T21:28:07.184Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/70f8268c9bac4f6d91a82df254332edfa07020fe02e97c6d3d0295ee4db3/pyroaring-1.1.0-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:e9c2b9aa8decdcf40ed8f4c887092c20a272f8c32215c3fee65e9db92ecf418e", size = 711970, upload-time = "2026-04-24T21:28:08.929Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/0b88a8a8e4ffdd0bf53765c3ea17ce3b747f7de42b1f10d5c50a13ba3ecc/pyroaring-1.1.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:5eb031237e9d39cbdfc9276facacdd88e27aefb58940bd8b56b878dfd38d6022", size = 385825, upload-time = "2026-04-24T21:28:10.077Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a7/f06a899b896bb74a031201fbba707abf23e2485f44ead28d2e91977ee204/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66aa6a321fbc598f26d5e66050a7f145c2253f3fe5737b589841ff0cbe5cb177", size = 2000799, upload-time = "2026-04-24T21:28:11.276Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/16/b13e0727ef5c91c84ac5d9b5c4af43cb3f28d8822d96d44aa4aeefc10b37/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cff06d18c9a30f8547a92757078aa345db1ba5b22e3082a05f64e50b384e27a", size = 1843405, upload-time = "2026-04-24T21:28:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4b/ff77d6eb4747c65aba49d345318059f1ccfbd206bbcd34686cea819187e9/pyroaring-1.1.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:043dbbaa905f7288c515ac06a96b67a3763f35e9ae06f0c0278c0d9964d16760", size = 2224307, upload-time = "2026-04-24T21:28:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d1/9b4e2175a9bd07592ef1c6f4692ba0cfe3abd54f33ebd574aa2b2ab88c2c/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71fec09bd42f8c33ac3b762cd00c5db842eb583ffd0e361739ce1c17ad078a6a", size = 2902586, upload-time = "2026-04-24T21:28:15.485Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/904952d6bfe2e4946f361958157774230cb1ac171d306e2460620274c58a/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c9f30ca28b991a920b446ed3ee19c7ecafcc49c46db592abf89cf239a7bb45f4", size = 2741581, upload-time = "2026-04-24T21:28:17.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/8ad5605870fbdcb568f0b847e1fea24adea15e07c90231fb62f339c08b14/pyroaring-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:67650460c65bdd7b4f5078d9c955aa38f64627d02cb48f9cfb24eae84bca2aba", size = 3182906, upload-time = "2026-04-24T21:28:18.435Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5d/264414a1b1bea72b2a7756e2b1dca709e5c695b0cd332a8f90c297ae3b33/pyroaring-1.1.0-cp312-cp312-win32.whl", hash = "sha256:61a8eabee99104ca197b6e7cce05dc4f27f503be52881800cd370eb5a5152d3f", size = 211231, upload-time = "2026-04-24T21:28:20.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/39/dd3341e235a3794c613ea32bd35618a88ff2ae067dbe9dd7c382c8c146d2/pyroaring-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:51ebe5e6f48e3dc9df91a4cb62137ef72e1469acd6f37479abd9991f6d945cc9", size = 263337, upload-time = "2026-04-24T21:28:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/12/5d/bb8e93dd7412180c621086ed46014a0f09f9a71d9370ce8cf607c5a2cf00/pyroaring-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:9882a204178cc8c915e0ce30abb4bdd1668e383c571b06649d5ed272d9625877", size = 216727, upload-time = "2026-04-24T21:28:22.536Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/75/1d39ecb04e6cd96d191eb8884864355051df80928dd5096a9dea43fbf63b/pyroaring-1.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:72f68a16b00b35481d9b3bfe897ecd8a1f7da69efd92ba5b17347ca11c21cb0d", size = 333363, upload-time = "2026-04-24T21:28:23.838Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3e/65cd0871e86d11c5c5cfd0f5abb0ca80eb2b6b5dbe5a2433f315a9ebd90c/pyroaring-1.1.0-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:4c443e9f942b6089efe8c9b264576e9d116f90be28a315679375bba2d8a915d6", size = 710573, upload-time = "2026-04-24T21:28:24.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a2/f8f23515f41414332e60cd86e4957e2a6838070b2ad5fe25e80f136de635/pyroaring-1.1.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:3beb40eb1220d1ce4fb3661bb019e9a21857e5bb294fe8c1c5016aeb6e82318c", size = 384880, upload-time = "2026-04-24T21:28:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5b/82dc44b5074a1ff62e702d12611272d1711a60d5518dab23f94e1f7a9b3d/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f1f56004e8f1c1489bf279c25f1fa4764252cd9af5fb35675774268a4a615ba", size = 1999529, upload-time = "2026-04-24T21:28:26.859Z" },
+    { url = "https://files.pythonhosted.org/packages/11/40/b07bac8cdc4b709a05f5c55bb52d4f684e5ea1fadfa0b6d9decf477a9d2a/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:13660386ea8905ee4d42c21a6275463e2dc7d31e0b5d65eec210aa7043ad96f4", size = 1842927, upload-time = "2026-04-24T21:28:28.056Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/60/c4b511965802dfc77978a9e16f2813f47fb3083db1822019ba1bb169c685/pyroaring-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0dfb6cf50fd8898179e460e699a6b8326ca508c627d083f7bf62f769fe1717d5", size = 2199538, upload-time = "2026-04-24T21:28:29.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/12/38f6b50b3f3f41a8b752d3e9efcf105b18eb2c66811831059f25613734ac/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:81ebbc0c880c8a10f13118632e5c0d59159ceada8b651bba18f2e6dc70efdeda", size = 2896904, upload-time = "2026-04-24T21:28:30.67Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b6/b5436e4b93c6bf2bd3dd6ccb88cbdc64b12084151a43e2f5c94be50eb710/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:370d191b0d1b32bbd99452ef5f0485f22fcc4bf7404d33b821d0ce2459951152", size = 2733819, upload-time = "2026-04-24T21:28:31.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/8f/f392f268de9607a5c7a95aaed6b9c8a81f00c14d85c33855e9f492095478/pyroaring-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8b3bfad0ae3ef0e67b40c193863dce8b7d79de545dadbe53c19acc3ace38f66", size = 3161730, upload-time = "2026-04-24T21:28:33.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ab/2260fd567a2d5d957393b932ea940dc31146bd509c88164c1b786eee7836/pyroaring-1.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:5e337f8c5b3c2e0c27da83fc2cb702684a47eee907a960cfee964fcb5344515b", size = 335093, upload-time = "2026-04-24T21:28:38.325Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/df82a832ff3760c7c7653b80d030fb43b18eb88bfa604e7de3e84457286e/pyroaring-1.1.0-cp314-cp314-macosx_14_0_universal2.whl", hash = "sha256:53acecba8f898e96b84d4139356e30719c70358177e270055901d3ec1cb0e34c", size = 712387, upload-time = "2026-04-24T21:28:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b9/a94d6b2d7a1be2fa5009ecfc345bacb2ee0b536020aeb23e92c6bb7e70f2/pyroaring-1.1.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:986efb3aec7655d69c14db2309a2072dbf181bdb906091fede83ad18e316cdaf", size = 385413, upload-time = "2026-04-24T21:28:40.563Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6a/3658eadbe28a5a2093c27857dd21441f1ea1cede2ddbe367df76e3018859/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92643c9dd303de8960c3dbed93a28b8d87da5ed0a7776568979f379d7bc8a885", size = 1995135, upload-time = "2026-04-24T21:28:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/4706ec770790d3433520eb0ea98fc662ccb1533164fd00b01f3413c3425c/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6a1d4c59d5b23c01d62f86d57ceefd0c0977de0425aafa7069f2d70563fed3b8", size = 1833652, upload-time = "2026-04-24T21:28:43.381Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/38/b8b861738e49fd4c4a54bebe257dced603999365629b4e10cb85fac940b0/pyroaring-1.1.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8ac1bc26223befbca986551521f37f4c1670dfe26fccb2f0fc2775e75be99c1", size = 2188218, upload-time = "2026-04-24T21:28:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/96afa9b5f509a5c607deaf30538edb3bdf026447a864cfe3f2c3d7484875/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b490f2d22df30affbfdcbe4f7896f321edb72a8dc0cbe5f38adec3de5b947c25", size = 2898243, upload-time = "2026-04-24T21:28:45.9Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/86f8720525250fe742fc77ea5c2a2074a1ea830efe84a79112ce6fe113d3/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:56a67794188275f8897a8f1fa64d6313c48241bebbdef38833063e7281b29ef8", size = 2715091, upload-time = "2026-04-24T21:28:47.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/21/29e8f58c8af2ce016904a7e6aa61be675945224971cd70f3f698e584a23f/pyroaring-1.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9d9f196007f0b15ea19c21732faacaea83cbf5946b6db4949b3b98cf871c93f0", size = 3149470, upload-time = "2026-04-24T21:28:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/e1/f67ef1c9de461a80707a2f2981320b1b30632720bac426a9bfd51e4744b6/pyroaring-1.1.0-cp314-cp314-win32.whl", hash = "sha256:abc0f0ce22464864fea208315d25e999e45cb5ee646ac1ca11d314a6a51dbe4a", size = 216552, upload-time = "2026-04-24T21:28:50.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/83/a8d9fee17e6eedf2a2281b2aabcdde86930408486381ec48d1f7d3404521/pyroaring-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:532ae6bb1d3431d9956ef07589dd5c8dd918301a83d937c7dc6e511b1364d76a", size = 270712, upload-time = "2026-04-24T21:28:51.817Z" },
+    { url = "https://files.pythonhosted.org/packages/42/50/ab2bf3fe45e4c2952690d657321a8470558f92cf93cb197fe5d31f7110d2/pyroaring-1.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:d2706a89242a347be20805147d58a38f4f4d8f6846228c4ee8dfd3587113719c", size = 224783, upload-time = "2026-04-24T21:28:53.183Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0c/9eb48ac698280170f184045814b7bd44829af37c1c6de79a4d7b5ea0c8b8/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:39eff7dd06c163c22d0a9f9fd72d27e671457bea8cdb71215382a10512539e1d", size = 345689, upload-time = "2026-04-24T21:28:54.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/61/66b18f8ed17e70f88a410dcfac21e5964c2ad01bd4d6a25024a87522c8a9/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_universal2.whl", hash = "sha256:562fa04bbfd41144d1276ed79505007557c161371450d68a1d71fc83dc01d083", size = 732373, upload-time = "2026-04-24T21:28:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7a/976482874ea5e4476f9dd84e7d0274e480446b1b6ab45dfe301281814b3b/pyroaring-1.1.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:591e2ed4d60443dafd9075c1f72e9aaf359ccf5120e32a8c340c2b2ae3da45e7", size = 392985, upload-time = "2026-04-24T21:28:56.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1eed09ff3aa792865dd52ef447cbe52dbc5901ed88bf1cf4513f7220150e/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:381eda673442c389993f8b0db2dbf5d02ea8ea9aac6ba736f64cc1ffb6c96885", size = 2045479, upload-time = "2026-04-24T21:28:58.008Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/de43464f9b28c445868e4bc8f0e6c6dcd51103bd9a757e3dcd9af25a4a69/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9127feb5356ba3a92bdffa04c1bf6bcbc8d436369f78badf441018c3029dd63", size = 1853013, upload-time = "2026-04-24T21:28:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/03/17/29b128a580ec43905fb766b934e7dcb1095059e99e38e941edf50152207b/pyroaring-1.1.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:650db21c10f42ff2b09ef02c10a779a3d59d0c7512552f3844738b30adbcb8a5", size = 2222628, upload-time = "2026-04-24T21:29:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d8/bb7d69978a5fcac95da48bedb114554d8345b50b77f042e8cd2a8277bb4b/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a5fbcb86e44f1c0c9c052917eee67a04cbac9de7392fb4bc77c140ff4a7e471", size = 2931231, upload-time = "2026-04-24T21:29:02.275Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/d44d144352a4586544313a97b2576f8f8673b98c02ae7fed77d38751cc1f/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0f1d76ef29034017eb2cceebd5fa0504d6ced218ce6432f99da5adecbe038269", size = 2729546, upload-time = "2026-04-24T21:29:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/0d01c6ba01c0d01609fddb1d46138a7ae95b7db386bac4afb0ff082d5c0e/pyroaring-1.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19d0c81c865d63791fe20e5b38733b66f4f962e677ae7e8b3d3c4947ac6e752f", size = 3177123, upload-time = "2026-04-24T21:29:04.619Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6d/f991526fdef3cf7739f6db0cdf12b157e840e0ddd4a7e1c2a477da9072d6/pyroaring-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:1fc112b9a9890f89cc645a16604783ed7fa25299f149b0ef7b45a5e2e3c1f31f", size = 241484, upload-time = "2026-04-24T21:29:06.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6e/fb9876940acb50df355a473c087b9924e7b3368070403683941653b6fabc/pyroaring-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d92a0f4c7e6bb7deeafac68c79c92ef9340895fe825cf1a31078443753ab6756", size = 304537, upload-time = "2026-04-24T21:29:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e0/39afe4bddbed6276c54e35e310aa345fbeb00f8890e96e7f48cdc2be9c66/pyroaring-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:99c42fe1449acfbf130da65e66b4d5b2726aba4497be359bae7672e38a15fc62", size = 234615, upload-time = "2026-04-24T21:29:08.751Z" },
 ]
 
 [[package]]
@@ -20259,8 +20275,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "jeepney", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -22077,11 +22093,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]
@@ -22936,7 +22952,7 @@ wheels = [
 
 [[package]]
 name = "ydb"
-version = "3.28.2"
+version = "3.28.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -22944,9 +22960,9 @@ dependencies = [
     { name = "packaging" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/f6/4040ffed706d1e5e6669c422baa79205dda48117672cd66361ccee6cb40c/ydb-3.28.2.tar.gz", hash = "sha256:a27325289a2a0f69e7326b14084c5612634b0801aebba695850ed1591c728e07", size = 1006082, upload-time = "2026-04-23T10:26:54.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/94/61ca54f510960e0e1851343039c714922db760c86a0d5e206e0fe13b078b/ydb-3.28.3.tar.gz", hash = "sha256:fc2169e64d59cbf5f4cade71134ad7210c83ef0af3d99e6de0c1f647c499871d", size = 1006136, upload-time = "2026-04-24T21:04:47.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/af/162862847e83b83f56d06cb1aebe99c5204a8156d28db546681556e739b4/ydb-3.28.2-py2.py3-none-any.whl", hash = "sha256:13511d59146a964207c7e13cb3de071a2b95fb5067e4b9e89c669c9e9bd39ee3", size = 1339613, upload-time = "2026-04-23T10:26:52.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/5b/12fb9da898a1a1edced49b96970b70bc7f77240dd3a27b80368f0da1ab6b/ydb-3.28.3-py2.py3-none-any.whl", hash = "sha256:49d3c0c5162ac93a09eb46181571b3c858311cf073e130b7721d813ece548aba", size = 1339732, upload-time = "2026-04-24T21:04:45.298Z" },
 ]
 
 [[package]]
@@ -23016,40 +23032,44 @@ wheels = [
 
 [[package]]
 name = "zope-interface"
-version = "8.3"
+version = "8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/04/0b1d92e7d31507c5fbe203d9cc1ae80fb0645688c7af751ea0ec18c2223e/zope_interface-8.3.tar.gz", hash = "sha256:e1a9de7d0b5b5c249a73b91aebf4598ce05e334303af6aa94865893283e9ff10", size = 256822, upload-time = "2026-04-10T06:12:35.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/65/34a6e6e4dfa260c4c55ee02bb2fc53625e126ff0181485286cf0c9d453d6/zope_interface-8.4.tar.gz", hash = "sha256:9dbee7925a23aa6349738892c911019d4095a96cff487b743482073ecbc174a8", size = 257736, upload-time = "2026-04-25T07:22:10.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/47/791e8da00c00332d4db7f9add22cb102c523e452ea0449bb63eb7dcc3c17/zope_interface-8.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8a2f9c4ee0f2ad4817e9481684993d33b66d9b815f9157a716a189af483bc34", size = 210367, upload-time = "2026-04-10T06:21:50.304Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d5/92bad86cb429af22f59f6e08227c58c74a3d8395a64a5ca61b9301fc6171/zope_interface-8.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:99c84e12efe0e17f03c6bb5a8ea18fb2841e6666ee0b8331d5967fec84337884", size = 210726, upload-time = "2026-04-10T06:21:52.375Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/55/ddf1aeb3e4d5f7a343599a76dafc0766ec42b32112bfedc37f7ddeff753f/zope_interface-8.3-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a918f8e73c35a1352a4b49db67b90b37d33fb7651c834def3f0e3784437bb3a8", size = 254046, upload-time = "2026-04-10T06:21:54.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/4f/a52a78b389c79d85d3d4afbf71b2984bd4a8a682beec248cdc21576b13a6/zope_interface-8.3-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5a5b50d0dcdb4200f1936f75b6688bd86de5c14c5d20bed2e004300a04521826", size = 258910, upload-time = "2026-04-10T06:21:56.588Z" },
-    { url = "https://files.pythonhosted.org/packages/08/34/2841cb5c1dea43a1e3893deb0ed412d4eeb16f4a3eb4daf2465d24b71069/zope_interface-8.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:731eaf0a0f2a683315a2dfc2953ef831ae51e062b87cff6220e0e5102a83b612", size = 259521, upload-time = "2026-04-10T06:21:58.505Z" },
-    { url = "https://files.pythonhosted.org/packages/23/ff/66ba0f3aba2d3724e425fdb99122d6f7927a37d623492a606477094a6891/zope_interface-8.3-cp310-cp310-win_amd64.whl", hash = "sha256:5e9861493457268f923d8aae4052383922162c3d56094c4e3a9ff83173d64be3", size = 214205, upload-time = "2026-04-10T06:22:00.611Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/99/cee01c7e8be6c5889f2c74914196decd91170011f420c9912792336f284c/zope_interface-8.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e8964f1a13b07c8770eab88b7a6cd0870c3e36442e4ef4937f36fd0b6d1cea2c", size = 210875, upload-time = "2026-04-10T06:22:02.746Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/f1/cf7a49b36385ed1ee0cc7f6b8861904f1533a3286e01cd1e3c2eb72976b9/zope_interface-8.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec2728e3cf685126ccd2e0f7635fb60edf116f76f402dd66f4df13d9d9348b4b", size = 211199, upload-time = "2026-04-10T06:22:04.596Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/86/1ccb73ce9189b1345b7824830a18796ae0b33317d3725d8a034a6ce06501/zope_interface-8.3-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:568b97cb701fd2830b52198a2885e851317a019e1912eaad107860e3cca71964", size = 259885, upload-time = "2026-04-10T06:22:06.403Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/de/d0185211ad4902641c0233b7c3b42e21582ffac24f5afe5cc4736b196346/zope_interface-8.3-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62839e4201869a29f99742df7f7139cac4ce301850d3787da37f84e271ad9b95", size = 264308, upload-time = "2026-04-10T06:22:08.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/e5/ac6f24cdaa04711246d425a2ca301e2f3c97e8d6d672b44258eb2ceb92ff/zope_interface-8.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d287183767926bc9841e51471a28b77c7b49fddf65016aa7faf5a1447e2b6558", size = 265594, upload-time = "2026-04-10T06:22:10.111Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ca/e888c67123b6a7019936c67b5ebcc9396fdb3067cf278d7541d24f4c1a86/zope_interface-8.3-cp311-cp311-win_amd64.whl", hash = "sha256:12a33bb596ca20520e44f97918950cfc66a632ac0278a7f40608217cc4269948", size = 214562, upload-time = "2026-04-10T06:22:12.681Z" },
-    { url = "https://files.pythonhosted.org/packages/16/1e/7ed593f9c3664e560febe1f132fdf73b8bb9a3de6e3448093b0167239c8c/zope_interface-8.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b361b7ce566bc024e55f74eb1e88afc14039d7bd8ea13eeff3b7a8400dc59683", size = 211571, upload-time = "2026-04-10T06:22:14.775Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/31/844979b472f30efd2a68480738c9a3be518786b0885137075616607e88c7/zope_interface-8.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5be73ca1304daa3046ee5835f7fa6b3badadf02102b570532dd57cd25dd72d6", size = 211748, upload-time = "2026-04-10T06:22:16.695Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/b6/71f5c9d8dde7334e1b67306fea5814c67eac92d871bb0dfc664c9f3355f1/zope_interface-8.3-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:961af756797e36c1e77f7d0dc8ac1322de0c071eaa1a641dbe3b790061968dd9", size = 264718, upload-time = "2026-04-10T06:22:19.473Z" },
-    { url = "https://files.pythonhosted.org/packages/94/e3/5eab77fd6795ca37b9ed1aeea5290170018938549322003745bdcd939238/zope_interface-8.3-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6329f296b70f62043bf2df06eb91b4be040baee32ec4a3e0314f3893fa5c51c", size = 269795, upload-time = "2026-04-10T06:22:21.728Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2f/4bc8807d65833f06335a49beb1786bafcf748cde7472ba14cdb4db463ba8/zope_interface-8.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f420f6c96307ff265981c510782f0ed97475107b78ca9fca0bb04fe36f363eb4", size = 269418, upload-time = "2026-04-10T06:22:23.802Z" },
-    { url = "https://files.pythonhosted.org/packages/50/3d/1cfaf770bc6bc64edec3d4c5f17b5dbe600bf93cd2caac5ee0880eb9f9e0/zope_interface-8.3-cp312-cp312-win_amd64.whl", hash = "sha256:ffeae9102aa6ba5bd2f9a547016347bd87c9cf01aea564936c0d165fff0b1242", size = 214390, upload-time = "2026-04-10T06:22:25.735Z" },
-    { url = "https://files.pythonhosted.org/packages/27/da/ff205c5463e52ad64cc40be667fdff2b01b9754a385c6b95bac01645fa4f/zope_interface-8.3-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:1aa0e1d72212cedc38b2156bbca08cf24625c057135a7947ef6b19bc732b2772", size = 211889, upload-time = "2026-04-10T06:22:27.612Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/21/0cc848e22769b1cf4c0cd636ec2e60ea05cfb958423435ea526d5a291fe8/zope_interface-8.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54ab83218a8f6947ba4b6cb1a121f1e1abe2e418b838ccdac71639d0f97e734e", size = 211961, upload-time = "2026-04-10T06:22:29.575Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/54/815c9dbb90336c50694b4c7ef7ced06bc389e5597200c77457b557a0221c/zope_interface-8.3-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:34d6c10fa790005487c471e0e4ab537b0fa9a70e55a96994e51ffeef92205fa4", size = 264409, upload-time = "2026-04-10T06:22:31.426Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/69/2e5c30adde0e94552d934971fa6eba107449d3d11fa086cfcfeb8ea6354d/zope_interface-8.3-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:93108d5f8dee20177a637438bf4df4c6faf8a317c9d4a8b1d5e78123854e3317", size = 269592, upload-time = "2026-04-10T06:22:33.393Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8a/fbb1dceb5c5400b2b27934aa102d29fe4cb06732122e7f409efebeb6e097/zope_interface-8.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f81d90f80b9fbf36602549e2f187861c9d7139837f8c9dd685ce3b933c6360f", size = 269548, upload-time = "2026-04-10T06:22:35.339Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/70/abd0bb9cc9b1a9a718f30c81f46a184a2e751dd80cf57db142ffa42730da/zope_interface-8.3-cp313-cp313-win_amd64.whl", hash = "sha256:96106a5f609bb355e1aec6ab0361213c8af0843ca1e1ba9c42eacfbd0910914e", size = 214391, upload-time = "2026-04-10T06:22:36.969Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/95fe0d4d8da09042383c42f239e0106f1019ec86a27ed9f5000e754f6e7a/zope_interface-8.3-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:96f0001b49227d756770fc70ecde49f19332ae98ec98e1bbbf2fd7a87e9d4e45", size = 211979, upload-time = "2026-04-10T06:22:38.628Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/01/b6f694444ea1c911a4ea915f4ef066a95e9d1a58256a30c131ec88c3ae64/zope_interface-8.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3853bfb808084e1b4a3a769b00bd8b58a52b0c4a4fc5c23de26d283cd8beb627", size = 212038, upload-time = "2026-04-10T06:22:40.475Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/cf/237de1fba4f05686bc344eeb035236bd89890679c8211f129f05b5971ccf/zope_interface-8.3-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:33a13acba79ef693fb64ceb6193ece913d39586f184797f133c1bc549da86851", size = 266041, upload-time = "2026-04-10T06:22:42.093Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5f/df85b1ff5626d7f05231e69b7efd38bdc2c82ca363495e0bb112aaf655b3/zope_interface-8.3-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9f7e4b46741a11a9e1fab8b68710f08dec700e9f1b877cdca02480fbebe4846", size = 269094, upload-time = "2026-04-10T06:22:43.832Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/10/7ad1ff9c514fe38b176fc1271967c453074eb386a4515bd3b957c485f3a8/zope_interface-8.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ce49d43366e12aeccd14fcaebb3ef110f50f5795e0d4a95383ea057365cedf2", size = 269413, upload-time = "2026-04-10T06:22:45.573Z" },
-    { url = "https://files.pythonhosted.org/packages/38/42/3b0b5edee7801e0dd5c42c2c9bb4ec8bec430a6628462eb1315db76a7954/zope_interface-8.3-cp314-cp314-win_amd64.whl", hash = "sha256:301db4049c79a15a3b29d89795e150daf0e9ae701404b112ad6585ea863f6ef5", size = 215170, upload-time = "2026-04-10T06:22:47.115Z" },
+    { url = "https://files.pythonhosted.org/packages/70/fb/cc696345b27909fe918a17f2b4deacee9bc8fd715ee04eb88c82677f1154/zope_interface-8.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:415de524326ddd61a78f0816f65942fa1aa35dced19e72579ad30dd106ce523e", size = 210401, upload-time = "2026-04-25T07:27:40.6Z" },
+    { url = "https://files.pythonhosted.org/packages/17/be/7fcce2121df992061093a8060130d0152ddf5bb32942ed5dad09a6a0baac/zope_interface-8.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fa0a26d5767087170b3da9ff503221d535ea266bf61b522d0afa2590fd05db0a", size = 210760, upload-time = "2026-04-25T07:27:42.943Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e9/4e3c564f9bd857abccd0839c22283ef7f85f3d09170c045a7cca42bb4988/zope_interface-8.4-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:8544081e32b515bbaf1c6339eef06b23ed470cf4876ff2f575803f82a744cc43", size = 254081, upload-time = "2026-04-25T07:27:45.392Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e2/390d27ae877dc364980ab4d333a07a9766a7c9b69535fe095bd18d06dc7c/zope_interface-8.4-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:892b4b5350e58d6914858f58eb85d39fe9b992640ac6ece695f46c978046554d", size = 258944, upload-time = "2026-04-25T07:27:47.439Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d2/993428933830d364d7d710db3f850ee5f3a631a023e598316588da58c406/zope_interface-8.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d683267a6243526869cb69677dcfc663416d5f87904c1576ddec6e420687d51", size = 259556, upload-time = "2026-04-25T07:27:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/29/82/0e4562eb9e7be8e82facbf1b70a777e9107e903448a81dc9c1246d152ab0/zope_interface-8.4-cp310-cp310-win_amd64.whl", hash = "sha256:f00fd65343d2a241a2b17688a12f5e815aa704ed64f9ca375de5f9e0ae9c9bda", size = 214238, upload-time = "2026-04-25T07:27:51.376Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/bd982648e1e62d7c06a56017fd88d1beea2ebc8d7a5972cce137e774aff2/zope_interface-8.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8b733af6e89a2b0b8edf5ff7a37988fe4e1788806e84e72127b88c47858f0da6", size = 210908, upload-time = "2026-04-25T07:27:53.363Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4f/fa87d3bd69d22b93fa5b968597a3dd0a297e44aa87e4611b0ca74c4aeec1/zope_interface-8.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:265bad2df2ec070f23ff863249a89b408b11908fd4207662781fd18e3c6fc912", size = 211235, upload-time = "2026-04-25T07:27:55.392Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/74/67379f7df4400ee45299c5200f17ec6c493e8a120ff4e5e9d26b09e32956/zope_interface-8.4-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e195e76767847afb5379ffd67690c17d3c6efdab58dc0e477cf81ac94d5a5a15", size = 259918, upload-time = "2026-04-25T07:27:57.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4e/c5106672b5c0b9071ce988d54124277762c3085cf1bc72e965e7173f1c26/zope_interface-8.4-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ec1a56b6cf9a757cbbce9da38284a01473b92b96c1517eabd99150f51f1bb69", size = 264343, upload-time = "2026-04-25T07:27:59.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/49/270c11e54e01b96d2efc59acbeb006a4171b8fafb75926c27d2184c32949/zope_interface-8.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:04c2c9b58e9c177628715d85e94834efa807c1f9f0a2f57ae0f7b553e8266ac4", size = 265629, upload-time = "2026-04-25T07:28:02.086Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/03/4ef05ada2230f05f08f579c45b60f127cce2bf379148cb7c21401052ca9d/zope_interface-8.4-cp311-cp311-win_amd64.whl", hash = "sha256:376d0ef005a131b349e2088e302aa094fa23c826d2ec8a7db4b00fb33c71e0d9", size = 214595, upload-time = "2026-04-25T07:28:04.408Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f6/22a304f4061d7ec02e20816d804ab0e844564055b25d471371173c44d73e/zope_interface-8.4-cp311-cp311-win_arm64.whl", hash = "sha256:caffd033b27e311b45e15f01923cc9e73c6bfd8e843b4532e29b59ee432bf893", size = 212904, upload-time = "2026-04-25T07:28:06.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/96/0017b980424125cf98a9851d8fd3e24939818b7a82ecdd19ae672bb2413f/zope_interface-8.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:84064876ed96ddd0744e3ad5d37134c758d77885e54113567792671405a02bac", size = 211604, upload-time = "2026-04-25T07:28:08.13Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/2cf5c45477fdd58a2c786d0c0d1817cbaaff8743d98ae72c643c4fe3be7b/zope_interface-8.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:81ed23698bfb588c48b1756129814b890febac971ff6c8a414f82601773145bb", size = 211783, upload-time = "2026-04-25T07:28:10.028Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/8c/efabdafc25ed44ef9c1084aad9870bb6c2c9b78e542684efe6865c0f0067/zope_interface-8.4-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e0b9d7e958657fad414f8272afcdf0b8a873fbbb2bb6a6287232d2f11a232bf8", size = 264752, upload-time = "2026-04-25T07:28:11.773Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5a/c4d52c58d5fee4ff67cc02f0dec24d0e84428520f67a52f1e4086f0e7779/zope_interface-8.4-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eef0a49e041f4dc4d2a6ab894b4fd0c5354e0e8037e731fb953531e59b0d3d33", size = 269829, upload-time = "2026-04-25T07:28:13.988Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d2/df8f339c93bb5adee695546ba90d0daa2917338a4792281f6b8e652a9328/zope_interface-8.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b302f955c36e924e1f4fe70dd9105ff06235857861c6ae72c3b10b016aeee99", size = 269452, upload-time = "2026-04-25T07:28:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/17/4b/bd97b1a21bb2c16d66a42f6c7a43c0a5afcfaf14c68d3b7d2ee6afb28e52/zope_interface-8.4-cp312-cp312-win_amd64.whl", hash = "sha256:4ae6a1e111642dbf724f635424dcaf5a5c8abbde49eac3f452f5323ffaa10232", size = 214420, upload-time = "2026-04-25T07:28:18.405Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/85/1477f23cf3b0476608ca987b4338f91439abb5b96564ac26b26d2cde38fd/zope_interface-8.4-cp312-cp312-win_arm64.whl", hash = "sha256:2e9e4aa33b76877af903d5532545e64d24ade0f6f80d9d1a31e6efcea76a60bc", size = 212992, upload-time = "2026-04-25T07:28:20.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6a/a08c62bc1fa0e34fe7b8b401646cba4817427c716bfbef6cc88937cd327f/zope_interface-8.4-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:cd55965d715413038774aead54851bc3dbdd74a69f3ce30252182a94407b9905", size = 211924, upload-time = "2026-04-25T07:28:22.219Z" },
+    { url = "https://files.pythonhosted.org/packages/50/30/2011f17e00ff078658bc317e1f7eccd7843fc1ce60695b665b0a52c45c1b/zope_interface-8.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0d88c1f106a4f06e074a3ada2d20f4a602e3f2871c4f55726ed5d91e94ec19b1", size = 211995, upload-time = "2026-04-25T07:28:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f3/a16fe884571cfa89271412dbb40def6d6865824428d1e14785a82795100c/zope_interface-8.4-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:36c575356732d59ffd3279ad67e302a6fe517e67db5b061b36b377ee0fa016c4", size = 264443, upload-time = "2026-04-25T07:28:26.401Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/e08923fcd8a8c8704af05a90418b07cd897ac90865925b37d7ad8139adfa/zope_interface-8.4-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:29f09ec8bda65f7b30294328070070a2590b90f252f834ee0817cdb0e2c35f6a", size = 269626, upload-time = "2026-04-25T07:28:28.423Z" },
+    { url = "https://files.pythonhosted.org/packages/27/67/96c94cd307f9946d0b0f03402a335f7aae7b4f0b129b5734cc56cc78cb65/zope_interface-8.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2bc388cebcb753d21eaf2a0481fd6f0ce6840a47300a40dcec0b56bac27d0f97", size = 269583, upload-time = "2026-04-25T07:28:30.434Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d4/7e9fcc8bb0dba5d023b9fca92035d68c018457cc550e9d51746670b76a6b/zope_interface-8.4-cp313-cp313-win_amd64.whl", hash = "sha256:3e5866917ccb57d929e515a1136d729bd3fa4f367965fb16e38a4bc72cb05521", size = 214422, upload-time = "2026-04-25T07:28:32.201Z" },
+    { url = "https://files.pythonhosted.org/packages/16/26/b0bcde302f6a4c155d047a8ab5cba1003363031919d6e8f3bcdc139c28a6/zope_interface-8.4-cp313-cp313-win_arm64.whl", hash = "sha256:f1f854bef8bc137519e4413bcc1322d55faad28b20b3ca39f7bec49d2f1b26df", size = 213029, upload-time = "2026-04-25T07:28:34.677Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d5/ca60c8b404b303d9490e1417430a5198a77557dbeb17c1cb31616e432318/zope_interface-8.4-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:7cbb887fdbfaacb4c362dbb487033551646e28013ad5ffe72e96eb260003a1a1", size = 212012, upload-time = "2026-04-25T07:28:36.88Z" },
+    { url = "https://files.pythonhosted.org/packages/83/64/6bb9f54250c817e24b39e986f173b6cd21ff658bec6c6cc0baad05d761e4/zope_interface-8.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a5638c6be715116d3453e6d099c299c6844d54810de7445ce116424e905ede06", size = 212071, upload-time = "2026-04-25T07:28:38.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cf/42851262e102723058019dc7d0b48210b85a935f79ae32ce60ddccc2e8fb/zope_interface-8.4-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b8147b40bfcd53803870a9519e0879ff066aeecc2fcff8295663c1b17fc38dc2", size = 266075, upload-time = "2026-04-25T07:28:41.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a7/e48c79b836f6f0a2c219288e2ec343517f90e95c93de5435a8a23918bf20/zope_interface-8.4-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:049ba3c7b38cc400ae08e011617635706e0f442e1d075db1b015246fcbf6091e", size = 269127, upload-time = "2026-04-25T07:28:42.868Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/0e26f24d3a2f34f0de2cfeaab6458a865284d9d1fa317ab78913aa1f7322/zope_interface-8.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9c4ac009c2c8e43283842f80387c4d4b41bcbc293391c3b9ab71532ae1ccc301", size = 269446, upload-time = "2026-04-25T07:28:44.97Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d5/20310601450367fc35fa28b0544c98d0347b8cc25eaf106a2c4cc36841e1/zope_interface-8.4-cp314-cp314-win_amd64.whl", hash = "sha256:4713bf651ec36e7eea49d2ace4f0e89bec2b33a339674874b1121f2537edc62a", size = 215199, upload-time = "2026-04-25T07:28:47.146Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/00/0d22ce75126e31f81baa5889e2a40aad37c8e34d1220cf8b18d744f2b5d9/zope_interface-8.4-cp314-cp314-win_arm64.whl", hash = "sha256:d934497c4b72d5f528d2b5ebe9b8b5a7004b5877948ebd4ea00c2432fb27178f", size = 213178, upload-time = "2026-04-25T07:28:48.868Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a Claude Code skill (`/aip-user-stories`) that generates recipe playbooks from Airflow Improvement Proposals (AIPs). The skill has two modes:

- **Post-implementation mode** — given an AIP URL and one or more PR URLs, it discovers the actual implementation in the codebase and generates verified recipe playbooks with three tiers of code confidence (verified, adapted, unverified).
- **Pre-implementation mode** — given only an AIP URL (no PRs), it generates speculative user stories with open design questions to help AIP authors validate their design before coding.

### Changes

- **New skill**: `.claude/skills/aip-user-stories/SKILL.md` — full skill definition with 6-phase workflow for both modes, including AIP parsing, PR discovery, codebase analysis, recipe proposal, generation, and assembly.
- **Playbook template**: `.claude/skills/aip-user-stories/references/playbook-template.md` — output template with sections for prerequisites, overview, recipes (post mode), and user stories (pre mode).
- **`.gitignore`**: Changed `.claude/` exclusion to `.claude/*` with `!.claude/skills/` so the skill files are tracked in git while other Claude Code artifacts remain ignored.
- **`.github/CODEOWNERS`**: Added `/.claude/skills/` entry with the same reviewers as other agentic instruction files.
- **`.pre-commit-config.yaml`**:
  - Added `--detect-license-in-X-top-lines 10` to the short-license hook so it finds the Apache header in files with YAML frontmatter (like `SKILL.md`).
  - Narrowed the exclude list for the short-license hook — `code-review.instructions.md` and GitHub skill files now carry their own license headers, so the broad excludes are no longer needed.
  - Added `.claude/skills` to `blacken-docs` exclude (Markdown code fences in skill files are illustrative, not standalone Python).
- **`.github/instructions/code-review.instructions.md`**: Added Apache License header (was previously excluded from the license check instead).

## Appendix

<details><summary>Example output for AIP-93 (pre mode)</summary>
<p>

# AIP-93 Asset Watermarks — Playbook

> **Airflow version:** Future 3.x (WIP — depends on AIP-103)
> **Required packages:** `apache-airflow` (core); provider packages for specific data sources (e.g., `apache-airflow-providers-amazon`, `apache-airflow-providers-postgres`)

## Prerequisites

- Airflow 3.x with AIP-103 (Task State Management) merged and enabled.
- A configured Task State backend (default: `DbTaskStateBackend` using the metadata database). Configurable via `[task_state] backend` in `airflow.cfg`.
- For S3 examples: `apache-airflow-providers-amazon`.
- For SQL examples: a database provider package (e.g., `apache-airflow-providers-postgres`).

## Overview

Incremental processing is the most common pattern in data orchestration, yet Airflow has never offered first-class support for persisting state — watermarks, cursors, or checkpoints — across executions. DAG authors using traditional operators resort to XCom or Variables, both of which are poor fits: XCom is scoped to a single DAG run and cleared on retry, while Variables are global singletons with no asset awareness.

For event-driven scheduling via Asset Watchers (AIP-82), the problem is worse. `BaseEventTrigger` instances running in the Triggerer have no built-in mechanism to persist state between invocations. Attempts to store state inside trigger instances or use Variables from async trigger code have proven fragile and unreliable.

AIP-93 proposes making `BaseEventTrigger` Asset-aware and leveraging AIP-103's state management infrastructure to give triggers and watchers a clean, scoped interface for storing and retrieving watermarks. The core pattern is: on each run, read the last watermark, scan for changes since that watermark, update the watermark, and yield events. This AIP also introduces a decorator-based authoring experience for Asset watchers, lowering the barrier for the community to build and distribute event-driven integrations.

**Relationship to AIP-103:** AIP-103 provides the persistence layer — `AssetScope`, `BaseTaskStateBackend`, and the `/state/asset/{asset_id}/{key}` Execution API endpoints. AIP-93 builds on top of this to define the patterns and APIs for using that layer within Asset Watchers and Event Triggers.

---

## User Stories

### 1. Persisting a Timestamp Watermark Across Trigger Runs

**Goal:** Store and retrieve a simple timestamp watermark so an Event Trigger can resume scanning from where it last left off, rather than re-processing everything from the beginning.

```python
# PROPOSED API — not yet implemented
import asyncio
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class IncrementalScanTrigger(BaseEventTrigger):
    """Trigger that scans a resource incrementally using a timestamp watermark."""

    def __init__(self, resource_id: str, poke_interval: float = 60.0):
        super().__init__()
        self.resource_id = resource_id
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "my_package.triggers.IncrementalScanTrigger",
            {"resource_id": self.resource_id, "poke_interval": self.poke_interval},
        )

    async def run(self):
        # Retrieve the last watermark from asset-scoped state (AIP-103)
        last_watermark = await self.asset_state.aget("last_scanned_at")

        while True:
            new_items = await self._scan_since(last_watermark)

            if new_items:
                now = datetime.now(timezone.utc).isoformat()
                await self.asset_state.aset("last_scanned_at", now)
                yield TriggerEvent({"status": "success", "items": new_items})
                return

            await asyncio.sleep(self.poke_interval)

    async def _scan_since(self, watermark: str | None) -> list:
        """Scan the resource for items newer than the watermark."""
        ...
```

This story illustrates the fundamental watermark pattern. The trigger reads a previously stored timestamp via `self.asset_state.aget()`, scans only for changes after that point, and writes the new watermark back via `self.asset_state.aset()`. The `asset_state` object is automatically scoped to the Asset this trigger is watching — no manual key namespacing needed.

**Open Design Questions:**

- **How does `asset_state` get injected into the trigger?** Currently `BaseEventTrigger` (in `airflow-core/src/airflow/triggers/base.py`) has no `asset_state` attribute. Does the Triggerer inject it when the trigger is associated with an `AssetWatcher`, or does the trigger need to explicitly request it? What happens if the same trigger class is used outside of an AssetWatcher context?
- **What happens if the watermark write succeeds but the `TriggerEvent` is lost?** If the Triggerer crashes between `aset()` and `yield TriggerEvent(...)`, the watermark advances but no event is emitted. On restart, the data in that window is silently skipped. Should watermark updates be transactional with event submission?
- **Should watermark reads/writes be atomic with respect to concurrent trigger instances?** If two Triggerer processes run the same watcher (e.g., during a Triggerer restart with overlap), both could read the same watermark and produce duplicate events. Does AIP-103 provide any concurrency control?
- **What is the serialization format for watermark values?** AIP-103's backend interface uses `str` for values. Should AIP-93 define a convention (ISO 8601 for timestamps, JSON for structured values), or leave it to trigger authors?

---

### 2. Using Asset State as a General Key-Value Store in Triggers

**Goal:** Store arbitrary structured state — not just timestamps — across trigger invocations, such as cursor positions, page tokens, or sets of previously seen IDs.

```python
# PROPOSED API — not yet implemented
import asyncio
import json

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class PaginatedAPITrigger(BaseEventTrigger):
    """Trigger that watches an API endpoint using cursor-based pagination."""

    def __init__(self, api_url: str, poke_interval: float = 120.0):
        super().__init__()
        self.api_url = api_url
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "my_package.triggers.PaginatedAPITrigger",
            {"api_url": self.api_url, "poke_interval": self.poke_interval},
        )

    async def run(self):
        # Retrieve multiple state keys
        cursor = await self.asset_state.aget("page_cursor")
        seen_ids_raw = await self.asset_state.aget("seen_ids")
        seen_ids = set(json.loads(seen_ids_raw)) if seen_ids_raw else set()

        while True:
            response = await self._fetch_page(cursor)
            new_items = [
                item for item in response["items"] if item["id"] not in seen_ids
            ]

            if new_items:
                seen_ids.update(item["id"] for item in new_items)
                await self.asset_state.aset(
                    "page_cursor", response.get("next_cursor", "")
                )
                await self.asset_state.aset(
                    "seen_ids", json.dumps(sorted(seen_ids))
                )
                yield TriggerEvent({"status": "success", "new_items": new_items})
                return

            cursor = response.get("next_cursor", cursor)
            await asyncio.sleep(self.poke_interval)

    async def _fetch_page(self, cursor: str | None) -> dict:
        """Fetch a page of results from the API."""
        ...
```

This story demonstrates using multiple state keys for different aspects of the same incremental process. The cursor tracks pagination position while the seen IDs set provides deduplication. Both are persisted and scoped to the same Asset.

**Open Design Questions:**

- **Is there a size limit on state values?** The `DbTaskStateBackend` stores values as strings in the metadata DB. For a growing set of seen IDs, this could become arbitrarily large. Should AIP-93 recommend or enforce limits? Should large state values use a different backend (e.g., object storage)?
- **Should there be batch get/set operations?** Reading `page_cursor` and `seen_ids` requires two separate round-trips through the Execution API. A `get_many(keys)` / `set_many(mapping)` API would reduce latency, especially for triggers managing multiple state keys.
- **How does state serialization interact with the backend?** AIP-103 uses `str` values. Should triggers be responsible for JSON serialization, or should the SDK provide typed helpers (e.g., `asset_state.get_json("seen_ids")`, `asset_state.set_json("seen_ids", data)`)?
- **What happens to accumulated state when a watcher is removed from an Asset?** If a user removes an `AssetWatcher` from an Asset definition, is the associated state garbage-collected, orphaned, or retained for potential re-attachment?

---

### 3. Watching an S3 Bucket for New Files

**Goal:** Incrementally detect new objects in an S3 bucket by persisting a timestamp watermark, avoiding a full bucket scan on every trigger invocation.

```python
# PROPOSED API — not yet implemented
import asyncio
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class S3NewObjectsTrigger(BaseEventTrigger):
    """Watch an S3 bucket/prefix for new objects using a timestamp watermark."""

    def __init__(
        self,
        bucket: str,
        prefix: str = "",
        aws_conn_id: str = "aws_default",
        poke_interval: float = 60.0,
    ):
        super().__init__()
        self.bucket = bucket
        self.prefix = prefix
        self.aws_conn_id = aws_conn_id
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "airflow.providers.amazon.triggers.s3.S3NewObjectsTrigger",
            {
                "bucket": self.bucket,
                "prefix": self.prefix,
                "aws_conn_id": self.aws_conn_id,
                "poke_interval": self.poke_interval,
            },
        )

    async def run(self):
        from airflow.providers.amazon.hooks.s3 import S3Hook

        hook = S3Hook(aws_conn_id=self.aws_conn_id)
        last_scanned = await self.asset_state.aget("last_scanned_at")

        while True:
            objects = await hook.list_keys_async(
                bucket_name=self.bucket,
                prefix=self.prefix,
                from_datetime=(
                    datetime.fromisoformat(last_scanned) if last_scanned else None
                ),
            )

            if objects:
                now = datetime.now(timezone.utc).isoformat()
                await self.asset_state.aset("last_scanned_at", now)
                yield TriggerEvent({
                    "status": "success",
                    "bucket": self.bucket,
                    "keys": objects,
                })
                return

            await asyncio.sleep(self.poke_interval)


# DAG file: using the trigger with an Asset and AssetWatcher
from airflow.sdk import DAG, Asset, AssetWatcher, task

s3_trigger = S3NewObjectsTrigger(bucket="my-data-lake", prefix="raw/events/")
data_lake = Asset(
    "s3://my-data-lake/raw/events/",
    watchers=[AssetWatcher(name="s3_new_objects", trigger=s3_trigger)],
)

with DAG(dag_id="process_new_events", schedule=[data_lake], catchup=False):

    @task
    def process_events(**context):
        triggering_event = context["triggering_event"]
        new_keys = triggering_event.payload["keys"]
        for key in new_keys:
            print(f"Processing: {key}")

    process_events()
```

This story shows the most common real-world use case for asset watermarks: monitoring cloud object storage. The trigger uses a timestamp watermark to avoid rescanning the entire bucket prefix on every poll. The DAG that schedules on this Asset receives the list of new keys via the `TriggerEvent` payload.

**Open Design Questions:**

- **Should the watermark be set before or after yielding the event?** Setting it before (as shown) risks skipping data if the event is lost. Setting it after risks reprocessing data if the trigger restarts between yield and set. What transaction guarantees does AIP-103 provide here?
- **How does this interact with S3 eventual consistency?** A newly written object might not appear in `list_keys` immediately. If the watermark advances past the object's `LastModified` timestamp before it becomes visible, the object is permanently skipped. Should triggers implement a configurable "lookback window" that overlaps the previous scan by a safety margin?
- **What if the bucket has millions of objects modified in one interval?** The trigger would yield a single `TriggerEvent` with a huge payload. Should there be a mechanism for batched events, or is pagination the trigger author's responsibility?
- **How does this integrate with `catchup=True`?** If a DAG has been paused and accumulates many events, does each event create a separate DAG run, or are they coalesced? How does this interact with the watermark — does each DAG run see a different watermark window?

---

### 4. Watching a SQL Table for New/Updated Rows

**Goal:** Detect new or modified rows in a relational database table by tracking a high-water mark on an `updated_at` column.

```python
# PROPOSED API — not yet implemented
import asyncio
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class SQLIncrementalTrigger(BaseEventTrigger):
    """Watch a SQL table for rows modified after the last watermark."""

    def __init__(
        self,
        conn_id: str,
        table: str,
        watermark_column: str = "updated_at",
        poke_interval: float = 60.0,
    ):
        super().__init__()
        self.conn_id = conn_id
        self.table = table
        self.watermark_column = watermark_column
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "my_package.triggers.SQLIncrementalTrigger",
            {
                "conn_id": self.conn_id,
                "table": self.table,
                "watermark_column": self.watermark_column,
                "poke_interval": self.poke_interval,
            },
        )

    async def run(self):
        from airflow.providers.common.sql.hooks.sql import DbApiHook

        hook = DbApiHook.get_hook(self.conn_id)
        last_watermark = await self.asset_state.aget("table_last_updated_at")

        while True:
            if last_watermark:
                query = (
                    f"SELECT * FROM {self.table} "
                    f"WHERE {self.watermark_column} > %s "
                    f"ORDER BY {self.watermark_column}"
                )
                records = hook.get_records(query, parameters=[last_watermark])
            else:
                query = (
                    f"SELECT * FROM {self.table} "
                    f"ORDER BY {self.watermark_column}"
                )
                records = hook.get_records(query)

            if records:
                max_watermark = max(row[-1] for row in records)
                await self.asset_state.aset(
                    "table_last_updated_at",
                    (
                        max_watermark.isoformat()
                        if isinstance(max_watermark, datetime)
                        else str(max_watermark)
                    ),
                )
                yield TriggerEvent({
                    "status": "success",
                    "table": self.table,
                    "row_count": len(records),
                })
                return

            await asyncio.sleep(self.poke_interval)


# DAG file
from airflow.sdk import DAG, Asset, AssetWatcher, task

pg_trigger = SQLIncrementalTrigger(
    conn_id="postgres_default",
    table="orders",
    watermark_column="updated_at",
)
orders_table = Asset(
    "postgres://warehouse/orders",
    watchers=[AssetWatcher(name="orders_watcher", trigger=pg_trigger)],
)

with DAG(dag_id="process_new_orders", schedule=[orders_table], catchup=False):

    @task
    def ingest_orders(**context):
        print("New rows detected in orders table")

    ingest_orders()
```

This story mirrors the S3 pattern but for relational databases. The watermark column (typically `updated_at` or an auto-incrementing ID) determines which rows are "new." The trigger reads the last watermark from asset state, queries for rows beyond it, and advances the watermark to the maximum value in the result set.

**Open Design Questions:**

- **SQL injection risk:** The table name and column name are interpolated directly into the query string. Should AIP-93 provide safe query-building utilities, or is this the trigger author's responsibility? Should `BaseEventTrigger` offer parameterized query helpers?
- **What about deleted rows?** A watermark on `updated_at` catches inserts and updates but misses deletes. Should AIP-93 address soft-delete patterns (e.g., an `is_deleted` flag) or is that out of scope?
- **First-run behavior:** On the first invocation, `last_watermark` is `None`, causing a full table scan. For large tables this could be catastrophic. Should there be a convention for setting an initial watermark (e.g., "only look at rows from the last 24 hours")?
- **Clock skew between Airflow and the database:** The watermark is derived from the max value in the result set (not from `datetime.now()`), which avoids clock skew. Should this pattern be documented as a best practice, or should AIP-93 enforce it?

---

### 5. Building a Custom Asset Watcher for Any Data Source

**Goal:** Apply the watermark pattern to a non-standard data source (e.g., a REST API, message queue, or custom service) using the same state management primitives.

```python
# PROPOSED API — not yet implemented
import asyncio
import json
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class WebhookLogTrigger(BaseEventTrigger):
    """Watch a webhook log API for new events since the last processed event ID."""

    def __init__(
        self, api_base_url: str, api_key_conn_id: str, poke_interval: float = 30.0
    ):
        super().__init__()
        self.api_base_url = api_base_url
        self.api_key_conn_id = api_key_conn_id
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "my_package.triggers.WebhookLogTrigger",
            {
                "api_base_url": self.api_base_url,
                "api_key_conn_id": self.api_key_conn_id,
                "poke_interval": self.poke_interval,
            },
        )

    async def run(self):
        import httpx

        last_event_id = await self.asset_state.aget("last_event_id")
        stats_raw = await self.asset_state.aget("processing_stats")
        stats = json.loads(stats_raw) if stats_raw else {"total_processed": 0}

        async with httpx.AsyncClient() as client:
            while True:
                params = {"after": last_event_id} if last_event_id else {}
                resp = await client.get(
                    f"{self.api_base_url}/events",
                    params=params,
                    headers=await self._get_auth_headers(),
                )
                resp.raise_for_status()
                events = resp.json()["data"]

                if events:
                    last_event_id = events[-1]["id"]
                    stats["total_processed"] += len(events)
                    stats["last_run"] = datetime.now(timezone.utc).isoformat()

                    await self.asset_state.aset("last_event_id", str(last_event_id))
                    await self.asset_state.aset(
                        "processing_stats", json.dumps(stats)
                    )

                    yield TriggerEvent({
                        "status": "success",
                        "event_count": len(events),
                        "event_ids": [e["id"] for e in events],
                    })
                    return

                await asyncio.sleep(self.poke_interval)

    async def _get_auth_headers(self) -> dict:
        """Retrieve API credentials from Airflow connection."""
        ...


# DAG file
from airflow.sdk import DAG, Asset, AssetWatcher, task

webhook_trigger = WebhookLogTrigger(
    api_base_url="https://api.example.com/v1",
    api_key_conn_id="example_api",
)
webhook_events = Asset(
    "https://api.example.com/v1/events",
    watchers=[AssetWatcher(name="webhook_log_watcher", trigger=webhook_trigger)],
)

with DAG(dag_id="process_webhook_events", schedule=[webhook_events], catchup=False):

    @task
    def handle_events(**context):
        event_ids = context["triggering_event"].payload["event_ids"]
        for event_id in event_ids:
            print(f"Processing webhook event: {event_id}")

    handle_events()
```

This story generalizes the watermark pattern beyond cloud storage and SQL. It uses an event ID as the watermark (rather than a timestamp), demonstrates multiple state keys for different concerns (cursor vs. statistics), and shows the pattern applied to an HTTP API.

**Open Design Questions:**

- **Should AIP-93 provide a base class or mixin that standardizes the watermark pattern?** All stories so far follow the same structure: read watermark, scan, update watermark, yield event. A `WatermarkTrigger` base class could reduce boilerplate and enforce best practices. But would this over-constrain trigger authors who need different patterns?
- **How should triggers handle transient errors?** If the API call fails mid-scan, the watermark hasn't advanced, so a retry will rescan from the same point — which is correct. But if the `aset()` call fails after a successful scan, the trigger might yield an event without persisting the watermark, causing duplicate processing on the next run. Should there be retry/rollback semantics?
- **Is there a discovery mechanism for available state keys?** Can a trigger introspect what keys are stored for its asset (e.g., `await self.asset_state.list_keys()`)? This would help with debugging and building generic monitoring tools.
- **How does this interact with trigger serialization?** `BaseEventTrigger.serialize()` returns the classpath and kwargs. The watermark state is NOT part of kwargs (it's in the state backend). Is this separation clear enough, or will trigger authors accidentally try to store state in kwargs?

---

### 6. Decorator-Based Asset Watcher Authoring

**Goal:** Define Asset watching logic using a simple decorator instead of writing a full `BaseEventTrigger` subclass, lowering the barrier to entry for building event-driven integrations.

```python
# PROPOSED API — not yet implemented
from datetime import datetime, timezone

from airflow.sdk import Asset, asset


# Option A: Decorator on a function that becomes the watcher
@asset.watcher(poke_interval=60.0)
async def watch_s3_bucket(asset_state, *, bucket: str, prefix: str = ""):
    """Watch an S3 bucket for new files."""
    from airflow.providers.amazon.hooks.s3 import S3Hook

    hook = S3Hook()
    last_scanned = await asset_state.aget("last_scanned_at")

    objects = await hook.list_keys_async(
        bucket_name=bucket,
        prefix=prefix,
        from_datetime=(
            datetime.fromisoformat(last_scanned) if last_scanned else None
        ),
    )

    if objects:
        await asset_state.aset(
            "last_scanned_at", datetime.now(timezone.utc).isoformat()
        )
        return {"keys": objects}  # Becomes TriggerEvent payload

    return None  # No event — will retry after poke_interval


# Using the decorated watcher with an Asset
data_lake = Asset(
    "s3://my-data-lake/raw/",
    watchers=[watch_s3_bucket(bucket="my-data-lake", prefix="raw/")],
)


# Option B: Decorator that registers directly on the asset
my_asset = Asset("s3://my-data-lake/raw/")


@my_asset.watch(poke_interval=60.0)
async def on_new_files(asset_state):
    last_scanned = await asset_state.aget("last_scanned_at")
    # ... scan logic ...
    return {"keys": ["file1.parquet", "file2.parquet"]}
```

This story addresses one of the AIP's explicit goals: a more intuitive, decorator-based authoring experience. Instead of subclassing `BaseEventTrigger`, implementing `serialize()`, and managing the async generator protocol, the user writes a simple function that receives `asset_state` and returns a payload (or `None` to retry).

**Open Design Questions:**

- **How does the decorator create a serializable trigger?** `BaseEventTrigger.serialize()` must return a classpath and kwargs for reconstruction by the Triggerer. A decorated function isn't a class. Does the decorator generate a synthetic class, or does it use a generic `FunctionTrigger` that stores the function reference and kwargs?
- **How are function arguments handled?** In Option A, `bucket` and `prefix` are passed when attaching the watcher. These need to survive serialization. Should they be stored in the trigger kwargs, or in the asset state?
- **What about the async generator protocol?** Current triggers use `async def run(self) -> AsyncIterator[TriggerEvent]` with `yield`. The decorator replaces this with a simpler return-value protocol. Can decorated watchers still use `yield` for streaming multiple events in one invocation?
- **Does the decorator approach support `cleanup()` and `on_kill()`?** These lifecycle methods exist on `BaseTrigger`. If the decorated function is the entire trigger, how does the user define cleanup logic? Additional decorators (`@watch_s3_bucket.on_kill`)? Optional callback parameters?

---

### 7. Asset-Aware Event Triggers

**Goal:** Make `BaseEventTrigger` aware of which Asset it is watching, so the trigger can automatically scope its state and behavior to the correct asset without manual configuration.

```python
# PROPOSED API — not yet implemented
import asyncio
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class GenericFileWatchTrigger(BaseEventTrigger):
    """A trigger that adapts its behavior based on the asset it's watching."""

    def __init__(self, poke_interval: float = 60.0):
        super().__init__()
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "my_package.triggers.GenericFileWatchTrigger",
            {"poke_interval": self.poke_interval},
        )

    async def run(self):
        # self.asset is injected by the Triggerer when the trigger is
        # associated with an AssetWatcher — contains asset name, uri, extra
        asset_uri = self.asset.uri
        scheme = asset_uri.split("://")[0]

        last_scanned = await self.asset_state.aget("last_scanned_at")

        while True:
            if scheme == "s3":
                new_items = await self._scan_s3(asset_uri, last_scanned)
            elif scheme == "gs":
                new_items = await self._scan_gcs(asset_uri, last_scanned)
            elif scheme.startswith("file"):
                new_items = await self._scan_local(asset_uri, last_scanned)
            else:
                raise ValueError(f"Unsupported asset scheme: {scheme}")

            if new_items:
                now = datetime.now(timezone.utc).isoformat()
                await self.asset_state.aset("last_scanned_at", now)
                yield TriggerEvent({
                    "status": "success",
                    "asset_uri": asset_uri,
                    "items": new_items,
                })
                return

            await asyncio.sleep(self.poke_interval)

    async def _scan_s3(self, uri: str, since: str | None) -> list:
        ...

    async def _scan_gcs(self, uri: str, since: str | None) -> list:
        ...

    async def _scan_local(self, uri: str, since: str | None) -> list:
        ...


# DAG file — same trigger class, different assets
from airflow.sdk import DAG, Asset, AssetWatcher, task

s3_data = Asset(
    "s3://bucket/raw/",
    watchers=[AssetWatcher(name="s3_watch", trigger=GenericFileWatchTrigger())],
)
gcs_data = Asset(
    "gs://bucket/raw/",
    watchers=[AssetWatcher(name="gcs_watch", trigger=GenericFileWatchTrigger())],
)

with DAG(
    dag_id="multi_cloud_ingest",
    schedule=[s3_data | gcs_data],
    catchup=False,
):

    @task
    def process(**context):
        ...

    process()
```

This story demonstrates the key architectural change AIP-93 proposes: making triggers aware of the asset they're monitoring. Currently, `BaseEventTrigger` (in `airflow-core/src/airflow/triggers/base.py`) has no knowledge of which asset it serves — the connection is external, via `AssetWatcherModel`. With asset-awareness, a single trigger class can adapt its behavior based on the asset URI, and `asset_state` is automatically scoped to the correct asset.

**Open Design Questions:**

- **What does `self.asset` expose?** Is it a full `Asset` object (with `name`, `uri`, `group`, `extra`, `watchers`) or a lightweight reference? Loading the full object might require a database query. Should it be lazy-loaded?
- **What happens when a trigger is shared across multiple assets?** The current `AssetWatcherModel` has a composite primary key `(asset_id, trigger_id)`. If the same trigger instance is assigned to multiple assets, which `self.asset` does it see? Is a trigger always 1:1 with an asset in the watcher context?
- **How does this interact with trigger deduplication?** `BaseEventTrigger.hash()` uses classpath and kwargs to identify unique triggers. Two watchers using `GenericFileWatchTrigger()` with the same `poke_interval` but different assets would hash to the same value. Should the asset identity be part of the trigger hash?
- **Should `self.asset.extra` be writable?** Asset `extra` metadata is currently user-defined at DAG parse time. If a trigger could update it (e.g., adding a `last_file_count` metric), it would blur the line between asset metadata and asset state. Should `extra` remain read-only with all mutable state going through `asset_state`?

---

### 8. Partitioned Asset Watermarks

**Goal:** Track independent watermarks per partition of a partitioned Asset, so each partition's incremental processing state is isolated.

```python
# PROPOSED API — not yet implemented
import asyncio
from datetime import datetime, timezone

from airflow.triggers.base import BaseEventTrigger, TriggerEvent


class PartitionedS3Trigger(BaseEventTrigger):
    """Watch an S3 prefix with date-partitioned subdirectories."""

    def __init__(
        self,
        bucket: str,
        base_prefix: str,
        partition_pattern: str = "dt={date}/",
        aws_conn_id: str = "aws_default",
        poke_interval: float = 60.0,
    ):
        super().__init__()
        self.bucket = bucket
        self.base_prefix = base_prefix
        self.partition_pattern = partition_pattern
        self.aws_conn_id = aws_conn_id
        self.poke_interval = poke_interval

    def serialize(self):
        return (
            "airflow.providers.amazon.triggers.s3.PartitionedS3Trigger",
            {
                "bucket": self.bucket,
                "base_prefix": self.base_prefix,
                "partition_pattern": self.partition_pattern,
                "aws_conn_id": self.aws_conn_id,
                "poke_interval": self.poke_interval,
            },
        )

    async def run(self):
        from airflow.providers.amazon.hooks.s3 import S3Hook

        hook = S3Hook(aws_conn_id=self.aws_conn_id)

        while True:
            partitions = await self._discover_partitions(hook)

            for partition_key in partitions:
                watermark = await self.asset_state.aget(
                    f"watermark:{partition_key}"
                )

                prefix = (
                    f"{self.base_prefix}"
                    f"{self.partition_pattern.format(date=partition_key)}"
                )
                new_objects = await hook.list_keys_async(
                    bucket_name=self.bucket,
                    prefix=prefix,
                    from_datetime=(
                        datetime.fromisoformat(watermark) if watermark else None
                    ),
                )

                if new_objects:
                    now = datetime.now(timezone.utc).isoformat()
                    await self.asset_state.aset(
                        f"watermark:{partition_key}", now
                    )

                    yield TriggerEvent({
                        "status": "success",
                        "partition_key": partition_key,
                        "keys": new_objects,
                    })
                    return

            await asyncio.sleep(self.poke_interval)

    async def _discover_partitions(self, hook) -> list[str]:
        """List partition subdirectories under the base prefix."""
        ...


# DAG file — partitioned asset with per-partition scheduling
from airflow.sdk import DAG, Asset, AssetWatcher, task
from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable

partitioned_trigger = PartitionedS3Trigger(
    bucket="data-lake",
    base_prefix="events/",
    partition_pattern="dt={date}/",
)
events = Asset(
    "s3://data-lake/events/",
    watchers=[AssetWatcher(name="partitioned_s3", trigger=partitioned_trigger)],
)

with DAG(
    dag_id="process_partitioned_events",
    timetable=PartitionedAssetTimetable(
        asset_condition=events,
        partition_mapper_config={},
    ),
    catchup=False,
):

    @task
    def process_partition(**context):
        partition = context["dag_run"].partition_key
        event = context["triggering_event"]
        keys = event.payload["keys"]
        print(f"Processing {len(keys)} files for partition {partition}")

    process_partition()
```

This story combines AIP-93 watermarks with Airflow's existing asset partition infrastructure (`PartitionedAssetTimetable` in `task-sdk/src/airflow/sdk/definitions/timetables/assets.py`). Each date partition (e.g., `dt=2025-01-15/`) gets its own watermark stored under a namespaced key (`watermark:2025-01-15`). When new files land in a partition, only that partition's watermark advances, and the resulting DAG run is scoped to that partition.

**Open Design Questions:**

- **Should partition-scoped state use the `AssetScope` or a new `PartitionScope`?** AIP-103 defines `AssetScope(asset_id=str)` but no partition-level scoping. The pattern above manually namespaces keys with `watermark:{partition_key}`. Should AIP-103 be extended with `AssetPartitionScope(asset_id, partition_key)` for first-class partition support?
- **How many partitions can a single trigger manage?** If an S3 prefix has thousands of date partitions, the trigger would make thousands of state reads per poll cycle. Should there be a mechanism to prune old partitions from active scanning (e.g., only scan the last N days)?
- **How does `TriggerEvent` map to partitioned DAG runs?** The current `Trigger.submit_event()` calls `AssetManager.register_asset_change()` without a partition key. How does the event's `partition_key` propagate from the trigger through to `AssetEvent.partition_key` and ultimately to `AssetPartitionDagRun`?
- **What happens when a new partition appears?** If `dt=2025-01-20/` is created for the first time, there's no watermark for it. The trigger would do a full scan of that partition. Is this the desired behavior, or should new partitions inherit a default watermark (e.g., "partition creation time")?


</p>
</details> 

<details><summary>Example output for AIP-76 (post mode)</summary>
<p>

# AIP-76 Asset Partitions — Playbook

> **Airflow version:** 3.2.0
> **Required packages:** `apache-airflow` (core only — no extra providers needed)

## Prerequisites

- Airflow 3.2.0 or later.
- Database migrated to include the partition schema (`airflow db migrate`).
- All imports come from `airflow.sdk`. No provider packages are needed for basic partition functionality.

## Overview

AIP-76 introduces **asset partitions** to Airflow, enabling data processing at finer granularity than a DAG's schedule. Before partitions, a DAG run represented a single unit of work for an entire dataset. With partitions, each DAG run can target a specific slice — an hour's worth of data, a region, or a combination of both — and downstream DAGs trigger only when matching partitions from all required upstream assets are available.

The implementation has two sides: **producers** emit partitioned asset events using `CronPartitionTimetable`, and **consumers** react to those events using `PartitionedAssetTimetable`. Between them, **partition mappers** transform partition keys so that upstream and downstream granularities can differ (e.g., hourly events roll up into daily partitions). The scheduler tracks partition key alignment across multiple upstream assets and only creates a downstream DAG run when all required partitions match.

Partitioned events are a separate scheduling path from regular asset-triggered DAGs. A `PartitionedAssetTimetable` consumer ignores non-partitioned events, and a regular `AssetTriggeredTimetable` consumer ignores partitioned events.

---

## Recipes

### 1. Produce Hourly Partitioned Events with CronPartitionTimetable

**Goal:** Set up a producer DAG that emits asset events tagged with a partition key on every cron tick.

```python
from airflow.sdk import DAG, Asset, CronPartitionTimetable, task

team_a_player_stats = Asset(
    uri="file://incoming/player-stats/team_a.csv",
    name="team_a_player_stats",
)

with DAG(
    dag_id="ingest_team_a_player_stats",
    schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
    tags=["player-stats", "ingestion"],
):

    @task(outlets=[team_a_player_stats])
    def ingest_team_a_stats():
        pass

    ingest_team_a_stats()
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

`CronPartitionTimetable` works like `CronTriggerTimetable` but additionally stamps each DAG run — and the asset events it emits — with a partition key derived from the run's scheduled time. The default `key_format` is `"%Y-%m-%dT%H:%M:%S"`, so a run scheduled at `2026-03-10 09:00 UTC` produces partition key `"2026-03-10T09:00:00"`.

You can customize the key format and offset:

```python
CronPartitionTimetable(
    "0 * * * *",
    timezone="UTC",
    key_format="%Y-%m-%d/%H",   # partition key: "2026-03-10/09"
    run_offset=-1,               # partition date is one cron interval before run date
)
```

---

### 2. Produce Partitioned Events with the @asset Decorator

**Goal:** Use the compact `@asset` decorator to define a single-task partitioned producer without an explicit DAG block.

```python
from airflow.sdk import CronPartitionTimetable, asset


@asset(
    uri="file://incoming/player-stats/team_b.csv",
    schedule=CronPartitionTimetable("15 * * * *", timezone="UTC"),
    tags=["player-stats", "ingestion"],
)
def team_b_player_stats():
    pass
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

The `@asset` decorator creates both a DAG and a single task in one step. The resulting asset can be referenced by name or URI in downstream `PartitionedAssetTimetable` consumers, just like any other asset.

---

### 3. Consume a Single Partitioned Asset

**Goal:** Set up a downstream DAG that triggers when a partitioned event arrives from one upstream asset.

```python
from airflow.sdk import PartitionedAssetTimetable, asset

combined_player_stats = Asset(uri="file://curated/player-stats/combined.csv", name="combined_player_stats")


@asset(
    uri="file://analytics/player-stats/computed-player-odds.csv",
    schedule=PartitionedAssetTimetable(assets=combined_player_stats),
    tags=["player-stats", "odds"],
)
def compute_player_odds():
    pass
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

When no `default_partition_mapper` is specified, `IdentityMapper` is used — the downstream partition key is the same as the upstream key. The consumer DAG gets one DAG run per unique partition key emitted by the upstream asset. Non-partitioned events from the same asset are ignored.

---

### 4. Consume Multiple Partitioned Assets with Aligned Keys

**Goal:** Trigger a downstream DAG only when *all* required upstream assets have emitted events with a matching partition key.

```python
from airflow.sdk import DAG, Asset, PartitionedAssetTimetable, StartOfHourMapper, task

team_a_player_stats = Asset(uri="file://incoming/player-stats/team_a.csv", name="team_a_player_stats")
team_b_player_stats = Asset(uri="file://incoming/player-stats/team_b.csv", name="team_b_player_stats")
team_c_player_stats = Asset(uri="file://incoming/player-stats/team_c.csv", name="team_c_player_stats")

with DAG(
    dag_id="clean_and_combine_player_stats",
    schedule=PartitionedAssetTimetable(
        assets=team_a_player_stats & team_b_player_stats & team_c_player_stats,
        default_partition_mapper=StartOfHourMapper(),
    ),
    catchup=False,
    tags=["player-stats", "cleanup"],
):

    @task
    def combine_player_stats():
        pass

    combine_player_stats()
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

The `&` operator creates an `AssetAll` condition — all three assets must have a matching partition key before the downstream DAG triggers. The `StartOfHourMapper` normalizes each upstream key (e.g., `"2026-03-10T09:15:00"`) to hour granularity (`"2026-03-10T09"`), so events from different producers that fall within the same hour are aligned.

If Team A emits `"2026-03-10T09:00:00"` and Team B emits `"2026-03-10T09:15:00"`, `StartOfHourMapper` maps both to `"2026-03-10T09"`. The downstream DAG won't run until Team C also emits an event that maps to the same key.

---

### 5. Chain Partitioned Assets Across Multiple Levels

**Goal:** Propagate partition keys through a multi-level pipeline: producer → consumer → consumer.

```python
from airflow.sdk import (
    Asset,
    CronPartitionTimetable,
    PartitionedAssetTimetable,
    StartOfHourMapper,
    asset,
    task,
)

team_a = Asset(uri="file://incoming/player-stats/team_a.csv", name="team_a_player_stats")
combined = Asset(uri="file://curated/player-stats/combined.csv", name="combined_player_stats")


@asset(
    uri="file://incoming/player-stats/team_a.csv",
    schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
)
def team_a_player_stats():
    pass


@asset(
    uri="file://curated/player-stats/combined.csv",
    schedule=PartitionedAssetTimetable(
        assets=team_a,
        default_partition_mapper=StartOfHourMapper(),
    ),
)
def combined_player_stats():
    pass


@asset(
    uri="file://analytics/player-stats/computed-player-odds.csv",
    schedule=PartitionedAssetTimetable(assets=combined),
)
def compute_player_odds():
    pass
```

*Adapted from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

Each level in the chain is an independent partition-aware DAG. `team_a_player_stats` produces events with full-timestamp keys. `combined_player_stats` maps those to hourly keys and emits new partition events. `compute_player_odds` picks up those hourly keys with the default `IdentityMapper`. The partition key flows through the chain, with each level optionally transforming the granularity.

---

### 6. Aggregate Hourly Partitions to Daily with Temporal Mappers

**Goal:** Roll up hourly upstream partition keys to daily granularity so the downstream DAG triggers once per day, after *any* hourly event within that day.

```python
from airflow.sdk import DAG, Asset, PartitionedAssetTimetable, StartOfDayMapper, task

hourly_sales = Asset(uri="file://incoming/sales/hourly.csv", name="hourly_sales")

with DAG(
    dag_id="daily_sales_summary",
    schedule=PartitionedAssetTimetable(
        assets=hourly_sales,
        default_partition_mapper=StartOfDayMapper(),
    ),
    catchup=False,
):

    @task
    def summarize_sales(dag_run=None):
        print(f"Processing daily partition: {dag_run.partition_key}")

    summarize_sales()
```

*Adapted from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

`StartOfDayMapper` truncates timestamp-based keys to `"%Y-%m-%d"` format. An upstream event with key `"2026-03-10T09:15:00"` maps to downstream key `"2026-03-10"`. The downstream DAG run is created when the *first* hourly event for that day arrives (since a single upstream asset is required). If you need all 24 hourly partitions before triggering, that requires rollup support which is tracked for future implementation.

Available temporal mappers and their output formats:

| Mapper | Default output format | Example output |
|---|---|---|
| `StartOfHourMapper` | `%Y-%m-%dT%H` | `2026-03-10T09` |
| `StartOfDayMapper` | `%Y-%m-%d` | `2026-03-10` |
| `StartOfWeekMapper` | `%Y-%m-%d (W%V)` | `2026-03-09 (W11)` |
| `StartOfMonthMapper` | `%Y-%m` | `2026-03` |
| `StartOfQuarterMapper` | `%Y-Q{quarter}` | `2026-Q1` |
| `StartOfYearMapper` | `%Y` | `2026` |

All temporal mappers accept optional `input_format` and `output_format` parameters to override the defaults:

```python
StartOfDayMapper(input_format="%Y/%m/%d %H:%M", output_format="%Y_%m_%d")
```

---

### 7. Map Composite Partition Keys with ProductMapper

**Goal:** Handle multi-dimensional partition keys (e.g., `"region|timestamp"`) by applying a different mapper to each segment.

```python
from airflow.sdk import (
    DAG,
    Asset,
    IdentityMapper,
    PartitionedAssetTimetable,
    ProductMapper,
    StartOfDayMapper,
    task,
)

regional_sales = Asset(uri="file://incoming/sales/regional.csv", name="regional_sales")

with DAG(
    dag_id="aggregate_regional_sales",
    schedule=PartitionedAssetTimetable(
        assets=regional_sales,
        default_partition_mapper=ProductMapper(IdentityMapper(), StartOfDayMapper()),
    ),
    catchup=False,
    tags=["sales", "aggregation"],
):

    @task
    def aggregate_sales(dag_run=None):
        print(dag_run.partition_key)

    aggregate_sales()
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

`ProductMapper` splits the incoming key by a delimiter (`"|"` by default), applies one mapper per segment, and rejoins the results. For input key `"us|2026-03-10T09:00:00"`:

1. Segment 0 (`"us"`) → `IdentityMapper` → `"us"`
2. Segment 1 (`"2026-03-10T09:00:00"`) → `StartOfDayMapper` → `"2026-03-10"`
3. Result: `"us|2026-03-10"`

`ProductMapper` requires at least two mappers (positional-only) and accepts a custom delimiter:

```python
ProductMapper(IdentityMapper(), StartOfHourMapper(), delimiter="::")
```

---

### 8. Restrict Partition Keys with AllowedKeyMapper

**Goal:** Accept only specific partition keys (e.g., region codes) and reject all others.

```python
from airflow.sdk import AllowedKeyMapper, Asset, PartitionedAssetTimetable, asset

region_raw_stats = Asset(uri="file://incoming/player-stats/by-region.csv", name="region_raw_stats")


@asset(
    uri="file://analytics/player-stats/regional-breakdown.csv",
    schedule=PartitionedAssetTimetable(
        assets=region_raw_stats,
        default_partition_mapper=AllowedKeyMapper(["us", "eu", "apac"]),
    ),
    tags=["player-stats", "regional"],
)
def regional_stats_breakdown():
    pass
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

`AllowedKeyMapper` validates that upstream partition keys belong to a fixed set. If the upstream emits `"us"`, the downstream triggers with key `"us"`. If it emits `"latam"` (not in the list), the event is silently ignored — no downstream DAG run is created for that partition.

This is useful for segment-based partitioning where partition keys are categorical values rather than timestamps.

---

### 9. Configure Per-Asset Mapper Overrides

**Goal:** Apply different partition mappers to different upstream assets in the same consumer DAG.

```python
from airflow.sdk import (
    DAG,
    Asset,
    IdentityMapper,
    PartitionedAssetTimetable,
    StartOfDayMapper,
    StartOfHourMapper,
    StartOfYearMapper,
    task,
)

hourly_sales = Asset(uri="file://incoming/sales/hourly.csv", name="hourly_sales")
daily_targets = Asset(uri="file://incoming/sales/targets.csv", name="daily_targets")

with DAG(
    dag_id="join_sales_and_targets",
    schedule=PartitionedAssetTimetable(
        assets=hourly_sales & daily_targets,
        default_partition_mapper=StartOfDayMapper(),
        partition_mapper_config={
            daily_targets: IdentityMapper(),
        },
    ),
):

    @task
    def join_data():
        pass

    join_data()
```

*Adapted from `airflow-core/docs/authoring-and-scheduling/assets.rst`*

The `default_partition_mapper` applies to all upstream assets unless overridden in `partition_mapper_config`. Here, `hourly_sales` events are mapped with `StartOfDayMapper` (truncating hourly keys to daily), while `daily_targets` events are passed through unchanged with `IdentityMapper`.

The downstream DAG triggers only when *both* assets produce a matching partition key after their respective mappers are applied. If `hourly_sales` emits `"2026-03-10T09:00:00"` (mapped to `"2026-03-10"`) and `daily_targets` emits `"2026-03-10"` (unchanged), the keys match and the DAG run is created.

You can also use `Asset.ref()` to reference assets by name or URI when the full `Asset` object isn't available:

```python
partition_mapper_config={
    Asset.ref(name="daily_targets"): IdentityMapper(),
}
```

**Caution with mismatched mappers:** If mappers produce incompatible key formats, the downstream DAG will never trigger. For example, mapping one asset with `StartOfYearMapper` (output: `"2026"`) and another with `StartOfHourMapper` (output: `"2026-03-10T09"`) means the keys will never align.

---

### 10. Read partition_key Inside a Running Task

**Goal:** Access the resolved partition key at task execution time to drive partition-specific logic.

```python
from airflow.sdk import DAG, Asset, PartitionedAssetTimetable, StartOfHourMapper, task

combined_player_stats = Asset(uri="file://curated/player-stats/combined.csv", name="combined_player_stats")

with DAG(
    dag_id="process_partition",
    schedule=PartitionedAssetTimetable(
        assets=combined_player_stats,
        default_partition_mapper=StartOfHourMapper(),
    ),
    catchup=False,
):

    @task
    def process(dag_run=None):
        partition_key = dag_run.partition_key
        print(f"Processing partition: {partition_key}")

    process()
```

*Verified — from `airflow-core/src/airflow/example_dags/example_asset_partition.py`*

The `dag_run.partition_key` attribute is available on the `DagRun` instance passed to every task. For partitioned DAG runs, it contains the resolved downstream partition key (after mapper transformation). For non-partitioned DAG runs, it is `None`.

---

### 11. Trigger a Partitioned DAG Run via REST API

**Goal:** Manually materialize a specific partition by triggering a DAG run with an explicit partition key.

```bash
curl -X POST "http://<airflow-host>/api/v2/dags/aggregate_regional_sales/dagRuns" \
  -H "Content-Type: application/json" \
  -d '{
    "logical_date": "2026-03-10T00:00:00Z",
    "partition_key": "us|2026-03-10T09:00:00"
  }'
```

*Verified — from `airflow-core/docs/authoring-and-scheduling/assets.rst`*

The REST API accepts `partition_key` in the request body when triggering a DAG run. The partition key is stored directly on the DAG run and is accessible via `dag_run.partition_key` in tasks. This bypasses the normal partition mapper pipeline — the key you provide is used as-is.

You can also trigger a partitioned DAG run from the Airflow UI via the "Trigger DAG" dialog, which includes a `partition_key` field.

---

## Not Yet Implemented

The following AIP-76 features are proposed but not present in the current codebase:

- **`PartitionAtRuntime`** — Dynamic partition keys determined during execution based on runtime data (e.g., querying a database for active customers). Tracked in [#44146](https://github.com/apache/airflow/issues/44146).
- **`PartitionByInterval` / `PartitionBySequence` / `PartitionByProduct`** — The AIP proposes these as high-level partition definition classes on assets. The implementation instead uses `CronPartitionTimetable` for producing partitions and `PartitionMapper` subclasses for consuming them.
- **Custom `PartitionKey` subclasses** — The AIP proposes rich, typed partition keys (e.g., a `Position(x, y, z)` class). The implementation uses plain string keys.
- **Rollup / many-to-one partition aggregation** — The ability to require that *all* upstream partitions within a range (e.g., all 24 hourly partitions) are present before triggering a daily downstream run. Currently, the first matching partition key triggers the downstream DAG. A TODO in the scheduler tracks this.
- **Partition-aware backfill** — The AIP describes explicit backfill for time-based partitions. Integration with the backfill system is not yet complete.
- **Partition skipping** — Runtime decision to skip specific partitions.
- **Watermarking** — Incremental load tracking via partition markers.
</p>
</details> 

<details><summary>Manifest / ADR</summary>
<p>

# Definition: AIP-to-User-Stories Playbook Skill

## 1. Intent & Context
- **Goal:** Create a Claude Code skill (`/aip-user-stories`) that auto-detects its mode from inputs: (1) **post-implementation** (PR URLs provided) generates verified recipe/how-to guides, and (2) **pre-implementation** (no PR URLs) generates user stories with speculative code to help AIP authors validate their design.
- **Mental Model:** AIPs describe *design intent*; PRs and merged code represent *actual implementation*. In post mode, the skill bridges this gap with verified recipes. In pre mode, no implementation exists — the skill helps AIP authors think through user stories and surface design questions. Mode is auto-detected: PRs present → post; no PRs → pre.
- **Interview:** thorough
- **Medium:** local

## 2. Approach

- **Architecture:** Single skill directory at `/home/USER/repositories/airflow/.claude/skills/aip-user-stories/` containing:
  - `SKILL.md` — main skill prompt with phase-based execution flow
  - `references/playbook-template.md` — output template for both modes (recipes for playbook, user stories for assist)
  
  **Two modes, auto-detected from inputs:**

  Invocation: `/aip-user-stories <AIP-URL> [<PR-URL>...] [<file>...]`
  - PR URLs present → **post-implementation** mode
  - No PR URLs → **pre-implementation** mode

  **Post-implementation mode** (PRs provided):
  1. **Parse** — extract AIP URL (or pasted content), PR URLs, optional example file paths. URLs identified by `https://` prefix; everything else is a file path.
  2. **Fetch** — retrieve AIP content via WebFetch (fallback: ask user to paste), PR diffs/metadata via `gh` CLI, read local example/source/test files.
  3. **Analyze** — cross-reference AIP features against actual code, flag unimplemented features. When multiple PRs conflict, prefer the latest PR with code changes (docs-only PRs inform context but don't override).
  4. **Propose** — present recipe list (title + one-liner) grouped by concept for user approval. For unimplemented AIP features, ask user whether to include (all-placeholder code) or skip.
  5. **Generate** — for each approved recipe, verify code against codebase (source, example DAGs, tests), produce content.
  6. **Assemble** — combine overview + recipes into playbook, write to `.claude/aip-{number}.md`.

  **Pre-implementation mode** (no PRs):
  1. **Parse** — extract AIP URL (or pasted content). File paths ignored with a warning (no implementation to reference).
  2. **Fetch** — retrieve AIP content via WebFetch (fallback: ask user to paste).
  3. **Analyze** — extract proposed features, APIs, and use cases from the AIP. No code verification (nothing is implemented).
  4. **Propose** — present user story list (title + one-liner) grouped by concept for user approval.
  5. **Generate** — for each approved story, produce: user story with goal, speculative code (all marked `# PROPOSED API — not yet implemented`), and open design questions the AIP should address.
  6. **Assemble** — combine overview + user stories into document, write to `.claude/aip-{number}.md`.

- **Execution Order:**
  - D1 (SKILL.md) → D2 (playbook template) → D3 (verify with AIP-76 example)
  - Rationale: SKILL.md defines process; template defines output format; AIP-76 validates the skill works.

- **Risk Areas:**
  - [R-1] WebFetch fails on Confluence AIP pages | Detect: empty content. Mitigation: paste fallback.
  - [R-2] LLM fills code blocks with plausible but wrong API calls (post mode) | Detect: code uses classes/functions not in codebase. Mitigation: explicit verification instruction + placeholder fallback.
  - [R-3] Recipe list misses important use cases visible in tests but not in examples | Detect: test files show uncovered patterns. Mitigation: include tests as verification source.
  - [R-4] Pre mode generates user stories that don't match AIP intent | Detect: stories propose features the AIP doesn't describe. Mitigation: stories must trace back to specific AIP sections.

- **Trade-offs:**
  - [T-1] Completeness vs accuracy → Prefer accuracy (post mode). When in doubt between adapted and unverified, prefer adapted if the individual components are each verified. Prefer completeness (pre mode — better to surface more stories for the author to evaluate).
  - [T-2] AIP fidelity vs implementation truth → Prefer implementation (post). Prefer AIP (pre — no implementation exists).
  - [T-3] Detailed placeholders vs brief placeholders → Prefer brief (TODO + See reference + ellipsis).

## 3. Global Invariants (The Constitution)

- [INV-G1] The skill prompt must not contain ambiguous instructions, vague language, or implicit expectations. No prescriptive HOW (step-by-step tool instructions), no arbitrary limits, no weak language ("try to", "maybe"). No AI-typical vocabulary (delve, tapestry, landscape, leverage, harness, navigate, seamless, robust, transformative, etc.) in its own prose or output instructions. | Verify: prompt quality review + vocabulary check
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Review the skill prompt at /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md against these prompt quality criteria: clarity (no ambiguous instructions), no conflicts (no contradictory rules), structure (critical rules surfaced prominently), information density (every word earns its place), no anti-patterns (no prescriptive HOW, arbitrary limits, capability instructions, weak language like 'try to' or 'maybe'), invocation fit (trigger/caller/consumer match), domain context (Airflow terms captured), complexity fit (matches task complexity), edge case coverage (handles boundary inputs), output calibration (format/length/detail match use case), emotional tone (calm, direct, trusted advisor). Report any MEDIUM+ issues."
  ```
  ```yaml
  verify:
    method: bash
    command: "grep -i -E '(delve|tapestry|landscape|leverage|harness|navigate|seamless|robust|transformative|meticulous|elevate|foster|empower|underpin|multifaceted|holistic|paradigm|synergy|ecosystem)' /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/*.md 2>/dev/null && echo 'FAIL: AI slop vocabulary found' || echo 'PASS'"
  ```

- [INV-G2] The skill directory must have SKILL.md + references/playbook-template.md. Template in companion file, not inlined. | Verify: directory structure check
  ```yaml
  verify:
    method: bash
    command: "test -f /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md && test -f /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md && echo 'PASS' || echo 'FAIL: missing SKILL.md or references/playbook-template.md'"
  ```

- [INV-G3] SKILL.md must have a description field that follows the What + When + Triggers pattern (trigger specification, not human-readable summary). Must include trigger terms for both modes (pre and post). | Verify: description check
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md frontmatter. Check that the 'description' field follows the pattern: WHAT the skill does + WHEN to use it + trigger terms. It should cover both pre-implementation and post-implementation modes. It should NOT be a human-readable summary but a trigger specification. Report PASS or FAIL with explanation."
  ```

- [INV-G4] In post mode, code blocks use three tiers: (1) **Verified** — pattern exists verbatim in codebase; clean code, no markers. (2) **Adapted** — combines verified components in a new way (e.g., swapping one mapper for another); clean code, brief note below the block: *"Adapted from [source file]"*. (3) **Unverified** — no codebase evidence; uses placeholder: `# TODO: Implement [description]` / `# See: [reference]` / `...`. Verification sources: source code, example DAGs, and test files. | Verify: three-tier instruction
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify the post-implementation mode defines three code block tiers: (1) Verified — verbatim from codebase, no markers, (2) Adapted — combines verified components, noted below block, (3) Unverified — TODO placeholder. Verification sources must include source code, example DAGs, and test files. Report PASS or FAIL."
  ```

- [INV-G5] In pre mode, ALL code blocks must be marked as speculative with `# PROPOSED API — not yet implemented`. No code should appear to be verified or production-ready. | Verify: pre mode code marking
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify the pre-implementation mode instructions require ALL code blocks to be marked as speculative/proposed, not verified. Look for explicit instruction about marking code as 'PROPOSED API' or similar. Report PASS or FAIL."
  ```

- [INV-G6] In post mode, the skill must follow implementation truth, not AIP spec. When AIP proposes APIs that differ from implementation, the playbook follows the implementation. | Verify: source of truth instruction
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify the post-implementation mode contains an explicit instruction that the playbook follows actual implementation, NOT the AIP specification, when they diverge. Report PASS or FAIL."
  ```

- [INV-G7] SKILL.md must include a Gotchas section with at least 3 specific, actionable failure modes grounded in this skill's domain. | Verify: gotchas check
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Find the Gotchas section. Verify it has at least 3 items, each specific to AIP/Airflow/code-verification domain and actionable. Report PASS or FAIL with the gotchas found."
  ```

- [INV-G8] The playbook template (references/playbook-template.md) must include: prerequisites/version section, brief conceptual overview section, and recipe/story sections. Must NOT include API reference, migration guide, or troubleshooting sections. | Verify: template structure
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md. Verify it includes sections for: (1) prerequisites/version requirements, (2) brief conceptual overview, (3) recipe sections (post mode) or user story sections (pre mode). Verify it does NOT include: API reference tables, migration guides, troubleshooting sections. Report PASS or FAIL."
  ```

- [INV-G9] The skill must write output to `.claude/aip-{number}.md` where `{number}` is the AIP number extracted from the URL or provided by the user. | Verify: output path instruction
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify it instructs the LLM to write output to '.claude/aip-{number}.md' where {number} is extracted from the AIP URL (or asked from the user). Report PASS or FAIL."
  ```

- [INV-G10] In pre mode, each user story must include open design questions probing: (a) API ergonomics — easy to use correctly, hard to misuse? (b) edge cases — unusual inputs or configurations? (c) compatibility — interaction with existing Airflow patterns (e.g., catchup, backfill, dynamic task mapping)? (d) implementation feasibility — constraints the AIP hasn't addressed? Generic questions like "what about error handling?" don't count. | Verify: design questions instruction
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify the pre-implementation mode instructions require each user story to include open design questions that probe specific areas (API ergonomics, edge cases, compatibility with existing Airflow patterns, implementation feasibility). Generic questions should not count. Report PASS or FAIL."
  ```

## 4. Process Guidance (Non-Verifiable)

- [PG-1] **Skill type**: Document/Scaffolding skill — produces structured output from external inputs.
- [PG-2] **Emotional tone**: Calm, direct, trusted advisor. No urgency language. Failure is normal.
- [PG-3] **Empty input behavior**: If no arguments provided, print usage synopsis showing both modes and stop.
- [PG-4] **Phase markers**: Use clear phase headings in the skill prompt so instructions for each phase don't rot mid-context.
- [PG-5] **No prescriptive HOW**: State goals and constraints. Don't prescribe tool usage sequences.
- [PG-6] **Playbook prose quality**: Each recipe should explain WHY this pattern works, not just WHAT the code does. No AI slop. If the user chose to skip unimplemented AIP features during the Propose phase, add a brief "Not Yet Implemented" note at the end listing them. Don't include this section if all features were covered.
- [PG-7] **AIP number extraction**: Extract from URL path (e.g., "AIP-76"). If undeterminable, ask user.
- [PG-8] **No provenance markers**: Output code blocks are clean. Verification is internal to generation.
- [PG-9] **File overwrite**: If `.claude/aip-{number}.md` already exists, ask user before overwriting.
- [PG-10] **Minimum input (post mode)**: At least one PR URL required. AIP URL + PR URL(s) is minimum valid invocation. Example file paths optional.
- [PG-11] **Minimum input (pre mode)**: Only AIP URL (or pasted content) required. File paths ignored with a warning (no implementation to reference). When presenting usage, show both invocation patterns: URL-based and paste-based.
- [PG-12] **Pre mode code quality**: Speculative code should follow AIP's proposed API as closely as possible, using the AIP's own code examples as the basis. Mark all code as proposed/unverified.
- [PG-13] **Mode auto-detection**: Mode is determined by presence of PR URLs. If any `https://github.com/.../pull/...` URLs are in the arguments, use post mode. Otherwise, pre mode. No flags needed.
- [PG-14] **Recipe granularity**: One recipe per distinct use case that the feature enables. A use case is a specific problem the user is solving, not an API class or configuration option. If two API classes serve the same use case, they belong in one recipe. If one API class serves multiple use cases, split into separate recipes.
- [PG-15] **Recipe sizing**: Each recipe's code should be the minimal example that illustrates how the feature addresses the use case. No boilerplate, no unrelated setup. Explanation should cover WHY this pattern works, not line-by-line narration.
- [PG-16] **Terminology consistency**: Use 'recipe' in post mode, 'user story' in pre mode, 'playbook' for the overall output, 'AIP' for the input. Modes are 'pre' and 'post' internally.

## 5. Known Assumptions

- [ASM-1] The Airflow codebase is checked out locally and the skill runs from within the repo. | Default: yes (skill lives in `.claude/skills/`) | Impact if wrong: post mode code verification fails; pre mode unaffected.
- [ASM-2] The `gh` CLI is available and authenticated for fetching PR data. | Default: yes | Impact if wrong: PR data cannot be fetched in post mode; pre mode unaffected.
- [ASM-3] WebFetch works reliably on Confluence pages. | Default: uncertain (Confluence pages are public but JavaScript-heavy; WebFetch may return partial content) | Impact if wrong: user pastes content instead. Paste is a co-equal input path, not a degraded fallback.
- [ASM-4] One AIP maps to a manageable number of recipes/stories (roughly 3-15). | Default: yes | Impact if wrong: large output; user can trim via the Propose phase.
- [ASM-5] WebFetch is available as a built-in Claude Code tool. | Default: yes | Impact if wrong: AIP URL fetching fails; user must paste.

## 6. Deliverables (The Work)

### Deliverable 1: SKILL.md — Main Skill Prompt

The skill file at `/home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md` containing the skill prompt and both mode definitions. References the template in `references/playbook-template.md`.

**Acceptance Criteria:**
- [AC-1.1] SKILL.md has valid YAML frontmatter with `name: aip-user-stories` and a trigger-pattern description covering both modes. | Verify: frontmatter check
  ```yaml
  verify:
    method: bash
    command: "head -10 /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md | grep -q 'name: aip-user-stories' && echo 'PASS' || echo 'FAIL'"
  ```

- [AC-1.2] SKILL.md defines argument parsing: `<AIP-URL> [<PR-URL>...] [<file>...]`. PR URLs auto-detected as GitHub pull request URLs. Mode auto-detected: PR URLs present → post, absent → pre. No arguments prints usage. | Verify: argument parsing
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify it defines argument parsing supporting: (1) AIP URL + optional PR URLs + optional file paths, (2) auto-detection of mode from presence of PR URLs, (3) URL detection by https:// prefix, (4) usage message when no arguments. Report PASS or FAIL."
  ```

- [AC-1.3] SKILL.md defines the six execution phases for post mode (Parse, Fetch, Analyze, Propose, Generate, Assemble) with clear inputs/outputs. | Verify: post mode phases
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify it defines post-implementation mode execution phases covering: (1) argument parsing, (2) fetching AIP + PR data + local files, (3) analyzing features against implementation, (4) proposing recipe list for user approval, (5) generating verified recipes, (6) assembling and writing playbook. Report PASS or FAIL."
  ```

- [AC-1.4] SKILL.md defines the six execution phases for pre mode (Parse, Fetch, Analyze, Propose, Generate, Assemble) with appropriate differences: no code verification, speculative code, design questions. | Verify: pre mode phases
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify it defines pre-implementation mode execution phases that: (1) don't require PR URLs, (2) skip code verification, (3) produce speculative code marked as proposed, (4) include open design questions per story, (5) propose user stories for approval. Report PASS or FAIL."
  ```

- [AC-1.5] Propose phase presents items as a numbered list with title + one-liner, grouped by concept, and waits for user approval. | Verify: proposal format
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify the Propose phase (both modes) instructs: (1) numbered list with title + one-sentence description, (2) grouped by concept, (3) wait for user approval before generating. Report PASS or FAIL."
  ```

- [AC-1.6] Handles unimplemented AIP features (post mode): asks user whether to include with placeholder code or skip. | Verify: unimplemented features
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify post mode handles AIP features not found in implementation by asking user to include or skip. Report PASS or FAIL."
  ```

- [AC-1.7] Error handling: fail with clear message for inaccessible URLs. For AIP content, URL fetch and pasted content are equally valid input paths — present both options rather than trying URL first and falling back. | Verify: error handling
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify it handles inaccessible URLs with clear messages. For AIP content, verify that pasted content is treated as an equally valid input path (not just a fallback). Report PASS or FAIL."
  ```

- [AC-1.8] Gotchas section with at least 3 specific, actionable failure modes. | Verify: gotchas quality
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Find the Gotchas section. Verify at least 3 items, each specific to AIP/Airflow domain and actionable. Report PASS or FAIL."
  ```

- [AC-1.9] Version detection: post mode greps the PR diff for `versionadded::` directives; if not found, asks the user. Pre mode asks the user for target version. | Verify: version detection
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify version detection: (1) post mode looks for versionadded directives in PR diff, falls back to asking user, (2) pre mode asks user for target version. Report PASS or FAIL."
  ```

- [AC-1.10] Multiple PR handling (post mode): latest PR with code changes takes priority; docs-only PRs inform context. | Verify: multi-PR
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md. Verify post mode handles multiple PRs: latest code-change PR takes priority, docs-only PRs inform context. Report PASS or FAIL."
  ```

- [AC-1.11] SKILL.md references the playbook template in references/playbook-template.md and instructs the LLM to follow it for output structure in both modes. | Verify: template reference
  ```yaml
  verify:
    method: bash
    command: "grep -q 'playbook-template' /home/USER/repositories/airflow/.claude/skills/aip-user-stories/SKILL.md && echo 'PASS' || echo 'FAIL: no reference to playbook template'"
  ```

### Deliverable 2: Playbook Template

Reference template at `/home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md`.

**Acceptance Criteria:**
- [AC-2.1] Template includes a prerequisites section with placeholders for Airflow version and required packages. | Verify: prerequisites section
  ```yaml
  verify:
    method: bash
    command: "grep -i 'prerequisit' /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md && echo 'PASS' || echo 'FAIL'"
  ```

- [AC-2.2] Template includes a conceptual overview section (2-3 paragraphs from AIP motivation). | Verify: overview section
  ```yaml
  verify:
    method: bash
    command: "grep -i 'overview' /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md && echo 'PASS' || echo 'FAIL'"
  ```

- [AC-2.3] Template defines recipe structure (post mode): title, goal, per-recipe prerequisites, code block(s), explanation. | Verify: recipe structure
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md. Verify the recipe section includes: (1) title, (2) goal, (3) per-recipe prerequisites, (4) code block area, (5) explanation. Report PASS or FAIL."
  ```

- [AC-2.4] Template defines user story structure (pre mode): title, goal, speculative code (marked as proposed), open design questions. | Verify: story structure
  ```yaml
  verify:
    method: subagent
    agent: general-purpose
    model: inherit
    prompt: "Read /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md. Verify it includes a pre-implementation mode section with: (1) user story title, (2) goal, (3) speculative code area with 'PROPOSED API' marking, (4) open design questions area. Report PASS or FAIL."
  ```

- [AC-2.5] Template does NOT include API reference, migration guide, or troubleshooting sections. | Verify: scope check
  ```yaml
  verify:
    method: bash
    command: "grep -i -E '(api reference|migration guide|troubleshoot)' /home/USER/repositories/airflow/.claude/skills/aip-user-stories/references/playbook-template.md && echo 'FAIL: out-of-scope sections found' || echo 'PASS'"
  ```

### Deliverable 3: Validation with AIP-76

Manual review that the skill would produce coherent output for AIP-76 inputs.

**Acceptance Criteria:**
- [AC-3.1] In post mode (AIP-76 + PR #63262 + example_asset_partition.py), the skill would identify recipe candidates covering: CronPartitionTimetable, PartitionedAssetTimetable, temporal mappers, ProductMapper, AllowedKeyMapper. | Verify: manual review
  ```yaml
  verify:
    method: manual
    prompt: "Review SKILL.md's Analyze phase and confirm it would identify these patterns from AIP-76 inputs."
  ```

- [AC-3.2] In post mode, PartitionAtRuntime (from AIP-76) would be flagged as unimplemented and the user asked how to handle it. | Verify: manual review
  ```yaml
  verify:
    method: manual
    prompt: "Review SKILL.md's unimplemented feature detection and confirm it applies to PartitionAtRuntime."
  ```

- [AC-3.3] In pre mode (AIP-76 only, no PRs), the skill would generate user stories using AIP's proposed API (PartitionByInterval, PartitionBySequence, PartitionAtRuntime) with speculative code and design questions. | Verify: manual review
  ```yaml
  verify:
    method: manual
    prompt: "Review SKILL.md's pre mode and confirm it would use AIP-76's proposed API in speculative code blocks."
  ```

</p>
</details> 

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
