### PR TITLE
Helm release docs: add Breeze + KinD verification path

### DIFF
--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -39,6 +39,7 @@
   - [Signature check](#signature-check)
   - [SHA512 sum check](#sha512-sum-check)
 - [Verify the release candidates by Contributors](#verify-the-release-candidates-by-contributors)
+  - [End-to-end verification with Breeze and KinD](#end-to-end-verification-with-breeze-and-kind)
 - [Publish the final release](#publish-the-final-release)
   - [Summarize the voting for the release](#summarize-the-voting-for-the-release)
   - [Publish release to SVN](#publish-release-to-svn)
@@ -757,7 +758,9 @@ Checking airflow-chart-1.0.0-source.tar.gz.sha512
 
 # Verify the release candidates by Contributors
 
-Contributors can run below commands to test the Helm Chart
+Contributors can run below commands to test the Helm Chart against any
+Kubernetes cluster they already have configured. Replace the version
+with the one being voted on:
 
 ```shell
 helm repo add apache-airflow-dev https://dist.apache.org/repos/dist/dev/airflow/helm-chart/1.1.0rc1/
@@ -767,6 +770,90 @@ helm install airflow apache-airflow-dev/airflow
 
 You can then perform any other verifications to check that it works as you expected by
 upgrading the Chart or installing by overriding default of `values.yaml`.
+
+## End-to-end verification with Breeze and KinD
+
+If you don't already have a Kubernetes cluster handy, the `breeze k8s`
+commands give you a clean room: a fresh KinD cluster plus the chart
+deployed from your local checkout. This runs the same chart files that
+were packaged into the RC tarball, so it doubles as a chart-content
+sanity check.
+
+1. Check out the RC tag so the local `chart/` directory is the candidate
+   under vote:
+
+   ```shell
+   git checkout helm-chart/${VERSION_RC}
+   ```
+
+2. Create the cluster, configure namespaces, build a k8s-ready airflow
+   image, and load it into KinD. On main these are bundled into a single
+   `breeze k8s deploy-cluster` (which also installs the shared k8s
+   tooling — kind, kubectl, helm — into Breeze's pinned virtualenv,
+   i.e. it includes the work `breeze k8s setup-env` would do); on older
+   tags, run `setup-env` plus the constituent commands in sequence:
+
+   ```shell
+   breeze k8s deploy-cluster --rebuild-base-image                  # main
+   # or, on older tags:
+   breeze k8s setup-env
+   breeze k8s create-cluster
+   breeze k8s configure-cluster
+   breeze k8s build-k8s-image --rebuild-base-image
+   breeze k8s upload-k8s-image
+   ```
+
+3. Helm-install the chart into the cluster:
+
+   ```shell
+   breeze k8s deploy-airflow
+   ```
+
+   The command prints the forwarded `localhost:<port>` URL of the
+   airflow API server (default credentials `admin` / `admin`).
+
+4. Confirm the deployment is healthy:
+
+   ```shell
+   breeze k8s status                            # cluster + connection
+   curl -s http://localhost:<port>/api/v2/monitor/health
+   curl -s http://localhost:<port>/api/v2/version
+   ```
+
+   You want all four `metadatabase`, `scheduler`, `triggerer`,
+   `dag_processor` health entries to be `healthy`, and the version
+   endpoint to report the airflow version pinned by the chart's
+   `values.yaml`.
+
+5. Open the forwarded URL in your browser and poke around the UI —
+   automated health checks pass even when the UI assets fail to load
+   or auth is broken, so a human eyeball over the running deployment
+   is worth the 30 seconds. The URL `breeze k8s deploy-airflow`
+   printed in step 3 (`http://localhost:<port>`) lands on the login
+   page; sign in with `admin` / `admin`. Suggested manual sanity
+   checks:
+
+   - the login page renders (UI assets served correctly);
+   - after login, the Dags list loads and shows the example Dags
+     bundled with the image;
+   - open one example Dag, trigger a run, and watch a task instance
+     reach `success` (exercises scheduler → triggerer → executor and
+     log retrieval end-to-end);
+   - the `Admin → Connections` and `Admin → Variables` pages render
+     without backend errors.
+
+   If the forwarded port has been reclaimed (e.g. you re-ran the
+   deploy or your shell rotated), `breeze k8s status` re-prints the
+   current URL.
+
+6. Tear down the cluster when you're done:
+
+   ```shell
+   breeze k8s delete-cluster
+   ```
+
+Switch back to your working branch (`git checkout <branch>`) before
+running any other release-prep commands.
 
 # Publish the final release
 

--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -799,6 +799,7 @@ sanity check.
    breeze k8s setup-env
    breeze k8s create-cluster
    breeze k8s configure-cluster
+   breeze ui compile-assets  # ensures the UI is built so the API server can serve index.html
    breeze k8s build-k8s-image --rebuild-base-image
    breeze k8s upload-k8s-image
    ```


### PR DESCRIPTION
The contributor verification section in
``dev/README_RELEASE_HELM_CHART.md`` currently only shows
``helm install`` against an existing cluster. Add an end-to-end
recipe that uses the ``breeze k8s`` commands to spin up a fresh
KinD cluster from scratch, build a k8s-ready airflow image,
load it into the cluster, and helm-install the chart from the
RC tag.

Useful when the verifier doesn't already have a Kubernetes
cluster handy — and doubles as a chart-content sanity check
because it deploys the same chart files that were packaged into
the RC tarball. Documents both the ``deploy-cluster`` aggregate
(on main) and the constituent ``create-cluster`` /
``configure-cluster`` / ``build-k8s-image`` / ``upload-k8s-image``
sequence (on older tags), plus the ``status`` /
``api/v2/monitor/health`` smoke checks and the
``delete-cluster`` teardown.

Verified against helm-chart/1.21.0rc2 — all airflow pods reached
Running, all four health entries (metadatabase, scheduler,
triggerer, dag_processor) reported healthy, and the version
endpoint returned the airflow image pinned by the chart.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)