### PR TITLE
Docs: add review checklist for example DAGs (continuation of #61786)

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -199,7 +199,7 @@ Review & Merge
 Respond to reviewer comments, push updates (same commands as above).  Once
 CI is green and reviews are ✅, a committer will merge.  🎉
 
-Example DAG Review Checklist
+Example Dag Review Checklist
 ----------------------------
 
 To help maintain consistency and quality across example DAGs,

--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -199,6 +199,14 @@ Review & Merge
 Respond to reviewer comments, push updates (same commands as above).  Once
 CI is green and reviews are ✅, a committer will merge.  🎉
 
+Example DAG Review Checklist
+----------------------------
+
+To help maintain consistency and quality across example DAGs,
+please refer to the example DAG review checklist:
+
+:doc:`example_dag_review_checklist`
+
 Next Steps
 ----------
 * Need a full development environment? See the `Development Environments Guide <https://github.com/apache/airflow/blob/main/contributing-docs/06_development_environments.rst>`_.

--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -202,8 +202,8 @@ CI is green and reviews are ✅, a committer will merge.  🎉
 Example Dag Review Checklist
 ----------------------------
 
-To help maintain consistency and quality across example DAGs,
-please refer to the example DAG review checklist:
+To help maintain consistency and quality across example Dags,
+please refer to the example Dag review checklist:
 
 :doc:`example_dag_review_checklist`
 

--- a/contributing-docs/example_dag_review_checklist.rst
+++ b/contributing-docs/example_dag_review_checklist.rst
@@ -1,8 +1,8 @@
-Example DAG Review Checklist
+Example Dag Review Checklist
 ============================
 
-This document provides a checklist for reviewing example DAGs submitted to
-Apache Airflow. The goal is to ensure that example DAGs are clean, consistent,
+This document provides a checklist for reviewing example Dags submitted to
+Apache Airflow. The goal is to ensure that example Dags are clean, consistent,
 and follow best practices while serving their multiple purposes:
 
 * Clean and consistent
@@ -14,16 +14,16 @@ and follow best practices while serving their multiple purposes:
 General Guidelines
 ------------------
 
-- [ ] The DAG has a clear and descriptive file name.
-- [ ] The purpose of the DAG is documented at the top of the file.
-- [ ] The DAG demonstrates a single feature or concept.
+- [ ] The Dag has a clear and descriptive file name.
+- [ ] The purpose of the Dag is documented at the top of the file.
+- [ ] The Dag demonstrates a single feature or concept.
 - [ ] Examples do not duplicate functionality across the repo.
 - [ ] Example runs in a reasonable amount of time (suitable for tutorials & CI).
 
 Example Categorization
 ----------------------
 
-Example DAGs should clearly indicate which category they belong to:
+Example Dags should clearly indicate which category they belong to:
 
 - [ ] **Tutorial Examples** — educational, simple to read and follow.
 - [ ] **Documentation Snippets** — aligned with docs examples.
@@ -33,8 +33,8 @@ Example DAGs should clearly indicate which category they belong to:
 Structure & Readability
 -----------------------
 
-- [ ] The DAG and task IDs are meaningful and consistent.
-- [ ] The code follows PEP 8 formatting.
+- [ ] The Dag and task IDs are meaningful and consistent.
+- [ ] The code follows `PEP 8 <https://peps.python.org/pep-0008/>` formatting.
 - [ ] Imports are organized, minimal, and sorted.
 - [ ] Reusable logic is factored into helper functions or modules.
 - [ ] Example layout is consistent with other examples of the same category.
@@ -42,18 +42,18 @@ Structure & Readability
 Documentation
 -------------
 
-- [ ] The DAG contains a module-level docstring explaining:
-  * What the DAG does
+- [ ] The Dag contains a module-level docstring explaining:
+  * What the Dag does
   * Why it exists
   * When and how to use it
   * Any prerequisites or expected services
-- [ ] The DAG contains ``doc_md`` for in-UI documentation where appropriate.
+- [ ] The Dag contains ``doc_md`` for in-UI documentation where appropriate.
 - [ ] Inline comments explain complex or non-obvious logic.
 
 Best Practices
 --------------
 
-- [ ] The DAG uses well-named variables and avoids hard-coded secrets.
+- [ ] The Dag uses well-named variables and avoids hard-coded secrets.
 - [ ] Default arguments are defined and minimal.
 - [ ] Tasks are idempotent and side-effect clean.
 - [ ] Uses modern Airflow APIs and operators.
@@ -63,12 +63,12 @@ Best Practices
 Testing & CI Compatibility
 --------------------------
 
-- [ ] The DAG parses cleanly (no import errors).
+- [ ] The Dag parses cleanly (no import errors).
 - [ ] Example does not depend on external services unless documented.
 - [ ] Example is uniquely identifiable and does not conflict with others.
 - [ ] Example respects AIRFLOW__* environment variables where applicable.
 
-Provider Example DAGs
+Provider Example Dags
 ---------------------
 
 Provider examples have slightly different expectations:

--- a/contributing-docs/example_dag_review_checklist.rst
+++ b/contributing-docs/example_dag_review_checklist.rst
@@ -1,0 +1,79 @@
+Example DAG Review Checklist
+============================
+
+This document provides a checklist for reviewing example DAGs submitted to
+Apache Airflow. The goal is to ensure that example DAGs are clean, consistent,
+and follow best practices while serving their multiple purposes:
+
+* Clean and consistent
+* Easy to understand
+* Useful for tutorials and documentation
+* Compatible with testing and CI processes
+* Properly structured across core and provider packages
+
+General Guidelines
+------------------
+
+- [ ] The DAG has a clear and descriptive file name.
+- [ ] The purpose of the DAG is documented at the top of the file.
+- [ ] The DAG demonstrates a single feature or concept.
+- [ ] Examples do not duplicate functionality across the repo.
+- [ ] Example runs in a reasonable amount of time (suitable for tutorials & CI).
+
+Example Categorization
+----------------------
+
+Example DAGs should clearly indicate which category they belong to:
+
+- [ ] **Tutorial Examples** — educational, simple to read and follow.
+- [ ] **Documentation Snippets** — aligned with docs examples.
+- [ ] **Testing/CI Examples** — used to exercise system features in CI.
+- [ ] Example type is noted in module-level docstring or metadata.
+
+Structure & Readability
+-----------------------
+
+- [ ] The DAG and task IDs are meaningful and consistent.
+- [ ] The code follows PEP 8 formatting.
+- [ ] Imports are organized, minimal, and sorted.
+- [ ] Reusable logic is factored into helper functions or modules.
+- [ ] Example layout is consistent with other examples of the same category.
+
+Documentation
+-------------
+
+- [ ] The DAG contains a module-level docstring explaining:
+  * What the DAG does
+  * Why it exists
+  * When and how to use it
+  * Any prerequisites or expected services
+- [ ] The DAG contains ``doc_md`` for in-UI documentation where appropriate.
+- [ ] Inline comments explain complex or non-obvious logic.
+
+Best Practices
+--------------
+
+- [ ] The DAG uses well-named variables and avoids hard-coded secrets.
+- [ ] Default arguments are defined and minimal.
+- [ ] Tasks are idempotent and side-effect clean.
+- [ ] Uses modern Airflow APIs and operators.
+- [ ] Avoids deprecated or discouraged features.
+- [ ] Providers examples import only allowed modules.
+
+Testing & CI Compatibility
+--------------------------
+
+- [ ] The DAG parses cleanly (no import errors).
+- [ ] Example does not depend on external services unless documented.
+- [ ] Example is uniquely identifiable and does not conflict with others.
+- [ ] Example respects AIRFLOW__* environment variables where applicable.
+
+Provider Example DAGs
+---------------------
+
+Provider examples have slightly different expectations:
+
+- [ ] The provider example uses provider-specific operators/hooks correctly.
+- [ ] Provider dependencies are clearly documented in the docstring.
+- [ ] Example is not auto-loaded unless intended.
+- [ ] Example naming follows provider naming conventions.

--- a/contributing-docs/example_dag_review_checklist.rst
+++ b/contributing-docs/example_dag_review_checklist.rst
@@ -1,3 +1,20 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
 Example Dag Review Checklist
 ============================
 
@@ -34,7 +51,7 @@ Structure & Readability
 -----------------------
 
 - [ ] The Dag and task IDs are meaningful and consistent.
-- [ ] The code follows `PEP 8 <https://peps.python.org/pep-0008/>` formatting.
+- [ ] The code follows `PEP 8 <https://peps.python.org/pep-0008/>`_ formatting.
 - [ ] Imports are organized, minimal, and sorted.
 - [ ] Reusable logic is factored into helper functions or modules.
 - [ ] Example layout is consistent with other examples of the same category.


### PR DESCRIPTION
Picking up #61786, which @Chandanakt opened back in February. @jscheffl already approved it but it got marked as draft over a static-check failure and ended up auto-closed by the bot after a few weeks of no activity. Since #52476 is still open and the rest of the Examples Refurbish epic depends on it, brought it back, rebased on main, and fixed the two prek hooks that were failing.

Credit for the actual checklist content stays with @Chandanakt, her three commits are preserved. The only thing I added on top is the ASF license header that the `insert-license` hook expects on every RST file under `contributing-docs/`, plus the closing underscore on the PEP 8 link so `rst-backticks` stops complaining.

closes: #52476

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes