### PR TITLE
Raise ValueError for unsupported old-format type tags in serde

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -302,12 +302,17 @@ def deserialize(o: T | None, full=True, type_hint: Any = None) -> object:
     raise TypeError(f"No deserializer found for {classname}")
 
 
+_UNSUPPORTED_OLD_TYPES: frozenset[str] = frozenset({"base_trigger", "airflow_exc_ser"})
+
+
 def _convert(old: dict) -> dict:
     """Convert an old style serialization to new style."""
     if OLD_TYPE in old and OLD_DATA in old:
         # Return old style dicts directly as they do not need wrapping
         if old[OLD_TYPE] == OLD_DICT:
             return old[OLD_DATA]
+        if old[OLD_TYPE] in _UNSUPPORTED_OLD_TYPES:
+            raise ValueError(f"Deserialization of type '{old[OLD_TYPE]}' is not supported.")
         return {
             CLASSNAME: OLD_TYPE_TO_FULL_QUALNAME.get(old[OLD_TYPE], old[OLD_TYPE]),
             VERSION: DEFAULT_VERSION,

--- a/task-sdk/tests/task_sdk/serde/test_serde.py
+++ b/task-sdk/tests/task_sdk/serde/test_serde.py
@@ -479,6 +479,13 @@ class TestSerDe:
         result = deserialize(data)
         assert result == datetime.timedelta(seconds=3600)
 
+    @pytest.mark.parametrize("old_type", ["base_trigger", "airflow_exc_ser"])
+    def test_unsupported_old_types_raise(self, old_type):
+        """Old-format type tags that cannot be safely deserialized must raise ValueError."""
+        data = {"__type": old_type, "__var": ["subprocess.Popen", {"args": ["id"]}]}
+        with pytest.raises(ValueError, match=f"Deserialization of type '{old_type}' is not supported"):
+            deserialize(data)
+
     def test_encode_asset(self):
         asset = Asset(uri="mytest://asset", name="test")
         obj = deserialize(serialize(asset))


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

`base_trigger` and `airflow_exc_ser` are old BaseSerialization format type tags that have no serde equivalent and cannot be round-tripped correctly. Previously they fell through `serde._convert()` with an `ImportError`, which callers with a BaseSerialization fallback would silently catch. Raising `ValueError` instead makes the failure explicit and prevents unintended fallback behaviour in this case.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
