### PR TITLE
maintainer-review: ask before opening files view in browser

### DIFF
--- a/.github/skills/maintainer-review/SKILL.md
+++ b/.github/skills/maintainer-review/SKILL.md
@@ -213,20 +213,29 @@ GitHub-web-only auto-linking and is not clickable in a
 terminal). Do not compress to `gh pr view 65981` (that's a
 shell command, not a link). Always emit the full HTTPS URL.
 
-**Golden rule 11 — auto-open each PR in the browser, by
-default.** When the maintainer says `[Y]es` at a PR's
+**Golden rule 11 — ask before opening the browser, and open
+the files tab.** When the maintainer says `[Y]es` at a PR's
 headline (Step 1 of [`review-flow.md`](review-flow.md)), the
-skill runs `gh pr view <N> --repo <repo> --web` to open the
-PR's GitHub page in the maintainer's default browser. This
-runs **in parallel** with the Step 2 fetch — by the time the
-diff and metadata land in the conversation, the maintainer
-already has the PR's web view in another window for visual
-context (CI breadcrumbs, conversation thread, file tree
-sidebar) that the terminal can't show. Disable per-session
-with the `no-browser` selector. The skill never opens drafts,
-already-merged PRs, or self-authored PRs in the browser
-(those are skipped before they reach the headline-confirm
-gate anyway).
+skill **prompts** before launching anything:
+
+> *Open files view in browser? `[y]es / [N]o` (default no).*
+
+The headline already carries the file-count and
+additions / deletions (`Files: N changed +X −Y`), so the
+maintainer has the size of the change in hand when deciding
+— don't re-render it. On `[y]`, the skill opens the PR's
+**files tab** (`https://github.com/<owner>/<repo>/pull/<N>/files`)
+via `xdg-open` / `open` / `start`, in the background. On any
+other reply, no browser action — the diff fetch (Step 2)
+proceeds either way.
+
+`gh pr view --web` is not used here: it always opens the
+conversation tab, but the files tab is the one that pairs
+naturally with the terminal-side line-comment workflow.
+
+The skill never opens drafts, already-merged PRs, or
+self-authored PRs (those are skipped before they reach the
+headline-confirm gate anyway).
 
 ---
 
@@ -275,7 +284,6 @@ query and chip semantics.
 | `dry-run` | examine and draft but refuse to actually post any review |
 | `no-adversarial` | skip the optional adversarial-reviewer step for this session |
 | `inline:off` (alias `body-only`) | suppress the inline-comments picker for this session and post body-only reviews |
-| `no-browser` | suppress the auto-open-in-browser action when entering a PR (default is to open) |
 | `lookahead:<N>` | size of the background-analysis lookahead window (default `3`); see [`review-flow.md#background-analysis-subagents`](review-flow.md#background-analysis-subagents) |
 | `no-prefetch` | disable background analysis subagents for this session — useful for tiny queues (`max:1`–`max:2`) where the wall-clock benefit is nil |
 
@@ -312,7 +320,6 @@ examples a maintainer can paste:
 | The team queue (PRs where `apache/airflow-providers-amazon` is requested) | `/maintainer-review team:airflow-providers-amazon` |
 | The wider curated queue triage already promoted | `/maintainer-review ready` |
 | Stay body-only this session (no inline picker) | `/maintainer-review inline:off` |
-| Don't auto-open the PR in the browser when I `[Y]es` it | `/maintainer-review no-browser` |
 | Dry-run the queue — draft everything, post nothing | `/maintainer-review dry-run` |
 | Same, against a different repo | `/maintainer-review dry-run repo:apache/airflow-site` |
 | Pair with an adversarial reviewer for a second read on each PR | `/maintainer-review with-reviewer:/codex-plugin:adversarial-review` |
@@ -510,7 +517,6 @@ writes a session log to disk.
 | `dry-run` | draft but never post |
 | `no-adversarial` | skip the optional second-reviewer step |
 | `inline:off` (alias `body-only`) | suppress the inline-comments picker; post body-only reviews this session |
-| `no-browser` | don't auto-open each PR in the browser at `[Y]es` |
 | `lookahead:<N>` | size of the background-analysis lookahead window (default `3`) |
 | `no-prefetch` | disable background analysis subagents for this session |
 

--- a/.github/skills/maintainer-review/prerequisites.md
+++ b/.github/skills/maintainer-review/prerequisites.md
@@ -151,28 +151,31 @@ a separate call. The state is one of:
 
 ## Browser-open availability (DEGRADES)
 
-By default the skill opens each `[Y]es`-confirmed PR in the
-maintainer's default browser via `gh pr view <N> --web` (see
-Golden rule 11 in [`SKILL.md`](SKILL.md)). At session start
-the skill checks that `gh pr view --web` is callable in this
-shell:
+The skill prompts before opening each PR's files tab in the
+maintainer's default browser (see Golden rule 11 in
+[`SKILL.md`](SKILL.md)). The opener is `xdg-open` (Linux),
+`open` (macOS), or `start` (Windows). At session start the
+skill checks that at least one is on `$PATH`:
 
 ```bash
-gh pr view --help 2>/dev/null | grep -q -- '--web' || echo "missing"
+command -v xdg-open >/dev/null 2>&1 \
+  || command -v open >/dev/null 2>&1 \
+  || command -v start >/dev/null 2>&1 \
+  || echo "missing"
 ```
 
