### PR TITLE
Fix copied text from Rendered Templates tab including line numbers

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
@@ -62,6 +62,7 @@ const RenderedTemplatesContent = () => {
                       <Box as="pre" borderRadius="md" fontSize="sm" m={0} overflowX="auto" p={2}>
                         <SyntaxHighlighter
                           language={language}
+                          lineNumberStyle={{ userSelect: "none" }}
                           PreTag="div" // Prevents double <pre> nesting
                           showLineNumbers
                           style={style}


### PR DESCRIPTION
closes: #66143 'react-syntax-highlighter' generates line numbers as `'span>' elements, each ending with '\n'. If you are selecting and copying text manually, these
spans are included in the selection, and an extra blank line is added after every line of code on paste.
Added 'LineNumberStyle={{ userSelect: "none" }}' to 'SyntaxHighlighter' in 'RenderedTemplates'.tsx' so that line number spans are ignored in text selection. The copy button is unaffected, it copies the raw value directly.
> Part of this implementation was aided by an AI assistant named Claude (claude.ai).
