### PR TITLE
fix(elasticsearch): allow pinning compatible-with on the ES client to keep ES 8 servers working

### DIFF
--- a/providers/elasticsearch/docs/changelog.rst
+++ b/providers/elasticsearch/docs/changelog.rst
@@ -35,6 +35,17 @@ a dictionary key in the task-log output when log-hits did not carry a
 ``host`` field. The Elasticsearch client is still connected using the
 full URL, so authentication is unaffected.
 
+A new ``[elasticsearch] es_compat_with`` config option lets operators pin
+the ``compatible-with`` HTTP content-negotiation level used by the
+Elasticsearch client. Since 6.5.1 the provider depends on
+``elasticsearch>=8.10,<10``, and an installed ``elasticsearch>=9`` client
+unconditionally negotiates ``compatible-with=9``, which Elasticsearch 8.x
+servers reject with HTTP 400 ``media_type_header_exception`` (regression
+introduced by #64070). Setting ``es_compat_with = "8"`` forces the client
+to negotiate ``compatible-with=8`` on every request so a single Airflow
+image stays compatible with both ``elasticsearch<9`` and
+``elasticsearch>=9`` servers. When unset, behavior is unchanged.
+
 6.5.3
 .....
 

--- a/providers/elasticsearch/docs/logging/index.rst
+++ b/providers/elasticsearch/docs/logging/index.rst
@@ -93,6 +93,27 @@ Additionally, in the ``elasticsearch_configs`` section, you can pass any paramet
     api_key = "SOMEAPIKEY"
     verify_certs = True
 
+Pinning the ``compatible-with`` content-negotiation level
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+Since provider 6.5.1, the Elasticsearch dependency is ``elasticsearch>=8.10,<10``,
+which means an installed ``elasticsearch>=9`` Python client (the default in fresh
+installs) negotiates ``compatible-with=9`` on every request. Elasticsearch 8.x
+servers reject this with HTTP 400 ``media_type_header_exception``.
+
+If you need to keep a single Airflow image compatible with an
+``elasticsearch<9`` server, set ``[elasticsearch] es_compat_with`` to the server
+major version. The provider then forces every request to use
+``Accept`` / ``Content-Type: application/vnd.elasticsearch+json; compatible-with=<major>``:
+
+.. code-block:: ini
+
+    [elasticsearch]
+    es_compat_with = 8
+
+When the option is unset the client behaves as before (negotiating its own
+major version).
+
 .. _elasticsearch-document-schema:
 
 Expected Elasticsearch document schema

--- a/providers/elasticsearch/provider.yaml
+++ b/providers/elasticsearch/provider.yaml
@@ -221,6 +221,20 @@ config:
         type: string
         example: ~
         default: "1000"
+      es_compat_with:
+        description: |
+          Pin the ``compatible-with`` HTTP content-negotiation level used by the
+          Elasticsearch client. Accepts a server major version string (e.g. ``"7"``,
+          ``"8"``, ``"9"``). When unset, the client negotiates its own major version,
+          which fails with HTTP 400 ``media_type_header_exception`` whenever the
+          client major does not match the server major (for example, an
+          ``elasticsearch>=9`` client talking to an Elasticsearch 8.x server).
+          Set this to the server major to keep a single Airflow image compatible
+          with both ``elasticsearch<9`` and ``elasticsearch>=9`` servers.
+        version_added: 6.5.2
+        type: string
+        example: "8"
+        default: ""
   elasticsearch_configs:
     description: ~
     options:

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -151,6 +151,27 @@ def get_es_kwargs_from_config() -> dict[str, Any]:
     return kwargs_dict
 
 
+def _apply_compat_with(client: elasticsearch.Elasticsearch) -> elasticsearch.Elasticsearch:
+    """Pin the ``compatible-with`` content negotiation header on ``client``.
+
+    When the installed ``elasticsearch`` Python client major does not match the
+    Elasticsearch server major, the server rejects every request with HTTP 400
+    ``media_type_header_exception`` (e.g. an ``elasticsearch>=9`` client talking
+    to an Elasticsearch 8.x server). The ``[elasticsearch] es_compat_with``
+    config accepts a major version string (``"7"``, ``"8"``, ``"9"``) and forces
+    the client to negotiate that compatibility level on every request, so a
+    single Airflow image can target either server major.
+
+    When the option is unset the client is returned unchanged and behaves as
+    today (negotiating the client's own major version).
+    """
+    compat = conf.get("elasticsearch", "es_compat_with", fallback=None)
+    if not compat:
+        return client
+    media = f"application/vnd.elasticsearch+json; compatible-with={compat}"
+    return client.options(headers={"accept": media, "content-type": media})
+
+
 def getattr_nested(obj, item, default):
     """
     Get item from obj but return default if not found.
@@ -269,7 +290,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         )
         self.closed = False
 
-        self.client = elasticsearch.Elasticsearch(self.host, **es_kwargs)
+        self.client = _apply_compat_with(elasticsearch.Elasticsearch(self.host, **es_kwargs))
         # in airflow.cfg, host of elasticsearch has to be http://dockerhostXxxx:9200
 
         self.frontend = frontend
@@ -653,7 +674,7 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
     def __attrs_post_init__(self):
         es_kwargs = get_es_kwargs_from_config()
-        self.client = elasticsearch.Elasticsearch(self.host, **es_kwargs)
+        self.client = _apply_compat_with(elasticsearch.Elasticsearch(self.host, **es_kwargs))
         self.index_patterns_callable = conf.get("elasticsearch", "index_patterns_callable", fallback="")
         self.PAGE = 0
         self.MAX_LINE_PER_PAGE = conf.getint("elasticsearch", "max_lines_per_page", fallback=1000)

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -248,6 +248,39 @@ class TestElasticsearchTaskHandler:
         assert isinstance(self.es_task_handler.client, elasticsearch.Elasticsearch)
         assert self.es_task_handler.index_patterns == "_all"
 
+    def test_client_compat_with_unset_returns_client_unchanged(self):
+        """When ``[elasticsearch] es_compat_with`` is not set, no compat headers are pinned."""
+        with conf_vars({("elasticsearch", "es_compat_with"): ""}):
+            handler = ElasticsearchTaskHandler(
+                base_log_folder=self.local_log_location,
+                end_of_log_mark=self.end_of_log_mark,
+                write_stdout=self.write_stdout,
+                json_format=self.json_format,
+                json_fields=self.json_fields,
+                host_field=self.host_field,
+                offset_field=self.offset_field,
+            )
+        # Without the override, the client lets elasticsearch-py negotiate per-API compat
+        # automatically (no caller-pinned ``accept``/``content-type`` headers).
+        assert "accept" not in handler.client._headers
+        assert "content-type" not in handler.client._headers
+
+    def test_client_compat_with_pins_headers(self):
+        """When ``es_compat_with`` is set, the client negotiates that compat level."""
+        with conf_vars({("elasticsearch", "es_compat_with"): "8"}):
+            handler = ElasticsearchTaskHandler(
+                base_log_folder=self.local_log_location,
+                end_of_log_mark=self.end_of_log_mark,
+                write_stdout=self.write_stdout,
+                json_format=self.json_format,
+                json_fields=self.json_fields,
+                host_field=self.host_field,
+                offset_field=self.offset_field,
+            )
+        expected = "application/vnd.elasticsearch+json; compatible-with=8"
+        assert handler.client._headers.get("accept") == expected
+        assert handler.client._headers.get("content-type") == expected
+
     def test_client_with_config(self):
         es_conf = dict(conf.getsection("elasticsearch_configs"))
         expected_dict = {


### PR DESCRIPTION
<!--
Thanks for contributing! Please follow these steps to make sure your PR
gets reviewed in a timely manner.

  Read https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.md
-->

closes: #66063
related: #64070

## What does this PR do

Adds a new `[elasticsearch] es_compat_with` config option that pins the
HTTP `Accept` / `Content-Type` `compatible-with` parameter used by the
Elasticsearch client created by the provider's logging components.

When set to a major version string (`"7"`, `"8"`, `"9"`), every request
the client makes negotiates that compatibility level via
`client.options(headers=...)`. When unset (default), the behavior is
unchanged — the elasticsearch-py client negotiates its own major
version, as today.

## Why

Since #64070 the provider declares `elasticsearch>=8.10,<10`, and a
fresh install resolves to the latest `elasticsearch>=9` Python client.
That client unconditionally negotiates
`Accept: application/vnd.elasticsearch+json; compatible-with=9` on every
request. Elasticsearch **8.x** servers reject this with HTTP 400
`media_type_header_exception` (`Accept version must be either version 8
or 7, but found 9`), which breaks the entire remote task log ingestion
path:

```
PUT http://<es-host>/_bulk [status:400]
Unable to insert logs into Elasticsearch.
Reason: BadRequestError(400, 'media_type_header_exception',
        'Invalid media-type value on headers [Content-Type, Accept]',
        Accept version must be either version 8 or 7, but found 9.
        Accept=application/vnd.elasticsearch+json; compatible-with=9)
```

This affects every operator who has an `elasticsearch<9` server and
upgrades to the Airflow image that bundles provider 6.5.1+ (notably
`apache/airflow:3.2.1`). There is no operator-side workaround today
because elasticsearch-py 9 attaches the compat header per API call and
the existing `elasticsearch_configs` section cannot override it.

`client.options(headers={...})` is the supported elasticsearch-py
mechanism for the override and merges into the per-request headers, so
this change does not require any client patching.

## What this PR is **not**

- It does **not** auto-detect the server major version. `client.info()`
  uses the same compat headers and would itself fail against a
  mismatched server, so a useful auto-detect needs a separate raw HTTP
  probe (or to be wired into the elasticsearch-py client itself). That
  can land as a follow-up; this PR aims to give operators a working
  escape hatch first.
- It does **not** change the dependency range or revert #64070. ES 9
  support is preserved.

## How was this tested?

Two new unit tests in
`providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py`:

- `test_client_compat_with_unset_returns_client_unchanged`: with the
  option unset, the resulting client carries no caller-pinned
  `accept`/`content-type` headers (existing default behavior).
- `test_client_compat_with_pins_headers`: with `es_compat_with = 8`,
  both `accept` and `content-type` on the resulting client are
  `application/vnd.elasticsearch+json; compatible-with=8`.

Manually verified the elasticsearch-py 9.3.0 behavior locally — the
default client `_headers` is empty, and `client.options(headers={...})`
returns a new client whose `_headers` carries exactly the override.

## Reproduction (without the fix)

1. Run Airflow 3.2.1 (provider 6.5.1+) with `ElasticsearchTaskHandler`
   pointed at any Elasticsearch 8.x server, with `write_to_es=True`.
2. Trigger any task. Worker logs the 400 above on every `_bulk`.

After the fix, set `[elasticsearch] es_compat_with = "8"` and the same
deployment writes logs successfully.

---

^ Add meaningful description above
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.md) for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
