### PR TITLE
Redact rendered template fields while still structured to preserve nested-key masking on truncation

### DIFF
--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -97,7 +97,10 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
         template_field = sort_dict_recursively(template_field)
     serialized = str(template_field)
     if len(serialized) > max_length:
-        rendered = redact(serialized, name)
+        # Redact while still structured to preserve nested-key context (so values under
+        # documented sensitive keys such as `password`, `token`, `secret`, `api_key`
+        # are masked recursively); only stringify the redacted result for truncation.
+        rendered = redact(template_field, name)
         return truncate_rendered_value(str(rendered), max_length)
     return template_field
 

--- a/airflow-core/src/airflow/serialization/helpers.py
+++ b/airflow-core/src/airflow/serialization/helpers.py
@@ -105,7 +105,10 @@ def serialize_template_field(template_field: Any, name: str) -> str | dict | lis
     serialized = serialize_object(template_field)
 
     if len(str(serialized)) > max_length:
-        rendered = redact(str(serialized), name)
+        # Redact while still structured to preserve nested-key context (so values under
+        # documented sensitive keys such as `password`, `token`, `secret`, `api_key`
+        # are masked recursively); only stringify the redacted result for truncation.
+        rendered = redact(serialized, name)
         return truncate_rendered_value(str(rendered), max_length)
 
     return serialized

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import pytest
+
 
 def test_serialize_template_field_with_very_small_max_length(monkeypatch):
     """Test that truncation message is prioritized even for very small max_length."""
@@ -29,3 +31,29 @@ def test_serialize_template_field_with_very_small_max_length(monkeypatch):
     # This ensures users always see why content is truncated
     assert result
     assert "Truncated. You can change this behaviour" in result
+
+
+@pytest.mark.enable_redact
+def test_serialize_template_field_masks_nested_sensitive_keys_on_truncation(monkeypatch):
+    """Nested sensitive-key masking applies consistently across the truncation path.
+
+    A value under a documented sensitive key (``password``, ``token``, ``secret``,
+    ``api_key``) is masked recursively by ``redact()`` when the structured value
+    is walked. The oversized branch must redact while still structured so that
+    nested-key context is preserved before stringification — otherwise the post-
+    stringify ``redact()`` call only sees the outer field name and the recursive
+    walker cannot reach the inner key.
+    """
+    monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "200")
+
+    from airflow.serialization.helpers import serialize_template_field
+
+    nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
+    payload = {"nested": {"password": nested_value, "zz_pad": "A" * 500}}
+
+    result = serialize_template_field(payload, "templates_dict")
+
+    assert isinstance(result, str)
+    assert "Truncated. You can change this behaviour" in result
+    assert nested_value not in result
+    assert "***" in result

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -657,3 +657,27 @@ def test_serialize_template_field_deeply_nested_dict_keys_recursively_normalized
     assert all(isinstance(k, str) for k in inner[float_key])
     assert "at 0x" not in str(r1)
     json.dumps(r1, sort_keys=True)
