### PR TITLE
Fix Edit Connection dialog: add lazyMount to prevent JSON editor infinite loading

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/EditConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/EditConnectionButton.tsx
@@ -71,7 +71,7 @@ const EditConnectionButton = ({ connection, disabled }: Props) => {
         </IconButton>
       </Tooltip>
 
-      <Dialog.Root onOpenChange={handleClose} open={open} size="xl">
+      <Dialog.Root lazyMount onOpenChange={handleClose} open={open} size="xl" unmountOnExit>
         <Dialog.Content backdrop>
           <Dialog.Header>
             <Heading size="xl">{translate("connections.edit")}</Heading>


### PR DESCRIPTION
Closes #65954

'EditConnectionButton' was missing 'lazyMount' and 'unmountOnExit' on 'Dialog.Root', causing the Monaco JSON editor to mount hidden with zero dimensions and get stuck on "Loading...".
Added both props to match `AddConnectionButton` which works correctly.
> I used Claude (claude.ai) as an AI assistant for parts of this implementation.
