### PR TITLE
Cli json pollution 66139

### DIFF
--- a/airflow-core/newsfragments/66139.bugfix.rst
+++ b/airflow-core/newsfragments/66139.bugfix.rst
@@ -1,0 +1,1 @@
+CLI machine-readable output (JSON/YAML) is no longer polluted by log messages. Logs are now redirected to stderr when these formats are requested.

--- a/airflow-core/newsfragments/66139.bugfix.rst
+++ b/airflow-core/newsfragments/66139.bugfix.rst
@@ -1,1 +1,1 @@
-CLI machine-readable output (JSON/YAML) is no longer polluted by log messages. Logs are now redirected to stderr when these formats are requested.
+CLI machine-readable output (JSON/YAML) is no longer polluted by log messages. Logs are now redirected to stderr globally for all commands when these formats are requested.

--- a/airflow-core/src/airflow/__main__.py
+++ b/airflow-core/src/airflow/__main__.py
@@ -52,6 +52,9 @@ def main():
         from airflow.configuration import write_default_airflow_configuration_if_needed
 
         conf = write_default_airflow_configuration_if_needed()
+    from airflow.utils.cli import _setup_cli_logging
+
+    _setup_cli_logging(args)
     args.func(args)
 
 

--- a/airflow-core/src/airflow/cli/commands/asset_command.py
+++ b/airflow-core/src/airflow/cli/commands/asset_command.py
@@ -53,6 +53,7 @@ def _list_assets(args, *, session: Session) -> tuple[Any, type[BaseModel]]:
     return assets, AssetResponse
 
 
+@suppress_logs_and_warning
 @cli_utils.action_cli
 @provide_session
 def asset_list(args, *, session: Session = NEW_SESSION) -> None:
@@ -105,6 +106,7 @@ def _detail_asset(args, *, session: Session) -> BaseModel:
     return AssetResponse.model_validate(asset)
 
 
+@suppress_logs_and_warning
 @cli_utils.action_cli
 @provide_session
 def asset_details(args, *, session: Session = NEW_SESSION) -> None:

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -392,8 +392,8 @@ def dag_next_execution(args) -> None:
             print(value)
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
 def dag_list_dags(args, session: Session = NEW_SESSION) -> None:
@@ -480,8 +480,8 @@ def dag_list_dags(args, session: Session = NEW_SESSION) -> None:
     )
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
 def dag_details(args, session: Session = NEW_SESSION):
@@ -502,8 +502,8 @@ def dag_details(args, session: Session = NEW_SESSION):
     )
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
 def dag_list_import_errors(args, session: Session = NEW_SESSION) -> None:
@@ -556,8 +556,8 @@ def dag_list_import_errors(args, session: Session = NEW_SESSION) -> None:
         sys.exit(1)
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 def dag_report(args) -> None:
     """Display dagbag stats at the command line."""
@@ -591,8 +591,8 @@ def dag_report(args) -> None:
     )
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
 def dag_list_jobs(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> None:
@@ -622,8 +622,8 @@ def dag_list_jobs(args, dag: DAG | None = None, session: Session = NEW_SESSION) 
     )
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
 def dag_list_dag_runs(args, dag: DAG | None = None, session: Session = NEW_SESSION) -> None:

