### PR TITLE
Adopt apache/airflow-steward framework via submodule

### DIFF
--- a/.apache-steward/pr-maintainer-review-criteria.md
+++ b/.apache-steward/pr-maintainer-review-criteria.md
@@ -1,0 +1,91 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — pr-maintainer-review criteria
+
+Per-project navigation map for the
+[`pr-maintainer-review`](apache-steward/.claude/skills/pr-maintainer-review/SKILL.md)
+skill's review-criteria source files. Companion to the framework's
+[`projects/_template/pr-maintainer-review-criteria.md`](apache-steward/projects/_template/pr-maintainer-review-criteria.md)
+scaffold.
+
+The framework does not restate the rules; this file points at them.
+The skill's review pass reads each source file at session start
+(and re-reads per-area files as PRs route into different trees) and
+quotes the **source rule verbatim** in any finding it raises.
+
+## Repo-wide source files
+
+| File | What it covers |
+|---|---|
+| [`.github/instructions/code-review.instructions.md`](../.github/instructions/code-review.instructions.md) | The rule set every Apache Airflow PR is reviewed against (architecture / DB / quality / testing / API / UI / generated files / AI-generated-code signals / quality signals). |
+| [`AGENTS.md`](../AGENTS.md) | Repo-wide AI/agent instructions (architecture boundaries, security model, coding standards, testing standards, commits & PR conventions). |
+
+## Per-area source files
+
+Always loaded — the skill also auto-discovers any `AGENTS.md`
+under the touched paths via `git ls-files`.
+
+| File | When it applies |
+|---|---|
+| [`registry/AGENTS.md`](../registry/AGENTS.md) | Registry-tree-specific rules. |
+| [`dev/AGENTS.md`](../dev/AGENTS.md) | `dev/` scripts conventions. |
+| [`dev/ide_setup/AGENTS.md`](../dev/ide_setup/AGENTS.md) | IDE bootstrap conventions. |
+| [`providers/AGENTS.md`](../providers/AGENTS.md) | Provider-tree boundary, compat-layer, and `provider.yaml` expectations. |
+| [`providers/elasticsearch/AGENTS.md`](../providers/elasticsearch/AGENTS.md) | Elasticsearch-specific rules. |
+| [`providers/opensearch/AGENTS.md`](../providers/opensearch/AGENTS.md) | OpenSearch-specific rules. |
+
+## Security-model calibration
+
+| File | Used by |
+|---|---|
+| [`airflow-core/docs/security/security_model.rst`](../airflow-core/docs/security/security_model.rst) | The skill's `Security model — calibration` section (`review-flow.md`). Used to distinguish actual vulnerabilities from documented limitations and deployment-hardening opportunities. |
+
+## Backports / version-specific PRs
+
+| Concept | Pattern |
+|---|---|
+| Backport branch pattern | `vX-Y-test` |
+
+Backports get a lighter-touch review focused on diff parity and
+cherry-pick conflicts; prefer `COMMENT` over `REQUEST_CHANGES`
+unless the cherry-pick has clearly drifted from the `main` change.
+
+## Section anchors
+
+The skill links per-finding to the section in
+[`.github/instructions/code-review.instructions.md`](../.github/instructions/code-review.instructions.md)
+that the finding cites:
+
+| Section | Anchor URL |
+|---|---|
+| Architecture boundaries | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#architecture-boundaries> |
+| Database / query correctness | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#database-and-query-correctness> |
+| Code quality | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#code-quality-rules> |
+| Testing | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#testing-requirements> |
+| API correctness | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#api-correctness> |
+| UI (React/TypeScript) | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ui-code-reacttypescript> |
+| Generated files | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#generated-files> |
+| AI-generated code signals | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#ai-generated-code-signals> |
+| Quality signals to check | <https://github.com/apache/airflow/blob/main/.github/instructions/code-review.instructions.md#quality-signals-to-check> |
+| Commits and PRs | <https://github.com/apache/airflow/blob/main/AGENTS.md#commits-and-prs> |
+| Security model | <https://github.com/apache/airflow/blob/main/AGENTS.md#security-model> |

--- a/.apache-steward/pr-triage-ci-check-map.md
+++ b/.apache-steward/pr-triage-ci-check-map.md
@@ -1,0 +1,68 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — pr-triage CI-check to doc-URL map
+
+Per-project CI-check categorisation table for the
+[`pr-triage`](apache-steward/.claude/skills/pr-triage/SKILL.md)
+skill's violations comments. Companion to the framework's
+[`projects/_template/pr-triage-ci-check-map.md`](apache-steward/projects/_template/pr-triage-ci-check-map.md)
+scaffold.
+
+When a PR has failing CI checks, the skill groups failures by
+category (static checks, tests, image builds, etc.) and links each
+category to the documentation for that area.
+
+## Table
+
+Pattern matching is **case-insensitive substring**, evaluated in
+the order below — first match wins. Put more-specific patterns
+above broader ones (e.g. `mypy-airflow-core` before bare `mypy`).
+
+| Pattern | Category | Doc URL |
+|---|---|---|
+| `static checks` | Pre-commit / static checks | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `pre-commit` | Pre-commit / static checks | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `prek` | Pre-commit / static checks | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `ruff` | Ruff (linting / formatting) | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `mypy-` | mypy (type checking) | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `unit test` | Unit tests | <https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst> |
+| `test-` | Unit tests | <https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst> |
+| `docs` | Build docs | <https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst> |
+| `spellcheck-docs` | Build docs | <https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst> |
+| `build-docs` | Build docs | <https://github.com/apache/airflow/blob/main/contributing-docs/11_documentation_building.rst> |
+| `helm` | Helm tests | <https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst> |
+| `k8s` | Kubernetes tests | <https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst> |
+| `kubernetes` | Kubernetes tests | <https://github.com/apache/airflow/blob/main/contributing-docs/testing/k8s_tests.rst> |
+| `build ci image` | Image build | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `build prod image` | Image build | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `ci-image` | Image build | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `prod-image` | Image build | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+| `provider` | Provider tests | <https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst> |
+| `*` (catch-all) | Other failing CI checks | <https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst> |
+
+## Fallbacks
+
+| Concept | Doc URL |
+|---|---|
+| Merge conflicts (rebase guide) | <https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst> |
+| Pull Request quality criteria (the Copilot-review / unresolved-threads fallback) | <https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria> |

