### PR TITLE
Configure S3Hook transfer_config_args via service_config

### DIFF
--- a/providers/amazon/docs/connections/aws.rst
+++ b/providers/amazon/docs/connections/aws.rst
@@ -383,6 +383,29 @@ provide selected options in the connection's extra field.
     }
 
 
+.. _howto/connection:aws:s3-transfer-config:
+
+S3 Transfer Config
+------------------
+
+You can use the service config to set transfer config options in :class:`~airflow.providers.amazon.aws.hooks.s3.S3Hook` methods.
+
+.. code-block:: json
+
+    {
+      "service_config": {
+        "s3": {
+          "transfer_config_args": {
+            "max_concurrency": 10,
+            "num_download_attempts": 10
+          }
+        }
+      }
+    }
+
+.. seealso::
+    - Boto3 TransferConfig: :external:py:class:`boto3.s3.transfer.TransferConfig`
+
 .. _howto/connection:aws:avoid-throttling-exceptions:
 
 Avoid Throttling exceptions

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -168,7 +168,8 @@ class S3Hook(AwsBaseHook):
     Provide thick wrapper around :external+boto3:py:class:`boto3.client("s3") <S3.Client>`
     and :external+boto3:py:class:`boto3.resource("s3") <S3.ServiceResource>`.
 
-    :param transfer_config_args: Configuration object for managed S3 transfers.
+    :param transfer_config_args: Default Configuration object for managed S3 transfers.
+        Can also be set in the service_config.
     :param extra_args: Extra arguments that may be passed to the download/upload operations.
 
     .. seealso::
@@ -198,13 +199,20 @@ class S3Hook(AwsBaseHook):
 
         if transfer_config_args and not isinstance(transfer_config_args, dict):
             raise TypeError(f"transfer_config_args expected dict, got {type(transfer_config_args).__name__}.")
-        self.transfer_config = TransferConfig(**transfer_config_args or {})
+        self._transfer_config_args = transfer_config_args or {}
 
         if extra_args and not isinstance(extra_args, dict):
             raise TypeError(f"extra_args expected dict, got {type(extra_args).__name__}.")
         self._extra_args = extra_args or {}
 
         super().__init__(*args, **kwargs)
+
+    @property
+    def transfer_config(self):
+        if not hasattr(self, "_transfer_config"):
+            self._transfer_config_args.update(self.service_config.get("transfer_config_args", {}))
+            self._transfer_config = TransferConfig(**self._transfer_config_args)
+        return self._transfer_config
 
     @cached_property
     def resource(self):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -101,6 +101,29 @@ class TestAwsS3Hook:
             S3Hook(transfer_config_args=transfer_config_args)
 
     @pytest.mark.parametrize(
+        ("transfer_config_args", "service_config"),
+        [
+            pytest.param(
+                {"use_threads": False},
+                {"transfer_config_args": {"use_threads": True}},
+                id="override_transfer_config_args",
+            ),
+            pytest.param(None, {"use_threads": True}, id="service_config_args"),
+        ],
+    )
+    def test_transfer_config_args_from_service_config(self, transfer_config_args, service_config):
+        conn = Connection(
+            conn_id="s3_conn",
+            conn_type="aws",
+            extra={
+                "service_config": {"s3": service_config},
+            },
+        )
+        with mock.patch.dict("os.environ", values={f"AIRFLOW_CONN_{conn.conn_id.upper()}": conn.get_uri()}):
+            hook = S3Hook(aws_conn_id=conn.conn_id, transfer_config_args=transfer_config_args)
+            assert hook.transfer_config.use_threads is True
+
+    @pytest.mark.parametrize(
         ("url", "expected"),
         [
             pytest.param(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Enable configuring the S3 transfer config arguments using the service config
---
Previously the `transfer_config_args` could only be configured by passing in arguments to the `S3Hook` object. This PR makes the `S3Hook` also read arguments from the s3 `service_config` in the connection's extras to override this behaviour. e.g.
```
"extras": {
  "service_config": {
    "s3": {
      "transfer_config_args": {
        "use_threads": true
      }
    }
  }
}
```

This allows deployment managers to change the transfer config options via configuration, for example in `S3TaskHandler.io`

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

