### PR TITLE
Allow automated edge worker maintenance

### DIFF
--- a/providers/edge3/provider.yaml
+++ b/providers/edge3/provider.yaml
@@ -248,3 +248,42 @@ config:
         type: string
         default: ~
         example: airflow.providers.edge3.cli.example_extended_sysinfo.get_example_extended_sysinfo
+      automatic_maintenance_on:
+        description: |
+          Enable automatic maintenance mode for edge workers based on reported system info status.
+
+          When configured, edge workers will automatically enter maintenance mode when the reported system
+          info status indicates a problem on the worker. So in conjunction with a
+          ``extended_system_info_function`` that reports system status, this can be used to automatically
+          take workers out when they are unhealthy.
+
+          Possible options are "Error", "Warning" and "Off". When set to "Error", workers will enter
+          maintenance mode when the system info function reports a status of "Error". When set to "Warning",
+          workers will enter maintenance mode when the system info function reports a status of "Error" or
+          "Warning".
+
+          When set to "Off", automatic maintenance mode is disabled and workers will not automatically enter
+          maintenance mode based on system info status.
+        version_added: 3.6.0
+        type: string
+        example: "Error"
+        default: "Off"
+      automatic_maintenance_exit:
+        description: |
+          Enable automatic exit from maintenance mode for edge workers based on reported system info status.
+
+          When configured, edge workers will automatically exit maintenance mode that was set by automatic
+          maintenance mode when the reported system info status indicates that the worker is healthy (again).
+          So in conjunction with a `extended_system_info_function` that reports system status, this can be
+          used to automatically bring workers back when they are healthy.
+
+          Possible options are "Warning", "Info" and "Off". When set to "Warning", workers will exit
+          maintenance mode when the system info function reports a status of "Warning" or "Info".
+          When set to "Info", workers will exit maintenance mode when the system info function reports a
+          status of "Info".
+          When set to "Off", automatic maintenance exit is disabled and workers will not automatically exit
+          maintenance mode based on system info status.
+        version_added: 3.6.0
+        type: string
+        example: "Info"
+        default: "Off"

