### PR TITLE
Make error messages consistent in local API client create_pool

### DIFF
--- a/airflow-core/src/airflow/api/client/local_client.py
+++ b/airflow-core/src/airflow/api/client/local_client.py
@@ -88,11 +88,11 @@ class Client:
             raise AirflowBadRequest("Pool name shouldn't be empty")
         pool_name_length = Pool.pool.property.columns[0].type.length
         if len(name) > pool_name_length:
-            raise AirflowBadRequest(f"pool name cannot be more than {pool_name_length} characters")
+            raise AirflowBadRequest(f"Pool name cannot be more than {pool_name_length} characters")
         try:
             slots = int(slots)
         except ValueError:
-            raise AirflowBadRequest(f"Bad value for `slots`: {slots}")
+            raise AirflowBadRequest(f"Invalid value for `slots`: {slots}")
         pool = Pool.create_or_update_pool(
             name=name, slots=slots, description=description, include_deferred=include_deferred
         )


### PR DESCRIPTION
## Summary

Two small consistency fixes in `Client.create_pool` in
`airflow-core/src/airflow/api/client/local_client.py`:

1. `"pool name cannot be more than ..."` → `"Pool name cannot be more than ..."`
   to match the adjacent `"Pool name shouldn't be empty"` message in
   the same method.
2. `"Bad value for `slots`: ..."` → `"Invalid value for `slots`: ..."`
   to match the `"Invalid value for ..."` wording used elsewhere
   (e.g. `api_fastapi/common/parameters.py`, `cli/commands/config_command.py`).

No behavior change — only error message text.