### PR TITLE
Add `allow_producer_teams` to the Asset SDK class

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/__init__.py
@@ -240,6 +240,13 @@ class BaseAsset:
         return AssetAll(self, other)
 
 
+def _validate_allow_producer_teams(instance, attribute, value):
+    for entry in value:
+        if not isinstance(entry, str) or not entry or entry.isspace():
+            raise ValueError("Each entry in allow_producer_teams must be a non-empty string")
+    return value
+
+
 def _validate_asset_watcher_trigger(instance, attribute, value):
     from airflow.triggers.base import BaseEventTrigger
 
@@ -278,6 +285,10 @@ class Asset(os.PathLike, BaseAsset):
     watchers: list[AssetWatcher] = attrs.field(
         factory=list,
     )
+    allow_producer_teams: list[str] = attrs.field(
+        factory=list,
+        validator=[_validate_allow_producer_teams],
+    )
 
     asset_type: ClassVar[str] = "asset"
     __version__: ClassVar[int] = 1
@@ -291,6 +302,7 @@ class Asset(os.PathLike, BaseAsset):
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
         watchers: list[AssetWatcher] = ...,
+        allow_producer_teams: list[str] = ...,
     ) -> None:
         """Canonical; both name and uri are provided."""
 
@@ -302,6 +314,7 @@ class Asset(os.PathLike, BaseAsset):
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
         watchers: list[AssetWatcher] = ...,
+        allow_producer_teams: list[str] = ...,
     ) -> None:
         """It's possible to only provide the name, either by keyword or as the only positional argument."""
 
@@ -313,6 +326,7 @@ class Asset(os.PathLike, BaseAsset):
         group: str = ...,
         extra: dict[str, JsonValue] | None = None,
         watchers: list[AssetWatcher] = ...,
+        allow_producer_teams: list[str] = ...,
     ) -> None:
         """It's possible to only provide the URI as a keyword argument."""
 
@@ -324,6 +338,7 @@ class Asset(os.PathLike, BaseAsset):
         group: str | None = None,
         extra: dict[str, JsonValue] | None = None,
         watchers: list[AssetWatcher] | None = None,
+        allow_producer_teams: list[str] | None = None,
     ) -> None:
         if name is None and uri is None:
             raise TypeError("Asset() requires either 'name' or 'uri'")
@@ -345,6 +360,8 @@ class Asset(os.PathLike, BaseAsset):
             kwargs["extra"] = extra
         if watchers is not None:
             kwargs["watchers"] = watchers
+        if allow_producer_teams is not None:
+            kwargs["allow_producer_teams"] = allow_producer_teams
 
         self.__attrs_init__(name=name, uri=uri, **kwargs)
 

--- a/task-sdk/tests/task_sdk/definitions/test_asset.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset.py
@@ -457,3 +457,51 @@ class TestAssetSubclasses:
         assert obj.name == arg
         assert obj.uri == arg
         assert obj.group == group
+
+
+class TestAllowProducerTeamsValidationProperty:
+    @pytest.mark.parametrize(
+        "teams",
+        [
+            [""],
+            ["  "],
+            ["\t"],
+            ["\n"],
+            [123],
+            [None],
+            [True],
+            [{}],
+            ["team_a", "  ", "team_b"],
+        ],
+    )
+    def test_rejects_lists_with_invalid_entries(self, teams):
+        with pytest.raises(ValueError, match="allow_producer_teams"):
+            Asset(name="test_asset", allow_producer_teams=teams)
+
+    @pytest.mark.parametrize(
+        "teams",
+        [
+            [],
+            ["team_a"],
+            ["team_a", "team_b"],
+            ["team-with-dashes"],
+            ["team_with_underscores"],
+        ],
+    )
+    def test_accepts_valid_allow_producer_teams(self, teams):
+        asset = Asset(name="test_asset", allow_producer_teams=teams)
+        assert asset.allow_producer_teams == teams
+
+
+class TestAllowProducerTeamsField:
+    def test_sets_field_correctly(self):
+        asset = Asset(name="x", allow_producer_teams=["team_a"])
+        assert asset.allow_producer_teams == ["team_a"]
+
+    def test_defaults_to_empty_list(self):
+        asset = Asset(name="x")
+        assert asset.allow_producer_teams == []
+
+    def test_explicit_empty_list(self):
+        asset = Asset(name="x", allow_producer_teams=[])
+        assert asset.allow_producer_teams == []


### PR DESCRIPTION
Add first step of [Dataset triggering access control](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=294816378#AIP67MultiteamdeploymentofAirflowcomponents-Datasettriggeringaccesscontrol).

This new parameter allow Dag author to specify which team(s) they allow to receive events from.

Example: `allow_producer_teams = [ "team1", "team2" ]`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
