### PR TITLE
Breeze: Include new providers in testing issue

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -2457,13 +2457,14 @@ def get_suffix_from_package_in_dist(dist_files: list[str], package: str) -> str 
     return None
 
 
-def get_prs_for_package(provider_id: str) -> list[int]:
+def get_prs_for_package(provider_id: str, current_release_version: str | None = None) -> list[int]:
     pr_matcher = re.compile(r".*\(#([0-9]*)\)``$")
     prs = []
-    provider_yaml_dict = get_provider_distributions_metadata().get(provider_id)
-    if not provider_yaml_dict:
-        raise RuntimeError(f"The provider id {provider_id} does not have provider.yaml file")
-    current_release_version = provider_yaml_dict["versions"][0]
+    if current_release_version is None:
+        provider_yaml_dict = get_provider_distributions_metadata().get(provider_id)
+        if not provider_yaml_dict:
+            raise RuntimeError(f"The provider id {provider_id} does not have provider.yaml file")
+        current_release_version = provider_yaml_dict["versions"][0]
     provider_details = get_provider_details(provider_id)
     changelog_lines = provider_details.changelog_path.read_text().splitlines()
     extract_prs = False
@@ -2486,6 +2487,25 @@ def get_prs_for_package(provider_id: str) -> list[int]:
             if match_result:
                 prs.append(int(match_result.group(1)))
     return prs
+
+
+def _is_initial_provider_release(provider_yaml_dict: dict[str, Any] | None) -> bool:
+    """Return True when metadata indicates this is the provider's first release."""
+    if not provider_yaml_dict:
+        return False
+    versions = provider_yaml_dict.get("versions", [])
+    return len(versions) == 1
+
+
+def _should_include_provider_in_issue(
+    provider_yaml_dict: dict[str, Any] | None,
+    prs_for_current_release: list[int],
+    prs_after_exclusions: list[int],
+) -> bool:
+    """Return True when provider should be included in provider testing issue."""
+    return bool(prs_after_exclusions) or (
+        _is_initial_provider_release(provider_yaml_dict) and not prs_for_current_release
+    )
 
 
 def create_github_issue_url(title: str, body: str, labels: Iterable[str]) -> str:
