### PR TITLE
Fix OpenSearch log handler to support single-URL opensearch secret from helm chart

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -336,7 +336,8 @@ if REMOTE_LOGGING:
     elif OPENSEARCH_HOST:
         from airflow.providers.opensearch.log.os_task_handler import OpensearchRemoteLogIO
 
-        OPENSEARCH_PORT = conf.getint("opensearch", "PORT", fallback=9200)
+        _opensearch_port_str = conf.get("opensearch", "PORT", fallback="")
+        OPENSEARCH_PORT: int | None = int(_opensearch_port_str) if _opensearch_port_str.strip() else None
         OPENSEARCH_USERNAME: str = conf.get_mandatory_value("opensearch", "USERNAME")
         OPENSEARCH_PASSWORD: str = conf.get_mandatory_value("opensearch", "PASSWORD")
         OPENSEARCH_WRITE_STDOUT: bool = conf.getboolean("opensearch", "WRITE_STDOUT")

--- a/providers/opensearch/docs/changelog.rst
+++ b/providers/opensearch/docs/changelog.rst
@@ -27,6 +27,21 @@
 Changelog
 ---------
 
+The OpenSearch log handler now fully supports a single-URL deployment style where
+``AIRFLOW__OPENSEARCH__HOST`` (e.g. ``https://user:password@opensearch.example.com:443``) is the
+only variable that needs to be set. Two bugs prevented this from working:
+
+* **Credentials silently discarded** — when ``AIRFLOW__OPENSEARCH__USERNAME`` /
+  ``AIRFLOW__OPENSEARCH__PASSWORD`` were absent, the userinfo embedded in the host URL
+  (``user:password@``) was stripped before building the OpenSearch client but never passed as
+  ``http_auth``, causing 401 errors. Credentials are now extracted from the URL and used for
+  authentication when the dedicated config keys are empty.
+
+* **Port ignored** — ``AIRFLOW__OPENSEARCH__PORT`` defaulted to ``9200`` in the logging-config
+  template, so a port embedded in the host URL (e.g. ``:443``) was silently overridden. The
+  default is now ``None``; when no explicit port is configured, the port is taken from the host
+  URL, falling back to ``9200`` only when the URL carries no port either.
+
 When the ``[opensearch] host`` config embeds credentials
 (``https://user:password@opensearch.example.com:9200``), the log-source
 label shown in task logs is now the host URL with the ``user:password@``

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -190,9 +190,13 @@ def _create_opensearch_client(
 ) -> OpenSearch:
     parsed_url = urlparse(_format_url(host))
     resolved_port = port if port is not None else (parsed_url.port or 9200)
+    # Fall back to credentials embedded in the host URL (e.g. https://user:pass@host:port)
+    # when explicit username/password are not provided.
+    effective_username = username or parsed_url.username or ""
+    effective_password = password or parsed_url.password or ""
     return OpenSearch(
         hosts=[{"host": parsed_url.hostname, "port": resolved_port, "scheme": parsed_url.scheme}],
-        http_auth=(username, password),
+        http_auth=(effective_username, effective_password),
         **os_kwargs,
     )
 
@@ -799,7 +803,7 @@ class OpensearchRemoteLogIO(LoggingMixin):  # noqa: D101
     write_to_opensearch: bool = False
     delete_local_copy: bool = False
     host: str = "localhost"
-    port: int | None = 9200
+    port: int | None = None
     username: str = ""
     password: str = ""
     host_field: str = "host"

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -36,6 +36,7 @@ from airflow.providers.opensearch.log.os_task_handler import (
     OpensearchRemoteLogIO,
     OpensearchTaskHandler,
     _build_log_fields,
+    _create_opensearch_client,
     _format_error_detail,
     _render_log_id,
     _strip_userinfo,
@@ -531,6 +532,55 @@ class TestOpensearchTaskHandler:
         assert result == "callable_index_pattern"
 
 
+class TestCreateOpensearchClient:
+    @pytest.mark.parametrize(
+        ("host", "username", "password", "expected_auth"),
+        [
+            # Explicit credentials are used as-is
+            ("http://opensearch.example.com:9200", "admin", "secret", ("admin", "secret")),
+            # Credentials embedded in host URL are extracted when explicit credentials are empty
+            ("https://user:pass@opensearch.example.com:9200", "", "", ("user", "pass")),
+            # Explicit credentials take priority over URL-embedded ones
+            (
+                "https://url_user:url_pass@opensearch.example.com:9200",
+                "explicit",
+                "creds",
+                ("explicit", "creds"),
+            ),
+            # No credentials anywhere — empty strings passed through
+            ("http://opensearch.example.com:9200", "", "", ("", "")),
+        ],
+    )
+    def test_credentials(self, host, username, password, expected_auth):
+        with patch("airflow.providers.opensearch.log.os_task_handler.OpenSearch") as mock_os:
+            _create_opensearch_client(host, None, username, password, {})
+        assert mock_os.call_args.kwargs["http_auth"] == expected_auth
+
+    @pytest.mark.parametrize(
+        ("host", "explicit_port", "expected_port"),
+        [
+            # Port from URL when explicit port is None
+            ("https://user:pass@opensearch.example.com:443", None, 443),
+            # Explicit port overrides URL port
+            ("https://user:pass@opensearch.example.com:443", 9200, 9200),
+            # Default fallback when neither explicit nor URL port
+            ("https://opensearch.example.com", None, 9200),
+        ],
+    )
+    def test_port(self, host, explicit_port, expected_port):
+        with patch("airflow.providers.opensearch.log.os_task_handler.OpenSearch") as mock_os:
+            _create_opensearch_client(host, explicit_port, "", "", {})
+        hosts = mock_os.call_args.kwargs["hosts"]
+        assert hosts[0]["port"] == expected_port
+
+    def test_url_credentials_do_not_appear_in_host_list(self):
+        """Userinfo must be stripped from the host entry passed to the OpenSearch client."""
+        with patch("airflow.providers.opensearch.log.os_task_handler.OpenSearch") as mock_os:
+            _create_opensearch_client("https://user:pass@opensearch.example.com:9200", None, "", "", {})
+        hosts = mock_os.call_args.kwargs["hosts"]
+        assert hosts == [{"host": "opensearch.example.com", "port": 9200, "scheme": "https"}]
+
+
 class TestTaskHandlerHelpers:
     def test_safe_attrgetter(self):
         class A: ...
@@ -702,6 +752,26 @@ class TestOpensearchRemoteLogIO:
         log_id = _render_log_id(self.opensearch_io.log_id_template, ti, ti.try_number)
         assert log_source_info == []
         assert f"*** Log {log_id} not found in Opensearch" in log_messages[0]
+
+    def test_port_extracted_from_url_when_not_explicit(self, tmp_path):
+        io = OpensearchRemoteLogIO(
+            host="https://user:pass@opensearch.example.com:443",
+            port=None,
+            username="",
+            password="",
+            base_log_folder=tmp_path,
+        )
+        assert io.port == 443
+
+    def test_explicit_port_overrides_url_port(self, tmp_path):
+        io = OpensearchRemoteLogIO(
+            host="https://user:pass@opensearch.example.com:443",
+            port=9200,
+            username="",
+            password="",
+            base_log_folder=tmp_path,
+        )
+        assert io.port == 9200
 
     def test_get_index_patterns_with_callable(self):
         with patch("airflow.providers.opensearch.log.os_task_handler.import_string") as mock_import_string:


### PR DESCRIPTION
with embedded credentials and port

When AIRFLOW__OPENSEARCH__HOST contains userinfo (user:password@) and/or a non-default port, the handler now uses them correctly:

- Credentials embedded in the host URL are extracted and used for HTTP auth when AIRFLOW__OPENSEARCH__USERNAME / PASSWORD are not set.
- OPENSEARCH_PORT now defaults to None instead of 9200, so a port in the host URL is no longer silently overridden by the hardcoded default.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Code v2.1.121 Sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=e020eb7 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @AlexMTX** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->