### PR TITLE
Preserve duplicate IMAP attachment filenames

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -192,6 +192,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -210,6 +211,8 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: If set to False, duplicate attachment filenames are saved with a
+            numeric suffix instead of overwriting an existing file. Defaults to True.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -218,7 +221,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file=overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -286,14 +289,23 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, *, overwrite_file: bool = True
+    ) -> None:
+        used_file_paths: set[str] = set()
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(
+                    name,
+                    payload,
+                    local_output_directory,
+                    overwrite_file=overwrite_file,
+                    used_file_paths=used_file_paths,
+                )
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -310,11 +322,37 @@ class ImapHook(BaseHook):
             else local_output_directory + "/" + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(
+        self,
+        name: str,
+        payload: Any,
+        local_output_directory: str,
+        *,
+        overwrite_file: bool = True,
+        used_file_paths: set[str] | None = None,
+    ) -> None:
         file_path = self._correct_path(name, local_output_directory)
+        if not overwrite_file:
+            if used_file_paths is None:
+                used_file_paths = set()
+            file_path = self._deduplicate_file_path(file_path, used_file_paths)
 
         with open(file_path, "wb") as file:
             file.write(payload)
+
+    def _deduplicate_file_path(self, file_path: str, used_file_paths: set[str]) -> str:
+        if file_path not in used_file_paths and not os.path.exists(file_path):
+            used_file_paths.add(file_path)
+            return file_path
+
+        root, extension = os.path.splitext(file_path)
+        counter = 1
+        while True:
+            candidate = f"{root}_{counter}{extension}"
+            if candidate not in used_file_paths and not os.path.exists(candidate):
+                used_file_paths.add(candidate)
+                return candidate
+            counter += 1
 
 
 class Mail(LoggingMixin):

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -318,6 +318,38 @@ class TestImapHook:
 
     @patch(open_string, new_callable=mock_open)
     @patch(imaplib_string)
+    def test_download_mail_attachments_preserves_duplicate_names(self, mock_imaplib, mock_open_method):
+        _create_fake_imap(mock_imaplib)
+
+        with patch("airflow.providers.imap.hooks.imap.os.path.exists", return_value=False):
+            with ImapHook() as imap_hook:
+                imap_hook._create_files(
+                    [("report.csv", b"first"), ("report.csv", b"second")],
+                    "test_directory",
+                    overwrite_file=False,
+                )
+
+        assert mock_open_method.call_args_list[0].args == ("test_directory/report.csv", "wb")
+        assert mock_open_method.call_args_list[1].args == ("test_directory/report_1.csv", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_preserves_existing_files(self, mock_imaplib, mock_open_method):
+        _create_fake_imap(mock_imaplib)
+
+        def exists(path):
+            return path in {"test_directory/report.csv", "test_directory/report_1.csv"}
+
+        with patch("airflow.providers.imap.hooks.imap.os.path.exists", side_effect=exists):
+            with ImapHook() as imap_hook:
+                imap_hook._create_files(
+                    [("report.csv", b"content")], "test_directory", overwrite_file=False
+                )
+
+        mock_open_method.assert_called_once_with("test_directory/report_2.csv", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
     def test_download_mail_attachments_not_found(self, mock_imaplib, mock_open_method):
         _create_fake_imap(mock_imaplib, with_mail=True)
 


### PR DESCRIPTION
Adds an `overwrite_file` option to `ImapHook.download_mail_attachments()` so duplicate attachment filenames can be preserved instead of silently overwriting earlier files. The default remains `True`, so existing behavior is unchanged unless callers opt in to suffix-based deduplication.

Closes: #65870
Related: #62321

Tests/validation:
- `git diff --check`
- `python3 -m py_compile providers/imap/src/airflow/providers/imap/hooks/imap.py providers/imap/tests/unit/imap/hooks/test_imap.py`
- Attempted `PYTHONPATH=devel-common/src:providers/imap/src:. python3 -m pytest providers/imap/tests/unit/imap/hooks/test_imap.py -q`, but the local environment is missing the Airflow test dependency `time_machine`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [OpenAI Codex GPT-5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=c00d3a1 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @arjunrawal1** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->