### PR TITLE
Rationalize null and max-lines eslint rules

### DIFF
--- a/airflow-core/src/airflow/ui/rules/core.js
+++ b/airflow-core/src/airflow/ui/rules/core.js
@@ -279,7 +279,7 @@ export const coreRules = /** @type {const} @satisfies {FlatConfig.Config} */ ({
      *
      * @see [max-lines](https://eslint.org/docs/latest/rules/max-lines)
      */
-    "max-lines": [ERROR, { max: 250, skipBlankLines: true, skipComments: true }],
+    "max-lines": [ERROR, { max: 500, skipBlankLines: true, skipComments: true }],
 
     /**
      * Enforce a maximum depth that callbacks can be nested to 3.

--- a/airflow-core/src/airflow/ui/rules/rem.js
+++ b/airflow-core/src/airflow/ui/rules/rem.js
@@ -104,7 +104,6 @@ export const remPlugin = {
                     return fixer.replaceText(attr.value.expression, fixedValue);
                   }
 
-                  // eslint-disable-next-line unicorn/no-null
                   return null;
                 },
                 messageId: "noRemInProps",

--- a/airflow-core/src/airflow/ui/rules/typescript.js
+++ b/airflow-core/src/airflow/ui/rules/typescript.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -504,7 +502,7 @@ export const typescriptRules = /** @type {const} @satisfies {FlatConfig.Config} 
     [`${typescriptNamespace}/naming-convention`]: [
       ERROR,
       {
-        format: null, // eslint-disable-line unicorn/no-null
+        format: null,
         leadingUnderscore: "allow",
         selector: "default",
         trailingUnderscore: "forbid",

--- a/airflow-core/src/airflow/ui/rules/unicorn.js
+++ b/airflow-core/src/airflow/ui/rules/unicorn.js
@@ -22,7 +22,7 @@
  */
 import unicorn from "eslint-plugin-unicorn";
 
-import { ERROR, WARN } from "./levels.js";
+import { ERROR, OFF, WARN } from "./levels.js";
 
 /**
  * ESLint `unicorn` namespace.
@@ -455,7 +455,7 @@ export const unicornRules = /** @type {const} @satisfies {FlatConfig.Config} */ 
      * @see [Reasoning](https://lou.cx/articles/we-don-t-need-null/)
      * @see [unicorn/no-null](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md)
      */
-    [`${unicornNamespace}/no-null`]: WARN,
+    [`${unicornNamespace}/no-null`]: OFF,
 
     /**
      * Disallow passing single-element arrays to Promise methods.

--- a/airflow-core/src/airflow/ui/src/components/BasicTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/components/BasicTooltip.tsx
@@ -46,7 +46,6 @@ export const BasicTooltip = ({ children, content }: Props): ReactElement => {
   const handleMouseLeave = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
-      // eslint-disable-next-line unicorn/no-null
       timeoutRef.current = null;
     }
     setIsOpen(false);

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines -- form aggregates date range, reprocess behavior, and param controls in a single UX flow */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
@@ -34,7 +34,6 @@ export const FieldAdvancedArray = ({ name, namespace = "default", onUpdate }: Fl
     if (value === "") {
       if (paramsDict[name]) {
         // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-        // eslint-disable-next-line unicorn/no-null
         paramsDict[name].value = null;
       }
       setParamsDict(paramsDict);

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -34,7 +34,6 @@ export const FieldDateTime = ({
   const handleChange = (value: string) => {
     // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
     if (paramsDict[name]) {
-      // eslint-disable-next-line unicorn/no-null
       paramsDict[name].value = value === "" ? null : value;
     }
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.test.tsx
@@ -30,7 +30,6 @@ const mockSetParamsDict = vi.fn();
 vi.mock("src/queries/useParamStore", () => ({
   paramPlaceholder: {
     schema: {},
-    // eslint-disable-next-line unicorn/no-null
     value: null,
   },
   useParamStore: () => ({
@@ -51,11 +50,9 @@ describe("FieldDropdown", () => {
   it("renders dropdown with null value in enum", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: [1, 2, 3, null],
         type: ["number", "null"],
       },
-      // eslint-disable-next-line unicorn/no-null
       value: null,
     };
 
@@ -69,7 +66,6 @@ describe("FieldDropdown", () => {
   it("displays custom label for null value via values_display", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: [1, 2, 3, null],
         type: ["number", "null"],
         values_display: {
@@ -92,7 +88,6 @@ describe("FieldDropdown", () => {
   it("handles string enum with null value", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: ["option1", "option2", null],
         type: ["string", "null"],
       },
@@ -109,11 +104,9 @@ describe("FieldDropdown", () => {
   it("handles enum with only null value", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: [null],
         type: ["null"],
       },
-      // eslint-disable-next-line unicorn/no-null
       value: null,
     };
 
@@ -127,11 +120,9 @@ describe("FieldDropdown", () => {
   it("renders when current value is null", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: ["value1", "value2", "value3", null],
         type: ["string", "null"],
       },
-      // eslint-disable-next-line unicorn/no-null
       value: null,
     };
 
@@ -145,7 +136,6 @@ describe("FieldDropdown", () => {
   it("preserves numeric type when selecting a number enum value (prevents 400 Bad Request)", () => {
     mockParamsDict.test_param = {
       schema: {
-        // eslint-disable-next-line unicorn/no-null
         enum: [1, 2, 3, 4, 5, 6, 7, 8, 9, null],
         type: ["number", "null"],
         values_display: {
@@ -153,7 +143,6 @@ describe("FieldDropdown", () => {
           "6": "Six",
         },
       },
-      // eslint-disable-next-line unicorn/no-null
       value: null,
     };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
@@ -56,8 +56,7 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
       ? (options.find((opt) => opt.value === NULL_STRING_VALUE) ?? null)
       : enumTypes.includes(typeof param.value)
         ? (options.find((opt) => opt.value === String(param.value)) ?? null)
-        : // eslint-disable-next-line unicorn/no-null
-          null;
+        : null;
 
   const handleChange = (
     selected: SingleValue<{
@@ -67,7 +66,6 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
   ) => {
     if (paramsDict[name]) {
       if (!selected || selected.value === NULL_STRING_VALUE) {
-        // eslint-disable-next-line unicorn/no-null
         paramsDict[name].value = null;
       } else {
         // Map the string value back to the original typed enum value (e.g. number, string)

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
@@ -59,7 +59,6 @@ export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: Flex
     setSelectedOptions(updatedOptions);
 
     // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-    // eslint-disable-next-line unicorn/no-null
     const newValueArray = updatedOptions.length ? updatedOptions.map((option) => option.value) : null;
 
     if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
@@ -28,7 +28,6 @@ export const FieldMultilineText = ({ name, namespace = "default", onUpdate }: Fl
   const handleChange = (value: string) => {
     if (paramsDict[name]) {
       // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-      // eslint-disable-next-line unicorn/no-null
       paramsDict[name].value = value === "" ? null : value;
     }
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
@@ -29,7 +29,6 @@ export const FieldNumber = ({ name, namespace = "default", onUpdate }: FlexibleF
       // If input is cleared, set the value to null or undefined
       if (paramsDict[name]) {
         // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-        // eslint-disable-next-line unicorn/no-null
         paramsDict[name].value = null;
       }
     } else {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
@@ -28,7 +28,6 @@ export const FieldObject = ({ name, namespace = "default", onUpdate }: FlexibleF
   const handleChange = (value: string) => {
     try {
       // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-      // eslint-disable-next-line unicorn/no-null
       const parsedValue = value === "" ? null : (JSON.parse(value) as JSON);
 
       if (paramsDict[name]) {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
@@ -30,7 +30,6 @@ export const FieldString = ({ name, namespace = "default", onUpdate }: FlexibleF
   const handleChange = (value: string) => {
     if (paramsDict[name]) {
       // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-      // eslint-disable-next-line unicorn/no-null
       paramsDict[name].value = value === "" ? null : value;
     }
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
@@ -45,7 +45,6 @@ export const FieldStringArray = ({ name, namespace = "default", onUpdate }: Flex
     if (Array.isArray(currentValue) && currentValue.length === 1 && currentValue[0] === "") {
       if (paramsDict[name]) {
         // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
-        // eslint-disable-next-line unicorn/no-null
         paramsDict[name].value = null;
       }
 

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -86,7 +86,6 @@ export const SearchDags = ({
         menuIsOpen
         onChange={onSelect}
         placeholder={translate("search.dags")}
-        // eslint-disable-next-line unicorn/no-null
         value={null} // null is required https://github.com/JedWatson/react-select/issues/3066
       />
     </Field.Root>

--- a/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskInstanceTooltip.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/components/TeamSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TeamSelector.tsx
@@ -62,7 +62,6 @@ export const TeamSelector = <T extends FieldValues = FieldValues>({ control }: P
                 data-testid="team-selector"
                 isClearable
                 isDisabled={isLoading}
-                // eslint-disable-next-line unicorn/no-null
                 onChange={(val) => onChange(val?.value ?? null)}
                 options={options}
                 placeholder={translate("team.selector.placeHolder")}

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { chakra, Code, Link } from "@chakra-ui/react";
 import type { TFunction } from "i18next";
 import type { JSX } from "react";

--- a/airflow-core/src/airflow/ui/src/components/ui/ProgressBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/ProgressBar.tsx
@@ -21,7 +21,6 @@ import { forwardRef } from "react";
 
 export const ProgressBar = forwardRef<HTMLDivElement, ChakraProgress.RootProps>((props, ref) => (
   // default to indeterminate
-  // eslint-disable-next-line unicorn/no-null
   <ChakraProgress.Root value={null} {...props} ref={ref}>
     <ChakraProgress.Track>
       <ChakraProgress.Range />

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { Flex } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { BiTargetLock } from "react-icons/bi";

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.test.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines */
-
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines -- virtualized Gantt body markup is kept in one file for readability */
 import { Badge, Box, Flex, Text } from "@chakra-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import dayjs from "dayjs";
@@ -86,11 +84,9 @@ const toTooltipSummary = (
   }
 
   return {
-    // eslint-disable-next-line unicorn/no-null
     child_states: null,
     max_end_date: dayjs(segment.x[1]).toISOString(),
     min_start_date: dayjs(segment.x[0]).toISOString(),
-    // eslint-disable-next-line unicorn/no-null
     state: segment.state ?? null,
     task_display_name: segment.y,
     task_id: segment.taskId,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines */
-
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines -- Gantt transform, time range, links, and axis ticks share one module */
 import dayjs from "dayjs";
 import type { To } from "react-router-dom";
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/useGraphFilteredNodes.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/useGraphFilteredNodes.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridPagination.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridPagination.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null -- GridRunsResponse uses null for optional API fields */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/TaskStreamFilter.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/dag.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/dag.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable unicorn/no-null */
 import { http, HttpResponse, type HttpHandler } from "msw";
 
 export const MOCK_DAG = {

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/dag_runs.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/dag_runs.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable unicorn/no-null */
 import { http, HttpResponse, type HttpHandler } from "msw";
 
 const dagRunBeforeFilter = {

--- a/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable unicorn/no-null,max-lines */
 import { http, HttpResponse, type HttpHandler } from "msw";
 
 const ti = {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { Box, Button, Heading, HStack, Link, VStack } from "@chakra-ui/react";
 import Editor, { type EditorProps } from "@monaco-editor/react";
 import { useState } from "react";

--- a/airflow-core/src/airflow/ui/src/pages/Dag/DagHeader.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/DagHeader.test.tsx
@@ -56,7 +56,6 @@ describe("Dag Documentation Modal", () => {
   it("Do not display documentation button only doc_md is not present", () => {
     render(
       <Wrapper>
-        {/* eslint-disable-next-line unicorn/no-null */}
         <Header dag={{ ...MOCK_DAG, doc_md: null } as unknown as DAGDetailsResponse} />
       </Wrapper>,
     );

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -39,7 +39,6 @@ const mockDag = {
   is_stale: true,
   last_parse_duration: 0.23,
   // `null` matches the API response shape for DAGs without version metadata.
-  // eslint-disable-next-line unicorn/no-null
   latest_dag_version: null,
   next_dagrun_logical_date: "2024-08-22T00:00:00+00:00",
   next_dagrun_run_after: "2024-08-22T19:00:00+00:00",

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { Flex, HStack, Link, Text } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -65,7 +65,6 @@ export const MetricSection = ({
       <Flex justify="space-between">
         <HStack>
           <RouterLink to={`/${kind}?${searchParams.toString()}`}>
-            {/* eslint-disable-next-line unicorn/no-null */}
             <StateBadge fontSize="md" state={state === "no_status" ? null : state}>
               {}
               {capped ? `${runs}+` : runs}

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null */
-
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -97,7 +97,6 @@ export const Details = () => {
       )}
       <ExtraLinks refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false} />
       {taskInstance === undefined ||
-      // eslint-disable-next-line unicorn/no-null
       ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
         <BlockingDeps
           refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeAll } from "vitest";

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -16,8 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-/* eslint-disable max-lines */
 import { Flex, Link } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";

--- a/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useEditConnection.tsx
@@ -102,7 +102,6 @@ export const useEditConnection = (
         conn_type: requestBody.conn_type,
         connection_id: initialConnection.connection_id,
         extra: requestBody.extra === "{}" ? undefined : requestBody.extra,
-        // eslint-disable-next-line unicorn/no-null
         port: requestBody.port === "" ? null : Number(requestBody.port),
         team_name: teamName,
       },

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -21,7 +21,6 @@ import { create } from "zustand";
 import type { ParamsSpec, ParamSpec } from "src/queries/useDagParams";
 
 export const paramPlaceholder: ParamSpec = {
-  // eslint-disable-next-line unicorn/no-null
   description: null,
   schema: {
     const: undefined,
@@ -80,7 +79,6 @@ const createParamStore = () =>
             updatedParamsDictEntries.push([
               key,
               {
-                // eslint-disable-next-line unicorn/no-null
                 description: baseParam.description ?? null,
                 schema: baseParam.schema,
                 value: parsedConf[key],
@@ -97,7 +95,6 @@ const createParamStore = () =>
             updatedParamsDictEntries.push([
               key,
               {
-                // eslint-disable-next-line unicorn/no-null
                 description: existingParam?.description ?? null,
                 schema: existingParam?.schema ?? paramPlaceholder.schema,
                 value,

--- a/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTrigger.ts
@@ -68,19 +68,16 @@ export const useTrigger = ({ dagId, onSuccessConfirm }: { dagId: string; onSucce
     const parsedConfig = JSON.parse(dagRunRequestBody.conf) as Record<string, unknown>;
 
     const logicalDate = dagRunRequestBody.logicalDate ? new Date(dagRunRequestBody.logicalDate) : undefined;
-    // eslint-disable-next-line unicorn/no-null
     const formattedLogicalDate = logicalDate?.toISOString() ?? null;
 
     const dataIntervalStart = dagRunRequestBody.dataIntervalStart
       ? new Date(dagRunRequestBody.dataIntervalStart)
       : undefined;
-    // eslint-disable-next-line unicorn/no-null
     const formattedDataIntervalStart = dataIntervalStart?.toISOString() ?? null;
 
     const dataIntervalEnd = dagRunRequestBody.dataIntervalEnd
       ? new Date(dagRunRequestBody.dataIntervalEnd)
       : undefined;
-    // eslint-disable-next-line unicorn/no-null
     const formattedDataIntervalEnd = dataIntervalEnd?.toISOString() ?? null;
 
     const checkDagRunId = dagRunRequestBody.dagRunId === "" ? undefined : dagRunRequestBody.dagRunId;

--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -18,8 +18,6 @@
  */
 
 /* eslint-disable perfectionist/sort-objects */
-
-/* eslint-disable max-lines */
 import {
   createSystem,
   defaultConfig,

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -57,10 +57,8 @@ describe("getDuration", () => {
   });
 
   it("handles small, null or undefined values", () => {
-    // eslint-disable-next-line unicorn/no-null
     expect(getDuration(null, null)).toBe(undefined);
     expect(getDuration(undefined, undefined)).toBe(undefined);
-    // eslint-disable-next-line unicorn/no-null
     expect(getDuration(null, "2024-03-14T10:00:10.000Z")).toBe(undefined);
     expect(renderDuration(0.000_01)).toBe(undefined);
   });
@@ -71,7 +69,6 @@ describe("getDuration", () => {
 
     const start = "2024-03-14T10:00:00.000Z";
 
-    // eslint-disable-next-line unicorn/no-null
     expect(getDuration(start, null)).toBe("00:00:10.000");
     expect(getDuration(start, undefined)).toBe("00:00:10.000");
 

--- a/airflow-core/src/airflow/ui/src/utils/logs.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/logs.test.ts
@@ -49,7 +49,6 @@ describe("parseStreamingLogContent", () => {
   });
 
   it("returns empty array for null data", () => {
-    // eslint-disable-next-line unicorn/no-null
     const data = null as unknown as TaskInstancesLogResponse;
 
     expect(parseStreamingLogContent(data)).toEqual([]);

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagsPage.ts
@@ -427,7 +427,6 @@ export class DagsPage extends BasePage {
       // Response parsing failed — return null so caller can handle.
     }
 
-    // eslint-disable-next-line unicorn/no-null
     return null;
   }
 


### PR DESCRIPTION
We were running up against `no-null` errors too often for the check to be useful. Unfortunately our API types didn't let us get rid of null entirely so we kept having to add in ignores.

Also, max-lines was happening a lot too. So its updated to 500

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Claude)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
