### PR TITLE
[AIP-94] airflowctl tasks: add clear and states-for-dag-run commands

### DIFF
--- a/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
+++ b/airflow-ctl-tests/tests/airflowctl_tests/test_airflowctl_commands.py
@@ -126,6 +126,9 @@ TEST_COMMANDS = [
     # Plugins command
     "plugins list",
     "plugins list-import-errors",
+    # Tasks commands
+    "tasks states-for-dag-run --dag-id=example_bash_operator --dag-run-id=run_1 --limit=5",
+    "tasks clear --dag-id=example_bash_operator --dag-run-id=run_1",
 ]
 
 NO_AUTH_TEST_COMMANDS = [

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -948,48 +948,21 @@ class TaskOperations(BaseOperations):
     def clear(
         self,
         dag_id: str,
-        dry_run: bool = False,
-        only_failed: bool = True,
-        only_running: bool = False,
-        reset_dag_runs: bool = True,
-        task_ids: list[str] | None = None,
-        dag_run_id: str | None = None,
-        include_upstream: bool = False,
-        include_downstream: bool = False,
-        include_future: bool = False,
-        include_past: bool = False,
-    ) -> ClearTaskInstanceCollectionResponse | ServerResponseError:
+        body: ClearTaskInstancesBody,
+    ) -> TaskInstanceCollectionResponse | ServerResponseError:
         """
         Clear task instances for a Dag run.
 
         Args:
             dag_id: The Dag ID.
-            dry_run: Perform a dry run (no actual changes).
-            only_failed: Only clear failed task instances.
-            only_running: Only clear running task instances.
-            reset_dag_runs: Reset Dag runs.
-            task_ids: Comma-separated list of task IDs to clear.
-            dag_run_id: The Dag run ID.
-            include_upstream: Include upstream tasks.
-            include_downstream: Include downstream tasks.
-            include_future: Include future Dag runs.
-            include_past: Include past Dag runs.
+            body: ClearTaskInstancesBody containing the clear parameters.
         """
         try:
-            body = {
-                "dry_run": dry_run,
-                "only_failed": only_failed,
-                "only_running": only_running,
-                "reset_dag_runs": reset_dag_runs,
-                "task_ids": task_ids,
-                "dag_run_id": dag_run_id,
-                "include_upstream": include_upstream,
-                "include_downstream": include_downstream,
-                "include_future": include_future,
-                "include_past": include_past,
-            }
-            self.response = self.client.post(f"dags/{dag_id}/clearTaskInstances", json=body)
-            return ClearTaskInstanceCollectionResponse.model_validate_json(self.response.content)
+            self.response = self.client.post(
+                f"dags/{dag_id}/clearTaskInstances",
+                json=body.model_dump(mode="json", exclude_unset=True),
+            )
+            return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e
 

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -945,3 +945,52 @@ class TaskOperations(BaseOperations):
         except ServerResponseError as e:
             raise e
 
+    def clear(
+        self,
+        dag_id: str,
+        dry_run: bool = False,
+        only_failed: bool = True,
+        only_running: bool = False,
+        reset_dag_runs: bool = True,
+        task_ids: list[str] | None = None,
+        dag_run_id: str | None = None,
+        include_upstream: bool = False,
+        include_downstream: bool = False,
+        include_future: bool = False,
+        include_past: bool = False,
+    ) -> ClearTaskInstanceCollectionResponse | ServerResponseError:
+        """
+        Clear task instances for a Dag run.
+
+        Args:
+            dag_id: The Dag ID.
+            dry_run: Perform a dry run (no actual changes).
+            only_failed: Only clear failed task instances.
+            only_running: Only clear running task instances.
+            reset_dag_runs: Reset Dag runs.
+            task_ids: Comma-separated list of task IDs to clear.
+            dag_run_id: The Dag run ID.
+            include_upstream: Include upstream tasks.
+            include_downstream: Include downstream tasks.
+            include_future: Include future Dag runs.
+            include_past: Include past Dag runs.
+        """
+        try:
+            body = {
+                "dry_run": dry_run,
+                "only_failed": only_failed,
+                "only_running": only_running,
+                "reset_dag_runs": reset_dag_runs,
+                "task_ids": task_ids,
+                "dag_run_id": dag_run_id,
+                "include_upstream": include_upstream,
+                "include_downstream": include_downstream,
+                "include_future": include_future,
+                "include_past": include_past,
+            }
+            self.response = self.client.post(f"dags/{dag_id}/clearTaskInstances", json=body)
+            return ClearTaskInstanceCollectionResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
+
+

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -920,3 +920,28 @@ class PluginsOperations(BaseOperations):
             return PluginImportErrorCollectionResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e
