### PR TITLE
Fix connection ID with slashes in Execution API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 
 @router.get(
-    "/{connection_id}",
+    "/{connection_id:path}",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
@@ -86,6 +86,40 @@ class TestGetConnection:
         session.delete(connection)
         session.commit()
 
+    def test_connection_get_with_slash_in_conn_id(self, client, session):
+        connection = Connection(
+            conn_id="test/conn_with_slash",
+            conn_type="http",
+            description="description",
+            host="localhost",
+            login="root",
+            password="admin",
+            schema="http",
+            port=8080,
+            extra='{"x_secret": "testsecret", "y_secret": "test"}',
+        )
+
+        session.add(connection)
+        session.commit()
+
+        response = client.get("/execution/connections/test/conn_with_slash")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "conn_id": "test/conn_with_slash",
+            "conn_type": "http",
+            "host": "localhost",
+            "login": "root",
+            "password": "admin",
+            "schema": "http",
+            "port": 8080,
+            "extra": '{"x_secret": "testsecret", "y_secret": "test"}',
+        }
+
+        # Remove connection
+        session.delete(connection)
+        session.commit()
+
     @mock.patch.dict(
         "os.environ",
         {"AIRFLOW_CONN_TEST_CONN2": '{"uri": "http://root:admin@localhost:8080/https?headers=header"}'},


### PR DESCRIPTION
## Summary

Connection IDs containing forward slashes (e.g., `team/connections/service_name`) return 404 from the Execution API because FastAPI treats slashes in `{connection_id}` as path separators.

This changes the route to use `{connection_id:path}`, matching the pattern already established by the `variables` and `xcoms` routes in the same API module.

- One-line route fix in `connections.py`
- Added test for connection IDs with slashes

Closes: #57864

## Credit

This PR picks up the work from #63103 by @diligejy, whose original fix was correct but the branch fell behind `main` and CI could no longer pass. Thank you @diligejy for identifying the fix!

## Test plan

- [x] New test `test_connection_get_with_slash_in_conn_id` validates `GET /execution/connections/test/conn_with_slash` returns 200
- [x] All existing connection tests continue to pass
- [x] Pre-commit checks pass (ruff, mypy, bandit, codespell)

##### Was generative AI tooling used to co-author this PR?
- [x] Yes (Claude Code)
- [ ] No
Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-06-22T06:40:22.912388+00:00 head=ec3a992 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anorum** · by `@potiuk` · 2026-06-22 06:40 UTC
>
> Paused pending your next update:
> - No activity for ~4.0 weeks; converting to draft so it's not blocking the review queue.
>
> **The ball is in your court** — Rebase onto `main`, address any new failures, and mark **Ready for review** again.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->