### PR TITLE
Use contextlib.suppress instead of try-except-pass and re-enable SIM105

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -586,10 +586,9 @@ class EksHook(AwsBaseHook):
             if fd is not None:
                 os.close(fd)
             if temp_path and os.path.exists(temp_path):
-                try:
+                # Best effort cleanup
+                with contextlib.suppress(OSError):
                     os.unlink(temp_path)
-                except OSError:
-                    pass  # Best effort cleanup
 
     @contextmanager
     def generate_config_file(

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import stat
@@ -1277,10 +1278,8 @@ class EksPodOperator(KubernetesPodOperator):
                     f.write(f"export AWS_SESSION_TOKEN='{session_token}'\n")
         except Exception:
             # If fdopen fails, we need to close the file descriptor manually
-            try:
+            with contextlib.suppress(OSError):
                 os.close(fd)
-            except OSError:
-                pass
             raise
 
     def _refresh_cached_properties(self) -> None:

--- a/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
@@ -32,6 +32,8 @@ else:
     from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
+import contextlib
+
 from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 
 DAG_ID = "example_s3tables"
@@ -83,10 +85,8 @@ with DAG(
         import boto3
 
         client = boto3.client("s3tables")
-        try:
+        with contextlib.suppress(client.exceptions.NotFoundException):
             client.delete_namespace(tableBucketARN=table_bucket_arn, namespace=namespace)
-        except client.exceptions.NotFoundException:
-            pass
 
     @task(trigger_rule=TriggerRule.ALL_DONE)
     def delete_table_bucket(table_bucket_arn: str):
@@ -94,10 +94,8 @@ with DAG(
         import boto3
 
         client = boto3.client("s3tables")
-        try:
+        with contextlib.suppress(client.exceptions.NotFoundException):
             client.delete_table_bucket(tableBucketARN=table_bucket_arn)
-        except client.exceptions.NotFoundException:
-            pass
 
     bucket_arn = create_table_bucket(name=bucket_name)
     setup_namespace = create_namespace(table_bucket_arn=bucket_arn, namespace=namespace)

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -432,10 +432,9 @@ def send_workload_to_executor(
     # If timeout fires during import, redis module gets partially cached in sys.modules
     # without the 'client' submodule bound, causing AttributeError on subsequent access.
     # See: https://github.com/apache/airflow/issues/41359
-    try:
+    # Redis not installed or not using Redis backend.
+    with contextlib.suppress(ImportError):
         import redis.client  # noqa: F401
-    except ImportError:
-        pass  # Redis not installed or not using Redis backend.
 
     try:
         with timeout(seconds=OPERATION_TIMEOUT):
@@ -462,10 +461,9 @@ def fetch_celery_task_state(async_result: AsyncResult) -> tuple[str, str | Excep
     """
     # Pre-import redis.client to avoid SIGALRM interrupting module initialization.
     # See: https://github.com/apache/airflow/issues/41359
-    try:
+    # Redis not installed or not using Redis backend.
+    with contextlib.suppress(ImportError):
         import redis.client  # noqa: F401
-    except ImportError:
-        pass  # Redis not installed or not using Redis backend.
 
     try:
         with timeout(seconds=OPERATION_TIMEOUT):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -29,7 +29,7 @@ import re
 import shlex
 import string
 from collections.abc import Callable, Container, Iterable, Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, suppress
 from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
@@ -657,10 +657,8 @@ class KubernetesPodOperator(BaseOperator):
                 finally:
                     # Stop watching events
                     events_task.cancel()
-                    try:
+                    with suppress(asyncio.CancelledError):
                         await events_task
-                    except asyncio.CancelledError:
-                        pass
 
             asyncio.run(_await_pod_start())
         except PodLaunchFailedException:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import traceback
 from collections.abc import AsyncIterator
@@ -288,10 +289,8 @@ class KubernetesPodTrigger(BaseTrigger):
         finally:
             # Stop watching events
             events_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await events_task
-            except asyncio.CancelledError:
-                pass
 
         return self.define_container_state(await self._get_pod())
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable
 from unittest import mock
 
@@ -117,10 +118,8 @@ class TestKubernetesDecoratorsBase:
         self.mock_fetch_logs = mock.patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs").start()
         self.mock_fetch_logs.return_value = "logs"
 
-        try:
+        with contextlib.suppress(Exception):
             yield
-        except Exception:
-            pass
         mock.patch.stopall()
 
     def teardown_method(self):

--- a/providers/common/ai/src/airflow/providers/common/ai/durable/storage.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/durable/storage.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from functools import lru_cache
 from typing import Any
@@ -150,9 +151,8 @@ class DurableStorage:
 
     def cleanup(self) -> None:
         """Delete the cache file after successful execution."""
-        try:
+        # Best-effort cleanup
+        with contextlib.suppress(FileNotFoundError, OSError):
             self._get_path().unlink()
-        except (FileNotFoundError, OSError):
-            pass  # Best-effort cleanup
         self._cache = None
         log.debug("Durable cache cleaned up")

--- a/providers/ssh/src/airflow/providers/ssh/tunnel.py
+++ b/providers/ssh/src/airflow/providers/ssh/tunnel.py
@@ -52,6 +52,7 @@ Use the context manager interface instead.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import socket
 import threading
@@ -222,28 +223,22 @@ class SSHTunnel:
         self._running = False
         # Wake the select loop
         if self._shutdown_w is not None:
-            try:
+            with contextlib.suppress(OSError):
                 self._shutdown_w.send(b"\x00")
-            except OSError:
-                pass
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None
         # Close the shutdown pair
         for sock in (self._shutdown_r, self._shutdown_w):
             if sock is not None:
-                try:
+                with contextlib.suppress(OSError):
                     sock.close()
-                except OSError:
-                    pass
         self._shutdown_r = None
         self._shutdown_w = None
         # Close the server socket
         if self._server_socket is not None:
-            try:
+            with contextlib.suppress(OSError):
                 self._server_socket.close()
-            except OSError:
-                pass
             self._server_socket = None
 
     def _serve_forever(self) -> None:
@@ -357,10 +352,8 @@ class SSHTunnel:
     def _close_pair(local_sock: socket.socket, chan: paramiko.Channel) -> None:
         """Close both ends of a forwarded connection."""
         for closeable in (chan, local_sock):
-            try:
+            with contextlib.suppress(OSError):
                 closeable.close()
-            except OSError:
-                pass
 
 
 class AsyncSSHTunnel:


### PR DESCRIPTION
## Summary

Re-enables the `SIM105` ruff rule by:

1. Replacing all 24 `try-except-pass` blocks across 17 files with `contextlib.suppress(...)`.
2. Moving `"SIM105"` from `lint.ignore` back to `lint.extend-select` in [`pyproject.toml`](https://github.com/apache/airflow/blob/main/pyproject.toml).

## Why this change

`SIM105` was originally enabled in #49251, which fixed all `try-except-pass` violations across the codebase. It was later moved to `lint.ignore` as a side-effect of #53475 (a kubernetes pod-operator asyncio refactor) — the move was undocumented in that PR's description and appears to have been a temporary workaround to land that change.

This PR finishes the cleanup: all violations that have accumulated since then are addressed, and the rule is restored to its enforcing state.

## Verification

- `ruff check --select SIM105 .` → `All checks passed!`