### PR TITLE
Fix task run context crash when DagRun state is expired

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -338,8 +338,11 @@ class DagRun(StrictBaseModel):
         for field_name in cls.model_fields:
             if field_name in insp.dict:
                 values[field_name] = insp.dict[field_name]
-            elif field_name == "state" and "_state" in insp.dict:
-                values["state"] = insp.dict["_state"]
+            elif field_name == "state":
+                if "_state" in insp.dict:
+                    values["state"] = insp.dict["_state"]
+                elif not insp.detached and (state_val := data._state) is not None:
+                    values["state"] = state_val
 
         if "consumed_asset_events" not in values:
             values["consumed_asset_events"] = []

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -307,6 +307,23 @@ class TestCliTasks:
         with redirect_stdout(io.StringIO()):
             task_command.task_render(args)
 
+    @pytest.mark.db_test
+    def test_task_render_handles_expired_dagrun(self, dag_maker, session):
+        """Test that model_validate extracts state from an expired DagRun instance."""
+        from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun as DagRunPydantic
+        from airflow.utils.state import DagRunState
+
+        with dag_maker(dag_id="test_expired", session=session):
+            pass
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        session.commit()
+        # After commit, SQLAlchemy expires all attributes — _state is no longer in insp.dict
+        # but the instance is still attached, so direct access triggers a lazy reload.
+
+        pydantic_dr = DagRunPydantic.model_validate(dr)
+        assert pydantic_dr.state == DagRunState.RUNNING
+
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_mapped_task_render(self):
         """


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What problem are we solving?
After `session.commit()`, SQLA expires all ORM instance attributes. The `safe_extract_from_orm` validator added in: https://github.com/apache/airflow/pull/63916, reads attributes from `insp.dict` to avoid `DetachedInstanceError` — but expired attributes are absent from `__dict__`. Since `DagRun._state` is expired after a commit, state is silently dropped from the extracted dict, and pydantic raises a `ResponseValidationError` because `state: DagRunState` is required.

### Current behaviour
Tasks fail to enter the running state with:

`ResponseValidationError: Field required at ('response', 'dag_run', 'state')`

### Fix
When `_state` is absent from `insp.dict` but the instance is still attached (not `insp.detached`), fall back to accessing `data._state` directly — this triggers SQLA's lazy reload. This guard preserves the original fix: on a genuinely detached instance, direct access would `raise DetachedInstanceError`, so that case is left alone.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
