### PR TITLE
Enable PT007 rule to apache.kafka Provider test

### DIFF
--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py
@@ -128,9 +128,9 @@ class TestConsumeFromTopic:
     @pytest.mark.parametrize(
         ("max_messages", "expected_consumed_messages"),
         [
-            [None, 1001],  # Consume all messages
-            [100, 1000],  # max_messages < max_batch_size -> max_messages is set to default max_batch_size
-            [2000, 1001],  # max_messages > max_batch_size
+            (None, 1001),  # Consume all messages
+            (100, 1000),  # max_messages < max_batch_size -> max_messages is set to default max_batch_size
+            (2000, 1001),  # max_messages > max_batch_size
         ],
     )
     def test_operator_consume(self, max_messages, expected_consumed_messages):


### PR DESCRIPTION
## Summary

Fix 3 `PT007` violations in `providers/apache/kafka/tests/unit/apache/kafka/operators/test_consume.py` by converting `pytest.mark.parametrize` value rows from `list` to `tuple`, following ruff's default `parametrize-values-row-type = "tuple"`.

This is one step in the gradual cleanup toward removing `PT007` from the ignore list in [`pyproject.toml`](https://github.com/apache/airflow/blob/main/pyproject.toml), mirroring the same approach used for the recently completed `PT006` series.

## Why this change

`PT007` flags cases where parameter rows in `@pytest.mark.parametrize(...)` use `list` instead of `tuple`. The rule treats this as a readability / consistency issue rather than a correctness one — pytest accepts both — so the change is purely stylistic but enforces a consistent convention across the codebase.

Reference: [ruff PT007 — pytest-parametrize-values-wrong-type](https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/) (derived from [`flake8-pytest-style`](https://github.com/m-burst/flake8-pytest-style)).