### PR TITLE
Convert RUNTIME_VARYING_CALLS to frozenset for O(1) membership lookup

### DIFF
--- a/airflow-core/src/airflow/utils/dag_version_inflation_checker.py
+++ b/airflow-core/src/airflow/utils/dag_version_inflation_checker.py
@@ -21,24 +21,26 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-RUNTIME_VARYING_CALLS = [
-    ("datetime", "now"),
-    ("datetime", "today"),
-    ("datetime", "utcnow"),
-    ("date", "today"),
-    ("time", "time"),
-    ("time", "localtime"),
-    ("random", "random"),
-    ("random", "randint"),
-    ("random", "choice"),
-    ("random", "uniform"),
-    ("uuid", "uuid4"),
-    ("uuid", "uuid1"),
-    ("pendulum", "now"),
-    ("pendulum", "today"),
-    ("pendulum", "yesterday"),
-    ("pendulum", "tomorrow"),
-]
+RUNTIME_VARYING_CALLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("datetime", "now"),
+        ("datetime", "today"),
+        ("datetime", "utcnow"),
+        ("date", "today"),
+        ("time", "time"),
+        ("time", "localtime"),
+        ("random", "random"),
+        ("random", "randint"),
+        ("random", "choice"),
+        ("random", "uniform"),
+        ("uuid", "uuid4"),
+        ("uuid", "uuid1"),
+        ("pendulum", "now"),
+        ("pendulum", "today"),
+        ("pendulum", "yesterday"),
+        ("pendulum", "tomorrow"),
+    }
+)
 
 
 class DagVersionInflationCheckLevel(Enum):


### PR DESCRIPTION
## Summary

Converts [`RUNTIME_VARYING_CALLS`](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/utils/dag_version_inflation_checker.py#L24) from `list` to `frozenset`.

## Why

The container is exclusively used for membership tests; it is never iterated, indexed, or mutated. Therefore, frozenset is the more idiomatic data structure for this use case.While the absolute savings on a single lookup are sub-microsecond, this change is forward-looking. The search overhead for a list grows linearly $O(n)$ with table size, whereas frozenset provides constant time $O(1)$ lookups. This ensures that adding more runtime-varying call sites in the future won't impact performance. It is a refinement of code style and correctness rather than a measurable production speedup.

## Reference: 

[Python TimeComplexity wiki](https://wiki.python.org/moin/TimeComplexity) — `x in list` is O(n), `x in set/frozenset` is O(1) average.