### PR TITLE
[v3-2-test] update Dag Runs document under Core Concept to make it consistent with BashOperator document (#64129)

### DIFF
--- a/airflow-core/docs/core-concepts/dag-run.rst
+++ b/airflow-core/docs/core-concepts/dag-run.rst
@@ -271,7 +271,8 @@ Example of a parameterized Dag:
 
     parameterized_task = BashOperator(
         task_id="parameterized_task",
-        bash_command="echo value: {{ dag_run.conf['conf1'] }}",
+        bash_command="echo \"here is the message: '$message'\"",
+        env={"message": '{{ dag_run.conf["message"] if dag_run else "" }}'},
         dag=dag,
     )
 


### PR DESCRIPTION
Backport of #64129 to `v3-2-test` so the corrected Dag-runs documentation example ships in Airflow 3.2.2 as well as on `main`.

The cherry-pick applied cleanly — 1 file, 2 insertions, 1 deletion (docs only, `airflow-core/docs/core-concepts/dag-run.rst`).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions