### PR TITLE
Install shared distros in CI image and tighten shared imports

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1464,6 +1464,20 @@ function check_run_tests() {
     fi
 }
 
+function reinstall_shared_distributions() {
+    # The shared distributions under shared/<name>/ are workspace members that are not
+    # transitively required by airflow-core or any provider, so the lowest-direct
+    # `uv sync` above wipes them out from the environment. Re-install them with
+    # --no-deps so that the `airflow_shared.*` namespace used by devel-common test
+    # utils resolves at test collection time without disturbing the lowest-direct
+    # resolution that was just applied.
+    echo
+    echo "${COLOR_BLUE}Re-installing shared distributions (airflow_shared.*) after uv sync${COLOR_RESET}"
+    echo
+    # shellcheck disable=SC2046
+    uv pip install --no-deps $(ls -d /opt/airflow/shared/*/)
+}
+
 function check_force_lowest_dependencies() {
     if [[ ${FORCE_LOWEST_DEPENDENCIES=} != "true" ]]; then
         return
@@ -1516,6 +1530,7 @@ function check_force_lowest_dependencies() {
         uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     fi
+    reinstall_shared_distributions
 }
 
 function check_airflow_python_client_installation() {

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -30,6 +30,7 @@ import attrs
 import structlog
 from sqlalchemy import func, or_, select, tuple_
 
+from airflow._shared.observability.metrics.stats import Stats
 from airflow._shared.timezones.timezone import coerce_datetime
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
@@ -40,7 +41,6 @@ from airflow.models.deadline import Deadline
 from airflow.models.deadline_alert import DeadlineAlert as DeadlineAlertModel
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.tasklog import LogTemplate
-from airflow.sdk._shared.observability.metrics.stats import Stats
 from airflow.serialization.decoders import decode_deadline_alert
 from airflow.serialization.definitions.deadline import DeadlineAlertFields, SerializedReferenceModels
 from airflow.serialization.definitions.param import SerializedParamsDict

--- a/devel-common/src/sphinx_exts/metrics_tables_from_registry.py
+++ b/devel-common/src/sphinx_exts/metrics_tables_from_registry.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow._shared.observability.metrics.metrics_registry import generate_metrics_rst_from_registry
+from airflow_shared.observability.metrics.metrics_registry import generate_metrics_rst_from_registry
 
 
 def generate_metrics(app):

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -1878,7 +1878,7 @@ def clear_lru_cache():
         return
 
     try:
-        from airflow._shared.module_loading import _get_grouped_entry_points
+        from airflow_shared.module_loading import _get_grouped_entry_points
     except ImportError:
         # compat for airflow < 3.2
         from airflow.utils.entry_points import _get_grouped_entry_points

--- a/devel-common/src/tests_common/test_utils/api_fastapi.py
+++ b/devel-common/src/tests_common/test_utils/api_fastapi.py
@@ -22,11 +22,7 @@ from uuid import UUID
 from airflow.models import DagRun, Log
 from airflow.models.dagrun import DagRunNote
 from airflow.models.taskinstance import TaskInstanceNote
-
-try:
-    from airflow.sdk._shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
-except ImportError:
-    from airflow.sdk.execution_time.secrets_masker import DEFAULT_SENSITIVE_FIELDS  # type:ignore[no-redef]
+from airflow_shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
 
 sensitive_fields = DEFAULT_SENSITIVE_FIELDS
 

--- a/devel-common/src/tests_common/test_utils/logs.py
+++ b/devel-common/src/tests_common/test_utils/logs.py
@@ -28,11 +28,7 @@ from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, NoReturn
 
 from airflow.models import Log
-
-try:
-    from airflow.sdk._shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
-except ImportError:
-    from airflow.sdk.execution_time.secrets_masker import DEFAULT_SENSITIVE_FIELDS  # type:ignore[no-redef]
+from airflow_shared.secrets_masker import DEFAULT_SENSITIVE_FIELDS
 
 if TYPE_CHECKING:
     from structlog.typing import EventDict, WrappedLogger

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -392,6 +392,20 @@ function check_run_tests() {
     fi
 }
 
+function reinstall_shared_distributions() {
+    # The shared distributions under shared/<name>/ are workspace members that are not
+    # transitively required by airflow-core or any provider, so the lowest-direct
+    # `uv sync` above wipes them out from the environment. Re-install them with
+    # --no-deps so that the `airflow_shared.*` namespace used by devel-common test
+    # utils resolves at test collection time without disturbing the lowest-direct
+    # resolution that was just applied.
+    echo
+    echo "${COLOR_BLUE}Re-installing shared distributions (airflow_shared.*) after uv sync${COLOR_RESET}"
+    echo
+    # shellcheck disable=SC2046
+    uv pip install --no-deps $(ls -d /opt/airflow/shared/*/)
+}
+
 function check_force_lowest_dependencies() {
     if [[ ${FORCE_LOWEST_DEPENDENCIES=} != "true" ]]; then
         return
@@ -444,6 +458,7 @@ function check_force_lowest_dependencies() {
         uv sync --resolution lowest-direct --no-binary-package lxml --no-binary-package xmlsec --all-extras \
             --no-python-downloads --no-managed-python
     fi
+    reinstall_shared_distributions
 }
 
 function check_airflow_python_client_installation() {

--- a/scripts/in_container/install_development_dependencies.py
+++ b/scripts/in_container/install_development_dependencies.py
@@ -78,6 +78,16 @@ def install_development_dependencies(constraint: str, github_actions: bool):
     )
     for provider_id in providers_dependencies:
         development_dependencies.extend(providers_dependencies[provider_id]["devel-deps"])
+    # The shared distributions under shared/<name>/ provide the canonical
+    # ``airflow_shared.<name>`` namespace used by devel-common. They are marked
+    # ``Private :: Do Not Upload`` so they don't get pulled from PyPI by Airflow's
+    # transitive deps; install them explicitly from the local source tree so that
+    # ``import airflow_shared.X`` works in Lowest Deps and Compat test images that
+    # otherwise only ship the embedded ``airflow._shared.X`` / ``airflow.sdk._shared.X``.
+    shared_distributions = sorted(
+        path.parent.as_posix() for path in (AIRFLOW_ROOT_PATH / "shared").glob("*/pyproject.toml")
+    )
+    development_dependencies.extend(shared_distributions)
     command = ["uv", "pip", "install", *development_dependencies, "--constraints", constraint]
     result = run_command(command, check=False, github_actions=github_actions)
     if result.returncode != 0:


### PR DESCRIPTION
First batch of fixes for the new ``check_shared_distributions_structure``
prek hook introduced in #65621.

## Summary

Two related fixes:

### 1. ``airflow-core`` Stats import
``airflow-core/src/airflow/serialization/definitions/dag.py`` was
importing ``Stats`` from ``airflow.sdk._shared.observability.metrics.stats``
(the task-sdk distribution's namespace). Every other airflow-core
module already imports the same ``Stats`` from
``airflow._shared.observability.metrics.stats``. Switch this one
import to match so it shares the singleton already initialized by
the executors and job runners.

### 2. ``airflow_shared.*`` available in CI test images
The shared distributions under ``shared/<name>/`` are marked
``Private :: Do Not Upload`` and are not pulled in transitively when
Airflow is installed from a published wheel — those wheels only embed
the modules under ``airflow/_shared/<name>`` and
``airflow/sdk/_shared/<name>``. As a result, ``import airflow_shared.X``
fails in the Lowest Deps and Compat test images (where only published
wheels are installed) even though the ``shared/`` source tree is
mounted at ``/opt/airflow/shared``.

Install all 13 shared distributions from local source inside
``install_development_dependencies.py`` (alongside ``devel-common``)
so the canonical ``airflow_shared.*`` namespace is always available
to test utilities.

With that in place, switch ``devel-common`` back to importing from
``airflow_shared.*`` rather than reaching into ``airflow._shared`` /
``airflow.sdk._shared`` (which is what the new hook requires):

* ``sphinx_exts/metrics_tables_from_registry.py``
* ``tests_common/pytest_plugin.py`` (``_get_grouped_entry_points``)
* ``tests_common/test_utils/api_fastapi.py`` (``DEFAULT_SENSITIVE_FIELDS``)
* ``tests_common/test_utils/logs.py`` (``DEFAULT_SENSITIVE_FIELDS``)

The two ``DEFAULT_SENSITIVE_FIELDS`` try/except fallbacks collapse
into a single direct import.

related: #65621

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)