### PR TITLE
[v3-2-test] Fix boring-cyborg prek hook for dict-form rules

### DIFF
--- a/scripts/ci/prek/boring_cyborg.py
+++ b/scripts/ci/prek/boring_cyborg.py
@@ -46,8 +46,14 @@ if CONFIG_KEY not in cyborg_config:
     raise SystemExit(f"Missing section {CONFIG_KEY}")
 
 errors = []
-# Check if all patterns in the cyborg config are existing in the repository
-for label, patterns in cyborg_config[CONFIG_KEY].items():
+# Each label rule is either a list of glob patterns (legacy form) or an object
+# with `paths` and an optional `targetBranchFilter` (see kaxil/boring-cyborg#112).
+# Only the glob patterns in `paths` need to exist in the repository.
+for label, rule in cyborg_config[CONFIG_KEY].items():
+    if isinstance(rule, dict):
+        patterns = rule.get("paths", [])
+    else:
+        patterns = rule
     for pattern in patterns:
         try:
             next(Path(AIRFLOW_ROOT_PATH).glob(pattern))


### PR DESCRIPTION
## Summary

Backports the prek-script half of #65386 to fix static checks on
v3-2-test, which broke after #65610 was merged here.

The new `backport-to-airflow-ctl-v0-1-test` rule introduced by #65610
uses the `{paths, targetBranchFilter}` object form supported by Boring
Cyborg's upstream (kaxil/boring-cyborg#112). v3-2-test's
`scripts/ci/prek/boring_cyborg.py` only understood the legacy
list-of-globs form, so it flagged `paths` and `targetBranchFilter` as
unused glob patterns and failed the `check-boring-cyborg-configuration`
hook on every push to v3-2-test.

The `.github/boring-cyborg.yml` half of #65386 is intentionally not
backported: it converts the `backport-to-v3-2-test` rule (which lives
on main) — that rule has no analogue here. The existing
`backport-to-v3-1-test` rule on this branch continues to use the
legacy list form and remains valid.

## Test plan

- [x] `prek run check-boring-cyborg-configuration --all-files` passes locally
- [ ] CI static checks pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7, 1M context)

Generated-by: Claude Code (Opus 4.7, 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)