### PR TITLE
docs(security): clarify Task Execution API coverage in DAG-author-isolation chapter

### DIFF
--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -218,6 +218,13 @@ have access to all Dags in the Airflow installation and they can
 modify any of those Dags - no matter which Dag the task code is executed for. This means that Dag authors can
 modify state of any task instance of any Dag, and there are no finer-grained access controls to limit that access.
 
+This applies to every interface a Dag author's code can reach — including the Task Execution API
+that workers use via the Task SDK. The Execution JWT issued to a running task does **not** carry
+per-Dag authorization: a task holding a valid token can call state-mutating Execution API endpoints
+(triggering Dag runs, clearing Dag runs, reading or writing variables, connections and XComs, etc.)
+for **any** Dag in the installation. The ``ti:self`` token scope restricts cross-task-instance state
+mutation only; it is not a per-Dag access control.
+
 There is an **experimental** multi-team feature in Airflow (``[core] multi_team``) that provides UI-level and
 REST API-level RBAC isolation between teams. However, this feature **does not yet guarantee task-level isolation**.
 At the task execution level, workloads from different teams still share the same Execution API, signing keys,


### PR DESCRIPTION
## Summary
- Adds one paragraph to *Limiting Dag Author access to subset of Dags* in `airflow-core/docs/security/security_model.rst` clarifying that the chapter covers the Task Execution API (used by the Task SDK), in addition to the UI and the public REST API.
- Spells out that the Execution JWT does **not** carry per-Dag authorization, and that the `ti:self` token scope restricts cross-task-instance state mutation only — it is not a per-Dag access control.

## Test plan
- [ ] `docs/build` renders the section without RST warnings.

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions