### PR TITLE
fix(ui): keep log controls visible during scrolling

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.tsx
@@ -213,7 +213,7 @@ export const Logs = () => {
   };
 
   return (
-    <Box display="flex" flexDirection="column" h="100%" p={2}>
+    <Box display="flex" flexDirection="column" h="100%" minH={0} p={4}>
       <TaskLogHeader {...logHeaderProps} />
       {showExternalLogRedirect && externalLogName && taskInstance ? (
         tryNumber === undefined ? (

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogContent.tsx
@@ -152,13 +152,13 @@ export const TaskLogContent = ({
   useHotkeys("mod+ArrowUp", () => handleScrollTo("top"), { enabled: !isLoading });
 
   return (
-    <Box display="flex" flexDirection="column" flexGrow={1} h="100%" minHeight={0} position="relative">
+    <Box display="flex" flex="1" flexDirection="column" minH={0} position="relative">
       <ErrorAlert error={error ?? logError} />
       <ProgressBar size="xs" visibility={isLoading ? "visible" : "hidden"} />
       <Box
         data-testid="virtual-scroll-container"
-        flexGrow={1}
-        minHeight={0}
+        flex="1"
+        minH={0}
         overflow="auto"
         position="relative"
         py={3}


### PR DESCRIPTION
## What

Fix the task log layout so the log header and control buttons remain visible when the log content is longer than the browser window.

Updated:
- `Logs.tsx`
- `TaskLogContent.tsx`

## Why

Previously, long task logs could push the log header and control buttons out of view. This made it difficult to search logs, change log settings, or use log controls while reviewing long logs.

## How

- Set the logs page container to use a constrained flex column layout.
- Allow the log content area to take the remaining height with `minH={0}`.
- Keep scrolling inside the virtual log content container instead of letting the full page content expand.

## Testing

- [x] Verified the log header remains visible with long logs
- [x] Verified the log content scrolls inside the log content area
- [x] `pnpm lint`

## Recording

https://github.com/user-attachments/assets/4ae683cf-afeb-4132-8d2f-841b4d6cd2ff

Fixes #63934