### PR TITLE
Regenerate meta-package pyproject.toml after vespa provider release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,7 +384,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-vertica>=3.9.1"
 ]
 "vespa" = [
-    "apache-airflow-providers-vespa>=0.1.0" # Set from local provider pyproject.toml
+    "apache-airflow-providers-vespa>=0.1.0"
 ]
 "weaviate" = [
     "apache-airflow-providers-weaviate>=3.0.0"
@@ -496,7 +496,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-teradata>=2.6.1",
     "apache-airflow-providers-trino>=5.8.1",
     "apache-airflow-providers-vertica>=3.9.1",
-    "apache-airflow-providers-vespa>=0.1.0", # Set from local provider pyproject.toml
+    "apache-airflow-providers-vespa>=0.1.0",
     "apache-airflow-providers-weaviate>=3.0.0",
     "apache-airflow-providers-yandex>=4.0.0",
     "apache-airflow-providers-ydb>=1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-airbyte>=5.0.0"
 ]
 "akeyless" = [
-    "apache-airflow-providers-akeyless>=1.0.0" # Set from local provider pyproject.toml
+    "apache-airflow-providers-akeyless>=1.0.0"
 ]
 "alibaba" = [
     "apache-airflow-providers-alibaba>=3.0.0"
@@ -402,7 +402,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow[aiobotocore,amazon-aws-auth,apache-atlas,apache-webhdfs,async,cloudpickle,github-enterprise,google-auth,graphviz,gunicorn,kerberos,ldap,memray,otel,pandas,polars,rabbitmq,s3fs,sentry,statsd,uv]",
     "apache-airflow-core[all]",
     "apache-airflow-providers-airbyte>=5.0.0",
-    "apache-airflow-providers-akeyless>=1.0.0", # Set from local provider pyproject.toml
+    "apache-airflow-providers-akeyless>=1.0.0",
     "apache-airflow-providers-alibaba>=3.0.0",
     "apache-airflow-providers-amazon>=9.0.0",
     "apache-airflow-providers-apache-cassandra>=3.7.0; python_version !=\"3.14\"",

--- a/scripts/ci/prek/update_airflow_pyproject_toml.py
+++ b/scripts/ci/prek/update_airflow_pyproject_toml.py
@@ -166,7 +166,10 @@ def _fallback_provider_version(
             f"[yellow]Provider id {provider_id} min version fallback:[/] "
             f"local provider pyproject.toml -> {local_version}"
         )
-        return local_version, " # Set from local provider pyproject.toml"
+        # No trailing comment: a local-fallback version flips to a real PyPI release
+        # without any other change to the pin, and a stale comment would then trigger
+        # the update-pyproject-toml prek hook on unrelated PRs / on main.
+        return local_version, ""
     return None, ""
 
 


### PR DESCRIPTION
The `update-pyproject-toml` prek hook regenerates the `apache-airflow`
meta-package optional dependencies from each provider's published PyPI
metadata. The `apache-airflow-providers-vespa` package was just
published to PyPI, so the `# Set from local provider pyproject.toml`
fallback comment is no longer applicable and the hook removes it.

Static checks on `main` currently fail without this regeneration —
e.g. https://github.com/apache/airflow/actions/runs/24967723876 (the
`Static checks` job, `Update Airflow's meta-package pyproject.toml`
hook).

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)