+
+
+@pytest.mark.enable_redact
+def test_serialize_template_field_masks_nested_sensitive_keys_on_truncation(monkeypatch):
+    """Nested sensitive-key masking applies consistently across the truncation path.
+
+    A value under a documented sensitive key (``password``, ``token``, ``secret``,
+    ``api_key``) is masked recursively by ``redact()`` when the structured value
+    is walked. The oversized branch must redact while still structured so that
+    nested-key context is preserved before stringification — otherwise the post-
+    stringify ``redact()`` call only sees the outer field name and the recursive
+    walker cannot reach the inner key.
+    """
+    monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "200")
+
+    nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
+    payload = {"nested": {"password": nested_value, "zz_pad": "A" * 500}}
+
+    result = serialize_template_field(payload, "templates_dict")
+
+    assert isinstance(result, str)
+    assert "Truncated. You can change this behaviour" in result
+    assert nested_value not in result
+    assert "***" in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,7 +384,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-vertica>=3.9.1"
 ]
 "vespa" = [
-    "apache-airflow-providers-vespa>=0.1.0" # Set from local provider pyproject.toml
+    "apache-airflow-providers-vespa>=0.1.0"
 ]
 "weaviate" = [
     "apache-airflow-providers-weaviate>=3.0.0"
@@ -496,7 +496,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-teradata>=2.6.1",
     "apache-airflow-providers-trino>=5.8.1",
     "apache-airflow-providers-vertica>=3.9.1",
-    "apache-airflow-providers-vespa>=0.1.0", # Set from local provider pyproject.toml
+    "apache-airflow-providers-vespa>=0.1.0",
     "apache-airflow-providers-weaviate>=3.0.0",
     "apache-airflow-providers-yandex>=4.0.0",
     "apache-airflow-providers-ydb>=1.4.0",

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1050,7 +1050,10 @@ def _serialize_template_field(template_field: Any, name: str) -> str | dict | li
         template_field = sort_dict_recursively(template_field)
     serialized = str(template_field)
     if len(serialized) > max_length:
-        rendered = redact(serialized, name)
+        # Redact while still structured to preserve nested-key context (so values under
+        # documented sensitive keys such as `password`, `token`, `secret`, `api_key`
+        # are masked recursively); only stringify the redacted result for truncation.
+        rendered = redact(template_field, name)
         return truncate_rendered_value(str(rendered), max_length)
     return template_field
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1084,7 +1084,10 @@ def _serialize_template_field(
     serialized = serialize_object(template_field)
 
     if len(str(serialized)) > max_length:
-        rendered = redact(str(serialized), name)
+        # Redact while still structured to preserve nested-key context (so values under
+        # documented sensitive keys such as `password`, `token`, `secret`, `api_key`
+        # are masked recursively); only stringify the redacted result for truncation.
+        rendered = redact(serialized, name)
         return truncate_rendered_value(str(rendered), max_length)
 
     return serialized

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2859,6 +2859,64 @@ class TestRuntimeTaskInstance:
         assert "***" in env_vars_value  # secrets are redacted before truncation
 
     @pytest.mark.enable_redact
+    def test_rendered_templates_mask_nested_keys_with_truncation(
+        self, create_runtime_ti, mock_supervisor_comms
+    ):
+        """Nested sensitive-key masking applies consistently across the truncation path.
+
+        A value under a documented sensitive key (``password``, ``token``, ``secret``,
+        ``api_key``) is masked recursively by ``redact()`` when the structured value
+        is walked. The oversized branch must redact while still structured so that
+        nested-key context is preserved before stringification — otherwise the post-
+        stringify ``redact()`` call only sees the outer field name and the recursive
+        walker cannot reach the inner key.
+        """
+        from airflow.sdk._shared.secrets_masker import _secrets_masker
+
+        # The SDK masker starts with an empty sensitive-fields list in the test runtime
+        # (settings.py has not run); register `password` explicitly so the structured
+        # walker has something to match. Production workers get this from settings.py.
+        masker = _secrets_masker()
+        if "password" not in masker.sensitive_variables_fields:
+            masker.sensitive_variables_fields = list(masker.sensitive_variables_fields) + ["password"]
+
+        nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
+
+        class CustomOperator(BaseOperator):
+            template_fields = ("env_vars",)
+
+            def __init__(self, env_vars, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.env_vars = env_vars
+
+            def execute(self, context):
+                pass
+
+        # Nested 'password' key under enough padding to exceed default 4096-char limit.
+        env_vars = {
+            "DB": {"password": nested_value, "host": "db.internal", "zz_pad": "A" * 5000},
+        }
+
+        task = CustomOperator(task_id="test_nested_truncation_masking", env_vars=env_vars)
+
+        runtime_ti = create_runtime_ti(task=task, dag_id="test_nested_truncation_masking_dag")
+        run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        msg = next(
+            c.kwargs["msg"]
+            for c in mock_supervisor_comms.send.mock_calls
+            if c.kwargs.get("msg") and getattr(c.kwargs["msg"], "type", None) == "SetRenderedFields"
+        )
+        env_vars_value = msg.rendered_fields["env_vars"]
+
+        assert isinstance(env_vars_value, str)
+        assert env_vars_value.startswith(
+            "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+        )
+        assert nested_value not in env_vars_value
+        assert "'password': '***'" in env_vars_value
+
+    @pytest.mark.enable_redact
     def test_rendered_templates_masks_secrets_in_complex_objects(
         self, create_runtime_ti, mock_supervisor_comms
     ):

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -2860,7 +2860,7 @@ class TestRuntimeTaskInstance:
 
     @pytest.mark.enable_redact
     def test_rendered_templates_mask_nested_keys_with_truncation(
-        self, create_runtime_ti, mock_supervisor_comms
+        self, create_runtime_ti, mock_supervisor_comms, monkeypatch
     ):
         """Nested sensitive-key masking applies consistently across the truncation path.
 
@@ -2873,12 +2873,25 @@ class TestRuntimeTaskInstance:
         """
         from airflow.sdk._shared.secrets_masker import _secrets_masker
 
+        # Earlier tests in this file (e.g. test_get_connection_from_context) call
+        # mask_secret(conn.password) where the fixture's password value is the literal
+        # "password"; that registers "password" as a regex pattern in the singleton
+        # masker. Without isolation, str(redacted) gets that regex applied and the
+        # dict KEY name "password" itself becomes "***", obscuring whether the
+        # structured nested-key walk fired. Reset the regex patterns for this test
+        # (monkeypatch restores them on teardown) so the assertion can distinguish
+        # value-masking (what we are testing) from key-token replacement.
+        masker = _secrets_masker()
+        monkeypatch.setattr(masker, "patterns", set())
+        monkeypatch.setattr(masker, "replacer", None)
         # The SDK masker starts with an empty sensitive-fields list in the test runtime
         # (settings.py has not run); register `password` explicitly so the structured
         # walker has something to match. Production workers get this from settings.py.
-        masker = _secrets_masker()
-        if "password" not in masker.sensitive_variables_fields:
-            masker.sensitive_variables_fields = list(masker.sensitive_variables_fields) + ["password"]
+        monkeypatch.setattr(
+            masker,
+            "sensitive_variables_fields",
+            list(masker.sensitive_variables_fields) + ["password"],
+        )
 
         nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -3004,7 +3004,7 @@ class TestRuntimeTaskInstance:
 
     @pytest.mark.enable_redact
     def test_rendered_templates_mask_nested_keys_with_truncation(
-        self, create_runtime_ti, mock_supervisor_comms
+        self, create_runtime_ti, mock_supervisor_comms, monkeypatch
     ):
         """Nested sensitive-key masking applies consistently across the truncation path.
 
@@ -3017,12 +3017,25 @@ class TestRuntimeTaskInstance:
         """
         from airflow.sdk._shared.secrets_masker import _secrets_masker
 
+        # Earlier tests in this file (e.g. test_get_connection_from_context) call
+        # mask_secret(conn.password) where the fixture's password value is the literal
+        # "password"; that registers "password" as a regex pattern in the singleton
+        # masker. Without isolation, str(redacted) gets that regex applied and the
+        # dict KEY name "password" itself becomes "***", obscuring whether the
+        # structured nested-key walk fired. Reset the regex patterns for this test
+        # (monkeypatch restores them on teardown) so the assertion can distinguish
+        # value-masking (what we are testing) from key-token replacement.
+        masker = _secrets_masker()
+        monkeypatch.setattr(masker, "patterns", set())
+        monkeypatch.setattr(masker, "replacer", None)
         # The SDK masker starts with an empty sensitive-fields list in the test runtime
         # (settings.py has not run); register `password` explicitly so the structured
         # walker has something to match. Production workers get this from settings.py.
-        masker = _secrets_masker()
-        if "password" not in masker.sensitive_variables_fields:
-            masker.sensitive_variables_fields = list(masker.sensitive_variables_fields) + ["password"]
+        monkeypatch.setattr(
+            masker,
+            "sensitive_variables_fields",
+            list(masker.sensitive_variables_fields) + ["password"],
+        )
 
         nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -3003,6 +3003,64 @@ class TestRuntimeTaskInstance:
         assert "***" in env_vars_value  # secrets are redacted before truncation
 
     @pytest.mark.enable_redact
+    def test_rendered_templates_mask_nested_keys_with_truncation(
+        self, create_runtime_ti, mock_supervisor_comms
+    ):
+        """Nested sensitive-key masking applies consistently across the truncation path.
+
+        A value under a documented sensitive key (``password``, ``token``, ``secret``,
+        ``api_key``) is masked recursively by ``redact()`` when the structured value
+        is walked. The oversized branch must redact while still structured so that
+        nested-key context is preserved before stringification — otherwise the post-
+        stringify ``redact()`` call only sees the outer field name and the recursive
+        walker cannot reach the inner key.
+        """
+        from airflow.sdk._shared.secrets_masker import _secrets_masker
+
+        # The SDK masker starts with an empty sensitive-fields list in the test runtime
+        # (settings.py has not run); register `password` explicitly so the structured
+        # walker has something to match. Production workers get this from settings.py.
+        masker = _secrets_masker()
+        if "password" not in masker.sensitive_variables_fields:
+            masker.sensitive_variables_fields = list(masker.sensitive_variables_fields) + ["password"]
+
+        nested_value = "REGRESSION-FIXTURE-NESTED-PASSWORD-VALUE"
+
+        class CustomOperator(BaseOperator):
+            template_fields = ("env_vars",)
+
+            def __init__(self, env_vars, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.env_vars = env_vars
+
+            def execute(self, context):
+                pass
+
+        # Nested 'password' key under enough padding to exceed default 4096-char limit.
+        env_vars = {
+            "DB": {"password": nested_value, "host": "db.internal", "zz_pad": "A" * 5000},
+        }
+
+        task = CustomOperator(task_id="test_nested_truncation_masking", env_vars=env_vars)
+
+        runtime_ti = create_runtime_ti(task=task, dag_id="test_nested_truncation_masking_dag")
+        run(runtime_ti, context=runtime_ti.get_template_context(), log=mock.MagicMock())
+
+        msg = next(
+            c.kwargs["msg"]
+            for c in mock_supervisor_comms.send.mock_calls
+            if c.kwargs.get("msg") and getattr(c.kwargs["msg"], "type", None) == "SetRenderedFields"
+        )
+        env_vars_value = msg.rendered_fields["env_vars"]
+
+        assert isinstance(env_vars_value, str)
+        assert env_vars_value.startswith(
+            "Truncated. You can change this behaviour in [core]max_templated_field_length. "
+        )
+        assert nested_value not in env_vars_value
+        assert "'password': '***'" in env_vars_value
+
+    @pytest.mark.enable_redact
     def test_rendered_templates_masks_secrets_in_complex_objects(
         self, create_runtime_ti, mock_supervisor_comms
     ):


### PR DESCRIPTION
When a rendered template field exceeds `[core] max_templated_field_length`, the
JSON-serializable serialization path stringifies the value before applying
`redact()`. That order loses the nested-key context that `redact()` uses to
mask values under sensitive keys such as `password`, `token`, `secret`, and
`api_key` — only registered `mask_secret()` value patterns survive the
truncation path.

This change applies `redact()` to the structured value first, then stringifies
the redacted result for truncation. Both nested-key-context masking and value-
pattern masking now behave consistently regardless of whether the rendered
field crosses the truncation boundary. The fit-in-limits branch is unchanged.

The same fix is applied in both `airflow-core/src/airflow/serialization/helpers.py`
(`serialize_template_field`) and `task-sdk/src/airflow/sdk/execution_time/task_runner.py`
(`_serialize_template_field`), since the two functions diverged into
near-duplicates after #59566 and carried the same bug pattern.

## Test plan

- [x] Add `test_serialize_template_field_masks_nested_sensitive_keys_on_truncation`
      to `airflow-core/tests/unit/serialization/test_helpers.py` covering the
      structured-redact-before-stringify behaviour for an oversized nested
      `password` payload.
- [x] Add `test_rendered_templates_mask_nested_keys_with_truncation` to
      `task-sdk/tests/task_sdk/execution_time/test_task_runner.py` covering the
      same behaviour through the runtime path.
- [x] Existing `test_serialize_template_field_with_very_small_max_length` and
      `test_rendered_templates_mask_secrets_with_truncation` continue to pass.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
