### PR TITLE
[v3-2-test] Regenerate meta-package pyproject.toml after vespa provider release (#65909)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-cohere>=1.4.0"
 ]
 "common.ai" = [
-    "apache-airflow-providers-common-ai>=0.0.1" # Set from local provider pyproject.toml
+    "apache-airflow-providers-common-ai>=0.0.1"
 ]
 "common.compat" = [
     "apache-airflow-providers-common-compat>=1.2.1"
@@ -421,7 +421,7 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-cloudant>=4.0.1",
     "apache-airflow-providers-cncf-kubernetes>=9.0.0",
     "apache-airflow-providers-cohere>=1.4.0",
-    "apache-airflow-providers-common-ai>=0.0.1", # Set from local provider pyproject.toml
+    "apache-airflow-providers-common-ai>=0.0.1",
     "apache-airflow-providers-common-compat>=1.2.1",
     "apache-airflow-providers-common-io>=1.4.2",
     "apache-airflow-providers-common-messaging>=2.0.0", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py

--- a/scripts/ci/prek/update_airflow_pyproject_toml.py
+++ b/scripts/ci/prek/update_airflow_pyproject_toml.py
@@ -166,7 +166,10 @@ def _fallback_provider_version(
             f"[yellow]Provider id {provider_id} min version fallback:[/] "
             f"local provider pyproject.toml -> {local_version}"
         )
-        return local_version, " # Set from local provider pyproject.toml"
+        # No trailing comment: a local-fallback version flips to a real PyPI release
+        # without any other change to the pin, and a stale comment would then trigger
+        # the update-pyproject-toml prek hook on unrelated PRs / on main.
+        return local_version, ""
     return None, ""
 
 


### PR DESCRIPTION
Backport of #65909 to `v3-2-test`.

The `update-pyproject-toml` prek hook regenerates the `apache-airflow`
meta-package optional dependencies from each provider's published PyPI
metadata. The `# Set from local provider pyproject.toml` fallback comment
goes stale the moment a provider ships its first PyPI release, which then
surfaces as a static-check failure on unrelated PRs and on the release
branches.

This backport applies the script change in
`scripts/ci/prek/update_airflow_pyproject_toml.py` so future first-release
events no longer trigger churn. The `MIN_VERSION_OVERRIDE` comment is kept.

### Conflict resolution

`pyproject.toml` conflicted because vespa and akeyless do not appear in
`v3-2-test`'s meta-package `pyproject.toml`. Took the v3-2-test version
as-is, then re-ran the regen prek hook with the updated script — that
naturally dropped the only remaining stale fallback comment on v3-2-test
(`apache-airflow-providers-common-ai`).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)