### PR TITLE
Fix Celery worker test mocking real broker after hostname-check refactor

### DIFF
--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -139,11 +139,15 @@ class TestWorkerStart:
             importlib.reload(cli_parser)
             cls.parser = cli_parser.get_parser()
 
+    @mock.patch("airflow.providers.celery.cli.celery_command.kombu.pools.reset")
+    @mock.patch("airflow.providers.celery.cli.celery_command.Celery")
     @mock.patch("airflow.providers.celery.cli.celery_command.setup_locations")
     @mock.patch("airflow.providers.celery.cli.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @conf_vars({("celery", "pool"): "prefork"})
-    def test_worker_started_with_required_arguments(self, mock_celery_app, mock_popen, mock_locations):
+    def test_worker_started_with_required_arguments(
+        self, mock_celery_app, mock_popen, mock_locations, mock_celery_cls, mock_pools_reset
+    ):
         pid_file = "pid_file"
         mock_locations.return_value = (pid_file, None, None, None)
         concurrency = "1"


### PR DESCRIPTION
After #65826, the duplicate-hostname check in `celery_command.worker()` runs on a fresh `Celery()` app rather than on the executor's module-level app. The PR updated the two `TestWorkerDuplicateHostnameCheck` tests to patch `airflow.providers.celery.cli.celery_command.Celery`, but missed `TestWorkerStart::test_worker_started_with_required_arguments`, which also passes `--celery-hostname` and therefore now hits the same code path.

Without the patch, the test instantiates a real Celery client and `temp_app.control.inspect().active_queues()` tries to open a broker connection, failing in CI with:

```
kombu.exceptions.OperationalError: [Errno 111] Connection refused
```

Mock `Celery` (and `kombu.pools.reset` for symmetry with the sibling tests) so the test no longer touches a real broker.

Example failure: https://github.com/apache/airflow/actions/runs/24934454291/job/73018112670

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)