### PR TITLE
Fix kubernetes cleanup-pods ignoring --verbose

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -149,10 +149,11 @@ def cleanup_pods(args):
     # * OnFailure: Restart Container; Pod phase stays Running.
     # * Never: Pod phase becomes Failed.
     pod_restart_policy_never = "never"
-
-    print("Loading Kubernetes configuration")
+    if args.verbose:
+        print("Loading Kubernetes configuration")
     kube_client = get_kube_client()
-    print(f"Listing pods in namespace {namespace}")
+    if args.verbose:
+        print(f"Listing pods in namespace {namespace}")
     airflow_pod_labels = [
         "dag_id",
         "task_id",
@@ -165,7 +166,8 @@ def cleanup_pods(args):
         pod_list = kube_client.list_namespaced_pod(**list_kwargs)
         for pod in pod_list.items:
             pod_name = pod.metadata.name
-            print(f"Inspecting pod {pod_name}")
+            if args.verbose:
+                print(f"Inspecting pod {pod_name}")
             pod_phase = pod.status.phase.lower()
             pod_reason = pod.status.reason.lower() if pod.status.reason else ""
             pod_restart_policy = pod.spec.restart_policy.lower()
@@ -190,7 +192,8 @@ def cleanup_pods(args):
                 except ApiException as e:
                     print(f"Can't remove POD: {e}", file=sys.stderr)
             else:
-                print(f"No action taken on pod {pod_name}")
+                if args.verbose:
+                    print(f"No action taken on pod {pod_name}")
         continue_token = pod_list.metadata._continue
         if not continue_token:
             break

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_definition.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_definition.py
@@ -85,10 +85,12 @@ class TestKubernetesCliDefinition:
             "my-namespace",
             "--min-pending-minutes",
             "60",
+            "--verbose",
         ]
         args = self.arg_parser.parse_args(params)
         assert args.namespace == "my-namespace"
         assert args.min_pending_minutes == 60
+        assert args.verbose is True
 
     def test_cleanup_pods_command_default_args(self):
         """Test cleanup-pods command with default arguments."""
@@ -97,6 +99,7 @@ class TestKubernetesCliDefinition:
         # Should use default values from configuration
         assert hasattr(args, "namespace")
         assert args.min_pending_minutes == 30
+        assert args.verbose is False
 
     def test_generate_dag_yaml_command_args(self):
         """Test generate-dag-yaml command with various arguments."""


### PR DESCRIPTION


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
