### PR TITLE
PR triage: respect ongoing maintainer conversations

### DIFF
--- a/.github/skills/pr-triage/SKILL.md
+++ b/.github/skills/pr-triage/SKILL.md
@@ -181,6 +181,32 @@ Do not paraphrase the footer, do not omit it from templates
 that carry it, and do not let per-PR edits drop it. See
 [`comment-templates.md#ai-attribution-footer`](comment-templates.md).
 
+**Golden rule 9 — never talk over an active maintainer
+conversation.** When a maintainer has commented on the PR
+recently, the skill steps back. Two specific cases, both
+enforced as pre-classification filters in
+[`classify.md#5-active-maintainer-conversation-on-the-pr`](classify.md):
+
+- **Author-response cooldown (≥ 72 hours).** If the most recent
+  comment by a `COLLABORATOR`/`MEMBER`/`OWNER` was posted after
+  the latest author push and is < 72 hours old, skip the PR.
+  The author needs at least three days to read maintainer
+  feedback and respond — auto-drafting in <24 hours reads as
+  the bot rushing the contributor.
+- **Maintainer-to-maintainer ping.** If the most recent
+  collaborator comment `@`-mentions another maintainer (or a
+  team) and that mentioned party hasn't replied yet, skip the
+  PR — the conversation is between maintainers, and a "the
+  author should work on comments" auto-draft de-focuses the
+  thread away from the input the original commenter was asking
+  for.
+
+These filters override every deterministic flag (failing CI,
+conflicts, unresolved threads). The cost of a missed auto-action
+on one of these PRs is one extra day of queue presence; the cost
+of an auto-action that talks over a maintainer is a contributor
+who reads it as the project being chaotic. Prefer the former.
+
 ---
 
 ## Inputs
@@ -257,9 +283,12 @@ pulls a PR out of a group.
 
 Apply the filter rules in
 [`classify.md#pre-classification-filters`](classify.md) to drop
-collaborators, bot accounts, and (for a sweep run)
-already-triaged PRs that are still inside their waiting window.
-Then classify each remaining PR into one of:
+collaborators, bot accounts, already-triaged PRs that are still
+inside their waiting window, and (per Golden rule 9) PRs with an
+active maintainer conversation — fresh `< 72h` collaborator
+comment after the last push, or a maintainer-to-maintainer ping
+that hasn't been answered yet. Then classify each remaining PR
+into one of:
 
 - `pending_workflow_approval` — needs `gh run approve` before
   CI can run (first-time contributor signal)

--- a/.github/skills/pr-triage/classify.md
+++ b/.github/skills/pr-triage/classify.md
@@ -61,6 +61,65 @@ thread), **do** include the PR — mark it as a regressed
 passing PR in the interaction loop so the maintainer can decide
 whether to pull the label.
 
+### 5. Active maintainer conversation on the PR
+
+Two sub-cases — if either matches, **skip silently**, regardless
+of conflicts, failing CI, or unresolved threads. These two cases
+override the deterministic-flag classification because acting on
+them would either rush the contributor or talk over a
+maintainer-to-maintainer conversation.
+
+#### 5a. Recent collaborator comment (author-response cooldown)
+
+The most recent comment on the PR is by a `COLLABORATOR`,
+`MEMBER`, or `OWNER` *and* its `createdAt` is **< 72 hours**
+ago *and* it was posted **after** the PR's last commit's
+`committedDate`.
+
+**Rationale.** A maintainer just engaged with the PR; the author
+deserves at least three days to read, think, and reply before
+the triage skill auto-drafts or auto-comments on top of that
+conversation. The 72-hour window is intentionally longer than
+the 24-hour CI grace below — review-style feedback takes longer
+to address than a flaky-CI nudge, and a same-day auto-action
+reads as the bot talking over the maintainer.
+
+#### 5b. Latest collaborator comment is a maintainer-to-maintainer ping
+
+The most recent comment on the PR is by a `COLLABORATOR`,
+`MEMBER`, or `OWNER` *and* its body `@`-mentions one or more
+other GitHub logins **other than the PR author** *and* none of
+those mentioned logins have posted a comment or review on the
+PR after that ping.
+
+Detect via:
+
+- the comment author's `authorAssociation` ∈
+  {`COLLABORATOR`, `MEMBER`, `OWNER`}
+- regex on the comment `bodyText` for `@<login>` mentions, then
+  remove the PR author's login from the resulting set
+- check `comments(last:10).nodes` and `latestReviews.nodes`
+  for any subsequent post by any of the remaining logins
+
+**Rationale.** When a maintainer pings other maintainers (e.g.
+*"@ash @kaxil could you weigh in on the API shape?"*), the PR
+is waiting on **maintainer input**, not on author work.
+Auto-drafting it with a "the author should work on comments"
+message is wrong on two counts: (a) the contributor isn't the
+bottleneck — the maintainer review/conversation is; (b) it
+de-focuses the thread away from the maintainer-to-maintainer
+discussion the original commenter was trying to start. Silently
+skip until one of the pinged collaborators responds, at which
+point 5a's 72-hour window starts ticking from *that* reply.
+
+**Out of scope for 5b.** A `@`-mention of a *team* (e.g.
+`@apache/airflow-committers`) is conservatively treated as a
+maintainer-to-maintainer ping (skip), because we can't cheaply
+expand team membership in the batch query and the false-positive
+cost (skipping a PR that should have been actioned) is much
+lower than the false-negative cost (talking over a real
+maintainer call-out).
+
 ---
 
 ## Classifications
