### PR TITLE
Add Execution API endpoints for callback lifecycle and token swap

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/callback.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/callback.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from enum import Enum
+
+from airflow.api_fastapi.core_api.base import StrictBaseModel
+
+
+class CallbackTerminalState(str, Enum):
+    """Terminal states a callback can transition to from RUNNING."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class CallbackTerminalStatePayload(StrictBaseModel):
+    """Payload for transitioning a callback from RUNNING to a terminal state."""
+
+    state: CallbackTerminalState
+    output: str | None = None

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
@@ -23,6 +23,7 @@ from airflow.api_fastapi.execution_api.routes import (
     asset_events,
     asset_state_store,
     assets,
+    callbacks,
     connection_tests,
     connections,
     dag_runs,
@@ -52,6 +53,7 @@ authenticated_router.include_router(asset_events.router, prefix="/asset-events",
 authenticated_router.include_router(
     connection_tests.router, prefix="/connection-tests", tags=["Connection Tests"]
 )
+authenticated_router.include_router(callbacks.router, prefix="/callbacks", tags=["Callbacks"])
 authenticated_router.include_router(connections.router, prefix="/connections", tags=["Connections"])
 authenticated_router.include_router(dag_runs.router, prefix="/dag-runs", tags=["Dag Runs"])
 authenticated_router.include_router(dags.router, prefix="/dags", tags=["Dags"])

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/callbacks.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/callbacks.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+import structlog
+from cadwyn import VersionedAPIRouter
+from fastapi import Body, HTTPException, Response, Security, status
+from structlog.contextvars import bind_contextvars
+
+from airflow.api_fastapi.auth.tokens import JWTGenerator
+from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.execution_api.datamodels.callback import CallbackTerminalStatePayload
+from airflow.api_fastapi.execution_api.datamodels.token import TIToken
+from airflow.api_fastapi.execution_api.deps import DepContainer
+from airflow.api_fastapi.execution_api.security import CurrentTIToken, ExecutionAPIRoute, require_auth
+from airflow.models.callback import Callback
+from airflow.utils.state import CallbackState
+
+log = structlog.get_logger(__name__)
+
+router = VersionedAPIRouter(route_class=ExecutionAPIRoute)
+
+
+def _require_self(token: TIToken, callback_id: UUID) -> None:
+    """Mirror the ``ti:self`` enforcement from security.py for callback routes."""
+    if str(token.id) != str(callback_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token subject does not match callback id",
+        )
+
+
+@router.post(
+    "/{callback_id}/run",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Security(require_auth, scopes=["token:execution", "token:workload"])],
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Token subject does not match callback id"},
+        status.HTTP_404_NOT_FOUND: {"description": "Callback not found"},
+        status.HTTP_409_CONFLICT: {"description": "Callback is not in a state that can be marked running"},
+    },
+)
+def callback_run(
+    callback_id: UUID,
+    response: Response,
+    session: SessionDep,
+    services=DepContainer,
+    token: TIToken = CurrentTIToken,
+) -> Response:
+    """
+    Mark a callback as RUNNING.
+
+    Mirrors ``PATCH /task-instances/{id}/run``: this is the single endpoint that
+    accepts a workload-scoped token and atomically (a) transitions the callback
+    from QUEUED to RUNNING and (b) issues a fresh execution-scoped token via the
+    ``Refreshed-API-Token`` response header. All subsequent supervisor calls hit
+    execution-only routes.
+    """
+    bind_contextvars(callback_id=str(callback_id))
+    _require_self(token, callback_id)
+
+    callback = session.get(Callback, callback_id)
+    if callback is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"reason": "not_found", "message": "Callback not found"},
+        )
+
+    # Allow QUEUED → RUNNING transition; treat RUNNING as idempotent so a retried
+    # supervisor start does not 409. Anything else (PENDING / SCHEDULED / terminal) rejects.
+    if callback.state == CallbackState.RUNNING:
+        log.info("Duplicate start request received", callback_id=str(callback.id))
+    elif callback.state == CallbackState.QUEUED:
+        callback.state = CallbackState.RUNNING
+        session.add(callback)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "reason": "invalid_state",
+                "message": "Callback was not in a state where it could be marked running",
+                "current_state": callback.state,
+            },
+        )
+
+    if token.claims.scope == "workload":
+        generator: JWTGenerator = services.get(JWTGenerator)
+        execution_token = generator.generate(extras={"sub": str(callback_id), "scope": "execution"})
+        response.headers["Refreshed-API-Token"] = execution_token
+
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+@router.patch(
+    "/{callback_id}/state",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Token subject does not match callback id"},
+        status.HTTP_404_NOT_FOUND: {"description": "Callback not found"},
+        status.HTTP_409_CONFLICT: {"description": "Callback is not in RUNNING state"},
+    },
+)
+def callback_update_state(
+    callback_id: UUID,
+    payload: Annotated[CallbackTerminalStatePayload, Body()],
+    session: SessionDep,
+    token: TIToken = CurrentTIToken,
+) -> Response:
+    """Mark a RUNNING callback as SUCCESS or FAILED."""
+    bind_contextvars(callback_id=str(callback_id))
+    _require_self(token, callback_id)
+
+    callback = session.get(Callback, callback_id)
+    if callback is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"reason": "not_found", "message": "Callback not found"},
+        )
+
+    if callback.state != CallbackState.RUNNING:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "reason": "invalid_state",
+                "message": "Callback was not in RUNNING state",
+                "current_state": callback.state,
+            },
+        )
+
+    callback.state = CallbackState(payload.state)
+    if payload.output is not None:
+        callback.output = payload.output
+    session.add(callback)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -51,6 +51,7 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddTeamNameField,
     AddVariableKeysEndpoint,
 )
+from airflow.api_fastapi.execution_api.versions.v2026_07_01 import AddCallbackEndpoints
 
 bundle = VersionBundle(
     HeadVersion(),
@@ -65,6 +66,10 @@ bundle = VersionBundle(
         AddTaskAndAssetStateStoreEndpoints,
         AddAssetsByAliasEndpoint,
         AddPartitionDateField,
+    ),
+    Version(
+        "2026-06-01",
+        AddCallbackEndpoints,
     ),
     Version(
         "2026-04-06",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_07_01.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_07_01.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from cadwyn import VersionChange, endpoint
+
+
+class AddCallbackEndpoints(VersionChange):
+    """Add the ``POST /callbacks/{callback_id}/run`` and ``PATCH /callbacks/{callback_id}/state`` endpoints."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        endpoint("/callbacks/{callback_id}/run", ["POST"]).didnt_exist,
+        endpoint("/callbacks/{callback_id}/state", ["PATCH"]).didnt_exist,
+    )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1327,12 +1327,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 cls.logger().debug("Draining executor event with state %s for connection test %s", state, key)
             elif isinstance(key, CallbackKey):
                 cls.logger().info("Received executor event with state %s for callback %s", state, key)
