### PR TITLE
UI: Mark task group as success/failed

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -263,6 +263,8 @@
   "task_one": "Task",
   "task_other": "Tasks",
   "taskGroup": "Task Group",
+  "taskGroup_one": "Task Group",
+  "taskGroup_other": "Task Groups",
   "taskId": "Task ID",
   "taskInstance": {
     "dagVersion": "Dag Version",

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/MarkTaskGroupAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/MarkTaskGroupAsButton.tsx
@@ -1,0 +1,137 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, HStack, IconButton, useDisclosure } from "@chakra-ui/react";
+import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { useTranslation } from "react-i18next";
+import { FiX } from "react-icons/fi";
+import { LuCheck } from "react-icons/lu";
+
+import type { LightGridTaskInstanceSummary, TaskInstanceState } from "openapi/requests/types.gen";
+import { StateBadge } from "src/components/StateBadge";
+import { Menu, Tooltip } from "src/components/ui";
+
+import { allowedStates } from "../utils";
+import MarkTaskGroupAsDialog from "./MarkTaskGroupAsDialog";
+
+type Props = {
+  readonly groupTaskInstance: LightGridTaskInstanceSummary;
+  readonly isHotkeyEnabled?: boolean;
+};
+
+const MarkTaskGroupAsButton = ({ groupTaskInstance, isHotkeyEnabled = false }: Props) => {
+  const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
+
+  const [state, setState] = useState<TaskInstanceState>("success");
+
+  useHotkeys(
+    "shift+f",
+    () => {
+      setState("failed");
+      onOpen();
+    },
+    { enabled: isHotkeyEnabled && groupTaskInstance.state !== "failed" },
+  );
+
+  useHotkeys(
+    "shift+s",
+    () => {
+      setState("success");
+      onOpen();
+    },
+    { enabled: isHotkeyEnabled && groupTaskInstance.state !== "success" },
+  );
+
+  return (
+    <Box>
+      <Menu.Root positioning={{ gutter: 0, placement: "bottom" }}>
+        <Menu.Trigger asChild>
+          <div>
+            <Tooltip
+              content={translate("dags:runAndTaskActions.markAs.button", {
+                type: translate("taskGroup_one"),
+              })}
+            >
+              <IconButton
+                aria-label={translate("dags:runAndTaskActions.markAs.button", {
+                  type: translate("taskGroup_one"),
+                })}
+                colorPalette="brand"
+                size="md"
+                variant="ghost"
+              >
+                <HStack gap={1} mx={1}>
+                  <LuCheck />
+                  <span>/</span>
+                  <FiX />
+                </HStack>
+              </IconButton>
+            </Tooltip>
+          </div>
+        </Menu.Trigger>
+        <Menu.Content>
+          {allowedStates.map((menuState) => {
+            const content = translate(
+              `dags:runAndTaskActions.markAs.buttonTooltip.${menuState === "success" ? "success" : "failed"}`,
+            );
+
+            return (
+              <Tooltip
+                closeDelay={100}
+                content={content}
+                disabled={!isHotkeyEnabled || groupTaskInstance.state === menuState}
+                key={menuState}
+                openDelay={100}
+              >
+                <Menu.Item
+                  asChild
+                  disabled={groupTaskInstance.state === menuState}
+                  key={menuState}
+                  onClick={() => {
+                    if (groupTaskInstance.state !== menuState) {
+                      setState(menuState);
+                      onOpen();
+                    }
+                  }}
+                  value={menuState}
+                >
+                  <StateBadge my={1} state={menuState}>
+                    {translate(`common:states.${menuState}`)}
+                  </StateBadge>
+                </Menu.Item>
+              </Tooltip>
+            );
+          })}
+        </Menu.Content>
+      </Menu.Root>
+
+      {open ? (
+        <MarkTaskGroupAsDialog
+          groupTaskInstance={groupTaskInstance}
+          onClose={onClose}
+          open={open}
+          state={state}
+        />
+      ) : undefined}
+    </Box>
+  );
+};
+
+export default MarkTaskGroupAsButton;

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/MarkTaskGroupAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/MarkTaskGroupAsDialog.tsx
@@ -1,0 +1,160 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+
+import type { LightGridTaskInstanceSummary, TaskInstanceState } from "openapi/requests/types.gen";
+import { ActionAccordion } from "src/components/ActionAccordion";
+import { StateBadge } from "src/components/StateBadge";
+import Time from "src/components/Time";
+import { Dialog } from "src/components/ui";
+import SegmentedControl from "src/components/ui/SegmentedControl";
+import { usePatchTaskGroup } from "src/queries/usePatchTaskGroup";
+import { usePatchTaskGroupDryRun } from "src/queries/usePatchTaskGroupDryRun";
+
+type Props = {
+  readonly groupTaskInstance: LightGridTaskInstanceSummary;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly state: TaskInstanceState;
+};
+
+const MarkTaskGroupAsDialog = ({ groupTaskInstance, onClose, open, state }: Props) => {
+  const { dagId = "", runId = "" } = useParams();
+  const groupId = groupTaskInstance.task_id;
+  const { t: translate } = useTranslation();
+
+  const [selectedOptions, setSelectedOptions] = useState<Array<string>>([]);
+
+  const past = selectedOptions.includes("past");
+  const future = selectedOptions.includes("future");
+  const upstream = selectedOptions.includes("upstream");
+  const downstream = selectedOptions.includes("downstream");
+
+  const [note, setNote] = useState<string | null>(null);
+
+  const { isPending, mutate } = usePatchTaskGroup({
+    dagId,
+    dagRunId: runId,
+    groupId,
+    onSuccess: onClose,
+  });
+  const { data, isPending: isPendingDryRun } = usePatchTaskGroupDryRun({
+    dagId,
+    dagRunId: runId,
+    groupId,
+    options: {
+      enabled: open,
+      refetchOnMount: "always",
+    },
+    requestBody: {
+      include_downstream: downstream,
+      include_future: future,
+      include_past: past,
+      include_upstream: upstream,
+      new_state: state,
+      note,
+    },
+  });
+
+  const affectedTasks = data ?? {
+    task_instances: [],
+    total_entries: 0,
+  };
+
+  return (
+    <Dialog.Root lazyMount onOpenChange={onClose} open={open} size="xl">
+      <Dialog.Content backdrop>
+        <Dialog.Header>
+          <VStack align="start" gap={4}>
+            <Heading size="xl">
+              <strong>
+                {translate("dags:runAndTaskActions.markAs.title", {
+                  state,
+                  type: translate("taskGroup_one"),
+                })}
+                :
+              </strong>{" "}
+              {groupTaskInstance.task_display_name} <Time datetime={groupTaskInstance.min_start_date} />{" "}
+              <StateBadge state={state} />
+            </Heading>
+          </VStack>
+        </Dialog.Header>
+
+        <Dialog.CloseTrigger />
+
+        <Dialog.Body width="full">
+          <Flex justifyContent="center">
+            <SegmentedControl
+              defaultValues={["downstream"]}
+              multiple
+              onChange={setSelectedOptions}
+              options={[
+                {
+                  label: translate("dags:runAndTaskActions.options.past"),
+                  value: "past",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.options.future"),
+                  value: "future",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.options.upstream"),
+                  value: "upstream",
+                },
+                {
+                  label: translate("dags:runAndTaskActions.options.downstream"),
+                  value: "downstream",
+                },
+              ]}
+            />
+          </Flex>
+          <ActionAccordion affectedTasks={affectedTasks} note={note} setNote={setNote} />
+          <Flex justifyContent="end" mt={3}>
+            <Button
+              colorPalette="brand"
+              loading={isPending || isPendingDryRun}
+              onClick={() => {
+                mutate({
+                  dagId,
+                  dagRunId: runId,
+                  groupId,
+                  requestBody: {
+                    include_downstream: downstream,
+                    include_future: future,
+                    include_past: past,
+                    include_upstream: upstream,
+                    new_state: state,
+                    note,
+                  },
+                });
+              }}
+            >
+              {translate("modal.confirm")}
+            </Button>
+          </Flex>
+        </Dialog.Body>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+};
+
+export default MarkTaskGroupAsDialog;

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/index.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskGroup/index.tsx
@@ -17,6 +17,4 @@
  * under the License.
  */
 
-export { default as MarkRunAsButton } from "./Run";
-export { default as MarkTaskGroupAsButton } from "./TaskGroup";
-export { default as MarkTaskInstanceAsButton } from "./TaskInstance";
+export { default } from "./MarkTaskGroupAsButton";

--- a/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/GroupTaskInstance/Header.tsx
@@ -24,6 +24,7 @@ import { MdOutlineTask } from "react-icons/md";
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { HeaderCard } from "src/components/HeaderCard";
+import { MarkTaskGroupAsButton } from "src/components/MarkAs";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
@@ -54,7 +55,12 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
   return (
     <Box>
       <HeaderCard
-        actions={<ClearTaskInstanceButton groupTaskInstance={taskInstance} isHotkeyEnabled />}
+        actions={
+          <>
+            <ClearTaskInstanceButton groupTaskInstance={taskInstance} isHotkeyEnabled />
+            <MarkTaskGroupAsButton groupTaskInstance={taskInstance} isHotkeyEnabled />
+          </>
+        }
         icon={<MdOutlineTask />}
         state={taskInstance.state}
         stats={stats}

--- a/airflow-core/src/airflow/ui/src/queries/usePatchTaskGroup.ts
+++ b/airflow-core/src/airflow/ui/src/queries/usePatchTaskGroup.ts
@@ -1,0 +1,78 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+
+import {
+  useTaskInstanceServiceGetTaskInstancesKey,
+  useTaskInstanceServicePatchTaskGroupInstances,
+} from "openapi/queries";
+import { createErrorToaster } from "src/utils";
+
+import { gridQueryKeys } from "./gridViewQueryKeys";
+import { useClearTaskInstancesDryRunKey } from "./useClearTaskInstancesDryRun";
+import { usePatchTaskGroupDryRunKey } from "./usePatchTaskGroupDryRun";
+
+export const usePatchTaskGroup = ({
+  dagId,
+  dagRunId,
+  groupId,
+  onSuccess,
+}: {
+  dagId: string;
+  dagRunId: string;
+  groupId: string;
+  onSuccess?: () => void;
+}) => {
+  const queryClient = useQueryClient();
+  const { t: translate } = useTranslation();
+
+  const onError = (error: unknown) => {
+    createErrorToaster(
+      error,
+      {
+        params: { resourceName: translate("taskGroup_one") },
+        titleKey: "toaster.update.error",
+      },
+      translate,
+    );
+  };
+
+  const onSuccessFn = async () => {
+    const queryKeys = [
+      [useTaskInstanceServiceGetTaskInstancesKey],
+      [usePatchTaskGroupDryRunKey, dagId, dagRunId, groupId],
+      [useClearTaskInstancesDryRunKey, dagId],
+    ];
+
+    await Promise.all([
+      ...gridQueryKeys(dagId).map((key) => queryClient.invalidateQueries({ queryKey: key })),
+      ...queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
+    ]);
+
+    if (onSuccess) {
+      onSuccess();
+    }
+  };
+
+  return useTaskInstanceServicePatchTaskGroupInstances({
+    onError,
+    onSuccess: onSuccessFn,
+  });
+};

--- a/airflow-core/src/airflow/ui/src/queries/usePatchTaskGroupDryRun.ts
+++ b/airflow-core/src/airflow/ui/src/queries/usePatchTaskGroupDryRun.ts
@@ -1,0 +1,66 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import { TaskInstanceService } from "openapi/requests/services.gen";
+import type {
+  PatchTaskGroupInstancesDryRunResponse,
+  PatchTaskInstanceBody,
+} from "openapi/requests/types.gen";
+
+type Props<TData, TError> = {
+  dagId: string;
+  dagRunId: string;
+  groupId: string;
+  options?: Omit<UseQueryOptions<TData, TError>, "queryFn" | "queryKey">;
+  requestBody: PatchTaskInstanceBody;
+};
+
+export const usePatchTaskGroupDryRunKey = "patchTaskGroupDryRun";
+
+export const usePatchTaskGroupDryRun = <TData = PatchTaskGroupInstancesDryRunResponse, TError = unknown>({
+  dagId,
+  dagRunId,
+  groupId,
+  options,
+  requestBody,
+}: Props<TData, TError>) =>
+  useQuery<TData, TError>({
+    ...options,
+    queryFn: () =>
+      TaskInstanceService.patchTaskGroupInstancesDryRun({
+        dagId,
+        dagRunId,
+        groupId,
+        requestBody,
+      }) as TData,
+    queryKey: [
+      usePatchTaskGroupDryRunKey,
+      dagId,
+      dagRunId,
+      groupId,
+      {
+        include_downstream: requestBody.include_downstream,
+        include_future: requestBody.include_future,
+        include_past: requestBody.include_past,
+        include_upstream: requestBody.include_upstream,
+        new_state: requestBody.new_state,
+      },
+    ],
+  });


### PR DESCRIPTION
## Summary

Wires the API endpoint added in #62812 (`PATCH /dags/{dag_id}/dagRuns/{dag_run_id}/taskGroupInstances/{group_id}`) into the UI so users can mark a whole task group as `success` / `failed` from the group's header card — same surface as today's Clear button on the task group page, and same UX as the existing per-task-instance / per-DAG-run "Mark as" actions.

related: #62812

## What changed

- New components mirroring the existing pattern under `src/components/MarkAs/`:
  - `MarkAs/TaskGroup/MarkTaskGroupAsButton.tsx` — menu trigger with `success` / `failed` items, `shift+s` / `shift+f` hotkeys (matches `MarkTaskInstanceAsButton`).
  - `MarkAs/TaskGroup/MarkTaskGroupAsDialog.tsx` — confirmation dialog with `past` / `future` / `upstream` / `downstream` segmented control + affected-tasks accordion + note (matches `MarkTaskInstanceAsDialog`).
- New React Query hooks:
  - `queries/usePatchTaskGroup.ts` — mutation; on success invalidates grid + TIs + dry-run query keys.
  - `queries/usePatchTaskGroupDryRun.ts` — query feeding the affected-tasks preview.
- Wired the new button alongside `ClearTaskInstanceButton` in `pages/GroupTaskInstance/Header.tsx`.
- Translation: added `taskGroup_one` / `taskGroup_other` in `en/common.json` so the existing `markAs.button` / `markAs.title` keys (which take a `{{type}}` placeholder) work.

### Screenshot
<img width="1459" height="852" alt="Screenshot 2026-04-30 at 12 19 08" src="https://github.com/user-attachments/assets/13c78e8d-269b-4496-b580-62f8cb7aa962" />
<img width="460" height="265" alt="Screenshot 2026-04-30 at 12 19 20" src="https://github.com/user-attachments/assets/0fe1c76d-9d6c-459e-92c2-67877fb92671" />
<img width="1266" height="846" alt="Screenshot 2026-04-30 at 12 19 31" src="https://github.com/user-attachments/assets/e1421557-d81d-4ee6-bd31-35abbb73f767" />
<img width="1496" height="831" alt="Screenshot 2026-04-30 at 12 19 42" src="https://github.com/user-attachments/assets/c0b9f321-f464-4b62-9395-f44d3fc462d3" />

Tested with notes as well, past/future enabled, nested task groups etc...

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)