### PR TITLE
Aip 94 tasks states for dag run

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -57,6 +57,7 @@ from airflowctl.api.operations import (
     PoolsOperations,
     ProvidersOperations,
     ServerResponseError,
+    TaskInstancesOperations,
     VariablesOperations,
     VersionOperations,
     XComOperations,
@@ -430,6 +431,12 @@ class Client(httpx.Client):
     def dag_runs(self):
         """Operations related to Dag runs."""
         return DagRunOperations(self)
+
+    @lru_cache()  # type: ignore[prop-decorator]
+    @property
+    def task_instances(self):
+        """Operations related to task instances."""
+        return TaskInstancesOperations(self)
 
     @lru_cache()  # type: ignore[prop-decorator]
     @property

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -68,6 +68,7 @@ from airflowctl.api.datamodels.generated import (
     ProviderCollectionResponse,
     QueuedEventCollectionResponse,
     QueuedEventResponse,
+    TaskInstanceCollectionResponse,
     TriggerDAGRunPostBody,
     VariableBody,
     VariableCollectionResponse,
@@ -637,6 +638,20 @@ class DagRunOperations(BaseOperations):
         try:
             self.response = self.client.get(f"/dags/{dag_id}/dagRuns", params=params)
             return DAGRunCollectionResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
+
+
+class TaskInstancesOperations(BaseOperations):
+    """Task instance operations."""
+
+    def list_for_dag_run(
+        self, dag_id: str, dag_run_id: str
+    ) -> TaskInstanceCollectionResponse | ServerResponseError:
+        """List task instances for a DAG run."""
+        try:
+            self.response = self.client.get(f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances")
+            return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e
 

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -261,16 +261,27 @@ ARG_AUTH_PASSWORD = Arg(
     help="The password to use for authentication",
 )
 
-# Dag / Task Commands Args
+# Dag Commands Args
 ARG_DAG_ID = Arg(
     flags=("dag_id",),
     type=str,
     help="The DAG ID",
 )
 
-ARG_DAG_RUN_ID = Arg(
-    flags=("dag_run_id",),
+# Task Commands Args
+ARG_TASK_DAG_ID = Arg(
+    flags=("--dag-id",),
+    dest="dag_id",
     type=str,
+    required=True,
+    help="The DAG ID",
+)
+
+ARG_TASK_DAG_RUN_ID = Arg(
+    flags=("--dag-run-id",),
+    dest="dag_run_id",
+    type=str,
+    required=True,
     help="The DAG run ID",
 )
 
@@ -938,8 +949,8 @@ TASK_COMMANDS = (
         help="Get task states for a DAG run",
         func=lazy_load_command("airflowctl.ctl.commands.task_command.states_for_dag_run"),
         args=(
-            ARG_DAG_ID,
-            ARG_DAG_RUN_ID,
+            ARG_TASK_DAG_ID,
+            ARG_TASK_DAG_RUN_ID,
             ARG_OUTPUT,
         ),
     ),

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -261,11 +261,17 @@ ARG_AUTH_PASSWORD = Arg(
     help="The password to use for authentication",
 )
 
-# Dag Commands Args
+# Dag / Task Commands Args
 ARG_DAG_ID = Arg(
     flags=("dag_id",),
     type=str,
-    help="The Dag ID of the Dag to pause or unpause",
+    help="The DAG ID",
+)
+
+ARG_DAG_RUN_ID = Arg(
+    flags=("dag_run_id",),
+    type=str,
+    help="The DAG run ID",
 )
 
 ARG_ACTION_ON_EXISTING_KEY = Arg(
@@ -926,6 +932,19 @@ DAG_COMMANDS = (
     ),
 )
 
+TASK_COMMANDS = (
+    ActionCommand(
+        name="states-for-dag-run",
+        help="Get task states for a DAG run",
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.states_for_dag_run"),
+        args=(
+            ARG_DAG_ID,
+            ARG_DAG_RUN_ID,
+            ARG_OUTPUT,
+        ),
+    ),
+)
+
 POOL_COMMANDS = (
     ActionCommand(
         name="import",
@@ -979,6 +998,11 @@ core_commands: list[CLICommand] = [
         name="pools",
         help="Manage Airflow pools",
         subcommands=POOL_COMMANDS,
+    ),
+    GroupCommand(
+        name="tasks",
+        help="Manage Airflow tasks",
+        subcommands=TASK_COMMANDS,
     ),
     ActionCommand(
         name="version",

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import sys
+
+import rich
+
+from airflowctl.api.client import NEW_API_CLIENT, ClientKind, ServerResponseError, provide_api_client
+from airflowctl.ctl.console_formatting import AirflowConsole
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> list[dict] | None:
+    """Get task states for a DAG run."""
+    try:
+        response = api_client.task_instances.list_for_dag_run(
+            dag_id=args.dag_id,
+            dag_run_id=args.dag_run_id,
+        )
+    except ServerResponseError as e:
+        rich.print(f"[red]Error fetching task states for DAG run {args.dag_run_id}: {e}[/red]")
+        sys.exit(1)
+
+    data = [
+        {"task_id": ti.task_id, "state": ti.state.value if ti.state is not None else None}
+        for ti in response.task_instances
+    ]
+    AirflowConsole().print_as(data=data, output=args.output)
+    return data

--- a/airflow-ctl/src/airflowctl/ctl/help_texts.yaml
+++ b/airflow-ctl/src/airflowctl/ctl/help_texts.yaml
@@ -100,3 +100,6 @@ xcom:
 plugins:
   list: "List all installed Airflow plugins"
   list-import-errors: "List all plugin import errors"
+
+taskinstances:
+  list-for-dag-run: "List task instances and their states for a specific DAG run"

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import pytest
+
+from airflowctl.api.client import ClientKind
+from airflowctl.api.datamodels.generated import TaskInstanceCollectionResponse, TaskInstanceResponse
+from airflowctl.ctl import cli_parser
+from airflowctl.ctl.commands import task_command
+
+
+def _make_task_instance(task_id: str, state: str) -> TaskInstanceResponse:
+    return TaskInstanceResponse(
+        id=uuid.uuid4(),
+        task_id=task_id,
+        dag_id="test_dag",
+        dag_run_id="test_run",
+        map_index=-1,
+        run_after=datetime.datetime(2025, 1, 1, 0, 0, 0),
+        try_number=1,
+        max_tries=1,
+        task_display_name=task_id,
+        dag_display_name="test_dag",
+        pool="default_pool",
+        pool_slots=1,
+        executor_config="{}",
+        state=state,
+    )
+
+
+class TestTaskCommand:
+    parser = cli_parser.get_parser()
+    dag_id = "test_dag"
+    dag_run_id = "test_run"
+
+    collection_response = TaskInstanceCollectionResponse(
+        task_instances=[
+            _make_task_instance("task_one", "success"),
+            _make_task_instance("task_two", "failed"),
+        ],
+        total_entries=2,
+    )
+
+    def test_states_for_dag_run(self, api_client_maker):
+        api_client = api_client_maker(
+            path=f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}/taskInstances",
+            response_json=self.collection_response.model_dump(mode="json"),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+        result = task_command.states_for_dag_run(
+            self.parser.parse_args(["tasks", "states-for-dag-run", self.dag_id, self.dag_run_id]),
+            api_client=api_client,
+        )
+        assert result == [
+            {"task_id": "task_one", "state": "success"},
+            {"task_id": "task_two", "state": "failed"},
+        ]
+
+    def test_states_for_dag_run_not_found(self, api_client_maker):
+        api_client = api_client_maker(
+            path=f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}/taskInstances",
+            response_json={"detail": "DAG run not found"},
+            expected_http_status_code=404,
+            kind=ClientKind.CLI,
+        )
+        with pytest.raises(SystemExit):
+            task_command.states_for_dag_run(
+                self.parser.parse_args(["tasks", "states-for-dag-run", self.dag_id, self.dag_run_id]),
+                api_client=api_client,
+            )

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
@@ -22,12 +22,16 @@ import uuid
 import pytest
 
 from airflowctl.api.client import ClientKind
-from airflowctl.api.datamodels.generated import TaskInstanceCollectionResponse, TaskInstanceResponse
+from airflowctl.api.datamodels.generated import (
+    TaskInstanceCollectionResponse,
+    TaskInstanceResponse,
+    TaskInstanceState,
+)
 from airflowctl.ctl import cli_parser
 from airflowctl.ctl.commands import task_command
 
 
-def _make_task_instance(task_id: str, state: str) -> TaskInstanceResponse:
+def _make_task_instance(task_id: str, state: TaskInstanceState) -> TaskInstanceResponse:
     return TaskInstanceResponse(
         id=uuid.uuid4(),
         task_id=task_id,
@@ -53,8 +57,8 @@ class TestTaskCommand:
 
     collection_response = TaskInstanceCollectionResponse(
         task_instances=[
-            _make_task_instance("task_one", "success"),
-            _make_task_instance("task_two", "failed"),
+            _make_task_instance("task_one", TaskInstanceState.SUCCESS),
+            _make_task_instance("task_two", TaskInstanceState.FAILED),
         ],
         total_entries=2,
     )
@@ -67,7 +71,9 @@ class TestTaskCommand:
             kind=ClientKind.CLI,
         )
         result = task_command.states_for_dag_run(
-            self.parser.parse_args(["tasks", "states-for-dag-run", self.dag_id, self.dag_run_id]),
+            self.parser.parse_args(
+                ["tasks", "states-for-dag-run", "--dag-id", self.dag_id, "--dag-run-id", self.dag_run_id]
+            ),
             api_client=api_client,
         )
         assert result == [
@@ -84,6 +90,8 @@ class TestTaskCommand:
         )
         with pytest.raises(SystemExit):
             task_command.states_for_dag_run(
-                self.parser.parse_args(["tasks", "states-for-dag-run", self.dag_id, self.dag_run_id]),
+                self.parser.parse_args(
+                    ["tasks", "states-for-dag-run", "--dag-id", self.dag_id, "--dag-run-id", self.dag_run_id]
+                ),
                 api_client=api_client,
             )

--- a/scripts/ci/prek/check_airflowctl_command_coverage.py
+++ b/scripts/ci/prek/check_airflowctl_command_coverage.py
@@ -50,6 +50,8 @@ EXCLUDED_METHODS = {
 }
 
 EXCLUDED_COMMANDS = {
+    # Exposed via the custom `tasks states-for-dag-run` command with dedicated unit tests
+    "taskinstances list-for-dag-run",
     "assets delete-dag-queued-events",
     "assets delete-queued-event",
     "assets delete-queued-events",

--- a/scripts/ci/prek/check_airflowctl_command_coverage.py
+++ b/scripts/ci/prek/check_airflowctl_command_coverage.py
@@ -50,7 +50,6 @@ EXCLUDED_METHODS = {
 }
 
 EXCLUDED_COMMANDS = {
-    # Exposed via the custom `tasks states-for-dag-run` command with dedicated unit tests
     "taskinstances list-for-dag-run",
     "assets delete-dag-queued-events",
     "assets delete-queued-event",


### PR DESCRIPTION
 ##### Add airflowctl tasks states-for-dag-run command
Add `airflowctl tasks states-for-dag-run --dag-id <id> --dag-run-id <run_id>` command that lists task IDs and their states for a given DAG run.
Calls `GET /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances` and  outputs `task_id` + `state` via `AirflowConsole`.
Implements part of the accepted AIP-94 (Decouple Remote Commands from airflow CLI to airflowctl). 
closes: #66175                                                                

 ---                                                      
  
Tested end-to-end against a local `airflow standalone` instance (SQLite + API server + scheduler):                                                          
                                                                              
1. Logged in via `airflowctl auth login --username admin --password <pwd>`    
2. Unpaused and triggered `example_bash_operator` with `--dag-run-id test_run_1`                                                         
3. Ran the new command and verified output across all formats:                
                                                                      
  **`-o json` (default):**
                                                                                
  ```json
  [{"task_id":"run_this_last","state":"skipped"},                               
   {"task_id":"run_after_loop","state":"success"},                      
   {"task_id":"runme_0","state":"success"},                                    
   {"task_id":"runme_1","state":"success"},                                     
   {"task_id":"runme_2","state":"success"},
   {"task_id":"also_run_this","state":"success"},                              
   {"task_id":"this_will_skip","state":"skipped"}]                              
  ```                                   
                                                                                
  **`-o table`:**                                                               
                                                                                
  ```text                                                                       
  task_id        | state                                                
  ===============+========                                                      
  run_this_last  | skipped
  run_after_loop | success                                                      
  runme_0        | success                                              
  runme_1        | success
  runme_2        | success
  also_run_this  | success                                                     
  this_will_skip | skipped                                                      
  ```                                   

  **`-o yaml`:** valid YAML list with the same data.                            
   
  **Error path** — non-existent run id:                                         
                                                                        
  ```text                                                                      
  Error fetching task states for DAG run does_not_exist: Client error message:  
  {'detail': 'DagRun with dag_id: `example_bash_operator` and run_id: `does_not_exist` was not found'}                                             
  ```                                                                           
                                    
  ### Other checks                                                              
                                                                     
  - Unit tests: 240 / 240 pass (`uv run --project airflow-ctl pytest airflow-ctl/tests/airflow_ctl`)                                               
  - Static checks: `prek run --from-ref upstream/main --stage pre-commit` — all pass
  - Help output matches AIP-94 spec: `--dag-id <id> --dag-run-id <run_id>` (both required)    