-                if state in (CallbackState.RUNNING, CallbackState.FAILED, CallbackState.SUCCESS):
+                if state in (CallbackState.FAILED, CallbackState.SUCCESS):
                     callback_keys_with_events.append(key)
             else:
                 cls.logger().error("Unknown workload key type in event buffer: %r", key)
 
-        # Handle callback state events
+        # Handle callback state events.
         for callback_id in callback_keys_with_events:
             state, info = event_buffer.pop(callback_id)
             callback = session.get(Callback, UUID(str(callback_id)))
@@ -1344,17 +1344,28 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 continue
 
-            if state == CallbackState.RUNNING:
-                callback.state = CallbackState.RUNNING
-                cls.logger().info("Callback %s is currently running", callback_id)
-            elif state == CallbackState.SUCCESS:
-                callback.state = CallbackState.SUCCESS
+            # Callback state transitions are now driven by the supervisor through
+            # the Execution API (POST /callbacks/{id}/run, PATCH /callbacks/{id}/state).
+            # The in-process events from the executor are kept as a fallback safety
+            # net for cases where the supervisor crashed before reporting a terminal state
+
+            need_to_modify = False
+
+            if state == CallbackState.SUCCESS:
                 cls.logger().info("Callback %s completed successfully", callback_id)
+                if callback.state in (CallbackState.QUEUED, CallbackState.RUNNING):
+                    callback.state = CallbackState.SUCCESS
+                    need_to_modify = True
             elif state == CallbackState.FAILED:
-                callback.state = CallbackState.FAILED
-                callback.output = str(info) if info else "Execution failed"
-                cls.logger().error("Callback %s failed: %s", callback_id, callback.output)
-            session.add(callback)
+                callback_output = str(info) if info else "Execution failed"
+                cls.logger().error("Callback %s failed: %s", callback_id, callback_output)
+                if callback.state in (CallbackState.QUEUED, CallbackState.RUNNING):
+                    callback.state = CallbackState.FAILED
+                    callback.output = callback_output
+                    need_to_modify = True
+
+            if need_to_modify:
+                session.add(callback)
 
         # Return if no finished tasks
         if not tis_with_right_state:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_token_scope_boundaries.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_token_scope_boundaries.py
