### PR TITLE
[v3-2-test] Fix static checks on SKILL.md files with YAML frontmatter

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -2,6 +2,8 @@
 applyTo: "**"
 excludeAgent: "coding-agent"
 ---
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
 
 # Airflow Code Review Instructions
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,6 +176,8 @@ repos:
           - "||"
           - --license-filepath
           - scripts/ci/license-templates/SHORT_LICENSE.md
+          - --detect-license-in-X-top-lines
+          - '30'
           - --fuzzy-match-generates-todo
         files:
           (?x)
@@ -186,10 +188,7 @@ repos:
           ^(?:.*/)?SKILL\.md$
         exclude:
           (?x)
-          ^scripts/ci/license-templates/|
-          ^\.github/instructions/|
-          ^\.github/skills/airflow-translations/SKILL\.md$|
-          ^\.github/skills/pr-triage/SKILL\.md$
+          ^scripts/ci/license-templates/
       - id: insert-license
         name: Add license for all other files
         args:


### PR DESCRIPTION
## Summary

- Backport the `.pre-commit-config.yaml` part of #65776 (`main` commit
  `0960ad2f6d`) — adds `--detect-license-in-X-top-lines '30'` to the
  agentic-markdown `insert-license` hook so it recognises the license
  header that sits below the YAML frontmatter, and drops the per-file
  exclude workarounds that compensated for its absence.
- Add the inner license header to
  `.github/instructions/code-review.instructions.md` to match what
  `airflow-translations/SKILL.md` and `pr-triage/SKILL.md` already do
  (and what `main` already has) so the file no longer needs to be
  excluded.
- This unblocks `v3-2-test` static checks, which were failing on
  `insert-license` + `lint-markdown` after #66169 added
  `prepare-providers-documentation/SKILL.md` without an exclude entry.

The new `aip-user-stories` skill that shipped alongside this config
change in #65776 is **not** backported — out of scope for v3-2-test.

## Test plan

- [ ] `prek run insert-license --all-files` passes locally
- [ ] `prek run lint-markdown --all-files` passes locally
- [ ] CI `Static checks` job goes green

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)