### PR TITLE
i18n(Ko): add missing translation in components.json (Apr 29)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -13,6 +13,7 @@
     "permissionDenied": "드라이 런 실패 : 백필 생성 권한이 없습니다. ",
     "reprocessBehavior": "재처리 동작",
     "run": "백필 실행",
+    "scheduleNotBackfillable": "이 Dag의 스케줄은 백필을 지원하지 않습니다.",
     "selectDescription": "이 Dag을(를) 특정 날짜 범위에 대해 실행합니다.",
     "selectLabel": "백필",
     "title": "백필 실행",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -10,7 +10,7 @@
     "maxRuns": "최대 활성 실행 수",
     "missingAndErroredRuns": "누락되었거나 오류가 발생한 실행",
     "missingRuns": "누락된 실행",
-    "permissionDenied": "드라이 런 실패 : 백필 생성 권한이 없습니다. ",
+    "permissionDenied": "드라이 런 실패 : 백필 생성 권한이 없습니다.",
     "reprocessBehavior": "재처리 동작",
     "run": "백필 실행",
     "scheduleNotBackfillable": "이 Dag의 스케줄은 백필을 지원하지 않습니다.",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## What
Translate the Korean tooltip when automatic backfills are not supported.

## Updated:

components.json

## Why
This updates the assigned Korean translation entry.

------

## ScreenShot

<img width="843" height="442" alt="Screenshot 2026-04-29 at 9 03 17 PM" src="https://github.com/user-attachments/assets/33d8ac7a-bb24-47c5-83c1-892e4cd2fe3b" />

## Before

<img width="1429" height="768" alt="Screenshot 2026-04-29 at 8 58 07 PM" src="https://github.com/user-attachments/assets/abae2ac6-6fb3-4381-b8ad-4ab922f625ec" />

## After

<img width="1424" height="765" alt="Screenshot 2026-04-29 at 8 58 23 PM" src="https://github.com/user-attachments/assets/72804f2f-68e7-4d26-ab54-f3686eca9a4d" />

Please review this translation.
/cc @kgw7401 @onestn

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
