### PR TITLE
[v3-2-test] KPO: treat registry 5xx errors as transient during pod startup (#65490)

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -203,6 +203,18 @@ def detect_pod_terminate_early_issues(pod: V1Pod) -> str | None:
         "temporarily unavailable",
         "timeout",
         "account limit",
+        # Upstream registry/auth outages (e.g. Docker Hub auth returning 5xx).
+        # kubelet will retry automatically; the caller's startup_timeout still
+        # bounds the total wait. These match both the underlying ErrImagePull
+        # message and the ImagePullBackOff message on kubelet >= 1.32, which
+        # appends the previous pull error to "Back-off pulling image ...".
+        # On older kubelets the bare ImagePullBackOff message carries no
+        # detail, so we fall back to the existing fail-fast path — matching
+        # "back-off pulling" unconditionally would cause a 120s wait for a
+        # genuinely missing image instead of failing fast.
+        "bad gateway",
+        "service unavailable",
+        "gateway timeout",
     ]
 
     FATAL_STATES = ["InvalidImageName", "ErrImageNeverPull"]

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/utils/test_pod_manager.py
@@ -36,6 +36,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodManager,
     PodPhase,
     XComRetrievalError,
+    detect_pod_terminate_early_issues,
     log_pod_event,
     parse_log_line,
 )
@@ -143,6 +144,61 @@ def test_log_pod_event_multiple_events():
     assert "event-uid-2" in seen_events
     assert len(seen_events) == 2
     assert mock_pod_manager.log.info.call_count == 2
+
+
+def _pod_with_waiting_container(reason: str, message: str):
+    pod = mock.MagicMock()
+    container_status = mock.MagicMock()
+    waiting_state = mock.MagicMock()
+    waiting_state.reason = reason
+    waiting_state.message = message
+    container_status.state.waiting = waiting_state
+    pod.status.container_statuses = [container_status]
+    return pod
+
+
+@pytest.mark.parametrize(
+    ("reason", "message"),
+    [
+        ("ErrImagePull", "rpc error: 502 Bad Gateway from auth.docker.io"),
+        ("ErrImagePull", "registry returned 503 Service Unavailable"),
+        ("ErrImagePull", "got 504 Gateway Timeout"),
+        # kubelet >= 1.32 appends the previous pull error to the
+        # ImagePullBackOff message, so the 5xx patterns still match.
+        ("ImagePullBackOff", 'Back-off pulling image "ubuntu:latest": 502 Bad Gateway'),
+        ("ErrImagePull", "too many requests"),
+        ("ErrImagePull", "pull QPS exceeded"),
+    ],
+)
+def test_detect_pod_terminate_early_issues_returns_none_for_transient_messages(reason, message):
+    """Transient registry/network errors should not trigger early termination.
+
+    kubelet retries image pulls automatically; `startup_timeout` bounds the
+    total wait. Returning None here keeps the monitoring loop going so those
+    retries have a chance to succeed.
+    """
+    pod = _pod_with_waiting_container(reason, message)
+    assert detect_pod_terminate_early_issues(pod) is None
+
+
+@pytest.mark.parametrize(
+    ("reason", "message"),
+    [
+        ("InvalidImageName", "Failed to apply default image tag"),
+        ("ErrImageNeverPull", "Container image pull policy is Never"),
+        ("ErrImagePull", "manifest unknown"),
+        ("ImagePullBackOff", "unauthorized: authentication required"),
+        # Bare ImagePullBackOff message (kubelet < 1.32) — must fail fast so
+        # a genuinely missing image doesn't wait out startup_timeout.
+        ("ImagePullBackOff", 'Back-off pulling image "nonexistent:latest"'),
+    ],
+)
+def test_detect_pod_terminate_early_issues_returns_error_for_fatal_messages(reason, message):
+    pod = _pod_with_waiting_container(reason, message)
+    error = detect_pod_terminate_early_issues(pod)
+    assert error is not None
+    assert reason in error
+    assert message in error
 
 
 class TestPodManager:


### PR DESCRIPTION
Backport of #65490 to `v3-2-test`.

The fix landed on `main` on April 19 but was never backported. It was
needed in the wild today: the `v3-2-test` K8s system-test job
[K8S System:CeleryExecutor-3.10-v1.30.13-false](https://github.com/apache/airflow/actions/runs/25169901734/job/73801589626)
hit `test_pod_affinity[backcompat]` failing with exactly this class of
error — Docker Hub returned a 502 Bad Gateway pulling
`docker.io/library/ubuntu:latest`, and `detect_pod_terminate_early_issues()`
on `v3-2-test` doesn't yet recognise `bad gateway` as transient, so it
aborted the pod before kubelet's next retry.

Original commit message:

> When a pod is starting, kubelet automatically retries failed image pulls
> with exponential backoff. `KubernetesPodOperator` monitors the pod via
> `detect_pod_terminate_early_issues()` and aborts early on what it deems
> a fatal pull error — but the transient-error pattern list did not cover
> registry 5xx / gateway outages. A short Docker Hub outage (502/503/504
> from `auth.docker.io` or the registry) was being classified as fatal
> and would abort the pod before kubelet's next retry, even though the
> pull would have succeeded once upstream recovered.
>
> Add \`bad gateway\`, \`service unavailable\`, \`gateway timeout\` to
> \`TRANSIENT_ERROR_PATTERNS\` so these conditions let kubelet keep
> retrying within the caller's \`startup_timeout\` budget.

Cherry-pick conflict was a single trivial import (`_parse_log_level`
doesn't exist on `v3-2-test`), resolved by keeping only the
`detect_pod_terminate_early_issues` import that the new tests need. All
11 affected unit tests pass locally, including the
`[ErrImagePull-rpc error: 502 Bad Gateway from auth.docker.io]` case
that mirrors the failing CI run.

(cherry picked from commit 938ccf3b2fc3238d36eca621a4580fd9424d161d)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)