### PR TITLE
Improve Playwright test patterns in connections e2e tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
@@ -170,6 +170,7 @@ export class ConnectionsPage extends BasePage {
     await expect(this.connectionIdInput).toBeVisible();
     await this.fillConnectionForm(updates);
     await this.saveConnection();
+    await this.waitForConnectionsListLoad();
   }
 
   public async fillConnectionForm(details: Partial<ConnectionDetails>): Promise<void> {
@@ -224,35 +225,33 @@ export class ConnectionsPage extends BasePage {
 
     if (details.extra !== undefined && details.extra !== "") {
       const extraAccordion = this.page.getByRole("button", { name: /extra fields json/i });
-      const accordionVisible = await extraAccordion.isVisible({ timeout: 5000 }).catch(() => false);
 
-      if (accordionVisible) {
-        await extraAccordion.click();
-        const monacoEditor = this.page.locator(".monaco-editor").first();
+      await expect(extraAccordion).toBeVisible({ timeout: 5000 });
+      await extraAccordion.click();
+      const monacoEditor = this.page.locator(".monaco-editor").first();
 
-        await monacoEditor.waitFor({ state: "visible", timeout: 30_000 });
+      await expect(monacoEditor).toBeVisible({ timeout: 30_000 });
 
-        // Set value via Monaco API to avoid auto-closing bracket/quote issues with keyboard input
-        await monacoEditor.evaluate((container, value) => {
-          const monacoApi = (globalThis as Record<string, unknown>).monaco as
-            | {
-                editor: {
-                  getEditors: () => Array<{ getDomNode: () => Node; setValue: (v: string) => void }>;
-                };
-              }
-            | undefined;
-
-          if (monacoApi !== undefined) {
-            const editor = monacoApi.editor.getEditors().find((e) => container.contains(e.getDomNode()));
-
-            if (editor !== undefined) {
-              editor.setValue(value);
+      // Set value via Monaco API to avoid auto-closing bracket/quote issues with keyboard input
+      await monacoEditor.evaluate((container, value) => {
+        const monacoApi = (globalThis as Record<string, unknown>).monaco as
+          | {
+              editor: {
+                getEditors: () => Array<{ getDomNode: () => Node; setValue: (v: string) => void }>;
+              };
             }
-          }
-        }, details.extra);
+          | undefined;
 
-        await this.connectionIdInput.click();
-      }
+        if (monacoApi !== undefined) {
+          const editor = monacoApi.editor.getEditors().find((e) => container.contains(e.getDomNode()));
+
+          if (editor !== undefined) {
+            editor.setValue(value);
+          }
+        }
+      }, details.extra);
+
+      await this.connectionIdInput.click();
     }
   }
 

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
@@ -52,7 +52,8 @@ test.describe("Connections Page - List and Display", () => {
   test("should display connections list page", async ({ connectionsPage }) => {
     await connectionsPage.navigate();
 
-    expect(connectionsPage.page.url()).toContain("/connections");
+    // Verify the page is loaded
+    await expect(connectionsPage.page).toHaveURL(/\/connections/);
 
     await expect(connectionsPage.connectionsTable).toBeVisible();
   });
@@ -128,6 +129,7 @@ test.describe("Connections Page - CRUD Operations", () => {
 
   test("should create a new connection and display it in list", async ({ connectionsPage }) => {
     test.slow();
+    await connectionsPage.navigate();
 
     const connId = `new_conn_${uniqueRunId("create")}`;
 
@@ -310,12 +312,13 @@ test.describe("Connections Page - Search and Filter", () => {
         async () => {
           const count = await connectionsPage.getConnectionCount();
 
-          return count > 0; // Just verify we have some results
+          return count > 0;
         },
         { intervals: [500] },
       )
       .toBe(true);
 
+    // Clear search
     await connectionsPage.searchConnections("");
 
     const finalCount = await connectionsPage.getConnectionCount();


### PR DESCRIPTION
Improve Playwright test patterns in connections e2e tests                                                                                            
                                                                                                                                                       
- Remove redundant `waitForLoadState("domcontentloaded")` in `ConnectionsPage.ts`.                                                                                                                        
- Replace manual `expect(url).toContain()` with web-first `toHaveURL()` in `connections.spec.ts` for auto-retry support.                             
                                                                                                                                                       
closes: #63088