### PR TITLE
Guard registry-build sync against partial extracts

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -260,6 +260,52 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: "Verify build emitted expected content"
+        env:
+          PROVIDER: ${{ inputs.provider }}
+        run: |
+          # Guard against silent no-op syncs. `aws s3 sync` exits 0 when the
+          # source dir is missing or empty, so without this a partial build
+          # (e.g. extract_metadata.py errored mid-run) would report green
+          # while uploading nothing or stale state. Mirrors the per-provider
+          # guard in the "Sync backfilled version pages to S3" step in
+          # registry-backfill.yml.
+          if [[ -n "${PROVIDER}" ]]; then
+            # Incremental: verify each target provider's pages and versions JSON exist.
+            for pid in ${PROVIDER}; do
+              LOCAL_PROV_DIR="registry/_site/providers/${pid}/"
+              LOCAL_API_DIR="registry/_site/api/providers/${pid}/"
+              LOCAL_VERSIONS_JSON="${LOCAL_API_DIR}versions.json"
+              if [ ! -d "${LOCAL_PROV_DIR}" ] || [ -z "$(ls -A "${LOCAL_PROV_DIR}" 2>/dev/null)" ]; then
+                echo "::error::Build did not emit ${LOCAL_PROV_DIR} -- aborting sync."
+                exit 1
+              fi
+              if [ ! -d "${LOCAL_API_DIR}" ] || [ -z "$(ls -A "${LOCAL_API_DIR}" 2>/dev/null)" ]; then
+                echo "::error::Build did not emit ${LOCAL_API_DIR} -- aborting sync."
+                exit 1
+              fi
+              if [ ! -s "${LOCAL_VERSIONS_JSON}" ]; then
+                echo "::error::${LOCAL_VERSIONS_JSON} missing or empty -- aborting sync."
+                exit 1
+              fi
+            done
+          else
+            # Full build: verify the top-level homepage and provider listing.
+            if [ ! -s "registry/_site/index.html" ]; then
+              echo "::error::Full build did not emit registry/_site/index.html -- aborting sync."
+              exit 1
+            fi
+            if [ ! -s "registry/_site/api/providers.json" ]; then
+              echo "::error::registry/_site/api/providers.json missing or empty -- aborting sync."
+              exit 1
+            fi
+            API_PROVIDERS_DIR="registry/_site/api/providers/"
+            if [ ! -d "${API_PROVIDERS_DIR}" ] || [ -z "$(ls -A "${API_PROVIDERS_DIR}" 2>/dev/null)" ]; then
+              echo "::error::${API_PROVIDERS_DIR} is missing or empty -- aborting sync."
+              exit 1
+            fi
+          fi
+
       - name: "Sync registry to S3"
         env:
           S3_BUCKET: ${{ steps.destination.outputs.bucket }}


### PR DESCRIPTION
## Summary

After #66100 (#1305 fix), `registry-build.yml` now fires on every wave-release dispatch. `aws s3 sync` exits 0 silently when its source directory is missing or empty, so a partial `breeze registry extract-data` failure (one provider errors mid-run, Eleventy still produces a tree, sync uploads stale or empty JSON) would currently report green while leaving the live registry in an inconsistent state.

## Fix

Mirror the per-provider guards that [`registry-backfill.yml` got in #66027](https://github.com/apache/airflow/blob/main/.github/workflows/registry-backfill.yml#L248-L268). The new "Verify build emitted expected content" step sits between artifact upload and the S3 sync, and:

- **Incremental** (`PROVIDER` set): for each target provider ID, assert `registry/_site/providers/<id>/`, `registry/_site/api/providers/<id>/`, and `registry/_site/api/providers/<id>/versions.json` exist and are non-empty. `versions.json` is the canonical per-provider artifact (drives the version-dropdown).
- **Full build** (`PROVIDER` empty): assert top-level `registry/_site/index.html`, `registry/_site/api/providers.json` (the global listing), and at least one provider subtree under `registry/_site/api/providers/` are present.

Any missing artifact aborts with `::error::` before `aws s3 sync` is invoked.

## Why this matters now

Before #66100 this path only fired on explicit per-provider doc dispatches, where a single failed provider mostly meant nothing got synced (loud failure). With wave dispatches now driving the incremental path automatically, a partial extract over ~22 providers would silently upload a hole-y registry to live S3 and the only signal would be users hitting 404s.

## Verification

- `prek run yamllint`: pass
- `prek run zizmor` (workflow security): pass
- Standalone `actionlint`: zero net-new findings vs. main
- Hand-walked the guard on three input shapes: 22-provider wave (incremental), single explicit dispatch (incremental), full rebuild against `main` (full).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes -- Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)