### PR TITLE
[v3-2-test] Change hebrew wording for Asset Triggered (#64177)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -168,7 +168,7 @@
   "reset": "אתחל",
   "runId": "מזהה ריצה",
   "runTypes": {
-    "asset_triggered": "הופעל על-ידי נכס",
+    "asset_triggered": "מופעל על-ידי נכס",
     "backfill": "השלמה למפרע",
     "manual": "הפעלה ידנית",
     "scheduled": "מתוזמן"


### PR DESCRIPTION
Manual backport of #64177 to `v3-2-test`. The backport label automation didn't pick this up, so cherry-picked locally.

Original PR: #64177

Cherry-picked from `46f344af1749b0b5a64ca6f92cb803bfe3c5e34f`.
