### PR TITLE
UI: Fix manual copy from Rendered Templates tab adding extra blank lines

### DIFF
--- a/airflow-core/newsfragments/66221.bugfix.rst
+++ b/airflow-core/newsfragments/66221.bugfix.rst
@@ -1,0 +1,1 @@
+Fix manual text selection and copy from the Rendered Templates tab so pasted content preserves the expected line structure.

--- a/airflow-core/newsfragments/66221.bugfix.rst
+++ b/airflow-core/newsfragments/66221.bugfix.rst
@@ -1,1 +1,0 @@
-Fix manual text selection and copy from the Rendered Templates tab so pasted content preserves the expected line structure.

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/RenderedTemplates.tsx
@@ -62,6 +62,7 @@ const RenderedTemplatesContent = () => {
                       <Box as="pre" borderRadius="md" fontSize="sm" m={0} overflowX="auto" p={2}>
                         <SyntaxHighlighter
                           language={language}
+                          lineProps={{ style: { display: "block" } }}
                           PreTag="div" // Prevents double <pre> nesting
                           showLineNumbers
                           style={style}


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

When manually selecting and copying text from the Rendered Templates tab, the pasted result contained an extra blank line. The copy button is unaffected.                                                                                                                                                                                                                                     

- bug video
   
  https://github.com/user-attachments/assets/ce494b8d-15ca-42c5-80b5-95303b2dc42b


# Root cause                                                                                                                                                                                                                                                             
During clipboard serialization, browsers reconstruct the copied text from that flex-based DOM structure rather than from the original source string, which can introduce unwanted line breaks and spacing in the pasted result.

 With react-syntax-highlighter, `display: 'flex'` is set:
```js
  // react-syntax-highlighter/src/highlight.js
  if (wrapLongLines & showLineNumbers) {     // wrapLongLines and showLineNumbers are true                                                                                                                                                                                                                       
    properties.style = { display: 'flex', ...properties.style };
  }                                                                                                                                                                                                                                                                             
```

html results like this:
```html
  <span style="display: flex;"> <!-- `display: flex` -->
    <span class="linenumber">1</span>
    <span>SELECT</span>
    <span> customer_id</span>
    ...
  </span>
```


### w3 specification (https://www.w3.org/TR/css-flexbox-1/#flex-items)
`display: flex` turns each token span into a flex item, and flex items are blockified. As a result, copied text is serialized from separate layout items, which can introduce unwanted newlines

<img width="772" height="99" alt="image" src="https://github.com/user-attachments/assets/5efb350c-ac99-4016-a7fa-05b2986f85e0" />

### browser implementation
<details>
<summary>Chrome</summary>

Chrome copies selected text through TextIterator.

  If the selected DOM node is block-like, Chrome adds newline boundaries around it. Then Chrome emits the newline before the node:

[text_iterator.cc#664](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/editing/iterators/text_iterator.cc#664)
```cc
  static bool ShouldEmitNewlinesBeforeAndAfterNode(const Node& node) { 
    // Block flow (versus inline flow) is represented by having
    // a newline both before and after the element.

    LayoutObject* r = node.GetLayoutObject();

    return !r->IsInline() && r->IsLayoutBlock() &&
           !r->IsFloatingOrOutOfFlowPositioned() && !r->IsBody();
  }
```

[text_iterator.cc#845](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/editing/iterators/text_iterator.cc#845)
```cc
  if (ShouldEmitNewlineBeforeNode(*node_)) {
    EmitChar16BeforeNode('\n', *node_);
  }
```

Because the parent is display:flex, each child <span> becomes a flex item. Flex items are blockified by the CSS spec. So Chrome sees the token spans more like block-like layout items, not one inline sentence.
Then TextIterator adds newline boundaries while producing clipboard text/plain.

</details>

<details>
<summary>Firefox</summary>
Firefox plaintext clipboard serialization checks computed CSS block-level style and schedules a line break for preformatted block elements.
  

[nsPlainTextSerializer.cpp#L1801-L1807](https://github.com/mozilla-firefox/firefox/blob/main/dom/serializers/nsPlainTextSerializer.cpp#L1801-L1807)
```cc
  bool nsPlainTextSerializer::IsCssBlockLevelElement(Element* aElement) {
    RefPtr<const ComputedStyle> computedStyle =
        nsComputedDOMStyle::GetComputedStyleNoFlush(aElement);
    if (computedStyle) {
      const nsStyleDisplay* displayStyle = computedStyle->StyleDisplay();
      return displayStyle->IsBlockOutsideStyle();
    }
```

  
[nsPlainTextSerializer.cpp#L934-L940](https://github.com/mozilla-firefox/firefox/blob/main/dom/serializers/nsPlainTextSerializer.cpp#L934-L940)
```cc
  if (mSettings.HasFlag(nsIDocumentEncoder::OutputForPlainTextClipboardCopy)) {
    if (DoOutput() && IsElementPreformatted() &&
        IsCssBlockLevelElement(aElement)) {
      // If we're closing a preformatted block element, output a line break
      // when we find a new container.
      mPreformattedBlockBoundary = true;
    }
  }
```

</details>

# Fix
Replacing the per-line flex layout with a plain block layout makes the rendered lines serialize more predictably during copy/paste, preserving the expected text structure.

- fixed video

  https://github.com/user-attachments/assets/5d32467f-c150-4afa-96fa-f4f1b23162b3

*  closes: #66143

cc @choo121600 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
codex gpt5.4, claude sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
