### PR TITLE
UI: Align Dag capitalization in e2e tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/RequiredActionsPage.ts
@@ -233,7 +233,7 @@ export class RequiredActionsPage extends BasePage {
     const dagRunId = await dagsPage.triggerDag(dagId);
 
     if (dagRunId === null) {
-      throw new Error("Failed to trigger DAG - dagRunId is null");
+      throw new Error("Failed to trigger Dag - dagRunId is null");
     }
 
     await this.waitForDagRunState(dagId, dagRunId, "Running");
@@ -328,7 +328,7 @@ export class RequiredActionsPage extends BasePage {
         },
         {
           intervals: [5000],
-          message: `DAG run ${runId} did not reach state "${expectedState}"`,
+          message: `Dag run ${runId} did not reach state "${expectedState}"`,
           timeout: 120_000,
         },
       )


### PR DESCRIPTION
Align e2e test error messages with Dag capitalization used in UI translations 
                                                                                                                                                         
  ---
                                                                                                                                                         
  ##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code (Opus 4.6)                                                                                                                     
  
  Generated-by: Claude Code (Opus 4.6) following [the                                                                                                    
  guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
