### PR TITLE
Add `BedrockDeleteGuardrailOperator`

### DIFF
--- a/providers/amazon/docs/operators/bedrock.rst
+++ b/providers/amazon/docs/operators/bedrock.rst
@@ -353,6 +353,20 @@ To create an Amazon Bedrock guardrail, use
     :start-after: [START howto_operator_bedrock_create_guardrail]
     :end-before: [END howto_operator_bedrock_create_guardrail]
 
+.. _howto/operator:BedrockDeleteGuardrailOperator:
+
+Delete a Guardrail
+------------------
+
+To delete an Amazon Bedrock guardrail, use
+:class:`~airflow.providers.amazon.aws.operators.bedrock.BedrockDeleteGuardrailOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bedrock_delete_guardrail]
+    :end-before: [END howto_operator_bedrock_delete_guardrail]
+
 
 Reference
 ---------

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -1128,3 +1128,41 @@ class BedrockCreateGuardrailOperator(AwsBaseOperator[BedrockHook]):
                 raise
         self.log.info("Guardrail %s: %s", self.guardrail_name, guardrail_id)
         return guardrail_id
+
+
+class BedrockDeleteGuardrailOperator(AwsBaseOperator[BedrockHook]):
+    """
+    Delete an Amazon Bedrock guardrail.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BedrockDeleteGuardrailOperator`
+
+    :param guardrail_identifier: The ID or ARN of the guardrail to delete. (templated)
+    :param guardrail_version: Optional version number to delete a specific version. (templated)
+    """
+
+    aws_hook_class = BedrockHook
+    template_fields: Sequence[str] = aws_template_fields("guardrail_identifier", "guardrail_version")
+
+    def __init__(
+        self,
+        *,
+        guardrail_identifier: str,
+        guardrail_version: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.guardrail_identifier = guardrail_identifier
+        self.guardrail_version = guardrail_version
+
+    def execute(self, context: Context) -> None:
+        self.log.info("Deleting Bedrock guardrail %s", self.guardrail_identifier)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "guardrailIdentifier": self.guardrail_identifier,
+                "guardrailVersion": self.guardrail_version,
+            }
+        )
+        self.hook.conn.delete_guardrail(**kwargs)
+        self.log.info("Deleted guardrail %s", self.guardrail_identifier)

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
@@ -18,16 +18,18 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from airflow.providers.amazon.aws.operators.bedrock import BedrockCreateGuardrailOperator
+from airflow.providers.amazon.aws.operators.bedrock import (
+    BedrockCreateGuardrailOperator,
+    BedrockDeleteGuardrailOperator,
+)
 from airflow.providers.common.compat.sdk import DAG, chain
 
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import TriggerRule, task
+    from airflow.sdk import TriggerRule
 else:
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 DAG_ID = "example_bedrock_guardrail"
@@ -58,17 +60,18 @@ with DAG(
     )
     # [END howto_operator_bedrock_create_guardrail]
 
-    @task(trigger_rule=TriggerRule.ALL_DONE)
-    def delete_guardrail(guardrail_id: str):
-        """Delete the guardrail."""
-        import boto3
-
-        boto3.client("bedrock").delete_guardrail(guardrailIdentifier=guardrail_id)
+    # [START howto_operator_bedrock_delete_guardrail]
+    delete_guardrail = BedrockDeleteGuardrailOperator(
+        task_id="delete_guardrail",
+        guardrail_identifier=create_guardrail.output,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_bedrock_delete_guardrail]
 
     chain(
         test_context,
         create_guardrail,
-        delete_guardrail(guardrail_id=create_guardrail.output),
+        delete_guardrail,
     )
 
     from tests_common.test_utils.watcher import watcher

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
@@ -34,6 +34,7 @@ from airflow.providers.amazon.aws.operators.bedrock import (
     BedrockCreateKnowledgeBaseOperator,
     BedrockCreateProvisionedModelThroughputOperator,
     BedrockCustomizeModelOperator,
+    BedrockDeleteGuardrailOperator,
     BedrockIngestDataOperator,
     BedrockInvokeModelOperator,
     BedrockRaGOperator,
@@ -870,6 +871,45 @@ class TestBedrockCreateGuardrailOperator:
 
         with pytest.raises(ClientError):
             self.operator.execute({})
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+GUARDRAIL_ID = "abc123"
+
+
+class TestBedrockDeleteGuardrailOperator:
+    def setup_method(self):
+        self.operator = BedrockDeleteGuardrailOperator(
+            task_id="delete_guardrail",
+            guardrail_identifier=GUARDRAIL_ID,
+        )
+
+    @mock.patch.object(BedrockHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        self.operator.execute({})
+
+        mock_client.delete_guardrail.assert_called_once_with(guardrailIdentifier=GUARDRAIL_ID)
+
+    @mock.patch.object(BedrockHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_version(self, mock_conn):
+        op = BedrockDeleteGuardrailOperator(
+            task_id="delete_guardrail",
+            guardrail_identifier=GUARDRAIL_ID,
+            guardrail_version="1",
+        )
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        op.execute({})
+
+        mock_client.delete_guardrail.assert_called_once_with(
+            guardrailIdentifier=GUARDRAIL_ID, guardrailVersion="1"
+        )
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
## What

Add `BedrockDeleteGuardrailOperator` to delete Amazon Bedrock guardrails.

## Why

Complements `BedrockCreateGuardrailOperator` (#66035, merged) to provide full lifecycle management of guardrails. The system test previously used a `@task` with raw boto3 for deletion — this operator replaces that workaround.

## What was done

- **Operator**: `BedrockDeleteGuardrailOperator` with `guardrail_identifier` and optional `guardrail_version`, using `prune_dict`. Added to existing `bedrock.py`.
- **Unit tests**: Added to existing `test_bedrock.py` — happy path, version param, template fields
- **System test**: Updated `example_bedrock_guardrail.py` — replaced `@task delete_guardrail` with operator
- **Docs**: Added delete section to `bedrock.rst` before Reference