### PR TITLE
Move jaeger CI host ports below ephemeral range to fix flake

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -173,7 +173,7 @@ class TestOtelIntegration:
     - start breeze with '--integration otel'
     - run on the shell 'export use_otel=true'
     - run the test
-    - check 'http://localhost:36686/'
+    - check 'http://localhost:26686/'
 
     To get a db dump on the stdout, run 'export log_level=debug'.
     """

--- a/scripts/ci/docker-compose/integration-otel.yml
+++ b/scripts/ci/docker-compose/integration-otel.yml
@@ -59,11 +59,15 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: true
       COLLLECTOR_ZIPKIN_HOST_PORT: 9411
+    # Host ports are intentionally below 32768 to stay outside Linux's default
+    # ephemeral port range (32768-60999). Picking high ports inside that range
+    # causes intermittent CI failures when the kernel transiently grabs the
+    # same port for an outbound connection from another process on the runner.
     ports:
-      - "36686:16686"
-      - "34317:4317"
-      - "34318:4318"
-      - "39422:9422"
+      - "26686:16686"
+      - "24317:4317"
+      - "27318:4318"
+      - "29422:9422"
 
   airflow:
     environment:


### PR DESCRIPTION
The `Integration core otel` job intermittently fails at docker compose
startup with:

    failed to bind host port for 0.0.0.0:34318:172.18.0.3:4318/tcp:
    address already in use

The four jaeger host ports in `scripts/ci/docker-compose/integration-otel.yml`
(34317, 34318, 36686, 39422) sit inside Linux's default ephemeral port
range (32768-60999). The kernel can transiently grab any of these as
the source port of an outbound TCP connection from another process on
the runner, which races with docker's bind. The existing retry-with-
docker-restart logic doesn't help — the holder is not a docker process.

Move the four jaeger host ports below 32768, matching the convention
already used by the other services in the same compose file (24318,
28889, 29090, 23000). Also updates the matching jaeger-UI URL in the
otel test docstring.

Example failure:
https://github.com/apache/airflow/actions/runs/24954132155/job/73070212907

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)