### PR TITLE
Fix slow and incomplete trigger cleanup in scheduler

### DIFF
--- a/airflow-core/newsfragments/66210.bugfix.rst
+++ b/airflow-core/newsfragments/66210.bugfix.rst
@@ -1,0 +1,1 @@
+Fix slow and incomplete trigger cleanup in scheduler. Unreferenced triggers are now reliably deleted instead of accumulating without bound, and the periodic cleanup no longer scans the full ``task_instance`` table on every cycle.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3036,16 +3036,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ~exists(
                     select(AssetWatcherModel.trigger_id).where(AssetWatcherModel.trigger_id == Trigger.id)
                 ),
-                ~exists(
-                    select(Callback.trigger_id).where(
-                        Callback.trigger_id == Trigger.id, Callback.trigger_id.is_not(None)
-                    )
-                ),
-                ~exists(
-                    select(TaskInstance.trigger_id).where(
-                        TaskInstance.trigger_id == Trigger.id, TaskInstance.trigger_id.is_not(None)
-                    )
-                ),
+                ~exists(select(Callback.trigger_id).where(Callback.trigger_id == Trigger.id)),
+                ~exists(select(TaskInstance.trigger_id).where(TaskInstance.trigger_id == Trigger.id)),
             )
             .execution_options(synchronize_session="fetch")
         )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -3033,9 +3033,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session.execute(
             delete(Trigger)
             .where(
-                Trigger.id.not_in(select(AssetWatcherModel.trigger_id)),
-                Trigger.id.not_in(select(Callback.trigger_id)),
-                Trigger.id.not_in(select(TaskInstance.trigger_id)),
+                ~exists(
+                    select(AssetWatcherModel.trigger_id).where(AssetWatcherModel.trigger_id == Trigger.id)
+                ),
+                ~exists(
+                    select(Callback.trigger_id).where(
+                        Callback.trigger_id == Trigger.id, Callback.trigger_id.is_not(None)
+                    )
+                ),
+                ~exists(
+                    select(TaskInstance.trigger_id).where(
+                        TaskInstance.trigger_id == Trigger.id, TaskInstance.trigger_id.is_not(None)
+                    )
+                ),
             )
             .execution_options(synchronize_session="fetch")
         )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -7504,6 +7504,24 @@ class TestSchedulerJob:
         self.job_runner._remove_unreferenced_triggers(session=session)
         assert session.scalars(select(Trigger.classpath)).one_or_none() == expected_classpath
 
+    @pytest.mark.need_serialized_dag(False)
+    def test_delete_unreferenced_triggers_with_null_trigger_id_ti(self, dag_maker, session):
+        """Unreferenced triggers are deleted even when other TIs have ``trigger_id IS NULL``."""
+        self.job_runner = SchedulerJobRunner(job=Job())
+
+        with dag_maker(dag_id="dag", session=session):
+            EmptyOperator(task_id="task")
+        dag_maker.create_dagrun()
+
+        unreferenced = Trigger(
+            classpath="airflow.providers.standard.triggers.file.FileDeleteTrigger", kwargs={}
+        )
+        session.add(unreferenced)
+        session.flush()
+
+        self.job_runner._remove_unreferenced_triggers(session=session)
+        assert session.scalar(select(func.count()).select_from(Trigger)) == 0
+
     @patch("airflow.serialization.serialized_objects.SerializedDAG.create_dagrun")
     def test_misconfigured_dags_doesnt_crash_scheduler(self, mock_create, session, dag_maker, caplog):
         """Test that if dagrun creation throws an exception, the scheduler doesn't crash"""


### PR DESCRIPTION
The `_remove_unreferenced_triggers` cleanup runs on every `parsing_cleanup_interval` and was using `NOT IN` subqueries against `task_instance`, `callback`, and `asset_watcher`. This caused two distinct problems:

1. **Correctness — orphan triggers were never deleted.** `task_instance.trigger_id` and `callback.trigger_id` are nullable. With `NOT IN`, a single `NULL` row in the subquery makes the predicate `UNKNOWN` for every outer row. In production almost every `task_instance` has `trigger_id IS NULL` (only deferred tasks set it), so unreferenced triggers were accumulating without bound. Thanks @kaxil for spotting this.
2. **Performance — full sequential scan every cycle.** PostgreSQL can't use a hashed subplan against a nullable column, so the query was forcing a sequential scan with Materialize over `task_instance`. On large deployments this was a catastrophic plan that ran on every parsing cleanup interval.

Rewrite the three subqueries as `NOT EXISTS` correlated subqueries. This both fixes the orphan-trigger leak and lets PostgreSQL use the existing `ti_trigger_id` and `idx_awm_trigger_id` indexes (short-circuiting per row instead of scanning).

Adds a regression test that pre-populates a `task_instance` with `trigger_id IS NULL` and asserts an unreferenced trigger is actually deleted — this would have failed under the old `NOT IN` query.

No schema changes required.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-opus-4-7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)