--- a/providers/edge3/src/airflow/providers/edge3/cli/example_extended_sysinfo.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/example_extended_sysinfo.py
@@ -46,7 +46,7 @@ async def get_example_extended_sysinfo() -> dict[str, str | int | float | dateti
     load_1 = loadavg[0]
 
     status = logging.INFO
-    status_text = "I am good, sun is shining 🌞"
+    status_text: str | None = "I am good, sun is shining 🌞"
     if cpu_usage > 95 or disk_free_gb < 5:
         status = logging.ERROR
         status_text = "Critical condition!"

--- a/providers/edge3/src/airflow/providers/edge3/cli/example_extended_sysinfo.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/example_extended_sysinfo.py
@@ -31,6 +31,7 @@ import sys
 from datetime import datetime
 
 import psutil
+from anyio import Path
 
 
 async def get_example_extended_sysinfo() -> dict[str, str | int | float | datetime]:
@@ -53,9 +54,18 @@ async def get_example_extended_sysinfo() -> dict[str, str | int | float | dateti
         status = logging.WARNING
         status_text = "Warning condition!"
 
+    # For testing allowing to mock some status from file
+    status_path = Path("/tmp/edge_error_status")
+    if await status_path.exists():
+        status = int(await status_path.read_text())
+        if await Path("/tmp/edge_error_status_text").exists():
+            status_text = await Path("/tmp/edge_error_status_text").read_text()
+        else:
+            status_text = None
+
     return {
         "status": status,
-        "status_text": status_text,
+        **({"status_text": status_text} if status_text else {}),
         "platform": sys.platform,
         "disk_free_gb": disk_free_gb,
         "cpu_usage": cpu_usage,

--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -156,6 +156,12 @@ class EdgeWorker:
         )
         self.push_logs = self.conf.getboolean("edge", "push_logs")
         self.push_log_chunk_size = self.conf.getint("edge", "push_log_chunk_size")
+        self.automatic_maintenance_on = (
+            self.conf.get("edge", "automatic_maintenance_on", fallback="Off") or "Off"
+        ).lower()
+        self.automatic_maintenance_exit = (
+            self.conf.get("edge", "automatic_maintenance_exit", fallback="Off") or "Off"
+        ).lower()
 
         self.extended_sysinfo: Callable[[], Awaitable[dict[str, str | int | float | datetime]]] | None = None
         extended_sysinfo_func_path = self.conf.get("edge", "extended_system_info_function", fallback=None)
@@ -326,6 +332,33 @@ class EdgeWorker:
             return True
         return False
 
+    def _adjust_maintenance_mode_based_on_sysinfo(
+        self, sysinfo: dict[str, str | int | float | datetime]
+    ) -> None:
+        """Adjust maintenance mode based on sysinfo status and config."""
+        status: int = sysinfo.get("status")  # type: ignore
+        if not self.maintenance_mode and (
+            (status >= logging.WARNING and self.automatic_maintenance_on == "warning")
+            or (status >= logging.ERROR and self.automatic_maintenance_on == "error")
+        ):
+            logger.info(
+                "Entering maintenance mode due to status %s in sysinfo.", logging.getLevelName(status)
+            )
+            self.maintenance_mode = True
+            self.maintenance_comments = f"[{datetime.now().strftime('%Y-%m-%d %H:%M')}] - Automatic maintenance mode entered due to status {logging.getLevelName(status)} in sysinfo."
+        elif (
+            self.maintenance_mode
+            and self.maintenance_comments
+            and "] - Automatic maintenance mode entered due to status " in self.maintenance_comments
+            and (
+                (status < logging.WARNING and self.automatic_maintenance_exit == "info")
+                or (status < logging.ERROR and self.automatic_maintenance_exit == "warning")
+            )
+        ):
+            logger.info("Exiting maintenance mode due to status %s in sysinfo.", logging.getLevelName(status))
+            self.maintenance_mode = False
+            self.maintenance_comments = None
+
     async def _get_sysinfo(self) -> dict[str, str | int | float | datetime]:
         """Produce the sysinfo from worker to post to central site."""
         sysinfo: dict[str, str | int | float | datetime] = {
@@ -358,6 +391,8 @@ class EdgeWorker:
             except Exception:
                 logger.exception("Failed to get extended sysinfo, skipping it.")
 
+        # After grabbing status, check if we need to enter/exit maintenance mode
+        self._adjust_maintenance_mode_based_on_sysinfo(sysinfo)
         return sysinfo
 
     def _get_state(self) -> EdgeWorkerState:
@@ -448,11 +483,12 @@ class EdgeWorker:
     async def start(self):
         """Start the execution in a loop until terminated."""
         try:
+            sysinfo = await self._get_sysinfo()
             register_result = await worker_register(
                 self.hostname,
-                EdgeWorkerState.STARTING,
+                EdgeWorkerState.MAINTENANCE_MODE if self.maintenance_mode else EdgeWorkerState.STARTING,
                 self.queues,
-                await self._get_sysinfo(),
+                sysinfo,
                 self.team_name,
             )
             self.versions_match = register_result.versions_match
@@ -595,8 +631,8 @@ class EdgeWorker:
 
     async def heartbeat(self, new_maintenance_comments: str | None = None) -> bool:
         """Report liveness state of worker to central site with stats."""
-        state = self._get_state()
         sysinfo = await self._get_sysinfo()
+        state = self._get_state()
         worker_state_changed: bool = False
         try:
             worker_info = await worker_set_state(
@@ -605,7 +641,7 @@ class EdgeWorker:
                 len(self.jobs),
                 self.queues,
                 sysinfo,
-                new_maintenance_comments,
+                new_maintenance_comments or self.maintenance_comments,
                 team_name=self.team_name,
             )
             self.versions_match = worker_info.versions_match

--- a/providers/edge3/src/airflow/providers/edge3/get_provider_info.py
+++ b/providers/edge3/src/airflow/providers/edge3/get_provider_info.py
@@ -144,6 +144,20 @@ def get_provider_info():
                         "default": None,
                         "example": "airflow.providers.edge3.cli.example_extended_sysinfo.get_example_extended_sysinfo",
                     },
+                    "automatic_maintenance_on": {
+                        "description": 'Enable automatic maintenance mode for edge workers based on reported system info status.\n\nWhen configured, edge workers will automatically enter maintenance mode when the reported system\ninfo status indicates a problem on the worker. So in conjunction with a\n``extended_system_info_function`` that reports system status, this can be used to automatically\ntake workers out when they are unhealthy.\n\nPossible options are "Error", "Warning" and "Off". When set to "Error", workers will enter\nmaintenance mode when the system info function reports a status of "Error". When set to "Warning",\nworkers will enter maintenance mode when the system info function reports a status of "Error" or\n"Warning".\n\nWhen set to "Off", automatic maintenance mode is disabled and workers will not automatically enter\nmaintenance mode based on system info status.\n',
+                        "version_added": "3.6.0",
+                        "type": "string",
+                        "example": "Error",
+                        "default": "Off",
+                    },
+                    "automatic_maintenance_exit": {
+                        "description": 'Enable automatic exit from maintenance mode for edge workers based on reported system info status.\n\nWhen configured, edge workers will automatically exit maintenance mode that was set by automatic\nmaintenance mode when the reported system info status indicates that the worker is healthy (again).\nSo in conjunction with a `extended_system_info_function` that reports system status, this can be\nused to automatically bring workers back when they are healthy.\n\nPossible options are "Warning", "Info" and "Off". When set to "Warning", workers will exit\nmaintenance mode when the system info function reports a status of "Warning" or "Info".\nWhen set to "Info", workers will exit maintenance mode when the system info function reports a\nstatus of "Info".\nWhen set to "Off", automatic maintenance exit is disabled and workers will not automatically exit\nmaintenance mode based on system info status.\n',
+                        "version_added": "3.6.0",
+                        "type": "string",
+                        "example": "Info",
+                        "default": "Off",
+                    },
                 },
             }
         },

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/routes/worker.py
@@ -164,10 +164,19 @@ def redefine_state(worker_state: EdgeWorkerState, body_state: EdgeWorkerState) -
 
 
 def redefine_maintenance_comments(
-    worker_maintenance_comment: str | None, body_maintenance_comments: str | None
+    worker_state: EdgeWorkerState,
+    worker_maintenance_comment: str | None,
+    body_maintenance_comments: str | None,
 ) -> str | None:
     """Add new maintenance comments or overwrite the old ones if it is too long."""
