### PR TITLE
Fix `refresh_from_task` not applied on retries

### DIFF
--- a/airflow-core/docs/administration-and-deployment/cluster-policies.rst
+++ b/airflow-core/docs/administration-and-deployment/cluster-policies.rst
@@ -41,10 +41,12 @@ There are three main types of cluster policy:
   ``task_instance_mutation_hook`` applies not to a task but to the instance of a task that
   relates to a particular DagRun. It is executed scheduler-side while task instances are created or
   reconciled (not in the Dag file processor, and not on the worker). The policy is only applied to the
-  currently executed run (i.e. instance) of that task. The ``dag_run`` argument lets the policy route on
-  run configuration (``dag_run.conf``); it may be ``None`` in early task-instance construction, and a hook
-  that only declares ``task_instance`` keeps working unchanged. Note that ``dag_run.conf`` is only populated
-  for manually triggered or API-triggered runs; scheduled runs carry an empty ``conf``.
+  currently executed run (i.e. instance) of that task. It may fire more than once for a given task
+  instance -- at creation and on each retry transition, where the next attempt gets a fresh
+  ``task_instance.id`` -- so implementations should be idempotent. The ``dag_run`` argument lets the policy
+  route on run configuration (``dag_run.conf``); it may be ``None`` in early task-instance construction, and
+  a hook that only declares ``task_instance`` keeps working unchanged. Note that ``dag_run.conf`` is only
+  populated for manually triggered or API-triggered runs; scheduled runs carry an empty ``conf``.
 
 .. warning::
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -102,6 +102,15 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.strings import get_random_string
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
+_RETRY_REFRESHED_TI_FIELDS = (
+    "queue",
+    "pool",
+    "pool_slots",
+    "priority_weight",
+    "executor",
+    "executor_config",
+)
+
 if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
@@ -2103,6 +2112,7 @@ class DagRun(Base, LoggingMixin):
         reschedule_ti_ids: set[UUID] = set()
         debug_try_number_check = self.log.isEnabledFor(logging.DEBUG)
         expected_try_number_by_ti_id: dict[UUID, tuple[int, int, str | None]] = {}
+        mutated_overrides_by_ti_id: dict[UUID, dict[str, Any]] = {}
         for ti in schedulable_tis:
             if not ti.is_schedulable:
                 empty_ti_ids.append(ti.id)
@@ -2113,16 +2123,30 @@ class DagRun(Base, LoggingMixin):
             # execute it to run in the worker.
             elif not ti.defer_task(session=session):
                 schedulable_ti_ids.append(ti.id)
-                if ti.state == TaskInstanceState.UP_FOR_RESCHEDULE:
+                is_reschedule = ti.state == TaskInstanceState.UP_FOR_RESCHEDULE
+                if is_reschedule:
                     reschedule_ti_ids.add(ti.id)
                 if debug_try_number_check:
                     expected_try_number_by_ti_id[ti.id] = (
-                        ti.try_number
-                        if ti.state == TaskInstanceState.UP_FOR_RESCHEDULE
-                        else ti.try_number + 1,
+                        ti.try_number if is_reschedule else ti.try_number + 1,
                         ti.try_number,
                         ti.state,
                     )
+                # Retry-only: first attempts use creation-time hook firing and
+                # reschedules do not bump try_number.
+                if ti.task is not None and ti.state == TaskInstanceState.UP_FOR_RETRY:
+                    saved_try = ti.try_number
+                    saved_values = tuple(getattr(ti, k) for k in _RETRY_REFRESHED_TI_FIELDS)
+                    ti.try_number = saved_try + 1
+                    ti.refresh_from_task(ti.task)
+                    ti.try_number = saved_try
+                    overrides = {
+                        k: getattr(ti, k)
+                        for k, prev in zip(_RETRY_REFRESHED_TI_FIELDS, saved_values)
+                        if getattr(ti, k) != prev
+                    }
+                    if overrides:
+                        mutated_overrides_by_ti_id[ti.id] = overrides
 
         count = 0
         # Don't only check if the TI.id is in id_chunk
@@ -2192,6 +2216,14 @@ class DagRun(Base, LoggingMixin):
                                 db_state,
                                 db_try_number,
                             )
