### PR TITLE
Fix AirflowSDKConfigParser missing mask_secrets method

### DIFF
--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -161,6 +161,35 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         if default_config is not None:
             self._update_defaults_from_string(default_config)
 
+    def mask_secrets(self) -> None:
+        """Mask sensitive config values in the secrets masker."""
+        from airflow.sdk._shared.configuration.exceptions import AirflowConfigException
+        from airflow.sdk._shared.configuration.parser import _build_kwarg_env_prefix, _collect_kwarg_env_vars
+        from airflow.sdk._shared.secrets_masker import mask_secret
+
+        for section, key in self.sensitive_config_values:
+            try:
+                with self.suppress_future_warnings():
+                    value = self.get(section, key, suppress_warnings=True)
+            except AirflowConfigException:
+                log.debug(
+                    "Could not retrieve value from section %s, for key %s. Skipping redaction of this conf.",
+                    section,
+                    key,
+                )
+                continue
+            mask_secret(value)
+
+        # Mask per-key backend kwarg env vars (AIRFLOW__SECRETS__BACKEND_KWARG__* etc.).
+        # These are not in sensitive_config_values but may contain sensitive values.
+        for _section, _kwargs_key in [
+            ("secrets", "backend_kwargs"),
+            ("workers", "secrets_backend_kwargs"),
+        ]:
+            _prefix = _build_kwarg_env_prefix(_section, _kwargs_key)
+            for _value in _collect_kwarg_env_vars(_prefix).values():
+                mask_secret(_value)
+
     def _get_custom_secret_backend(self, worker_mode: bool | None = None) -> Any | None:
         return super()._get_custom_secret_backend(
             worker_mode=worker_mode if worker_mode is not None else True

--- a/task-sdk/src/airflow/sdk/configuration.py
+++ b/task-sdk/src/airflow/sdk/configuration.py
@@ -167,6 +167,14 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
         from airflow.sdk._shared.configuration.parser import _build_kwarg_env_prefix, _collect_kwarg_env_vars
         from airflow.sdk._shared.secrets_masker import mask_secret
 
+        core_mask_secret: Any | None = None
+        try:
+            import importlib
+
+            core_mask_secret = importlib.import_module("airflow._shared.secrets_masker").mask_secret
+        except ImportError:
+            pass
+
         for section, key in self.sensitive_config_values:
             try:
                 with self.suppress_future_warnings():
@@ -179,6 +187,8 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
                 )
                 continue
             mask_secret(value)
+            if core_mask_secret:
+                core_mask_secret(value)
 
         # Mask per-key backend kwarg env vars (AIRFLOW__SECRETS__BACKEND_KWARG__* etc.).
         # These are not in sensitive_config_values but may contain sensitive values.
@@ -189,6 +199,8 @@ class AirflowSDKConfigParser(_SharedAirflowConfigParser):
             _prefix = _build_kwarg_env_prefix(_section, _kwargs_key)
             for _value in _collect_kwarg_env_vars(_prefix).values():
                 mask_secret(_value)
+                if core_mask_secret:
+                    core_mask_secret(_value)
 
     def _get_custom_secret_backend(self, worker_mode: bool | None = None) -> Any | None:
         return super()._get_custom_secret_backend(

--- a/task-sdk/tests/task_sdk/test_configuration.py
+++ b/task-sdk/tests/task_sdk/test_configuration.py
@@ -199,10 +199,15 @@ class TestAirflowSDKConfigParser:
             parser.add_section("test_section")
         parser.set("test_section", "secret_key", "super_secret_value")
 
-        with mock.patch.dict(
-            "os.environ", {"AIRFLOW__SECRETS__BACKEND_KWARG__SOME_KEY": "secret_kwarg_value"}
+        with (
+            mock.patch.dict(
+                "os.environ", {"AIRFLOW__SECRETS__BACKEND_KWARG__SOME_KEY": "secret_kwarg_value"}
+            ),
+            mock.patch("airflow._shared.secrets_masker.mask_secret") as mock_core_mask_secret,
         ):
             parser.mask_secrets()
 
         mock_mask_secret.assert_any_call("super_secret_value")
         mock_mask_secret.assert_any_call("secret_kwarg_value")
+        mock_core_mask_secret.assert_any_call("super_secret_value")
+        mock_core_mask_secret.assert_any_call("secret_kwarg_value")

--- a/task-sdk/tests/task_sdk/test_configuration.py
+++ b/task-sdk/tests/task_sdk/test_configuration.py
@@ -184,3 +184,25 @@ class TestGetAirflowConfig:
         env = {"AIRFLOW_HOME": "$CUSTOM_DIR/airflow", "CUSTOM_DIR": "/resolved"}
         with mock.patch.dict("os.environ", env, clear=True):
             assert get_airflow_config() == "/resolved/airflow/airflow.cfg"
+
+
+class TestAirflowSDKConfigParser:
+    @mock.patch("airflow.sdk._shared.secrets_masker.mask_secret")
+    def test_mask_secrets(self, mock_mask_secret):
+        from airflow.sdk.configuration import AirflowSDKConfigParser
+
+        parser = AirflowSDKConfigParser()
+
+        # Set a sensitive value
+        parser.sensitive_config_values.add(("test_section", "secret_key"))
+        if not parser.has_section("test_section"):
+            parser.add_section("test_section")
+        parser.set("test_section", "secret_key", "super_secret_value")
+
+        with mock.patch.dict(
+            "os.environ", {"AIRFLOW__SECRETS__BACKEND_KWARG__SOME_KEY": "secret_kwarg_value"}
+        ):
+            parser.mask_secrets()
+
+        mock_mask_secret.assert_any_call("super_secret_value")
+        mock_mask_secret.assert_any_call("secret_kwarg_value")


### PR DESCRIPTION
AirflowSDKConfigParser was missing the mask_secrets() method which caused an AttributeError on startup whenever settings.initialize() called conf.mask_secrets() (e.g. running airflow db migrate).

The method existed only on the core AirflowConfigParser and was never added to the SDK subclass. Added mask_secrets() to AirflowSDKConfigParser using SDK-native imports, matching the same logic as the core implementation.

closes: #66074

Was generative AI tooling used to co-author this PR?
 Yes — Claude (For Pr description)