### PR TITLE
Docs: clarify removal of --subdir argument in Airflow 3 CLI

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -145,7 +145,7 @@ By default, Airflow looks for DAGs in the directory specified by the ``dags_fold
    .. code-block:: bash
 
       airflow dags test <DAG_ID> -f <path_to_dag_file>
-      
+
 Display Dag structure
 ---------------------
 

--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -133,9 +133,19 @@ The following file formats are supported:
  * ``xlib``
  * ``x11``
 
-By default, Airflow looks for Dags in the directory specified by the ``dags_folder`` option in the
-``[core]`` section of the ``airflow.cfg`` file. You can select a new directory with the ``--subdir`` argument.
+By default, Airflow looks for DAGs in the directory specified by the ``dags_folder`` option in the
+``[core]`` section of the ``airflow.cfg`` file.
 
+.. note::
+
+   The ``--subdir`` argument is no longer supported in Airflow 3.x.
+
+   To test a DAG from a specific file, use:
+
+   .. code-block:: bash
+
+      airflow dags test <DAG_ID> -f <path_to_dag_file>
+      
 Display Dag structure
 ---------------------
 

--- a/airflow-core/docs/start.rst
+++ b/airflow-core/docs/start.rst
@@ -124,6 +124,22 @@ before running ``pip install`` commands:
    .. code-block:: bash
 
       airflow standalone
+   
+   .. note::
+
+   In Airflow 3.x, the admin password may not always be displayed in the terminal output when running ``airflow standalone``.
+
+   The password is automatically generated and stored in the file:
+
+   ``~/airflow/simple_auth_manager_passwords.json.generated``
+
+   To retrieve it, run:
+
+   .. code-block:: bash
+
+      cat ~/airflow/simple_auth_manager_passwords.json.generated
+
+   Use this password to log into the web interface instead of default credentials.
 
 5. Access the Airflow UI:
 

--- a/airflow-core/docs/start.rst
+++ b/airflow-core/docs/start.rst
@@ -124,22 +124,6 @@ before running ``pip install`` commands:
    .. code-block:: bash
 
       airflow standalone
-   
-   .. note::
-
-   In Airflow 3.x, the admin password may not always be displayed in the terminal output when running ``airflow standalone``.
-
-   The password is automatically generated and stored in the file:
-
-   ``~/airflow/simple_auth_manager_passwords.json.generated``
-
-   To retrieve it, run:
-
-   .. code-block:: bash
-
-      cat ~/airflow/simple_auth_manager_passwords.json.generated
-
-   Use this password to log into the web interface instead of default credentials.
 
 5. Access the Airflow UI:
 


### PR DESCRIPTION
### What is this change about?

The CLI documentation still mentions the `--subdir` argument to select a DAG directory.

However, in Airflow 3.x, this argument is no longer supported. The CLI now uses
`--dagfile-path` (`-f`) instead.

### What is the problem?

Users following the documentation may try to use `--subdir`, which results in:
airflow command error: unrecognized arguments: --subdir

This creates confusion, especially for new users.

### What is the fix?

- Remove outdated reference to `--subdir`
- Add a note explaining its removal in Airflow 3.x
- Provide the correct usage using `-f`

### Additional context

This was verified using Airflow 3.2.0 CLI help output (`airflow dags test --help`),
which shows `--dagfile-path` but no `--subdir`.

---

This is a documentation-only change.
