### PR TITLE
Add `GlueCatalogDeleteDatabaseOperator`

### DIFF
--- a/providers/amazon/docs/operators/glue_catalog.rst
+++ b/providers/amazon/docs/operators/glue_catalog.rst
@@ -40,3 +40,17 @@ Reference
 ~~~~~~~~~
 
 * `AWS boto3 Library Documentation for Glue <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html>`__
+
+.. _howto/operator:GlueCatalogDeleteDatabaseOperator:
+
+Delete a Catalog Database
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To delete a database from the AWS Glue Data Catalog, use
+:class:`~airflow.providers.amazon.aws.operators.glue_catalog.GlueCatalogDeleteDatabaseOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_glue_catalog.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_glue_catalog_delete_database]
+    :end-before: [END howto_operator_glue_catalog_delete_database]

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
@@ -107,3 +107,47 @@ class GlueCatalogCreateDatabaseOperator(AwsBaseOperator[AwsBaseHook]):
         else:
             self.log.info("Created Glue Catalog database: %s", self.database_name)
         return self.database_name
+
+
+class GlueCatalogDeleteDatabaseOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Delete a database from the AWS Glue Data Catalog.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GlueCatalogDeleteDatabaseOperator`
+
+    :param database_name: The name of the database to delete.
+    :param catalog_id: The ID of the Data Catalog. Defaults to the account ID.
+    """
+
+    aws_hook_class = AwsBaseHook
+    template_fields: tuple[str, ...] = (
+        *AwsBaseOperator.template_fields,
+        "database_name",
+    )
+
+    def __init__(
+        self,
+        *,
+        database_name: str,
+        catalog_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.database_name = database_name
+        self.catalog_id = catalog_id
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "glue"}
+
+    def execute(self, context: Context) -> None:
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "Name": self.database_name,
+                "CatalogId": self.catalog_id,
+            }
+        )
+        self.hook.conn.delete_database(**kwargs)
+        self.log.info("Deleted Glue Catalog database: %s", self.database_name)

--- a/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
@@ -18,16 +18,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from airflow.providers.amazon.aws.operators.glue_catalog import GlueCatalogCreateDatabaseOperator
+from airflow.providers.amazon.aws.operators.glue_catalog import (
+    GlueCatalogCreateDatabaseOperator,
+    GlueCatalogDeleteDatabaseOperator,
+)
 from airflow.providers.common.compat.sdk import DAG, chain
 
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import TriggerRule, task
+    from airflow.sdk import TriggerRule
 else:
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 DAG_ID = "example_glue_catalog"
@@ -52,17 +54,18 @@ with DAG(
     )
     # [END howto_operator_glue_catalog_create_database]
 
-    @task(trigger_rule=TriggerRule.ALL_DONE)
-    def delete_database(name: str):
-        """Delete the Glue Catalog database."""
-        import boto3
-
-        boto3.client("glue").delete_database(Name=name)
+    # [START howto_operator_glue_catalog_delete_database]
+    delete_database = GlueCatalogDeleteDatabaseOperator(
+        task_id="delete_database",
+        database_name=db_name,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_glue_catalog_delete_database]
 
     chain(
         test_context,
         create_database,
-        delete_database(name=db_name),
+        delete_database,
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
@@ -20,7 +20,10 @@ from unittest.mock import MagicMock
 
 from botocore.exceptions import ClientError
 
-from airflow.providers.amazon.aws.operators.glue_catalog import GlueCatalogCreateDatabaseOperator
+from airflow.providers.amazon.aws.operators.glue_catalog import (
+    GlueCatalogCreateDatabaseOperator,
+    GlueCatalogDeleteDatabaseOperator,
+)
 
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
 
@@ -87,6 +90,43 @@ class TestGlueCatalogCreateDatabaseOperator:
 
     def test_template_fields(self):
         op = GlueCatalogCreateDatabaseOperator(
+            task_id="test",
+            database_name=DB_NAME,
+        )
+        validate_template_fields(op)
+
+
+class TestGlueCatalogDeleteDatabaseOperator:
+    def test_execute(self):
+        op = GlueCatalogDeleteDatabaseOperator(
+            task_id="delete_db",
+            database_name=DB_NAME,
+        )
+        mock_conn = MagicMock()
+        op.hook.conn = mock_conn
+
+        op.execute({})
+
+        mock_conn.delete_database.assert_called_once_with(Name=DB_NAME)
+
+    def test_execute_with_catalog_id(self):
+        op = GlueCatalogDeleteDatabaseOperator(
+            task_id="delete_db",
+            database_name=DB_NAME,
+            catalog_id="123456789012",
+        )
+        mock_conn = MagicMock()
+        op.hook.conn = mock_conn
+
+        op.execute({})
+
+        mock_conn.delete_database.assert_called_once_with(
+            Name=DB_NAME,
+            CatalogId="123456789012",
+        )
+
+    def test_template_fields(self):
+        op = GlueCatalogDeleteDatabaseOperator(
             task_id="test",
             database_name=DB_NAME,
         )


### PR DESCRIPTION
## What
Add a delete operator to complement the merged `GlueCatalogCreateDatabaseOperator` (#65977).

## How
- New `GlueCatalogDeleteDatabaseOperator` using `AwsBaseOperator[AwsBaseHook]` pattern
- Supports optional `catalog_id` parameter
- Uses `prune_dict` pattern
- System test updated to use the operator instead of a raw `@task` wrapper

## Files (4 modified)
- `operators/glue_catalog.py` — added `GlueCatalogDeleteDatabaseOperator`
- `test_glue_catalog.py` — added 3 delete tests
- `example_glue_catalog.py` — replaced `@task delete_database` with operator
- `glue_catalog.rst` — added delete section

## Testing
- Unit tests: 7 passed (4 create + 3 delete)
- mypy: no issues
- Static checks: 43 passed, 0 PR-related failures
