### PR TITLE
Fix deprecation warnings for workers.logGroomerSidecar (#66238)

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -826,7 +826,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if ne .Values.workers.logGroomerSidecar.retentionDays nil }}
+{{- if ne (int .Values.workers.logGroomerSidecar.retentionDays) 15 }}
 
  DEPRECATION WARNING:
     `workers.logGroomerSidecar.retentionDays` has been renamed to `workers.celery.logGroomerSidecar.retentionDays`.
@@ -834,7 +834,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if ne .Values.workers.logGroomerSidecar.retentionMinutes nil }}
+{{- if ne (int .Values.workers.logGroomerSidecar.retentionMinutes) 0 }}
 
  DEPRECATION WARNING:
     `workers.logGroomerSidecar.retentionMinutes` has been renamed to `workers.celery.logGroomerSidecar.retentionMinutes`.
@@ -842,7 +842,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if ne .Values.workers.logGroomerSidecar.frequencyMinutes nil }}
+{{- if ne (int .Values.workers.logGroomerSidecar.frequencyMinutes) 15 }}
 
  DEPRECATION WARNING:
     `workers.logGroomerSidecar.frequencyMinutes` has been renamed to `workers.celery.logGroomerSidecar.frequencyMinutes`.
@@ -850,7 +850,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if ne .Values.workers.logGroomerSidecar.maxSizeBytes nil }}
+{{- if ne (int .Values.workers.logGroomerSidecar.maxSizeBytes) 0 }}
 
  DEPRECATION WARNING:
     `workers.logGroomerSidecar.maxSizeBytes` has been renamed to `workers.celery.logGroomerSidecar.maxSizeBytes`.
@@ -858,7 +858,7 @@ DEPRECATION WARNING:
 
 {{- end }}
 
-{{- if ne .Values.workers.logGroomerSidecar.maxSizePercent nil }}
+{{- if ne (int .Values.workers.logGroomerSidecar.maxSizePercent) 0 }}
 
  DEPRECATION WARNING:
     `workers.logGroomerSidecar.maxSizePercent` has been renamed to `workers.celery.logGroomerSidecar.maxSizePercent`.


### PR DESCRIPTION
Forward porting #66238 which landed by accident on maintenance branch first,... Thanks @Miretpl for fixing!

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
