### PR TITLE
Prefer gh auth over GitHub tokens for Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -58,6 +58,7 @@ from airflow_breeze.utils.docker_command_utils import (
     fix_ownership_using_docker,
     perform_environment_checks,
 )
+from airflow_breeze.utils.github import retrieve_github_token
 from airflow_breeze.utils.path_utils import AIRFLOW_HOME_PATH, AIRFLOW_ROOT_PATH
 from airflow_breeze.utils.run_utils import run_command
 
@@ -778,16 +779,7 @@ def upgrade(
 
     console_print("[info]Running upgrade of important CI environment.[/]")
 
-    # Resolve GitHub token: prefer --github-token / GITHUB_TOKEN env var, fall back to gh CLI
-    if not github_token:
-        gh_token_result = run_command(
-            ["gh", "auth", "token"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if gh_token_result.returncode == 0 and gh_token_result.stdout.strip():
-            github_token = gh_token_result.stdout.strip()
+    github_token = retrieve_github_token(github_token)
 
     # Create a copy of the environment to pass to commands
     command_env = os.environ.copy()
@@ -797,7 +789,7 @@ def upgrade(
         console_print("[success]GitHub token set in environment.[/]")
     else:
         console_print(
-            "[warning]Could not retrieve GitHub token from --github-token or gh CLI. "
+            "[warning]Could not retrieve GitHub token from --github-token, gh CLI, or token env. "
             "Commands may fail if they require authentication.[/]"
         )
 

--- a/dev/breeze/src/airflow_breeze/commands/issues_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/issues_commands.py
@@ -31,7 +31,7 @@ from airflow_breeze.commands.common_options import (
 from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.confirm import Answer, user_confirm
 from airflow_breeze.utils.console import console_print
-from airflow_breeze.utils.run_utils import run_command
+from airflow_breeze.utils.github import retrieve_github_token
 from airflow_breeze.utils.shared_options import get_dry_run
 
 
@@ -42,18 +42,7 @@ def issues_group():
 
 def _resolve_github_token(github_token: str | None) -> str | None:
     """Resolve GitHub token from option, environment, or gh CLI."""
-    if github_token:
-        return github_token
-    gh_token_result = run_command(
-        ["gh", "auth", "token"],
-        capture_output=True,
-        text=True,
-        check=False,
-        dry_run_override=False,
-    )
-    if gh_token_result.returncode == 0:
-        return gh_token_result.stdout.strip()
-    return None
+    return retrieve_github_token(github_token)
 
 
 def _get_collaborator_logins(repo) -> set[str]:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -3052,11 +3052,6 @@ def generate_issue_content_core(
     )
 
 
-def _get_github_token(github_token: str) -> str:
-    """Return github_token as-is, or fall back to ``gh auth token``."""
-    return retrieve_github_token(github_token) or github_token
-
-
 def _get_airflowctl_prs(
     verbose: bool,
     previous_release: str,
@@ -3267,7 +3262,7 @@ def generate_airflowctl_changelog(
     verbose = get_verbose()
 
     prs = _get_airflowctl_prs(verbose, previous_release, current_release, excluded_pr_list)
-    github_token = _get_github_token(github_token)
+    github_token = retrieve_github_token(github_token) or ""
 
     g = Github(github_token)
     repo = g.get_repo("apache/airflow")
@@ -4431,7 +4426,7 @@ def generate_issue_content(
         excluded_prs = []
     prs = [pr for pr in change_prs if pr is not None and pr not in excluded_prs]
 
-    github_token = _get_github_token(github_token)
+    github_token = retrieve_github_token(github_token) or ""
     g = Github(github_token)
     repo = g.get_repo("apache/airflow")
     pull_requests: dict[int, PullRequestOrIssue] = {}

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -137,6 +137,7 @@ from airflow_breeze.utils.docker_command_utils import (
     fix_ownership_using_docker,
     perform_environment_checks,
 )
+from airflow_breeze.utils.github import retrieve_github_token
 from airflow_breeze.utils.helm_chart_utils import chart_version
 from airflow_breeze.utils.packages import (
     PackageSuspendedException,
@@ -2675,16 +2676,7 @@ def generate_issue_content_providers(
             all_prs.update(prs)
             provider_prs[provider_id] = filtered_prs
             all_retrieved_prs.update(provider_prs[provider_id])
-        if not github_token:
-            # Get GitHub token from gh CLI and set it in environment copy
-            gh_token_result = run_command(
-                ["gh", "auth", "token"],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if gh_token_result.returncode == 0:
-                github_token = gh_token_result.stdout.strip()
+        github_token = retrieve_github_token(github_token)
         g = Github(github_token)
         repo = g.get_repo("apache/airflow")
         pull_requests: dict[int, PullRequest.PullRequest | Issue.Issue] = {}
@@ -3062,17 +3054,7 @@ def generate_issue_content_core(
 
 def _get_github_token(github_token: str) -> str:
     """Return github_token as-is, or fall back to ``gh auth token``."""
-    if github_token:
-        return github_token
-    result = run_command(
-        ["gh", "auth", "token"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        return result.stdout.strip()
-    return github_token
+    return retrieve_github_token(github_token) or github_token
 
 
 def _get_airflowctl_prs(

--- a/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
@@ -127,10 +127,9 @@ def workflow_run_publish(
         )
         sys.exit(1)
     if os.environ.get("GITHUB_TOKEN", ""):
-        console_print("\n[warning]GITHUB_TOKEN environment variable is set.")
         console_print(
-            "\nBreeze will first try your `gh auth login` credentials and use GITHUB_TOKEN only as "
-            "a fallback. The fallback token needs sufficient permissions to trigger workflows."
+            "\n[warning]GITHUB_TOKEN is set; Breeze will try your `gh auth login` first and only "
+            "use this token as a fallback. The fallback token must have workflow-trigger scope."
         )
     console_print(
         f"[blue]Validating ref: {ref}[/blue]",

--- a/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/workflow_commands.py
@@ -28,7 +28,7 @@ from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.gh_workflow_utils import trigger_workflow_and_monitor
-from airflow_breeze.utils.run_utils import run_command
+from airflow_breeze.utils.github import run_gh_command
 
 WORKFLOW_NAME_MAPS = {
     "publish-docs": "publish-docs-to-s3.yml",
@@ -127,24 +127,19 @@ def workflow_run_publish(
         )
         sys.exit(1)
     if os.environ.get("GITHUB_TOKEN", ""):
-        console_print("\n[warning]Your authentication will use GITHUB_TOKEN environment variable.")
+        console_print("\n[warning]GITHUB_TOKEN environment variable is set.")
         console_print(
-            "\nThis might not be what you want unless your token has "
-            "sufficient permissions to trigger workflows."
-        )
-        console_print(
-            "If you remove GITHUB_TOKEN, workflow_run will use the authentication you already "
-            "set-up with `gh auth login`.\n"
+            "\nBreeze will first try your `gh auth login` credentials and use GITHUB_TOKEN only as "
+            "a fallback. The fallback token needs sufficient permissions to trigger workflows."
         )
     console_print(
         f"[blue]Validating ref: {ref}[/blue]",
     )
 
     if not skip_tag_validation:
-        tag_result = run_command(
+        tag_result = run_gh_command(
             ["gh", "api", f"repos/apache/airflow/git/refs/tags/{ref}"],
             capture_output=True,
-            check=False,
         )
 
         stdout = tag_result.stdout.decode("utf-8")

--- a/dev/breeze/src/airflow_breeze/utils/gh_workflow_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/gh_workflow_utils.py
@@ -25,7 +25,7 @@ from shutil import which
 
 from airflow_breeze.global_constants import MIN_GH_VERSION
 from airflow_breeze.utils.console import console_print
-from airflow_breeze.utils.run_utils import run_command
+from airflow_breeze.utils.github import run_gh_command
 
 
 def tigger_workflow(workflow_name: str, repo: str, branch: str = "main", **kwargs):
@@ -50,7 +50,7 @@ def tigger_workflow(workflow_name: str, repo: str, branch: str = "main", **kwarg
         command.extend(["-f", f"{key}={value}"])
 
     console_print(f"[blue]Running command: {' '.join(command)}[/blue]")
-    result = run_command(command, capture_output=True, check=False)
+    result = run_gh_command(command, capture_output=True)
 
     if result.returncode != 0:
         console_print(f"[red]Error running workflow: {result.stderr}[/red]")
@@ -109,7 +109,7 @@ def get_workflow_run_id(workflow_name: str, repo: str) -> int:
         "databaseId",
     ]
 
-    result = run_command(command, capture_output=True, check=False)
+    result = run_gh_command(command, capture_output=True)
     if result.returncode != 0:
         console_print(f"[red]Error fetching workflow run ID: {result.stderr}[/red]")
         sys.exit(1)
@@ -139,7 +139,7 @@ def get_workflow_run_info(run_id: str, repo: str, fields: str) -> dict:
     make_sure_gh_is_installed()
     command = ["gh", "run", "view", run_id, "--json", fields, "--repo", repo]
 
-    result = run_command(command, capture_output=True, check=False)
+    result = run_gh_command(command, capture_output=True)
     if result.returncode != 0:
         console_print(f"[red]Error fetching workflow run status: {result.stderr}[/red]")
         sys.exit(1)

--- a/dev/breeze/src/airflow_breeze/utils/github.py
+++ b/dev/breeze/src/airflow_breeze/utils/github.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 import tempfile
 import zipfile
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -34,6 +36,81 @@ from airflow_breeze.utils.shared_options import get_dry_run, get_verbose
 
 if TYPE_CHECKING:
     from requests import Response
+
+GITHUB_TOKEN_ENV_VARS = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+def env_without_github_tokens(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return a copy of *env* with ambient GitHub CLI token variables removed."""
+    cleaned_env = dict(os.environ if env is None else env)
+    for token_env_var in GITHUB_TOKEN_ENV_VARS:
+        cleaned_env.pop(token_env_var, None)
+    return cleaned_env
+
+
+def get_github_token_from_env(env: Mapping[str, str] | None = None) -> str | None:
+    """Return an ambient GitHub token using the same precedence as the GitHub CLI."""
+    source_env = os.environ if env is None else env
+    for token_env_var in GITHUB_TOKEN_ENV_VARS:
+        token = source_env.get(token_env_var)
+        if token:
+            return token
+    return None
+
+
+def run_gh_command(
+    command: Sequence[str],
+    *,
+    retry_with_github_token: bool = True,
+    env: Mapping[str, str] | None = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[Any]:
+    """
+    Run a ``gh`` command using stored ``gh auth login`` credentials before ambient token env vars.
+
+    Locally, ``GH_TOKEN``/``GITHUB_TOKEN`` can shadow the user's normal GitHub CLI login. We first
+    run with those variables removed, then retry with the original environment only when that fails.
+    """
+    command_env = os.environ.copy() if env is None else dict(env)
+    check = kwargs.pop("check", False)
+    result = subprocess.run(command, env=env_without_github_tokens(command_env), check=False, **kwargs)
+    if result.returncode == 0:
+        return result
+    if not retry_with_github_token or not get_github_token_from_env(command_env):
+        if check:
+            result.check_returncode()
+        return result
+    return subprocess.run(command, env=command_env, check=check, **kwargs)
+
+
+def retrieve_github_token(token: str | None = None, *, env: Mapping[str, str] | None = None) -> str | None:
+    """
+    Resolve a GitHub token for local Breeze commands.
+
+    Explicit ``--github-token`` values are preserved. Ambient ``GH_TOKEN``/``GITHUB_TOKEN`` values are
+    used only after trying the user's stored ``gh auth login`` credential.
+    """
+    env_token = get_github_token_from_env(env)
+    source_env = os.environ if env is None else env
+    env_tokens = {
+        source_env[token_env_var] for token_env_var in GITHUB_TOKEN_ENV_VARS if source_env.get(token_env_var)
+    }
+    if token and token not in env_tokens:
+        return token
+    try:
+        gh_token_result = run_gh_command(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            check=False,
+            retry_with_github_token=False,
+            env=env,
+        )
+    except FileNotFoundError:
+        return token or env_token
+    if gh_token_result.returncode == 0 and gh_token_result.stdout.strip():
+        return gh_token_result.stdout.strip()
+    return token or env_token
 
 
 def get_ga_output(name: str, value: Any) -> str:

--- a/dev/breeze/src/airflow_breeze/utils/github.py
+++ b/dev/breeze/src/airflow_breeze/utils/github.py
@@ -73,6 +73,8 @@ def run_gh_command(
     """
     command_env = os.environ.copy() if env is None else dict(env)
     check = kwargs.pop("check", False)
+    if get_dry_run():
+        return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
     result = subprocess.run(command, env=env_without_github_tokens(command_env), check=False, **kwargs)
     if result.returncode == 0:
         return result

--- a/dev/breeze/src/airflow_breeze/utils/github.py
+++ b/dev/breeze/src/airflow_breeze/utils/github.py
@@ -89,8 +89,10 @@ def retrieve_github_token(token: str | None = None, *, env: Mapping[str, str] | 
     """
     Resolve a GitHub token for local Breeze commands.
 
-    Explicit ``--github-token`` values are preserved. Ambient ``GH_TOKEN``/``GITHUB_TOKEN`` values are
-    used only after trying the user's stored ``gh auth login`` credential.
+    Non-empty token arguments are preserved when they do not match ``GH_TOKEN`` or
+    ``GITHUB_TOKEN`` from the environment. Matching values are treated as ambient env input because
+    Click can populate ``--github-token`` from ``envvar="GITHUB_TOKEN"``. Ambient env tokens are used
+    only after trying the user's stored ``gh auth login`` credential.
     """
     env_token = get_github_token_from_env(env)
     source_env = os.environ if env is None else env

--- a/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
+++ b/dev/breeze/src/airflow_breeze/utils/provider_dependencies.py
@@ -39,7 +39,12 @@ from airflow_breeze.global_constants import (
 )
 from airflow_breeze.utils.ci_group import ci_group
 from airflow_breeze.utils.console import console_print
-from airflow_breeze.utils.github import download_constraints_file, get_active_airflow_versions, get_tag_date
+from airflow_breeze.utils.github import (
+    download_constraints_file,
+    get_active_airflow_versions,
+    get_tag_date,
+    retrieve_github_token,
+)
 from airflow_breeze.utils.packages import get_provider_distributions_metadata
 from airflow_breeze.utils.path_utils import (
     AIRFLOW_PYPROJECT_TOML_FILE_PATH,
@@ -48,7 +53,6 @@ from airflow_breeze.utils.path_utils import (
     PROVIDER_DEPENDENCIES_JSON_HASH_PATH,
     PROVIDER_DEPENDENCIES_JSON_PATH,
 )
-from airflow_breeze.utils.run_utils import run_command
 from airflow_breeze.utils.shared_options import get_verbose
 
 _regenerate_provider_deps_lock = Lock()
@@ -248,12 +252,9 @@ def get_all_constraint_files_and_airflow_releases(
         shutil.rmtree(CONSTRAINTS_CACHE_PATH, ignore_errors=True)
     if not CONSTRAINTS_CACHE_PATH.exists():
         if not github_token:
-            gh_auth_command = run_command(
-                ["gh", "auth", "token"], check=False, capture_output=True, text=True
-            )
-            if gh_auth_command.returncode == 0:
-                console_print("\n[info]Retrieved GitHub token from gh auth token command[/]\n")
-                github_token = gh_auth_command.stdout.strip()
+            github_token = retrieve_github_token()
+            if github_token:
+                console_print("\n[info]Resolved GitHub token for constraints refresh[/]\n")
             else:
                 console_print(
                     "[error]You need to provide GITHUB_TOKEN to generate providers metadata.[/]\n\n"

--- a/dev/breeze/tests/test_github_utils.py
+++ b/dev/breeze/tests/test_github_utils.py
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+from airflow_breeze.utils.github import (
+    env_without_github_tokens,
+    retrieve_github_token,
+    run_gh_command,
+)
+
+
+def _completed_process(returncode: int, stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_env_without_github_tokens_removes_ambient_token_vars(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+    monkeypatch.setenv("OTHER_VAR", "kept")
+
+    cleaned_env = env_without_github_tokens()
+
+    assert "GH_TOKEN" not in cleaned_env
+    assert "GITHUB_TOKEN" not in cleaned_env
+    assert cleaned_env["OTHER_VAR"] == "kept"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_prefers_clean_gh_auth_token(mock_run, monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "env-gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "env-github-token")
+    mock_run.return_value = _completed_process(returncode=0, stdout="stored-gh-token\n")
+
+    assert retrieve_github_token() == "stored-gh-token"
+
+    mock_run.assert_called_once()
+    call_env = mock_run.call_args.kwargs["env"]
+    assert "GH_TOKEN" not in call_env
+    assert "GITHUB_TOKEN" not in call_env
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_falls_back_to_env_token(mock_run, monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "env-gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "env-github-token")
+    mock_run.return_value = _completed_process(returncode=1)
+
+    assert retrieve_github_token() == "env-gh-token"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_falls_back_to_env_token_when_gh_is_missing(mock_run, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-github-token")
+    mock_run.side_effect = FileNotFoundError
+
+    assert retrieve_github_token() == "env-github-token"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_keeps_explicit_token(mock_run, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+
+    assert retrieve_github_token("explicit-token") == "explicit-token"
+
+    mock_run.assert_not_called()
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_does_not_treat_env_token_argument_as_explicit(mock_run, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+    mock_run.return_value = _completed_process(returncode=0, stdout="stored-gh-token\n")
+
+    assert retrieve_github_token("env-token") == "stored-gh-token"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_run_gh_command_retries_with_original_env_after_clean_env_failure(mock_run, monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "env-gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "env-github-token")
+    mock_run.side_effect = [
+        _completed_process(returncode=1),
+        _completed_process(returncode=0),
+    ]
+
+    result = run_gh_command(["gh", "workflow", "run", "docs.yml"], capture_output=True)
+
+    assert result.returncode == 0
+    assert mock_run.call_count == 2
+    first_env = mock_run.call_args_list[0].kwargs["env"]
+    second_env = mock_run.call_args_list[1].kwargs["env"]
+    assert "GH_TOKEN" not in first_env
+    assert "GITHUB_TOKEN" not in first_env
+    assert second_env["GH_TOKEN"] == "env-gh-token"
+    assert second_env["GITHUB_TOKEN"] == "env-github-token"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_run_gh_command_does_not_retry_after_clean_env_success(mock_run, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+    mock_run.return_value = _completed_process(returncode=0)
+
+    result = run_gh_command(["gh", "api", "repos/apache/airflow"], capture_output=True)
+
+    assert result.returncode == 0
+    mock_run.assert_called_once()

--- a/dev/breeze/tests/test_github_utils.py
+++ b/dev/breeze/tests/test_github_utils.py
@@ -24,6 +24,7 @@ from airflow_breeze.utils.github import (
     retrieve_github_token,
     run_gh_command,
 )
+from airflow_breeze.utils.shared_options import set_dry_run
 
 
 def _completed_process(returncode: int, stdout: str = "") -> subprocess.CompletedProcess[str]:
@@ -120,3 +121,15 @@ def test_run_gh_command_does_not_retry_after_clean_env_success(mock_run, monkeyp
 
     assert result.returncode == 0
     mock_run.assert_called_once()
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_run_gh_command_skips_subprocess_in_dry_run(mock_run):
+    set_dry_run(True)
+    try:
+        result = run_gh_command(["gh", "workflow", "run", "docs.yml"], capture_output=True)
+    finally:
+        set_dry_run(False)
+
+    assert result.returncode == 0
+    mock_run.assert_not_called()

--- a/dev/breeze/tests/test_github_utils.py
+++ b/dev/breeze/tests/test_github_utils.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import subprocess
 from unittest import mock
 
+import pytest
+
 from airflow_breeze.utils.github import (
     env_without_github_tokens,
     retrieve_github_token,
@@ -75,6 +77,14 @@ def test_retrieve_github_token_falls_back_to_env_token_when_gh_is_missing(mock_r
 
 
 @mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_retrieve_github_token_falls_back_to_env_token_when_gh_returns_whitespace(mock_run, monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-github-token")
+    mock_run.return_value = _completed_process(returncode=0, stdout="  \n")
+
+    assert retrieve_github_token() == "env-github-token"
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
 def test_retrieve_github_token_keeps_explicit_token(mock_run, monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "env-token")
 
@@ -121,6 +131,26 @@ def test_run_gh_command_does_not_retry_after_clean_env_success(mock_run, monkeyp
 
     assert result.returncode == 0
     mock_run.assert_called_once()
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_run_gh_command_raises_when_check_true_and_no_env_token_to_retry(mock_run, monkeypatch):
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    mock_run.return_value = _completed_process(returncode=1)
+
+    with pytest.raises(subprocess.CalledProcessError) as ctx:
+        run_gh_command(["gh", "api", "repos/apache/airflow"], capture_output=True, check=True)
+
+    assert ctx.value.returncode == 1
+
+
+@mock.patch("airflow_breeze.utils.github.subprocess.run")
+def test_run_gh_command_raises_when_gh_is_missing(mock_run):
+    mock_run.side_effect = FileNotFoundError
+
+    with pytest.raises(FileNotFoundError):
+        run_gh_command(["gh", "api", "repos/apache/airflow"], capture_output=True)
 
 
 @mock.patch("airflow_breeze.utils.github.subprocess.run")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR intentionally focuses on the Breeze auth-resolution paths first, keeping the change small enough to review safely while establishing a reusable helper that can be extended to prek or token-scope validation in follow-up work.

Normalize Breeze GitHub auth resolution so local `GH_TOKEN` / `GITHUB_TOKEN` no longer accidentally shadows a valid `gh auth login` credential.

This adds shared helpers for Breeze GitHub auth handling:

- `run_gh_command(...)` for commands that invoke the GitHub CLI directly. It first runs `gh` with `GH_TOKEN` / `GITHUB_TOKEN` removed so `gh auth login` can be used, then falls back to the original environment if needed.
- `retrieve_github_token(...)` for commands that need a token string. It preserves explicit `--github-token` values, otherwise prefers cleaned `gh auth token`, then falls back to `GH_TOKEN` / `GITHUB_TOKEN`.

The duplicated local `gh auth token` fallback logic in Breeze commands is replaced with the shared helper. This updates workflow-run, issue maintenance, CI upgrade, release issue/changelog generation, and provider metadata refresh paths.

The main design choice is to treat environment tokens as fallback credentials, not as the preferred local credential. This preserves CI/token-only compatibility while making local Breeze behavior less surprising when a stale or under-scoped `GITHUB_TOKEN` is present.

Tests added for:
- removing `GH_TOKEN` / `GITHUB_TOKEN` from the first `gh` attempt
- preferring cleaned `gh auth token`
- falling back to env tokens when `gh auth` is unavailable
- preserving explicit token arguments
- retrying direct `gh` commands with the original env only after cleaned-env failure

Related: https://github.com/apache/airflow/issues/55567

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: Codex GPT 5.5
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