--- a/.apache-steward/pr-triage-comment-templates.md
+++ b/.apache-steward/pr-triage-comment-templates.md
@@ -1,0 +1,77 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — pr-triage comment templates
+
+Per-project comment-body library for the
+[`pr-triage`](apache-steward/.claude/skills/pr-triage/SKILL.md)
+skill. The framework's
+[`comment-templates.md`](apache-steward/.claude/skills/pr-triage/comment-templates.md)
+documents what each template **must** contain (the contract); this
+file declares Airflow's actual wording, URLs, and tone.
+
+## Project-specific URLs
+
+| Placeholder | Value |
+|---|---|
+| `<quality_criteria_url>` | <https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria> |
+| `<two_stage_triage_rationale_url>` | <https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated> |
+| `<project_display_name>` | `Apache Airflow` |
+
+## Quality-criteria marker string
+
+| Concept | Value |
+|---|---|
+| Triage-marker visible link text | `Pull Request quality criteria` |
+
+This is the literal string the framework searches for to detect
+already-triaged PRs. **Do not paraphrase** — the same exact string
+must appear verbatim in every triage comment the skill posts, and
+[`pr-stats`](apache-steward/.claude/skills/pr-stats/SKILL.md) uses
+the same marker for its "is this PR triaged" detection.
+
+## AI-attribution footer
+
+The block appended verbatim to every contributor-facing comment
+(see
+[`comment-templates.md` § AI-attribution footer](apache-steward/.claude/skills/pr-triage/comment-templates.md#ai-attribution-footer)
+for the rules — always-include, never-paraphrase, render at end of
+body).
+
+```markdown
+---
+
+_Note: This comment was drafted by an AI-assisted triage tool and may contain mistakes. Once you have addressed the points above, an Apache Airflow maintainer — a real person — will take the next look at your PR. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so that our maintainers' limited time is spent where it matters most: the conversation with you._
+```
+
+## Template bodies
+
+The framework's
+[`comment-templates.md`](apache-steward/.claude/skills/pr-triage/comment-templates.md)
+currently embeds Airflow-flavoured body text inline (a pre-
+extraction migration artefact). Airflow uses those inline defaults
+as-is; this section becomes load-bearing once the framework
+completes the extraction so non-Airflow adopters can override
+section-by-section without forking the whole file.
+
+Until then, treat this section as a stub: the framework's defaults
+*are* Airflow's defaults.

--- a/.apache-steward/pr-triage-config.md
+++ b/.apache-steward/pr-triage-config.md
@@ -1,0 +1,55 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — pr-triage configuration
+
+Per-project configuration for the
+[`pr-triage`](apache-steward/.claude/skills/pr-triage/SKILL.md) and
+[`pr-stats`](apache-steward/.claude/skills/pr-stats/SKILL.md)
+skills. Companion to the framework's
+[`projects/_template/pr-triage-config.md`](apache-steward/projects/_template/pr-triage-config.md)
+scaffold.
+
+## Identifiers
+
+| Key | Value | Used by |
+|---|---|---|
+| `committers_team` | `apache/airflow-committers` | `classify-and-act.md` row F5b — team-mention detection. |
+| `area_label_prefix` | `area:` | `classify-and-act.md`, `pr-stats` — area-label grouping. |
+
+## Project-specific labels
+
+| Concept | Label |
+|---|---|
+| `ready_for_maintainer_review` | `ready for maintainer review` |
+| `quality_violations_close` | `quality violations - closed` |
+| `suspicious_changes` | `suspicious changes` |
+| `work_in_progress` | (Airflow uses GitHub's draft state, not a WIP label — leave the rule disabled) |
+
+## Grace windows
+
+| Concept | Value |
+|---|---|
+| Stale-draft close threshold | 30 days |
+| Inactive-open → draft threshold | 14 days |
+| Stale-review-ping cooldown | 7 days |
+| Stale-workflow-approval threshold | 7 days |

--- a/.apache-steward/project.md
+++ b/.apache-steward/project.md
@@ -1,0 +1,69 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — project manifest
+
+This is the **project configuration** for `apache-airflow` as an
+adopter of the [`apache/airflow-steward`](https://github.com/apache/airflow-steward)
+framework. The framework lives at
+[`.apache-steward/apache-steward/`](apache-steward/) as a git
+submodule; this directory carries the airflow-specific content the
+framework's skills resolve via the
+[`<project-config>/` placeholder convention](apache-steward/AGENTS.md#placeholder-convention-used-in-skill-files).
+
+apache-airflow adopts only the
+[PR triage and review](apache-steward/.claude/skills/pr-triage/SKILL.md)
+skill family — the security workflow runs out of the private
+security-tracker repo (`apache/airflow-s`), not out of the public
+upstream. Files declaring security-workflow specifics
+(`canned-responses.md`, `scope-labels.md`, `release-trains.md`,
+etc.) intentionally do **not** live here; they're declared in the
+security tracker's own `.apache-steward/` directory.
+
+## Identity
+
+| Key | Value |
+|---|---|
+| `project_name` | Apache Airflow |
+| `vendor` | Apache Software Foundation |
+| `short_name` | Airflow |
+| `product_family_url` | <https://airflow.apache.org/> |
+
+## Repositories
+
+| Key | Value | Purpose |
+|---|---|---|
+| `upstream_repo` | `apache/airflow` | Public codebase — this repo. PR-skill default target. |
+| `upstream_repo_url` | <https://github.com/apache/airflow> | |
+| `upstream_default_branch` | `main` | |
+
+## Pointers to sibling files
+
+The PR-skill family resolves its project-specific content from
+these files in this directory:
+
+| File | Used by |
+|---|---|
+| [`pr-triage-config.md`](pr-triage-config.md) | `pr-triage`, `pr-stats` |
+| [`pr-triage-comment-templates.md`](pr-triage-comment-templates.md) | `pr-triage` |
+| [`pr-triage-ci-check-map.md`](pr-triage-ci-check-map.md) | `pr-triage` |
+| [`pr-maintainer-review-criteria.md`](pr-maintainer-review-criteria.md) | `pr-maintainer-review` |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".apache-steward/apache-steward"]
+	path = .apache-steward/apache-steward
+	url = https://github.com/apache/airflow-steward.git


### PR DESCRIPTION
## Summary

Apache Airflow becomes an adopter of the [`apache/airflow-steward`](https://github.com/apache/airflow-steward) framework — a project-agnostic skill library for ASF-project automation. The framework lands as a git submodule at `.apache-steward/apache-steward/`; the per-project adopter configuration sits alongside it under `.apache-steward/`.

This is the **first of three** airflow-side PRs that complete the migration:

1. **(this PR)** Add the submodule + adopter config. Existing `.claude/skills/` symlinks and `.github/skills/{pr-triage,pr-stats,maintainer-review}` stay in place — nothing breaks for current users.
2. **Follow-up** — replace the `.claude/skills/` symlinks with submodule-pointing ones; delete the duplicate `.github/skills/` copies.
3. **Follow-up** — update contributor docs to reference the framework.

## Why

The `pr-triage`, `pr-stats`, and `maintainer-review` (renamed `pr-maintainer-review`) skills were lifted into the framework over the last week ([apache/airflow-steward#33](https://github.com/apache/airflow-steward/pull/33)) so other ASF projects can adopt the same playbook. Airflow now consumes them via submodule rather than maintaining its own copies under `.github/skills/`. Project-specific knobs (committers team, area-label prefix, comment-template URLs, CI-check map, review-criteria source files) live in `.apache-steward/` per the framework's [adopter contract](https://github.com/apache/airflow-steward/blob/main/README.md#adopting-the-framework).

The security workflow is **not** adopted here — those skills run out of the private security-tracker repo `apache/airflow-s`, not out of the public upstream — so no security-workflow project-config files (`canned-responses.md`, `scope-labels.md`, `release-trains.md`, etc.) live in this directory.

## What's in `.apache-steward/`

| File | Purpose |
|---|---|
| `project.md` | Identity (`Apache Airflow` / `apache/airflow`), upstream repo, sibling-file pointers |
| `pr-triage-config.md` | Committers team (`apache/airflow-committers`), area-label prefix (`area:`), project labels (`ready for maintainer review`, etc.), grace windows |
| `pr-triage-comment-templates.md` | Comment-body URLs (PR quality criteria, two-stage triage rationale), AI-attribution footer, project display name |
| `pr-triage-ci-check-map.md` | CI-check pattern → category + doc-URL map (lifted from what `pr-triage/comment-templates.md` currently embeds inline) |
| `pr-maintainer-review-criteria.md` | Review-criteria source files (`code-review.instructions.md`, `AGENTS.md`, per-area `AGENTS.md`s), security-model calibration, backport pattern, section anchors |

## Operational notes

- **Fresh clones / parent `git pull`:** run `git submodule update --init --recursive`. Wire it as a post-merge hook to make it automatic — the framework's `setup-verify-steward` skill checks integration and reminds.
- **Submodule pointer:** pinned at the latest framework `main` (commit 9774cc9, includes the four steward PRs that lifted + documented these skills).
- **No skill behaviour change yet:** the existing `.github/skills/{pr-triage,pr-stats,maintainer-review}` and the symlinks under `.claude/skills/` are untouched. Skills run from the same content they always did. The cutover is in the follow-up PR.

## Test plan
- [x] All `prek run` hooks pass (markdownlint, codespell, license-header, etc.)
- [x] `.apache-steward/` content describes airflow accurately (committers team, area-label prefix, URLs, AGENTS.md paths)
- [ ] Reviewer eyeballs `.apache-steward/project.md` for accuracy
- [ ] Reviewer confirms the existing `.claude/skills/` and `.github/skills/` setup still works (no behaviour change in this PR)
- [ ] CI passes (lychee link-check, full prek)

🤖 Generated with [Claude Code](https://claude.com/claude-code)