### PR TITLE
i18n(Ko): add missing translation in dag.json (Apr 29)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -71,6 +71,7 @@
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
     "search": {
+      "matchCount": "{{current}} 중 {{total}}",
       "noMatches": "일치하는 결과 없음",
       "placeholder": "로그 검색"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -71,7 +71,7 @@
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
     "search": {
-      "matchCount": "{{current}} 중 {{total}}",
+      "matchCount": "{{total}}개 중 {{current}}개",
       "noMatches": "일치하는 결과 없음",
       "placeholder": "로그 검색"
     },


### PR DESCRIPTION

## What
Translate the Korean message for the log search empty state.

## Updated:

components.json
dag.json

## Why
This updates the assigned Korean translation entry.

------

## ScreenShot

<img width="805" height="579" alt="image" src="https://github.com/user-attachments/assets/594170fb-f3e8-4e04-8846-65f1033d4e51" />
