### PR TITLE
Download providers.json in registry-backfill publish-versions job

### DIFF
--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -284,6 +284,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
+      - name: "Download providers.json from S3"
+        env:
+          S3_BUCKET: ${{ needs.prepare.outputs.bucket }}
+        run: |
+          # `breeze registry publish-versions` calls publish_registry_versions.py,
+          # which reads providers.json (lines 119-127) to know which provider
+          # IDs to iterate. The job runs in a fresh checkout where providers.json
+          # is gitignored, so without this step the publish raises FileNotFoundError.
+          # Download to dev/registry/ -- the function's inline path fallback
+          # resolves the file from there.
+          mkdir -p dev/registry
+          aws s3 cp \
+            "${S3_BUCKET}api/providers.json" \
+            dev/registry/providers.json
+
       - name: "Publish version metadata"
         env:
           S3_BUCKET: ${{ needs.prepare.outputs.bucket }}

--- a/dev/breeze/tests/test_publish_registry_versions.py
+++ b/dev/breeze/tests/test_publish_registry_versions.py
@@ -250,3 +250,29 @@ class TestPublishVersions:
                 "s3://staging-docs-airflow-apache-org/registry/",
                 providers_json_path=tmp_path / "nonexistent.json",
             )
+
+    def test_inline_fallback_to_dev_registry_providers_json(self, tmp_path, monkeypatch):
+        """publish_versions resolves providers.json from dev/registry/ when
+        registry/src/_data/providers.json is absent.
+
+        The Registry Backfill workflow's ``publish-versions`` job runs in a
+        fresh checkout where providers.json is gitignored, so it downloads
+        the file to ``dev/registry/providers.json``. Without this fallback,
+        the publish step would raise FileNotFoundError.
+        """
+        monkeypatch.chdir(tmp_path)
+        # registry/src/_data/providers.json deliberately absent
+        (tmp_path / "dev" / "registry").mkdir(parents=True)
+        (tmp_path / "dev" / "registry" / "providers.json").write_text(json.dumps({"providers": []}))
+
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = []
+        with (
+            patch(
+                "airflow_breeze.utils.publish_registry_versions.boto3.client",
+                return_value=client,
+            ),
+            patch("airflow_breeze.utils.publish_registry_versions.invalidate_cloudfront"),
+        ):
+            # Empty providers list -> no per-provider work, returns cleanly.
+            publish_versions("s3://staging-docs-airflow-apache-org/registry/")


### PR DESCRIPTION
## Summary

The `Registry Backfill` workflow's `publish-versions` job runs in a fresh checkout where `providers.json` is gitignored. `breeze registry publish-versions` calls `publish_registry_versions.py:119-127`, which reads `providers.json` to know which provider IDs to iterate. Without the file present, it raises `FileNotFoundError` before writing any per-provider `versions.json` updates to S3 — leaving dropdowns stale even when backfill jobs successfully uploaded the version pages.

## Fix

Add a `Download providers.json from S3` step in the `publish-versions` job, between `Configure AWS credentials` and `Publish version metadata`. Writes to `dev/registry/providers.json`; the function's existing inline path fallback (`publish_registry_versions.py:121-122`) resolves the file from there.

No `|| true` — failure here is a real problem and should fail the job loudly.

## Test

New `test_inline_fallback_to_dev_registry_providers_json` in `dev/breeze/tests/test_publish_registry_versions.py` locks in the contract this PR depends on: `monkeypatch.chdir(tmp_path)`, places only `dev/registry/providers.json` (no eleventy data dir copy), asserts `publish_versions()` resolves it without raising. Mocks `boto3.client` and `invalidate_cloudfront`. Runs in 0.04s.

## Companion PR

#66027 (`Make registry-backfill workflow actually publish backfilled pages`) handles the per-version page sync. PR-B (this one) handles the dropdown refresh. Both are needed for a fully-green smoke test (`amazon/9.24.0 google/21.0.0 common-compat/1.14.2`); they're independent and can land in either order.

## Verification after both merge

```
gh workflow run registry-backfill.yml -R apache/airflow \
  -f destination=staging \
  -f provider-versions="amazon/9.24.0 google/21.0.0 common-compat/1.14.2"
```

Expect:
- All backfill jobs + publish-versions job exit 0
- `aws s3 cp s3://staging-docs-airflow-apache-org/registry/api/providers/amazon/versions.json -` lists `9.24.0`
- (After CloudFront cache clears) the dropdown on `https://airflow.apache.org/registry/providers/amazon/9.24.0/` lists 9.24.0

Linked prior fixes: #65972, #65975, #65987, #65984, #65989, #66027.
