### PR TITLE
Fix dev/registry tomllib import on Python 3.10

### DIFF
--- a/dev/registry/extract_metadata.py
+++ b/dev/registry/extract_metadata.py
@@ -42,7 +42,11 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-import tomllib
+try:
+    import tomllib  # Python 3.11+ stdlib
+except ModuleNotFoundError:  # pragma: no cover -- Python 3.10 fallback
+    import tomli as tomllib
+
 import yaml
 from registry_contract_models import validate_providers_catalog
 

--- a/dev/registry/extract_versions.py
+++ b/dev/registry/extract_versions.py
@@ -46,7 +46,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-import tomllib
+try:
+    import tomllib  # Python 3.11+ stdlib
+except ModuleNotFoundError:  # pragma: no cover -- Python 3.10 fallback
+    import tomli as tomllib
 from registry_contract_models import validate_provider_version_metadata
 
 try:

--- a/dev/registry/pyproject.toml
+++ b/dev/registry/pyproject.toml
@@ -35,6 +35,9 @@ classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "pydantic>=2.12.0",
     "pyyaml>=6.0.3",
+    # extract_versions.py and extract_metadata.py read pyproject.toml via
+    # tomllib (3.11+ stdlib). Fall back to the `tomli` backport on 3.10.
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

`dev/registry/extract_versions.py` and `extract_metadata.py` both `import tomllib` directly. `tomllib` is Python 3.11+ stdlib. uv on bare CI runners may pick Python 3.10 and the scripts crash on import:

```
File "dev/registry/extract_versions.py", line 49, in <module>
    import tomllib
ModuleNotFoundError: No module named 'tomllib'
```

Failure observed in [Registry Backfill workflow run 25028614525](https://github.com/apache/airflow/actions/runs/25028614525) — every backfill job fails before extracting any data.

The bug was latent: previously `breeze registry backfill` invoked `uv run python ...` from the airflow workspace root (without `--project dev/registry`), so uv used the airflow workspace's pyproject to resolve Python. After #65972 landed `--project dev/registry`, uv started honouring this pyproject's constraint specifically, and CI runners with Python 3.10 as default started picking it.

## Fix

Add the standard `tomli` fallback in both scripts:

```python
try:
    import tomllib  # Python 3.11+ stdlib
except ModuleNotFoundError:  # pragma: no cover -- Python 3.10 fallback
    import tomli as tomllib
```

Plus declare `tomli` as a runtime dep on Python <3.11 in `[project].dependencies`. The existing `[build-system].requires` already conditionally pulled `tomli`, but it wasn't a runtime dep so the scripts couldn't actually use it — this PR adds it where it belongs.

## Alternative considered (rejected)

Bumping `requires-python` to `>=3.11` would break the airflow workspace sync on the 3.10 CI image build:

```
Using CPython 3.11.2 interpreter at: /usr/bin/python3
error: Project virtual environment directory `/usr/local` cannot be used because it is not a compatible environment but cannot be recreated because it is not a virtual environment
```

uv refuses to mix Python versions across workspace members. So `dev/registry` has to keep `>=3.10` until the airflow workspace itself bumps. The fallback-import approach matches what the rest of the codebase does for the same compatibility window.
