### PR TITLE
Fix celery version compat logic after PR 62645

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -223,16 +223,15 @@ def execute_workload(input: str) -> None:
     try:
         BaseExecutor.run_workload(workload)
     except Exception as e:
-        if AIRFLOW_V_3_1_9_PLUS:
-            from airflow.sdk.exceptions import TaskAlreadyRunningError
+        from airflow.sdk.exceptions import TaskAlreadyRunningError
 
-            if isinstance(e, TaskAlreadyRunningError):
-                log.info("[%s] Task already running elsewhere, ignoring redelivered message", celery_task_id)
-                # Raise Ignore() so Celery does not record a FAILURE result for this duplicate
-                # delivery. Without this, the broker redelivering the message (e.g. after a
-                # visibility timeout) would cause Celery to mark the task as failed, even though
-                # the original worker is still executing it successfully.
-                raise Ignore()
+        if isinstance(e, TaskAlreadyRunningError):
+            log.info("[%s] Task already running elsewhere, ignoring redelivered message", celery_task_id)
+            # Raise Ignore() so Celery does not record a FAILURE result for this duplicate
+            # delivery. Without this, the broker redelivering the message (e.g. after a
+            # visibility timeout) would cause Celery to mark the task as failed, even though
+            # the original worker is still executing it successfully.
+            raise Ignore()
         raise
 
 


### PR DESCRIPTION
Noticed that after #62645 the logic in Celery had been changed and branched depending on Airflow 3.3.0 or earlier.

But follow-up logic was copied to handle `TaskAlreadyRunningError` - in the branch for Airflow 3.3.0 there was due to copy&paste a un-needed check for Airflow 3.1.9 added. Can not be below 3.1.9 if Airflow is larger than 3.3.0 checked before.

Cleanup the not needed condition.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
