### PR TITLE
CI: Use SQLite backend for import and OpenAPI spec generation scripts

### DIFF
--- a/scripts/ci/prek/check_imports_in_providers.py
+++ b/scripts/ci/prek/check_imports_in_providers.py
@@ -34,7 +34,7 @@ initialize_breeze_prek(__name__, __file__)
 
 cmd_result = run_command_via_breeze_shell(
     ["python3", "/opt/airflow/scripts/in_container/run_check_imports_in_providers.py"],
-    backend="postgres",
+    backend="sqlite",
     skip_environment_initialization=False,
 )
 

--- a/scripts/ci/prek/generate_openapi_spec_providers.py
+++ b/scripts/ci/prek/generate_openapi_spec_providers.py
@@ -35,7 +35,7 @@ initialize_breeze_prek(__name__, __file__)
 
 cmd_result = run_command_via_breeze_shell(
     ["python3", "/opt/airflow/scripts/in_container/run_generate_openapi_spec_providers.py", sys.argv[1]],
-    backend="postgres",
+    backend="sqlite",
     skip_environment_initialization=False,
 )
 


### PR DESCRIPTION
## Why

No need to start Postgres for these prek hooks at all, using SQLite should be enough.