### PR TITLE
Add airflowctl tasks clear command

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -220,6 +220,23 @@ ARG_OUTPUT = Arg(
     default="json",
     type=str,
 )
+ARG_TASK_DAG_ID = Arg(
+    flags=("--dag-id",),
+    type=str,
+    required=True,
+    help="The Dag ID.",
+)
+ARG_TASK_DAG_RUN_ID = Arg(
+    flags=("--dag-run-id",),
+    type=str,
+    required=True,
+    help="The Dag run ID.",
+)
+ARG_TASK_IDS = Arg(
+    flags=("--task-ids",),
+    type=string_list_type,
+    help="Comma-separated task IDs to clear.",
+)
 
 # Authentication arguments
 ARG_AUTH_URL = Arg(
@@ -953,6 +970,47 @@ VARIABLE_COMMANDS = (
     ),
 )
 
+TASK_COMMANDS = (
+    ActionCommand(
+        name="clear",
+        help="Clear task instances",
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.task_clear"),
+        args=(
+            ARG_TASK_DAG_ID,
+            ARG_TASK_DAG_RUN_ID,
+            ARG_TASK_IDS,
+            Arg(
+                flags=("--only-failed",),
+                action="store_true",
+                default=False,
+                help="Clear only failed tasks.",
+            ),
+            Arg(
+                flags=("--only-running",),
+                action="store_true",
+                default=False,
+                help="Clear only running tasks.",
+            ),
+            Arg(
+                flags=("--upstream",),
+                dest="include_upstream",
+                action="store_true",
+                default=False,
+                help="Include upstream tasks.",
+            ),
+            Arg(
+                flags=("--downstream",),
+                dest="include_downstream",
+                action="store_true",
+                default=False,
+                help="Include downstream tasks.",
+            ),
+            Arg(flags=("--dry-run",), action="store_true", default=False, help="Perform a dry run."),
+            ARG_OUTPUT,
+        ),
+    ),
+)
+
 core_commands: list[CLICommand] = [
     GroupCommand(
         name="auth",
@@ -994,6 +1052,11 @@ core_commands: list[CLICommand] = [
         name="variables",
         help="Manage Airflow variables",
         subcommands=VARIABLE_COMMANDS,
+    ),
+    GroupCommand(
+        name="tasks",
+        help="Manage Airflow tasks",
+        subcommands=TASK_COMMANDS,
     ),
 ]
 # Add generated group commands

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from airflowctl.api.client import NEW_API_CLIENT, Client, ClientKind, provide_api_client
+from airflowctl.ctl.console_formatting import AirflowConsole
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def task_clear(args, api_client: Client = NEW_API_CLIENT) -> dict:
+    """Clear task instances."""
+    if args.only_failed and args.only_running:
+        raise SystemExit("--only-failed and --only-running cannot both be set")
+
+    payload = {
+        "dag_run_id": args.dag_run_id,
+        "task_ids": args.task_ids,
+        "only_failed": args.only_failed,
+        "only_running": args.only_running,
+        "include_upstream": args.include_upstream,
+        "include_downstream": args.include_downstream,
+        "dry_run": args.dry_run,
+    }
+    payload = {key: value for key, value in payload.items() if value is not None}
+
+    response = api_client.post(f"dags/{args.dag_id}/clearTaskInstances", json=payload)
+    data = response.json()
+    AirflowConsole().print_as(data=[data], output=args.output)
+    return data

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflowctl.ctl import cli_parser
+from airflowctl.ctl.commands import task_command
+
+
+class TestTaskCommands:
+    parser = cli_parser.get_parser()
+
+    def test_clear_tasks(self):
+        api_client = mock.Mock()
+        response_data = {"task_instances": [{"task_id": "extract"}], "total_entries": 1}
+        api_client.post.return_value.json.return_value = response_data
+
+        args = self.parser.parse_args(
+            [
+                "tasks",
+                "clear",
+                "--dag-id",
+                "example_dag",
+                "--dag-run-id",
+                "manual__2026-05-02T00:00:00+00:00",
+                "--task-ids",
+                "extract,transform",
+                "--only-failed",
+                "--upstream",
+                "--dry-run",
+                "--output",
+                "json",
+            ]
+        )
+
+        with mock.patch("airflowctl.ctl.commands.task_command.AirflowConsole") as console:
+            result = task_command.task_clear(args, api_client=api_client)
+
+        assert result == response_data
+        api_client.post.assert_called_once_with(
+            "dags/example_dag/clearTaskInstances",
+            json={
+                "dag_run_id": "manual__2026-05-02T00:00:00+00:00",
+                "task_ids": ["extract", "transform"],
+                "only_failed": True,
+                "only_running": False,
+                "include_upstream": True,
+                "include_downstream": False,
+                "dry_run": True,
+            },
+        )
+        console.return_value.print_as.assert_called_once_with(data=[response_data], output="json")
+
+    def test_clear_tasks_filters_none_task_ids(self):
+        api_client = mock.Mock()
+        response_data = {"task_instances": [], "total_entries": 0}
+        api_client.post.return_value.json.return_value = response_data
+
+        args = self.parser.parse_args(["tasks", "clear", "--dag-id", "example_dag", "--dag-run-id", "run_1"])
+
+        task_command.task_clear(args, api_client=api_client)
+
+        api_client.post.assert_called_once_with(
+            "dags/example_dag/clearTaskInstances",
+            json={
+                "dag_run_id": "run_1",
+                "only_failed": False,
+                "only_running": False,
+                "include_upstream": False,
+                "include_downstream": False,
+                "dry_run": False,
+            },
+        )
+
+    def test_clear_tasks_rejects_only_failed_and_only_running(self):
+        args = self.parser.parse_args(
+            [
+                "tasks",
+                "clear",
+                "--dag-id",
+                "example_dag",
+                "--dag-run-id",
+                "run_1",
+                "--only-failed",
+                "--only-running",
+            ]
+        )
+
+        with pytest.raises(SystemExit, match="--only-failed and --only-running cannot both be set"):
+            task_command.task_clear(args, api_client=mock.Mock())


### PR DESCRIPTION
Adds `airflowctl tasks clear`, backed by the public REST API endpoint:

`POST /api/v2/dags/{dag_id}/clearTaskInstances`

The command supports dag-run scoped task clearing with optional task IDs, failed/running filters, upstream/downstream inclusion, and dry-run mode.

Closes #66176

## Tests
- `uv run --project airflow-ctl pytest airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py -xvs`
- `ruff format --check airflow-ctl/src/airflowctl/ctl/commands/task_command.py airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py`
- `ruff check airflow-ctl/src/airflowctl/ctl/commands/task_command.py airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/commands/test_task_command.py`
- `git diff --check`

---

### Was generative AI tooling used to co-author this PR?

- [X] Yes

<!-- pr-triage-fold: triaged=2026-06-22T06:40:22.912388+00:00 head=86cc5f7 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @NamanSinghai** · by `@potiuk` · 2026-06-22 06:40 UTC
>
> This PR is being closed to keep the queue clean:
> - Draft triaged 34 days ago with no response since.
>
> **The ball is in your court** — Reopen or open a fresh PR once you pick it back up — no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->