### PR TITLE
Fix launcher RBAC for fully-qualified executors

### DIFF
--- a/chart/templates/rbac/job-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/job-launcher-rolebinding.yaml
@@ -59,7 +59,8 @@ roleRef:
   {{- end }}
 subjects:
   {{- range $executor := $executors }}
-  {{- if has $executor $schedulerLaunchExecutors }}
+  {{- $executorClass := last (splitList "." ($executor | trim)) }}
+  {{- if has $executorClass $schedulerLaunchExecutors }}
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
@@ -67,7 +68,8 @@ subjects:
   {{- end }}
   {{- end }}
   {{- range $executor := $executors }}
-  {{- if has $executor $workerLaunchExecutors }}
+  {{- $executorClass := last (splitList "." ($executor | trim)) }}
+  {{- if has $executorClass $workerLaunchExecutors }}
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -59,7 +59,8 @@ roleRef:
   {{- end }}
 subjects:
   {{- range $executor := $executors }}
-  {{- if has $executor $schedulerLaunchExecutors }}
+  {{- $executorClass := last (splitList "." ($executor | trim)) }}
+  {{- if has $executorClass $schedulerLaunchExecutors }}
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
@@ -67,7 +68,8 @@ subjects:
   {{- end }}
   {{- end }}
   {{- range $executor := $executors }}
-  {{- if has $executor $workerLaunchExecutors }}
+  {{- $executorClass := last (splitList "." ($executor | trim)) }}
+  {{- if has $executorClass $workerLaunchExecutors }}
   - kind: ServiceAccount
     name: {{ include "worker.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"

--- a/helm-tests/tests/helm_tests/airflow_aux/test_job_launcher_role.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_job_launcher_role.py
@@ -28,10 +28,29 @@ class TestJobLauncher:
         ("executor", "rbac", "allow", "expected_accounts"),
         [
             ("KubernetesExecutor", True, True, ["scheduler", "worker"]),
+            (
+                "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor",
+                True,
+                True,
+                ["scheduler", "worker"],
+            ),
             ("CeleryExecutor", True, True, ["worker"]),
+            (
+                "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+                True,
+                True,
+                ["worker"],
+            ),
             ("LocalExecutor", True, True, ["scheduler"]),
+            ("airflow.executors.local_executor.LocalExecutor", True, True, ["scheduler"]),
             ("LocalExecutor", False, False, []),
             ("CeleryExecutor,KubernetesExecutor", True, True, ["scheduler", "worker"]),
+            (
+                "CeleryExecutor,airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor",
+                True,
+                True,
+                ["scheduler", "worker"],
+            ),
         ],
     )
     def test_job_launcher_rolebinding(self, executor, rbac, allow, expected_accounts):

--- a/helm-tests/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/helm-tests/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -28,10 +28,29 @@ class TestPodLauncher:
         ("executor", "rbac", "allow", "expected_accounts"),
         [
             ("KubernetesExecutor", True, True, ["scheduler", "worker"]),
+            (
+                "airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor",
+                True,
+                True,
+                ["scheduler", "worker"],
+            ),
             ("CeleryExecutor", True, True, ["worker"]),
+            (
+                "airflow.providers.celery.executors.celery_executor.CeleryExecutor",
+                True,
+                True,
+                ["worker"],
+            ),
             ("LocalExecutor", True, True, ["scheduler"]),
+            ("airflow.executors.local_executor.LocalExecutor", True, True, ["scheduler"]),
             ("LocalExecutor", False, False, []),
             ("CeleryExecutor,KubernetesExecutor", True, True, ["scheduler", "worker"]),
+            (
+                "CeleryExecutor,airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor",
+                True,
+                True,
+                ["scheduler", "worker"],
+            ),
         ],
     )
     def test_pod_launcher_role(self, executor, rbac, allow, expected_accounts):


### PR DESCRIPTION
## Why

The chart schema accepts fully-qualified executor class paths in `executor`, and the chart writes that value directly into Airflow config.

Airflow runtime also treats fully-qualified executor paths as valid, but the po launcher RoleBindings only matched short executor names such as `CeleryExecutor` and `KubernetesExecutor`.

As a result, valid configurations like `airflow.providers.celery.executors.celery_executor.CeleryExecutor` could
miss the expected scheduler or worker subjects in the generated RoleBinding,
which breaks the RBAC needed to launch pods or jobs.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
