### PR TITLE
[v3-2-test] Skip test_schedule_tis_start_trigger pending #55068 backport decision

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -2005,6 +2005,8 @@ class DagRun(Base, LoggingMixin):
             # to render start_from_trigger in the scheduler. If we need to
             # render the value in a worker, it kind of defeats the purpose of
             # this feature (which is to save a worker process if possible).
+            # Re-enabled on main by #55068 but not backported to 3.2;
+            # decision tracked at https://github.com/apache/airflow/issues/66307
             # elif task.start_trigger_args is not None:
             #     if task.expand_start_from_trigger(context=ti.get_template_context()):
             #         ti.start_date = timezone.utcnow()

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -2260,6 +2260,11 @@ def test_schedule_tis_only_one_scheduler_update_succeeds_when_competing(dag_make
     assert refreshed_ti.try_number == 1
 
 
+@pytest.mark.skip(
+    reason="start_from_trigger scheduling path is disabled on v3-2-test "
+    "(re-enabled on main by #55068, not backported); "
+    "tracked at https://github.com/apache/airflow/issues/66307"
+)
 @pytest.mark.need_serialized_dag
 def test_schedule_tis_start_trigger(dag_maker, session):
     """


### PR DESCRIPTION
The `test_schedule_tis_start_trigger` test fails on `v3-2-test` because
the `start_from_trigger` deferred-at-schedule code path in
`DagRun.schedule_tis` is commented out as a TODO on this branch.

That path was re-enabled on `main` by #55068 (merged 2026-03-25), one
day after `v3-2-test` was cut. The PR is a 19-file feature change
that's too large to backport blindly into a release branch, so the
right call here is the conservative one: skip the test, link a
tracking issue at both the skip-reason and the disabled production-code
site, and leave the underlying decision (option 1: backport #55068,
option 2: formally drop `start_from_trigger` on 3.2) to the issue.

closes: nothing yet — see #66307 for the open decision

Failing CI run that surfaced this:
https://github.com/apache/airflow/actions/runs/25270258994/job/74097048671

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
