### PR TITLE
Add requirePersistence option to worker logGroomerSidecar

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -35,6 +35,7 @@
 {{- if or (contains "CeleryExecutor" .Values.executor) (contains "CeleryKubernetesExecutor" .Values.executor) }}
 ---
 {{- $persistence := or .Values.workers.persistence.enabled }}
+{{- $logGroomerRequirePersistence := .Values.workers.logGroomerSidecar.requirePersistence }}
 {{- $keda := .Values.workers.keda.enabled }}
 {{- $hpa := and .Values.workers.hpa.enabled (not .Values.workers.keda.enabled) }}
 {{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
@@ -348,7 +349,7 @@ spec:
         {{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) }}
           {{- include "git_sync_container" . | nindent 8 }}
         {{- end }}
-        {{- if and $persistence .Values.workers.logGroomerSidecar.enabled }}
+        {{- if and .Values.workers.logGroomerSidecar.enabled (or $persistence (not $logGroomerRequirePersistence)) }}
         - name: worker-log-groomer
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2445,6 +2445,11 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "requirePersistence": {
+                            "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs (deprecated, use ``workers.celery.logGroomerSidecar.requirePersistence`` instead).",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "command": {
                             "description": "Command to use when running the Airflow log groomer sidecar (templated) (deprecated, use ``workers.celery.logGroomerSidecar.command`` instead).",
                             "type": [
@@ -3663,6 +3668,14 @@
                             "properties": {
                                 "enabled": {
                                     "description": "Whether to deploy the Airflow log groomer sidecar.",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "requirePersistence": {
+                                    "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs.",
                                     "type": [
                                         "boolean",
                                         "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2446,7 +2446,7 @@
                             "default": true
                         },
                         "requirePersistence": {
-                            "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs (deprecated, use ``workers.celery.logGroomerSidecar.requirePersistence`` instead).",
+                            "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed (deprecated, use ``workers.celery.logGroomerSidecar.requirePersistence`` instead).",
                             "type": "boolean",
                             "default": true
                         },
@@ -3675,7 +3675,7 @@
                                     "default": null
                                 },
                                 "requirePersistence": {
-                                    "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs.",
+                                    "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed.",
                                     "type": [
                                         "boolean",
                                         "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2446,7 +2446,7 @@
                             "default": true
                         },
                         "requirePersistence": {
-                            "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed (deprecated, use ``workers.celery.logGroomerSidecar.requirePersistence`` instead).",
+                            "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an ``emptyDir`` volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed (deprecated, use ``workers.celery.logGroomerSidecar.requirePersistence`` instead).",
                             "type": "boolean",
                             "default": true
                         },
@@ -3675,7 +3675,7 @@
                                     "default": null
                                 },
                                 "requirePersistence": {
-                                    "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an emptyDir volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed.",
+                                    "description": "Whether persistence is required for log groomer sidecar. When false, the log groomer can run on Deployments (without persistence) using an ``emptyDir`` volume for logs. Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will work without persistence by default and this parameter will be removed.",
                                     "type": [
                                         "boolean",
                                         "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1150,6 +1150,8 @@ workers:
 
     # Whether persistence is required for log groomer sidecar. When false, the log groomer
     # can run on Deployments (without persistence) using an emptyDir volume for logs.
+    # Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will
+    # work without persistence by default and this parameter will be removed.
     # (deprecated, use `workers.celery.logGroomerSidecar.requirePersistence` instead)
     requirePersistence: true
 
@@ -1566,6 +1568,8 @@ workers:
 
       # Whether persistence is required for log groomer sidecar. When false, the log groomer
       # can run on Deployments (without persistence) using an emptyDir volume for logs.
+      # Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will
+      # work without persistence by default and this parameter will be removed.
       requirePersistence: ~
 
       # Command to use when running the Airflow Celery worker log groomer sidecar (templated)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1149,7 +1149,7 @@ workers:
     enabled: true
 
     # Whether persistence is required for log groomer sidecar. When false, the log groomer
-    # can run on Deployments (without persistence) using an emptyDir volume for logs.
+    # can run on Deployments (without persistence) using an `emptyDir` volume for logs.
     # Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will
     # work without persistence by default and this parameter will be removed.
     # (deprecated, use `workers.celery.logGroomerSidecar.requirePersistence` instead)
@@ -1567,7 +1567,7 @@ workers:
       enabled: ~
 
       # Whether persistence is required for log groomer sidecar. When false, the log groomer
-      # can run on Deployments (without persistence) using an emptyDir volume for logs.
+      # can run on Deployments (without persistence) using an `emptyDir` volume for logs.
       # Note: This parameter is transitional for chart 1.2x. In chart 2.x, log groomer will
       # work without persistence by default and this parameter will be removed.
       requirePersistence: ~

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1148,6 +1148,11 @@ workers:
     # (deprecated, use `workers.celery.logGroomerSidecar.enabled` instead)
     enabled: true
 
+    # Whether persistence is required for log groomer sidecar. When false, the log groomer
+    # can run on Deployments (without persistence) using an emptyDir volume for logs.
+    # (deprecated, use `workers.celery.logGroomerSidecar.requirePersistence` instead)
+    requirePersistence: true
+
     # Command to use when running the Airflow Celery worker log groomer sidecar (templated)
     # (deprecated, use `workers.celery.logGroomerSidecar.command` instead)
     command: ~
@@ -1558,6 +1563,10 @@ workers:
     logGroomerSidecar:
       # Whether to deploy the Airflow Celery worker log groomer sidecar
       enabled: ~
+
+      # Whether persistence is required for log groomer sidecar. When false, the log groomer
+      # can run on Deployments (without persistence) using an emptyDir volume for logs.
+      requirePersistence: ~
 
       # Command to use when running the Airflow Celery worker log groomer sidecar (templated)
       command: ~

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2356,15 +2356,15 @@ class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
         ("persistence_enabled", "log_groomer_enabled", "require_persistence", "expect_log_groomer"),
         [
             # With requirePersistence=true (default behavior, backwards compatible)
-            # persistence default (true) + logGroomer default (true) -> renders
+            # persistence default (true) + logGroomer default (true) + requirePersistence default (true) -> renders
             (None, None, None, True),
-            # persistence default (true) + logGroomer false -> no render
+            # persistence default (true) + logGroomer false + requirePersistence default (true) -> no render
             (None, False, None, False),
-            # persistence true + logGroomer default (true) -> renders
+            # persistence true + logGroomer default (true) + requirePersistence default (true) -> renders
             (True, None, None, True),
-            # persistence true + logGroomer true -> renders
+            # persistence true + logGroomer true + requirePersistence default (true) -> renders
             (True, True, None, True),
-            # persistence true + logGroomer false -> no render
+            # persistence true + logGroomer false + requirePersistence default (true) -> no render
             (True, False, None, False),
             # persistence false + logGroomer default (true) + requirePersistence default (true) -> NO render
             (False, None, None, False),
@@ -2372,7 +2372,7 @@ class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
             (False, True, None, False),
             # persistence false + logGroomer true + requirePersistence true -> NO render
             (False, True, True, False),
-            # persistence false + logGroomer false -> no render
+            # persistence false + logGroomer false + requirePersistence default (true) -> no render
             (False, False, None, False),
             # With requirePersistence=false (new behavior)
             # persistence false + logGroomer true + requirePersistence false -> renders
@@ -2406,10 +2406,6 @@ class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
             },
             show_only=["templates/workers/worker-deployment.yaml"],
         )
-
-        # Verify resource kind based on persistence
-        expected_kind = "StatefulSet" if persistence_enabled is not False else "Deployment"
-        assert jmespath.search("kind", docs[0]) == expected_kind
 
         # Verify log groomer presence
         containers = jmespath.search("spec.template.spec.containers", docs[0])

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2352,6 +2352,82 @@ class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
     obj_name = "workers-celery"
     folder = "workers"
 
+    @pytest.mark.parametrize(
+        ("persistence_enabled", "log_groomer_enabled", "require_persistence", "expect_log_groomer"),
+        [
+            # With requirePersistence=true (default behavior, backwards compatible)
+            # persistence default (true) + logGroomer default (true) -> renders
+            (None, None, None, True),
+            # persistence default (true) + logGroomer false -> no render
+            (None, False, None, False),
+            # persistence true + logGroomer default (true) -> renders
+            (True, None, None, True),
+            # persistence true + logGroomer true -> renders
+            (True, True, None, True),
+            # persistence true + logGroomer false -> no render
+            (True, False, None, False),
+            # persistence false + logGroomer default (true) + requirePersistence default (true) -> NO render
+            (False, None, None, False),
+            # persistence false + logGroomer true + requirePersistence default (true) -> NO render
+            (False, True, None, False),
+            # persistence false + logGroomer true + requirePersistence true -> NO render
+            (False, True, True, False),
+            # persistence false + logGroomer false -> no render
+            (False, False, None, False),
+            # With requirePersistence=false (new behavior)
+            # persistence false + logGroomer true + requirePersistence false -> renders
+            (False, True, False, True),
+            # persistence false + logGroomer default (true) + requirePersistence false -> renders
+            (False, None, False, True),
+            # persistence true + logGroomer true + requirePersistence false -> renders
+            (True, True, False, True),
+        ],
+    )
+    def test_log_groomer_with_persistence_and_require_persistence_combinations(
+        self, persistence_enabled, log_groomer_enabled, require_persistence, expect_log_groomer
+    ):
+        """Test log groomer sidecar rendering with various persistence, enabled, and requirePersistence combinations."""
+        celery_values = {}
+        if persistence_enabled is not None:
+            celery_values["persistence"] = {"enabled": persistence_enabled}
+
+        log_groomer_values = {}
+        if log_groomer_enabled is not None:
+            log_groomer_values["enabled"] = log_groomer_enabled
+        if require_persistence is not None:
+            log_groomer_values["requirePersistence"] = require_persistence
+        if log_groomer_values:
+            celery_values["logGroomerSidecar"] = log_groomer_values
+
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {"celery": celery_values} if celery_values else {},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        # Verify resource kind based on persistence
+        expected_kind = "StatefulSet" if persistence_enabled is not False else "Deployment"
+        assert jmespath.search("kind", docs[0]) == expected_kind
+
+        # Verify log groomer presence
+        containers = jmespath.search("spec.template.spec.containers", docs[0])
+        container_names = [c["name"] for c in containers]
+
+        if expect_log_groomer:
+            assert "worker-log-groomer" in container_names, (
+                f"Expected log groomer with persistence={persistence_enabled}, "
+                f"enabled={log_groomer_enabled}, requirePersistence={require_persistence}"
+            )
+            assert len(containers) == 2
+        else:
+            assert "worker-log-groomer" not in container_names, (
+                f"Did not expect log groomer with persistence={persistence_enabled}, "
+                f"enabled={log_groomer_enabled}, requirePersistence={require_persistence}"
+            )
+            assert len(containers) == 1
+
 
 class TestWorkerKedaAutoScaler:
     """Tests worker keda auto scaler."""


### PR DESCRIPTION
# Context

Currently, the worker log groomer sidecar only renders when `workers.persistence.enabled` is `true` (i.e., StatefulSet mode). This prevents using the log groomer on Deployments with emptyDir volumes for logs.

This change adds a new `requirePersistence` option that defaults to `true`, preserving **full backwards compatibility**. When set to `false`, the log groomer can be enabled regardless of whether persistence is enabled.

This is useful for deployments that:
- Use emptyDir for local logs with remote logging (S3, GCS, etc.)
- Want to clean up local log files to prevent ephemeral storage exhaustion
- Prefer Deployments over StatefulSets for workers

# Configuration

```yaml
workers:
  logGroomerSidecar:
    enabled: true
    requirePersistence: false  # Allow log groomer on Deployments
```

# Backward Compatibility

This change is **fully backwards compatible**. The new `requirePersistence` option defaults to `true`, which preserves the existing behavior where log groomer only renders when persistence is enabled.

| `persistence` | `enabled` | `requirePersistence` | Log groomer renders |
|---------------|-----------|---------------------|---------------------|
| true | true | true (default) | ✓ |
| true | false | true (default) | ✗ |
| false | true | true (default) | ✗ (existing behavior) |
| false | true | **false** | ✓ (new opt-in behavior) |

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes - Claude (Anthropic)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.