### PR TITLE
Fix resolve_xcom_backend to rely on config schema default

### DIFF
--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -26,7 +26,6 @@ import pytest
 from sqlalchemy import delete, func, select
 
 from airflow._shared.timezones import timezone
-from airflow.configuration import conf
 from airflow.models.dag import DAG
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun, DagRunType
@@ -154,16 +153,6 @@ class TestXCom:
 
     @conf_vars({("core", "xcom_backend"): ""})
     def test_resolve_xcom_class_fallback_to_basexcom(self):
-        cls = resolve_xcom_backend()
-        assert issubclass(cls, BaseXCom)
-        assert cls.serialize_value([1]) == [1]
-
-    @conf_vars({("core", "xcom_backend"): "to be removed"})
-    def test_resolve_xcom_class_fallback_to_basexcom_no_config(self):
-        from airflow.sdk.configuration import conf as sdk_conf
-
-        conf.remove_option("core", "xcom_backend")
-        sdk_conf.remove_option("core", "xcom_backend")
         cls = resolve_xcom_backend()
         assert issubclass(cls, BaseXCom)
         assert cls.serialize_value([1]) == [1]

--- a/task-sdk/src/airflow/sdk/execution_time/xcom.py
+++ b/task-sdk/src/airflow/sdk/execution_time/xcom.py
@@ -26,8 +26,8 @@ def resolve_xcom_backend():
 
     :returns: returns the custom XCom class if configured.
     """
-    clazz = conf.getimport("core", "xcom_backend", fallback="airflow.sdk.bases.xcom.BaseXCom")
-    if not clazz:
+    clazz = conf.getimport("core", "xcom_backend")
+    if clazz is None:
         return BaseXCom
     if not issubclass(clazz, BaseXCom):
         raise TypeError(


### PR DESCRIPTION
Remove the hardcoded fallback string in conf.getimport — it was duplicating (and diverging from) the canonical default already declared in config.yml. Use explicit `is None` check instead of falsy check.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Similar to: https://github.com/apache/airflow/pull/65759#discussion_r3142869614

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
