### PR TITLE
[v3-2-test] Run breeze via uvx from the current worktree (#65873)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 
 - Install prek: `uv tool install prek`
 - Enable commit hooks: `prek install`
+- Install breeze shim (one-time, per machine): `scripts/tools/setup_breeze` — installs `~/.local/bin/breeze` that runs breeze via `uvx` from the current git worktree's `dev/breeze` (so each worktree, including ephemeral agent worktrees, gets its own breeze tied to its sources). See [ADR 0017](dev/breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md).
 - **Never run pytest, python, or airflow commands directly on the host** — always use `breeze`.
 - Place temporary scripts in `dev/` (mounted as `/opt/airflow/dev/` inside Breeze).
 

--- a/airflow-core/docs/security/vulnerabilities-in-3rd-party-dependencies.rst
+++ b/airflow-core/docs/security/vulnerabilities-in-3rd-party-dependencies.rst
@@ -139,7 +139,8 @@ used by Airflow and you would like to get rid of those. There are a few things y
   .. code-block:: bash
 
       git clone git@github.com:apache/airflow.git
-      uv tool install -e ./dev/breeze --force
+      cd airflow
+      ./scripts/tools/setup_breeze
       breeze release-management constraints-version-check --python 3.10 --package PACKAGE_NAME --explain-why
 
   Fragment of example output of such tool is shown below - indicating that ``apache-beam`` blocks upgrade of

--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -410,33 +410,22 @@ syndrome - because not only others can reproduce easily what you do, but also th
 the same environment to run all tests - so you should be able to easily reproduce the same failures you
 see in CI in your local environment.
 
-1. Install ``uv`` or ``pipx``. We recommend to install ``uv`` as the general purpose python development
-   environment - you can install it via https://docs.astral.sh/uv/getting-started/installation/ or you can
-   install ``pipx`` (>=1.2.1) - follow the instructions in `Install pipx <https://pipx.pypa.io/stable/>`_
-   It is important to install version of pipx >= 1.2.1 to workaround ``packaging`` breaking change introduced
-   in September 2023
+1. Install ``uv``. You can install it via https://docs.astral.sh/uv/getting-started/installation/.
+   ``uv`` is the recommended general-purpose Python development environment for Airflow.
 
-2. Run ``uv tool install -e ./dev/breeze`` (or ``pipx install -e ./dev/breeze``) in your checked-out
-   repository. Make sure to follow any instructions printed during the installation - this is needed
-   to make sure that the ``breeze`` command is available in your PATH
+2. Run ``./scripts/tools/setup_breeze`` in your checked-out repository. This installs a small shim
+   at ``~/.local/bin/breeze`` that runs Breeze via ``uvx`` from the current git worktree's
+   ``dev/breeze`` folder, so each worktree (including ephemeral ones used by coding agents) gets
+   its own Breeze tied to that worktree's sources. See
+   `ADR 0017 <../dev/breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md>`_ for the
+   rationale.
 
-.. warning::
-
-  If you see below warning while running pipx - it means that you have hit the
-  `known issue <https://github.com/pypa/pipx/issues/1092>`_ with ``packaging`` version 23.2:
-
-  .. code-block:: bash
-
-    ⚠️ Ignoring --editable install option. pipx disallows it for anything but a local path,
-    to avoid having to create a new src/ directory.
-
-  The workaround is to downgrade packaging to 23.1 and re-running the ``pipx install`` command, for example
-  by running ``pip install "packaging<23.2"``.
-
-  .. code-block:: bash
-
-     pip install "packaging==23.1"
-     pipx install -e ./dev/breeze --force
+   The legacy global install path (``uv tool install -e ./dev/breeze`` or
+   ``pipx install -e ./dev/breeze``) still works for users who explicitly want a single shared
+   install, but it is no longer the recommended approach and conflicts with the shim (both target
+   ``~/.local/bin/breeze``). If you previously installed Breeze that way, uninstall it first
+   (``uv tool uninstall apache-airflow-breeze`` or ``pipx uninstall apache-airflow-breeze``) before
+   running ``setup_breeze``.
 
 3. Initialize breeze autocomplete
 

--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -67,7 +67,7 @@ Option A – Breeze on Your Laptop
 
     git clone https://github.com/<you>/airflow.git
     cd airflow
-    uv tool install -e ./dev/breeze
+    ./scripts/tools/setup_breeze
 
 2. Setup your idea workspace to detect project src/ and tests/ folders as source roots.
 
@@ -178,7 +178,7 @@ Option B – One-Click GitHub Codespaces
       uv tool install prek
       prek install -f
       prek install -f --hook-type pre-push # for running mypy checks when pushing to repo
-      uv tool install -e ./dev/breeze
+      ./scripts/tools/setup_breeze
       uv run dev/ide_setup/setup_vscode.py
       breeze start-airflow
 

--- a/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_gitpod.rst
@@ -57,21 +57,22 @@ Connect your project to Gitpod
 Installing Breeze
 ---------------
 
-Gitpod's default image includes the required packages. You can install Breeze using either uv or pipx:
-
-Using uv (recommended):
+Gitpod's default image includes the required packages. The recommended way to install Breeze is
+the shim installer, which works the same in Gitpod as on a local machine:
 
 .. code-block:: bash
 
    pip install uv
-   uv tool install -e ./dev/breeze
+   ./scripts/tools/setup_breeze
 
-Using pipx (alternative):
+This installs ``~/.local/bin/breeze`` as a small shim that runs Breeze via ``uvx`` from the
+current git worktree's ``dev/breeze`` folder. See
+`ADR 0017 <../../dev/breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md>`_ for the
+rationale.
 
-.. code-block:: bash
-
-   pip install pipx
-   pipx install -e ./dev/breeze
+The legacy global install path (``uv tool install -e ./dev/breeze`` or
+``pipx install -e ./dev/breeze``) still works for users who explicitly want a single shared
+install, but is no longer recommended.
 
 Initializing the Database
 -----------------------

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -387,11 +387,16 @@ cd airflow
 export AIRFLOW_REPO_ROOT=$(pwd)
 ```
 
-- Install `breeze` command:
+- Install `breeze` command (recommended — installs a shim at `~/.local/bin/breeze` that runs
+  breeze via `uvx` from the current git worktree's `dev/breeze`; see
+  [ADR 0017](breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md)):
 
 ```shell script
-uv tool install -e ./dev/breeze
+./scripts/tools/setup_breeze
 ```
+
+The legacy global install (`uv tool install -e ./dev/breeze` or `pipx install -e ./dev/breeze`)
+still works but is no longer recommended.
 
 - Verify your GPG signing key is ready.
 

--- a/dev/breeze/README.md
+++ b/dev/breeze/README.md
@@ -35,19 +35,49 @@ that is used by Airflow developers to effortlessly setup and maintain consistent
 for Airflow Development.
 
 This package should never be installed in "production" mode. The `breeze` entrypoint will actually
-fail if you do so. It is supposed to be installed only in [editable/development mode](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#working-in-development-mode)
-directly from Airflow sources using `uv tool` or `pipx` - usually with `--force` flag to account
-for re-installation  that might often be needed if dependencies change during development.
+fail if you do so. It is supposed to be run directly against the Airflow sources you have checked
+out, in [editable/development mode](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#working-in-development-mode).
+
+The recommended way to make `breeze` available is to install a small **shim script** at
+`~/.local/bin/breeze` that runs breeze from the `dev/breeze` folder of the *current* git
+worktree via `uvx`. This avoids a single global install and means each git worktree
+(including ephemeral worktrees used by coding agents) gets its own breeze, tied to that
+worktree's sources. Because the shim is a real file on `PATH`, subprocesses (pre-commit
+hooks, CI scripts, dev tools) see it just like a `uv tool`-installed binary. See
+[ADR 0017](doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md) for the rationale.
+
+The `scripts/tools/setup_breeze` script installs the shim for you. If you previously
+installed breeze globally via `uv tool install -e ./dev/breeze` or `pipx install -e ./dev/breeze`,
+remove that install first — both write to `~/.local/bin/breeze` and would conflict:
 
 ```shell
-uv tool install -e ./dev/breeze --force
+uv tool uninstall apache-airflow-breeze   # or: pipx uninstall apache-airflow-breeze
 ```
 
-or
+To install the shim manually, write this file to `~/.local/bin/breeze` and `chmod +x` it:
 
 ```shell
-pipx install -e ./dev/breeze --force
+#!/usr/bin/env bash
+# Apache Airflow breeze shim — managed by scripts/tools/setup_breeze (ADR 0017).
+set -e
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "breeze: not inside a git repository — cd into an Airflow worktree first" >&2
+    exit 1
+}
+if [ ! -d "${repo_root}/dev/breeze" ]; then
+    echo "breeze: ${repo_root} is not an Airflow worktree (no dev/breeze)" >&2
+    exit 1
+fi
+exec env AIRFLOW_ROOT_PATH="${repo_root}" SKIP_BREEZE_SELF_UPGRADE_CHECK=1 \
+    uvx --from "${repo_root}/dev/breeze" --quiet breeze "$@"
 ```
+
+Then `breeze` invoked from any Airflow checkout uses that checkout's source. The first call in
+a fresh worktree pays a one-time `uvx` resolve/install; subsequent calls hit the cache.
+
+The legacy global-install path (`uv tool install -e ./dev/breeze --force` or
+`pipx install -e ./dev/breeze --force`) still works for users who explicitly want a single
+shared install, but it is no longer the recommended approach.
 
 You can read more about Breeze in the [documentation](https://github.com/apache/airflow/blob/main/dev/breeze/doc/README.rst)
 

--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -267,9 +267,52 @@ Set your working directory to the root of this cloned repository.
 
     cd  airflow
 
-Run this command to install Breeze (make sure to use ``-e`` flag) - you can choose ``uv`` (recommended) or
-``pipx``:
+The recommended way to make ``breeze`` available is to install a small **shim script** at
+``~/.local/bin/breeze`` that runs breeze from the ``dev/breeze`` folder of the current git
+worktree via ``uvx``. This avoids a single global install and means each git worktree
+(including ephemeral worktrees used by coding agents) gets its own breeze, tied to that
+worktree's sources. Because the shim is a real file on ``PATH``, subprocesses (pre-commit
+hooks, CI scripts, dev tools) see it just like a ``uv tool``-installed binary. See
+`ADR 0017 <adr/0017-use-uvx-to-run-breeze-from-local-sources.md>`_ for the rationale.
 
+The easiest way to set this up is to run the helper script:
+
+.. code-block:: bash
+
+    ./scripts/tools/setup_breeze
+
+It checks for ``uv``, refuses to proceed if a legacy global breeze install is present
+(see Uninstalling Breeze below), then writes the shim to ``~/.local/bin/breeze`` and
+marks it executable. To do it manually, write this file to ``~/.local/bin/breeze`` and
+``chmod +x`` it:
+
+.. code-block:: bash
+
+    #!/usr/bin/env bash
+    # Apache Airflow breeze shim — managed by scripts/tools/setup_breeze (ADR 0017).
+    set -e
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "breeze: not inside a git repository — cd into an Airflow worktree first" >&2
+        exit 1
+    }
+    if [ ! -d "${repo_root}/dev/breeze" ]; then
+        echo "breeze: ${repo_root} is not an Airflow worktree (no dev/breeze)" >&2
+        exit 1
+    fi
+    exec env AIRFLOW_ROOT_PATH="${repo_root}" SKIP_BREEZE_SELF_UPGRADE_CHECK=1 \
+        uvx --from "${repo_root}/dev/breeze" --quiet breeze "$@"
+
+Then ``breeze`` invoked from any Airflow checkout uses that checkout's source. The first call in
+a fresh worktree pays a one-time ``uvx`` resolve/install; subsequent calls hit the cache.
+
+Alternative: legacy global install (``uv tool`` or ``pipx``)
+............................................................
+
+If you prefer a single global install on ``PATH`` (the pre-ADR-0017 behaviour), you can still
+install Breeze with ``uv tool`` or ``pipx``. This is *not* recommended for setups with multiple
+checkouts or git worktrees, because all worktrees end up sharing one ``breeze`` binary tied to
+whichever source tree was last used for ``uv tool install --force``. It also conflicts with the
+shim approach above — both target ``~/.local/bin/breeze``.
 
 .. code-block:: bash
 
@@ -297,8 +340,9 @@ Run this command to install Breeze (make sure to use ``-e`` flag) - you can choo
 
         pipx install -e dev\breeze
 
-Once this is complete, you should have ``breeze`` binary on your PATH and available to run by ``breeze``
-command.
+Once either installation completes, you should have ``breeze`` available to run by ``breeze``
+command (the recommended setup uses a shim script at ``~/.local/bin/breeze`` that delegates
+to ``uvx``; the legacy global install puts a fully-installed binary at the same path).
 
 Those are all available commands for Breeze and details about the commands are described below:
 
@@ -307,19 +351,23 @@ Those are all available commands for Breeze and details about the commands are d
   :width: 100%
   :alt: Breeze commands
 
-Breeze installed this way is linked to your checked out sources of Airflow, so Breeze will
-automatically use latest version of sources from ``./dev/breeze``. Sometimes, when dependencies are
-updated ``breeze`` commands with offer you to run self-upgrade.
+Under the recommended uvx-based setup, Breeze always runs from the ``dev/breeze`` folder of the
+current git worktree, and ``uvx`` automatically rebuilds its cached environment whenever
+``pyproject.toml`` / ``uv.lock`` change — so there is no manual self-upgrade step.
 
-You can always run such self-upgrade at any time:
+If you used the legacy global install, Breeze is linked to the checked-out sources of Airflow it
+was installed from, so Breeze will automatically use the latest version of those sources. When
+breeze's own dependencies are updated, ``breeze`` commands will offer you to run self-upgrade,
+which you can also run at any time:
 
 .. code-block:: bash
 
     breeze setup self-upgrade
 
-If you have several checked out Airflow sources, Breeze will warn you if you are using it from a different
-source tree and will offer you to re-install from those sources - to make sure that you are using the right
-version.
+If you have several checked-out Airflow sources, the legacy global install will warn you if you
+are using it from a different source tree and offer you to re-install from those sources — to
+make sure that you are using the right version. (The recommended uvx-based setup avoids this
+class of problem entirely: each worktree has its own ephemeral install.)
 
 You can skip Breeze's upgrade check by setting ``SKIP_BREEZE_UPGRADE_CHECK`` variable to non empty value.
 
@@ -332,8 +380,19 @@ that Breeze works on
 
 .. warning:: Upgrading from earlier Python version
 
-    If you used Breeze with Python 3.8 and when running it, it will complain that it needs Python 3.10. In this
-    case you should force-reinstall Breeze with ``uv`` (or ``pipx``):
+    If breeze complains it needs a newer Python than what it picked up:
+
+    * **Recommended (uvx) setup:** export ``UV_PYTHON`` to the desired version before invoking
+      breeze, e.g.:
+
+        .. code-block:: bash
+
+            UV_PYTHON=3.10 breeze ...
+
+      or set it permanently in your shell rc. ``uvx`` will rebuild its cached environment with
+      that interpreter on the next call.
+
+    * **Legacy global install:** force-reinstall Breeze with ``uv`` (or ``pipx``):
 
         .. code-block:: bash
 
@@ -364,12 +423,12 @@ that Breeze works on
 
     .. note:: creating virtual env for ``apache-airflow-breeze`` with a specific python version
 
-        The ``uv tool install`` or  ``pipx install`` use default system python version to create virtual
-        env for breeze. You can use a specific version by providing python version in ``uv`` or
-        python executable in ``pipx`` in ``--python``.
+        For the recommended uvx setup, ``UV_PYTHON=3.10.16 breeze ...`` selects the Python version
+        for the cached environment.
 
-        If you have breeze installed already with another Python version you can reinstall breeze with reinstall
-        command
+        For a legacy global install, ``uv tool install`` or ``pipx install`` use the default system
+        python version to create the virtual env for breeze. You can pin a specific version with
+        ``--python``:
 
         .. code-block:: bash
 
@@ -492,14 +551,27 @@ Automating breeze installation
 ------------------------------
 
 Breeze on POSIX-compliant systems (Linux, MacOS) can be automatically installed by running the
-``scripts/tools/setup_breeze`` bash script. This includes checking and installing ``uv``, setting up
-``breeze`` with it and setting up autocomplete.
+``scripts/tools/setup_breeze`` bash script. It checks/installs ``uv``, refuses to proceed if a
+legacy global breeze install is present, then writes the shim script (see ADR 0017) to
+``~/.local/bin/breeze``.
 
 
 Uninstalling Breeze
 -------------------
 
-Since Breeze is installed with ``uv tool`` or ``pipx``, you need to use the appropriate tool to uninstall it.
+Under the recommended uvx-based setup, just delete the shim script:
+
+.. code-block:: bash
+
+    rm ~/.local/bin/breeze
+
+To also drop the cached environment:
+
+.. code-block:: bash
+
+    uv cache clean apache-airflow-breeze
+
+If you used the legacy global install, use the appropriate tool to uninstall it:
 
 .. code-block:: bash
 

--- a/dev/breeze/doc/adr/0016-use-uv-tool-to-install-breeze.md
+++ b/dev/breeze/doc/adr/0016-use-uv-tool-to-install-breeze.md
@@ -35,7 +35,7 @@ Date: 2024-11-11
 
 ## Status
 
-Accepted
+Superseded by [17. Use `uvx` to run breeze from local sources](0017-use-uvx-to-run-breeze-from-local-sources.md)
 
 Supersedes [10. Use pipx to install breeze](0010-use-pipx-to-install-breeze.md)
 

--- a/dev/breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md
+++ b/dev/breeze/doc/adr/0017-use-uvx-to-run-breeze-from-local-sources.md
@@ -1,0 +1,172 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [17. Use `uvx` to run breeze from local sources](#17-use-uvx-to-run-breeze-from-local-sources)
+  - [Status](#status)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# 17. Use `uvx` to run breeze from local sources
+
+Date: 2026-04-26
+
+## Status
+
+Accepted
+
+Supersedes [16. Use uv tool to install breeze](0016-use-uv-tool-to-install-breeze.md)
+
+## Context
+
+ADR 0016 recommended installing breeze once globally with ``uv tool install -e ./dev/breeze``.
+That model assumes a single working copy of Airflow per machine: the editable install points
+at one specific ``dev/breeze`` folder, and the resulting ``breeze`` binary on ``PATH`` is shared
+by every shell, every directory, every checkout.
+
+Two patterns have made that single-install model awkward:
+
+1. **Multiple checkouts / git worktrees.** Maintainers and contributors increasingly keep more
+   than one working copy of Airflow open at the same time — separate clones for parallel
+   feature work, ``v3-1-test`` backports, release verification, or just a clean tree to
+   reproduce a bug. Each worktree may have a different version of breeze itself (different
+   dependencies, different commands, different bugfixes). With a single ``uv tool`` install,
+   only one of those worktrees is "live"; calling ``breeze`` from any other worktree silently
+   runs the wrong code, and switching requires a ``uv tool install --force`` round-trip that
+   breaks the other worktree.
+
+2. **Agentic workflows.** Coding agents (Claude Code, Cursor, etc.) routinely create
+   short-lived git worktrees so multiple agents can work in parallel without stepping on
+   each other's branches. Those worktrees are created and destroyed automatically, and
+   each one needs its own working ``breeze`` immediately, without a manual reinstall step.
+   A single global install actively breaks this: agents in different worktrees fight over
+   the same ``~/.local/bin/breeze`` symlink, and an agent that does ``uv tool install
+   --force`` to "fix" itself silently sabotages every other worktree on the machine.
+
+``uv`` ships a tool — ``uvx`` — that runs a command from a project directory in an
+ephemeral, cached environment without installing anything globally. ``uvx --from
+./dev/breeze breeze ...`` resolves dependencies once per ``pyproject.toml`` /``uv.lock``
+hash, caches the resulting environment, and reuses it on subsequent calls. The first
+call in a fresh worktree is slow (one resolve + install); every call after that is
+fast.
+
+That gives us a way to make ``breeze`` always run from the *current* worktree's source
+without ever touching a shared global install — but the dispatch mechanism has to be
+something subprocesses can see. A shell function would not do: the codebase has many
+sites (``scripts/ci/prek/breeze_cmd_line.py``, CI scripts, dev tools) that invoke
+``breeze`` via ``subprocess.run(["breeze", ...])``, and subprocesses do not inherit
+shell functions. The dispatcher has to be a real file on ``PATH``.
+
+## Decision
+
+The recommended way to run breeze is via a small **shim script** at
+``~/.local/bin/breeze``, which delegates to ``uvx`` against the current git worktree:
+
+```shell
+#!/usr/bin/env bash
+# Apache Airflow breeze shim — managed by scripts/tools/setup_breeze (ADR 0017).
+# Runs breeze from the dev/breeze folder of the current git worktree via 'uvx',
+# so each worktree (e.g. parallel agentic runs) gets its own ephemerally-installed
+# breeze tied to that worktree's source.
+set -e
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "breeze: not inside a git repository — cd into an Airflow worktree first" >&2
+    exit 1
+}
+if [ ! -d "${repo_root}/dev/breeze" ]; then
+    echo "breeze: ${repo_root} is not an Airflow worktree (no dev/breeze)" >&2
+    exit 1
+fi
+exec env AIRFLOW_ROOT_PATH="${repo_root}" SKIP_BREEZE_SELF_UPGRADE_CHECK=1 \
+    uvx --from "${repo_root}/dev/breeze" --quiet breeze "$@"
+```
+
+``scripts/tools/setup_breeze`` writes this file (replacing any previous
+``uv tool install`` of breeze) and marks it executable. The location
+(``~/.local/bin``) matches where ``uv tool install`` would have created
+``breeze``, so the file naturally lives on ``PATH`` for users who already had
+the ``uv tool`` install working.
+
+The user-facing command stays the same — they still type ``breeze`` — but each
+invocation:
+
+* resolves ``$(git rev-parse --show-toplevel)`` from the current working directory,
+* dispatches to ``uvx --from <that-worktree>/dev/breeze breeze``,
+* and therefore always runs the breeze code that belongs to that worktree.
+
+Because the shim is a real file on ``PATH`` (not a shell function), it is also
+visible to subprocesses — pre-commit hooks, CI scripts, dev tools, and anything
+else that does ``subprocess.run(["breeze", ...])`` will pick it up exactly like
+they picked up the old ``uv tool``-installed binary.
+
+The two ``env`` variables matter: ``AIRFLOW_ROOT_PATH`` short-circuits breeze's
+installation-source detection (which walks up from ``__file__`` and would
+otherwise misfire because ``__file__`` lives inside the uvx cache, not the
+source tree), and ``SKIP_BREEZE_SELF_UPGRADE_CHECK=1`` disables the "your
+install is older than your sources" nag — moot under uvx, which auto-rebuilds
+the env when ``pyproject.toml`` / ``uv.lock`` change.
+
+``uv tool install -e ./dev/breeze`` and ``pipx install -e ./dev/breeze`` remain
+supported as alternatives for users who explicitly want the old single-install
+behaviour, but they are no longer the recommended path.
+
+## Consequences
+
+**Wins**
+
+* **Per-worktree isolation.** Each git worktree (and each clone) gets its own
+  breeze, transparently. No more ``uv tool install --force`` ping-pong when
+  switching between trees, and agents working in parallel worktrees never
+  clobber each other.
+* **No stale installs.** The breeze that runs is always the breeze that's
+  checked out — not whatever was current the last time someone reinstalled.
+  The "your installed breeze is older than your sources" warning class largely
+  goes away.
+* **Cheap setup in fresh worktrees.** Spinning up a new worktree (manually or
+  via an agent) needs no extra install step; ``breeze`` works the moment
+  ``cd`` lands in the tree.
+* **Subprocess-safe.** The shim is a real binary on ``PATH``, so anything that
+  shells out to ``breeze`` — pre-commit hooks, CI helpers, dev scripts —
+  resolves it exactly like a ``uv tool`` install did.
+
+**Costs**
+
+* **First call in a new worktree is slow.** ``uvx`` has to resolve and install
+  breeze's dependencies the first time it sees a given ``pyproject.toml`` /
+  ``uv.lock``. Subsequent calls hit the cache and are fast.
+* **Adds a small bash startup overhead.** The shim is a tiny bash script that
+  runs ``git rev-parse`` and ``uvx`` for every invocation. Negligible at the
+  command line, but noticeable inside tight loops or shell completion that
+  re-invokes ``breeze`` many times.
+* **Requires a git checkout.** ``breeze`` invoked outside a git tree errors
+  out with a clear message rather than running. This matches actual usage —
+  breeze is meaningless outside an Airflow source tree — but is a behavioural
+  change from the global install, which would silently run against whatever
+  tree it was last installed from.
+* **One-time migration.** Users who previously installed breeze with
+  ``uv tool install`` need to ``uv tool uninstall apache-airflow-breeze``
+  before installing the shim, otherwise both write to ``~/.local/bin/breeze``
+  and conflict. ``scripts/tools/setup_breeze`` detects the legacy install and
+  refuses to proceed until it is removed.

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3715,11 +3715,12 @@ def prepare_python_client(
                 f"but default version is {DEFAULT_PYTHON_MAJOR_MINOR_VERSION} - this might cause "
                 f"reproducibility problems with prepared package.[/]"
             )
+            console_print(f"[info]Please rerun breeze with Python {DEFAULT_PYTHON_MAJOR_MINOR_VERSION}.[/]")
             console_print(
-                f"[info]Please reinstall breeze with uv using Python {DEFAULT_PYTHON_MAJOR_MINOR_VERSION}:[/]"
-            )
-            console_print(
-                f"\nuv tool install --python {DEFAULT_PYTHON_MAJOR_MINOR_VERSION} -e ./dev/breeze --force\n"
+                "\n  - For the recommended uvx-based setup, set UV_PYTHON before invoking breeze:\n"
+                f"        UV_PYTHON={DEFAULT_PYTHON_MAJOR_MINOR_VERSION} breeze ...\n"
+                "  - For a legacy global install, reinstall with the right Python:\n"
+                f"        uv tool install --python {DEFAULT_PYTHON_MAJOR_MINOR_VERSION} -e ./dev/breeze --force\n"
             )
             sys.exit(1)
 

--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -75,6 +75,16 @@ def reinstall_breeze(breeze_sources: Path, re_run: bool = True):
         subprocess.check_call(
             ["pipx", "install", "-e", breeze_sources.as_posix(), "--force"], stderr=subprocess.STDOUT
         )
+    else:
+        # Recommended setup: breeze is invoked via the `uvx`-based shell function
+        # (see ADR 0017). There is no global install to reinstall — uvx will
+        # rebuild the cached env on next call when pyproject.toml / uv.lock change.
+        console_print(
+            "[info]No global breeze install detected (uv tool / pipx). "
+            "Assuming the recommended uvx-based setup — nothing to reinstall.[/]\n"
+            "[info]If you suspect a stale cached env, clear it with:[/]\n"
+            "    uv cache clean apache-airflow-breeze\n"
+        )
 
     if re_run:
         # Make sure we don't loop forever if the metadata hash hasn't been updated yet (else it is tricky to

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -263,7 +263,13 @@ def assert_prek_installed():
         need_to_reinstall_prek = True
         console_print(f"\n[error]Error checking for prek installation: [/]\n{e}\n")
     if need_to_reinstall_prek:
-        console_print("[info]Reinstall breeze: 'uv tool install -e ./dev/breeze --force'[/]")
+        console_print(
+            "[info]Reinstall breeze:[/]\n"
+            "  - For the recommended uvx-based setup, clear the cached env:\n"
+            "        uv cache clean apache-airflow-breeze\n"
+            "  - For a legacy global install:\n"
+            "        uv tool install -e ./dev/breeze --force"
+        )
         sys.exit(1)
 
 

--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -307,11 +307,11 @@ def initialize_breeze_prek(name: str, file: str):
     if shutil.which("breeze") is None:
         console.print(
             "[red]The `breeze` command is not on path.[/]\n\n"
-            "[yellow]Please install breeze.\n"
-            "You can use uv with `uv tool install -e ./dev/breeze or "
-            "`pipx install -e ./dev/breeze`.\n"
-            "It will install breeze from Airflow sources "
-            "(make sure you run `pipx ensurepath` if you use pipx)[/]\n\n"
+            "[yellow]Please install breeze. Recommended: run `./scripts/tools/setup_breeze` "
+            "from the repo root — it installs a shim at `~/.local/bin/breeze` that runs breeze "
+            "via `uvx` from the current git worktree (see ADR 0017).\n"
+            "Legacy global install (`uv tool install -e ./dev/breeze` or "
+            "`pipx install -e ./dev/breeze`) still works but is no longer recommended.[/]\n\n"
             "[bright_blue]You can also set SKIP_BREEZE_PREK_HOOKS env variable to non-empty "
             "value to skip all breeze tests."
         )

