### PR TITLE
Add data-testid to XCom value for stable E2E selectors

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XComEntry.tsx
@@ -87,7 +87,7 @@ export const XComEntry = ({ dagId, mapIndex, open = false, runId, taskId, xcomKe
       width={200} // TODO: Make Skeleton take style from column definition
     />
   ) : (
-    <HStack>
+    <HStack data-testid="xcom-value">
       {isObjectOrArray ? (
         <RenderedJsonField collapsed={!open} content={xcomValue as object} enableClipboard={false} />
       ) : (

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/XComsPage.ts
@@ -161,12 +161,6 @@ export class XComsPage extends BasePage {
     const firstRow = this.tableRows.first();
 
     await expect(firstRow).toBeVisible({ timeout: 10_000 });
-
-    const valueCell = firstRow.locator("td").last();
-
-    await expect(valueCell).toBeVisible();
-    await expect(
-      valueCell.getByRole("button").or(valueCell.locator("pre")).or(valueCell.locator("code")),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(firstRow.getByTestId("xcom-value")).toBeVisible({ timeout: 10_000 });
   }
 }


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
## Change
Adds a stable `data-testid="xcom-value"` to the XCom value `HStack` so E2E tests can target the rendered value reliably, and switches the corresponding Playwright page object off the brittle last-cell-in-row selector.

no user-visible behavior difference.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
