### PR TITLE
Allow Worker Log Groomer Sidecar Without Persistence

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -348,7 +348,7 @@ spec:
         {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) }}
           {{- include "git_sync_container" . | nindent 8 }}
         {{- end }}
-        {{- if and $persistence .Values.workers.logGroomerSidecar.enabled }}
+        {{- if .Values.workers.logGroomerSidecar.enabled }}
         - name: worker-log-groomer
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2352,6 +2352,60 @@ class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
     obj_name = "workers-celery"
     folder = "workers"
 
+    @pytest.mark.parametrize(
+        ("persistence_enabled", "log_groomer_enabled", "expect_log_groomer"),
+        [
+            # persistence default (true) + logGroomer default (true) -> renders
+            (None, None, True),
+            # persistence default (true) + logGroomer false -> no render
+            (None, False, False),
+            # persistence true + logGroomer default (true) -> renders
+            (True, None, True),
+            # persistence true + logGroomer true -> renders
+            (True, True, True),
+            # persistence true + logGroomer false -> no render
+            (True, False, False),
+            # persistence false + logGroomer default (true) -> renders
+            (False, None, True),
+            # persistence false + logGroomer true -> renders
+            (False, True, True),
+            # persistence false + logGroomer false -> no render
+            (False, False, False),
+        ],
+    )
+    def test_log_groomer_with_persistence_combinations(
+        self, persistence_enabled, log_groomer_enabled, expect_log_groomer
+    ):
+        """Test log groomer sidecar rendering with various persistence and enabled combinations."""
+        celery_values = {}
+        if persistence_enabled is not None:
+            celery_values["persistence"] = {"enabled": persistence_enabled}
+        if log_groomer_enabled is not None:
+            celery_values["logGroomerSidecar"] = {"enabled": log_groomer_enabled}
+
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {"celery": celery_values} if celery_values else {},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        # Verify resource kind based on persistence
+        expected_kind = "StatefulSet" if persistence_enabled is not False else "Deployment"
+        assert jmespath.search("kind", docs[0]) == expected_kind
+
+        # Verify log groomer presence
+        containers = jmespath.search("spec.template.spec.containers", docs[0])
+        container_names = [c["name"] for c in containers]
+
+        if expect_log_groomer:
+            assert "worker-log-groomer" in container_names
+            assert len(containers) == 2
+        else:
+            assert "worker-log-groomer" not in container_names
+            assert len(containers) == 1
+
 
 class TestWorkerKedaAutoScaler:
     """Tests worker keda auto scaler."""


### PR DESCRIPTION
# Context

Previously, the worker log groomer sidecar only rendered when `workers.persistence.enabled` was `true` (i.e., StatefulSet mode). This prevented using the log groomer on `Deployments` with `emptyDir` volumes for logs.

This change removes the persistence requirement from the log groomer condition. Now the log groomer renders whenever `logGroomerSidecar.enabled` is `true`, regardless of the persistence setting.

This is useful for deployments that:
- Use emptyDir for local logs with remote logging (S3, GCS, etc.)
- Want to clean up local log files to prevent ephemeral storage exhaustion
- Prefer Deployments over StatefulSets for workers

Users who don't want the log groomer can disable it by setting `workers.logGroomerSidecar.enabled: false`.

# Backward Compatibility

This change may add a new sidecar container to existing worker Deployments. Specifically:

  | `persistence.enabled` | `logGroomerSidecar.enabled` | Before | After |
  |-----------------------|----------------------------|--------|-------|
  | (default: `true`) | (default: `true`) | Log groomer renders | No change |
  | (default: `true`) | `false` | No log groomer | No change |
  | `true` | (default: `true`) | Log groomer renders | No change |
  | `true` | `true` | Log groomer renders | No change |
  | `true` | `false` | No log groomer | No change |
  | `false` | (default: `true`) | **No log groomer** | **Log groomer now renders** ⚠️ |
  | `false` | `true` | **No log groomer** | **Log groomer now renders** ⚠️ |
  | `false` | `false` | No log groomer | No change |

  **Impact:** Users with `persistence.enabled: false` who left `logGroomerSidecar.enabled` or the
  default (`true`) will now get the log groomer sidecar. This will cause worker pods to be recreated on
  upgrade.

  **Mitigation:** Users who don't want the log groomer can explicitly set
  `workers.logGroomerSidecar.enabled: false`.

  **Rationale:** 
* This is much cleaner solution (without introducing a new argument, etc.).
* The log groomer being silently disabled when persistence is off could be considered a
  bug—users who enable the log groomer expect it to run. The sidecar is lightweight and helps prevent
  ephemeral storage exhaustion.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
