### PR TITLE
[v3-2-test] Fix bulk delete toaster on variables page (#64142)

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useBulkDeleteVariables.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useBulkDeleteVariables.ts
@@ -54,7 +54,9 @@ export const useBulkDeleteVariables = ({ clearSelections, onSuccessConfirm }: Pr
             keys: success.join(", "),
             resourceName: translate("admin:variables.variable_other"),
           }),
-          title: translate("toaster.bulkDelete.success.title"),
+          title: translate("toaster.bulkDelete.success.title", {
+            resourceName: translate("admin:variables.variable_other"),
+          }),
           type: "success",
         });
         clearSelections();


### PR DESCRIPTION
Manual backport of #64142 to `v3-2-test`. The backport label automation didn't pick this up, so cherry-picked locally.

Original PR: #64142

Cherry-picked from `45bdd0d3efcca84566e5739a1b361dcbf8dd7b25`.
