### PR TITLE
Make mongo testcontainer fixture resilient to Docker Hub flakes

### DIFF
--- a/providers/mongo/tests/conftest.py
+++ b/providers/mongo/tests/conftest.py
@@ -16,13 +16,41 @@
 # under the License.
 from __future__ import annotations
 
+import time
+
 import pytest
 from testcontainers.mongodb import MongoDbContainer
 
 pytest_plugins = "tests_common.pytest_plugin"
 
+# Pinned to a specific major to keep the image tag stable and avoid drifting
+# under us when Docker Hub re-resolves :latest on every run.
+MONGO_IMAGE = "mongo:8.0"
+
 
 @pytest.fixture(scope="session")
 def mongodb_container():
-    with MongoDbContainer("mongo:latest") as mongo:
-        yield mongo.get_connection_url()
+    # Retry container start to absorb transient Docker Hub failures (e.g.
+    # registry-auth timeouts) so a single registry blip does not cascade
+    # into setup errors across the whole mongo test suite.
+    last_exc: Exception | None = None
+    for attempt in range(3):
+        container = MongoDbContainer(MONGO_IMAGE)
+        try:
+            container.start()
+        except Exception as exc:
+            last_exc = exc
+            try:
+                container.stop()
+            except Exception:
+                pass
+            if attempt < 2:
+                time.sleep(5 * (attempt + 1))
+                continue
+            raise
+        try:
+            yield container.get_connection_url()
+        finally:
+            container.stop()
+        return
+    raise last_exc  # pragma: no cover


### PR DESCRIPTION
A transient Docker Hub auth-server timeout while pulling `mongo:latest`
caused all 33 mongo provider unit tests to fail at fixture setup with
`context deadline exceeded` — see e.g. [this Compat 3.2.1 / Py3.10 run on `main`](https://github.com/apache/airflow/actions/runs/25154778326/job/73736510149).

The fixture in `providers/mongo/tests/conftest.py` does a one-shot
`MongoDbContainer("mongo:latest")` start, so any registry blip during
the image pull cascades into the entire mongo unit-test file erroring
out at setup. This PR makes the fixture less fragile in two small ways:

- **Pin the image to `mongo:8.0`** instead of `:latest` so the tag is
  stable and does not re-resolve a moving target on every run.
- **Retry container start up to 3 times** with 5s/10s backoff, so a
  single transient registry-auth timeout no longer fails 33 tests.

No production code changes — test-fixture only.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)