-If `--web` is missing (older `gh`) or the command can't reach
-a browser (headless session, missing `xdg-open` /
-`open` / `start`), announce once and degrade to URL-only:
+If none is available (headless session, container with no
+freedesktop tools), announce once and degrade — the prompt is
+still asked, but on `[y]` the skill **prints the files-tab
+URL** instead of trying to launch:
 
-> *`gh pr view --web` not available — falling back to printing
-> the PR URL only. Click the URL in your terminal to open the
-> PR.*
+> *No browser opener (`xdg-open` / `open` / `start`) available
+> — on `[y]` I'll print the files-tab URL for you to click
+> manually.*
 
 The PR URL is still always rendered per Golden rule 10, so
-the maintainer can click it manually in any URL-aware
-terminal. If the maintainer passed `no-browser`, skip this
-check entirely and stay quiet.
+the maintainer can click it directly in any URL-aware
+terminal at any time.
 
 ---
 

--- a/.github/skills/maintainer-review/review-flow.md
+++ b/.github/skills/maintainer-review/review-flow.md
@@ -63,22 +63,37 @@ The headline is your at-a-glance frame. Below it, ask:
 
 If the maintainer hits `[Y]`:
 
-1. **Auto-open in browser.** Per Golden rule 11 in `SKILL.md`,
-   immediately run
+1. **Ask before opening the browser.** Per Golden rule 11 in
+   `SKILL.md`, do **not** auto-open anything. Prompt:
+
+   > *Open files view in browser? `[y]es / [N]o` (default no).*
+
+   The headline above already shows file count and additions /
+   deletions (`Files: N changed +X −Y`), so the maintainer has
+   the size of the change in front of them when answering — no
+   need to re-render it.
+
+   On `[y]`, build the **files-tab** URL — not the conversation
+   tab — and hand it to the OS opener:
 
    ```bash
-   gh pr view <N> --repo <repo> --web
+   url="https://github.com/<owner>/<repo>/pull/<N>/files"
+   if   command -v xdg-open >/dev/null 2>&1; then xdg-open "$url"
+   elif command -v open     >/dev/null 2>&1; then open "$url"
+   elif command -v start    >/dev/null 2>&1; then start "$url"
+   else echo "$url"   # print and let the maintainer click
+   fi
    ```
 
-   in the background (no `--wait`; do not block on it). This
-   pops the GitHub PR page in the maintainer's default browser
-   so they can keep visual context — CI breadcrumbs, the
-   conversation timeline, the file-tree sidebar — alongside
-   the terminal-side review. Suppressed for the session if the
-   maintainer passed `no-browser`.
+   Run it in the background (no blocking). On `[N]` (or any
+   non-`y` reply, including bare Enter), do nothing.
 
-2. **Continue to Step 2** in parallel — the diff fetch happens
-   concurrently with the browser launch.
+   `gh pr view --web` is **not** used here — it always opens
+   the conversation tab; the files tab needs the explicit URL
+   above.
+
+2. **Continue to Step 2** — the diff fetch starts immediately
+   regardless of the browser answer.
 
 The headline plus the `[Y]` confirmation is a cheap gate that
 prevents silently spending tokens on a PR the maintainer


### PR DESCRIPTION
Update the maintainer-review skill so it no longer auto-opens the
PR's conversation tab in the browser when the maintainer enters a
PR. Instead, it prompts (`Open files view in browser? [y/N]`,
default no) and on confirmation opens the **files** tab —
`https://github.com/<owner>/<repo>/pull/<N>/files` — which is the
tab that pairs naturally with the terminal-side line-comment
workflow.

The headline already shows file count and additions/deletions, so
the maintainer has the size of the change in hand when answering
the prompt — no extra render needed.

Side effects:

- The `no-browser` selector is dropped from the docs (it
  suppressed an action that no longer happens by default).
- The prerequisites availability check switches from
  `gh pr view --web` to `xdg-open` / `open` / `start`, since
  `gh pr view --web` always opens the conversation tab and the
  files tab needs the explicit URL.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)