### PR TITLE
[v3-2-test] Speed up 'Generate the FastAPI API spec' prek hook (~2min → ~25s) (#64131)

### DIFF
--- a/scripts/ci/prek/generate_openapi_spec.py
+++ b/scripts/ci/prek/generate_openapi_spec.py
@@ -33,7 +33,7 @@ initialize_breeze_prek(__name__, __file__)
 
 cmd_result = run_command_via_breeze_shell(
     ["python3", "/opt/airflow/scripts/in_container/run_generate_openapi_spec.py"],
-    backend="postgres",
+    backend="sqlite",
     skip_environment_initialization=False,
 )
 


### PR DESCRIPTION
## Summary

- Cherry-picks #64131 (`main` commit `5d9819fea5`) to v3-2-test.
- Switches the `generate-openapi-spec` prek hook from `backend="postgres"`
  to `backend="sqlite"` in `scripts/ci/prek/generate_openapi_spec.py`.
- The OpenAPI spec generator only introspects FastAPI routes and does
  not query the database, so the postgres-container startup + migration
  overhead (~90s) is wasted.

#64131 was merged on `main` on 2026-03-24 and backported to `v3-1-test`
the same day as #64132 — but the cut of `v3-2-test` happened a few
hours earlier, so it landed without the fix. Same shape as the recent
#66209 backport (which fixed the *providers* OpenAPI spec generator
and the providers import-checker hooks); this is the matching core
hook, the last remaining `backend="postgres"` under
`scripts/ci/prek/`.

## Test plan

- [ ] CI `Static checks` job is faster on v3-2-test
- [ ] `Generate the FastAPI API spec` prek hook still produces a clean
      spec (no functional change beyond DB backend)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)