@@ -279,7 +338,13 @@ Extended-engagement logic:
 If the failure is *still* fresh (within the grace window), the
 PR is **not** classified as `deterministic_flag` on the CI-
 failure signal alone. Conflicts and unresolved threads have no
-grace window — they're immediately actionable.
+*CI*-grace window — but the **author-response cooldown** in
+pre-classification filter [`#5a`](#5-active-maintainer-conversation-on-the-pr)
+still applies to them: a fresh maintainer comment (< 72h, after
+the last push) silences the auto-action even when conflicts or
+unresolved threads are present, on the principle that the author
+deserves three days to read maintainer feedback before a bot
+talks over it.
 
 Record the "effective grace" result on the PR record so the
 suggested-action reason string can reference it ("CI failed 8h
@@ -345,6 +410,7 @@ relies on:
 
 | Classification | Required fields |
 |---|---|
+| Pre-filter 5 (active maintainer conversation) | `comments(last:10).nodes.{author.login,authorAssociation,bodyText,createdAt}`, `latestReviews.nodes.{author.login,submittedAt}`, `commits(last:1).nodes.commit.committedDate` |
 | `pending_workflow_approval` | `statusCheckRollup.state`, `authorAssociation`, `head_sha` |
 | `stale_copilot_review` | `reviewThreads.nodes.{isResolved,comments.nodes.{author.login,createdAt,url}}`, `comments(last:10).nodes.{author.login,createdAt}` (to detect author replies after the Copilot comment) |
 | `deterministic_flag` | `mergeable`, `statusCheckRollup.{state,contexts}`, `reviewThreads.nodes.{isResolved,comments.nodes.authorAssociation}`, `updatedAt`, `comments(last:10).nodes.{author.login,authorAssociation,createdAt}` |

--- a/.github/skills/pr-triage/fetch-and-batch.md
+++ b/.github/skills/pr-triage/fetch-and-batch.md
@@ -88,6 +88,7 @@ query(
         comments(last: 10) {
           nodes {
             author { login }
+            authorAssociation
             createdAt
             bodyText
           }
@@ -127,8 +128,13 @@ Every field above is consumed by Step 2 (classify) or Step 3
 - `latestReviews` → stale `CHANGES_REQUESTED` detection and
   `has_collaborator_review` flag (extended grace period)
 - `comments(last: 10)` → "already triaged" detection (viewer's
-  prior triage comment) and "author responded after triage"
-  detection
+  prior triage comment), "author responded after triage"
+  detection, and the active-maintainer-conversation pre-filter
+  (recent collaborator comment + maintainer-to-maintainer
+  `@`-ping detection — see
+  [`classify.md#5-active-maintainer-conversation-on-the-pr`](classify.md))
+  — which is why the comment node carries `authorAssociation`
+  and `bodyText` in addition to author login
 - `baseRef.target.history.totalCount` → commits-behind anchor
   (combined with PR head commit count; see
   [`#commits-behind`](#commits-behind))


### PR DESCRIPTION
The `pr-triage` skill (`.github/skills/pr-triage/`) sometimes drafted PRs in
under 24 hours after a maintainer commented, including cases where the
maintainer's comment was actually a `@`-mention asking *another* maintainer for
input. Both behaviours rush the contributor and pull focus away from the
maintainer-to-maintainer conversation that should happen next.

This PR adds two pre-classification filters in `classify.md` (and codifies the
principle as Golden rule 9 in `SKILL.md`):

1. **Author-response cooldown of 72 hours.** When the most recent comment by a
   `COLLABORATOR`/`MEMBER`/`OWNER` was posted after the last author push and is
   < 72h old, the skill skips the PR — the author needs at least three days to
   read maintainer feedback and respond. This applies even to "no grace window"
   signals like merge conflicts and unresolved review threads.
2. **Maintainer-to-maintainer ping detection.** When the latest collaborator
   comment `@`-mentions other maintainer(s) — or a team — and they have not
   replied yet, the skill skips the PR. The conversation is between maintainers,
   and an auto-draft saying "the author should work on comments" is wrong on
   two counts: the contributor isn't the bottleneck, and the auto-comment
   de-focuses the thread away from the input the original commenter was asking
   for.

The batched GraphQL query in `fetch-and-batch.md` now also fetches
`authorAssociation` per comment, so the new pre-filter can distinguish
collaborator comments from author/contributor comments without an extra
round-trip.

The trigger for both rules was concrete feedback from Jens Scheffler in the
Apache Airflow Slack `#auto-triage-feedback` channel (devcall + follow-up). The
related "mark auto-triage responses as AI-assisted" feedback from the same
discussion is already covered by the existing AI-attribution footer (Golden
rule 8) shipped earlier.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)