### PR TITLE
Fix edge3 worker deadlock regression test on Python 3.14

### DIFF
--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -20,6 +20,7 @@ import asyncio
 import contextlib
 import importlib
 import json
+import multiprocessing
 import signal
 from datetime import datetime
 from io import StringIO
@@ -77,6 +78,18 @@ MOCK_COMMAND = {
     "log_path": "mock.log",
     "bundle_info": {"name": "hello", "version": "abc"},
 }
+
+
+def _emit_large_exception_target(results_queue):
+    """Worker-process target used by ``test_fetch_and_run_job_possible_deadlock``.
+
+    Pushes a >64 KB pickled exception to ``results_queue``. On Linux the OS pipe
+    backing ``multiprocessing.Queue`` only has ~64 KB of buffer, so the queue's
+    feeder thread blocks on ``send_bytes`` and the subprocess can't terminate
+    until the parent reads from the queue — exactly the production deadlock
+    condition that #66144 fixed.
+    """
+    results_queue.put(Exception(f"Task execution failed with large error message {'-' * 66000}"))
 
 
 class _MockProcess(Process):
@@ -310,7 +323,6 @@ class TestEdgeWorker:
         assert len(worker_with_job.jobs) == 1  # no new job added (was removed at the end...)
         mock_logs_push.assert_not_called()
 
-    @patch("airflow.sdk.execution_time.supervisor.supervise")
     @patch("airflow.providers.edge3.cli.worker.jobs_fetch")
     @patch("airflow.providers.edge3.cli.worker.jobs_set_state")
     @patch("airflow.providers.edge3.cli.worker.EdgeWorker._push_logs_in_chunks")
@@ -322,14 +334,17 @@ class TestEdgeWorker:
         mock_push_log_chunks,
         mock_jobs_set_state,
         mock_jobs_fetch,
-        mock_supervise,
         worker_with_job: EdgeWorker,
     ):
-        """Verify that a large exception from the subprocess does not deadlock fetch_and_run_job."""
+        """Verify that a large exception from the subprocess does not deadlock fetch_and_run_job.
 
-        large_exception = Exception(f"Task execution failed with large error message {'-' * 66000}")
-        mock_supervise.side_effect = large_exception
-
+        Uses an explicit ``fork`` context to spawn the simulated worker subprocess. Python 3.14
+        flipped the POSIX default ``multiprocessing`` start method to ``forkserver``, which
+        spawns a fresh interpreter for the child — patches applied in the test process do not
+        propagate, so older variants of this test that mocked ``supervise`` no longer triggered
+        the deadlock condition. Forking a small top-level target sidesteps that and reproduces
+        the actual queue-feeder/pipe-buffer deadlock the fix targets.
+        """
         mock_jobs_fetch.side_effect = [
             EdgeJobFetched(
                 dag_id="test",
@@ -342,22 +357,32 @@ class TestEdgeWorker:
             ),
             None,
         ]
-        worker_with_job.__dict__["_execution_api_server_url"] = "https://mock-server/execution"
         worker_with_job.concurrency = 1  # only one job at a time
         assert worker_with_job.free_concurrency == 0
 
-        try:
-            await asyncio.wait_for(worker_with_job.fetch_and_run_job(), timeout=10.0)
-        except asyncio.TimeoutError:
-            # Clean up any hanging subprocess to prevent blocking pytest
-            for job in list(worker_with_job.jobs):
-                if job.process.is_alive():
-                    job.process.terminate()
-                    job.process.join(timeout=1.0)
-                    if job.process.is_alive():
-                        job.process.kill()
-                        job.process.join()
-            pytest.fail("fetch_and_run_job timed out after 10s - DEADLOCK DETECTED. ")
+        ctx = multiprocessing.get_context("fork")
+        results_queue = ctx.Queue()
+        process = ctx.Process(target=_emit_large_exception_target, args=(results_queue,))
+
+        with patch.object(EdgeWorker, "_launch_job", return_value=(process, results_queue)):
+            process.start()
+            try:
+                await asyncio.wait_for(worker_with_job.fetch_and_run_job(), timeout=10.0)
+            except asyncio.TimeoutError:
+                # Clean up any hanging subprocess to prevent blocking pytest
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=1.0)
+                    if process.is_alive():
+                        process.kill()
+                        process.join()
+                pytest.fail("fetch_and_run_job timed out after 10s - DEADLOCK DETECTED. ")
+            finally:
+                if process.is_alive():
+                    process.join(timeout=1.0)
+                    if process.is_alive():
+                        process.terminate()
+                        process.join(timeout=1.0)
 
         # If we reach here without timeout, the deadlock was not triggered
         assert mock_jobs_set_state.call_count >= 1


### PR DESCRIPTION
## Summary

The `test_fetch_and_run_job_possible_deadlock` regression test added in #66144
was passing under the PR build (Python 3.10) but fails on the scheduled
Python 3.14 run — see https://github.com/apache/airflow/actions/runs/25230313598.

Python 3.14 flipped the POSIX default `multiprocessing` start method from
`fork` to `forkserver`. The test mocked `airflow.sdk.execution_time.supervisor.supervise`
expecting the patch to be inherited by the worker subprocess; with `forkserver`
the child is spawned from a fresh interpreter and the patch does not apply,
so the real `supervise()` runs, makes API retries, and the test times out
at 10 s instead of exercising the queue-deadlock path.

Make the test independent of the start method by patching `EdgeWorker._launch_job`
to return a (Process, Queue) pair built from an explicit `fork` context, with
a tiny top-level target that pushes a >64 KB pickled exception onto the queue.
That reproduces the actual production deadlock — `Queue` feeder thread blocked
on the 64 KB OS pipe buffer while `Process.is_alive()` still reports True —
without relying on test-side patches surviving the spawn.

No production code change; only `providers/edge3/tests/unit/edge3/cli/test_worker.py`.

## Test plan

- [x] Run `test_fetch_and_run_job_possible_deadlock` on Python 3.14 — passes.
- [x] Run on Python 3.10 — passes.
- [x] Confirm regression detection: temporarily revert the `worker.py` fix
      (`while job.is_running and results_queue.empty():` → `while job.is_running:`)
      and re-run; test fails with the expected DEADLOCK timeout.
- [x] Run the full `providers/edge3/tests/unit/edge3/cli/test_worker.py` suite on
      Python 3.14 — 42 passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)