-    if body_maintenance_comments:
+    if worker_state not in (
+        EdgeWorkerState.MAINTENANCE_REQUEST,
+        EdgeWorkerState.MAINTENANCE_PENDING,
+        EdgeWorkerState.MAINTENANCE_MODE,
+        EdgeWorkerState.OFFLINE_MAINTENANCE,
+    ):
+        return None
+    if body_maintenance_comments and body_maintenance_comments != worker_maintenance_comment:
         if (
             worker_maintenance_comment
             and len(body_maintenance_comments) + len(worker_maintenance_comment) < 1020
@@ -206,7 +215,7 @@ def register(
             )
     worker.state = redefine_state(worker.state, body.state)
     worker.maintenance_comment = redefine_maintenance_comments(
-        worker.maintenance_comment, body.maintenance_comments
+        worker.state, worker.maintenance_comment, body.maintenance_comments
     )
     worker.queues = body.queues
     worker.sysinfo = body.sysinfo
@@ -229,7 +238,7 @@ def set_state(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Worker not found")
     worker.state = redefine_state(worker.state, body.state)
     worker.maintenance_comment = redefine_maintenance_comments(
-        worker.maintenance_comment, body.maintenance_comments
+        worker.state, worker.maintenance_comment, body.maintenance_comments
     )
     worker.jobs_active = body.jobs_active
     worker.sysinfo = body.sysinfo

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -673,6 +673,77 @@ class TestEdgeWorker:
         mock_loop.assert_called_once()
         assert mock_set_state.call_count == 1
 
+    @pytest.mark.parametrize(
+        ("automatic_maintenance_on", "sysinfo_status", "expected_maintenance_mode"),
+        [
+            pytest.param("Warning", logging.INFO, False, id="Warning 20"),
+            pytest.param("Warning", logging.WARNING, True, id="Warning 30"),
+            pytest.param("Warning", logging.ERROR, True, id="Warning 40"),
+            pytest.param("Error", logging.INFO, False, id="Error 20"),
+            pytest.param("Error", logging.WARNING, False, id="Error 30"),
+            pytest.param("Error", logging.ERROR, True, id="Error 40"),
+            pytest.param("Gargelfu", logging.ERROR, False, id="Gargelfu 40"),
+            pytest.param("Off", logging.ERROR, False, id="Off 40"),
+            pytest.param(None, logging.ERROR, False, id="None 40"),
+        ],
+    )
+    def test_adjust_maintenance_mode_based_on_sysinfo_on(
+        self,
+        automatic_maintenance_on: str,
+        sysinfo_status: int,
+        expected_maintenance_mode: bool,
+        worker_with_job: EdgeWorker,
+    ):
+        assert worker_with_job.maintenance_mode is False
+        worker_with_job.automatic_maintenance_on = (
+            automatic_maintenance_on.lower() if automatic_maintenance_on else "off"
+        )
+        worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": sysinfo_status})
+        assert worker_with_job.maintenance_mode is expected_maintenance_mode
+
+    @pytest.mark.parametrize(
+        ("automatic_maintenance_exit", "sysinfo_status", "expected_maintenance_mode"),
+        [
+            pytest.param("Info", logging.INFO, False, id="Info 20"),
+            pytest.param("Info", logging.WARNING, True, id="Info 30"),
+            pytest.param("Info", logging.ERROR, True, id="Info 40"),
+            pytest.param("Warning", logging.INFO, False, id="Warning 20"),
+            pytest.param("Warning", logging.WARNING, False, id="Warning 30"),
+            pytest.param("Warning", logging.ERROR, True, id="Warning 40"),
+            pytest.param("Gargelfu", logging.ERROR, True, id="Gargelfu 40"),
+            pytest.param("Off", logging.ERROR, True, id="Off 40"),
+            pytest.param(None, logging.ERROR, True, id="None 40"),
+        ],
+    )
+    def test_adjust_maintenance_mode_based_on_sysinfo_exit(
+        self,
+        automatic_maintenance_exit: str,
+        sysinfo_status: int,
+        expected_maintenance_mode: bool,
+        worker_with_job: EdgeWorker,
+    ):
+        # Set initial error status
+        worker_with_job.automatic_maintenance_on = "warning"
+        worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": logging.ERROR})
+        assert worker_with_job.maintenance_mode is True
+
+        worker_with_job.automatic_maintenance_exit = (
+            automatic_maintenance_exit.lower() if automatic_maintenance_exit else "off"
+        )
+        worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": sysinfo_status})
+        assert worker_with_job.maintenance_mode is expected_maintenance_mode
+
+    def test_adjust_maintenance_mode_based_on_sysinfo_no_exit(self, worker_with_job: EdgeWorker):
+        """Ensure maintenance is not automatically exited if made manually on, even if sysinfo status improves."""
+        # Set initial error status
+        worker_with_job.automatic_maintenance_exit = "warning"
+        worker_with_job.maintenance_mode = True  # simulate manual maintenance mode activation
+        worker_with_job.maintenance_comments = "Manually set for testing"
+
+        worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": logging.INFO})
+        assert worker_with_job.maintenance_mode is True
+        assert worker_with_job.maintenance_comments == "Manually set for testing"
+
     @pytest.mark.asyncio
     async def test_get_sysinfo(self, worker_with_job: EdgeWorker):
         concurrency = 8

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -694,10 +694,8 @@ class TestEdgeWorker:
         expected_maintenance_mode: bool,
         worker_with_job: EdgeWorker,
     ):
-        assert worker_with_job.maintenance_mode is False
-        worker_with_job.automatic_maintenance_on = (
-            automatic_maintenance_on.lower() if automatic_maintenance_on else "off"
-        )
+        worker_with_job.maintenance_mode = False
+        worker_with_job.automatic_maintenance_on = (automatic_maintenance_on or "off").lower()
         worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": sysinfo_status})
         assert worker_with_job.maintenance_mode is expected_maintenance_mode
 
@@ -727,9 +725,7 @@ class TestEdgeWorker:
         worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": logging.ERROR})
         assert worker_with_job.maintenance_mode is True
 
-        worker_with_job.automatic_maintenance_exit = (
-            automatic_maintenance_exit.lower() if automatic_maintenance_exit else "off"
-        )
+        worker_with_job.automatic_maintenance_exit = (automatic_maintenance_exit or "off").lower()
         worker_with_job._adjust_maintenance_mode_based_on_sysinfo({"status": sysinfo_status})
         assert worker_with_job.maintenance_mode is expected_maintenance_mode
 


### PR DESCRIPTION
Sometimes edge workers are known not to be healthy and in https://github.com/apache/airflow/pull/65472 we added an interface that edge workers can report their health state to the reporting.

This PR enables the option that workers - if certain level of health exceeded - turn themself into maintenance. And also optionally can turn operational if the condition resolved.

In such case a system information hook most probably is to be deployed and configured to check for a specific condition (e.g. free disk space). Looks like:
<img width="1383" height="248" alt="image" src="https://github.com/user-attachments/assets/634f819c-717e-4845-af2b-2d871ec513d5" />

When all is good back again then it looks like:
<img width="1371" height="222" alt="image" src="https://github.com/user-attachments/assets/0036d1aa-06e9-4e40-bfb2-868ac7f908bc" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
