### PR TITLE
Add optional object-level retention support to GcsToGcsOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
@@ -237,7 +237,8 @@ class GCSHook(GoogleBaseHook):
             Can be omitted; then the same name is used.
         :param retain_until_time: Optional datetime specifying until when the destination
             object should be retained. Requires the destination bucket to have
-            object retention enabled. If ``tzinfo`` has not been set, UTC will be assumed.
+            object retention enabled. The value is passed to the GCS client as-is;
+            timezone handling follows the GCS client behavior.
         :param retention_mode: Optional retention mode for the destination object.
             Must be ``"Locked"`` or ``"Unlocked"``. Defaults to ``"Unlocked"`` when
             ``retain_until_time`` is set. Cannot be provided without ``retain_until_time``.

--- a/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
@@ -222,6 +222,8 @@ class GCSHook(GoogleBaseHook):
         source_object: str,
         destination_bucket: str,
         destination_object: str | None = None,
+        retain_until_time: datetime | None = None,
+        retention_mode: str | None = None,
     ) -> None:
         """
         Similar to copy; supports files over 5 TB, and copying between locations and/or storage classes.
@@ -233,6 +235,12 @@ class GCSHook(GoogleBaseHook):
         :param destination_bucket: The destination of the object to copied to.
         :param destination_object: The (renamed) path of the object if given.
             Can be omitted; then the same name is used.
+        :param retain_until_time: Optional datetime specifying until when the destination
+            object should be retained. Requires the destination bucket to have
+            object retention enabled.
+        :param retention_mode: Optional retention mode for the destination object.
+            Can be ``"Locked"`` or ``"Unlocked"``. Only used when ``retain_until_time``
+            is set.
         """
         destination_object = destination_object or source_object
         if source_bucket == destination_bucket and source_object == destination_object:
@@ -248,18 +256,30 @@ class GCSHook(GoogleBaseHook):
         source_object = source_bucket.blob(blob_name=source_object)  # type: ignore[attr-defined]
         destination_bucket = client.bucket(destination_bucket)
 
-        token, bytes_rewritten, total_bytes = destination_bucket.blob(  # type: ignore[attr-defined]
+        destination_blob = destination_bucket.blob(  # type: ignore[attr-defined]
             blob_name=destination_object
-        ).rewrite(source=source_object)
+        )
+
+        token, bytes_rewritten, total_bytes = destination_blob.rewrite(source=source_object)
 
         self.log.info("Total Bytes: %s | Bytes Written: %s", total_bytes, bytes_rewritten)
 
         while token is not None:
-            token, bytes_rewritten, total_bytes = destination_bucket.blob(  # type: ignore[attr-defined]
-                blob_name=destination_object
-            ).rewrite(source=source_object, token=token)
+            token, bytes_rewritten, total_bytes = destination_blob.rewrite(source=source_object, token=token)
 
             self.log.info("Total Bytes: %s | Bytes Written: %s", total_bytes, bytes_rewritten)
