### PR TITLE
Fix Slack notifier howto guide code example for Airflow 3

### DIFF
--- a/providers/slack/docs/notifications/slack_notifier_howto_guide.rst
+++ b/providers/slack/docs/notifications/slack_notifier_howto_guide.rst
@@ -35,7 +35,10 @@ Example Code:
     from airflow.providers.slack.notifications.slack import send_slack_notification
 
     with DAG(
+        dag_id="slack_notifier",
+        schedule=None,
         start_date=datetime(2023, 1, 1),
+        catchup=False,
         on_success_callback=[
             send_slack_notification(
                 text="The Dag {{ dag.dag_id }} succeeded",

--- a/providers/slack/docs/notifications/slack_notifier_howto_guide.rst
+++ b/providers/slack/docs/notifications/slack_notifier_howto_guide.rst
@@ -30,7 +30,7 @@ Example Code:
 .. code-block:: python
 
     from datetime import datetime
-    from airflow import DAG
+    from airflow.sdk import DAG
     from airflow.providers.standard.operators.bash import BashOperator
     from airflow.providers.slack.notifications.slack import send_slack_notification
 


### PR DESCRIPTION
The code snippet in the Slack notifier how-to guide was missing the required `dag_id` positional argument, `schedule`, and `catchup=False` on the `DAG` constructor. Without `dag_id` the example raises a `TypeError` at parse time and won't work in Airflow 3.

Added the three missing parameters to match the pattern used by other up-to-date notifier guides (apprise, slackwebhook, etc.).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)