### PR TITLE
i18n(Ko): add missing translations in dag.json (May 2nd)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -104,6 +104,10 @@
       "assetEvent_one": "생성된 에셋 이벤트",
       "assetEvent_other": "생성된 에셋 이벤트"
     },
+    "deadlines": {
+      "showAll": "모두 표시",
+      "title": "데드라인"
+    },
     "failedLogs": {
       "hideLogs": "로그 숨기기",
       "showLogs": "로그 보기",


### PR DESCRIPTION
Add deadlines for missing Korean translations

### Before
<img width="1111" height="560" alt="스크린샷 2026-05-02 오후 8 33 14" src="https://github.com/user-attachments/assets/be27fbb7-eb55-43e8-b0c2-9a025d926e9d" />

<img width="1012" height="708" alt="스크린샷 2026-05-02 오후 8 26 20" src="https://github.com/user-attachments/assets/7d8d353d-25cc-45f3-b200-000945b28694" />


### After
<img width="1133" height="563" alt="스크린샷 2026-05-02 오후 8 44 10" src="https://github.com/user-attachments/assets/b775cf4e-f901-405a-99c4-b696afaf5109" />

<img width="1012" height="708" alt="스크린샷 2026-05-02 오후 8 34 41" src="https://github.com/user-attachments/assets/79293cbd-ec52-4c4b-99c9-905e910841f8" />

Please review this translations.
/cc @kgw7401 @onestn @choo121600