### PR TITLE
fix(backfill): populate partition_date on partitioned backfill runs

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -487,6 +487,7 @@ def _create_backfill_dag_run_partitioned(
         ),
         logical_date=info.logical_date,
         partition_key=info.partition_key,
+        partition_date=info.partition_date,
         data_interval=info.data_interval if info.logical_date else None,
         run_after=info.run_after,
         conf=dag_run_conf,

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -285,6 +285,9 @@ def test_create_backfill_partitioned(reverse, existing, start_date, dag_maker, s
     assert partition_keys == expected_dates
     assert all(x.state == DagRunState.QUEUED for x in dag_runs)
     assert all(x.conf == expected_run_conf for x in dag_runs)
+    # Calendar view filters partitioned Dags by partition_date, so the backfill
+    # path must populate it alongside partition_key.
+    assert all(x.partition_date is not None for x in dag_runs)
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -286,8 +286,12 @@ def test_create_backfill_partitioned(reverse, existing, start_date, dag_maker, s
     assert all(x.state == DagRunState.QUEUED for x in dag_runs)
     assert all(x.conf == expected_run_conf for x in dag_runs)
     # Calendar view filters partitioned Dags by partition_date, so the backfill
-    # path must populate it alongside partition_key.
-    assert all(x.partition_date is not None for x in dag_runs)
+    # path must populate it alongside partition_key. The UTC day of
+    # partition_date must equal the date portion of partition_key so the
+    # calendar groups the run under the correct day.
+    assert [x.partition_date.date() if x.partition_date else None for x in dag_runs] == [
+        datetime.fromisoformat(d).date() for d in expected_dates
+    ]
 
 
 @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -286,11 +286,15 @@ def test_create_backfill_partitioned(reverse, existing, start_date, dag_maker, s
     assert all(x.state == DagRunState.QUEUED for x in dag_runs)
     assert all(x.conf == expected_run_conf for x in dag_runs)
     # Calendar view filters partitioned Dags by partition_date, so the backfill
-    # path must populate it alongside partition_key. The UTC day of
-    # partition_date must equal the date portion of partition_key so the
-    # calendar groups the run under the correct day.
-    assert [x.partition_date.date() if x.partition_date else None for x in dag_runs] == [
-        datetime.fromisoformat(d).date() for d in expected_dates
+    # path must populate it alongside partition_key. Verify that backfill copies
+    # info.partition_date faithfully — i.e. the stored value matches what the
+    # timetable computed for each partition_key.
+    expected_partition_date_by_key = {
+        info.partition_key: info.partition_date
+        for info in dag.iter_dagrun_infos_between(pendulum.parse("2026-02-15"), pendulum.parse("2026-02-24"))
+    }
+    assert [x.partition_date for x in dag_runs] == [
+        expected_partition_date_by_key[x.partition_key] for x in dag_runs
     ]
 
 


### PR DESCRIPTION
## Why
The Calendar view filters historical runs of partitioned Dags by partition_date, but the partitioned-backfill code path only sets partition_key, leaving partition_date NULL. As a result, backfilled partition runs were silently excluded from the calendar. The scheduler already populates both fields when creating scheduled partition runs — this was an oversight on the backfill side.

## What
- Forward `partition_date=info.partition_date` through `create_dagrun` in `create_backfill_dag_run_partitioned`, mirroring what the scheduler already does.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
