### PR TITLE
i18n(Ko): translate no matches message

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -66,6 +66,9 @@
     },
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
+    "search": {
+      "noMatches": "일치하는 결과 없음"
+    },
     "settings": "로그 설정",
     "viewInExternal": "{{name}}에서 로그 보기 (시도 {{attempt}})",
     "warning": "경고"


### PR DESCRIPTION
## What

Translate the Korean message for the log search empty state.

Updated:
- `dag.json`
  - `logs.search.noMatches`

## Why

This updates the assigned Korean translation entry.

## Testing

- [x] Checked the updated translation entry
- [x] pnpm lint

## Screenshots

<img width="1148" height="246" alt="image" src="https://github.com/user-attachments/assets/40fb342b-165c-4864-8688-b1be6d14f742" />

Please review this translation.
/cc @kgw7401 @onestn