### PR TITLE
Bump registry-build timeout from 30m to 45m

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -93,7 +93,7 @@ jobs:
       disable-airflow-repo-cache: "false"
 
   build-and-publish-registry:
-    timeout-minutes: 30
+    timeout-minutes: 45
     name: "Build & Publish Registry"
     needs: [build-ci-image]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recent successful full registry builds run 26-30 minutes (most recent: 29m49s, 26m13s, 20m43s). The 30-minute job timeout left near-zero headroom -- a pypistats slowdown or transient network blip during the ~86 sequential per-provider PyPI fetches in `extract_metadata.py` would race the timeout and silently fail the registry update.

After #66100, `registry-build.yml` fires automatically on every wave-release dispatch, so this exposure is now hot.

## Fix

Bump `timeout-minutes: 30` to `45` on the `build-and-publish-registry` job. 45 minutes gives ~50% headroom over current full-build runtime without going so high that a genuinely stuck job sits around forever.

## Why not parallelise PyPI fetches instead

The real underlying cost is ~86 sequential `urllib` calls to pypistats.org and pypi.org in `extract_metadata.py:fetch_pypi_downloads` / `fetch_pypi_dates`. Parallelising those (e.g., `concurrent.futures.ThreadPoolExecutor`) would actually shrink the build, not just give it more rope. That's a meaningful follow-up but lives in `dev/registry/extract_metadata.py`, not in workflow YAML, and shouldn't block this trivial timeout bump that unblocks the immediate timeout race.

---

##### Was generative AI tooling used to co-author this PR?

- [ ]
