### PR TITLE
Fix AwaitMessageTrigger missing super().__init__() call

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -82,6 +82,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
         poll_interval: float = 5,
         commit_offset: bool = True,
     ) -> None:
+        super().__init__()
         self.topics = topics
         self.apply_function = apply_function
         self.apply_function_args = apply_function_args or ()

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -180,6 +180,21 @@ class TestTrigger:
 
         await trigger.cleanup()
 
+    def test_trigger_has_task_instance_attribute(self):
+        """AwaitMessageTrigger must initialise _task_instance via super().__init__().
+
+        Without the super().__init__() call, accessing trigger.task_instance raises
+        AttributeError when used as an AssetWatcher trigger (where the triggerer never
+        sets the attribute via the task_instance setter).
+        """
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            topics=["noop"],
+        )
+
+        assert hasattr(trigger, "_task_instance")
+        assert trigger.task_instance is None
+
 
 @mark_common_msg_queue_test
 class TestMessageQueueTrigger:


### PR DESCRIPTION
### Summary

Fix `AwaitMessageTrigger` not calling `super().__init__()`, which caused an `AttributeError`
when the trigger was used as an `AssetWatcher` trigger.

### Analysis

`BaseTrigger.__init__()` initialises `self._task_instance = None`, which is required for the
`task_instance` property to work correctly:

```python
# airflow-core/src/airflow/triggers/base.py
class BaseTrigger:
    def __init__(self, **kwargs):
        self._task_instance = None  # ← must be set by super().__init__()
        ...

    @property
    def task_instance(self):
        return self._task_instance  # ← AttributeError if _task_instance never set
```

`AwaitMessageTrigger.__init__()` was missing the `super().__init__()` call, so
`_task_instance` was never initialised.

When the trigger is used as an `AssetWatcher` trigger, there is no associated task instance,
so `_task_instance` is never set. When the triggerer later accesses `trigger.task_instance`,
it raises:
<img width="1352" height="214" alt="image" src="https://github.com/user-attachments/assets/3c52c582-2b04-4239-a3a1-535d98dfaf62" />

```
AttributeError: 'AwaitMessageTrigger' object has no attribute '_task_instance'
```

This was confirmed by running `KafkaMessageQueueTrigger` (which delegates to
`AwaitMessageTrigger`) as an `AssetWatcher` trigger in a Breeze dev environment.

### Changes

Added `super().__init__()` call to `AwaitMessageTrigger.__init__()`.

### Test

- Added `test_trigger_has_task_instance_attribute` — verifies that `_task_instance` is
  properly initialised to `None` after instantiation, which is the condition required for
  `AssetWatcher` usage to work without `AttributeError`
- All provider unit tests pass (`uv run --project providers/apache/kafka pytest providers/apache/kafka/tests/unit/`)
- Static checks pass (`prek run --from-ref main --stage pre-commit`)


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
---

I'm happy to make any adjustments based on your feedback. Thank you to the maintainers for taking the time to review this contribution!

