### PR TITLE
Convert STATES_SENT_DIRECTLY to frozenset for O(1) membership lookup

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -161,13 +161,15 @@ SERVER_TERMINATED = "SERVER_TERMINATED"
 # These are the task instance states that require some additional information to transition into.
 # "Directly" here means that the PATCH API calls to transition into these states are
 # made from _handle_request() itself and don't have to come all the way to wait().
-STATES_SENT_DIRECTLY = [
-    TaskInstanceState.DEFERRED,
-    TaskInstanceState.UP_FOR_RESCHEDULE,
-    TaskInstanceState.UP_FOR_RETRY,
-    TaskInstanceState.SUCCESS,
-    SERVER_TERMINATED,
-]
+STATES_SENT_DIRECTLY: frozenset[TaskInstanceState | str] = frozenset(
+    {
+        TaskInstanceState.DEFERRED,
+        TaskInstanceState.UP_FOR_RESCHEDULE,
+        TaskInstanceState.UP_FOR_RETRY,
+        TaskInstanceState.SUCCESS,
+        SERVER_TERMINATED,
+    }
+)
 
 # Setting a fair buffer size here to handle most message sizes. Intention is to enforce a buffer size
 # that is big enough to handle small to medium messages while not enforcing hard latency issues


### PR DESCRIPTION
## Summary

Converts [`STATES_SENT_DIRECTLY`](task-sdk/src/airflow/sdk/execution_time/supervisor.py) from `list` to `frozenset`. 

It is only used for membership tests, never iterated, so `frozenset` is the appropriate data structure.

## Why

Reference: [Python TimeComplexity wiki](https://wiki.python.org/moin/TimeComplexity) — `x in list` is O(n), `x in frozenset` is O(1) average.

The absolute savings on a single lookup are sub-microsecond — this is a small correctness/style improvement rather than a measurable production speedup. The framing is "right data structure for the access pattern" with a forward-looking benefit: if more states are added, the relative win grows linearly and existing call sites won't slow down.

## Related

PR #66306