### PR TITLE
Fix dagRuns API URLSearchParams Bug

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -52,7 +52,7 @@ export const MetricSection = ({
 
   const stateParam = kind === "task_instances" ? SearchParamsKeys.TASK_STATE : SearchParamsKeys.STATE;
   const searchParams = new URLSearchParams(
-    `?${stateParam}=${state}&${SearchParamsKeys.START_DATE}=${startDate}`,
+    `?${stateParam}=${state}&${SearchParamsKeys.START_DATE_GTE}=${startDate}`,
   );
   const { t: translate } = useTranslation();
 


### PR DESCRIPTION
Use start_date_gte for dashboard filters

When navigating from the "Start" page via the MetricSection to the dag runs the URL parameters that are passed are "state" and "start_date". However the backend requires "start_date_gte" as expected lower-bound date filter parameter.

This PR ensures that the expected start date filters are applied correctly, by passing the right parameter ("start_date_gte" instead of "start_date") to the dagRuns endpoint.