### PR TITLE
Fix database cleanup lifecycle hooks

### DIFF
--- a/chart/templates/database-cleanup/database-cleanup-cronjob.yaml
+++ b/chart/templates/database-cleanup/database-cleanup-cronjob.yaml
@@ -27,6 +27,7 @@
 {{- $topologySpreadConstraints := or .Values.databaseCleanup.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $securityContext := include "airflowPodSecurityContext" (list .Values.databaseCleanup .Values) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list .Values.databaseCleanup .Values) }}
+{{- $containerLifecycleHooks := or .Values.databaseCleanup.containerLifecycleHooks .Values.containerLifecycleHooks }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -92,6 +93,9 @@ spec:
               image: {{ template "airflow_image" . }}
               imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
               securityContext: {{ $containerSecurityContext | nindent 16 }}
+              {{- if $containerLifecycleHooks }}
+              lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 16 }}
+              {{- end }}
               {{- if .Values.databaseCleanup.command }}
               command: {{ tpl (toYaml .Values.databaseCleanup.command) . | nindent 16 }}
               {{- end }}

--- a/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_database_cleanup.py
@@ -393,6 +393,47 @@ class TestDatabaseCleanup:
             == resources
         )
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            pytest.param(
+                {
+                    "databaseCleanup": {
+                        "enabled": True,
+                        "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                    },
+                },
+                id="component",
+            ),
+            pytest.param(
+                {
+                    "databaseCleanup": {"enabled": True},
+                    "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                },
+                id="global-fallback",
+            ),
+            pytest.param(
+                {
+                    "databaseCleanup": {
+                        "enabled": True,
+                        "containerLifecycleHooks": {"preStop": {"exec": {"command": ["echo", "cleanup"]}}},
+                    },
+                    "containerLifecycleHooks": {"postStart": {"exec": {"command": ["echo", "global"]}}},
+                },
+                id="component-overrides-global",
+            ),
+        ],
+    )
+    def test_should_render_container_lifecycle_hooks(self, values):
+        docs = render_chart(
+            values=values,
+            show_only=["templates/database-cleanup/database-cleanup-cronjob.yaml"],
+        )
+
+        assert jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].lifecycle", docs[0]) == {
+            "preStop": {"exec": {"command": ["echo", "cleanup"]}}
+        }
+
     def test_should_set_job_history_limits(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
## Why

The chart already exposes `databaseCleanup.containerLifecycleHooks` in values.yaml, but the cleanup CronJob template never used that value. In practice, this means users can configure the option but it has no effect.

This change fixes that mismatch between chart values and template behavior.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
