### PR TITLE
Fix double cancellation for airflow 3.3+ for EmrServerlessStartJobTrigger

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/emr.py
@@ -469,26 +469,28 @@ class EmrServerlessStartJobTrigger(AwsBaseWaiterTrigger):
                     self.status_queries,
                 )
             yield TriggerEvent({"status": "success", self.return_key: self.return_value})
-        except asyncio.CancelledError:
-            # TODO: Remove this CancelledError handler once the minimum Airflow version
-            # supported by the provider is >= 3.3. In Airflow 3.3+, BaseTrigger.on_kill()
-            # handles cancellation instead. Keeping this for backward compatibility with
-            # older Airflow versions.
-            if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
-                self.log.info(
-                    "Task was cancelled. Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",
-                    self.application_id,
-                    self.job_id,
-                )
-                hook.conn.cancel_job_run(applicationId=self.application_id, jobRunId=self.job_id)
-                self.log.info("EMR Serverless job %s cancelled successfully.", self.job_id)
-            else:
-                self.log.info(
-                    "Trigger may have shutdown or cancel_on_kill is disabled. "
-                    "Skipping job cancellation. Application ID: %s, Job ID: %s",
-                    self.application_id,
-                    self.job_id,
-                )
+        except asyncio.CancelledError as e:
+            # TODO: Remove this handler once the minimum supported Airflow version is 3.3+.
+            # On Airflow 3.3+, the triggerer passes a sentinel via task.cancel(msg) for
+            # user-initiated kills and calls on_kill() separately — skip here to avoid
+            # cancelling the job twice. On older Airflow there is no sentinel, so we
+            # handle cancellation here as before.
+            if not (e.args and e.args[0] == "__airflow_user_action__"):
+                if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
+                    self.log.info(
+                        "Task was cancelled. Cancelling EMR Serverless job. Application ID: %s, Job ID: %s",
+                        self.application_id,
+                        self.job_id,
+                    )
+                    hook.conn.cancel_job_run(applicationId=self.application_id, jobRunId=self.job_id)
+                    self.log.info("EMR Serverless job %s cancelled successfully.", self.job_id)
+                else:
+                    self.log.info(
+                        "Trigger may have shutdown or cancel_on_kill is disabled. "
+                        "Skipping job cancellation. Application ID: %s, Job ID: %s",
+                        self.application_id,
+                        self.job_id,
+                    )
             raise
         except Exception as e:
             yield TriggerEvent({"status": "failure", "message": str(e)})


### PR DESCRIPTION

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

related to https://github.com/apache/airflow/pull/65740 which added `on_kill()` to `EmrServerlessStartJobTrigger` to cancel the EMR Serverless job when a user kills the task. However, the existing `CancelledError` handler in run() was left untouched which means that on Airflow 3.3 onwards (or main branch for that matter), both paths would fire for the same user kill, sending `cancel_job_run` twice.

This PR guards the `CancelledError` handler with the `__airflow_user_action__` sentinel that Airflow 3.3 sets when cancelling a trigger due to a user action. On 3.3+, `on_kill()` handles the cancellation and the `CancelledError` handler skips it. On older Airflow where the sentinel doesn't exist, the handler runs as before — so backward compatibility is preserved.



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
