### PR TITLE
Extract Client factory from TriggerRunnerSupervisor into overridable method

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -447,6 +447,9 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
     @functools.cached_property
     def client(self) -> Client:
+        return self.make_client()
+
+    def make_client(self) -> Client:
         from airflow.sdk.api.client import Client
 
         client = Client(base_url=None, token="", dry_run=True, transport=in_process_api_server().transport)

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -450,6 +450,15 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         return self.make_client()
 
     def make_client(self) -> Client:
+        """
+        Build the API client used to talk to the API server.
+
+        Subclasses may override this to substitute a different transport — e.g. a
+        real HTTP client pointing at a remote API server — instead of the default
+        in-process one. The returned client must have ``base_url`` set; downstream
+        request handling (``self.client.variables``, ``.xcoms``, etc.) reads it
+        when issuing requests.
+        """
         from airflow.sdk.api.client import Client
 
         client = Client(base_url=None, token="", dry_run=True, transport=in_process_api_server().transport)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -261,25 +261,9 @@ def test_run_invokes_seams_in_order(supervisor_builder, mocker):
     assert events == ["enter", "tick-1", "tick-2", "tick-3", "exit"]
 
 
-def test_make_client_builds_in_process_client(supervisor_builder, mocker):
-    supervisor = supervisor_builder()
-    api_server = mocker.Mock(transport=mocker.sentinel.transport)
-    client = mocker.Mock()
-    client_cls = mocker.patch("airflow.sdk.api.client.Client", return_value=client)
-    mocker.patch("airflow.jobs.triggerer_job_runner.in_process_api_server", return_value=api_server)
-
-    assert supervisor.make_client() is client
-
-    client_cls.assert_called_once_with(
-        base_url=None,
-        token="",
-        dry_run=True,
-        transport=mocker.sentinel.transport,
-    )
-    assert client.base_url == "http://in-process.invalid./"
-
-
 def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, mocker):
+    """``supervisor.client`` delegates to ``make_client`` (the subclass-override hook)
+    and caches the result across accesses."""
     supervisor = supervisor_builder()
     make_client = mocker.patch.object(
         TriggerRunnerSupervisor,
@@ -288,8 +272,10 @@ def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, m
         return_value=mocker.sentinel.client,
     )
 
-    assert supervisor.client is mocker.sentinel.client
-    assert supervisor.client is mocker.sentinel.client
+    first = supervisor.client
+    second = supervisor.client
+
+    assert first is second is mocker.sentinel.client  # cached — same object
     make_client.assert_called_once_with(supervisor)
 
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -261,6 +261,38 @@ def test_run_invokes_seams_in_order(supervisor_builder, mocker):
     assert events == ["enter", "tick-1", "tick-2", "tick-3", "exit"]
 
 
+def test_make_client_builds_in_process_client(supervisor_builder, mocker):
+    supervisor = supervisor_builder()
+    api_server = mocker.Mock(transport=mocker.sentinel.transport)
+    client = mocker.Mock()
+    client_cls = mocker.patch("airflow.sdk.api.client.Client", return_value=client)
+    mocker.patch("airflow.jobs.triggerer_job_runner.in_process_api_server", return_value=api_server)
+
+    assert supervisor.make_client() is client
+
+    client_cls.assert_called_once_with(
+        base_url=None,
+        token="",
+        dry_run=True,
+        transport=mocker.sentinel.transport,
+    )
+    assert client.base_url == "http://in-process.invalid./"
+
+
+def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, mocker):
+    supervisor = supervisor_builder()
+    make_client = mocker.patch.object(
+        TriggerRunnerSupervisor,
+        "make_client",
+        autospec=True,
+        return_value=mocker.sentinel.client,
+    )
+
+    assert supervisor.client is mocker.sentinel.client
+    assert supervisor.client is mocker.sentinel.client
+    make_client.assert_called_once_with(supervisor)
+
+
 def test_run_context_exits_when_subprocess_dies(supervisor_builder, mocker):
     """Breaking out of the loop on a dead subprocess still unwinds run_context."""
     from contextlib import contextmanager


### PR DESCRIPTION
Splits the in-process Client construction out of the cached_property into a separate make_client() method so subclasses can override how the Client is built while still benefiting from the cached_property.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by:  claude code (opus 4.7)