--- a/scripts/tools/setup_breeze
+++ b/scripts/tools/setup_breeze
@@ -20,7 +20,6 @@ set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 AIRFLOW_SOURCES=$(cd "${MY_DIR}/../.." && pwd)
 
-BREEZE_BINARY=breeze
 COLOR_RED=$'\e[31m'
 COLOR_GREEN=$'\e[32m'
 COLOR_YELLOW=$'\e[33m'
@@ -29,63 +28,149 @@ COLOR_RESET=$'\e[0m'
 
 UV_VERSION="0.11.7"
 
+SHIM_DIR="${HOME}/.local/bin"
+SHIM_PATH="${SHIM_DIR}/breeze"
+
+# Marker line embedded in the shim — used to tell our own shim apart from a
+# foreign breeze binary (e.g. left over from `uv tool install`).
+SHIM_MARKER="# Apache Airflow breeze shim — managed by scripts/tools/setup_breeze (ADR 0017)."
+
+# The shim itself. Runs breeze via 'uvx' against the dev/breeze folder of the
+# *current* git worktree, so multiple checkouts / agentic worktrees never
+# share a single global install. See ADR 0017.
+read -r -d '' BREEZE_SHIM_BODY <<BREEZE_SHIM || true
+#!/usr/bin/env bash
+${SHIM_MARKER}
+# Runs breeze from the dev/breeze folder of the current git worktree via 'uvx',
+# so each worktree (e.g. parallel agentic runs) gets its own ephemerally-installed
+# breeze tied to that worktree's source.
+set -e
+repo_root=\$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "breeze: not inside a git repository — cd into an Airflow worktree first" >&2
+    exit 1
+}
+if [ ! -d "\${repo_root}/dev/breeze" ]; then
+    echo "breeze: \${repo_root} is not an Airflow worktree (no dev/breeze)" >&2
+    exit 1
+fi
+exec env AIRFLOW_ROOT_PATH="\${repo_root}" SKIP_BREEZE_SELF_UPGRADE_CHECK=1 \\
+    uvx --from "\${repo_root}/dev/breeze" --quiet breeze "\$@"
+BREEZE_SHIM
+
 function manual_instructions() {
     echo
-    echo "${COLOR_BLUE}Please run those commands manually (you might need to restart shell between them)${COLOR_RESET}"
+    echo "${COLOR_BLUE}Please complete the setup manually:${COLOR_RESET}"
     echo
-    echo "    python -m pip install \"uv==${UV_VERSION}\""
-    echo "    uv tool install -e '${AIRFLOW_SOURCES}/dev/breeze/'"
-    echo "    breeze setup autocomplete --force"
+    echo "  1. Install uv (any reasonably recent version, >= ${UV_VERSION}):"
     echo
-    echo "   After that, both pipx and breeze should be available on your path"
+    echo "        python -m pip install \"uv>=${UV_VERSION}\""
+    echo
+    echo "  2. Make sure ${SHIM_DIR} exists and is on your PATH."
+    echo
+    echo "  3. Write the following file to ${SHIM_PATH} and mark it executable (chmod +x):"
+    echo
+    echo "${BREEZE_SHIM_BODY}" | sed 's/^/        /'
     echo
     exit 1
 }
 
