### PR TITLE
Add multi-team dimensions to boto3 user agent string

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -605,12 +605,25 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
         return airflow_version
 
+    @staticmethod
+    def _is_multi_team() -> bool:
+        """Return True if the current task is running under multi-team Airflow."""
+        return bool(os.environ.get("AIRFLOW_CTX_TEAM_NAME"))
+
+    @staticmethod
+    @return_on_error("00000000-0000-0000-0000-000000000000")
+    def _generate_team_name_key() -> str:
+        """Generate a hashed key from the team name, using the same approach as :meth:`_generate_dag_key`."""
+        return generate_uuid(os.environ.get("AIRFLOW_CTX_TEAM_NAME"))
+
     def _generate_user_agent_extra_field(self, existing_user_agent_extra: str) -> str:
         user_agent_extra_values = [
             f"Airflow/{self._get_airflow_version()}",
             f"AmPP/{self._get_provider_version()}",
             f"Caller/{self._get_caller()}",
             f"DagRunKey/{self._generate_dag_key()}",
+            f"MultiTeam/{self._is_multi_team()}",
+            f"TeamNameKey/{self._generate_team_name_key()}",
             existing_user_agent_extra or "",
         ]
         return " ".join(user_agent_extra_values).strip()

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_base_aws.py
@@ -406,7 +406,7 @@ class TestAwsBaseHook:
         """
         client_meta = AwsBaseHook(aws_conn_id=None, client_type="s3").conn_client_meta
 
-        expected_user_agent_tag_keys = ["Airflow", "AmPP", "Caller", "DagRunKey"]
+        expected_user_agent_tag_keys = ["Airflow", "AmPP", "Caller", "DagRunKey", "MultiTeam", "TeamNameKey"]
 
         result_user_agent_tags = client_meta.config.user_agent.split(" ")
         result_user_agent_tag_keys = [tag.split("/")[0].lower() for tag in result_user_agent_tags]
@@ -472,6 +472,29 @@ class TestAwsBaseHook:
             dag_run_key = self.fetch_tags()["DagRunKey"]
 
             assert UUID(dag_run_key).version == expected_version
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected"),
+        [
+            pytest.param({"AIRFLOW_CTX_TEAM_NAME": "my-team"}, "True", id="multi-team-enabled"),
+            pytest.param({}, "False", id="multi-team-disabled"),
+        ],
+    )
+    def test_user_agent_multi_team(self, env_var, expected):
+        with mock.patch.dict(os.environ, env_var, clear=True):
+            assert AwsBaseHook._is_multi_team() == (expected == "True")
+
+    @pytest.mark.parametrize(
+        ("env_var", "expected_version"),
+        [
+            pytest.param({"AIRFLOW_CTX_TEAM_NAME": "my-team"}, 5, id="team-set"),
+            pytest.param({}, None, id="team-not-set"),
+        ],
+    )
+    def test_user_agent_team_name_key_is_hashed_correctly(self, env_var, expected_version):
+        with mock.patch.dict(os.environ, env_var, clear=True):
+            team_name_key = AwsBaseHook._generate_team_name_key()
+            assert UUID(team_name_key).version == expected_version
 
     @pytest.mark.parametrize(
         "sts_endpoint",


### PR DESCRIPTION
Add MultiTeam and TeamNameKey dimensions to the user agent extra field in AwsBaseHook. MultiTeam indicates whether the task is running under multi-team Airflow (True/False). TeamNameKey is a SHA-1 hashed UUID of the team name, following the same privacy-preserving pattern as DagRunKey. Both are derived from the AIRFLOW_CTX_TEAM_NAME environment variable propagated by the execution API.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
