### PR TITLE
Small param rename in BaseExecutor and CeleryExecutor

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -295,7 +295,7 @@ class BaseExecutor(LoggingMixin):
 
         return workloads_to_schedule
 
-    def _process_workloads(self, workloads: Sequence[ExecutorWorkload]) -> None:
+    def _process_workloads(self, workload_items: Sequence[ExecutorWorkload]) -> None:
         """
         Process the given workloads.
 
@@ -303,7 +303,7 @@ class BaseExecutor(LoggingMixin):
         the execution of workloads (e.g., queuing them to workers, submitting to
         external systems, etc.).
 
-        :param workloads: List of workloads to process
+        :param workload_items: List of workloads to process
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _process_workloads()")
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -173,7 +173,7 @@ class CeleryExecutor(BaseExecutor):
 
         self._send_workloads(task_tuples_to_send)
 
-    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
+    def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         # Airflow V3 version -- have to delay imports until we know we are on v3.
         from airflow.executors.workloads import ExecuteTask
 
@@ -181,7 +181,7 @@ class CeleryExecutor(BaseExecutor):
             from airflow.executors.workloads import ExecuteCallback
 
         workloads_to_be_sent: list[WorkloadInCelery] = []
-        for workload in workloads:
+        for workload in workload_items:
             if isinstance(workload, ExecuteTask):
                 workloads_to_be_sent.append((workload.ti.key, workload, workload.ti.queue, self.team_name))
             elif AIRFLOW_V_3_2_PLUS and isinstance(workload, ExecuteCallback):


### PR DESCRIPTION
Most/all of the executors which implemented this needed to import `from airflow.executors import workloads` which was causing name shadowing and they were working around it bu doing `from airflow.executors import workloads as ws` instead.  It's cleaner and easier to rename the param in a smarter way.

Related to:

 https://github.com/apache/airflow/pull/62984#discussion_r3114021206
https://github.com/apache/airflow/pull/63657
https://github.com/apache/airflow/pull/63498
https://github.com/apache/airflow/pull/63454
https://github.com/apache/airflow/pull/63035
https://github.com/apache/airflow/pull/63888

Part of: https://github.com/apache/airflow/issues/62887

cc: @dondaum 