### PR TITLE
feat(cli): add `airflow dags clear` for partition-range reprocessing

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1140,6 +1140,8 @@ DAGS_COMMANDS = (
             ARG_PARTITION_KEY,
             ARG_PARTITION_DATE_START,
             ARG_PARTITION_DATE_END,
+            ARG_ONLY_FAILED,
+            ARG_ONLY_RUNNING,
             ARG_YES,
             ARG_VERBOSE,
         ),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -205,6 +205,10 @@ ARG_PARTITION_KEY = Arg(
     ("--partition-key",),
     help="Clear all Dag runs whose partition_key matches this exact value.",
 )
+ARG_CLEAR_RUN_ID = Arg(
+    ("--run-id",),
+    help="Clear the Dag run with this run_id.",
+)
 ARG_OUTPUT_PATH = Arg(
     (
         "-o",
@@ -1136,7 +1140,7 @@ DAGS_COMMANDS = (
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_clear"),
         args=(
             ARG_DAG_ID,
-            ARG_RUN_ID,
+            ARG_CLEAR_RUN_ID,
             ARG_PARTITION_KEY,
             ARG_PARTITION_DATE_START,
             ARG_PARTITION_DATE_END,

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -185,21 +185,25 @@ ARG_END_DATE = Arg(
     ),
     type=parsedate,
 )
-ARG_PARTITION_START = Arg(
-    ("--partition-start",),
+ARG_PARTITION_DATE_START = Arg(
+    ("--partition-date-start",),
     help=(
-        "Inclusive lower bound of the partition window (matched against DagRun.partition_date). "
+        "Inclusive lower bound of the partition_date window (matched against DagRun.partition_date). "
         "Accepts the same datetime formats as --start-date."
     ),
     type=parsedate,
 )
-ARG_PARTITION_END = Arg(
-    ("--partition-end",),
+ARG_PARTITION_DATE_END = Arg(
+    ("--partition-date-end",),
     help=(
-        "Inclusive upper bound of the partition window (matched against DagRun.partition_date). "
+        "Inclusive upper bound of the partition_date window (matched against DagRun.partition_date). "
         "Accepts the same datetime formats as --end-date."
     ),
     type=parsedate,
+)
+ARG_PARTITION_KEY = Arg(
+    ("--partition-key",),
+    help="Clear all Dag runs whose partition_key matches this exact value.",
 )
 ARG_OUTPUT_PATH = Arg(
     (
@@ -1119,20 +1123,23 @@ DAGS_COMMANDS = (
     ),
     ActionCommand(
         name="clear",
-        help="Clear Dag runs whose partition_date falls in a given window",
+        help="Clear Dag runs selected by run_id, partition_key, or a partition_date window",
         description=(
-            "Clear all Dag runs of the given dag_id whose partition_date falls within "
-            "[--partition-start, --partition-end] (inclusive on both ends). Resets the "
-            "matched task instances and re-queues the runs for reprocessing. Intended for "
-            "partitioned Dags, whose runs are keyed by partition_date instead of "
-            "logical_date. For traditional, non-partitioned Dags, use "
+            "Clear Dag runs of the given dag_id and re-queue them for reprocessing. Exactly one "
+            "of the following selectors must be provided: --run-id (single run); --partition-key "
+            "(every run with that exact partition_key); or a partition_date window via "
+            "--partition-date-start and/or --partition-date-end (inclusive on both ends). "
+            "Intended for partitioned Dags, whose runs are keyed by partition_date / "
+            "partition_key instead of logical_date. For traditional, non-partitioned Dags, use "
             "`airflow tasks clear --start-date / --end-date`."
         ),
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_clear"),
         args=(
             ARG_DAG_ID,
-            ARG_PARTITION_START,
-            ARG_PARTITION_END,
+            ARG_RUN_ID,
+            ARG_PARTITION_KEY,
+            ARG_PARTITION_DATE_START,
+            ARG_PARTITION_DATE_END,
             ARG_YES,
             ARG_ONLY_FAILED,
             ARG_ONLY_RUNNING,

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1141,8 +1141,6 @@ DAGS_COMMANDS = (
             ARG_PARTITION_DATE_START,
             ARG_PARTITION_DATE_END,
             ARG_YES,
-            ARG_ONLY_FAILED,
-            ARG_ONLY_RUNNING,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -185,6 +185,22 @@ ARG_END_DATE = Arg(
     ),
     type=parsedate,
 )
+ARG_PARTITION_START = Arg(
+    ("--partition-start",),
+    help=(
+        "Inclusive lower bound of the partition window (matched against DagRun.partition_date). "
+        "Accepts the same datetime formats as --start-date."
+    ),
+    type=parsedate,
+)
+ARG_PARTITION_END = Arg(
+    ("--partition-end",),
+    help=(
+        "Inclusive upper bound of the partition window (matched against DagRun.partition_date). "
+        "Accepts the same datetime formats as --end-date."
+    ),
+    type=parsedate,
+)
 ARG_OUTPUT_PATH = Arg(
     (
         "-o",
@@ -1100,6 +1116,28 @@ DAGS_COMMANDS = (
         help="Get DAG details given a DAG id",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_details"),
         args=(ARG_DAG_ID, ARG_OUTPUT, ARG_VERBOSE),
+    ),
+    ActionCommand(
+        name="clear",
+        help="Clear Dag runs whose partition_date falls in a given window",
+        description=(
+            "Clear all Dag runs of the given dag_id whose partition_date falls within "
+            "[--partition-start, --partition-end] (inclusive on both ends). Resets the "
+            "matched task instances and re-queues the runs for reprocessing. Intended for "
+            "partitioned Dags, whose runs are keyed by partition_date instead of "
+            "logical_date. For traditional, non-partitioned Dags, use "
+            "`airflow tasks clear --start-date / --end-date`."
+        ),
+        func=lazy_load_command("airflow.cli.commands.dag_command.dag_clear"),
+        args=(
+            ARG_DAG_ID,
+            ARG_PARTITION_START,
+            ARG_PARTITION_END,
+            ARG_YES,
+            ARG_ONLY_FAILED,
+            ARG_ONLY_RUNNING,
+            ARG_VERBOSE,
+        ),
     ),
     ActionCommand(
         name="list",

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -182,12 +182,7 @@ def dag_clear(args, session: Session = NEW_SESSION) -> None:
 
     cleared = 0
     for run_id in run_ids:
-        cleared += dag.clear(
-            run_id=run_id,
-            only_failed=args.only_failed,
-            only_running=args.only_running,
-            session=session,
-        )
+        cleared += dag.clear(run_id=run_id, session=session)
     print(f"Cleared {cleared} task instance(s) across {len(run_ids)} Dag run(s).")
 
 

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -184,7 +184,12 @@ def dag_clear(args, session: Session = NEW_SESSION) -> None:
 
     cleared = 0
     for run_id in run_ids:
-        cleared += dag.clear(run_id=run_id, session=session)
+        cleared += dag.clear(
+            run_id=run_id,
+            only_failed=args.only_failed,
+            only_running=args.only_running,
+            session=session,
+        )
     print(f"Cleared {cleared} task instance(s) across {len(run_ids)} Dag run(s).")
 
 

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -126,36 +126,52 @@ def dag_delete(args) -> None:
 @providers_configuration_loaded
 @provide_session
 def dag_clear(args, session: Session = NEW_SESSION) -> None:
-    """Clear Dag runs whose partition_date falls in [partition_start, partition_end]."""
-    if args.partition_start is None and args.partition_end is None:
-        raise SystemExit("At least one of --partition-start or --partition-end must be provided.")
+    """Clear Dag runs selected by run_id, partition_key, or a partition_date window."""
+    has_range = args.partition_date_start is not None or args.partition_date_end is not None
+    selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])
+    if selectors_used == 0:
+        raise SystemExit(
+            "One of --run-id, --partition-key, or --partition-date-start / --partition-date-end "
+            "must be provided."
+        )
+    if selectors_used > 1:
+        raise SystemExit(
+            "--run-id, --partition-key, and --partition-date-start / --partition-date-end are "
+            "mutually exclusive; provide exactly one selector."
+        )
     if (
-        args.partition_start is not None
-        and args.partition_end is not None
-        and args.partition_start > args.partition_end
+        args.partition_date_start is not None
+        and args.partition_date_end is not None
+        and args.partition_date_start > args.partition_date_end
     ):
-        raise SystemExit("--partition-start must be on or before --partition-end.")
+        raise SystemExit("--partition-date-start must be on or before --partition-date-end.")
 
     dag = get_db_dag(bundle_names=None, dag_id=args.dag_id)
 
-    query = select(DagRun).where(
-        DagRun.dag_id == args.dag_id,
-        DagRun.partition_date.is_not(None),
-    )
-    if args.partition_start is not None:
-        query = query.where(DagRun.partition_date >= args.partition_start)
-    if args.partition_end is not None:
-        query = query.where(DagRun.partition_date <= args.partition_end)
-    query = query.order_by(DagRun.partition_date)
+    query = select(DagRun).where(DagRun.dag_id == args.dag_id)
+    if args.run_id is not None:
+        query = query.where(DagRun.run_id == args.run_id)
+    elif args.partition_key is not None:
+        query = query.where(DagRun.partition_key == args.partition_key)
+    else:
+        query = query.where(DagRun.partition_date.is_not(None))
+        if args.partition_date_start is not None:
+            query = query.where(DagRun.partition_date >= args.partition_date_start)
+        if args.partition_date_end is not None:
+            query = query.where(DagRun.partition_date <= args.partition_date_end)
+    query = query.order_by(DagRun.partition_date, DagRun.run_id)
 
     runs = list(session.scalars(query).all())
     if not runs:
-        print("No matching Dag runs found in the given partition window.")
+        print("No matching Dag runs found.")
         return
 
     run_ids = [run.run_id for run in runs]
     if not args.yes:
-        listing = "\n".join(f"  {run.run_id}  partition_date={run.partition_date}" for run in runs)
+        listing = "\n".join(
+            f"  {run.run_id}  partition_key={run.partition_key}  partition_date={run.partition_date}"
+            for run in runs
+        )
         question = (
             f"You are about to clear {len(runs)} Dag run(s) of {args.dag_id!r}:\n"
             f"{listing}\n\nAre you sure? [y/n]"

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -47,7 +47,12 @@ from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.timetables.base import TimeRestriction
 from airflow.utils import cli as cli_utils
-from airflow.utils.cli import get_bagged_dag, suppress_logs_and_warning, validate_dag_bundle_arg
+from airflow.utils.cli import (
+    get_bagged_dag,
+    get_db_dag,
+    suppress_logs_and_warning,
+    validate_dag_bundle_arg,
+)
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.helpers import ask_yesno
 from airflow.utils.platform import getuser
@@ -115,6 +120,59 @@ def dag_delete(args) -> None:
             raise AirflowException(err)
     else:
         print("Cancelled")
+
+
+@cli_utils.action_cli
+@providers_configuration_loaded
+@provide_session
+def dag_clear(args, session: Session = NEW_SESSION) -> None:
+    """Clear Dag runs whose partition_date falls in [partition_start, partition_end]."""
+    if args.partition_start is None and args.partition_end is None:
+        raise SystemExit("At least one of --partition-start or --partition-end must be provided.")
+    if (
+        args.partition_start is not None
+        and args.partition_end is not None
+        and args.partition_start > args.partition_end
+    ):
+        raise SystemExit("--partition-start must be on or before --partition-end.")
+
+    dag = get_db_dag(bundle_names=None, dag_id=args.dag_id)
+
+    query = select(DagRun).where(
+        DagRun.dag_id == args.dag_id,
+        DagRun.partition_date.is_not(None),
+    )
+    if args.partition_start is not None:
+        query = query.where(DagRun.partition_date >= args.partition_start)
+    if args.partition_end is not None:
+        query = query.where(DagRun.partition_date <= args.partition_end)
+    query = query.order_by(DagRun.partition_date)
+
+    runs = list(session.scalars(query).all())
+    if not runs:
+        print("No matching Dag runs found in the given partition window.")
+        return
+
+    run_ids = [run.run_id for run in runs]
+    if not args.yes:
+        listing = "\n".join(f"  {run.run_id}  partition_date={run.partition_date}" for run in runs)
+        question = (
+            f"You are about to clear {len(runs)} Dag run(s) of {args.dag_id!r}:\n"
+            f"{listing}\n\nAre you sure? [y/n]"
+        )
+        if not ask_yesno(question):
+            print("Cancelled, nothing was cleared.")
+            return
+
+    cleared = 0
+    for run_id in run_ids:
+        cleared += dag.clear(
+            run_id=run_id,
+            only_failed=args.only_failed,
+            only_running=args.only_running,
+            session=session,
+        )
+    print(f"Cleared {cleared} task instance(s) across {len(run_ids)} Dag run(s).")
 
 
 @cli_utils.action_cli

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -148,7 +148,9 @@ def dag_clear(args, session: Session = NEW_SESSION) -> None:
 
     dag = get_db_dag(bundle_names=None, dag_id=args.dag_id)
 
-    query = select(DagRun).where(DagRun.dag_id == args.dag_id)
+    query = select(DagRun.run_id, DagRun.partition_key, DagRun.partition_date).where(
+        DagRun.dag_id == args.dag_id
+    )
     if args.run_id is not None:
         query = query.where(DagRun.run_id == args.run_id)
     elif args.partition_key is not None:
@@ -161,7 +163,7 @@ def dag_clear(args, session: Session = NEW_SESSION) -> None:
             query = query.where(DagRun.partition_date <= args.partition_date_end)
     query = query.order_by(DagRun.partition_date, DagRun.run_id)
 
-    runs = list(session.scalars(query).all())
+    runs = list(session.execute(query).all())
     if not runs:
         print("No matching Dag runs found.")
         return

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1221,9 +1221,31 @@ class TestCliDagsClear:
                 for row in session.scalars(select(DagRun).where(DagRun.dag_id == self.DAG_ID)).all()
             }
 
-    def test_requires_at_least_one_bound(self, parser):
+    def test_requires_a_selector(self, parser):
         args = parser.parse_args(["dags", "clear", self.DAG_ID, "--yes"])
-        with pytest.raises(SystemExit, match="At least one of --partition-start"):
+        with pytest.raises(SystemExit, match="One of --run-id, --partition-key"):
+            dag_command.dag_clear(args)
+
+    @pytest.mark.parametrize(
+        "extra_args",
+        [
+            pytest.param(
+                ["--run-id", "part_2026_03_10", "--partition-key", "2026-03-10T00:00:00"],
+                id="run-id+partition-key",
+            ),
+            pytest.param(
+                ["--run-id", "part_2026_03_10", "--partition-date-start", "2026-03-08T00:00:00"],
+                id="run-id+date-range",
+            ),
+            pytest.param(
+                ["--partition-key", "2026-03-10T00:00:00", "--partition-date-end", "2026-03-14T00:00:00"],
+                id="partition-key+date-range",
+            ),
+        ],
+    )
+    def test_rejects_multiple_selectors(self, parser, extra_args):
+        args = parser.parse_args(["dags", "clear", self.DAG_ID, "--yes", *extra_args])
+        with pytest.raises(SystemExit, match="mutually exclusive"):
             dag_command.dag_clear(args)
 
     @pytest.mark.usefixtures("seeded_partitioned_runs")
@@ -1233,14 +1255,14 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-start",
+                "--partition-date-start",
                 "2026-03-14T00:00:00",
-                "--partition-end",
+                "--partition-date-end",
                 "2026-03-08T00:00:00",
                 "--yes",
             ]
         )
-        with pytest.raises(SystemExit, match="--partition-start must be on or before"):
+        with pytest.raises(SystemExit, match="--partition-date-start must be on or before"):
             dag_command.dag_clear(args)
 
     @pytest.mark.usefixtures("seeded_partitioned_runs")
@@ -1251,9 +1273,9 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-start",
+                "--partition-date-start",
                 "2026-03-08T00",
-                "--partition-end",
+                "--partition-date-end",
                 "2026-03-14T23",
                 "--yes",
             ]
@@ -1275,7 +1297,7 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-end",
+                "--partition-date-end",
                 "2026-03-09T00:00:00",
                 "--yes",
             ]
@@ -1294,7 +1316,7 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-start",
+                "--partition-date-start",
                 "2026-03-13T00:00:00",
                 "--yes",
             ]
@@ -1313,9 +1335,9 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-start",
+                "--partition-date-start",
                 "2027-01-01T00:00:00",
-                "--partition-end",
+                "--partition-date-end",
                 "2027-12-31T00:00:00",
                 "--yes",
             ]
@@ -1333,9 +1355,9 @@ class TestCliDagsClear:
                 "dags",
                 "clear",
                 self.DAG_ID,
-                "--partition-start",
+                "--partition-date-start",
                 "2026-03-08T00:00:00",
-                "--partition-end",
+                "--partition-date-end",
                 "2026-03-14T00:00:00",
             ]
         )
@@ -1346,13 +1368,51 @@ class TestCliDagsClear:
         assert states["part_2026_03_10"] == DagRunState.FAILED
         assert states["part_2026_03_14"] == DagRunState.SUCCESS
 
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_clears_by_run_id(self, parser):
+        args = parser.parse_args(["dags", "clear", self.DAG_ID, "--run-id", "part_2026_03_10", "--yes"])
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.SUCCESS
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        assert states["part_2026_03_14"] == DagRunState.SUCCESS
+        assert states["non_partitioned"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_clears_by_partition_key(self, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-key",
+                "2026-03-10T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.SUCCESS
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        assert states["part_2026_03_14"] == DagRunState.SUCCESS
+        assert states["non_partitioned"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_run_id_not_found_is_a_no_op(self, parser, capsys):
+        args = parser.parse_args(["dags", "clear", self.DAG_ID, "--run-id", "does_not_exist", "--yes"])
+        dag_command.dag_clear(args)
+        assert "No matching Dag runs" in capsys.readouterr().out
+        assert self._get_run_states()["part_2026_03_10"] == DagRunState.FAILED
+
     def test_missing_dag_raises(self, parser):
         args = parser.parse_args(
             [
                 "dags",
                 "clear",
                 "does_not_exist",
-                "--partition-start",
+                "--partition-date-start",
                 "2026-03-08T00:00:00",
                 "--yes",
             ]

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -41,8 +41,9 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun
 from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
-from airflow.sdk import DAG, BaseOperator, task
+from airflow.sdk import DAG, BaseOperator, CronPartitionTimetable, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
@@ -1156,6 +1157,208 @@ class TestCliDagsReserialize:
         assert len(dag_processor_parsing_result.serialized_dags) == 1
         assert len(serialized_dag_hash) == 1
         assert dag_processor_parsing_result.serialized_dags[0].hash == serialized_dag_hash[0]
+
+
+class TestCliDagsClear:
+    """Tests for the `airflow dags clear` partition-range subcommand."""
+
+    DAG_ID = "test_dags_clear_partitioned"
+
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        return cli_parser.get_parser()
+
+    @pytest.fixture(autouse=True)
+    def _clear_db(self):
+        yield
+        clear_db_runs()
+        clear_db_dags()
+
+    @pytest.fixture
+    def seeded_partitioned_runs(self, dag_maker):
+        with dag_maker(
+            self.DAG_ID,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2026, 3, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        # Three partitioned runs, plus one unpartitioned run that must never be touched.
+        dag_maker.create_dagrun(
+            run_id="part_2026_03_08",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 8, tzinfo=pendulum.UTC),
+            partition_key="2026-03-08T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_2026_03_10",
+            state=DagRunState.FAILED,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 10, tzinfo=pendulum.UTC),
+            partition_key="2026-03-10T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_2026_03_14",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 14, tzinfo=pendulum.UTC),
+            partition_key="2026-03-14T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="non_partitioned",
+            state=DagRunState.SUCCESS,
+            logical_date=datetime(2026, 3, 9, tzinfo=pendulum.UTC),
+            partition_date=None,
+        )
+        dag_maker.sync_dagbag_to_db()
+
+    def _get_run_states(self):
+        with create_session() as session:
+            return {
+                row.run_id: row.state
+                for row in session.scalars(select(DagRun).where(DagRun.dag_id == self.DAG_ID)).all()
+            }
+
+    def test_requires_at_least_one_bound(self, parser):
+        args = parser.parse_args(["dags", "clear", self.DAG_ID, "--yes"])
+        with pytest.raises(SystemExit, match="At least one of --partition-start"):
+            dag_command.dag_clear(args)
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_rejects_inverted_window(self, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-start",
+                "2026-03-14T00:00:00",
+                "--partition-end",
+                "2026-03-08T00:00:00",
+                "--yes",
+            ]
+        )
+        with pytest.raises(SystemExit, match="--partition-start must be on or before"):
+            dag_command.dag_clear(args)
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_clears_runs_in_window_inclusive(self, parser):
+        # Literal flag values from issue #65921: short ISO `YYYY-MM-DDTHH` form.
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-start",
+                "2026-03-08T00",
+                "--partition-end",
+                "2026-03-14T23",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # Inclusive both ends: 03-08 and 03-14 boundary runs are cleared (state -> QUEUED).
+        assert states["part_2026_03_08"] == DagRunState.QUEUED
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        assert states["part_2026_03_14"] == DagRunState.QUEUED
+        # Run with NULL partition_date is never matched.
+        assert states["non_partitioned"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_open_lower_bound(self, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-end",
+                "2026-03-09T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.QUEUED
+        assert states["part_2026_03_10"] == DagRunState.FAILED
+        assert states["part_2026_03_14"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_open_upper_bound(self, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-start",
+                "2026-03-13T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.SUCCESS
+        assert states["part_2026_03_10"] == DagRunState.FAILED
+        assert states["part_2026_03_14"] == DagRunState.QUEUED
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_no_matching_runs_is_a_no_op(self, parser, capsys):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-start",
+                "2027-01-01T00:00:00",
+                "--partition-end",
+                "2027-12-31T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+        out = capsys.readouterr().out
+        assert "No matching Dag runs" in out
+        assert self._get_run_states()["part_2026_03_10"] == DagRunState.FAILED
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    @mock.patch("airflow.cli.commands.dag_command.ask_yesno", return_value=False)
+    def test_prompt_decline_does_not_clear(self, mock_ask, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-start",
+                "2026-03-08T00:00:00",
+                "--partition-end",
+                "2026-03-14T00:00:00",
+            ]
+        )
+        dag_command.dag_clear(args)
+        mock_ask.assert_called_once()
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.SUCCESS
+        assert states["part_2026_03_10"] == DagRunState.FAILED
+        assert states["part_2026_03_14"] == DagRunState.SUCCESS
+
+    def test_missing_dag_raises(self, parser):
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                "does_not_exist",
+                "--partition-start",
+                "2026-03-08T00:00:00",
+                "--yes",
+            ]
+        )
+        with pytest.raises(AirflowException, match="could not be found in the database"):
+            dag_command.dag_clear(args)
 
 
 class TestDagDetailsIsBackfillable:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -41,6 +41,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun
 from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, BaseOperator, CronPartitionTimetable, task
@@ -49,7 +50,7 @@ from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.session import create_session
-from airflow.utils.state import DagRunState
+from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.config import conf_vars
@@ -1405,6 +1406,46 @@ class TestCliDagsClear:
         dag_command.dag_clear(args)
         assert "No matching Dag runs" in capsys.readouterr().out
         assert self._get_run_states()["part_2026_03_10"] == DagRunState.FAILED
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_only_failed_skips_non_failed_task_instances(self, parser):
+        # Explicitly set TI states so we can assert selectively.
+        # part_2026_03_10 has a FAILED DagRun; mark its single TI as FAILED.
+        # part_2026_03_08 has a SUCCESS DagRun; mark its single TI as SUCCESS.
+        with create_session() as session:
+            for run_id, ti_state in [
+                ("part_2026_03_08", TaskInstanceState.SUCCESS),
+                ("part_2026_03_10", TaskInstanceState.FAILED),
+            ]:
+                session.execute(
+                    TaskInstance.__table__.update()
+                    .where(TaskInstance.dag_id == self.DAG_ID)
+                    .where(TaskInstance.run_id == run_id)
+                    .values(state=ti_state)
+                )
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-03-08T00:00:00",
+                "--partition-date-end",
+                "2026-03-14T00:00:00",
+                "--only-failed",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # part_2026_03_10 had a FAILED TI — its run should be re-queued.
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        # part_2026_03_08 had no FAILED TI — its run state must be unchanged.
+        assert states["part_2026_03_08"] == DagRunState.SUCCESS
+        # Non-partitioned run is always untouched.
+        assert states["non_partitioned"] == DagRunState.SUCCESS
 
     def test_missing_dag_raises(self, parser):
         args = parser.parse_args(


### PR DESCRIPTION
## Why

`airflow tasks clear --start-date / --end-date` filters by `logical_date`, so it cannot reach DagRuns whose `partition_date` / `partition_key` is what identifies them (rollup or offset partitions). Today the only ways to bulk-reprocess such runs are N API calls or N UI clicks. 

closes: #65921

## What

- Add `airflow dags clear <dag_id>` with three mutually-exclusive selectors:
    - `--run-id` (single run)
    - `--partition-key` (every run with that exact key)
    - `--partition-date-start` / `--partition-date-end` (inclusive `partition_date` window; runs with NULL `partition_date` are never matched; inverted window is rejected)
- Reuse `Dag.clear()` per matched `run_id`, so TI reset + DagRun re-queue behave identically to every other clear path.
- Print a listing (`run_id`, `partition_key`, `partition_date`) before prompting; `--yes` skips the prompt.
- Honor `--only-failed` / `--only-running` to scope which TIs get reset.



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the
guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
