### PR TITLE
Fix Monaco JSON editor loading in UI

### DIFF
--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -50,6 +50,7 @@
     "i18next": "^25.8.16",
     "i18next-browser-languagedetector": "^8.2.1",
     "i18next-http-backend": "^3.0.5",
+    "monaco-editor": "^0.53.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-chartjs-2": "^5.3.1",

--- a/airflow-core/src/airflow/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/ui/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       i18next-http-backend:
         specifier: ^3.0.5
         version: 3.0.5
+      monaco-editor:
+        specifier: ^0.53.0
+        version: 0.53.0
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -34,6 +34,7 @@ import { ChakraCustomProvider } from "src/context/ChakraCustomProvider";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
+import { configureMonaco } from "src/utils/configureMonaco";
 import { getRedirectPath } from "src/utils/links.ts";
 
 import i18n from "./i18n/config";
@@ -47,6 +48,8 @@ Reflect.set(globalThis, "ReactJSXRuntime", ReactJSXRuntime);
 Reflect.set(globalThis, "ReactRouterDOM", ReactRouterDOM);
 Reflect.set(globalThis, "ChakraUI", ChakraUI);
 Reflect.set(globalThis, "EmotionReact", EmotionReact);
+
+configureMonaco();
 
 // URLs that returned 403 Forbidden. Permissions won't change mid-session,
 // so we block further requests to avoid spamming the server with polling.

--- a/airflow-core/src/airflow/ui/src/utils/configureMonaco.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/configureMonaco.test.ts
@@ -1,0 +1,83 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { loader } from "@monaco-editor/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { configureMonaco } from "./configureMonaco";
+
+type MonacoEnvironmentWithGetWorker = {
+  readonly getWorker: (workerId: string, label: string) => unknown;
+};
+type MonacoTestGlobal = {
+  MonacoEnvironment?: MonacoEnvironmentWithGetWorker;
+} & typeof globalThis;
+
+vi.mock("@monaco-editor/react", () => ({
+  loader: {
+    config: vi.fn(),
+  },
+}));
+
+vi.mock("monaco-editor/esm/vs/basic-languages/python/python.contribution", () => ({}));
+
+vi.mock("monaco-editor/esm/vs/editor/editor.api.js", () => ({
+  editor: {},
+}));
+
+vi.mock("monaco-editor/esm/vs/language/json/monaco.contribution", () => ({}));
+
+vi.mock("monaco-editor/esm/vs/editor/editor.worker?worker", () => ({ default: AbortController }));
+
+vi.mock("monaco-editor/esm/vs/language/json/json.worker?worker", () => ({
+  default: EventTarget,
+}));
+
+const getConfiguredWorker = (label: string) =>
+  ((globalThis as MonacoTestGlobal).MonacoEnvironment as MonacoEnvironmentWithGetWorker).getWorker("", label);
+
+const getConstructorName = (value: unknown) => (value instanceof Object ? value.constructor.name : undefined);
+
+describe("configureMonaco", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    (globalThis as MonacoTestGlobal).MonacoEnvironment = undefined;
+  });
+
+  it("configures Monaco to use the bundled editor package", () => {
+    configureMonaco();
+
+    expect(loader.config).toHaveBeenCalledWith({ monaco: { editor: {} } });
+  });
+
+  it("uses the bundled JSON worker for JSON models", () => {
+    configureMonaco();
+
+    const worker = getConfiguredWorker("json");
+
+    expect(getConstructorName(worker)).toBe("EventTarget");
+  });
+
+  it("falls back to the bundled editor worker for other models", () => {
+    configureMonaco();
+
+    const worker = getConfiguredWorker("python");
+
+    expect(getConstructorName(worker)).toBe("AbortController");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/utils/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/utils/configureMonaco.ts
@@ -1,0 +1,52 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { loader, type Monaco } from "@monaco-editor/react";
+import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+
+type WorkerConstructor = new () => Worker;
+type MonacoGlobal = {
+  MonacoEnvironment?: {
+    readonly getWorker: (workerId: string, label: string) => Worker;
+  };
+} & typeof globalThis;
+
+const EditorWorkerConstructor = EditorWorker as unknown as WorkerConstructor;
+const JsonWorkerConstructor = JsonWorker as unknown as WorkerConstructor;
+
+const workersByLabel: Record<string, WorkerConstructor> = {
+  json: JsonWorkerConstructor,
+};
+
+export const configureMonaco = () => {
+  const monacoGlobal = globalThis as MonacoGlobal;
+
+  monacoGlobal.MonacoEnvironment = {
+    getWorker: (_workerId: string, label: string) => {
+      const Worker = workersByLabel[label] ?? EditorWorkerConstructor;
+
+      return new Worker();
+    },
+  };
+
+  loader.config({ monaco: monaco as unknown as Monaco });
+};

--- a/airflow-core/src/airflow/ui/src/utils/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/utils/configureMonaco.ts
@@ -19,9 +19,9 @@
 import { loader, type Monaco } from "@monaco-editor/react";
 import "monaco-editor/esm/vs/basic-languages/python/python.contribution";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
-import "monaco-editor/esm/vs/language/json/monaco.contribution";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import "monaco-editor/esm/vs/language/json/monaco.contribution";
 
 type WorkerConstructor = new () => Worker;
 type MonacoGlobal = {

--- a/airflow-core/src/airflow/ui/src/vite-env.d.ts
+++ b/airflow-core/src/airflow/ui/src/vite-env.d.ts
@@ -24,3 +24,7 @@
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare module "monaco-editor/esm/vs/editor/editor.api.js" {
+  export * from "monaco-editor/esm/vs/editor/editor.api";
+}

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-23T17:27:51.729719469Z"
+exclude-newer = "2026-04-24T03:41:10.634705822Z"
 exclude-newer-span = "P4D"
 
 [options.exclude-newer-package]
@@ -7911,6 +7911,7 @@ source = { editable = "dev/registry" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -7922,6 +7923,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Fixes #65954

Configures Monaco to use bundled editor and JSON workers instead of relying on the default loader path. This prevents JSON editors/viewers from getting stuck on `Loading...` in packaged Airflow UI views such as Connections and XComs.

Tests:
- `corepack pnpm test src/utils/configureMonaco.test.ts`
- `corepack pnpm lint`
- `corepack pnpm build`