### PR TITLE
[v3-2-test] Use contextlib.suppress instead of try-except-pass in providers (#66178)

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/eks.py
@@ -586,10 +586,9 @@ class EksHook(AwsBaseHook):
             if fd is not None:
                 os.close(fd)
             if temp_path and os.path.exists(temp_path):
-                try:
+                # Best effort cleanup
+                with contextlib.suppress(OSError):
                     os.unlink(temp_path)
-                except OSError:
-                    pass  # Best effort cleanup
 
     @contextmanager
     def generate_config_file(

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/eks.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import stat
@@ -1200,10 +1201,8 @@ class EksPodOperator(KubernetesPodOperator):
                     f.write(f"export AWS_SESSION_TOKEN='{session_token}'\n")
         except Exception:
             # If fdopen fails, we need to close the file descriptor manually
-            try:
+            with contextlib.suppress(OSError):
                 os.close(fd)
-            except OSError:
-                pass
             raise
 
     def _refresh_cached_properties(self) -> None:

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_jdbc_script.py
@@ -18,15 +18,14 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-try:
+with contextlib.suppress(ImportError):
     from pyspark.sql import SparkSession
-except ImportError:
-    pass
 
 SPARK_WRITE_TO_JDBC: str = "spark_to_jdbc"
 SPARK_READ_FROM_JDBC: str = "jdbc_to_spark"

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -375,10 +375,9 @@ def send_workload_to_executor(
     # If timeout fires during import, redis module gets partially cached in sys.modules
     # without the 'client' submodule bound, causing AttributeError on subsequent access.
     # See: https://github.com/apache/airflow/issues/41359
-    try:
+    # Redis not installed or not using Redis backend.
+    with contextlib.suppress(ImportError):
         import redis.client  # noqa: F401
-    except ImportError:
-        pass  # Redis not installed or not using Redis backend
 
     try:
         with timeout(seconds=OPERATION_TIMEOUT):
@@ -409,10 +408,9 @@ def fetch_celery_task_state(async_result: AsyncResult) -> tuple[str, str | Excep
     """
     # Pre-import redis.client to avoid SIGALRM interrupting module initialization.
     # See: https://github.com/apache/airflow/issues/41359
-    try:
+    # Redis not installed or not using Redis backend.
+    with contextlib.suppress(ImportError):
         import redis.client  # noqa: F401
-    except ImportError:
-        pass  # Redis not installed or not using Redis backend
 
     try:
         with timeout(seconds=OPERATION_TIMEOUT):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -29,7 +29,7 @@ import re
 import shlex
 import string
 from collections.abc import Callable, Container, Iterable, Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, suppress
 from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
@@ -655,10 +655,8 @@ class KubernetesPodOperator(BaseOperator):
                 finally:
                     # Stop watching events
                     events_task.cancel()
-                    try:
+                    with suppress(asyncio.CancelledError):
                         await events_task
-                    except asyncio.CancelledError:
-                        pass
 
             asyncio.run(_await_pod_start())
         except PodLaunchFailedException:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import traceback
 from collections.abc import AsyncIterator
@@ -285,10 +286,8 @@ class KubernetesPodTrigger(BaseTrigger):
         finally:
             # Stop watching events
             events_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await events_task
-            except asyncio.CancelledError:
-                pass
 
         return self.define_container_state(await self._get_pod())
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/decorators/test_kubernetes_commons.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable
 from unittest import mock
 
@@ -108,10 +109,8 @@ class TestKubernetesDecoratorsBase:
         self.mock_fetch_logs = mock.patch(f"{POD_MANAGER_CLASS}.fetch_requested_container_logs").start()
         self.mock_fetch_logs.return_value = "logs"
 
-        try:
+        with contextlib.suppress(Exception):
             yield
-        except Exception:
-            pass
         mock.patch.stopall()
 
     def teardown_method(self):


### PR DESCRIPTION
## Summary

- Cherry-picks #66178 (`main` commit `9b9789ae6b`,
  "Use contextlib.suppress instead of try-except-pass in providers") to
  v3-2-test, dropping the two files that don't exist in v3-2-test
  (`providers/common/ai/.../durable/storage.py` and
  `providers/ssh/.../tunnel.py`) and the test example file
  (`example_s3_tables.py`) that also isn't on v3-2-test.
- Adds a follow-up commit applying the same SIM105 fix to
  `providers/apache/spark/.../hooks/spark_jdbc_script.py`. On main this
  file was rewritten in #64174 to raise an explicit
  `AirflowOptionalProviderFeatureException`, but that change is out of
  scope for v3-2-test, so we use the minimum SIM105-compliant edit
  (`contextlib.suppress(ImportError)`).

The SIM105 rule was re-enabled on v3-2-test by #66264 (the backport of
main's #66193). #66264 cherry-picked the rule re-enablement but did
**not** include the provider-side fixes that #66178 had already done on
main, so v3-2-test's static-checks job has been failing with 8 SIM105
hits across these 7 files since #66264 merged. This PR closes that gap.

## Test plan

- [ ] `prek run ruff --all-files` passes locally (verified — 8 SIM105
      hits resolved)
- [ ] CI `Static checks` job goes green on v3-2-test

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)