### PR TITLE
Bump pip to 26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ ARG PYTHON_LTO="true"
 # You can swap comments between those two args to test pip from the main version
 # When you attempt to test if the version of `pip` from specified branch works for our builds
 # Also use `force pip` label on your PR to swap all places we use `uv` to `pip`
-ARG AIRFLOW_PIP_VERSION=26.0.1
+ARG AIRFLOW_PIP_VERSION=26.1
 # ARG AIRFLOW_PIP_VERSION="git+https://github.com/pypa/pip.git@main"
 ARG AIRFLOW_UV_VERSION=0.11.7
 ARG AIRFLOW_USE_UV="false"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1823,7 +1823,7 @@ COPY --from=scripts common.sh install_packaging_tools.sh install_additional_depe
 # You can swap comments between those two args to test pip from the main version
 # When you attempt to test if the version of `pip` from specified branch works for our builds
 # Also use `force pip` label on your PR to swap all places we use `uv` to `pip`
-ARG AIRFLOW_PIP_VERSION=26.0.1
+ARG AIRFLOW_PIP_VERSION=26.1
 # ARG AIRFLOW_PIP_VERSION="git+https://github.com/pypa/pip.git@main"
 ARG AIRFLOW_UV_VERSION=0.11.7
 ARG AIRFLOW_PREK_VERSION="0.3.9"

--- a/dev/breeze/doc/ci/02_images.md
+++ b/dev/breeze/doc/ci/02_images.md
@@ -442,7 +442,7 @@ can be used for CI images:
 | `DEV_APT_DEPS`                    |                             | Dev APT dependencies installed in the first part of the image (default empty means default dependencies are used) |
 | `ADDITIONAL_DEV_APT_DEPS`         |                             | Additional apt dev dependencies installed in the first part of the image                                          |
 | `ADDITIONAL_DEV_APT_ENV`          |                             | Additional env variables defined when installing dev deps                                                         |
-| `AIRFLOW_PIP_VERSION`             | `26.0.1`                    | `pip` version used.                                                                                               |
+| `AIRFLOW_PIP_VERSION`             | `26.1`                      | `pip` version used.                                                                                               |
 | `AIRFLOW_UV_VERSION`              | `0.11.7`                     | `uv` version used.                                                                                                |
 | `AIRFLOW_PREK_VERSION`            | `0.3.9`                     | `prek` version used.                                                                                              |
 | `AIRFLOW_USE_UV`                  | `true`                      | Whether to use UV for installation.                                                                               |

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -263,7 +263,7 @@ class VersionedFile(NamedTuple):
     file_name: str
 
 
-AIRFLOW_PIP_VERSION = "26.0.1"
+AIRFLOW_PIP_VERSION = "26.1"
 AIRFLOW_UV_VERSION = "0.11.7"
 AIRFLOW_USE_UV = False
 GITPYTHON_VERSION = "3.1.46"

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -240,7 +240,7 @@ if MYSQL_INNOVATION_RELEASE:
 
 ALLOWED_INSTALL_MYSQL_CLIENT_TYPES = ["mariadb"]
 
-PIP_VERSION = "26.0.1"
+PIP_VERSION = "26.1"
 UV_VERSION = "0.11.7"
 
 # packages that providers docs

--- a/dev/breeze/uv.lock
+++ b/dev/breeze/uv.lock
@@ -7,8 +7,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-20T16:55:30.186451507Z"
+exclude-newer = "2026-04-22T22:06:11.205944821Z"
 exclude-newer-span = "P4D"
+
+[options.exclude-newer-package]
+pip = "2026-04-28T04:00:00Z"
 
 [[package]]
 name = "anyio"
@@ -1213,11 +1216,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]

--- a/scripts/ci/install_breeze.sh
+++ b/scripts/ci/install_breeze.sh
@@ -21,7 +21,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/../../"
 
 PYTHON_ARG=""
 
-PIP_VERSION="26.0.1"
+PIP_VERSION="26.1"
 if [[ ${PYTHON_VERSION=} != "" ]]; then
     PYTHON_ARG="--python=$(which python"${PYTHON_VERSION}") "
 fi


### PR DESCRIPTION
[Pip 26.1 is here](https://discuss.python.org/t/annoucement-pip-26-1-release/107108)! I had to bypass the cooldown to enable it, let me know if that's unacceptable, I can just wait four days.

Pip 26.1 [brings ](https://github.com/pypa/pip/blob/main/NEWS.rst) some improvements to performance and the resolver, it can now handle `pip install apache-airflow[all]`, with no constraints, something pip had been struggling on since Airflow 3.x.