### PR TITLE
Fix AWS auth manager batch team context

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py
@@ -288,6 +288,9 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
                     "entity_id": cast("ConnectionDetails", request["details"]).conn_id
                     if request.get("details")
                     else None,
+                    "team_name": self._get_team_name(cast("ConnectionDetails", request["details"]))
+                    if request.get("details")
+                    else None,
                 },
             )
             for request in requests
@@ -307,6 +310,9 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
                     "method": request["method"],
                     "entity_type": AvpEntities.DAG,
                     "entity_id": cast("DagDetails", request["details"]).id
+                    if request.get("details")
+                    else None,
+                    "team_name": self._get_team_name(cast("DagDetails", request["details"]))
                     if request.get("details")
                     else None,
                     "context": {
@@ -337,6 +343,9 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
                     "entity_id": cast("PoolDetails", request["details"]).name
                     if request.get("details")
                     else None,
+                    "team_name": self._get_team_name(cast("PoolDetails", request["details"]))
+                    if request.get("details")
+                    else None,
                 },
             )
             for request in requests
@@ -356,6 +365,9 @@ class AwsAuthManager(BaseAuthManager[AwsAuthManagerUser]):
                     "method": request["method"],
                     "entity_type": AvpEntities.VARIABLE,
                     "entity_id": cast("VariableDetails", request["details"]).key
+                    if request.get("details")
+                    else None,
+                    "team_name": self._get_team_name(cast("VariableDetails", request["details"]))
                     if request.get("details")
                     else None,
                 },

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -64,6 +64,12 @@ else:
 
 mock = Mock()
 
+
+def _with_team_name(details, team_name="team_a"):
+    setattr(details, "team_name", team_name)
+    return details
+
+
 SAML_METADATA_PARSED = {
     "idp": {
         "entityId": "https://portal.sso.us-east-1.amazonaws.com/saml/assertion/<assertion>",
@@ -447,7 +453,9 @@ class TestAwsAuthManager:
         mock_avp_facade.is_authorized = is_authorized
 
         result = auth_manager.is_authorized_dag(
-            method="GET", details=DagDetails(id="dag_1", team_name="team_a"), user=mock
+            method="GET",
+            details=_with_team_name(DagDetails(id="dag_1")),
+            user=mock,
         )
 
         is_authorized.assert_called_once_with(
@@ -588,7 +596,10 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_connection(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": ConnectionDetails(conn_id="test", team_name="team_a")},
+                {
+                    "method": "PUT",
+                    "details": _with_team_name(ConnectionDetails(conn_id="test")),
+                },
             ],
             user=mock,
         )
@@ -624,12 +635,15 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_dag(
             requests=[
                 {"method": "GET"},
-                {"method": "GET", "details": DagDetails(id="dag_1", team_name="team_a")},
+                {
+                    "method": "GET",
+                    "details": _with_team_name(DagDetails(id="dag_1")),
+                },
             ]
             + [
                 {
                     "method": "GET",
-                    "details": DagDetails(id="dag_1", team_name="team_a"),
+                    "details": _with_team_name(DagDetails(id="dag_1")),
                     "access_entity": dag_access_entity,
                 }
                 for dag_access_entity in (
@@ -702,7 +716,10 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_pool(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": PoolDetails(name="test", team_name="team_a")},
+                {
+                    "method": "PUT",
+                    "details": _with_team_name(PoolDetails(name="test")),
+                },
             ],
             user=mock,
         )
@@ -738,7 +755,10 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_variable(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": VariableDetails(key="test", team_name="team_a")},
+                {
+                    "method": "PUT",
+                    "details": _with_team_name(VariableDetails(key="test")),
+                },
             ],
             user=mock,
         )

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py
@@ -588,7 +588,7 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_connection(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": ConnectionDetails(conn_id="test")},
+                {"method": "PUT", "details": ConnectionDetails(conn_id="test", team_name="team_a")},
             ],
             user=mock,
         )
@@ -599,11 +599,13 @@ class TestAwsAuthManager:
                     "method": "GET",
                     "entity_type": AvpEntities.CONNECTION,
                     "entity_id": None,
+                    "team_name": None,
                 },
                 {
                     "method": "PUT",
                     "entity_type": AvpEntities.CONNECTION,
                     "entity_id": "test",
+                    "team_name": "team_a",
                 },
             ],
             user=ANY,