+
+        if retain_until_time is not None:
+            destination_blob.retention.mode = retention_mode or "Unlocked"
+            destination_blob.retention.retain_until_time = retain_until_time
+            destination_blob.patch()
+            self.log.info(
+                "Applied retention (mode=%s, retain_until_time=%s) to object %s in bucket %s",
+                destination_blob.retention.mode,
+                retain_until_time,
+                destination_object,
+                destination_bucket.name,  # type: ignore[attr-defined]
+            )
         get_hook_lineage_collector().add_input_asset(
             context=self,
             scheme="gs",

--- a/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/gcs.py
@@ -237,10 +237,10 @@ class GCSHook(GoogleBaseHook):
             Can be omitted; then the same name is used.
         :param retain_until_time: Optional datetime specifying until when the destination
             object should be retained. Requires the destination bucket to have
-            object retention enabled.
+            object retention enabled. If ``tzinfo`` has not been set, UTC will be assumed.
         :param retention_mode: Optional retention mode for the destination object.
-            Can be ``"Locked"`` or ``"Unlocked"``. Only used when ``retain_until_time``
-            is set.
+            Must be ``"Locked"`` or ``"Unlocked"``. Defaults to ``"Unlocked"`` when
+            ``retain_until_time`` is set. Cannot be provided without ``retain_until_time``.
         """
         destination_object = destination_object or source_object
         if source_bucket == destination_bucket and source_object == destination_object:
@@ -250,6 +250,10 @@ class GCSHook(GoogleBaseHook):
             )
         if not source_bucket or not source_object:
             raise ValueError("source_bucket and source_object cannot be empty.")
+        if retention_mode is not None and retain_until_time is None:
+            raise ValueError("retention_mode cannot be set without retain_until_time.")
+        if retention_mode is not None and retention_mode not in ("Locked", "Unlocked"):
+            raise ValueError(f"retention_mode must be 'Locked' or 'Unlocked', got {retention_mode!r}.")
 
         client = self.get_conn()
         source_bucket = client.bucket(source_bucket)

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import AirflowException
@@ -31,6 +31,9 @@ from airflow.providers.google.version_compat import BaseOperator
 WILDCARD = "*"
 
 if TYPE_CHECKING:
+    from datetime import datetime
+    from typing import Any
+
     from airflow.providers.common.compat.sdk import Context
 
 
@@ -206,7 +209,7 @@ class GCSToGCSOperator(BaseOperator):
         source_object_required=False,
         exact_match=False,
         match_glob: str | None = None,
-        retain_until_time=None,
+        retain_until_time: datetime | None = None,
         retention_mode: str | None = None,
         **kwargs,
     ):

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -99,9 +99,10 @@ class GCSToGCSOperator(BaseOperator):
     :param retain_until_time: (Optional) A datetime specifying until when the destination
         objects should be retained. Requires the destination bucket to have object retention
         enabled. The retention is applied after each object is copied/moved.
+        If tzinfo has not been set, UTC will be assumed.
     :param retention_mode: (Optional) The retention mode for destination objects.
-        Can be ``"Locked"`` or ``"Unlocked"``. Only used when ``retain_until_time`` is set.
-        Defaults to ``"Unlocked"`` if not specified.
+        Must be ``"Locked"`` or ``"Unlocked"``. Defaults to ``"Unlocked"`` when
+        ``retain_until_time`` is set. Cannot be provided without ``retain_until_time``.
 
     :Example:
 

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import AirflowException
@@ -96,6 +96,12 @@ class GCSToGCSOperator(BaseOperator):
         copied.
     :param match_glob: (Optional) filters objects based on the glob pattern given by the string (
         e.g, ``'**/*/.json'``)
+    :param retain_until_time: (Optional) A datetime specifying until when the destination
+        objects should be retained. Requires the destination bucket to have object retention
+        enabled. The retention is applied after each object is copied/moved.
+    :param retention_mode: (Optional) The retention mode for destination objects.
+        Can be ``"Locked"`` or ``"Unlocked"``. Only used when ``retain_until_time`` is set.
+        Defaults to ``"Unlocked"`` if not specified.
 
     :Example:
 
@@ -199,6 +205,8 @@ class GCSToGCSOperator(BaseOperator):
         source_object_required=False,
         exact_match=False,
         match_glob: str | None = None,
+        retain_until_time=None,
+        retention_mode: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -237,6 +245,8 @@ class GCSToGCSOperator(BaseOperator):
         self.source_object_required = source_object_required
         self.exact_match = exact_match
         self.match_glob = match_glob
+        self.retain_until_time = retain_until_time
+        self.retention_mode = retention_mode
 
     def execute(self, context: Context) -> list[str]:
         hook = GCSHook(
@@ -566,7 +576,18 @@ class GCSToGCSOperator(BaseOperator):
             dest_bucket,
             destination_object,
         )
-        hook.rewrite(self.source_bucket, source_object, dest_bucket, destination_object)
+        rewrite_kwargs: dict[str, Any] = {}
+        if self.retain_until_time is not None:
+            rewrite_kwargs["retain_until_time"] = self.retain_until_time
+            if self.retention_mode is not None:
+                rewrite_kwargs["retention_mode"] = self.retention_mode
+        hook.rewrite(
+            self.source_bucket,
+            source_object,
+            dest_bucket,
+            destination_object,
+            **rewrite_kwargs,
+        )
 
         if self.move_object:
             hook.delete(self.source_bucket, source_object)

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -102,7 +102,8 @@ class GCSToGCSOperator(BaseOperator):
     :param retain_until_time: (Optional) A datetime specifying until when the destination
         objects should be retained. Requires the destination bucket to have object retention
         enabled. The retention is applied after each object is copied/moved.
-        If tzinfo has not been set, UTC will be assumed.
+        The value is passed to the GCS client as-is; timezone handling follows the
+        GCS client behavior.
     :param retention_mode: (Optional) The retention mode for destination objects.
         Must be ``"Locked"`` or ``"Unlocked"``. Defaults to ``"Unlocked"`` when
         ``retain_until_time`` is set. Cannot be provided without ``retain_until_time``.

--- a/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
@@ -528,6 +528,104 @@ class TestGCSHook:
 
     @mock.patch("google.cloud.storage.Bucket")
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_rewrite_with_retention(self, mock_service, mock_bucket):
+        source_bucket = "test-source-bucket"
+        source_object = "test-source-object"
+        destination_bucket = "test-dest-bucket"
+        destination_object = "test-dest-object"
+        retain_until = datetime(2027, 1, 1)
+
+        source_blob = mock_bucket.blob(source_object)
+
+        # Given
+        bucket_mock = mock_service.return_value.bucket
+        bucket_mock.return_value = mock_bucket
+        get_blob_method = bucket_mock.return_value.blob
+        destination_blob = get_blob_method.return_value
+        rewrite_method = destination_blob.rewrite
+        rewrite_method.side_effect = [(None, mock.ANY, mock.ANY)]
+
+        # When
+        self.gcs_hook.rewrite(
+            source_bucket=source_bucket,
+            source_object=source_object,
+            destination_bucket=destination_bucket,
+            destination_object=destination_object,
+            retain_until_time=retain_until,
+            retention_mode="Locked",
+        )
+
+        # Then
+        rewrite_method.assert_called_once_with(source=source_blob)
+        assert destination_blob.retention.mode == "Locked"
+        assert destination_blob.retention.retain_until_time == retain_until
+        destination_blob.patch.assert_called_once()
+
+    @mock.patch("google.cloud.storage.Bucket")
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_rewrite_without_retention_does_not_patch(self, mock_service, mock_bucket):
+        source_bucket = "test-source-bucket"
+        source_object = "test-source-object"
+        destination_bucket = "test-dest-bucket"
+        destination_object = "test-dest-object"
+
+        mock_bucket.blob(source_object)
+
+        # Given
+        bucket_mock = mock_service.return_value.bucket
+        bucket_mock.return_value = mock_bucket
+        get_blob_method = bucket_mock.return_value.blob
+        destination_blob = get_blob_method.return_value
+        rewrite_method = destination_blob.rewrite
+        rewrite_method.side_effect = [(None, mock.ANY, mock.ANY)]
+
+        # When
+        self.gcs_hook.rewrite(
+            source_bucket=source_bucket,
+            source_object=source_object,
+            destination_bucket=destination_bucket,
+            destination_object=destination_object,
+        )
+
+        # Then — no retention set, so patch should not be called
+        destination_blob.patch.assert_not_called()
+
+    @mock.patch("google.cloud.storage.Bucket")
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
+    def test_rewrite_with_retention_defaults_to_unlocked(self, mock_service, mock_bucket):
+        source_bucket = "test-source-bucket"
+        source_object = "test-source-object"
+        destination_bucket = "test-dest-bucket"
+        destination_object = "test-dest-object"
+        retain_until = datetime(2027, 6, 1)
+
+        source_blob = mock_bucket.blob(source_object)
+
+        # Given
+        bucket_mock = mock_service.return_value.bucket
+        bucket_mock.return_value = mock_bucket
+        get_blob_method = bucket_mock.return_value.blob
+        destination_blob = get_blob_method.return_value
+        rewrite_method = destination_blob.rewrite
+        rewrite_method.side_effect = [(None, mock.ANY, mock.ANY)]
+
+        # When — retention_mode not specified, should default to "Unlocked"
+        self.gcs_hook.rewrite(
+            source_bucket=source_bucket,
+            source_object=source_object,
+            destination_bucket=destination_bucket,
+            destination_object=destination_object,
+            retain_until_time=retain_until,
+        )
+
+        # Then
+        rewrite_method.assert_called_once_with(source=source_blob)
+        assert destination_blob.retention.mode == "Unlocked"
+        assert destination_blob.retention.retain_until_time == retain_until
+        destination_blob.patch.assert_called_once()
+
+    @mock.patch("google.cloud.storage.Bucket")
+    @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_delete(self, mock_service, mock_bucket, caplog):
         test_bucket = "test_bucket"
         test_object = "test_object"

--- a/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
@@ -495,25 +495,32 @@ class TestGCSHook:
                 destination_object=destination_object,
             )
 
-    def test_rewrite_retention_mode_without_retain_until_time(self):
-        with pytest.raises(ValueError, match="retention_mode cannot be set without retain_until_time."):
+    @pytest.mark.parametrize(
+        ("retain_until_time", "retention_mode", "expected_error"),
+        [
+            pytest.param(
+                None,
+                "Locked",
+                "retention_mode cannot be set without retain_until_time.",
+                id="mode_without_retain_until_time",
+            ),
+            pytest.param(
+                datetime(2027, 1, 1),
+                "Invalid",
+                "retention_mode must be 'Locked' or 'Unlocked'",
+                id="invalid_mode_value",
+            ),
+        ],
+    )
+    def test_rewrite_invalid_retention_params(self, retain_until_time, retention_mode, expected_error):
+        with pytest.raises(ValueError, match=expected_error):
             self.gcs_hook.rewrite(
                 source_bucket="test-source-bucket",
                 source_object="test-source-object",
                 destination_bucket="test-dest-bucket",
                 destination_object="test-dest-object",
-                retention_mode="Locked",
-            )
-
-    def test_rewrite_invalid_retention_mode(self):
-        with pytest.raises(ValueError, match="retention_mode must be 'Locked' or 'Unlocked'"):
-            self.gcs_hook.rewrite(
-                source_bucket="test-source-bucket",
-                source_object="test-source-object",
-                destination_bucket="test-dest-bucket",
-                destination_object="test-dest-object",
-                retain_until_time=datetime(2027, 1, 1),
-                retention_mode="Invalid",
+                retain_until_time=retain_until_time,
+                retention_mode=retention_mode,
             )
 
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))

--- a/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_gcs.py
@@ -495,6 +495,27 @@ class TestGCSHook:
                 destination_object=destination_object,
             )
 
+    def test_rewrite_retention_mode_without_retain_until_time(self):
+        with pytest.raises(ValueError, match="retention_mode cannot be set without retain_until_time."):
+            self.gcs_hook.rewrite(
+                source_bucket="test-source-bucket",
+                source_object="test-source-object",
+                destination_bucket="test-dest-bucket",
+                destination_object="test-dest-object",
+                retention_mode="Locked",
+            )
+
+    def test_rewrite_invalid_retention_mode(self):
+        with pytest.raises(ValueError, match="retention_mode must be 'Locked' or 'Unlocked'"):
+            self.gcs_hook.rewrite(
+                source_bucket="test-source-bucket",
+                source_object="test-source-object",
+                destination_bucket="test-dest-bucket",
+                destination_object="test-dest-object",
+                retain_until_time=datetime(2027, 1, 1),
+                retention_mode="Invalid",
+            )
+
     @mock.patch(GCS_STRING.format("GCSHook.get_conn"))
     def test_rewrite_exposes_lineage(self, mock_service, hook_lineage_collector):
         source_bucket_name = "test-source-bucket"

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -1062,3 +1062,47 @@ class TestGoogleCloudStorageToCloudStorageOperator:
         )
         result = operator.execute(None)
         assert result == [f"gs://{DESTINATION_BUCKET}/backup/file.txt"]
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_copy_single_file_with_retention(self, mock_hook):
+        retain_until = datetime(2027, 1, 1)
+        mock_hook.return_value.list.return_value = [SOURCE_OBJECT_NO_WILDCARD]
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            retain_until_time=retain_until,
+            retention_mode="Locked",
+        )
+
+        operator.execute(None)
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+            DESTINATION_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+            retain_until_time=retain_until,
+            retention_mode="Locked",
+        )
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_copy_single_file_without_retention(self, mock_hook):
+        mock_hook.return_value.list.return_value = [SOURCE_OBJECT_NO_WILDCARD]
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+        )
+
+        operator.execute(None)
+        # When no retention is set, rewrite should be called without retention kwargs
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+            DESTINATION_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+        )

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py
@@ -1088,6 +1088,29 @@ class TestGoogleCloudStorageToCloudStorageOperator:
         )
 
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
+    def test_copy_single_file_with_retention_without_mode(self, mock_hook):
+        retain_until = datetime(2027, 1, 1)
+        mock_hook.return_value.list.return_value = [SOURCE_OBJECT_NO_WILDCARD]
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=SOURCE_OBJECT_NO_WILDCARD,
+            retain_until_time=retain_until,
+        )
+
+        operator.execute(None)
+        # When retention_mode is not set, only retain_until_time should be passed
+        mock_hook.return_value.rewrite.assert_called_once_with(
+            TEST_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+            DESTINATION_BUCKET,
+            SOURCE_OBJECT_NO_WILDCARD,
+            retain_until_time=retain_until,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook")
     def test_copy_single_file_without_retention(self, mock_hook):
         mock_hook.return_value.list.return_value = [SOURCE_OBJECT_NO_WILDCARD]
         operator = GCSToGCSOperator(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #60853

Reopens #64755 (the original PR was auto-closed because I accidentally deleted my fork — restored the branch and resubmitting with the same commits).

Add optional `retain_until_time` and `retention_mode` parameters to
`GCSHook.rewrite()` and `GcsToGcsOperator`, allowing object-level
retention to be applied to destination objects immediately after
copy/move operations.

This eliminates the need for a two-step "copy → set retention" workflow,
which is error-prone in compliance-driven pipelines where partial-success
can leave objects unprotected.

**Changes:**
- `GCSHook.rewrite()` — accepts `retain_until_time` and `retention_mode`,
  applies retention via `blob.patch()` after the rewrite completes
- `GCSToGCSOperator` — accepts the same parameters, passes them through
  `_copy_single_object()` to the hook. Retention kwargs are only passed
  when `retain_until_time` is set (fully backward compatible)
- Unit tests for both hook and operator covering retention, default mode,
  and no-retention cases

**Testing:**
- All existing tests passed for providers/google/tests/unit/google/cloud/hooks/test_gcs.py and providers/google/tests/unit/google/cloud/transfers/test_gcs_to_gcs.py 
 
<img width="786" height="656" alt="image" src="https://github.com/user-attachments/assets/f4e13bd2-b649-4d32-a3d4-369caafd4f49" />

- Validated against real GCS with a retention-enabled bucket — retention
  mode and retain_until_time correctly applied and verified

<img width="786" height="515" alt="image" src="https://github.com/user-attachments/assets/4b9a0563-cbc7-441a-8b8b-c3bee6c2697e" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
