### PR TITLE
[v3-2-test] Update pools slot input (#63900)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -353,6 +353,10 @@
   "triggered": "Triggered",
   "tryNumber": "Try Number",
   "user": "User",
+  "validation": {
+    "mustBeAtLeast": "Must be at least {{min}}.",
+    "mustBeValidNumber": "Must be a valid number."
+  },
   "wrap": {
     "hotkey": "w",
     "tooltip": "Press {{hotkey}} to toggle wrap",

--- a/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Pools/PoolForm.tsx
@@ -42,6 +42,8 @@ type PoolFormProps = {
   readonly setError: (error: unknown) => void;
 };
 
+const POOL_SLOTS_MIN = -1;
+
 const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: PoolFormProps) => {
   const { t: translate } = useTranslation(["admin", "common"]);
   const {
@@ -87,23 +89,41 @@ const PoolForm = ({ error, initialPool, isPending, manageMutate, setError }: Poo
       <Controller
         control={control}
         name="slots"
-        render={({ field }) => (
-          <Field.Root mt={4}>
+        render={({ field, fieldState }) => (
+          <Field.Root invalid={Boolean(fieldState.error)} mt={4}>
             <Field.Label fontSize="md">{translate("pools.form.slots")}</Field.Label>
             <Input
-              min={-1}
+              min={POOL_SLOTS_MIN}
+              onBlur={field.onBlur}
               onChange={(event) => {
-                const value = event.target.valueAsNumber;
+                const { value: raw, valueAsNumber } = event.target;
 
-                field.onChange(isNaN(value) ? field.value : value);
+                field.onChange(raw === "" ? Number.NaN : valueAsNumber);
               }}
+              ref={field.ref}
               size="sm"
               type="number"
-              value={field.value}
+              value={Number.isFinite(field.value) ? field.value : ""}
             />
-            <Field.HelperText>{translate("pools.form.slotsHelperText")}</Field.HelperText>
+            {fieldState.error ? (
+              <Field.ErrorText>{fieldState.error.message}</Field.ErrorText>
+            ) : (
+              <Field.HelperText>{translate("pools.form.slotsHelperText")}</Field.HelperText>
+            )}
           </Field.Root>
         )}
+        rules={{
+          validate: (value: number) => {
+            if (!Number.isFinite(value)) {
+              return translate("common:validation.mustBeValidNumber");
+            }
+            if (value < POOL_SLOTS_MIN) {
+              return translate("common:validation.mustBeAtLeast", { min: POOL_SLOTS_MIN });
+            }
+
+            return true;
+          },
+        }}
       />
 
       <Controller


### PR DESCRIPTION
Manual backport of #63900 to `v3-2-test`. The backport label automation didn't pick this up, so cherry-picked locally.

Original PR: #63900

Cherry-picked from `ee2e5d2c6ef0bef2ba2b50b3ea6bb683e783d51b`.