+
+        for ti_id, overrides in mutated_overrides_by_ti_id.items():
+            session.execute(
+                update(TI)
+                .where(TI.id == ti_id)
+                .values(**overrides)
+                .execution_options(synchronize_session=False)
+            )
 
         # Tasks using EmptyOperator should not be executed, mark them as success
         if empty_ti_ids:

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -102,15 +102,6 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.strings import get_random_string
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
-_RETRY_REFRESHED_TI_FIELDS = (
-    "queue",
-    "pool",
-    "pool_slots",
-    "priority_weight",
-    "executor",
-    "executor_config",
-)
-
 if TYPE_CHECKING:
     from typing import Literal, TypeAlias
 
@@ -2112,7 +2103,8 @@ class DagRun(Base, LoggingMixin):
         reschedule_ti_ids: set[UUID] = set()
         debug_try_number_check = self.log.isEnabledFor(logging.DEBUG)
         expected_try_number_by_ti_id: dict[UUID, tuple[int, int, str | None]] = {}
-        mutated_overrides_by_ti_id: dict[UUID, dict[str, Any]] = {}
+        count = 0
+        had_retry_mutation = False
         for ti in schedulable_tis:
             if not ti.is_schedulable:
                 empty_ti_ids.append(ti.id)
@@ -2122,6 +2114,19 @@ class DagRun(Base, LoggingMixin):
             # If not, we'll add this "ti" into "schedulable_ti_ids" and later
             # execute it to run in the worker.
             elif not ti.defer_task(session=session):
+                # Retries flow through the ORM so refresh_from_task can re-apply task
+                # defaults and run task_instance_mutation_hook against the about-to-run
+                # try_number. First attempts and reschedules stay on the bulk UPDATE path.
+                # Pass dag_run so the mutation hook stays run-aware on retries (see #68198).
+                if ti.task is not None and ti.state == TaskInstanceState.UP_FOR_RETRY:
+                    ti.try_number += 1
+                    ti.state = TaskInstanceState.SCHEDULED
+                    ti.scheduled_dttm = timezone.utcnow()
+                    ti.refresh_from_task(ti.task, dag_run=self)
+                    count += 1
+                    had_retry_mutation = True
+                    continue
+
                 schedulable_ti_ids.append(ti.id)
                 is_reschedule = ti.state == TaskInstanceState.UP_FOR_RESCHEDULE
                 if is_reschedule:
@@ -2132,23 +2137,10 @@ class DagRun(Base, LoggingMixin):
                         ti.try_number,
                         ti.state,
                     )
-                # Retry-only: first attempts use creation-time hook firing and
-                # reschedules do not bump try_number.
-                if ti.task is not None and ti.state == TaskInstanceState.UP_FOR_RETRY:
-                    saved_try = ti.try_number
-                    saved_values = tuple(getattr(ti, k) for k in _RETRY_REFRESHED_TI_FIELDS)
-                    ti.try_number = saved_try + 1
-                    ti.refresh_from_task(ti.task)
-                    ti.try_number = saved_try
-                    overrides = {
-                        k: getattr(ti, k)
-                        for k, prev in zip(_RETRY_REFRESHED_TI_FIELDS, saved_values)
-                        if getattr(ti, k) != prev
-                    }
-                    if overrides:
-                        mutated_overrides_by_ti_id[ti.id] = overrides
-
-        count = 0
+        if had_retry_mutation:
+            # Airflow disables SQLA autoflush, so retry-branch mutations need an
+            # explicit flush to be visible to the bulk UPDATE/SELECTs that follow.
+            session.flush()
         # Don't only check if the TI.id is in id_chunk
         # but also check if the TI.state is in the schedulable states.
         # Plus, a scheduled empty operator should not be scheduled again.
@@ -2216,14 +2208,6 @@ class DagRun(Base, LoggingMixin):
                                 db_state,
                                 db_try_number,
                             )