--- a/airflow-core/src/airflow/cli/commands/pool_command.py
+++ b/airflow-core/src/airflow/cli/commands/pool_command.py
@@ -65,8 +65,8 @@ def pool_get(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 def pool_set(args):
     """Create new pool with a given name and slots."""
@@ -90,8 +90,8 @@ def pool_delete(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_cli
 @suppress_logs_and_warning
+@cli_utils.action_cli
 @providers_configuration_loaded
 def pool_import(args):
     """Import pools from the file."""

--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -290,8 +290,8 @@ def task_failed_deps(args) -> None:
         print("Task instance dependencies are all met.")
 
 
-@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
+@cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def task_state(args) -> None:
     """
@@ -307,8 +307,8 @@ def task_state(args) -> None:
     print(ti.state)
 
 
-@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
+@cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def task_list(args, dag: DAG | None = None) -> None:
     """List the tasks within a DAG at the command line."""
@@ -354,8 +354,8 @@ def _guess_debugger() -> _SupportedDebugger:
     raise exc
 
 
-@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
+@cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 @provide_session
 def task_states_for_dag_run(args, session: Session = NEW_SESSION) -> None:
@@ -457,8 +457,8 @@ def task_test(args, dag: DAG | None = None) -> None:
                 session.delete(ti.dag_run)
 
 
-@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
+@cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def task_render(args, dag: DAG | None = None) -> None:
     """Render and displays templated fields for a given task."""

--- a/airflow-core/src/airflow/utils/cli.py
+++ b/airflow-core/src/airflow/utils/cli.py
@@ -59,6 +59,20 @@ def _check_cli_args(args):
         )
 
 
+def _setup_cli_logging(args):
+    """
+    Sets up logging for the CLI.
+
+    If machine-readable output is requested (json, yaml), it redirects logs to stderr.
+    """
+    output = getattr(args, "output", None)
+    if output and output != "table":
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stdout:
+                handler.setStream(sys.stderr)
+
+
 def action_cli(func=None, check_db=True):
     def action_logging(f: T) -> T:
         """
@@ -93,6 +107,7 @@ def action_cli(func=None, check_db=True):
             :param kwargs: A passthrough keyword argument
             """
             _check_cli_args(args)
+            _setup_cli_logging(args[0])
             metrics = _build_metrics(f.__name__, args[0])
             cli_action_loggers.on_pre_execution(**metrics)
             verbose = getattr(args[0], "verbose", False)
@@ -444,6 +459,7 @@ def suppress_logs_and_warning(f: T) -> T:
     @functools.wraps(f)
     def _wrapper(*args, **kwargs):
         _check_cli_args(args)
+        _setup_cli_logging(args[0])
         if args[0].verbose:
             f(*args, **kwargs)
         else:

--- a/airflow-core/tests/unit/cli/test_cli_output_pollution.py
+++ b/airflow-core/tests/unit/cli/test_cli_output_pollution.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from unittest import mock
+
+import pytest
+
+from airflow.__main__ import main
+
+pytestmark = pytest.mark.db_test
+
+class TestCliOutputPollution:
+    def test_cli_list_dags_json_output_no_pollution(self, stdout_capture, stderr_capture):
+        \"\"\"
+        Test that 'airflow dags list -o json' output is not polluted by logs.
+        \"\"\"
+        root_logger = logging.getLogger()
+        original_streams = {h: h.stream for h in root_logger.handlers if isinstance(h, logging.StreamHandler)}
+        
+        try:
+            with mock.patch(\"sys.argv\", [\"airflow\", \"dags\", \"list\", \"-o\", \"json\"]):
+                with stdout_capture as temp_stdout, stderr_capture as temp_stderr:
+                    logging.info(\"Pollution message\")
+                    
+                    main()
+                    
+                    stdout_val = temp_stdout.getvalue().strip()
+                    stderr_val = temp_stderr.getvalue().strip()
+                    
+            # Verify stdout is valid JSON
+            try:
+                data = json.loads(stdout_val)
+                assert isinstance(data, list)
+            except json.JSONDecodeError as e:
+                pytest.fail(f\"CLI output is not valid JSON: {stdout_val}\\nError: {e}\")
+                
+            # Verify that the pollution message is NOT in stdout but IS in stderr
+            assert \"Pollution message\" not in stdout_val
+            assert \"Pollution message\" in stderr_val
+        finally:
+            # Restore original streams
+            for handler, stream in original_streams.items():
+                handler.setStream(stream)
+
+    def test_cli_list_dags_table_output_still_on_stdout(self, stdout_capture, stderr_capture):
+        \"\"\"
+        Test that 'airflow dags list' (default table) still prints to stdout.
+        \"\"\"
+        with mock.patch(\"sys.argv\", [\"airflow\", \"dags\", \"list\"]):
+            with stdout_capture as temp_stdout, stderr_capture as temp_stderr:
+                logging.info(\"Regular log message\")
+                
+                main()
+                
+                stdout_val = temp_stdout.getvalue().strip()
+                
+        # In table mode, logs might still be on stdout depending on config, 
+        # but our fix ONLY redirects if output != 'table'.
+        # So we just check that we didn't break normal output.
+        assert \"dag_id\" in stdout_val

--- a/airflow-core/tests/unit/cli/test_cli_output_pollution.py
+++ b/airflow-core/tests/unit/cli/test_cli_output_pollution.py
@@ -30,16 +30,16 @@ pytestmark = pytest.mark.db_test
 
 class TestCliOutputPollution:
     def test_cli_list_dags_json_output_no_pollution(self, stdout_capture, stderr_capture):
-        \"\"\"
+        """
         Test that 'airflow dags list -o json' output is not polluted by logs.
-        \"\"\"
+        """
         root_logger = logging.getLogger()
         original_streams = {h: h.stream for h in root_logger.handlers if isinstance(h, logging.StreamHandler)}
         
         try:
-            with mock.patch(\"sys.argv\", [\"airflow\", \"dags\", \"list\", \"-o\", \"json\"]):
+            with mock.patch("sys.argv", ["airflow", "dags", "list", "-o", "json"]):
                 with stdout_capture as temp_stdout, stderr_capture as temp_stderr:
-                    logging.info(\"Pollution message\")
+                    logging.info("Pollution message")
                     
                     main()
                     
@@ -51,23 +51,23 @@ class TestCliOutputPollution:
                 data = json.loads(stdout_val)
                 assert isinstance(data, list)
             except json.JSONDecodeError as e:
-                pytest.fail(f\"CLI output is not valid JSON: {stdout_val}\\nError: {e}\")
+                pytest.fail(f"CLI output is not valid JSON: {stdout_val}\nError: {e}")
                 
             # Verify that the pollution message is NOT in stdout but IS in stderr
-            assert \"Pollution message\" not in stdout_val
-            assert \"Pollution message\" in stderr_val
+            assert "Pollution message" not in stdout_val
+            assert "Pollution message" in stderr_val
         finally:
             # Restore original streams
             for handler, stream in original_streams.items():
                 handler.setStream(stream)
 
     def test_cli_list_dags_table_output_still_on_stdout(self, stdout_capture, stderr_capture):
-        \"\"\"
+        """
         Test that 'airflow dags list' (default table) still prints to stdout.
-        \"\"\"
-        with mock.patch(\"sys.argv\", [\"airflow\", \"dags\", \"list\"]):
+        """
+        with mock.patch("sys.argv", ["airflow", "dags", "list"]):
             with stdout_capture as temp_stdout, stderr_capture as temp_stderr:
-                logging.info(\"Regular log message\")
+                logging.info("Regular log message")
                 
                 main()
                 
@@ -76,4 +76,4 @@ class TestCliOutputPollution:
         # In table mode, logs might still be on stdout depending on config, 
         # but our fix ONLY redirects if output != 'table'.
         # So we just check that we didn't break normal output.
-        assert \"dag_id\" in stdout_val
+        assert "dag_id" in stdout_val


### PR DESCRIPTION
### CLI: Eliminate JSON/YAML output pollution by redirecting logs to stderr (#66139)

This PR resolves the issue where machine-readable CLI outputs (JSON/YAML) were being polluted by log messages (e.g., Alembic migrations, import warnings), making them unparseable by tools like `jq`.

#### **Problem**
When running `airflow dags list -o json`, logs were printed to `stdout` before the JSON payload. This resulted in invalid JSON files and broken pipes when used in automation scripts.

#### **Solution: Global Log Redirection**
A global redirection strategy is implemented to address log pollution at the architectural level:

1. **Global Entry Point Injection:** In `airflow/__main__.py`, the CLI detects machine-readable output flags (`-o json`, `-o yaml`) at the start of execution.
2. **Centralized Redirection Logic:** Added `_setup_cli_logging` in `airflow/utils/cli.py`. This function identifies `StreamHandler`s pointing to `sys.stdout` and redirects them to `sys.stderr`.
3. **Execution Order Fix:** Ensures log redirection occurs before command execution and database initialization.
4. **Consistency:** Applied the behavior uniformly across CLI commands.

#### **Regression Testing**
Added `airflow-core/tests/unit/cli/test_cli_output_pollution.py` which:
- Simulates full CLI execution via `airflow.__main__.main`
- Injects logs during execution
- Verifies `stdout` contains valid JSON only
- Confirms logs are emitted to `stderr`
- Ensures default (table) output remains unchanged

---

### **Closes / Related Issues**
- closes #66139