@@ -46,6 +46,7 @@ from airflow.api_fastapi.execution_api.routes import execution_api_router
 NON_DEFAULT_TOKEN_POLICY: dict[str, set[str]] = {
     # The /run endpoint exchanges a workload token for a short-lived execution token.
     "PATCH /task-instances/{task_instance_id}/run": {"execution", "workload"},
+    "POST /callbacks/{callback_id}/run": {"execution", "workload"},
     # Connection test routes run from a queued worker context (workload-only).
     "PATCH /connection-tests/{connection_test_id}": {"workload"},
     "GET /connection-tests/{connection_test_id}/connection": {"workload"},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_callbacks.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_callbacks.py
@@ -1,0 +1,300 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Literal
+from unittest import mock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import Request
+
+from airflow.api_fastapi.auth.tokens import JWTGenerator, JWTValidator
+from airflow.api_fastapi.execution_api.app import lifespan
+from airflow.api_fastapi.execution_api.datamodels.token import TIClaims, TIToken
+from airflow.api_fastapi.execution_api.security import require_auth
+from airflow.executors.workloads.callback import CallbackFetchMethod
+from airflow.models.callback import ExecutorCallback
+from airflow.utils.state import CallbackState
+
+from tests_common.test_utils.db import clear_db_callbacks
+
+pytestmark = pytest.mark.db_test
+
+
+class _FakeCallbackDef:
+    """Minimal CallbackDefinitionProtocol stand-in for tests."""
+
+    path: str = "tests.fake.callback"
+    kwargs: dict = {}
+    executor: str | None = None
+
+    def serialize(self) -> dict:
+        return {"path": self.path, "kwargs": self.kwargs, "executor": self.executor}
+
+
+def _make_callback(state: CallbackState, session) -> ExecutorCallback:
+    cb = ExecutorCallback(callback_def=_FakeCallbackDef(), fetch_method=CallbackFetchMethod.IMPORT_PATH)
+    cb.state = state
+    session.add(cb)
+    session.commit()
+    return cb
+
+
+def _override_require_auth(exec_app, scope: Literal["execution", "workload"] = "execution") -> None:
+    """Override require_auth to return a token whose sub matches the path callback_id."""
+
+    async def _token(request: Request) -> TIToken:
+        path_id = request.path_params.get("callback_id")
+        cb_id = UUID(path_id) if path_id else uuid4()
+        return TIToken(id=cb_id, claims=TIClaims(scope=scope))
+
+    exec_app.dependency_overrides[require_auth] = _token
+
+
+@pytest.fixture
+def _use_real_jwt_bearer(exec_app):
+    """Remove the mock require_auth override so the real JWT validation runs end-to-end."""
+    exec_app.dependency_overrides.pop(require_auth, None)
+
+
+class TestCallbackRun:
+    def setup_method(self):
+        clear_db_callbacks()
+
+    def teardown_method(self):
+        clear_db_callbacks()
+
+    @pytest.mark.parametrize("scope", ["workload", "execution"])
+    def test_run_marks_callback_running_and_swaps_workload_token(self, client, exec_app, session, scope):
+        cb = _make_callback(CallbackState.QUEUED, session)
+
+        mock_gen = mock.MagicMock(spec=JWTGenerator)
+        mock_gen.generate.return_value = "mock-execution-token"
+        lifespan.registry.register_value(JWTGenerator, mock_gen)
+
+        _override_require_auth(exec_app, scope=scope)
+
+        response = client.post(f"/execution/callbacks/{cb.id}/run")
+
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        cb_after = session.get(ExecutorCallback, cb.id)
+        assert cb_after.state == CallbackState.RUNNING
+
+        if scope == "workload":
+            assert response.headers["Refreshed-API-Token"] == "mock-execution-token"
+            mock_gen.generate.assert_called_once()
+            extras = mock_gen.generate.call_args.kwargs["extras"]
+            assert extras == {"sub": str(cb.id), "scope": "execution"}
+        else:
+            # Execution-scoped tokens skip the swap; the middleware handles refresh elsewhere.
+            assert "Refreshed-API-Token" not in response.headers
+            mock_gen.generate.assert_not_called()
+
+    @pytest.mark.parametrize("scope", ["workload", "execution"])
+    def test_run_is_idempotent_when_already_running(self, client, exec_app, session, scope):
+        """
+        A retried ``POST /callbacks/{id}/run`` against a callback already in RUNNING
+        state must succeed (204) without regressing the row, and a workload-scoped
+        retry must still receive a fresh execution token via ``Refreshed-API-Token``
+        so the supervisor can complete the workload→execution swap that may have
+        been lost when the original response was dropped.
+        """
+        cb = _make_callback(CallbackState.RUNNING, session)
+
+        mock_gen = mock.MagicMock(spec=JWTGenerator)
+        mock_gen.generate.return_value = "mock-execution-token"
+        lifespan.registry.register_value(JWTGenerator, mock_gen)
+
+        _override_require_auth(exec_app, scope=scope)
+
+        response = client.post(f"/execution/callbacks/{cb.id}/run")
+
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        cb_after = session.get(ExecutorCallback, cb.id)
+        assert cb_after.state == CallbackState.RUNNING
+
+        if scope == "workload":
+            assert response.headers["Refreshed-API-Token"] == "mock-execution-token"
+            mock_gen.generate.assert_called_once()
+            extras = mock_gen.generate.call_args.kwargs["extras"]
+            assert extras == {"sub": str(cb.id), "scope": "execution"}
+        else:
+            assert "Refreshed-API-Token" not in response.headers
+            mock_gen.generate.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            CallbackState.PENDING,
+            CallbackState.SCHEDULED,
+            CallbackState.SUCCESS,
+            CallbackState.FAILED,
+        ],
+    )
+    def test_run_returns_409_for_non_runnable_state(self, client, exec_app, session, state):
+        cb = _make_callback(state, session)
+        _override_require_auth(exec_app, scope="workload")
+
+        response = client.post(f"/execution/callbacks/{cb.id}/run")
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "invalid_state"
+        assert response.json()["detail"]["current_state"] == state.value
+
+    def test_run_returns_404_when_callback_missing(self, client, exec_app):
+        missing_id = uuid4()
+
+        async def _token(request: Request) -> TIToken:
+            return TIToken(id=missing_id, claims=TIClaims(scope="workload"))
+
+        exec_app.dependency_overrides[require_auth] = _token
+
+        response = client.post(f"/execution/callbacks/{missing_id}/run")
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["reason"] == "not_found"
+
+    def test_run_rejects_mismatched_sub(self, client, exec_app, session):
+        cb = _make_callback(CallbackState.QUEUED, session)
+
+        async def _token(request: Request) -> TIToken:
+            return TIToken(id=uuid4(), claims=TIClaims(scope="workload"))
+
+        exec_app.dependency_overrides[require_auth] = _token
+
+        response = client.post(f"/execution/callbacks/{cb.id}/run")
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Token subject does not match callback id"
+
+
+class TestCallbackUpdateState:
+    def setup_method(self):
+        clear_db_callbacks()
+
+    def teardown_method(self):
+        clear_db_callbacks()
+
+    @pytest.mark.parametrize(
+        ("payload_state", "expected_state"),
+        [
+            ("success", CallbackState.SUCCESS),
+            ("failed", CallbackState.FAILED),
+        ],
+    )
+    def test_update_state_writes_terminal_state(
+        self, client, exec_app, session, payload_state, expected_state
+    ):
+        cb = _make_callback(CallbackState.RUNNING, session)
+        _override_require_auth(exec_app, scope="execution")
+
+        response = client.patch(
+            f"/execution/callbacks/{cb.id}/state",
+            json={"state": payload_state, "output": "an output"},
+        )
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 204
+        session.expire_all()
+        cb_after = session.get(ExecutorCallback, cb.id)
+        assert cb_after.state == expected_state
+        assert cb_after.output == "an output"
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            CallbackState.QUEUED,
+            CallbackState.PENDING,
+            CallbackState.SCHEDULED,
+            CallbackState.SUCCESS,
+            CallbackState.FAILED,
+        ],
+    )
+    def test_update_state_returns_409_when_not_running(self, client, exec_app, session, state):
+        cb = _make_callback(state, session)
+        _override_require_auth(exec_app, scope="execution")
+
+        response = client.patch(
+            f"/execution/callbacks/{cb.id}/state",
+            json={"state": "success"},
+        )
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["reason"] == "invalid_state"
+
+    def test_update_state_returns_404_when_callback_missing(self, client, exec_app):
+        missing_id = uuid4()
+        _override_require_auth(exec_app, scope="execution")
+
+        response = client.patch(
+            f"/execution/callbacks/{missing_id}/state",
+            json={"state": "success"},
+        )
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 404
+
+    def test_update_state_rejects_mismatched_sub(self, client, exec_app, session):
+        cb = _make_callback(CallbackState.RUNNING, session)
+
+        async def _token(request: Request) -> TIToken:
+            return TIToken(id=uuid4(), claims=TIClaims(scope="execution"))
+
+        exec_app.dependency_overrides[require_auth] = _token
+
+        response = client.patch(
+            f"/execution/callbacks/{cb.id}/state",
+            json={"state": "success"},
+        )
+        exec_app.dependency_overrides.pop(require_auth, None)
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("_use_real_jwt_bearer")
+    def test_update_state_rejects_workload_scope(self, client, session):
+        cb = _make_callback(CallbackState.RUNNING, session)
+
+        validator = mock.AsyncMock(spec=JWTValidator)
+        validator.avalidated_claims.return_value = {
+            "sub": str(cb.id),
+            "scope": "workload",
+            "exp": 9999999999,
+            "iat": 1000000000,
+            "nbf": 1000000000,
+        }
+        lifespan.registry.register_value(JWTValidator, validator)
+
+        response = client.patch(
+            f"/execution/callbacks/{cb.id}/state",
+            json={"state": "success"},
+        )
+
+        assert response.status_code == 403
+        assert "Token type 'workload' not allowed" in response.json()["detail"]

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -68,7 +68,7 @@ from airflow.models.asset import (
     PartitionedAssetKeyLog,
 )
 from airflow.models.backfill import Backfill, BackfillDagRun, ReprocessBehavior, _create_backfill
