### PR TITLE
Fix GCSToGCSOperator ignoring replace=False for single-file copy

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -416,11 +416,20 @@ class GCSToGCSOperator(BaseOperator):
         # and copy directly
         if len(objects) == 0 and prefix:
             if hook.exists(self.source_bucket, prefix):
-                uri = self._copy_single_object(
-                    hook=hook, source_object=prefix, destination_object=self.destination_object
-                )
-                if uri:
-                    result_uris.append(uri)
+                # `objects` may have been emptied by _ignore_existing_files; respect replace=False here too.
+                destination_object = self.destination_object or prefix
+                if not self.replace and hook.exists(self.destination_bucket, destination_object):
+                    self.log.info(
+                        "Skipped object %s; already exists in destination bucket %s.",
+                        destination_object,
+                        self.destination_bucket,
+                    )
+                else:
+                    uri = self._copy_single_object(
+                        hook=hook, source_object=prefix, destination_object=self.destination_object
+                    )
+                    if uri:
+                        result_uris.append(uri)
             elif self.source_object_required:
                 msg = f"{prefix} does not exist in bucket {self.source_bucket}"
                 self.log.warning(msg)

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -677,6 +677,68 @@ class TestGoogleCloudStorageToCloudStorageOperator:
         ):
             operator.execute(None)
 
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_replace_false_skips_single_file_when_destination_exists(self, mock_hook):
+        mock_hook.return_value.list.side_effect = [
+            [SOURCE_OBJECT_NO_WILDCARD],
+            [SOURCE_OBJECT_NO_WILDCARD],
+        ]
+        mock_hook.return_value.exists.return_value = True
+
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            replace=False,
+        )
+
+        operator.execute(None)
+
+        mock_hook.return_value.exists.assert_any_call(DESTINATION_BUCKET, SOURCE_OBJECT_NO_WILDCARD)
+        mock_hook.return_value.rewrite.assert_not_called()
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_replace_false_copies_single_file_when_destination_missing(self, mock_hook):
+        mock_hook.return_value.list.side_effect = [[], []]
+        mock_hook.return_value.exists.side_effect = lambda bucket, _obj: bucket == TEST_BUCKET
+
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            replace=False,
+        )
+
+        operator.execute(None)
+
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET, SOURCE_OBJECT_NO_WILDCARD, DESTINATION_BUCKET, SOURCE_OBJECT_NO_WILDCARD
+        )
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_execute_replace_true_copies_single_file_even_when_destination_exists(self, mock_hook):
+        mock_hook.return_value.list.return_value = []
+        mock_hook.return_value.exists.return_value = True
+
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            replace=True,
+        )
+
+        operator.execute(None)
+
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET, SOURCE_OBJECT_NO_WILDCARD, DESTINATION_BUCKET, SOURCE_OBJECT_NO_WILDCARD
+        )
+
     @pytest.mark.parametrize(
         (
             "existing_objects",


### PR DESCRIPTION
## Summary

Respect `replace=False` in the single-file fallback path of
`GCSToGCSOperator._copy_source_without_wildcard`. When the source is a
single object (no wildcard), `_ignore_existing_files` correctly empties
`objects` if the destination already has the file, but the subsequent
`if len(objects) == 0 and prefix:` branch then called
`_copy_single_object` unconditionally, overwriting the destination.

This adds a destination existence check guarded by `not self.replace`
inside that branch, skipping the copy when the destination already exists.

### Alternative considered

I also considered limiting the fallback itself to the case where the
source list was empty *before* `_ignore_existing_files` ran. The chosen
approach is smaller and keeps the intent local to where the copy happens;
happy to switch to the alternative if reviewers prefer it.

closes: #66009

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)