-function check_breeze_installed() {
-    set +e
-    command -v "${BREEZE_BINARY}" >/dev/null 2>/dev/null
-    local breeze_on_path=$?
-    command -v "uv" >/dev/null 2>/dev/null
-    local uv_on_path=$?
-    set -e
-    if [[ ${breeze_on_path} != "0" || ${uv_on_path} != "0"  ]]; then
+function ensure_uv_installed() {
+    if ! command -v "uv" >/dev/null 2>/dev/null; then
         echo
-        if [[ ${uv_on_path} != 0 ]]; then
-            echo "${COLOR_RED}The 'uv' is not on path. It should be installed and 'uv' should be available on your PATH.${COLOR_RESET}"
-            export TIMEOUT=0
-            if "${MY_DIR}/confirm" "Installing uv?"; then
-                python -m pip install "uv==${UV_VERSION}" --upgrade
-                echo
-                echo "${COLOR_YELLOW}Please close and re-open the shell and retry. You might need to add 'uv' to the PATH!${COLOR_RESET}"
-                echo
-                exit
-            else
-                manual_instructions
-            fi
-        fi
-        if [[ ${breeze_on_path} != 0 ]]; then
-            echo "${COLOR_RED}The '${BREEZE_BINARY}' is not on path. Breeze should be installed and 'breeze' should be available on your PATH!${COLOR_RESET}"
-            export TIMEOUT=0
+        echo "${COLOR_RED}'uv' is not on PATH. It is required to run breeze via uvx.${COLOR_RESET}"
+        export TIMEOUT=0
+        if "${MY_DIR}/confirm" "Installing uv via pip"; then
+            python -m pip install "uv>=${UV_VERSION}" --upgrade
             echo
-            echo "${COLOR_YELLOW}Installing Breeze. This will install breeze via uv and modify your ${SHELL} to run it${COLOR_RESET}"
+            echo "${COLOR_YELLOW}Please close and re-open the shell, then re-run this script.${COLOR_RESET}"
             echo
-            if "${MY_DIR}/confirm" "installing and modifying the startup scripts"; then
-                uv tool install -e "${AIRFLOW_SOURCES}/dev/breeze/" --force
-                ${BREEZE_BINARY} setup autocomplete --force --answer yes
-                echo
-                echo "${COLOR_YELLOW}Please close and re-open the shell and retry. Then rerun your last command!${COLOR_RESET}"
-                echo
-                exit
-            else
-                manual_instructions
-            fi
+            exit
+        else
+            manual_instructions
         fi
     fi
 }
 
-check_breeze_installed
+function fail_on_legacy_global_install() {
+    # If a previous setup did `uv tool install -e ./dev/breeze`, both that install
+    # and our shim want to live at ~/.local/bin/breeze. Refuse to proceed until
+    # the user removes the legacy install — silent overwrite would corrupt uv's
+    # tool state and confuse later upgrades.
+    local legacy_uv=0 legacy_pipx=0
+    if uv tool list 2>/dev/null | grep -q '^apache-airflow-breeze\b'; then
+        legacy_uv=1
+    fi
+    if command -v pipx >/dev/null 2>&1 && pipx list --short 2>/dev/null | grep -q '^apache-airflow-breeze\b'; then
+        legacy_pipx=1
+    fi
+    if [[ ${legacy_uv} -eq 0 && ${legacy_pipx} -eq 0 ]]; then
+        return
+    fi
+    echo
+    echo "${COLOR_RED}A legacy global breeze install was detected.${COLOR_RESET}"
+    echo "${COLOR_YELLOW}It must be removed before installing the new shim, otherwise both${COLOR_RESET}"
+    echo "${COLOR_YELLOW}write to ${SHIM_PATH} and conflict. Run:${COLOR_RESET}"
+    echo
+    if [[ ${legacy_uv} -eq 1 ]]; then
+        echo "    uv tool uninstall apache-airflow-breeze"
+    fi
+    if [[ ${legacy_pipx} -eq 1 ]]; then
+        echo "    pipx uninstall apache-airflow-breeze"
+    fi
+    echo
+    echo "${COLOR_YELLOW}Then re-run this script.${COLOR_RESET}"
+    echo
+    exit 1
+}
+
+function check_shim_dir_on_path() {
+    case ":${PATH}:" in
+        *":${SHIM_DIR}:"*) return ;;
+    esac
+    echo
+    echo "${COLOR_YELLOW}Note: ${SHIM_DIR} is not on your PATH.${COLOR_RESET}"
+    echo "${COLOR_YELLOW}Add this to your shell rc to make 'breeze' available:${COLOR_RESET}"
+    echo
+    echo "    export PATH=\"${SHIM_DIR}:\$PATH\""
+    echo
+}
+
+function install_breeze_shim() {
+    mkdir -p "${SHIM_DIR}"
+
+    # If something exists at SHIM_PATH that we did not write, do not overwrite it
+    # silently — it could be the user's own script.
+    if [[ -e "${SHIM_PATH}" ]] && ! grep -qF "${SHIM_MARKER}" "${SHIM_PATH}"; then
+        echo
+        echo "${COLOR_RED}${SHIM_PATH} already exists and is not the breeze shim managed by this script.${COLOR_RESET}"
+        echo "${COLOR_YELLOW}Inspect it; if it is safe to replace, remove it and re-run this script.${COLOR_RESET}"
+        echo
+        exit 1
+    fi
+
+    if [[ -f "${SHIM_PATH}" ]] && grep -qF "${SHIM_MARKER}" "${SHIM_PATH}"; then
+        # Refresh in place — body might have changed across releases.
+        printf '%s\n' "${BREEZE_SHIM_BODY}" > "${SHIM_PATH}"
+        chmod +x "${SHIM_PATH}"
+        echo "${COLOR_GREEN}Refreshed breeze shim at ${SHIM_PATH}.${COLOR_RESET}"
+        return
+    fi
+
+    export TIMEOUT=0
+    if "${MY_DIR}/confirm" "Install breeze shim at ${SHIM_PATH}"; then
+        printf '%s\n' "${BREEZE_SHIM_BODY}" > "${SHIM_PATH}"
+        chmod +x "${SHIM_PATH}"
+        echo "${COLOR_GREEN}Installed breeze shim at ${SHIM_PATH}.${COLOR_RESET}"
+    else
+        manual_instructions
+    fi
+}
+
+ensure_uv_installed
+fail_on_legacy_global_install
+install_breeze_shim
+check_shim_dir_on_path
 
 echo
