### PR TITLE
i18n(ko): add missing translations(Apr 30)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -195,8 +195,8 @@
   },
   "search": {
     "advanced": {
-      "description": "Match anywhere in the value (substring search). Slower on large deployments because it can't use the default B-tree index. See the docs section on custom metadata indexes for details.",
-      "title": "Match anywhere"
+      "description": "값의 어느 위치에서든 일치하는 항목을 찾습니다(부분 문자열 검색). 기본 B-트리 인덱스를 사용할 수 없어 대규모 배포 환경에서는 속도가 느릴 수 있습니다. 자세한 내용은 문서의 커스텀 메타데이터 인덱스 섹션을 참고하세요.",
+      "title": "부분 일치"
     }
   },
   "security": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -193,6 +193,12 @@
     },
     "tooltip": "{{hotkey}}를 눌러 {{direction}}로 스크롤"
   },
+  "search": {
+    "advanced": {
+      "description": "Match anywhere in the value (substring search). Slower on large deployments because it can't use the default B-tree index. See the docs section on custom metadata indexes for details.",
+      "title": "Match anywhere"
+    }
+  },
   "security": {
     "actions": "작업",
     "permissions": "권한",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -10,6 +10,7 @@
     "maxRuns": "최대 활성 실행 수",
     "missingAndErroredRuns": "누락되었거나 오류가 발생한 실행",
     "missingRuns": "누락된 실행",
+    "overrideExistingParams": "Override parameters on existing runs",
     "permissionDenied": "드라이 런 실패: 백필 생성 권한이 없습니다.",
     "reprocessBehavior": "재처리 동작",
     "run": "백필 실행",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -10,7 +10,7 @@
     "maxRuns": "최대 활성 실행 수",
     "missingAndErroredRuns": "누락되었거나 오류가 발생한 실행",
     "missingRuns": "누락된 실행",
-    "overrideExistingParams": "Override parameters on existing runs",
+    "overrideExistingParams": "기존 실행의 매개변수 덮어쓰기",
     "permissionDenied": "드라이 런 실패: 백필 생성 권한이 없습니다.",
     "reprocessBehavior": "재처리 동작",
     "run": "백필 실행",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -43,7 +43,7 @@
   "extraLinks": "추가 링크",
   "grid": {
     "buttons": {
-      "newerRuns": "Newer runs",
+      "newerRuns": "최신 실행",
       "olderRuns": "이전 실행",
       "resetToLatest": "최신 버전으로 재설정",
       "toggleGroup": "그룹 토글"
@@ -72,7 +72,7 @@
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
     "search": {
-      "matchCount": "{{current}} of {{total}}",
+      "matchCount": "{{total}}개 중 {{current}}개",
       "noMatches": "일치하는 결과 없음",
       "placeholder": "로그 검색"
     },
@@ -82,7 +82,7 @@
   },
   "navigation": {
     "navigation": "탐색: Shift+{{arrow}}",
-    "openGraphFilters": "Task Filters: Ctrl+Shift+F",
+    "openGraphFilters": "작업 필터: Ctrl+Shift+F",
     "toggleGroup": "그룹 전환: Space"
   },
   "notFound": {
@@ -134,14 +134,14 @@
       "label": "그래프 방향"
     },
     "graphFilters": {
-      "clearFilters": "Clear Filters",
-      "durationGte": "Min duration (s)",
-      "durationGteHint": "For mapped tasks, measures total span across all instances",
-      "mapIndex": "Min. map index",
-      "mapIndexHint": "Shows mapped tasks expanded to at least this index",
-      "selectStatus": "Select status",
-      "selectTaskGroup": "Select task group",
-      "title": "Task Filters"
+      "clearFilters": "필터 초기화",
+      "durationGte": "최소 실행 시간(초)",
+      "durationGteHint": "매핑된 작업의 경우 모든 인스턴스에 걸친 총 소요 시간을 기준으로 합니다.",
+      "mapIndex": "최소 맵 인덱스",
+      "mapIndexHint": "매핑된 작업을 해당 인덱스까지 펼쳐 표시합니다.",
+      "selectStatus": "상태 선택",
+      "selectTaskGroup": "작업 그룹 선택",
+      "title": "작업 필터"
     },
     "showVersionIndicator": {
       "label": "버전 인디케이터 표시",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -43,6 +43,7 @@
   "extraLinks": "추가 링크",
   "grid": {
     "buttons": {
+      "newerRuns": "Newer runs",
       "olderRuns": "이전 실행",
       "resetToLatest": "최신 버전으로 재설정",
       "toggleGroup": "그룹 토글"
@@ -71,6 +72,7 @@
     "info": "정보",
     "noTryNumber": "시도 횟수 없음",
     "search": {
+      "matchCount": "{{current}} of {{total}}",
       "noMatches": "일치하는 결과 없음",
       "placeholder": "로그 검색"
     },
@@ -80,6 +82,7 @@
   },
   "navigation": {
     "navigation": "탐색: Shift+{{arrow}}",
+    "openGraphFilters": "Task Filters: Ctrl+Shift+F",
     "toggleGroup": "그룹 전환: Space"
   },
   "notFound": {
@@ -129,6 +132,16 @@
     },
     "graphDirection": {
       "label": "그래프 방향"
+    },
+    "graphFilters": {
+      "clearFilters": "Clear Filters",
+      "durationGte": "Min duration (s)",
+      "durationGteHint": "For mapped tasks, measures total span across all instances",
+      "mapIndex": "Min. map index",
+      "mapIndexHint": "Shows mapped tasks expanded to at least this index",
+      "selectStatus": "Select status",
+      "selectTaskGroup": "Select task group",
+      "title": "Task Filters"
     },
     "showVersionIndicator": {
       "label": "버전 인디케이터 표시",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
@@ -35,9 +35,9 @@
       "title": "{{type}} 지우기"
     },
     "clearAllMapped": {
-      "button": "Clear All Mapped Tasks",
-      "buttonTooltip": "Press shift+c to clear all mapped task instances",
-      "title": "Clear All Mapped Task Instances"
+      "button": "매핑된 작업 전체 초기화",
+      "buttonTooltip": "Shift+C를 눌러 매핑된 작업 인스턴스를 모두 초기화합니다.",
+      "title": "매핑된 작업 인스턴스 전체 초기화"
     },
     "confirmationDialog": {
       "description": "태스크가 현재 {{time}}에 사용자 {{user}} 님에 의해 시작되어, 현재 {{state}} 상태입니다. \n실행이 완료되거나 태스크 지우기 대화 상자에서 \"실행 중인 태스크 재실행 방지\" 옵션을 선택 해제할 때까지 이 태스크를 지울 수 없습니다.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
@@ -34,6 +34,11 @@
       "error": "{{type}}을(를) 지우지 못했습니다.",
       "title": "{{type}} 지우기"
     },
+    "clearAllMapped": {
+      "button": "Clear All Mapped Tasks",
+      "buttonTooltip": "Press shift+c to clear all mapped task instances",
+      "title": "Clear All Mapped Task Instances"
+    },
     "confirmationDialog": {
       "description": "태스크가 현재 {{time}}에 사용자 {{user}} 님에 의해 시작되어, 현재 {{state}} 상태입니다. \n실행이 완료되거나 태스크 지우기 대화 상자에서 \"실행 중인 태스크 재실행 방지\" 옵션을 선택 해제할 때까지 이 태스크를 지울 수 없습니다.",
       "title": "태스크 인스턴스를 삭제할 수 없습니다."


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Added missing 17 keys for ko
- missing translation list e1fc9a412331e8a88a13dfba87773d6cea7949a4
- translate to korean 7d26bd36ea233cd39e02f088b8fb3775672c193d
                                                                                                                                                     
screenshot(before & after)
`breeze vi check-translation-completeness --language ko --add-missing --remove-unused` 
<table>              
    <tr>
      <th>Before</th>                                                                                                                                                                                                                                                                                   
      <th>After</th>
    </tr>                                                                                                                                                                                                                                                                                               
    <tr>                                                                                                                                              
      <td><img width="1156" height="884" alt="image" src="https://github.com/user-attachments/assets/4e7f415e-73ca-4b6b-b688-905a516fec41" /></td>     
<td><img width="1126" height="719" alt="image" src="https://github.com/user-attachments/assets/ebd2c46e-aef1-452a-b95d-79c80683e965" /></td>                                                                                                                                                  
    </tr>                                                                                                                                                                                                                                                                                               
  </table> 


### translation ui screenshots
<details>                                                                                                                                                                      
  <summary>common.json </summary>                                                                                                                   

- search.advanced.title/description                                                                                                                                                                                 
  <img width="1303" height="738" alt="image" src="https://github.com/user-attachments/assets/5dba2de0-ca9c-4fc2-8bcd-fc9029c83c8f" />
                                                                                                                                                                                 
  </details> 

<details>                                                                                                                                                                      
  <summary>component.json </summary>                                                                                                                   
                                                     
- overrideExistingParams                                                                                                                            
  <img width="1196" height="731" alt="image" src="https://github.com/user-attachments/assets/cb6abbb0-8b6a-462b-a324-2957e864fae4" />
                                                                                                                                                                                 
  </details>  


<details>                                                                                                                                                                      
  <summary>dags.json </summary>                                                                                                                   

- clearAllMapped.buttonTooltip
  <img width="2054" height="677" alt="image" src="https://github.com/user-attachments/assets/c60f1c87-3b2d-4a52-ab7d-4a53c561cf45" />


- clearAllMapped.title
  <img width="1972" height="616" alt="image" src="https://github.com/user-attachments/assets/6b81340c-da72-4a89-ab0f-baa5110dff7d" />                                                                                                                                                                                 


- clearAllMapped.button
  <img width="1905" height="786" alt="image" src="https://github.com/user-attachments/assets/b97e5ce4-f18f-4bfd-968d-7319d123299a" />
                                                                                                                                                                                 
  </details>  

<details>                                                                                                                                                                      
  <summary>dag.json </summary>                                                                                                                   

- grid.buttons.newerRuns
  <img width="692" height="837" alt="image" src="https://github.com/user-attachments/assets/05656067-9b7a-43e6-912d-778b3468a476" />


- logs.search.matchCount
  <img width="1147" height="395" alt="image" src="https://github.com/user-attachments/assets/71edbaa7-01cf-46af-9a4b-304d7d667705" />


- navigation.openGraphFilters
  <img width="1450" height="487" alt="image" src="https://github.com/user-attachments/assets/64d3ca1d-e48f-4e55-a479-bbf5e51cfbba" />


- graphFilters.*
  <img width="1503" height="990" alt="image" src="https://github.com/user-attachments/assets/712bb31c-fa8b-43ec-99f8-69f8a95f21ca" />


                                                                                                                                                                                 
  </details>  




please review this translation
cc @kgw7401 @onestn @noeunkim 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