+
+
+class TaskOperations(BaseOperations):
+    """Task instance operations."""
+
+    def states_for_dag_run(
+        self, dag_id: str, dag_run_id: str, limit: int = 100
+    ) -> TaskInstanceCollectionResponse | ServerResponseError:
+        """
+        Get task instance states for a DAG run.
+
+        Args:
+            dag_id: The DAG ID.
+            dag_run_id: The DAG run ID.
+            limit: Maximum number of task instances to return.
+        """
+        try:
+            self.response = self.client.get(
+                f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances",
+                params={"limit": limit},
+            )
+            return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
+

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -948,7 +948,7 @@ POOL_COMMANDS = (
 TASKS_COMMANDS = (
     ActionCommand(
         name="clear",
-        help="Clear task instances for a DAG run",
+        help="Clear task instances for a Dag run",
         func=lazy_load_command("airflowctl.ctl.commands.task_command.clear"),
         args=(
             ARG_DAG_ID,
@@ -988,7 +988,7 @@ TASKS_COMMANDS = (
     ),
     ActionCommand(
         name="states-for-dag-run",
-        help="Get task instance states for a DAG run",
+        help="Get task instance states for a Dag run",
         func=lazy_load_command("airflowctl.ctl.commands.task_command.states_for_dag_run"),
         args=(
             ARG_DAG_ID,

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -944,6 +944,66 @@ POOL_COMMANDS = (
     ),
 )
 
+
+TASKS_COMMANDS = (
+    ActionCommand(
+        name="clear",
+        help="Clear task instances for a DAG run",
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.clear"),
+        args=(
+            ARG_DAG_ID,
+            ARG_OUTPUT,
+            ARG_DAG_RUN_ID,
+            Arg(
+                flags=("--task-ids",),
+                help="Comma-separated list of task IDs to clear",
+            ),
+            Arg(
+                flags=("--dry-run",),
+                action="store_true",
+                help="Perform a dry run (no actual changes)",
+            ),
+            Arg(
+                flags=("--only-failed",),
+                action="store_true",
+                default=True,
+                help="Only clear failed task instances",
+            ),
+            Arg(
+                flags=("--only-running",),
+                action="store_true",
+                help="Only clear running task instances",
+            ),
+            Arg(
+                flags=("--upstream",),
+                action="store_true",
+                help="Include upstream tasks",
+            ),
+            Arg(
+                flags=("--downstream",),
+                action="store_true",
+                help="Include downstream tasks",
+            ),
+        ),
+    ),
+    ActionCommand(
+        name="states-for-dag-run",
+        help="Get task instance states for a DAG run",
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.states_for_dag_run"),
+        args=(
+            ARG_DAG_ID,
+            ARG_DAG_RUN_ID,
+            ARG_OUTPUT,
+            Arg(
+                flags=("--limit",),
+                type=int,
+                default=100,
+                help="Maximum number of task instances to return",
+            ),
+        ),
+    ),
+)
+
 VARIABLE_COMMANDS = (
     ActionCommand(
         name="import",
@@ -994,6 +1054,11 @@ core_commands: list[CLICommand] = [
         name="variables",
         help="Manage Airflow variables",
         subcommands=VARIABLE_COMMANDS,
+    ),
+    GroupCommand(
+        name="tasks",
+        help="Manage Airflow task instances",
+        subcommands=TASKS_COMMANDS,
     ),
 ]
 # Add generated group commands

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -31,7 +31,7 @@ from airflowctl.api.datamodels.generated import (
     ClearTaskInstancesBody,
     ClearTaskInstanceCollectionResponse,
 )
-from airflowctl.api.operations import TaskOperations
+
 from airflowctl.ctl.console_formatting import AirflowConsole
 
 
@@ -39,20 +39,23 @@ from airflowctl.ctl.console_formatting import AirflowConsole
 def clear(args, api_client=NEW_API_CLIENT) -> None:
     """Clear task instances for a Dag run."""
     try:
-        ops = TaskOperations(client=api_client.client)
-        cleared = ops.clear(
-            dag_id=args.dag_id,
-            dry_run=getattr(args, "dry_run", False),
-            only_failed=getattr(args, "only_failed", True),
-            only_running=getattr(args, "only_running", False),
-            reset_dag_runs=getattr(args, "reset_dag_runs", True),
-            task_ids=getattr(args, "task_ids", None),
+        task_ids = getattr(args, "task_ids", None)
+        if task_ids:
+            task_ids = task_ids.split(",")
+
+        body = ClearTaskInstancesBody(
+            dry_run=getattr(args, "dry_run", False) or False,
+            only_failed=getattr(args, "only_failed", True) or True,
+            only_running=getattr(args, "only_running", False) or False,
+            reset_dag_runs=getattr(args, "reset_dag_runs", True) or True,
+            task_ids=task_ids,
             dag_run_id=getattr(args, "dag_run_id", None),
-            include_upstream=getattr(args, "upstream", False),
-            include_downstream=getattr(args, "downstream", False),
-            include_future=getattr(args, "include_future", False),
-            include_past=getattr(args, "include_past", False),
+            include_upstream=getattr(args, "upstream", False) or False,
+            include_downstream=getattr(args, "downstream", False) or False,
+            include_future=getattr(args, "include_future", False) or False,
+            include_past=getattr(args, "include_past", False) or False,
         )
+        cleared = api_client.client.tasks.clear(dag_id=args.dag_id, body=body)
         rich.print(
             f"[green]Cleared {len(cleared.task_instances)} task instance(s) for Dag {args.dag_id}[/green]"
         )

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -71,8 +71,7 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
 def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
     """Get task instance states for a Dag run."""
     try:
-        ops = TaskOperations(client=api_client.client)
-        tis = ops.states_for_dag_run(args.dag_id, args.dag_run_id, getattr(args, "limit", 100))
+        tis = api_client.client.tasks.list(dag_id=args.dag_id, dag_run_id=args.dag_run_id)
         rich.print(f"[green]Found {len(tis.task_instances)} task instance(s)[/green]")
         AirflowConsole().print_as(
             data=[t.model_dump() for t in tis.task_instances],

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -30,8 +30,8 @@ from airflowctl.api.client import (
 from airflowctl.api.datamodels.generated import (
     ClearTaskInstancesBody,
     ClearTaskInstanceCollectionResponse,
-    TaskInstanceCollectionResponse,
 )
+from airflowctl.api.operations import TaskOperations
 from airflowctl.ctl.console_formatting import AirflowConsole
 
 
@@ -75,14 +75,8 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
 def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
     """Get task instance states for a DAG run."""
     try:
-        response = api_client.client.get(
-            f"dags/{args.dag_id}/dagRuns/{args.dag_run_id}/taskInstances",
-            params={"limit": getattr(args, "limit", 100)},
-        )
-        if response.status_code >= 400:
-            rich.print(f"[red]Error: {response.status_code} {response.text}[/red]")
-            sys.exit(1)
-        tis = TaskInstanceCollectionResponse.model_validate_json(response.content)
+        ops = TaskOperations(client=api_client.client)
+        tis = ops.states_for_dag_run(args.dag_id, args.dag_run_id, getattr(args, "limit", 100))
         rich.print(f"[green]Found {len(tis.task_instances)} task instance(s)[/green]")
         AirflowConsole().print_as(
             data=[t.model_dump() for t in tis.task_instances],

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Task commands for airflowctl."""
+from __future__ import annotations
+
+import sys
+
+import rich
+
+from airflowctl.api.client import (
+    NEW_API_CLIENT,
+    ClientKind,
+    ServerResponseError,
+    provide_api_client,
+)
+from airflowctl.api.datamodels.generated import (
+    ClearTaskInstancesBody,
+    ClearTaskInstanceCollectionResponse,
+    TaskInstanceCollectionResponse,
+)
+from airflowctl.ctl.console_formatting import AirflowConsole
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def clear(args, api_client=NEW_API_CLIENT) -> None:
+    """Clear task instances for a DAG run."""
+    try:
+        body = ClearTaskInstancesBody(
+            dry_run=getattr(args, "dry_run", False),
+            only_failed=getattr(args, "only_failed", True),
+            only_running=getattr(args, "only_running", False),
+            reset_dag_runs=getattr(args, "reset_dag_runs", True),
+            task_ids=getattr(args, "task_ids", None),
+            dag_run_id=getattr(args, "dag_run_id", None),
+            include_upstream=getattr(args, "upstream", False),
+            include_downstream=getattr(args, "downstream", False),
+            include_future=getattr(args, "include_future", False),
+            include_past=getattr(args, "include_past", False),
+        )
+        response = api_client.client.post(
+            f"dags/{args.dag_id}/clearTaskInstances",
+            json=body.model_dump(mode="json", exclude_none=True),
+        )
+        if response.status_code >= 400:
+            rich.print(f"[red]Error: {response.status_code} {response.text}[/red]")
+            sys.exit(1)
+        cleared = ClearTaskInstanceCollectionResponse.model_validate_json(response.content)
+        rich.print(
+            f"[green]Cleared {len(cleared.task_instances)} task instance(s) for DAG {args.dag_id}[/green]"
+        )
+        AirflowConsole().print_as(
+            data=[t.model_dump() for t in cleared.task_instances],
+            output=args.output,
+        )
+    except ServerResponseError as e:
+        rich.print(f"[red]Error clearing task instances: {e}[/red]")
+        sys.exit(1)
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
+    """Get task instance states for a DAG run."""
+    try:
+        response = api_client.client.get(
+            f"dags/{args.dag_id}/dagRuns/{args.dag_run_id}/taskInstances",
+            params={"limit": getattr(args, "limit", 100)},
+        )
+        if response.status_code >= 400:
+            rich.print(f"[red]Error: {response.status_code} {response.text}[/red]")
+            sys.exit(1)
+        tis = TaskInstanceCollectionResponse.model_validate_json(response.content)
+        rich.print(f"[green]Found {len(tis.task_instances)} task instance(s)[/green]")
+        AirflowConsole().print_as(
+            data=[t.model_dump() for t in tis.task_instances],
+            output=args.output,
+        )
+    except ServerResponseError as e:
+        rich.print(f"[red]Error getting task instances: {e}[/red]")
+        sys.exit(1)

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -39,7 +39,9 @@ from airflowctl.ctl.console_formatting import AirflowConsole
 def clear(args, api_client=NEW_API_CLIENT) -> None:
     """Clear task instances for a Dag run."""
     try:
-        body = ClearTaskInstancesBody(
+        ops = TaskOperations(client=api_client.client)
+        cleared = ops.clear(
+            dag_id=args.dag_id,
             dry_run=getattr(args, "dry_run", False),
             only_failed=getattr(args, "only_failed", True),
             only_running=getattr(args, "only_running", False),
@@ -51,14 +53,6 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
             include_future=getattr(args, "include_future", False),
             include_past=getattr(args, "include_past", False),
         )
-        response = api_client.client.post(
-            f"dags/{args.dag_id}/clearTaskInstances",
-            json=body.model_dump(mode="json", exclude_none=True),
-        )
-        if response.status_code >= 400:
-            rich.print(f"[red]Error: {response.status_code} {response.text}[/red]")
-            sys.exit(1)
-        cleared = ClearTaskInstanceCollectionResponse.model_validate_json(response.content)
         rich.print(
             f"[green]Cleared {len(cleared.task_instances)} task instance(s) for Dag {args.dag_id}[/green]"
         )
@@ -69,7 +63,6 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
     except ServerResponseError as e:
         rich.print(f"[red]Error clearing task instances: {e}[/red]")
         sys.exit(1)
-
 
 @provide_api_client(kind=ClientKind.CLI)
 def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -37,7 +37,7 @@ from airflowctl.ctl.console_formatting import AirflowConsole
 
 @provide_api_client(kind=ClientKind.CLI)
 def clear(args, api_client=NEW_API_CLIENT) -> None:
-    """Clear task instances for a DAG run."""
+    """Clear task instances for a Dag run."""
     try:
         body = ClearTaskInstancesBody(
             dry_run=getattr(args, "dry_run", False),
@@ -60,7 +60,7 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
             sys.exit(1)
         cleared = ClearTaskInstanceCollectionResponse.model_validate_json(response.content)
         rich.print(
-            f"[green]Cleared {len(cleared.task_instances)} task instance(s) for DAG {args.dag_id}[/green]"
+            f"[green]Cleared {len(cleared.task_instances)} task instance(s) for Dag {args.dag_id}[/green]"
         )
         AirflowConsole().print_as(
             data=[t.model_dump() for t in cleared.task_instances],
@@ -73,7 +73,7 @@ def clear(args, api_client=NEW_API_CLIENT) -> None:
 
 @provide_api_client(kind=ClientKind.CLI)
 def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
-    """Get task instance states for a DAG run."""
+    """Get task instance states for a Dag run."""
     try:
         ops = TaskOperations(client=api_client.client)
         tis = ops.states_for_dag_run(args.dag_id, args.dag_run_id, getattr(args, "limit", 100))

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1868,6 +1868,45 @@ class TestTaskOperations:
         assert len(response.task_instances) == 1
         assert response.task_instances[0].task_id == "task_1"
 
+    def test_clear(self):
+        """Test clear calls the correct endpoint with correct params."""
+        import httpx
+        from airflowctl.api.datamodels.generated import ClearTaskInstanceCollectionResponse, TaskInstanceResponse
+
+        clear_response = ClearTaskInstanceCollectionResponse(
+            task_instances=[
+                TaskInstanceResponse(
+                    task_id="task_1",
+                    dag_id="example_dag",
+                    dag_run_id="run_1",
+                    logical_date="2025-01-01T00:00:00Z",
+                    start_date="2025-01-01T00:01:00Z",
+                    end_date="2025-01-01T00:05:00Z",
+                    duration=240.0,
+                    state="cleared",
+                    try_number=1,
+                    max_tries=2,
+                    task_display_name="Task 1",
+                )
+            ],
+            total_entries=1,
+        )
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/dags/example_dag/clearTaskInstances"
+            body = json.loads(request.content)
+            assert body["only_failed"] is True
+            return httpx.Response(200, json=json.loads(clear_response.model_dump_json()))
+
+        from airflowctl.api.operations import make_api_client, TaskOperations
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        ops = TaskOperations(client=client.client)
+        response = ops.clear("example_dag", only_failed=True)
+        assert response.total_entries == 1
+        assert len(response.task_instances) == 1
+        assert response.task_instances[0].state == "cleared"
+
+
             return httpx.Response(200, json=json.loads(self.plugin_collection_response.model_dump_json()))
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1871,9 +1871,9 @@ class TestTaskOperations:
     def test_clear(self):
         """Test clear calls the correct endpoint with correct params."""
         import httpx
-        from airflowctl.api.datamodels.generated import ClearTaskInstanceCollectionResponse, TaskInstanceResponse
+        from airflowctl.api.datamodels.generated import ClearTaskInstancesBody, TaskInstanceCollectionResponse, TaskInstanceResponse
 
-        clear_response = ClearTaskInstanceCollectionResponse(
+        clear_response = TaskInstanceCollectionResponse(
             task_instances=[
                 TaskInstanceResponse(
                     task_id="task_1",
@@ -1901,7 +1901,8 @@ class TestTaskOperations:
         from airflowctl.api.operations import make_api_client, TaskOperations
         client = make_api_client(transport=httpx.MockTransport(handle_request))
         ops = TaskOperations(client=client.client)
-        response = ops.clear("example_dag", only_failed=True)
+        body = ClearTaskInstancesBody(only_failed=True)
+        response = ops.clear("example_dag", body=body)
         assert response.total_entries == 1
         assert len(response.task_instances) == 1
         assert response.task_instances[0].state == "cleared"

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1825,6 +1825,49 @@ class TestPluginsOperations:
 
         def handle_request(request: httpx.Request) -> httpx.Response:
             assert request.url.path == ("/api/v2/plugins")
+
+
+class TestTaskOperations:
+    """Unit tests for TaskOperations."""
+
+    def test_states_for_dag_run(self):
+        """Test states_for_dag_run calls the correct endpoint with correct params."""
+        import httpx
+        from airflowctl.api.datamodels.generated import TaskInstanceCollectionResponse, TaskInstanceResponse
+
+        task_response = TaskInstanceCollectionResponse(
+            task_instances=[
+                TaskInstanceResponse(
+                    task_id="task_1",
+                    dag_id="example_dag",
+                    dag_run_id="run_1",
+                    logical_date="2025-01-01T00:00:00Z",
+                    start_date="2025-01-01T00:01:00Z",
+                    end_date="2025-01-01T00:05:00Z",
+                    duration=240.0,
+                    state="success",
+                    try_number=1,
+                    max_tries=2,
+                    task_display_name="Task 1",
+                )
+            ],
+            total_entries=1,
+        )
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/dags/example_dag/dagRuns/run_1/taskInstances"
+            params = dict(request.url.params)
+            assert params.get("limit") == "10"
+            return httpx.Response(200, json=json.loads(task_response.model_dump_json()))
+
+        from airflowctl.api.operations import make_api_client, TaskOperations
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        ops = TaskOperations(client=client.client)
+        response = ops.states_for_dag_run("example_dag", "run_1", limit=10)
+        assert response.total_entries == 1
+        assert len(response.task_instances) == 1
+        assert response.task_instances[0].task_id == "task_1"
+
             return httpx.Response(200, json=json.loads(self.plugin_collection_response.model_dump_json()))
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))


### PR DESCRIPTION
## Summary

Implements two new subcommands under `airflowctl tasks`:

- `airflowctl tasks clear` — clear task instances via `POST /api/v2/dags/{dag_id}/clearTaskInstances`
- `airflowctl tasks states-for-dag-run` — get task instance states via `GET /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances`

closes: apache/airflow#66176 and apache/airflow#66175.