### PR TITLE
[v3-2-test] Fix PoolBar links using wrong query params for task instances page (#64182)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PoolBar.tsx
@@ -106,7 +106,7 @@ export const PoolBar = ({
           return slot.color !== "success" && "name" in pool ? (
             <Link asChild flex={flexValue} key={slot.key}>
               <RouterLink
-                to={`/task_instances?${SearchParamsKeys.STATE}=${slot.color}&${SearchParamsKeys.POOL}=${pool.name}`}
+                to={`/task_instances?${SearchParamsKeys.TASK_STATE}=${slot.slotType}&${SearchParamsKeys.POOL_NAME_PATTERN}=${pool.name}`}
               >
                 {poolContent}
               </RouterLink>


### PR DESCRIPTION
Manual backport of #64182 to `v3-2-test`. The backport label automation didn't pick this up, so cherry-picked locally.

Original PR: #64182

Cherry-picked from `0c2a8d548bd8c29653e4ce91b912562a170205fd`.
