### PR TITLE
i18n(Ko): add missing translations (May 2nd)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -263,6 +263,8 @@
   "task_one": "작업",
   "task_other": "작업들",
   "taskGroup": "작업 그룹",
+  "taskGroup_one": "작업 그룹",
+  "taskGroup_other": "작업 그룹들",
   "taskId": "작업 ID",
   "taskInstance": {
     "dagVersion": "Dag 버전",


### PR DESCRIPTION
Added missing Korean translations

<img width="1582" height="972" alt="before_i18n" src="https://github.com/user-attachments/assets/b941a302-857e-48b4-82e9-5c3a29645e93" />
<img width="1538" height="928" alt="after_i18n" src="https://github.com/user-attachments/assets/03f36f1e-1948-419a-8ee5-dfbb25368d56" />

Please review this translations.
/cc @kgw7401 @onestn @noeunkim @choo121600

