### PR TITLE
Show dag run duration in grid tooltip

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -84,6 +84,7 @@ export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
           alignItems="center"
           color="fg"
           dagId={dagId}
+          duration={run.duration}
           flexDir="column"
           height={`${(run.duration / max) * BAR_HEIGHT}px`}
           justifyContent="flex-end"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
@@ -31,6 +31,7 @@ describe("GridButton", () => {
     render(
       <GridButton
         dagId="example_dag"
+        duration={3661}
         label="2026-04-21T00:00:00+00:00"
         runId="manual__2026-04-21T00:00:00+00:00"
         searchParams=""
@@ -49,6 +50,7 @@ describe("GridButton", () => {
     expect(screen.getByTestId("basic-tooltip")).toHaveTextContent(
       "common:runId: manual__2026-04-21T00:00:00+00:00",
     );
+    expect(screen.getByTestId("basic-tooltip")).toHaveTextContent("duration: 01:01:01");
 
     vi.useRealTimers();
   });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -55,10 +55,10 @@ export const GridButton = ({
       <br />
       {translate("common:runId")}: {runId}
       <br />
-      {translate("duration")}: {renderDuration(duration)}
-      <br />
       {translate("state")}:{" "}
       {state ? translate(`common:states.${state}`) : translate("common:states.no_status")}
+      <br />
+      {translate("duration")}: {renderDuration(duration)}
     </>
   );
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -22,9 +22,11 @@ import { Link } from "react-router-dom";
 
 import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
 import { BasicTooltip } from "src/components/BasicTooltip";
+import { renderDuration } from "src/utils/datetimeUtils";
 
 type Props = {
   readonly dagId: string;
+  readonly duration?: number | null;
   readonly isGroup?: boolean;
   readonly label: string;
   readonly runId: string;
@@ -36,6 +38,7 @@ type Props = {
 export const GridButton = ({
   children,
   dagId,
+  duration,
   isGroup,
   label,
   runId,
@@ -51,6 +54,8 @@ export const GridButton = ({
       {label}
       <br />
       {translate("common:runId")}: {runId}
+      <br />
+      {translate("duration")}: {renderDuration(duration)}
       <br />
       {translate("state")}:{" "}
       {state ? translate(`common:states.${state}`) : translate("common:states.no_status")}


### PR DESCRIPTION
Adds DAG run duration to the grid tooltip in the Dag details view.

Updates:
- pass `run.duration` from the grid bar into `GridButton`
- show duration in the grid tooltip alongside run ID and state
- add a focused UI test for the tooltip content

Verification:
- `corepack pnpm exec vitest run src/layouts/Details/Grid/GridButton.test.tsx`
- `corepack pnpm exec eslint src/layouts/Details/Grid/GridButton.tsx src/layouts/Details/Grid/GridButton.test.tsx src/layouts/Details/Grid/Bar.tsx`
- `corepack pnpm exec prettier --check src/layouts/Details/Grid/GridButton.tsx src/layouts/Details/Grid/GridButton.test.tsx src/layouts/Details/Grid/Bar.tsx`

This closes: #65786

