### PR TITLE
Iterate file objects directly instead of calling readlines()

### DIFF
--- a/dev/airflow_perf/sql_queries.py
+++ b/dev/airflow_perf/sql_queries.py
@@ -145,7 +145,7 @@ def make_report() -> list[Query]:
     """
     queries = []
     with open(LOG_FILE, "r+") as f:
-        raw_queries = [line for line in f.readlines() if is_query(line)]
+        raw_queries = [line for line in f if is_query(line)]
 
     for query in raw_queries:
         time, info, stack, sql = query.replace("@SQLALCHEMY ", "").split("|$")

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -670,7 +670,7 @@ def get_task_sdk_version():
 def get_airflow_extras():
     airflow_dockerfile = AIRFLOW_ROOT_PATH / "Dockerfile"
     with open(airflow_dockerfile) as dockerfile:
-        for line_raw in dockerfile.readlines():
+        for line_raw in dockerfile:
             if "ARG AIRFLOW_EXTRAS=" in line_raw:
                 line = line_raw.split("=")[1].strip()
                 return line.replace('"', "")

--- a/devel-common/src/sphinx_exts/redirects.py
+++ b/devel-common/src/sphinx_exts/redirects.py
@@ -41,7 +41,7 @@ def generate_redirects(app):
         return
 
     with open(redirect_file_path) as redirects:
-        for line in redirects.readlines():
+        for line in redirects:
             # Skip empty line
             if not line.strip():
                 continue

--- a/providers/google/tests/system/google/cloud/gcs/resources/transform_script.py
+++ b/providers/google/tests/system/google/cloud/gcs/resources/transform_script.py
@@ -23,6 +23,6 @@ destination = sys.argv[2]
 
 print("Running script")
 with open(source) as src, open(destination, "w+") as dest:
-    lines = [line.upper() for line in src.readlines()]
+    lines = [line.upper() for line in src]
     print(lines)
     dest.writelines(lines)

--- a/scripts/ci/prek/newsfragments.py
+++ b/scripts/ci/prek/newsfragments.py
@@ -67,7 +67,7 @@ def main(filenames: list[str]) -> int:
     failed = False
     for filename in filenames:
         with open(filename) as f:
-            lines = [line.strip() for line in f.readlines()]
+            lines = [line.strip() for line in f]
         errors = validate_newsfragment(filename, lines)
         for error in errors:
             print(error)


### PR DESCRIPTION
## Summary

Replaces all five remaining `FURB129` violations: `for line in f.readlines()` → `for line in f`. File objects are iterable and yield lines lazily, while `readlines()` reads the entire file into a list before iteration starts.

## Why

Reference: [ruff FURB129 — readlines-in-for](https://docs.astral.sh/ruff/rules/readlines-in-for/).

- [`dev/airflow_perf/sql_queries.py:148`](https://github.com/apache/airflow/blob/main/dev/airflow_perf/sql_queries.py#L148) filters lines with `if is_query(line)` — non-matching lines never need to be in memory.
- [`dev/breeze/src/airflow_breeze/global_constants.py:673`](https://github.com/apache/airflow/blob/main/dev/breeze/src/airflow_breeze/global_constants.py#L673) returns on the first match — the rest of the Dockerfile is no longer read.

The remaining three sites store all lines in a list anyway, so memory usage is equivalent — those changes are just for idiom consistency

## Verification

- `ruff check --select FURB129 .` → `All checks passed!`