### PR TITLE
Fix AwaitMessageTrigger missing _task_instance attribute

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -82,6 +82,7 @@ class AwaitMessageTrigger(BaseEventTrigger):
         poll_interval: float = 5,
         commit_offset: bool = True,
     ) -> None:
+        super().__init__()
         self.topics = topics
         self.apply_function = apply_function
         self.apply_function_args = apply_function_args or ()

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -77,6 +77,16 @@ class TestTrigger:
             )
         )
 
+    def test_trigger_initializes_base_state(self):
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            apply_function="test.noop",
+            topics=["noop"],
+        )
+
+        assert trigger._task_instance is None
+        assert trigger.task_instance is None
+
     def test_trigger_serialization(self):
         trigger = AwaitMessageTrigger(
             kafka_config_id="kafka_d",

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -30,6 +30,7 @@ from tests_common.test_utils.common_msg_queue import (
     collect_queue_param_deprecation_warning,
     mark_common_msg_queue_test,
 )
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 USED_FIXTURES = [collect_queue_param_deprecation_warning]
 
@@ -84,8 +85,13 @@ class TestTrigger:
             topics=["noop"],
         )
 
-        assert trigger._task_instance is None
-        assert trigger.task_instance is None
+        if AIRFLOW_V_3_3_PLUS:
+            # The trigger._task_instance attribute was introduced in https://github.com/apache/airflow/pull/55068
+            assert trigger._task_instance is None
+            assert trigger.task_instance is None
+        else:
+            assert not hasattr(trigger, "_task_instance")
+            assert trigger.task_instance is None
 
     def test_trigger_serialization(self):
         trigger = AwaitMessageTrigger(


### PR DESCRIPTION

* related: https://github.com/apache/airflow/pull/64833
* https://github.com/apache/airflow/pull/55068 (introduce the `trigger._task_instance`)

## Why

While working on adding E2E test for event driving Dag with Kafka in #64833, I encounter the following error:

```
  airflow-triggerer-1  | 2026-05-02T15:25:00.831436Z [error    ] Trigger ID 1 exited with error 'AwaitMessageTrigger' object has no attribute '_task_instance' [airflow.jobs.triggerer_job_runner] error_detail=[{'exc_type': 'AttributeError', 'exc_value': "'AwaitMessageTrigger' object has no attribute '_task_instance'", 'exc_notes': [], 'syntax_error': None, 'is_cause': False, 'frames': [{'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/jobs/triggerer_job_runner.py', 'lineno': 1238, 'name': 'cleanup_finished_triggers'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 119, 'name': 'greenback_shim'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 208, 'name': '_greenback_shim'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 84, 'name': 'trampoline'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/outcome/_impl.py', 'lineno': 185, 'name': 'send'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/jobs/triggerer_job_runner.py', 'lineno': 1387, 'name': 'run_trigger'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/triggers/base.py', 'lineno': 104, 'name': 'task_instance'}], 'is_group': False, 'exceptions': []}] loc=triggerer_job_runner.py:929
  airflow-triggerer-1  | 2026-05-02T15:25:00.832067Z [error    ] Trigger exited without sending an event. Dependent tasks will be failed. [airflow.jobs.triggerer_job_runner] loc=triggerer_job_runner.py:929 name='ID 1'
  airflow-triggerer-1  | 2026-05-02T15:25:02.858280Z [error    ] Trigger ID 1 exited with error 'AwaitMessageTrigger' object has no attribute '_task_instance' [airflow.jobs.triggerer_job_runner] error_detail=[{'exc_type': 'AttributeError', 'exc_value': "'AwaitMessageTrigger' object has no attribute '_task_instance'", 'exc_notes': [], 'syntax_error': None, 'is_cause': False, 'frames': [{'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/jobs/triggerer_job_runner.py', 'lineno': 1238, 'name': 'cleanup_finished_triggers'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 119, 'name': 'greenback_shim'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 208, 'name': '_greenback_shim'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/greenback/_impl.py', 'lineno': 84, 'name': 'trampoline'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/outcome/_impl.py', 'lineno': 185, 'name': 'send'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/jobs/triggerer_job_runner.py', 'lineno': 1387, 'name': 'run_trigger'}, {'filename': '/home/airflow/.local/lib/python3.10/site-packages/airflow/triggers/base.py', 'lineno': 104, 'name': 'task_instance'}], 'is_group': False, 'exceptions': []}] loc=triggerer_job_runner.py:929
```

The root cause is: `AwaitMessageTrigger.__init__` never calls `super().__init__()`, so `_task_instance` is never set. The triggerer crashes on cleanup with `AttributeError: 'AwaitMessageTrigger' object has no attribute '_task_instance'`, and dependent tasks fail.

## What

- Call `super().__init__()` in `AwaitMessageTrigger.__init__`.
- Add a unit test asserting `_task_instance` / `task_instance` are initialized after construction.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code <current model name> following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
