### PR TITLE
Add tests for ti:self JWT scope enforcement on execution API

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
@@ -158,6 +158,66 @@ class TestTokenTypeScopeEnforcement:
         assert run.status_code == 200
 
 
+class TestTiSelfScopeEnforcement:
+    """End-to-end: routes with the ``ti:self`` Security scope reject mismatched JWT subjects."""
+
+    PATH_TI_ID = "00000000-0000-0000-0000-000000000001"
+    OTHER_TI_ID = "00000000-0000-0000-0000-000000000002"
+
+    @pytest.fixture
+    def app(self):
+        """One router enforces ti:self, another doesn't — to confirm enforcement is opt-in."""
+        app = FastAPI()
+
+        authenticated_router = APIRouter(dependencies=[Security(require_auth)])
+        ti_self_router = APIRouter(dependencies=[Security(require_auth, scopes=["ti:self"])])
+
+        @ti_self_router.get("/{task_instance_id}/state")
+        def state_endpoint(task_instance_id: str):
+            return {"ok": True}
+
+        @authenticated_router.get("/no-scope/{task_instance_id}")
+        def no_scope_endpoint(task_instance_id: str):
+            return {"ok": True}
+
+        authenticated_router.include_router(ti_self_router, prefix="/ti")
+        app.include_router(authenticated_router)
+        return app
+
+    def _override_jwt(self, app, token_ti_id: str):
+        async def mock_jwt(request: Request):
+            return TIToken(id=UUID(token_ti_id), claims=TIClaims(scope="execution"))
+
+        app.dependency_overrides[_jwt_bearer] = mock_jwt
+
+    def test_matching_subject_is_accepted(self, app):
+        self._override_jwt(app, self.PATH_TI_ID)
+        client = TestClient(app)
+
+        resp = client.get(f"/ti/{self.PATH_TI_ID}/state", headers={"Authorization": "Bearer fake"})
+
+        assert resp.status_code == 200
+
+    def test_mismatched_subject_is_rejected(self, app):
+        """A task cannot read or write another task's resources — the cross-TI isolation guarantee."""
+        self._override_jwt(app, self.OTHER_TI_ID)
+        client = TestClient(app)
+
+        resp = client.get(f"/ti/{self.PATH_TI_ID}/state", headers={"Authorization": "Bearer fake"})
+
+        assert resp.status_code == 403
+        assert "does not match" in resp.json()["detail"]
+
+    def test_no_enforcement_without_ti_self_scope(self, app):
+        """Routes without ``ti:self`` don't compare the JWT subject to the path."""
+        self._override_jwt(app, self.OTHER_TI_ID)
+        client = TestClient(app)
+
+        resp = client.get(f"/no-scope/{self.PATH_TI_ID}", headers={"Authorization": "Bearer fake"})
+
+        assert resp.status_code == 200
+
+
 class TestGetTeamNameDep:
     """Tests for get_team_name_dep avoiding unnecessary async sessions."""
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
@@ -159,7 +159,7 @@ class TestTokenTypeScopeEnforcement:
 
 
 class TestTiSelfScopeEnforcement:
-    """End-to-end: routes with the ``ti:self`` Security scope reject mismatched JWT subjects."""
+    """Routes with the ``ti:self`` scope reject mismatched JWT subjects."""
 
     PATH_TI_ID = "00000000-0000-0000-0000-000000000001"
     OTHER_TI_ID = "00000000-0000-0000-0000-000000000002"
@@ -184,9 +184,9 @@ class TestTiSelfScopeEnforcement:
         app.include_router(authenticated_router)
         return app
 
-    def _override_jwt(self, app, token_ti_id: str):
+    def _override_jwt(self, app: FastAPI, token_ti_id: UUID):
         async def mock_jwt(request: Request):
-            return TIToken(id=UUID(token_ti_id), claims=TIClaims(scope="execution"))
+            return TIToken(id=token_ti_id, claims=TIClaims(scope="execution"))
 
         app.dependency_overrides[_jwt_bearer] = mock_jwt
 
@@ -194,28 +194,25 @@ class TestTiSelfScopeEnforcement:
         self._override_jwt(app, self.PATH_TI_ID)
         client = TestClient(app)
 
-        resp = client.get(f"/ti/{self.PATH_TI_ID}/state", headers={"Authorization": "Bearer fake"})
+        resp = client.get(
+            f"/ti/{self.PATH_TI_ID}/state",
+            headers={"Authorization": "Bearer fake"},
+        )
 
         assert resp.status_code == 200
 
     def test_mismatched_subject_is_rejected(self, app):
-        """A task cannot read or write another task's resources — the cross-TI isolation guarantee."""
+        """A task cannot read or write another task's resources."""
         self._override_jwt(app, self.OTHER_TI_ID)
         client = TestClient(app)
 
-        resp = client.get(f"/ti/{self.PATH_TI_ID}/state", headers={"Authorization": "Bearer fake"})
+        resp = client.get(
+            f"/ti/{self.PATH_TI_ID}/state",
+            headers={"Authorization": "Bearer fake"},
+        )
 
         assert resp.status_code == 403
         assert "does not match" in resp.json()["detail"]
-
-    def test_no_enforcement_without_ti_self_scope(self, app):
-        """Routes without ``ti:self`` don't compare the JWT subject to the path."""
-        self._override_jwt(app, self.OTHER_TI_ID)
-        client = TestClient(app)
-
-        resp = client.get(f"/no-scope/{self.PATH_TI_ID}", headers={"Authorization": "Bearer fake"})
-
-        assert resp.status_code == 200
 
 
 class TestGetTeamNameDep:


### PR DESCRIPTION
The ti:self scope check at security.py rejects requests where the JWT subject does not match the task_instance_id in the path. This is the cross-task isolation guarantee for any router that opts into ti:self (e.g. /task-instances, /hitl, and the upcoming task state endpoints from AIP-103). Until now the check was uncovered.

Adds three tests mirroring the existing TestTokenTypeScopeEnforcement pattern: matching subject is accepted, mismatched subject returns 403, and routes without ti:self ignore subject mismatches.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

execution API uses the `ti:self` scope to enforce that a task can only access its own resources — JWT subject must equal the `task_instance_id` in the request path. The check lives at http://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/execution_api/security.py#L185-L193 and is what stops a task from reading or writing another task's state, HITL responses, etc.

I noticed that`test_security.py` only tested token-type enforcement (workload vs execution); the cross-TI check was relying on no one breaking it.

While working on AIP-103 (task / asset state endpoints), I needed this guarantee to be defended before claiming that "a task can only access its own state" is true. Filing this separately so the coverage benefits every router using `ti:self`, not just the state endpoints.

## Summary

Adding tests for three cases:

- Matching JWT subject is accepted (200)
- Mismatched JWT subject is rejected (403, "does not match")

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
