### PR TITLE
i18n(ko): Add Korean translations for deadline status UI (May 2)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -40,6 +40,12 @@
     "parseDuration": "파싱 기간:",
     "parsedAt": "파싱 시간:"
   },
+  "deadlineStatus": {
+    "stillRunning": "실행 중",
+    "upcoming": "예정",
+    "upcomingCount_one": "예정된 데드라인 {{count}}개",
+    "upcomingCount_other": "예정된 데드라인 {{count}}개"
+  },
   "extraLinks": "추가 링크",
   "grid": {
     "buttons": {


### PR DESCRIPTION
## Summary
Added Korean translations for deadline status labels in the DAG UI:
- `stillRunning`: "실행 중" (Running)
  -  meaning: Dag run execution not completed
- `upcoming`: "예정" (Upcoming)
  -  meaning: deadline time not reached
<img width="2927" height="360" alt="image" src="https://github.com/user-attachments/assets/8ec8bed8-ea5d-4c67-8019-512aedd89a47" />

- `upcomingCount_one/other`: "예정된 데드라인 {{count}}개"
<img width="2918" height="263" alt="image" src="https://github.com/user-attachments/assets/33cf3d63-f94a-4cd2-b464-63cd72e0d863" />

## English (Original)
<img width="532" height="122" alt="image" src="https://github.com/user-attachments/assets/d9de52ea-a5b0-4dc9-802e-acf0f468b638" />

## Changes
- Updated `airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json`




---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenCode

Generated-by: OpenCode following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)