### PR TITLE
i18n(ko): add missing translations in components.json (Apr 29)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -90,7 +90,8 @@
     "otherDagRuns": "+다른 Dag 실행",
     "taskCount_one": "{{count}}개 작업",
     "taskCount_other": "{{count}}개 작업",
-    "taskGroup": "작업 그룹"
+    "taskGroup": "작업 그룹",
+    "zoomToTask": "선택된 작업으로 확대"
   },
   "limitedList": "+{{count}}개 더 보기",
   "limitedList.allItems": "모든 {{count}}개 항목:",


### PR DESCRIPTION
# What
Translate the Korean message for the log search empty state.

Updated:

- components.json

# Why

This updates the assigned Korean translation entry.

# Testing

- [x] Checked the updated translation entry
- [x] pnpm lint

# Screenshots
<img width="1166" height="561" alt="image" src="https://github.com/user-attachments/assets/9228d084-f9fd-4d62-ac7c-496ccec57bb4" />

before
<img width="552" height="413" alt="image" src="https://github.com/user-attachments/assets/b47a8e6c-071e-466e-8e40-c4662edb3f6e" />

after
<img width="576" height="476" alt="image" src="https://github.com/user-attachments/assets/a190922e-84de-49d0-82b7-2b8ee865c013" />

Please review this translation.
/cc @kgw7401 @onestn