@@ -622,10 +624,14 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_dag(
             requests=[
                 {"method": "GET"},
-                {"method": "GET", "details": DagDetails(id="dag_1")},
+                {"method": "GET", "details": DagDetails(id="dag_1", team_name="team_a")},
             ]
             + [
-                {"method": "GET", "details": DagDetails(id="dag_1"), "access_entity": dag_access_entity}
+                {
+                    "method": "GET",
+                    "details": DagDetails(id="dag_1", team_name="team_a"),
+                    "access_entity": dag_access_entity,
+                }
                 for dag_access_entity in (
                     DagAccessEntity.AUDIT_LOG,
                     DagAccessEntity.CODE,
@@ -648,12 +654,14 @@ class TestAwsAuthManager:
                     "method": "GET",
                     "entity_type": AvpEntities.DAG,
                     "entity_id": None,
+                    "team_name": None,
                     "context": None,
                 },
                 {
                     "method": "GET",
                     "entity_type": AvpEntities.DAG,
                     "entity_id": "dag_1",
+                    "team_name": "team_a",
                     "context": None,
                 },
             ]
@@ -662,6 +670,7 @@ class TestAwsAuthManager:
                     "method": "GET",
                     "entity_type": AvpEntities.DAG,
                     "entity_id": "dag_1",
+                    "team_name": "team_a",
                     "context": {"dag_entity": {"string": dag_entity}},
                 }
                 for dag_entity in (
@@ -693,7 +702,7 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_pool(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": PoolDetails(name="test")},
+                {"method": "PUT", "details": PoolDetails(name="test", team_name="team_a")},
             ],
             user=mock,
         )
@@ -704,11 +713,13 @@ class TestAwsAuthManager:
                     "method": "GET",
                     "entity_type": AvpEntities.POOL,
                     "entity_id": None,
+                    "team_name": None,
                 },
                 {
                     "method": "PUT",
                     "entity_type": AvpEntities.POOL,
                     "entity_id": "test",
+                    "team_name": "team_a",
                 },
             ],
             user=ANY,
@@ -727,7 +738,7 @@ class TestAwsAuthManager:
         result = auth_manager.batch_is_authorized_variable(
             requests=[
                 {"method": "GET"},
-                {"method": "PUT", "details": VariableDetails(key="test")},
+                {"method": "PUT", "details": VariableDetails(key="test", team_name="team_a")},
             ],
             user=mock,
         )
@@ -738,11 +749,13 @@ class TestAwsAuthManager:
                     "method": "GET",
                     "entity_type": AvpEntities.VARIABLE,
                     "entity_id": None,
+                    "team_name": None,
                 },
                 {
                     "method": "PUT",
                     "entity_type": AvpEntities.VARIABLE,
                     "entity_id": "test",
+                    "team_name": "team_a",
                 },
             ],
             user=ANY,


### PR DESCRIPTION
## What

Propagate `team_name` from resource details when `AwsAuthManager` converts batch authorization requests into AVP facade requests for:

- connections
- DAGs
- pools
- variables

The single-resource authorization methods and the filter paths already include this team context. The batch methods were still dropping it, so bulk authorization could be evaluated with a different context than the equivalent single-resource check.

## Why

In multi-team deployments, `team_name` is part of the authorization context for these resources. Dropping it in batch requests can produce incorrect allow/deny decisions for bulk checks while single-item checks use the expected team-aware context.

## Tests

- `git diff --check`
- `python3 -m py_compile providers/amazon/src/airflow/providers/amazon/aws/auth_manager/aws_auth_manager.py providers/amazon/tests/unit/amazon/aws/auth_manager/test_aws_auth_manager.py`

I could not run the full pytest target in this local non-Breeze environment because the checkout is missing Airflow test/runtime dependencies such as `tests_common`, `time_machine`, and `pathspec`.
