### PR TITLE
Add MwaaServerlessStartWorkflowRunOperator

### DIFF
--- a/providers/amazon/docs/operators/mwaa_serverless.rst
+++ b/providers/amazon/docs/operators/mwaa_serverless.rst
@@ -1,0 +1,42 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+================================================
+Amazon MWAA Serverless (Managed Workflows)
+================================================
+
+Amazon MWAA Serverless provides a serverless execution environment for Apache Airflow
+workflows. Use the operators below to manage MWAA Serverless workflow runs.
+
+.. _howto/operator:MwaaServerlessStartWorkflowRunOperator:
+
+Start a Workflow Run
+~~~~~~~~~~~~~~~~~~~~
+
+To start a new execution of an MWAA Serverless workflow, use
+:class:`~airflow.providers.amazon.aws.operators.mwaa_serverless.MwaaServerlessStartWorkflowRunOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_mwaa_serverless.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_mwaa_serverless_start_workflow_run]
+    :end-before: [END howto_operator_mwaa_serverless_start_workflow_run]
+
+Reference
+~~~~~~~~~
+
+* `AWS boto3 Library Documentation for MWAA Serverless <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/mwaa-serverless.html>`__

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -376,6 +376,12 @@ integrations:
     external-doc-url: https://aws.amazon.com/verified-permissions/
     logo: /docs/integration-logos/Amazon-Verified-Permissions.png
     tags: [aws]
+  - integration-name: Amazon MWAA Serverless
+    external-doc-url: https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-serverless.html
+    logo: /docs/integration-logos/Amazon-MWAA.png
+    how-to-guide:
+      - /docs/apache-airflow-providers-amazon/operators/mwaa_serverless.rst
+    tags: [aws]
   - integration-name: Amazon Neptune
     external-doc-url: https://aws.amazon.com/neptune/
     logo: /docs/integration-logos/Amazon-Neptune_64.png
@@ -462,6 +468,9 @@ operators:
   - integration-name: Amazon Managed Workflows for Apache Airflow (MWAA)
     python-modules:
       - airflow.providers.amazon.aws.operators.mwaa
+  - integration-name: Amazon MWAA Serverless
+    python-modules:
+      - airflow.providers.amazon.aws.operators.mwaa_serverless
   - integration-name: Amazon Simple Storage Service (S3)
     python-modules:
       - airflow.providers.amazon.aws.operators.s3

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa_serverless.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/mwaa_serverless.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Amazon MWAA Serverless operators."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.operators.base_aws import AwsBaseOperator
+from airflow.providers.amazon.aws.utils.mixins import aws_template_fields
+from airflow.utils.helpers import prune_dict
+
+if TYPE_CHECKING:
+    from airflow.sdk import Context
+
+
+class MwaaServerlessStartWorkflowRunOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Start a new execution of an Amazon MWAA Serverless workflow.
+
+    This operator triggers a workflow run that executes the tasks defined in the
+    workflow. MWAA Serverless handles task scheduling, worker scaling, dependency
+    resolution, and monitoring.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:MwaaServerlessStartWorkflowRunOperator`
+
+    :param workflow_arn: The ARN of the workflow to run. (templated)
+    :param override_parameters: Optional parameters to override defaults for this run. (templated)
+    :param workflow_version: Optional version of the workflow to execute. (templated)
+    """
+
+    template_fields: tuple[str, ...] = aws_template_fields(
+        "workflow_arn",
+        "override_parameters",
+        "workflow_version",
+    )
+    template_fields_renderers = {"override_parameters": "json"}
+    aws_hook_class = AwsBaseHook
+
+    def __init__(
+        self,
+        *,
+        workflow_arn: str,
+        override_parameters: dict[str, Any] | None = None,
+        workflow_version: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.workflow_arn = workflow_arn
+        self.override_parameters = override_parameters
+        self.workflow_version = workflow_version
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "mwaa-serverless"}
+
+    def execute(self, context: Context) -> str:
+        self.log.info("Starting MWAA Serverless workflow run for %s", self.workflow_arn)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "WorkflowArn": self.workflow_arn,
+                "OverrideParameters": self.override_parameters,
+                "WorkflowVersion": self.workflow_version,
+            }
+        )
+        response = self.hook.conn.start_workflow_run(**kwargs)
+        run_id = response["RunId"]
+        self.log.info("Started workflow run %s (status: %s)", run_id, response.get("Status"))
+        return run_id

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -345,6 +345,13 @@ def get_provider_info():
                 "tags": ["aws"],
             },
             {
+                "integration-name": "Amazon MWAA Serverless",
+                "external-doc-url": "https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-serverless.html",
+                "logo": "/docs/integration-logos/Amazon-MWAA.png",
+                "how-to-guide": ["/docs/apache-airflow-providers-amazon/operators/mwaa_serverless.rst"],
+                "tags": ["aws"],
+            },
+            {
                 "integration-name": "Amazon Neptune",
                 "external-doc-url": "https://aws.amazon.com/neptune/",
                 "logo": "/docs/integration-logos/Amazon-Neptune_64.png",
@@ -453,6 +460,10 @@ def get_provider_info():
             {
                 "integration-name": "Amazon Managed Workflows for Apache Airflow (MWAA)",
                 "python-modules": ["airflow.providers.amazon.aws.operators.mwaa"],
+            },
+            {
+                "integration-name": "Amazon MWAA Serverless",
+                "python-modules": ["airflow.providers.amazon.aws.operators.mwaa_serverless"],
             },
             {
                 "integration-name": "Amazon Simple Storage Service (S3)",

--- a/providers/amazon/tests/system/amazon/aws/example_mwaa_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa_serverless.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from airflow.providers.amazon.aws.operators.mwaa_serverless import (
+    MwaaServerlessStartWorkflowRunOperator,
+)
+from airflow.providers.amazon.aws.operators.s3 import (
+    S3CreateBucketOperator,
+    S3CreateObjectOperator,
+    S3DeleteBucketOperator,
+)
+from airflow.providers.common.compat.sdk import DAG, chain
+
+from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk import TriggerRule, task
+else:
+    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
+    from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
+
+DAG_ID = "example_mwaa_serverless"
+
+# Externally fetched variables:
+ROLE_ARN_KEY = "ROLE_ARN"
+
+# Valid MWAA Serverless YAML: tasks as mapping, FQN operators, flat parameters.
+WORKFLOW_YAML = """\
+systest_mwaa_serverless:
+  schedule: null
+  description: "System test: S3 key sensor on workflow definition"
+  tasks:
+    check_file:
+      task_id: check_file
+      operator: airflow.providers.amazon.aws.sensors.s3.S3KeySensor
+      bucket_name: {bucket}
+      bucket_key: workflow.yaml
+"""
+
+sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
+
+
+@task
+@retry(
+    retry=retry_if_exception_type(Exception),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=2, min=4, max=30),
+    reraise=True,
+)
+def create_workflow(bucket: str, role_arn: str) -> str:
+    """Create the MWAA Serverless workflow with retry for IAM propagation."""
+    import boto3
+
+    mwaa = boto3.client("mwaa-serverless")
+    return mwaa.create_workflow(
+        Name=bucket,
+        DefinitionS3Location={"Bucket": bucket, "ObjectKey": "workflow.yaml"},
+        RoleArn=role_arn,
+    )["WorkflowArn"]
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def stop_workflow_run(workflow_arn: str, run_id: str):
+    """Stop the workflow run."""
+    import boto3
+
+    boto3.client("mwaa-serverless").stop_workflow_run(WorkflowArn=workflow_arn, RunId=run_id)
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+@retry(
+    retry=retry_if_exception_type(Exception),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=5, max=30),
+    reraise=True,
+)
+def delete_workflow(workflow_arn: str):
+    """Delete the MWAA Serverless workflow."""
+    import boto3
+
+    boto3.client("mwaa-serverless").delete_workflow(WorkflowArn=workflow_arn)
+
+
+with DAG(
+    dag_id=DAG_ID,
+    schedule=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+) as dag:
+    test_context = sys_test_context_task()
+    env_id = test_context[ENV_ID_KEY]
+    role_arn = test_context[ROLE_ARN_KEY]
+    bucket_name = f"{env_id}-mwaa-sl"
+
+    create_bucket = S3CreateBucketOperator(task_id="create_bucket", bucket_name=bucket_name)
+
+    upload_workflow_yaml = S3CreateObjectOperator(
+        task_id="upload_workflow_yaml",
+        s3_bucket=bucket_name,
+        s3_key="workflow.yaml",
+        data=WORKFLOW_YAML.format(bucket=bucket_name),
+    )
+
+    workflow_arn = create_workflow(bucket=bucket_name, role_arn=role_arn)
+
+    # [START howto_operator_mwaa_serverless_start_workflow_run]
+    start_workflow = MwaaServerlessStartWorkflowRunOperator(
+        task_id="start_workflow",
+        workflow_arn=workflow_arn,
+    )
+    # [END howto_operator_mwaa_serverless_start_workflow_run]
+
+    delete_bucket = S3DeleteBucketOperator(
+        task_id="delete_bucket",
+        bucket_name=bucket_name,
+        force_delete=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    chain(
+        test_context,
+        create_bucket,
+        upload_workflow_yaml,
+        workflow_arn,
+        start_workflow,
+        stop_workflow_run(workflow_arn=workflow_arn, run_id=start_workflow.output),
+        delete_workflow(workflow_arn=workflow_arn),
+        delete_bucket,
+    )
+
+    from tests_common.test_utils.watcher import watcher
+
+    list(dag.tasks) >> watcher()
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+test_run = get_test_run(dag)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_mwaa_serverless.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.operators.mwaa_serverless import (
+    MwaaServerlessStartWorkflowRunOperator,
+)
+
+from unit.amazon.aws.utils.test_template_fields import validate_template_fields
+
+WORKFLOW_ARN = "arn:aws:mwaa-serverless:us-east-1:123456789012:workflow/test-workflow"
+RUN_ID = "run-abc123"
+
+
+class TestMwaaServerlessStartWorkflowRunOperator:
+    def setup_method(self):
+        self.operator = MwaaServerlessStartWorkflowRunOperator(
+            task_id="start_workflow",
+            workflow_arn=WORKFLOW_ARN,
+        )
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_client.start_workflow_run.return_value = {
+            "RunId": RUN_ID,
+            "Status": "STARTING",
+        }
+        mock_conn.return_value = mock_client
+
+        result = self.operator.execute({})
+
+        mock_client.start_workflow_run.assert_called_once_with(WorkflowArn=WORKFLOW_ARN)
+        assert result == RUN_ID
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_overrides(self, mock_conn):
+        op = MwaaServerlessStartWorkflowRunOperator(
+            task_id="start_workflow",
+            workflow_arn=WORKFLOW_ARN,
+            override_parameters={"bucket": "my-bucket"},
+            workflow_version="2",
+        )
+        mock_client = mock.MagicMock()
+        mock_client.start_workflow_run.return_value = {
+            "RunId": RUN_ID,
+            "Status": "STARTING",
+        }
+        mock_conn.return_value = mock_client
+
+        result = op.execute({})
+
+        mock_client.start_workflow_run.assert_called_once_with(
+            WorkflowArn=WORKFLOW_ARN,
+            OverrideParameters={"bucket": "my-bucket"},
+            WorkflowVersion="2",
+        )
+        assert result == RUN_ID
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)


### PR DESCRIPTION
## What
Add an operator for Amazon MWAA Serverless to start workflow runs.

## Motivation
`TriggerDagRunOperator` triggers a DAG run within the same Airflow environment. `MwaaServerlessStartWorkflowRunOperator` serves the analogous purpose for MWAA Serverless — it triggers a workflow execution on a remote MWAA Serverless environment from any Airflow DAG. This enables patterns like:

- **Cross-environment orchestration**: A central Airflow instance triggers serverless workflows that run on MWAA Serverless with automatic scaling and task isolation
- **Hybrid pipelines**: Combine provisioned MWAA for long-running orchestration with MWAA Serverless for burst workloads
- **CI/CD for workflows**: A deployment DAG validates and triggers workflow runs on MWAA Serverless as part of a release pipeline

MWAA Serverless is a separate service from MWAA (similar to how EMR Serverless is separate from EMR), with its own API (`mwaa-serverless`) and resource model (workflows instead of environments).

## How
- New `MwaaServerlessStartWorkflowRunOperator` using `AwsBaseOperator[AwsBaseHook]` with `client_type="mwaa-serverless"`
- Supports `override_parameters` for runtime customization and `workflow_version` for version pinning
- Returns the workflow run ID
- Follows EMR/EMR Serverless pattern: separate integration entry, separate operator file, shared logo

## Files
- `operators/mwaa_serverless.py` — operator
- `test_mwaa_serverless.py` — unit tests (3 tests)
- `example_mwaa_serverless.py` — system test
- `mwaa_serverless.rst` — docs
- `provider.yaml` + `get_provider_info.py` — new MWAA Serverless integration + operator entries

## Testing
- Unit tests: 3 passed
- mypy: no issues
- Static checks: 43 passed, 0 PR-related failures