-echo "${COLOR_GREEN}Breeze is correctly installed! You can run it via 'breeze' command. Go ahead and develop Airflow.${COLOR_RESET}"
+echo "${COLOR_GREEN}Breeze is configured. Run 'breeze' from any Airflow worktree.${COLOR_RESET}"
 echo


### PR DESCRIPTION
Backport of #65873 to `v3-2-test`.

Replace `uv tool install -e ./dev/breeze` with a small shim script at
`~/.local/bin/breeze` that runs breeze via `uvx --from <repo>/dev/breeze`.
Each git worktree (including ephemeral worktrees used by coding agents)
gets its own breeze tied to its own sources, removing the
single-global-install ping-pong between checkouts.

ADR 0017 documents the rationale and supersedes 0016. `setup_breeze`
writes the shim and refuses to proceed if a legacy `uv tool` / `pipx`
install of breeze is still present.

### Conflict resolution

`dev/README_AIRFLOW3_DEV.md` had a conflict because PR #65873 modified
the "Testing changes for Airflow 2.11.x" section, which does not exist
on `v3-2-test` (it was added to `main` in a later commit). The shim
guidance had no anchor in this file, so the README change was dropped
from the backport. The shim itself is fully present in the other 15
files; contributor docs (`contributing-docs/03_contributors_quick_start.rst`,
`dev/breeze/doc/01_installation.rst`, etc.) cover the new install flow.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)