### PR TITLE
Fix Edge worker reporting crashed tasks as SUCCESS

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -291,7 +291,7 @@ class EdgeWorker:
         except Exception as e:
             logger.exception("Task execution failed")
             results_queue.put(e)
-            return 1
+            sys.exit(1)
 
     def _launch_job(self, workload: ExecuteTask) -> tuple[Process, Queue[Exception]]:
         # Improvement: Use frozen GC to prevent child process from copying unnecessary memory

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -231,9 +231,10 @@ class TestEdgeWorker:
         mock_supervise.side_effect = Exception("Supervise failed")
         edge_job = worker_with_job.jobs.pop().edge_job
         q = mock.MagicMock()
-        result = worker_with_job._run_job_via_supervisor(edge_job.command, q)
+        with pytest.raises(SystemExit) as exc_info:
+            worker_with_job._run_job_via_supervisor(edge_job.command, q)
 
-        assert result == 1
+        assert exc_info.value.code == 1
         q.put.assert_called_once()
 
     @patch("airflow.providers.edge3.cli.worker.jobs_fetch")


### PR DESCRIPTION
  _run_job_via_supervisor returned 1 on caught exception, but
  multiprocessing.Process ignores the target's return value — exit code
  was always 0, so Job.is_success was True and crashed tasks were
  reported to the central server as SUCCESS despite the Task execution
  failed traceback in the log. Use sys.exit(1) so the subprocess exits
  with code 1 and fetch_and_run_job takes the FAILED branch.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode Opus 4.7
