### PR TITLE
Fix FAB mysql migration error caused by pre defiend fk name in orm create

### DIFF
--- a/providers/fab/src/airflow/providers/fab/migrations/versions/0001_3_5_0_fix_fab_db_inconsistencies.py
+++ b/providers/fab/src/airflow/providers/fab/migrations/versions/0001_3_5_0_fix_fab_db_inconsistencies.py
@@ -181,6 +181,15 @@ def _drop_unique_constraint_if_exists(table_name: str, constraint_name: str) -> 
                 batch_op.drop_constraint(constraint_name, type_="unique")
 
 
+def _resolve_fk_name(bind, table_name: str, column_name: str, default: str) -> str:
+    if bind is None:
+        return default
+    for fk in sa.inspect(bind).get_foreign_keys(table_name):
+        if fk["constrained_columns"] == [column_name]:
+            return fk["name"] or default
+    return default
+
+
 def _drop_index_if_exists(table_name: str, index_name: str) -> None:
     dialect_name = op.get_context().dialect.name
 
@@ -247,13 +256,20 @@ def upgrade() -> None:
         op.execute(sa.text(_mysql_create_idx_permission_view_id_if_not_exists()))
         op.execute(sa.text(_mysql_create_idx_role_id_if_not_exists()))
 
+    pvr_role_fk = _resolve_fk_name(
+        bind, "ab_permission_view_role", "role_id", "ab_permission_view_role_role_id_fkey"
+    )
+    pvr_view_fk = _resolve_fk_name(
+        bind,
+        "ab_permission_view_role",
+        "permission_view_id",
+        "ab_permission_view_role_permission_view_id_fkey",
+    )
     with op.batch_alter_table(
         "ab_permission_view_role", schema=None, naming_convention=_naming_convention
     ) as batch_op:
-        batch_op.drop_constraint(batch_op.f("ab_permission_view_role_role_id_fkey"), type_="foreignkey")
-        batch_op.drop_constraint(
-            batch_op.f("ab_permission_view_role_permission_view_id_fkey"), type_="foreignkey"
-        )
+        batch_op.drop_constraint(pvr_role_fk, type_="foreignkey")
+        batch_op.drop_constraint(pvr_view_fk, type_="foreignkey")
         batch_op.create_foreign_key(
             batch_op.f("ab_permission_view_role_permission_view_id_fkey"),
             "ab_permission_view",
@@ -285,9 +301,11 @@ def upgrade() -> None:
     with op.batch_alter_table("ab_register_user", schema=None) as batch_op:
         batch_op.create_unique_constraint(batch_op.f("ab_register_user_email_uq"), ["email"])
 
+    user_role_fk = _resolve_fk_name(bind, "ab_user_role", "role_id", "ab_user_role_role_id_fkey")
+    user_user_fk = _resolve_fk_name(bind, "ab_user_role", "user_id", "ab_user_role_user_id_fkey")
     with op.batch_alter_table("ab_user_role", schema=None, naming_convention=_naming_convention) as batch_op:
-        batch_op.drop_constraint(batch_op.f("ab_user_role_role_id_fkey"), type_="foreignkey")
-        batch_op.drop_constraint(batch_op.f("ab_user_role_user_id_fkey"), type_="foreignkey")
+        batch_op.drop_constraint(user_role_fk, type_="foreignkey")
+        batch_op.drop_constraint(user_user_fk, type_="foreignkey")
         batch_op.create_foreign_key(
             batch_op.f("ab_user_role_role_id_fkey"), "ab_role", ["role_id"], ["id"], ondelete="CASCADE"
         )

--- a/providers/fab/tests/unit/fab/auth_manager/models/test_db.py
+++ b/providers/fab/tests/unit/fab/auth_manager/models/test_db.py
@@ -194,5 +194,64 @@ try:
                 if original_revision and current_revision != original_revision:
                     manager.upgradedb(to_revision=original_revision)
 
+        @pytest.mark.backend("mysql")
+        def test_upgradedb_mysql_succeeds_with_implicit_fk_names(self, session):
+            # Legacy MySQL DBs carry FKs auto-named like ``<table>_ibfk_N`` rather than the
+            # naming-convention names ``batch_op.f()`` produces. The upgrade must resolve the
+            # live FK names via introspection so the drops issue the correct identifiers.
+            manager = FABDBManager(session=session)
+            original_revision = manager.get_current_revision()
+
+            try:
+                manager.downgrade(to_revision="6709f7a774b9")
+
+                replacements = {
+                    "ab_permission_view_role": [
+                        ("permission_view_id", "ab_permission_view", "id"),
+                        ("role_id", "ab_role", "id"),
+                    ],
+                    "ab_user_role": [
+                        ("user_id", "ab_user", "id"),
+                        ("role_id", "ab_role", "id"),
+                    ],
+                }
+                with engine.begin() as conn:
+                    for table_name, fks in replacements.items():
+                        for fk in sa.inspect(conn).get_foreign_keys(table_name):
+                            if fk["name"]:
+                                conn.execute(
+                                    sa.text(f"ALTER TABLE `{table_name}` DROP FOREIGN KEY `{fk['name']}`")
+                                )
+                        for column, ref_table, ref_column in fks:
+                            conn.execute(
+                                sa.text(
+                                    f"ALTER TABLE `{table_name}` "
+                                    f"ADD FOREIGN KEY (`{column}`) "
+                                    f"REFERENCES `{ref_table}` (`{ref_column}`) ON DELETE CASCADE"
+                                )
+                            )
+
+                implicit_fk_names = {
+                    fk["name"] for fk in sa.inspect(engine).get_foreign_keys("ab_permission_view_role")
+                }
+                assert any(name and "_ibfk_" in name for name in implicit_fk_names)
+
+                manager.upgradedb(to_revision="02ca36b0235b")
+
+                pvr_fk_names = {
+                    fk["name"] for fk in sa.inspect(engine).get_foreign_keys("ab_permission_view_role")
+                }
+                user_role_fk_names = {
+                    fk["name"] for fk in sa.inspect(engine).get_foreign_keys("ab_user_role")
+                }
+                assert "ab_permission_view_role_role_id_fkey" in pvr_fk_names
+                assert "ab_permission_view_role_permission_view_id_fkey" in pvr_fk_names
+                assert "ab_user_role_role_id_fkey" in user_role_fk_names
+                assert "ab_user_role_user_id_fkey" in user_role_fk_names
+            finally:
+                current_revision = manager.get_current_revision()
+                if original_revision and current_revision != original_revision:
+                    manager.upgradedb(to_revision=original_revision)
+
 except ModuleNotFoundError:
     pass


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/65402

Before applied (https://github.com/apache/airflow/pull/62308), the [naming_convention](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/base.py#L32) was not applied to FAB, and foreign key names were instead generated by MySQL's default naming convention. (e.g. `ab_permission_view_role_ibfk_1`

<img width="662" height="338" alt="image" src="https://github.com/user-attachments/assets/0874c973-32e1-4adf-8624-46ae8e357857" />


As a result, running this migration on environments that were initialized prior to that PR fails with the above error. 
```
sqlalchemy.exc.OperationalError: (MySQLdb.OperationalError) (1091, "Can't DROP 'ab_permission_view_role_role_id_fkey'; check that column/key exists")
[SQL: ALTER TABLE ab_permission_view_role DROP FOREIGN KEY ab_permission_view_role_role_id_fkey]
```
This commit fixes the issue.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
