### PR TITLE
Remove non-essential sorting xcom assertions in E2E tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
@@ -125,32 +125,6 @@ export class XComsPage extends BasePage {
     }
   }
 
-  public async verifySortByColumn(columnName: string): Promise<void> {
-    await this.navigate();
-
-    const columnHeader = this.xcomsTable.getByRole("columnheader", { name: columnName });
-
-    await expect(columnHeader).toBeVisible({ timeout: 10_000 });
-
-    const firstSortResponse = this.page.waitForResponse(
-      (response) => response.url().includes("xcomEntries") && response.ok(),
-      { timeout: 10_000 },
-    );
-
-    await columnHeader.click();
-    await firstSortResponse;
-    await expect(this.page).toHaveURL(/sorting/);
-
-    const secondSortResponse = this.page.waitForResponse(
-      (response) => response.url().includes("xcomEntries") && response.ok(),
-      { timeout: 10_000 },
-    );
-
-    await columnHeader.click();
-    await secondSortResponse;
-    await expect(this.page).toHaveURL(/sorting/);
-  }
-
   public async verifyXComDetailsDisplay(): Promise<void> {
     const firstRow = this.tableRows.first();
 

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/xcoms.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/xcoms.spec.ts
@@ -57,12 +57,4 @@ test.describe("XComs Page", () => {
   test("verify filtering by DAG display name", async ({ xcomRunsData, xcomsPage }) => {
     await xcomsPage.verifyDagDisplayNameFiltering(xcomRunsData.dagId);
   });
-
-  test("verify sorting by key column", async ({ xcomsPage }) => {
-    await xcomsPage.verifySortByColumn("Key");
-  });
-
-  test("verify sorting by timestamp column", async ({ xcomsPage }) => {
-    await xcomsPage.verifySortByColumn("Timestamp");
-  });
 });


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->


Sorting is not essential for the E2E test coverage. However, this part has been causing failures in XCom-related tests.
Therefore, the sorting-related assertions are removed.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