@@ -2595,19 +2615,21 @@ def generate_issue_content_providers(
         version: str
         pr_list: list[PullRequest.PullRequest | Issue.Issue]
         suffix: str
+        is_new: bool
 
     if not provider_distributions:
         provider_distributions = list(get_provider_dependencies().keys())
     with ci_group("Generates GitHub issue content with people who can test it"):
+        provider_distributions_metadata = get_provider_distributions_metadata()
         if excluded_pr_list:
-            excluded_prs = [int(pr) for pr in excluded_pr_list.split(",")]
+            excluded_prs = {int(pr) for pr in excluded_pr_list.split(",")}
         else:
-            excluded_prs = []
+            excluded_prs = set()
         commented_prs = get_commented_out_prs_from_provider_changelogs()
         console_print(
             "[info]Automatically excluding {len(commented_prs)} PRs that are only commented out in changelog:"
         )
-        excluded_prs.extend(commented_prs)
+        excluded_prs.update(commented_prs)
         all_prs: set[int] = set()
         all_retrieved_prs: set[int] = set()
         provider_prs: dict[str, list[int]] = {}
@@ -2620,15 +2642,23 @@ def generate_issue_content_providers(
             else:
                 console_print(f"Skipping extracting PRs for provider {provider_id} as it is missing in dist")
                 continue
-            prs = get_prs_for_package(provider_id)
-            if not prs:
+            provider_yaml_dict = provider_distributions_metadata.get(provider_id)
+            if not provider_yaml_dict:
+                raise RuntimeError(f"The provider id {provider_id} does not have provider.yaml file")
+            prs = get_prs_for_package(provider_id, current_release_version=provider_yaml_dict["versions"][0])
+            filtered_prs = [pr for pr in prs if pr not in excluded_prs]
+            if not _should_include_provider_in_issue(provider_yaml_dict, prs, filtered_prs):
                 console_print(
                     f"[warning]Skipping provider {provider_id}. "
-                    "The changelog file doesn't contain any PRs for the release.\n"
+                    "The changelog file does not contain PR references for the release.\n"
                 )
                 continue
+            if not prs and _is_initial_provider_release(provider_yaml_dict):
+                console_print(
+                    f"[info]Including provider {provider_id}: initial release without PR references in changelog."
+                )
             all_prs.update(prs)
-            provider_prs[provider_id] = [pr for pr in prs if pr not in excluded_prs]
+            provider_prs[provider_id] = filtered_prs
             all_retrieved_prs.update(provider_prs[provider_id])
         if not github_token:
             # Get GitHub token from gh CLI and set it in environment copy
@@ -2651,8 +2681,8 @@ def generate_issue_content_providers(
             f"Retrieving {all_retrieved_prs_len} (excluded {all_prs_len - all_retrieved_prs_len})"
         )
         console_print(f"Retrieved PRs: {all_retrieved_prs}")
-        excluded_prs = sorted(set(all_prs) - set(all_retrieved_prs))
-        console_print(f"Excluded PRs: {excluded_prs}")
+        excluded_prs_for_report = sorted(set(all_prs) - set(all_retrieved_prs))
+        console_print(f"Excluded PRs: {excluded_prs_for_report}")
         with Progress(console=get_console(), disable=disable_progress) as progress:
             task = progress.add_task(f"Retrieving {all_retrieved_prs_len} PRs ", total=all_retrieved_prs_len)
             for pr_number in all_retrieved_prs:
@@ -2701,25 +2731,26 @@ def generate_issue_content_providers(
                                 f"Failed to retrieve linked issue #{linked_issue_number}: Unknown Issue"
                             )
                 progress.advance(task)
-        get_provider_distributions_metadata.cache_clear()
         providers: dict[str, ProviderPRInfo] = {}
         for provider_id in prepared_package_ids:
             if provider_id not in provider_prs:
                 continue
             pull_request_list = [pull_requests[pr] for pr in provider_prs[provider_id] if pr in pull_requests]
-            provider_yaml_dict = get_provider_distributions_metadata().get(provider_id)
-            if pull_request_list:
-                if only_available_in_dist:
-                    package_suffix = get_suffix_from_package_in_dist(files_in_dist, provider_id)
-                else:
-                    package_suffix = ""
-                providers[provider_id] = ProviderPRInfo(
-                    version=provider_yaml_dict["versions"][0],
-                    provider_id=provider_id,
-                    pypi_package_name=provider_yaml_dict["package-name"],
-                    pr_list=pull_request_list,
-                    suffix=package_suffix if package_suffix else "",
-                )
+            provider_yaml_dict = provider_distributions_metadata.get(provider_id)
+            if not provider_yaml_dict:
+                continue
+            if only_available_in_dist:
+                package_suffix = get_suffix_from_package_in_dist(files_in_dist, provider_id)
+            else:
+                package_suffix = ""
+            providers[provider_id] = ProviderPRInfo(
+                version=provider_yaml_dict["versions"][0],
+                provider_id=provider_id,
+                pypi_package_name=provider_yaml_dict["package-name"],
+                pr_list=pull_request_list,
+                suffix=package_suffix if package_suffix else "",
+                is_new=_is_initial_provider_release(provider_yaml_dict),
+            )
         template = jinja2.Template(
             (Path(__file__).parents[1] / "provider_issue_TEMPLATE.md.jinja2").read_text()
         )

--- a/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
+++ b/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
@@ -11,6 +11,8 @@ These are providers that require testing as there were some substantial changes 
 
 {% for provider_id, provider_info in providers.items()  %}
 ## Provider [{{ provider_id }}: {{ provider_info.version }}{{ provider_info.suffix }}](https://pypi.org/project/{{ provider_info.pypi_package_name }}/{{ provider_info.version }}{{ provider_info.suffix }})
+{%- if provider_info.is_new %} **:tada: New provider**{%- endif %}
+{%- if provider_info.pr_list %}
 {%- for pr in provider_info.pr_list %}
    - [ ] [{{ pr.title }} (#{{ pr.number }})]({{ pr.html_url }}): @{{ pr.user.login }}
    {%- if pr.number in linked_issues %}
@@ -20,6 +22,9 @@ These are providers that require testing as there were some substantial changes 
      {%- endfor %}
    {%- endif %}
 {%- endfor %}
+{%- else %}
+   - [ ] Initial release does not list PR references in changelog. Please run smoke tests.
+{%- endif %}
 {%- endfor %}
 
 <!--

--- a/dev/breeze/tests/test_provider_issue_template.py
+++ b/dev/breeze/tests/test_provider_issue_template.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Template
+
+TEMPLATE_PATH = Path(__file__).parents[1] / "src" / "airflow_breeze" / "provider_issue_TEMPLATE.md.jinja2"
+
+
+@pytest.mark.parametrize(("is_new", "has_marker"), [(True, True), (False, False)])
+def test_provider_issue_template_marks_new_provider(is_new: bool, has_marker: bool):
+    provider_info = SimpleNamespace(
+        version="0.1.0",
+        suffix="",
+        pypi_package_name="apache-airflow-providers-vespa",
+        pr_list=[],
+        is_new=is_new,
+    )
+    template = Template(TEMPLATE_PATH.read_text())
+
+    rendered = template.render(
+        providers={"vespa": provider_info},
+        linked_issues={},
+        date="2026-04-24",
+    )
+
+    assert (":tada: New provider" in rendered) is has_marker

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow_breeze.commands.release_management_commands import (
+    _is_initial_provider_release,
+    _should_include_provider_in_issue,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider_yaml_dict", "expected"),
+    [
+        ({"versions": ["0.1.0"]}, True),
+        ({"versions": ["2.1.0", "2.0.0"]}, False),
+        ({"versions": []}, False),
+        (None, False),
+    ],
+)
+def test_is_initial_provider_release(provider_yaml_dict: dict | None, expected: bool):
+    assert _is_initial_provider_release(provider_yaml_dict) is expected
+
+
+@pytest.mark.parametrize(
+    ("provider_yaml_dict", "prs_for_current_release", "prs_after_exclusions", "expected"),
+    [
+        ({"versions": ["0.1.0"]}, [12345], [12345], True),
+        ({"versions": ["0.1.0"]}, [], [], True),
+        ({"versions": ["0.2.0", "0.1.0"]}, [], [], False),
+        ({"versions": ["0.1.0"]}, [12345], [], False),
+    ],
+)
+def test_should_include_provider_in_issue(
+    provider_yaml_dict: dict | None,
+    prs_for_current_release: list[int],
+    prs_after_exclusions: list[int],
+    expected: bool,
+):
+    assert (
+        _should_include_provider_in_issue(
+            provider_yaml_dict=provider_yaml_dict,
+            prs_for_current_release=prs_for_current_release,
+            prs_after_exclusions=prs_after_exclusions,
+        )
+        is expected
+    )


### PR DESCRIPTION
Include newly introduced providers (for example initial 0.1.0 releases) in the
provider testing-status issue even when the changelog section has no PR references.

Also mark those providers in the issue output as ":tada: New provider", for example:
<img width="1131" height="183" alt="image" src="https://github.com/user-attachments/assets/ea28b7e5-87ab-4345-8ab2-33c27eb6f2ed" />


Validation performed:
- `prek run --from-ref main --stage pre-commit`
- `prek run --from-ref main --stage manual`
- `uv run --project dev/breeze pytest dev/breeze/tests/test_release_management_commands.py dev/breeze/tests/test_provider_issue_template.py -xvs`
- `breeze ci selective-check --commit-ref f8e72790c0`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (GPT-5.3-Codex)

Generated-by: GitHub Copilot (GPT-5.3-Codex) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)