### PR TITLE
UI: fix Searchbar input rewind 

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.test.tsx
@@ -116,6 +116,33 @@ describe("Test SearchBar", () => {
     expect((input as HTMLInputElement).value).toBe("user-typing");
   });
 
+  it("does not rewind in-flight typing when defaultValue echoes a stale value", () => {
+    vi.useFakeTimers();
+
+    const onChange = vi.fn();
+    const { rerender } = render(<SearchBar defaultValue="" onChange={onChange} placeholder="Search Dags" />, {
+      wrapper: Wrapper,
+    });
+    const input = screen.getByTestId("search-dags");
+
+    // Type "ab" and let the debounce flush so the parent receives onChange("ab").
+    fireEvent.change(input, { target: { value: "ab" } });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onChange).toHaveBeenLastCalledWith("ab");
+
+    // The user keeps typing before the parent's URL state has propagated back.
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect((input as HTMLInputElement).value).toBe("abc");
+
+    // The lagging echo of our own send arrives: parent rerenders with the
+    // previously-sent value. The in-flight character must not be clobbered.
+    rerender(<SearchBar defaultValue="ab" onChange={onChange} placeholder="Search Dags" />);
+
+    expect((input as HTMLInputElement).value).toBe("abc");
+  });
+
   it("does not render advanced toggle by default", () => {
     render(<SearchBar defaultValue="" onChange={vi.fn()} placeholder="Search" />, {
       wrapper: Wrapper,

--- a/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchBar.tsx
@@ -46,14 +46,21 @@ export const SearchBar = ({
   placeholder,
   ...props
 }: Props) => {
-  const handleSearchChange = useDebouncedCallback((val: string) => onChange(val), debounceDelay);
+  const lastSentValue = useRef(defaultValue);
+  const handleSearchChange = useDebouncedCallback((val: string) => {
+    lastSentValue.current = val;
+    onChange(val);
+  }, debounceDelay);
   const searchRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
   const metaKey = getMetaKey();
   const { t: translate } = useTranslation(["dags"]);
 
   useEffect(() => {
-    setValue(defaultValue);
+    if (defaultValue !== lastSentValue.current) {
+      setValue(defaultValue);
+      lastSentValue.current = defaultValue;
+    }
   }, [defaultValue]);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -62,6 +69,7 @@ export const SearchBar = ({
   };
   const clearSearch = () => {
     handleSearchChange.cancel();
+    lastSentValue.current = "";
     setValue("");
     onChange("");
   };


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## What this fixes

  When typing or deleting characters quickly in the DAG search bar, the input would occasionally rewind by 1–2 characters. Reported in #66184 with a reproduction video.

here is video that user report in issue

https://private-user-images.githubusercontent.com/10968348/586290693-37d7f9c9-c066-4722-8515-a0b5358ce515.mov?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzc3NDU5NDcsIm5iZiI6MTc3Nzc0NTY0NywicGF0aCI6Ii8xMDk2ODM0OC81ODYyOTA2OTMtMzdkN2Y5YzktYzA2Ni00NzIyLTg1MTUtYTBiNTM1OGNlNTE1Lm1vdj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTAyVDE4MTQwN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWMwNGM1M2NjYTA2ZTQ4YjBhMzNiZjU3Yjg3NTdhOTYzMzQwMjBmZTU5YjI2ZDAwMzgxNTJmNmEyODNhODEwOGYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRnF1aWNrdGltZSJ9.Jff21HtfFacP1fxKHVSzUMae2bNqx2Lde-tSjWHB1yM

## Root cause
  #65054 added an unconditional effect that resyncs the input from the `defaultValue` prop on every change:

  ```tsx
  useEffect(() => {
    setValue(defaultValue);
  }, [defaultValue]);
```

  That created a race with the 200 ms-debounced onChange:

  1. User types "abc" → debounce flushes → onChange("abc").
  2. Parent updates the URL params. defaultValue will eventually re-render as "abc".
  3. Before the round trip completes, the user types "abcd".
  4. The lagging defaultValue="abc" arrives and the effect calls setValue("abc"), clobbering the in-flight "d".

##  Fix

  Track the last value pushed via onChange in a ref and skip the sync when the incoming defaultValue is just an echo of our own send. External defaultValue changes (navigation, links with ?search=…, programmatic resets) still flow through, because for those defaultValue !== lastSentValue.current.

https://github.com/user-attachments/assets/ce8ec971-0913-43d2-acd1-10897e17c37a

  clearSearch resets the ref so the cleared state isn't fought by a subsequent echo.
                                                                                                                                                                                                                                                                           
###  Tests

  Added does not rewind in-flight typing when defaultValue echoes a stale value in SearchBar.test.tsx. It uses fake timers to flush the debounce on "ab", simulates the user typing "abc" before the parent's URL state propagates, and rerenders with the lagging echo defaultValue="ab". The input must remain "abc".                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                           
  Verified the new test fails on the parent commit (reproducing the bug from #66184) and passes with the fix.                                                                                                                 

* close: #66814

cc @choo121600 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
codex(gpt 5.5), claude opus 4.7

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