-from airflow.models.callback import Callback, ExecutorCallback
+from airflow.models.callback import Callback, CallbackKey, ExecutorCallback
 from airflow.models.connection_test import (
     ConnectionTestKey,
     ConnectionTestRequest,
@@ -691,6 +691,106 @@ class TestSchedulerJob:
         assert session.get(ExecutorCallback, scheduled_callback.id).state == CallbackState.SCHEDULED
         assert session.get(ExecutorCallback, queued_callback.id).state == CallbackState.QUEUED
         assert session.get(ExecutorCallback, running_callback.id).state == CallbackState.RUNNING
+
+    @pytest.mark.parametrize(
+        ("db_state", "event_state", "expected_state"),
+        [
+            # RUNNING events are informational; the API is the source of truth for
+            # the QUEUED -> RUNNING transition, so RUNNING events never modify state.
+            (CallbackState.QUEUED, CallbackState.RUNNING, CallbackState.QUEUED),
+            # QUEUED -> terminal fallback: if the supervisor crashes before calling
+            # the start API, the executor still emits a terminal event and the
+            # scheduler must advance the row so it does not stay QUEUED forever.
+            (CallbackState.QUEUED, CallbackState.SUCCESS, CallbackState.SUCCESS),
+            (CallbackState.QUEUED, CallbackState.FAILED, CallbackState.FAILED),
+            (CallbackState.RUNNING, CallbackState.SUCCESS, CallbackState.SUCCESS),
+            (CallbackState.RUNNING, CallbackState.FAILED, CallbackState.FAILED),
+            # Stale events must not regress an already-terminal callback. The API
+            # path (POST /run, PATCH /state) is authoritative; events are a fallback.
+            (CallbackState.SUCCESS, CallbackState.RUNNING, CallbackState.SUCCESS),
+            (CallbackState.SUCCESS, CallbackState.FAILED, CallbackState.SUCCESS),
+            (CallbackState.FAILED, CallbackState.RUNNING, CallbackState.FAILED),
+            (CallbackState.FAILED, CallbackState.SUCCESS, CallbackState.FAILED),
+            # Already RUNNING in DB: a duplicate RUNNING event is a no-op.
+            (CallbackState.RUNNING, CallbackState.RUNNING, CallbackState.RUNNING),
+        ],
+    )
+    def test_process_executor_events_writes_callback_state_forward_only(
+        self, dag_maker, session, db_state, event_state, expected_state
+    ):
+        def test_callback():
+            pass
+
+        with dag_maker(dag_id="test_callback_forward_only"):
+            pass
+        dag_run = dag_maker.create_dagrun()
+
+        callback = Deadline(
+            deadline_time=timezone.utcnow(),
+            callback=SyncCallback(test_callback),
+            dagrun_id=dag_run.id,
+            deadline_alert_id=None,
+        ).callback
+        callback.state = db_state
+        callback.data["dag_run_id"] = dag_run.id
+        callback.data["dag_id"] = dag_run.dag_id
+        session.add(callback)
+        session.flush()
+
+        executor = MockExecutor(do_update=False)
+        executor.event_buffer[CallbackKey(id=str(callback.id))] = (event_state, None)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
+        self.job_runner._process_executor_events(executor=executor, session=session)
+
+        session.flush()
+        session.expire_all()
+        assert session.get(ExecutorCallback, callback.id).state == expected_state
+
+    @pytest.mark.parametrize(
+        "db_state",
+        [CallbackState.QUEUED, CallbackState.RUNNING],
+    )
+    def test_process_executor_events_failed_event_captures_output(self, dag_maker, session, db_state):
+        """
+        A FAILED executor event must mark the callback row FAILED and persist the failure
+        message regardless of whether the row is still QUEUED (supervisor crashed before
+        the start API call) or already RUNNING (supervisor crashed mid-execution).
+        """
+
+        def test_callback():
+            pass
+
+        with dag_maker(dag_id="test_callback_failed_event_output"):
+            pass
+        dag_run = dag_maker.create_dagrun()
+
+        callback = Deadline(
+            deadline_time=timezone.utcnow(),
+            callback=SyncCallback(test_callback),
+            dagrun_id=dag_run.id,
+            deadline_alert_id=None,
+        ).callback
+        callback.state = db_state
+        callback.data["dag_run_id"] = dag_run.id
+        callback.data["dag_id"] = dag_run.dag_id
+        session.add(callback)
+        session.flush()
+
+        failure_message = "supervisor crashed before reporting state"
+        executor = MockExecutor(do_update=False)
+        executor.event_buffer[CallbackKey(id=str(callback.id))] = (CallbackState.FAILED, failure_message)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(scheduler_job, executors=[executor])
+        self.job_runner._process_executor_events(executor=executor, session=session)
+
+        session.flush()
+        session.expire_all()
+        persisted = session.get(ExecutorCallback, callback.id)
+        assert persisted.state == CallbackState.FAILED
+        assert persisted.output == failure_message
 
     @mock.patch("airflow.jobs.scheduler_job_runner.TaskCallbackRequest")
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -50,6 +50,7 @@ from airflow.sdk.api.datamodels._generated import (
     AssetResponse,
     AssetStateStorePutBody,
     AssetStateStoreResponse,
+    CallbackTerminalState,
     ConnectionResponse,
     ConnectionTestConnectionResponse,
     ConnectionTestResultBody,
@@ -181,6 +182,7 @@ _trace_propagator = TraceContextTextMapPropagator()
 _log_retry_warning = before_log(log, logging.WARNING)
 
 __all__ = [
+    "CallbackOperations",
     "Client",
     "ConnectionOperations",
     "ServerResponseError",
@@ -1083,6 +1085,36 @@ class ConnectionTestOperations:
         self.client.patch(f"connection-tests/{id}", content=body.model_dump_json())
 
 
+class CallbackOperations:
+    __slots__ = ("client",)
+
+    def __init__(self, client: Client):
+        self.client = client
+
+    def start(self, id: uuid.UUID | str) -> None:
+        """
+        Mark a callback as RUNNING and exchange a workload token for an execution token.
+
+        Mirrors ``TaskInstanceOperations.start``: this is the single API call that
+        accepts a workload-scoped token; the server returns the new execution token
+        via the ``Refreshed-API-Token`` response header and the Client's response
+        hook automatically swaps it onto subsequent requests.
+        """
+        self.client.post(f"callbacks/{id}/run")
+
+    def finish(
+        self,
+        id: uuid.UUID | str,
+        state: CallbackTerminalState,
+        output: str | None = None,
+    ) -> None:
+        """Tell the API server that this callback has reached a terminal state."""
+        body: dict[str, Any] = {"state": state}
+        if output is not None:
+            body["output"] = output
+        self.client.patch(f"callbacks/{id}/state", json=body)
+
+
 class BearerAuth(httpx.Auth):
     def __init__(self, token: str):
         self.token: str = token
@@ -1295,6 +1327,12 @@ class Client(httpx.Client):
     def dags(self) -> DagsOperations:
         """Operations related to DAGs."""
         return DagsOperations(self)
+
+    @lru_cache()  # type: ignore[misc]
+    @property
+    def callbacks(self) -> CallbackOperations:
+        """Operations related to Callbacks."""
+        return CallbackOperations(self)
 
 
 # This is only used for parsing. ServerResponseError is raised instead

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -63,6 +63,27 @@ class AssetProfile(BaseModel):
     type: Annotated[str, Field(title="Type")]
 
 
+class CallbackTerminalState(str, Enum):
+    """
+    Terminal states a callback can transition to from RUNNING.
+    """
+
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class CallbackTerminalStatePayload(BaseModel):
+    """
+    Payload for transitioning a callback from RUNNING to a terminal state.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    state: CallbackTerminalState
+    output: Annotated[str | None, Field(title="Output")] = None
+
+
 class ConnectionResponse(BaseModel):
     """
     Connection schema for responses with fields that are needed for Runtime.

--- a/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
@@ -33,6 +33,7 @@ import structlog
 from pydantic import Field, TypeAdapter
 
 from airflow.sdk._shared.module_loading import UNUSUAL_MODULE_PREFIX, accepts_context, accepts_keyword_args
+from airflow.sdk.api.datamodels._generated import CallbackTerminalState
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     ErrorResponse,
@@ -433,6 +434,16 @@ def supervise_callback(
         else:
             logger = structlog.get_logger(logger_name="callback").bind()
 
+        # Mark the callback as RUNNING via the API. This is the single endpoint
+        # that accepts a workload-scoped token; it returns a fresh execution
+        # token via the Refreshed-API-Token header
+        # If this API call fails, the callback fails and stays QUEUED, but the
+        # scheduler's _process_executor_events converts it to a failed state.
+        client.callbacks.start(id)
+
+        terminal_state = CallbackTerminalState.FAILED
+        terminal_output = None
+
         try:
             process = CallbackSubprocess.start(
                 id=id,
@@ -454,9 +465,23 @@ def supervise_callback(
                 exit_code=exit_code,
                 duration=end - start,
             )
-            if exit_code != 0:
-                raise RuntimeError(f"Callback subprocess exited with code {exit_code}")
-            return exit_code
+            if exit_code == 0:
+                terminal_state = CallbackTerminalState.SUCCESS
+            else:
+                terminal_output = f"Callback subprocess exited with code {exit_code}"
+        except Exception as e:
+            terminal_output = f"Callback supervisor error: {type(e).__name__}: {e}"
+            log.exception("Callback supervisor error", workload_id=id)
+            raise
         finally:
+            try:
+                client.callbacks.finish(id, state=terminal_state, output=terminal_output)
+            except Exception:
+                log.exception("Failed to report final callback state", workload_id=id)
+
             if log_path and log_file_descriptor:
                 log_file_descriptor.close()
+
+        if exit_code != 0:
+            raise RuntimeError(f"Callback subprocess exited with code {exit_code}")
+        return exit_code

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -2031,3 +2031,81 @@ class TestAssetStateOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.asset_state_store.clear(uri="s3://bucket/key")
         assert result == OKResponse(ok=True)
+
+
+class TestCallbackOperations:
+    def test_start_posts_and_picks_up_refreshed_token(self):
+        """start() POSTs to /callbacks/{id}/run; the response hook applies the new bearer."""
+        callback_id = uuid6.uuid7()
+        seen: dict[str, str | None] = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == f"/callbacks/{callback_id}/run":
+                seen["method"] = request.method
+                seen["auth"] = request.headers.get("Authorization")
+                return httpx.Response(
+                    status_code=204,
+                    headers={"Refreshed-API-Token": "new-execution-token"},
+                )
+            seen["follow_up_auth"] = request.headers.get("Authorization")
+            return httpx.Response(status_code=200, json={})
+
+        client = Client(
+            base_url="test://server",
+            token="initial-workload-token",
+            transport=httpx.MockTransport(handle_request),
+        )
+
+        client.callbacks.start(callback_id)
+
+        assert seen["method"] == "POST"
+        assert seen["auth"] == "Bearer initial-workload-token"
+
+        # A subsequent call should now carry the refreshed token, proving the
+        # response hook adopted Refreshed-API-Token onto the client's auth.
+        client.get(f"/callbacks/{callback_id}/something-else")
+        assert seen["follow_up_auth"] == "Bearer new-execution-token"
+
+    def test_start_propagates_server_error(self):
+        callback_id = uuid6.uuid7()
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                status_code=409,
+                json={"detail": {"reason": "invalid_state", "current_state": "success"}},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+
+        with pytest.raises(ServerResponseError) as exc_info:
+            client.callbacks.start(callback_id)
+
+        assert exc_info.value.response.status_code == 409
+
+    @pytest.mark.parametrize(
+        ("state", "output"),
+        [
+            ("success", None),
+            ("failed", "Callback subprocess exited with code 1"),
+        ],
+    )
+    def test_finish_patches_state_endpoint(self, state, output):
+        callback_id = uuid6.uuid7()
+        seen: dict = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == f"/callbacks/{callback_id}/state":
+                seen["method"] = request.method
+                seen["body"] = json.loads(request.read())
+                return httpx.Response(status_code=204)
+            return httpx.Response(status_code=400)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        client.callbacks.finish(callback_id, state=state, output=output)
+
+        assert seen["method"] == "PATCH"
+        assert seen["body"]["state"] == state
+        if output is not None:
+            assert seen["body"]["output"] == output
+        else:
+            assert "output" not in seen["body"]

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -26,11 +26,18 @@ from dataclasses import dataclass
 from operator import attrgetter
 from typing import Any
 from unittest.mock import ANY, Mock, patch
+from uuid import uuid4
 
 import pytest
 import structlog
 
-from airflow.sdk.execution_time.callback_supervisor import CallbackSubprocess, Path, execute_callback
+from airflow.sdk.api.client import CallbackOperations, Client
+from airflow.sdk.execution_time.callback_supervisor import (
+    CallbackSubprocess,
+    Path,
+    execute_callback,
+    supervise_callback,
+)
 from airflow.sdk.execution_time.comms import (
     BundleInfo,
     ConnectionResult,
@@ -529,3 +536,126 @@ class TestCallbackSubprocessStart:
             self.mock_super_start.call_args.kwargs["target"]()
 
         assert exc_info.value.code == 1
+
+
+class TestSuperviseCallback:
+    """supervise_callback drives every callback state transition through the API."""
+
+    def _make_mock_client(self, mocker):
+        client = mocker.Mock(spec=Client)
+        client.callbacks = mocker.Mock(spec=CallbackOperations)
+        return client
+
+    def test_start_called_before_subprocess_then_finish_success(self, mocker):
+        cb_id = str(uuid4())
+        client = self._make_mock_client(mocker)
+
+        order: list[str] = []
+        client.callbacks.start.side_effect = lambda _id: order.append("start_api")
+        client.callbacks.finish.side_effect = lambda _id, state, output=None: order.append(f"finish:{state}")
+
+        proc = mocker.Mock()
+        proc.wait.return_value = 0
+
+        def _subprocess_start(**_):
+            order.append("subprocess_start")
+            return proc
+
+        mocker.patch.object(CallbackSubprocess, "start", side_effect=_subprocess_start)
+
+        exit_code = supervise_callback(
+            id=cb_id,
+            callback_path="tests.fake.callback",
+            callback_kwargs={},
+            dag_rel_path=Path("test.py"),
+            token="workload-token",
+            client=client,
+        )
+
+        assert exit_code == 0
+        client.callbacks.start.assert_called_once_with(cb_id)
+        client.callbacks.finish.assert_called_once_with(cb_id, state="success", output=None)
+        assert order == ["start_api", "subprocess_start", "finish:success"]
+
+    def test_finish_called_with_failed_when_subprocess_exits_nonzero(self, mocker):
+        cb_id = str(uuid4())
+        client = self._make_mock_client(mocker)
+
+        proc = mocker.Mock()
+        proc.wait.return_value = 1
+        mocker.patch.object(CallbackSubprocess, "start", return_value=proc)
+
+        with pytest.raises(RuntimeError, match="exited with code 1"):
+            supervise_callback(
+                id=cb_id,
+                callback_path="tests.fake.callback",
+                callback_kwargs={},
+                dag_rel_path=Path("test.py"),
+                token="workload-token",
+                client=client,
+            )
+
+        client.callbacks.start.assert_called_once_with(cb_id)
+        client.callbacks.finish.assert_called_once()
+        kwargs = client.callbacks.finish.call_args.kwargs
+        assert kwargs["state"] == "failed"
+        assert "exited with code 1" in kwargs["output"]
+
+    def test_finish_called_with_failed_when_subprocess_raises(self, mocker):
+        cb_id = str(uuid4())
+        client = self._make_mock_client(mocker)
+
+        mocker.patch.object(CallbackSubprocess, "start", side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            supervise_callback(
+                id=cb_id,
+                callback_path="tests.fake.callback",
+                callback_kwargs={},
+                dag_rel_path=Path("test.py"),
+                token="workload-token",
+                client=client,
+            )
+
+        client.callbacks.finish.assert_called_once()
+        kwargs = client.callbacks.finish.call_args.kwargs
+        assert kwargs["state"] == "failed"
+        assert "RuntimeError" in kwargs["output"]
+
+    def test_callbacks_start_failure_propagates_and_does_not_call_finish(self, mocker):
+        cb_id = str(uuid4())
+        client = self._make_mock_client(mocker)
+        client.callbacks.start.side_effect = RuntimeError("API unreachable")
+
+        with pytest.raises(RuntimeError, match="API unreachable"):
+            supervise_callback(
+                id=cb_id,
+                callback_path="tests.fake.callback",
+                callback_kwargs={},
+                dag_rel_path=Path("test.py"),
+                token="workload-token",
+                client=client,
+            )
+        client.callbacks.finish.assert_not_called()
+
+    def test_finish_failure_is_swallowed(self, mocker):
+        """If the terminal-state report fails, supervisor must still propagate the run result."""
+        cb_id = str(uuid4())
+        client = self._make_mock_client(mocker)
+        client.callbacks.finish.side_effect = RuntimeError("network down")
+
+        proc = mocker.Mock()
+        proc.wait.return_value = 0
+        mocker.patch.object(CallbackSubprocess, "start", return_value=proc)
+
+        # Should not raise — finish() is best-effort because the executor's
+        # event channel is the safety net.
+        exit_code = supervise_callback(
+            id=cb_id,
+            callback_path="tests.fake.callback",
+            callback_kwargs={},
+            dag_rel_path=Path("test.py"),
+            token="workload-token",
+            client=client,
+        )
+        assert exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ wheels = [
 
 [[package]]
 name = "apache-airflow"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow-core" },
@@ -1911,7 +1911,7 @@ requires-dist = [
 
 [[package]]
 name = "apache-airflow-core"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "airflow-core" }
 dependencies = [
     { name = "a2wsgi" },


### PR DESCRIPTION
 ### Problems

#### 1. Workload token leaks into callback supervisor's runtime API calls

related https://github.com/apache/airflow/pull/60108, When the executor enqueues an ExecuteCallback, the supervisor receives a long-lived `workload`-scoped token (intended only as a one-time admission ticket, like for ExecuteTask). However, unlike ExecuteTask — which immediately swaps it for an `execution`-scoped token via PATCH /task-instances/{id}/run — supervise_callback never performs the swap. It carries the `workload` token straight through into runtime API calls (e.g. Connection.get(), Variable.get()).

```
2026-04-29T11:08:35.766821Z [warning  ] Token type not allowed for endpoint [airflow.api_fastapi.execution_api.security] allowed_types=['execution'] correlation_id=019dd8ed-2e34-7b0d-bfba-d7fe16612411 loc=security.py:174 path=/execution/connections/slack_default token_scope=workload
2026-04-29T11:08:35.767466Z [info     ] request finished               [http.access] client_addr=172.18.0.7:47640 duration_us=1634 loc=http_access_log.py:98 method=GET path=/execution/connections/slack_default query= status_code=403
```
These shared endpoints only accept execution-scoped tokens, so any callback that touches Connections or Variables hits 403 from require_auth's scope check.

#### 2. process_executor_events is the only writer of callback state, and it's executor-specific

  Today, callback state transitions (QUEUED → RUNNING → SUCCESS/FAILED) are written only by the scheduler's _process_executor_events, which reads from each executor's in-process event_buffer. It does not work for executors that don't use the scheduler's in-process event channel — most notably EdgeExecutor, where workers run on remote machines and report back via HTTP. Their callbacks stay forever in QUEUED.

### Solution

Move callback state transitions to the Execution API, mirroring the ExecuteTask pattern:

- `POST /callbacks/{id}/run` — accepts both workload and execution tokens; transitions QUEUED → RUNNING and returns a fresh execution token via the Refreshed-API-Token header (same swap mechanism PR #60108 introduced for TI). All subsequent callback API calls use the execution token.
- `PATCH /callbacks/{id}/state` — execution-only; records the terminal SUCCESS / FAILED outcome with optional output.
- `supervise_callback` calls `client.callbacks.start()` before forking the subprocess and `client.callbacks.finish()` afterward, so the API is the single source of truth for callback
   state — works uniformly across all executors (Local, Celery, Kubernetes, Edge).
- `_process_executor_events` keeps its callback handling as a forward-only fallback for cases where the supervisor crashes before reporting a terminal state; it never regresses a state already advanced by the API.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE

-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude code (opus 4.7) to make test codes and ci green

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.


<!-- pr-triage-fold: triaged=2026-07-18T15:46:56Z head=d91a114 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @wjddn279** · by `@potiuk` · 2026-07-18 15:46 UTC
>
> Some review feedback is waiting on you:
> - :x: **Unresolved review comments**: 4 thread(s) from `ashb`, `potiuk`. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for details.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
