### PR TITLE
Stringify task_instance.id when setting OTEL span attribute

### DIFF
--- a/airflow-core/newsfragments/66053.bugfix.rst
+++ b/airflow-core/newsfragments/66053.bugfix.rst
@@ -1,0 +1,1 @@
+Fix OTEL warning ``Invalid type UUID for attribute 'airflow.task_instance.id'`` by stringifying the task instance UUID when setting the span attribute in the execution API's ``_emit_task_span``.

--- a/airflow-core/newsfragments/66053.bugfix.rst
+++ b/airflow-core/newsfragments/66053.bugfix.rst
@@ -1,1 +1,0 @@
-Fix OTEL warning ``Invalid type UUID for attribute 'airflow.task_instance.id'`` by stringifying the task instance UUID when setting the span attribute in the execution API's ``_emit_task_span``.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -488,7 +488,7 @@ def _emit_task_span(ti, state):
                 "airflow.task_instance.try_number": ti.try_number,
                 "airflow.task_instance.map_index": ti.map_index if ti.map_index is not None else -1,
                 "airflow.task_instance.state": state,
-                "airflow.task_instance.id": ti.id,
+                "airflow.task_instance.id": str(ti.id),
             }
         )
         status_code = StatusCode.OK if state == TaskInstanceState.SUCCESS else StatusCode.ERROR

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -3694,6 +3694,7 @@ class TestEmitTaskSpan:
     def _make_ti(self, task_id="my_task", map_index=-1, queued_dttm=None, start_date=None):
         dr_carrier, ti_carrier = self._make_carriers()
         ti = mock.MagicMock()
+        ti.id = UUID("0182e924-0f1e-77e6-ab50-e977118bc139")
         ti.dag_id = "test_dag"
         ti.task_id = task_id
         ti.run_id = "test_run"
@@ -3730,6 +3731,10 @@ class TestEmitTaskSpan:
         assert attrs["airflow.task_instance.try_number"] == 1
         assert attrs["airflow.task_instance.map_index"] == 2
         assert attrs["airflow.task_instance.state"] == TaskInstanceState.SUCCESS
+        # The OTEL SDK only accepts str/bytes/int/float/bool attribute values,
+        # so the UUID must be stringified before being set on the span.
+        assert attrs["airflow.task_instance.id"] == str(ti.id)
+        assert isinstance(attrs["airflow.task_instance.id"], str)
 
     def test_emit_task_span_name_unmapped(self):
         _emit_task_span(self._make_ti(task_id="my_task", map_index=-1), TaskInstanceState.SUCCESS)


### PR DESCRIPTION
closes: #66052

## Summary

`_emit_task_span()` in the execution API was setting the `airflow.task_instance.id` span attribute to the raw `UUID` object. The OTEL SDK only accepts `str / bytes / int / float / bool` attribute values (or homogeneous sequences), so it dropped the attribute and logged a warning per task state transition:

```
[warning  ] Invalid type UUID for attribute 'airflow.task_instance.id' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types [opentelemetry.attributes] correlation_id=... loc=__init__.py:119 ti_id=...
```

The fix stringifies the UUID, matching the convention already used at the top of the same module (`bind_contextvars(ti_id=str(task_instance_id))`).

## Root cause

Introduced in #63839 (merged 2026-03-24, "Introduce parent task spans and nest worker and trigger spans under them"). First shipped in 3.2.0; reproducible on 3.2.1 and `main`.

## Reproduction

1. Run Airflow 3.2.x with native OTEL tracing enabled (`[traces] otel_on = True` and an OTLP endpoint).
2. Trigger any DAG.
3. `docker logs <api-server> | grep "Invalid type UUID"` — one warning per task state transition.

## Impact

Cosmetic but noisy — the task itself runs fine, the span is still emitted with the other attributes (`dag_id`, `task_id`, `run_id`, `try_number`, `map_index`, `state`), only the TI UUID attribute is dropped. This prevents trace search by task instance ID in the trace backend.

## Tests

Extended `TestEmitTaskSpan.test_emit_task_span_sets_attributes` to set a real UUID on the mock TI and assert the span attribute is present, equal to `str(ti.id)`, and of type `str`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Anthropic) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
