### PR TITLE
Fix in-process execution API startup for triggerer

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import time
+from concurrent.futures import TimeoutError
 from contextlib import AsyncExitStack
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -358,7 +359,12 @@ class InProcessExecutionAPI:
 
         self._cm = AsyncExitStack()
 
-        asyncio.run_coroutine_threadsafe(start_lifespan(self._cm, self.app), middleware.loop)
+        try:
+            asyncio.run_coroutine_threadsafe(start_lifespan(self._cm, self.app), middleware.loop).result(
+                timeout=30
+            )
+        except TimeoutError as err:
+            raise RuntimeError("Timed out while starting the in-process execution API lifespan") from err
         return httpx.WSGITransport(app=middleware)  # type: ignore[arg-type]
 
     @cached_property

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -16,8 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-import pytest
+import asyncio
+import threading
+from contextlib import asynccontextmanager
 
+import pytest
+from fastapi import FastAPI
+
+from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TaskInstance
 from airflow.api_fastapi.execution_api.versions import bundle
 
@@ -58,6 +64,38 @@ def test_ti_self_routes_have_task_instance_id_param(client):
                 assert "task_instance_id" in route.dependant.path_param_names, (
                     f"Route {route.path} has ti:self scope but no {{task_instance_id}} path parameter"
                 )
+
+
+class TestInProcessExecutionAPI:
+    def test_transport_waits_for_lifespan_startup(self):
+        entered_lifespan = threading.Event()
+
+        @asynccontextmanager
+        async def lifespan(app):
+            await asyncio.sleep(0.05)
+            app.state.lifespan_called = True
+            entered_lifespan.set()
+            yield
+
+        api = InProcessExecutionAPI()
+        api._app = FastAPI(lifespan=lifespan)
+
+        api.transport
+
+        assert entered_lifespan.is_set()
+        assert api.app.state.lifespan_called
+
+    def test_transport_surfaces_lifespan_startup_errors(self):
+        @asynccontextmanager
+        async def lifespan(app):
+            raise RuntimeError("lifespan failed")
+            yield
+
+        api = InProcessExecutionAPI()
+        api._app = FastAPI(lifespan=lifespan)
+
+        with pytest.raises(RuntimeError, match="lifespan failed"):
+            api.transport
 
 
 class TestCorrelationIdMiddleware:


### PR DESCRIPTION
Fixes #65945

The triggerer uses the in-process Execution API through `a2wsgi`, but the app lifespan startup was scheduled on the background loop without waiting for it to complete. That could let triggerer startup continue while the Execution API was not fully initialized, and any startup failure could be hidden until later request handling.

This change waits for the in-process Execution API lifespan to complete before returning the transport, and surfaces startup timeout/failure immediately.

Tests:
- `uv run ruff check airflow-core/src/airflow/api_fastapi/execution_api/app.py airflow-core/tests/unit/api_fastapi/execution_api/test_app.py`
- `AIRFLOW_HOME=/tmp/airflow-65945-test uv run pytest airflow-core/tests/unit/api_fastapi/execution_api/test_app.py -q --with-db-init`