### PR TITLE
Fix breeze registry backfill failing on workspace dependency resolution

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/registry_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/registry_commands.py
@@ -243,6 +243,34 @@ def _run_extract_script(
     return result.returncode
 
 
+def _run_extract_versions(provider_id: str, version: str) -> int:
+    """Run extract_versions.py on the host for a single provider/version.
+
+    Resolves dependencies via ``--project dev/registry`` so uv reads
+    ``dev/registry/pyproject.toml`` (pyyaml + pydantic) instead of syncing
+    the airflow workspace. Without this flag uv pulls in providers like
+    samba -> smbprotocol -> pyspnego[kerberos] -> gssapi, which fails on
+    runners without libkrb5-dev. Returns the script exit code.
+
+    No extras fallback (unlike :func:`_run_extract_script`): this script's
+    deps live in ``dev/registry/pyproject.toml`` and aren't provider-version
+    dependent, so a single invocation either works or doesn't.
+    """
+    cmd = [
+        "uv",
+        "run",
+        "--project",
+        str(DEV_REGISTRY_DIR),
+        "python",
+        str(DEV_REGISTRY_DIR / "extract_versions.py"),
+        "--provider",
+        provider_id,
+        "--version",
+        version,
+    ]
+    return run_command(cmd, check=False, cwd=str(AIRFLOW_ROOT_PATH)).returncode
+
+
 def _backfill_docker(
     python: str,
     provider: str,
@@ -402,19 +430,9 @@ def backfill(python: str, provider: str, versions: tuple[str, ...], use_docker: 
     # Step 1: extract_versions.py (host, reads git tags) -> metadata.json
     click.echo("Step 1: Extracting version metadata from git tags...")
     for version in versions:
-        versions_cmd = [
-            "uv",
-            "run",
-            "python",
-            str(DEV_REGISTRY_DIR / "extract_versions.py"),
-            "--provider",
-            provider,
-            "--version",
-            version,
-        ]
-        result = run_command(versions_cmd, check=False, cwd=str(AIRFLOW_ROOT_PATH))
-        if result.returncode != 0:
-            click.echo(f"WARNING: extract_versions.py failed for {version} (exit {result.returncode})")
+        rc = _run_extract_versions(provider, version)
+        if rc != 0:
+            click.echo(f"WARNING: extract_versions.py failed for {version} (exit {rc})")
             failed.append(f"{version}/extract_versions.py")
 
     # Step 2: extract_parameters.py + extract_connections.py

--- a/dev/breeze/tests/test_registry_backfill.py
+++ b/dev/breeze/tests/test_registry_backfill.py
@@ -24,11 +24,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow_breeze.commands.registry_commands import (
+    AIRFLOW_ROOT_PATH,
+    DEV_REGISTRY_DIR,
     _build_pip_spec,
     _create_isolated_providers_json,
     _find_provider_yaml,
     _read_provider_yaml_info,
     _run_extract_script,
+    _run_extract_versions,
 )
 
 
@@ -204,3 +207,61 @@ class TestRunExtractScript:
 
         assert rc == 1
         assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_extract_versions
+# ---------------------------------------------------------------------------
+class TestRunExtractVersions:
+    def test_success(self):
+        ok_result = MagicMock(returncode=0)
+        with patch(
+            "airflow_breeze.commands.registry_commands.run_command", return_value=ok_result
+        ) as mock_run:
+            rc = _run_extract_versions("amazon", "9.24.0")
+
+        assert rc == 0
+        mock_run.assert_called_once()
+
+    def test_passes_provider_and_version_args(self):
+        ok_result = MagicMock(returncode=0)
+        with patch(
+            "airflow_breeze.commands.registry_commands.run_command", return_value=ok_result
+        ) as mock_run:
+            _run_extract_versions("google", "21.0.0")
+
+        cmd = mock_run.call_args[0][0]
+        assert "--provider" in cmd
+        assert "google" in cmd
+        assert "--version" in cmd
+        assert "21.0.0" in cmd
+
+    def test_invokes_uv_with_dev_registry_project(self):
+        """Regression test: uv must resolve deps from dev/registry/pyproject.toml,
+        not the airflow workspace, otherwise providers like samba pull in gssapi
+        and fail to build on runners without libkrb5-dev.
+        """
+        ok_result = MagicMock(returncode=0)
+        with patch(
+            "airflow_breeze.commands.registry_commands.run_command", return_value=ok_result
+        ) as mock_run:
+            _run_extract_versions("amazon", "9.24.0")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "uv"
+        assert cmd[1] == "run"
+        assert "--project" in cmd
+        project_idx = cmd.index("--project")
+        assert cmd[project_idx + 1] == str(DEV_REGISTRY_DIR)
+        # The --project flag must come before "python" so uv applies it.
+        assert project_idx < cmd.index("python")
+        # cwd stays at the airflow root so the script's relative path resolves
+        # the same way as the registry-backfill.yml workflow runs it.
+        assert mock_run.call_args.kwargs["cwd"] == str(AIRFLOW_ROOT_PATH)
+
+    def test_returns_failure_code(self):
+        fail_result = MagicMock(returncode=1)
+        with patch("airflow_breeze.commands.registry_commands.run_command", return_value=fail_result):
+            rc = _run_extract_versions("amazon", "9.24.0")
+
+        assert rc == 1


### PR DESCRIPTION
## Summary

`breeze registry backfill` is currently broken on bare CI runners, every job in the `Registry Backfill` workflow fails before extracting any data. The backfill command's first step invokes:

```
uv run python dev/registry/extract_versions.py --provider X --version Y
```

with `cwd=AIRFLOW_ROOT_PATH` and no `--project` flag. uv discovers the workspace's `pyproject.toml` and tries to sync the entire workspace's deps, which transitively pulls in `samba -> smbprotocol -> pyspnego[kerberos] -> gssapi==1.11.1`. The gssapi build needs `krb5-config` (libkrb5-dev), which isn't installed on the GitHub `ubuntu-24.04` runner image, so the build fails:

```
× Failed to build `gssapi==1.11.1`
╰─▶ subprocess.CalledProcessError: Command 'krb5-config --libs gssapi'
```

The script reports `WARNING: extract_versions.py failed`, continues with `extract_parameters.py` + `extract_connections.py` (which work fine inside the breeze CI container), but the recorded failure flips the whole job to exit 1. The "Sync backfilled version pages to S3" step never runs, so nothing lands.

## Design rationale

**Why `--project dev/registry` rather than `--no-project`?** `extract_versions.py` imports `yaml` and (transitively, via `registry_contract_models`) `pydantic` — both declared in `dev/registry/pyproject.toml`. `--no-project` would silently rely on whatever happens to be on the ambient PATH; `--project dev/registry` deterministically resolves the same deps the workflow YAML already uses.

This brings the breeze invocation into line with the same fix applied to the `registry-build.yml` and `registry-backfill.yml` workflows in #63766. The workflow YAMLs were patched there but the equivalent invocation inside `breeze registry backfill` was missed.

**Why the helper extraction?** The inline command moved into a private `_run_extract_versions(provider_id, version)` helper so the regression has a unit test. Four tests are added; one asserts `--project` is present and points to `DEV_REGISTRY_DIR`, so a future refactor can't silently re-introduce the workspace-discovery path.

## Gotchas / tradeoffs

- The [`Extract version metadata from git tags`](https://github.com/apache/airflow/blob/main/.github/workflows/registry-backfill.yml#L179-L189) step in `registry-backfill.yml` already runs the same script correctly in a step *before* `breeze registry backfill`. Step 1 of the breeze command therefore re-runs the same extraction. That redundancy is left in place by this PR; removing it is a follow-up. The duplicate run is now fast (uv resolves from `dev/registry` deps, no workspace sync).
- No fallback retry path (unlike `_run_extract_script`): this script's deps live in `dev/registry/pyproject.toml` and aren't provider-version dependent, so a single invocation either works or doesn't.

## Known issues / follow-up

- The most-recent [`Registry Backfill` run](https://github.com/apache/airflow/actions/runs/24974797364) (2026-04-27) shows 90 of 90 backfill jobs failing identically with this error. After this PR merges, dispatchers can re-run the workflow to fill the historical version pages the previous attempt tried and failed to write.
- The duplicate-extract noted above is a separate cleanup; tracking as future work, not in scope here.
