### PR TITLE
Fix for duplicate Rookie authors selection in Top Rookie PR list

### DIFF
--- a/dev/stats/get_important_pr_candidates.py
+++ b/dev/stats/get_important_pr_candidates.py
@@ -1044,7 +1044,21 @@ def main(
     # Format date range for display
     date_range_str = f"{date_start.strftime('%Y-%m-%d')} to {date_end.strftime('%Y-%m-%d')}"
     console.print(f"\n[bold green]🏆 Top {top_number} PRs ({date_range_str}):[/bold green]\n")
-    top_final = heapq.nlargest(top_number, scores.items(), key=lambda x: x[1])
+
+    if rookie:
+        # One PR per author to ensure fair representation of different rookies
+        seen_authors: set[str] = set()
+        selected = []
+        for pr_num, score in sorted(scores.items(), key=lambda x: x[1], reverse=True):
+            pr_stat = next((pr for pr in pr_stats if pr.number == pr_num), None)
+            if pr_stat and pr_stat.author not in seen_authors:
+                selected.append((pr_num, score))
+                seen_authors.add(pr_stat.author)
+            if len(selected) >= top_number:
+                break
+        top_final = selected
+    else:
+        top_final = heapq.nlargest(top_number, scores.items(), key=lambda x: x[1])
 
     for i, (pr_num, score) in enumerate(top_final, 1):
         pr_stat = next((pr for pr in pr_stats if pr.number == pr_num), None)


### PR DESCRIPTION
This is a fix to ensure duplicate authors do not show up in Top Rookie PR list.

##### Was generative AI tooling used to co-author this PR?

- Yes (please specify the tool below)
Sonnet 4.6 Adaptive

## Fix duplicate rookie authors in Top Rookie PR list

### Problem

When running the script in `--rookie` mode, the same author can appear multiple times in the Top N list. For example, in the April 2026 run, X appeared at both position 10 and 11:

This is unfair to other rookie contributors — a single prolific rookie can dominate the list, crowding out other genuine newcomers.

### Root Cause

The final selection in `main()` uses `heapq.nlargest` on scores with no per-author constraint:

```python
# Applied to both rookie and non-rookie mode — no author deduplication
top_final = heapq.nlargest(top_number, scores.items(), key=lambda x: x[1])
```

### Fix

In `--rookie` mode, enforce a maximum of **1 PR per author** when selecting the Top N, while leaving the non-rookie path completely unchanged:

### Why this is safe

- The `else` branch is identical to the original `heapq.nlargest` - non-rookie mode is completely unchanged
- `pr_stat.author` consistently uses `pr_data["author"]["login"]` (GitHub login) throughout the script — no mismatch risk
- No new imports required — `set` and `sorted` are Python builtins
- Only one line in `main()` is replaced — no other logic is touched

### Impact

Each rookie author can appear **at most once** in the Top N list, ensuring the award highlights a broader set of new contributors rather than being dominated by a single active newcomer.


I have tested local, works fine before and after fix runs. Local pre-commit checks do not give errors related to this PR.