### PR TITLE
i18n(Ko): add missing translations in components.json (May 4)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/components.json
@@ -10,6 +10,7 @@
     "maxRuns": "최대 활성 실행 수",
     "missingAndErroredRuns": "누락되었거나 오류가 발생한 실행",
     "missingRuns": "누락된 실행",
+    "overrideExistingParams": "기존 실행 파라미터 덮어쓰기",
     "permissionDenied": "드라이 런 실패 : 백필 생성 권한이 없습니다. ",
     "reprocessBehavior": "재처리 동작",
     "run": "백필 실행",


### PR DESCRIPTION
This PR adds a missing Korean translation for `overrideExistingParams` in components.json.
- `Override parameters on existing runs` → `기존 실행 파라미터 덮어쓰기`

---
<img width="1087" height="774" alt="image" src="https://github.com/user-attachments/assets/9055c8a1-a9df-47e3-ab25-972dcde6221b" />


## Before
<img width="1568" height="660" alt="image" src="https://github.com/user-attachments/assets/fd678dad-0f87-4790-a318-643fed659f56" />

## After
<img width="1908" height="805" alt="image" src="https://github.com/user-attachments/assets/f674500d-ebf2-44f6-a2a7-45206b968dc3" />

Please review this translation.
/cc @choo121600 @onestn @noeunkim