### PR TITLE
Fix rendering of "Alternative: legacy global install" section in breeze docs

### DIFF
--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -306,7 +306,7 @@ Then ``breeze`` invoked from any Airflow checkout uses that checkout's source. T
 a fresh worktree pays a one-time ``uvx`` resolve/install; subsequent calls hit the cache.
 
 Alternative: legacy global install (``uv tool`` or ``pipx``)
-............................................................
+------------------------------------------------------------
 
 If you prefer a single global install on ``PATH`` (the pre-ADR-0017 behaviour), you can still
 install Breeze with ``uv tool`` or ``pipx``. This is *not* recommended for setups with multiple


### PR DESCRIPTION
# What
Fix RST heading level for the "Alternative: legacy global install" section in breeze installation docs.

# Why
The section was using `.` (level 4) underline but should use `-` (level 2) to match other subsections under the Installation heading. This ensures proper document structure and table of contents rendering.

**This causes broken rendering in GitHub's preview** - the section appears with incorrect nesting and breaks the document structure and table of contents.

# Testing
## Screenshots

**Before** ([Link](https://github.com/apache/airflow/blob/main/dev/breeze/doc/01_installation.rst))
<img width="632" height="253" alt="image" src="https://github.com/user-attachments/assets/df97bcdf-6a31-4a58-b526-63cc3281f86d" />

**After** ([Link](https://github.com/kir-rin/airflow/blob/4532df6d69c3e6ed943b96fc97d650a0d6a0415e/dev/breeze/doc/01_installation.rst))
<img width="621" height="273" alt="image" src="https://github.com/user-attachments/assets/ab2f9df8-964f-45c4-8cba-07f5fafe3b67" />


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenCode

Generated-by: OpenCode following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)