### PR TITLE
UI: Add Clear All Mapped Tasks button 

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
@@ -34,6 +34,11 @@
       "error": "Failed to clear {{type}}",
       "title": "Clear {{type}}"
     },
+    "clearAllMapped": {
+      "button": "Clear All Mapped Tasks",
+      "buttonTooltip": "Clear all mapped task instances",
+      "title": "Clear All Mapped Task Instances"
+    },
     "confirmationDialog": {
       "description": "Task is currently in a {{state}} state started by user {{user}} at {{time}}. \nThe user is unable to clear this task until it is done running or a user unchecks the \"Prevent rerun if task is running\" option in the clear task dialog.",
       "title": "Cannot Clear Task Instance"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
@@ -36,7 +36,7 @@
     },
     "clearAllMapped": {
       "button": "Clear All Mapped Tasks",
-      "buttonTooltip": "Clear all mapped task instances",
+      "buttonTooltip": "Press shift+c to clear all mapped task instances",
       "title": "Clear All Mapped Task Instances"
     },
     "confirmationDialog": {

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -76,7 +76,9 @@ const ClearTaskInstanceButton = ({
         closeDelay={100}
         content={
           allMapped
-            ? translate("dags:runAndTaskActions.clearAllMapped.buttonTooltip")
+            ? isHotkeyEnabled
+              ? translate("dags:runAndTaskActions.clearAllMapped.buttonTooltip")
+              : translate("dags:runAndTaskActions.clearAllMapped.button")
             : isHotkeyEnabled
               ? translate("dags:runAndTaskActions.clear.buttonTooltip")
               : translate("dags:runAndTaskActions.clear.button", { type: translate("taskInstance_one") })

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -28,17 +28,27 @@ import { Tooltip } from "src/components/ui";
 import ClearTaskInstanceDialog from "./ClearTaskInstanceDialog";
 
 type Props = {
+  // Clear all mapped TIs of a task at once. When set, dagId/dagRunId/taskId
+  // are required; taskInstance/groupTaskInstance must be absent.
+  readonly allMapped?: boolean;
+  readonly dagId?: string;
+  readonly dagRunId?: string;
   readonly groupTaskInstance?: LightGridTaskInstanceSummary;
   readonly isHotkeyEnabled?: boolean;
   // Optional: allow parent to handle opening a stable, page-level dialog
   readonly onOpen?: (ti: LightGridTaskInstanceSummary | TaskInstanceResponse) => void;
+  readonly taskId?: string;
   readonly taskInstance?: TaskInstanceResponse;
 };
 
 const ClearTaskInstanceButton = ({
+  allMapped = false,
+  dagId,
+  dagRunId,
   groupTaskInstance,
   isHotkeyEnabled = false,
   onOpen,
+  taskId,
   taskInstance,
 }: Props) => {
   const { onClose, onOpen: onOpenInternal, open } = useDisclosure();
@@ -65,16 +75,20 @@ const ClearTaskInstanceButton = ({
       <Tooltip
         closeDelay={100}
         content={
-          isHotkeyEnabled
-            ? translate("dags:runAndTaskActions.clear.buttonTooltip")
-            : translate("dags:runAndTaskActions.clear.button", { type: translate("taskInstance_one") })
+          allMapped
+            ? translate("dags:runAndTaskActions.clearAllMapped.buttonTooltip")
+            : isHotkeyEnabled
+              ? translate("dags:runAndTaskActions.clear.buttonTooltip")
+              : translate("dags:runAndTaskActions.clear.button", { type: translate("taskInstance_one") })
         }
         openDelay={100}
       >
         <IconButton
-          aria-label={translate("dags:runAndTaskActions.clear.button", {
-            type: translate("taskInstance_one"),
-          })}
+          aria-label={
+            allMapped
+              ? translate("dags:runAndTaskActions.clearAllMapped.button")
+              : translate("dags:runAndTaskActions.clear.button", { type: translate("taskInstance_one") })
+          }
           colorPalette="brand"
           onClick={() => (onOpen && selectedInstance ? onOpen(selectedInstance) : onOpenInternal())}
           size="md"
@@ -88,7 +102,24 @@ const ClearTaskInstanceButton = ({
         <ClearGroupTaskInstanceDialog onClose={onClose} open={open} taskInstance={groupTaskInstance} />
       ) : undefined}
 
-      {useInternalDialog && open && !isGroup && taskInstance ? (
+      {useInternalDialog &&
+      open &&
+      !isGroup &&
+      allMapped &&
+      dagId !== undefined &&
+      dagRunId !== undefined &&
+      taskId !== undefined ? (
+        <ClearTaskInstanceDialog
+          allMapped
+          dagId={dagId}
+          dagRunId={dagRunId}
+          onClose={onClose}
+          open={open}
+          taskId={taskId}
+        />
+      ) : undefined}
+
+      {useInternalDialog && open && !isGroup && !allMapped && taskInstance ? (
         <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
       ) : undefined}
     </>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
@@ -67,7 +67,10 @@ const ClearTaskInstanceConfirmationDialog = ({
       include_past: dagDetails?.past,
       include_upstream: dagDetails?.upstream,
       only_failed: dagDetails?.onlyFailed,
-      task_ids: [[dagDetails?.taskId ?? "", dagDetails?.mapIndex ?? 0]],
+      task_ids:
+        dagDetails?.mapIndex === undefined
+          ? [dagDetails?.taskId ?? ""]
+          : [[dagDetails.taskId, dagDetails.mapIndex]],
     },
   });
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -34,34 +34,44 @@ import { isStatePending, useAutoRefresh } from "src/utils";
 
 import ClearTaskInstanceConfirmationDialog from "./ClearTaskInstanceConfirmationDialog";
 
-// Pass `taskInstance` for single-TI clear (preserves the richer title display,
-// bundle-version comparison, etc.). For clearing every mapped TI of a task at
-// once, pass `allMapped` together with `dagId`, `dagRunId` and `taskId`.
+// Discriminated union: callers pass either `allMapped: true` together with
+// `dagId`/`dagRunId`/`taskId` (clears every mapped TI of the task), or a full
+// `taskInstance` (clears that single TI and reads its display fields). The
+// two variants are mutually exclusive at the type level — no defensive
+// runtime fallback chains needed in the body.
 type Props = {
-  readonly allMapped?: boolean;
-  readonly dagId?: string;
-  readonly dagRunId?: string;
-  readonly mapIndex?: number;
   readonly onClose: () => void;
   readonly open: boolean;
-  readonly taskId?: string;
-  readonly taskInstance?: TaskInstanceResponse;
-};
+} & (
+  | {
+      readonly allMapped: true;
+      readonly dagId: string;
+      readonly dagRunId: string;
+      readonly taskId: string;
+    }
+  | {
+      readonly allMapped?: false;
+      readonly taskInstance: TaskInstanceResponse;
+    }
+);
 
-const ClearTaskInstanceDialog = ({
-  allMapped = false,
-  dagId: dagIdProp,
-  dagRunId: dagRunIdProp,
-  mapIndex: mapIndexProp,
-  onClose: onCloseDialog,
-  open: openDialog,
-  taskId: taskIdProp,
-  taskInstance,
-}: Props) => {
-  const dagId = dagIdProp ?? taskInstance?.dag_id ?? "";
-  const dagRunId = dagRunIdProp ?? taskInstance?.dag_run_id ?? "";
-  const taskId = taskIdProp ?? taskInstance?.task_id ?? "";
-  const mapIndex = allMapped ? undefined : (mapIndexProp ?? taskInstance?.map_index);
+// react/destructuring-assignment expects every prop access via signature
+// destructure, but TypeScript's discriminated-union narrowing needs the union
+// kept whole on the parameter — otherwise the `props.allMapped` discriminator
+// is severed from `props.dagId` / `props.taskInstance`. Disable the rule for
+// the parameter and the prop extraction; everything after uses local
+// variables.
+/* eslint-disable react/destructuring-assignment */
+const ClearTaskInstanceDialog = (props: Props) => {
+  const allMapped = props.allMapped === true;
+  const dagId = props.allMapped ? props.dagId : props.taskInstance.dag_id;
+  const dagRunId = props.allMapped ? props.dagRunId : props.taskInstance.dag_run_id;
+  const taskId = props.allMapped ? props.taskId : props.taskInstance.task_id;
+  const mapIndex: number | undefined = props.allMapped ? undefined : props.taskInstance.map_index;
+  const taskInstance: TaskInstanceResponse | undefined = props.allMapped ? undefined : props.taskInstance;
+  const onCloseDialog = props.onClose;
+  const openDialog = props.open;
+  /* eslint-enable react/destructuring-assignment */
   const { t: translate } = useTranslation();
   const { onClose, onOpen, open } = useDisclosure();
 
@@ -85,10 +95,6 @@ const ClearTaskInstanceDialog = ({
   const { isPending: isPendingPatchDagRun, mutate: mutatePatchTaskInstance } = usePatchTaskInstance({
     dagId,
     dagRunId,
-    // For allMapped the per-call mutate below omits map_index so the backend
-    // patches every mapped TI at once; -1 here is only used for query-key
-    // invalidation.
-    mapIndex: mapIndex ?? -1,
     taskId,
   });
 
@@ -261,8 +267,6 @@ const ClearTaskInstanceDialog = ({
               },
             });
             if (note !== (taskInstance?.note ?? null)) {
-              // Omit map_index when allMapped so the backend patches the note
-              // on every mapped TI at once.
               mutatePatchTaskInstance({
                 dagId,
                 dagRunId,

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -34,20 +34,36 @@ import { isStatePending, useAutoRefresh } from "src/utils";
 
 import ClearTaskInstanceConfirmationDialog from "./ClearTaskInstanceConfirmationDialog";
 
+// Pass `taskInstance` for single-TI clear (preserves the richer title display,
+// bundle-version comparison, etc.). For clearing every mapped TI of a task at
+// once, pass `allMapped` together with `dagId`, `dagRunId` and `taskId`.
 type Props = {
+  readonly allMapped?: boolean;
+  readonly dagId?: string;
+  readonly dagRunId?: string;
+  readonly mapIndex?: number;
   readonly onClose: () => void;
   readonly open: boolean;
-  readonly taskInstance: TaskInstanceResponse;
+  readonly taskId?: string;
+  readonly taskInstance?: TaskInstanceResponse;
 };
 
-const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, taskInstance }: Props) => {
-  const taskId = taskInstance.task_id;
-  const mapIndex = taskInstance.map_index;
+const ClearTaskInstanceDialog = ({
+  allMapped = false,
+  dagId: dagIdProp,
+  dagRunId: dagRunIdProp,
+  mapIndex: mapIndexProp,
+  onClose: onCloseDialog,
+  open: openDialog,
+  taskId: taskIdProp,
+  taskInstance,
+}: Props) => {
+  const dagId = dagIdProp ?? taskInstance?.dag_id ?? "";
+  const dagRunId = dagRunIdProp ?? taskInstance?.dag_run_id ?? "";
+  const taskId = taskIdProp ?? taskInstance?.task_id ?? "";
+  const mapIndex = allMapped ? undefined : (mapIndexProp ?? taskInstance?.map_index);
   const { t: translate } = useTranslation();
   const { onClose, onOpen, open } = useDisclosure();
-
-  const dagId = taskInstance.dag_id;
-  const dagRunId = taskInstance.dag_run_id;
 
   const { isPending, mutate } = useClearTaskInstances({
     dagId,
@@ -65,11 +81,14 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
   const [runOnLatestVersion, setRunOnLatestVersion] = useState(false);
   const [preventRunningTask, setPreventRunningTask] = useState(true);
 
-  const [note, setNote] = useState<string | null>(taskInstance.note);
+  const [note, setNote] = useState<string | null>(taskInstance?.note ?? null);
   const { isPending: isPendingPatchDagRun, mutate: mutatePatchTaskInstance } = usePatchTaskInstance({
     dagId,
     dagRunId,
-    mapIndex,
+    // For allMapped the per-call mutate below omits map_index so the backend
+    // patches every mapped TI at once; -1 here is only used for query-key
+    // invalidation.
+    mapIndex: mapIndex ?? -1,
     taskId,
   });
 
@@ -98,7 +117,7 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
       include_upstream: upstream,
       only_failed: onlyFailed,
       run_on_latest_version: runOnLatestVersion,
-      task_ids: [[taskId, mapIndex]],
+      task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],
     },
   });
 
@@ -107,11 +126,13 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
     total_entries: 0,
   };
 
-  // Check if bundle versions are different
+  // Check if bundle versions are different (not applicable for allMapped —
+  // mapped TIs may be on several versions)
   const currentDagBundleVersion = dagDetails?.bundle_version;
-  const taskInstanceDagVersionBundleVersion = taskInstance.dag_version?.bundle_version;
+  const taskInstanceDagVersionBundleVersion = taskInstance?.dag_version?.bundle_version;
   const bundleVersionsDiffer = currentDagBundleVersion !== taskInstanceDagVersionBundleVersion;
   const shouldShowBundleVersionOption =
+    !allMapped &&
     bundleVersionsDiffer &&
     taskInstanceDagVersionBundleVersion !== null &&
     taskInstanceDagVersionBundleVersion !== "";
@@ -124,12 +145,20 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
             <VStack align="start" gap={4}>
               <Heading size="xl">
                 <strong>
-                  {translate("dags:runAndTaskActions.clear.title", {
-                    type: translate("taskInstance_one"),
-                  })}
+                  {allMapped
+                    ? translate("dags:runAndTaskActions.clearAllMapped.title")
+                    : translate("dags:runAndTaskActions.clear.title", {
+                        type: translate("taskInstance_one"),
+                      })}
                   :
                 </strong>{" "}
-                {taskInstance.task_display_name} <Time datetime={taskInstance.start_date} />
+                {allMapped ? (
+                  taskId
+                ) : (
+                  <>
+                    {taskInstance?.task_display_name} <Time datetime={taskInstance?.start_date} />
+                  </>
+                )}
               </Heading>
             </VStack>
           </Dialog.Header>
@@ -144,12 +173,12 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
                 onChange={setSelectedOptions}
                 options={[
                   {
-                    disabled: taskInstance.logical_date === null,
+                    disabled: allMapped || taskInstance?.logical_date === null,
                     label: translate("dags:runAndTaskActions.options.past"),
                     value: "past",
                   },
                   {
-                    disabled: taskInstance.logical_date === null,
+                    disabled: allMapped || taskInstance?.logical_date === null,
                     label: translate("dags:runAndTaskActions.options.future"),
                     value: "future",
                   },
@@ -227,15 +256,17 @@ const ClearTaskInstanceDialog = ({ onClose: onCloseDialog, open: openDialog, tas
                 include_upstream: upstream,
                 only_failed: onlyFailed,
                 run_on_latest_version: runOnLatestVersion,
-                task_ids: [[taskId, mapIndex]],
+                task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],
                 ...(preventRunningTask ? { prevent_running_task: true } : {}),
               },
             });
-            if (note !== taskInstance.note) {
+            if (note !== (taskInstance?.note ?? null)) {
+              // Omit map_index when allMapped so the backend patches the note
+              // on every mapped TI at once.
               mutatePatchTaskInstance({
                 dagId,
                 dagRunId,
-                mapIndex,
+                ...(allMapped ? {} : { mapIndex }),
                 requestBody: { note },
                 taskId,
               });

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -20,13 +20,16 @@ import { Box } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { MdOutlineTask } from "react-icons/md";
+import { useParams } from "react-router-dom";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
+import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
+  const { dagId = "", runId = "" } = useParams();
   const { t: translate } = useTranslation();
   const entries: Array<{ label: string; value: number | ReactNode | string }> = [];
   let taskCount: number = 0;
@@ -55,6 +58,9 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
   return (
     <Box>
       <HeaderCard
+        actions={
+          <ClearTaskInstanceButton allMapped dagId={dagId} dagRunId={runId} taskId={taskInstance.task_id} />
+        }
         icon={<MdOutlineTask />}
         state={taskInstance.state}
         stats={stats}

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -59,7 +59,13 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
     <Box>
       <HeaderCard
         actions={
-          <ClearTaskInstanceButton allMapped dagId={dagId} dagRunId={runId} taskId={taskInstance.task_id} />
+          <ClearTaskInstanceButton
+            allMapped
+            dagId={dagId}
+            dagRunId={runId}
+            isHotkeyEnabled
+            taskId={taskInstance.task_id}
+          />
         }
         icon={<MdOutlineTask />}
         state={taskInstance.state}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -355,7 +355,12 @@ export const TaskInstances = () => {
 
   return (
     <>
-      <TaskInstancesFilter />
+      <Flex alignItems="center" justifyContent="space-between">
+        <TaskInstancesFilter />
+        {dagId !== undefined && runId !== undefined && taskId !== undefined ? (
+          <ClearTaskInstanceButton allMapped dagId={dagId} dagRunId={runId} taskId={taskId} />
+        ) : undefined}
+      </Flex>
       <DataTable
         columns={columns}
         data={data?.task_instances ?? []}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -355,12 +355,7 @@ export const TaskInstances = () => {
 
   return (
     <>
-      <Flex alignItems="center" justifyContent="space-between">
-        <TaskInstancesFilter />
-        {dagId !== undefined && runId !== undefined && taskId !== undefined ? (
-          <ClearTaskInstanceButton allMapped dagId={dagId} dagRunId={runId} taskId={taskId} />
-        ) : undefined}
-      </Flex>
+      <TaskInstancesFilter />
       <DataTable
         columns={columns}
         data={data?.task_instances ?? []}

--- a/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
+++ b/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 
 import {
   UseTaskInstanceServiceGetMappedTaskInstanceKeyFn,
+  useTaskInstanceServiceGetMappedTaskInstanceKey,
   UseTaskInstanceServiceGetTaskInstanceKeyFn,
   useTaskInstanceServiceGetTaskInstancesKey,
   useTaskInstanceServicePatchTaskInstance,
@@ -40,7 +41,7 @@ export const usePatchTaskInstance = ({
 }: {
   dagId: string;
   dagRunId: string;
-  mapIndex: number;
+  mapIndex?: number;
   onSuccess?: () => void;
   taskId: string;
 }) => {
@@ -61,15 +62,38 @@ export const usePatchTaskInstance = ({
   const onSuccessFn = async () => {
     const queryKeys = [
       UseTaskInstanceServiceGetTaskInstanceKeyFn({ dagId, dagRunId, taskId }),
-      UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId }),
       [useTaskInstanceServiceGetTaskInstancesKey],
       [usePatchTaskInstanceDryRunKey, dagId, dagRunId, { mapIndex, taskId }],
       [useClearTaskInstancesDryRunKey, dagId],
     ];
 
+    if (mapIndex !== undefined) {
+      queryKeys.push(UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId }));
+    }
+
     await Promise.all([
       ...gridQueryKeys(dagId).map((key) => queryClient.invalidateQueries({ queryKey: key })),
       ...queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
+      // Wildcard match when patching every mapped TI (mapIndex undefined):
+      // invalidate the mapped-TI cache for every map_index of this task.
+      // The mapped-TI key embeds its params as a single object, so prefix
+      // matching on a partial key doesn't catch them — match via predicate.
+      ...(mapIndex === undefined
+        ? [
+            queryClient.invalidateQueries({
+              predicate: ({ queryKey }) => {
+                if (queryKey[0] !== useTaskInstanceServiceGetMappedTaskInstanceKey) {
+                  return false;
+                }
+                const params = queryKey[1] as
+                  | { dagId?: string; dagRunId?: string; taskId?: string }
+                  | undefined;
+
+                return params?.dagId === dagId && params.dagRunId === dagRunId && params.taskId === taskId;
+              },
+            }),
+          ]
+        : []),
     ]);
 
     if (onSuccess) {


### PR DESCRIPTION
Picks up stale PR apache/airflow#60591 by @VedantMadane and addresses outstanding review comments.

Closes #60460.

## What's included

- **Button on the mapped task instance header** that clears all mapped task instances at once, using the existing backend support for ``task_ids: [taskId]`` (no ``map_index``).
- Consolidation of the former ``ClearTaskInstance`` / ``ClearAllMappedTaskInstances`` dialogs into a single ``ClearTaskInstanceDialog`` with an ``allMapped`` mode.

https://github.com/user-attachments/assets/339ed834-36d0-4e60-976e-f402b3b8282b


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)