### PR TITLE
UI: distinguish `upstream_failed` from `failed` in default state palette

### DIFF
--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -367,7 +367,7 @@ const defaultAirflowTheme = {
       skipped: generateSemanticTokens("pink"),
       up_for_reschedule: generateSemanticTokens("sky"),
       up_for_retry: generateSemanticTokens("yellow"),
-      upstream_failed: generateSemanticTokens("orange"),
+      upstream_failed: generateSemanticTokens("amber"),
       running: generateSemanticTokens("cyan"),
       restarting: generateSemanticTokens("violet"),
       deferred: generateSemanticTokens("purple"),


### PR DESCRIPTION
related: #66323

`failed` and `upstream_failed` currently render with ΔE2000=6.2 in normal vision — below the "easily distinguishable" threshold of ~10. In a Grid view they look like the same color, especially in dense state mixes. Issue #66323 has the full simulation data; this PR is the smallest fix for the immediate normal-vision regression.

`upstream_failed` switches from `orange.600` (hue ~36°) to `amber.600` (hue ~58°), pushing it clear of `red.600` (hue ~27°). The `amber` palette is already defined in `theme.ts` so no new tokens are introduced.

<img width="1400" height="557" alt="Image" src="https://github.com/user-attachments/assets/05636c41-57f5-4de5-87ec-8a3fb69ed3d6" />

[airflow_state_colors.py](https://github.com/user-attachments/files/27329085/airflow_state_colors.py)

<img width="1358" height="540" alt="Image" src="https://github.com/user-attachments/assets/e93ba874-c7a0-487b-8ab2-989ef9e61edf" />

### Before / after (Brettel/Machado simulation, ΔE2000)

| pair | before normal | after normal | before deutan | after deutan |
|---|---:|---:|---:|---:|
| failed vs upstream_failed | **6.2** | 20.9 | **0.4** | 8.3 |
| upstream_failed vs up_for_retry | 24.8 | 10.8 | 9.1 | 1.2 |

Normal-vision `upstream_failed` vs `up_for_retry` drops from 24.8 to 10.8 — still above the 10 threshold, so no new normal-vision regression.

The deuteranopia collapse of `upstream_failed` vs `up_for_retry` (8.3 → 1.2) is part of the broader colorblind story in #66323. The warm-hue band structurally collapses under deuteranopia regardless of which OKLCH is chosen — fixing that fully needs either a per-user CB-safe preset (Okabe-Ito-derived, what GitHub Primer ships as four theme variants) or a non-warm hue for one of these states. Both are bigger conversations.

Filing as a draft to invite discussion. Reasonable alternatives:
- this PR's choice — `amber.600`, simplest swap.
- tune the `orange.600` OKLCH directly to a higher hue.
- bundle with broader CB work — ship Okabe-Ito preset + extend `ThemeColors` (#64232 pattern) to expose state-color tokens.

Happy to take it in any direction. If `amber.600` is fine, will mark ready, add a newsfragment + tests.