-
-        for ti_id, overrides in mutated_overrides_by_ti_id.items():
-            session.execute(
-                update(TI)
-                .where(TI.id == ti_id)
-                .values(**overrides)
-                .execution_options(synchronize_session=False)
-            )
 
         # Tasks using EmptyOperator should not be executed, mark them as success
         if empty_ti_ids:

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2669,6 +2669,153 @@ def test_schedule_tis_up_for_reschedule_does_not_increment_try_number(dag_maker,
     assert refreshed_ti.try_number == 3
 
 
+def test_schedule_tis_reapplies_mutation_hook_on_retry(dag_maker, session, monkeypatch):
+    def reroute_retries(task_instance, dag_run=None):
+        if (task_instance.try_number or 0) >= 2:
+            task_instance.queue = "retry_queue"
+
+    monkeypatch.setattr("airflow.models.taskinstance.task_instance_mutation_hook", reroute_retries)
+
+    with dag_maker(session=session) as dag:
+        BashOperator(task_id="task", bash_command="echo 1", queue="default")
+
+    dr = dag_maker.create_dagrun(session=session)
+    ti = dr.get_task_instance("task", session=session)
+    ti.refresh_from_task(dag.get_task("task"))
+    ti.state = TaskInstanceState.UP_FOR_RETRY
+    ti.try_number = 1
+    session.commit()
+
+    assert dr.schedule_tis((ti,), session=session) == 1
+    session.commit()
+
+    session.expire_all()
+    refreshed_ti = session.scalar(
+        select(TI).where(
+            TI.dag_id == ti.dag_id,
+            TI.task_id == ti.task_id,
+            TI.run_id == ti.run_id,
+            TI.map_index == ti.map_index,
+        )
+    )
+    assert refreshed_ti.state == TaskInstanceState.SCHEDULED
+    assert refreshed_ti.try_number == 2
+    assert refreshed_ti.queue == "retry_queue"
+
+
+def test_schedule_tis_does_not_apply_retry_mutation_hook_on_first_attempt(dag_maker, session, monkeypatch):
+    def reroute_retries(task_instance, dag_run=None):
+        if (task_instance.try_number or 0) >= 1:
+            task_instance.queue = "retry_queue"
+
+    monkeypatch.setattr("airflow.models.taskinstance.task_instance_mutation_hook", reroute_retries)
+
+    with dag_maker(session=session) as dag:
+        BashOperator(task_id="task", bash_command="echo 1", queue="default")
+
+    dr = dag_maker.create_dagrun(session=session)
+    ti = dr.get_task_instance("task", session=session)
+    ti.refresh_from_task(dag.get_task("task"))
+    ti.state = None
+    ti.try_number = 0
+    ti.queue = "default"
+    session.merge(ti)
+    session.commit()
+
+    assert dr.schedule_tis((ti,), session=session) == 1
+    session.commit()
+
+    session.expire_all()
+    refreshed_ti = session.scalar(
+        select(TI).where(
+            TI.dag_id == ti.dag_id,
+            TI.task_id == ti.task_id,
+            TI.run_id == ti.run_id,
+            TI.map_index == ti.map_index,
+        )
+    )
+    assert refreshed_ti.state == TaskInstanceState.SCHEDULED
+    assert refreshed_ti.try_number == 1
+    assert refreshed_ti.queue == "default"
+
+
+def test_schedule_tis_recomputes_priority_weight_for_dynamic_strategy(dag_maker, session):
+    from airflow import plugins_manager
+
+    from tests_common.test_utils.mock_plugins import mock_plugin_manager
+    from unit.plugins.priority_weight_strategy import (
+        DecreasingPriorityStrategy,
+        TestPriorityWeightStrategyPlugin,
+    )
+
+    try:
+        with mock_plugin_manager(plugins=[TestPriorityWeightStrategyPlugin]):
+            with dag_maker(session=session) as dag:
+                BashOperator(
+                    task_id="task",
+                    bash_command="echo 1",
+                    weight_rule=DecreasingPriorityStrategy(),
+                )
+
+            dr = dag_maker.create_dagrun(session=session)
+            ti = dr.get_task_instance("task", session=session)
+            ti.refresh_from_task(dag.get_task("task"))
+            ti.state = TaskInstanceState.UP_FOR_RETRY
+            ti.try_number = 1
+            session.merge(ti)
+            session.commit()
+
+            assert dr.schedule_tis((ti,), session=session) == 1
+            session.commit()
+
+            session.expire_all()
+            refreshed_ti = session.scalar(
+                select(TI).where(
+                    TI.dag_id == ti.dag_id,
+                    TI.task_id == ti.task_id,
+                    TI.run_id == ti.run_id,
+                    TI.map_index == ti.map_index,
+                )
+            )
+            # DecreasingPriorityStrategy returns max(3 - try + 1, 1). After schedule_tis
+            # bumps try_number 1 -> 2, the strategy is re-evaluated against try=2 giving 2.
+            assert refreshed_ti.try_number == 2
+            assert refreshed_ti.priority_weight == 2
+    finally:
+        # mock_plugin_manager clears strategy caches on entry but not on exit.
+        plugins_manager.get_priority_weight_strategy_plugins.cache_clear()
+
+
+def test_schedule_tis_does_not_touch_priority_weight_for_static_strategy(dag_maker, session):
+    with dag_maker(session=session) as dag:
+        BashOperator(task_id="task", bash_command="echo 1", priority_weight=42)
+
+    dr = dag_maker.create_dagrun(session=session)
+    ti = dr.get_task_instance("task", session=session)
+    ti.refresh_from_task(dag.get_task("task"))
+    ti.state = TaskInstanceState.UP_FOR_RETRY
+    ti.try_number = 1
+    original_priority = ti.priority_weight
+    original_queue = ti.queue
+    session.commit()
+
+    assert dr.schedule_tis((ti,), session=session) == 1
+    session.commit()
+
+    session.expire_all()
+    refreshed_ti = session.scalar(
+        select(TI).where(
+            TI.dag_id == ti.dag_id,
+            TI.task_id == ti.task_id,
+            TI.run_id == ti.run_id,
+            TI.map_index == ti.map_index,
+        )
+    )
+    assert refreshed_ti.try_number == 2
+    assert refreshed_ti.priority_weight == original_priority
+    assert refreshed_ti.queue == original_queue
+
+
 def test_schedule_tis_empty_operator_is_noop_if_ti_already_running(dag_maker, session):
     with dag_maker(session=session) as dag:
         EmptyOperator(task_id="empty_task")

--- a/airflow-core/tests/unit/plugins/priority_weight_strategy.py
+++ b/airflow-core/tests/unit/plugins/priority_weight_strategy.py
@@ -44,7 +44,7 @@ class DecreasingPriorityStrategy(PriorityWeightStrategy):
     """A priority weight strategy that decreases the priority weight with each attempt."""
 
     def get_weight(self, ti: TaskInstance):
-        return max(3 - ti.try_number + 1, 1)
+        return max(3 - (ti.try_number or 0) + 1, 1)
 
 
 class TestPriorityWeightStrategyPlugin(AirflowPlugin):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Summary

`task_instance_mutation_hook` and dynamic `PriorityWeightStrategy`
subclasses are not re-applied on natural retries: `refresh_from_task`
is missing from the `UP_FOR_RETRY → SCHEDULED` transition.

This adds it to `DagRun.schedule_tis` against the new computed
`try_number`. First attempts and `UP_FOR_RESCHEDULE` are unaffected,
per-TI UPDATEs only fire when field values actually change.

Related: #32452, #32471, #20143

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude Opus 4.7 for code planning and implementing the new tests.

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

## Verification

### Setup

Mutation hook (`$AIRFLOW_HOME/plugins/airflow_local_settings.py`):

```python
from __future__ import annotations

import logging

from airflow.models.taskinstance import TaskInstance

log = logging.getLogger(__name__)
log.warning("[mutation-hook-demo] airflow_local_settings.py LOADED")


def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
    log.warning(
        "[mutation-hook-demo] hook fired: task=%s try=%s queue_before=%s",
        task_instance.task_id,
        task_instance.try_number,
        task_instance.queue,
    )
    if (task_instance.try_number or 0) >= 1:
        task_instance.queue = "recovery"
```

Demo DAG:

```python
from __future__ import annotations

from datetime import timedelta

from decreasing_priority_plugin import DecreasingPriorityStrategy

from airflow.exceptions import AirflowException
from airflow.operators.python import PythonOperator
from airflow.sdk import DAG
from airflow.utils import timezone


def fails_until_last_try(**context) -> str:
    ti = context["ti"]
    if ti.try_number < 3:
        raise AirflowException(f"forced failure on try {ti.try_number}")
    return "recovered"


with DAG(
    dag_id="example_mutation_hook_retry_queue",
    schedule=None,
    start_date=timezone.datetime(2026, 1, 1),
    catchup=False,
    tags=["mutation_hook_demo"],
):
    PythonOperator(
        task_id="fail_until_last_try",
        python_callable=fails_until_last_try,
        queue="default",
        retries=2,
        retry_delay=timedelta(seconds=5),
        weight_rule=DecreasingPriorityStrategy(),
    )
```

### Result

| try | queue    | priority_weight |
|-----|----------|-----------------|
| 1   | default  | 9               |
| 2   | recovery | 8               |
| 3   | recovery | 7               |

Try 1:

<img width="674" height="810" alt="image" src="https://github.com/user-attachments/assets/b290a735-2518-491e-9b63-947c2c6ac6e7" />

Try 2:

<img width="533" height="819" alt="image" src="https://github.com/user-attachments/assets/b3211441-35f6-4ff3-8888-f9b4db333dcc" />

Try 3:

<img width="503" height="826" alt="image" src="https://github.com/user-attachments/assets/72c9e938-7371-4403-943a-c9440d47767c" />

