### PR TITLE
select unassigned asset triggers from db

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -427,7 +427,12 @@ class Trigger(Base):
             .where(or_(cls.triggerer_id.is_(None), cls.triggerer_id.not_in(alive_triggerer_ids)))
             .order_by(coalesce(TaskInstance.priority_weight, 0).desc(), cls.created_date),
             # Asset triggers
-            select(cls.id).where(cls.assets.any()).order_by(cls.created_date),
+            select(cls.id)
+            .where(
+                cls.assets.any(),
+                or_(cls.triggerer_id.is_(None), cls.triggerer_id.not_in(alive_triggerer_ids)),
+            )
+            .order_by(cls.created_date),
         ]
 
         # Process each query while avoiding unnecessary queries when capacity is reached

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -920,6 +920,7 @@ def test_kwargs_not_encrypted():
     assert trigger.kwargs["param1"] == "value1"
     assert trigger.kwargs["param2"] == "value2"
 
+
 def test_asset_trigger_unassigned_included(session):
     """Asset triggers with triggerer_id=None are returned."""
     asset = AssetModel("test_asset")

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -919,3 +919,101 @@ def test_kwargs_not_encrypted():
 
     assert trigger.kwargs["param1"] == "value1"
     assert trigger.kwargs["param2"] == "value2"
+
+def test_asset_trigger_unassigned_included(session):
+    """Asset triggers with triggerer_id=None are returned."""
+    asset = AssetModel("test_asset")
+    trigger = Trigger(classpath="some.trigger", kwargs={})
+    session.add(trigger)
+    session.flush()  # ensure trigger.id is available
+    asset.add_trigger(trigger, "test_watcher")
+    session.add(asset)
+    session.flush()
+
+    alive_ids = [100, 200]
+    result = Trigger.get_sorted_triggers(
+        capacity=10,
+        alive_triggerer_ids=alive_ids,
+        queues=None,
+        session=session,
+    )
+    ids = [row[0] for row in result]
+
+    assert trigger.id in ids
+
+
+def test_asset_trigger_dead_triggerer_included(session):
+    """Asset triggers assigned to a dead triggerer are returned."""
+    asset = AssetModel("test_asset")
+    trigger = Trigger(classpath="some.trigger", kwargs={})
+    trigger.triggerer_id = 999  # dead
+    session.add(trigger)
+    session.flush()
+    asset.add_trigger(trigger, "test_watcher")
+    session.add(asset)
+    session.flush()
+
+    alive_ids = [100, 200]
+    result = Trigger.get_sorted_triggers(
+        capacity=10,
+        alive_triggerer_ids=alive_ids,
+        queues=None,
+        session=session,
+    )
+    ids = [row[0] for row in result]
+
+    assert trigger.id in ids
+
+
+def test_asset_trigger_alive_triggerer_excluded(session):
+    """Asset triggers assigned to a living triggerer are not returned."""
+    asset = AssetModel("test_asset")
+    trigger = Trigger(classpath="some.trigger", kwargs={})
+    trigger.triggerer_id = 100  # alive
+    session.add(trigger)
+    session.flush()
+    asset.add_trigger(trigger, "test_watcher")
+    session.add(asset)
+    session.flush()
+
+    alive_ids = [100, 200]
+    result = Trigger.get_sorted_triggers(
+        capacity=10,
+        alive_triggerer_ids=alive_ids,
+        queues=None,
+        session=session,
+    )
+    ids = [row[0] for row in result]
+
+    assert trigger.id not in ids
+
+
+def test_asset_trigger_ordering_and_capacity(session):
+    """Asset triggers are ordered by created_date (oldest first) and respect capacity."""
+    now = datetime.datetime(2025, 1, 1, tzinfo=timezone.utc)
+    asset = AssetModel("test_asset")
+    triggers = []
+    for i in range(5):
+        trigger = Trigger(
+            classpath="some.trigger",
+            kwargs={},
+            created_date=now + datetime.timedelta(hours=i),
+        )
+        trigger.triggerer_id = None  # all unassigned
+        session.add(trigger)
+        session.flush()
+        asset.add_trigger(trigger, f"watcher_{i}")
+        triggers.append(trigger)
+    session.add(asset)
+    session.flush()
+
+    result = Trigger.get_sorted_triggers(
+        capacity=3,
+        alive_triggerer_ids=[],
+        queues=None,
+        session=session,
+    )
+    ids = [row[0] for row in result]
+
+    # Only the three oldest should be returned, in order
+    assert ids == [triggers[0].id, triggers[1].id, triggers[2].id]


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Fixes a bug where multiple triggerer replicas could pick up the same asset trigger from db. The query now selects only unassigned triggers, similar to task instance triggers.

* related: #65286
* related: #65622

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
