### PR TITLE
fix RFC 2047 filename decoding

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -24,6 +24,7 @@ It uses the imaplib library that is already integrated in python 3.
 from __future__ import annotations
 
 import email
+import email.header
 import imaplib
 import os
 import re
@@ -388,6 +389,22 @@ class MailPart:
         """
         return self.part.get_content_maintype() != "multipart" and self.part.get("Content-Disposition")
 
+    @staticmethod
+    def _decode_filename(filename: str | None) -> str | None:
+        """
+        Decode an RFC 2047 MIME-encoded filename into a Unicode string.
+
+        :param filename: The raw filename, possibly RFC 2047 encoded.
+        :returns: The decoded Unicode filename, or None if the input is None.
+        """
+        if filename is None:
+            return None
+        decoded_parts = email.header.decode_header(filename)
+        return "".join(
+            part.decode(encoding or "utf-8") if isinstance(part, bytes) else part
+            for part, encoding in decoded_parts
+        )
+
     def has_matching_name(self, name: str) -> tuple[Any, Any] | None:
         """
         Check if the given name matches the part's name.
@@ -395,7 +412,7 @@ class MailPart:
         :param name: The name to look for.
         :returns: True if it matches the name (including regular expression).
         """
-        return re.match(name, self.part.get_filename())  # type: ignore
+        return re.match(name, self._decode_filename(self.part.get_filename()))  # type: ignore
 
     def has_equal_name(self, name: str) -> bool:
         """
@@ -404,7 +421,7 @@ class MailPart:
         :param name: The name to look for.
         :returns: True if it is equal to the given name.
         """
-        return self.part.get_filename() == name
+        return self._decode_filename(self.part.get_filename()) == name
 
     def get_file(self) -> tuple:
         """
@@ -412,4 +429,4 @@ class MailPart:
 
         :returns: the part's name and payload.
         """
-        return self.part.get_filename(), self.part.get_payload(decode=True)
+        return self._decode_filename(self.part.get_filename()), self.part.get_payload(decode=True)

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -445,6 +445,41 @@ class TestImapHook:
                 )
 
     @patch(imaplib_string)
+    def test_retrieve_mail_attachments_with_rfc2047_encoded_filename(self, mock_imaplib):
+        encoded_name = (
+            "=?UTF-8?B?0J/QtdGA0LXRh9C10L3RjCDRgtC+0YfQtdC6INC/0YDQvtC00LDQtl8yMDI2LTA0LTIxLnhsc3g=?="
+        )
+        decoded_name = "Перечень точек продаж_2026-04-21.xlsx"
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_name)
+
+        with ImapHook() as imap_hook:
+            attachments = imap_hook.retrieve_mail_attachments(name=decoded_name)
+
+        assert len(attachments) == 1
+        assert attachments[0][0] == decoded_name
+
+    @patch(imaplib_string)
+    def test_has_mail_attachment_with_rfc2047_encoded_filename(self, mock_imaplib):
+        encoded_name = "=?UTF-8?B?0YLQtdGB0YIuY3N2?="
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_name)
+
+        with ImapHook() as imap_hook:
+            has_attachment = imap_hook.has_mail_attachment("тест.csv")
+
+        assert has_attachment
+
+    @patch(imaplib_string)
+    def test_retrieve_mail_attachments_with_rfc2047_encoded_filename_regex(self, mock_imaplib):
+        encoded_name = "=?UTF-8?B?0YLQtdGB0YIuY3N2?="
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_name)
+
+        with ImapHook() as imap_hook:
+            attachments = imap_hook.retrieve_mail_attachments(name=r".*\.csv", check_regex=True)
+
+        assert len(attachments) == 1
+        assert attachments[0][0] == "тест.csv"
+
+    @patch(imaplib_string)
     def test_has_mail_attachment_with_max_mails(self, mock_imaplib):
         mock_conn = _create_fake_imap(mock_imaplib, with_mail=True)
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

Fix IMAP hook not decoding RFC 2047 encoded attachment filenames

IMAP attachment filenames containing non-ASCII characters (Cyrillic, Chinese, etc.) are now properly decoded from RFC 2047 MIME encoding format to Unicode strings.

Previously, filenames were returned in their raw encoded form (e.g., `=?UTF-8?B?0YLQtdGB0YIuY3N2?=` instead of `тест.csv`), making it impossible to:
- Filter attachments by localized filenames
- Match filenames using regex patterns
- Identify files generated by external systems with non-Latin names

This was particularly problematic in production environments processing emails from banks, ERP systems, and reporting tools that use localized filenames.

**Changes:**
- Added `_decode_filename()` static method to `MailPart` class that decodes RFC 2047 MIME-encoded filenames using Python's `email.header.decode_header()`
- Applied decoding in all three filename access points:
  - `has_matching_name()` - for regex matching
  - `has_equal_name()` - for exact matching  
  - `get_file()` - when returning filename/payload tuples
- Handles both encoded and plain ASCII filenames transparently
- Fully backward compatible - existing code continues to work

**Testing:**
- Added test for exact match with Cyrillic filename (Перечень точек продаж_2026-04-21.xlsx)
- Added test for `has_mail_attachment()` with encoded filename
- Added test for regex matching with encoded filename
- All tests use real RFC 2047 encoded strings from production scenarios

**Example:**
```python
# Before: required manual decoding workaround
files = imap_hook.retrieve_mail_attachments(name='(.*)')
for file in files:
    decoded = decode_header(file[0])  # manual decoding
    
# After: works directly with Unicode filenames
files = imap_hook.retrieve_mail_attachments(name='Перечень точек продаж_2026-04-21.xlsx')
```

* closes: #65871 


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - Claude Code
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

