### PR TITLE
Fix dags test run start date

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -911,6 +911,18 @@ class TestCliDags:
         assert "data_interval" in mock_get_or_create_dagrun.call_args.kwargs
 
     @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
+    def test_dag_test_uses_current_time_as_start_date(self, mock_get_or_create_dagrun, time_machine):
+        run_start_date = timezone.parse("2026-04-29T21:04:00+00:00")
+        time_machine.move_to(run_start_date, tick=False)
+        cli_args = self.parser.parse_args(["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat()])
+
+        dag_command.dag_test(cli_args)
+
+        kwargs = mock_get_or_create_dagrun.call_args.kwargs
+        assert kwargs["logical_date"] == DEFAULT_DATE
+        assert kwargs["start_date"] == run_start_date
+
+    @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
     def test_dag_with_parsing_context(
         self, mock_get_or_create_dagrun, testing_dag_bundle, configure_testing_dag_bundle
     ):

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1283,7 +1283,8 @@ class DAG:
 
             log.debug("Getting dagrun for dag %s", self.dag_id)
             logical_date = timezone.coerce_datetime(logical_date)
-            run_after = timezone.coerce_datetime(run_after) or timezone.coerce_datetime(timezone.utcnow())
+            run_start_date = timezone.coerce_datetime(timezone.utcnow())
+            run_after = timezone.coerce_datetime(run_after) or run_start_date
             if logical_date is None:
                 data_interval: DataInterval | None = None
             else:
@@ -1331,7 +1332,7 @@ class DAG:
 
             dr: DagRun = get_or_create_dagrun(
                 dag=scheduler_dag,
-                start_date=logical_date or run_after,
+                start_date=run_start_date,
                 logical_date=logical_date,
                 data_interval=data_interval,
                 run_after=run_after,


### PR DESCRIPTION
Fixes #66127.

## What
- Use the actual invocation time as the DagRun start_date for DAG.test()/airflow dags test.
- Keep logical_date and run_after semantics unchanged.
- Add a CLI regression test proving historical logical dates do not become DagRun.start_date.

## Test plan
- uv run --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_dag_test_uses_current_time_as_start_date -q
- uv run --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_dag_test_with_custom_timetable airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_dag_test_uses_current_time_as_start_date -q
- uv run prek run --files airflow-core/tests/unit/cli/commands/test_dag_command.py task-sdk/src/airflow/sdk/definitions/dag.py

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=a8470d1 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anmolxlight** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~43 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->