### PR TITLE
Avoid rebuilding callback field list on every serialization loop

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -129,6 +129,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+_CALLBACK_TYPES = ("execute", "failure", "success", "retry", "skipped")
+_OPERATOR_CALLBACK_FIELDS = frozenset(f"on_{x}_callback" for x in _CALLBACK_TYPES)
+_HAS_CALLBACK_FIELDS = frozenset(f"has_on_{x}_callback" for x in _CALLBACK_TYPES)
+
 
 def _get_registered_priority_weight_strategy(
     importable_string: str,
@@ -981,7 +985,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
                 if cls._is_excluded(v, k, op):
                     continue
 
-                if k in [f"on_{x}_callback" for x in ("execute", "failure", "success", "retry", "skipped")]:
+                if k in _OPERATOR_CALLBACK_FIELDS:
                     if bool(v):
                         serialized_op["partial_kwargs"][f"has_{k}"] = True
                     continue
@@ -1333,7 +1337,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
         preprocessed = encoded_op.copy()
 
         # Handle callback field renaming for backward compatibility
-        for callback_type in ("execute", "failure", "success", "retry", "skipped"):
+        for callback_type in _CALLBACK_TYPES:
             old_key = f"on_{callback_type}_callback"
             new_key = f"has_{old_key}"
             if old_key in preprocessed:
@@ -1579,9 +1583,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
         """
         if field_name == "downstream_task_ids":
             return set(value) if value is not None else set()
-        elif field_name in [
-            f"has_on_{x}_callback" for x in ("execute", "failure", "success", "retry", "skipped")
-        ]:
+        elif field_name in _HAS_CALLBACK_FIELDS:
             return bool(value)
         elif field_name in {"retry_delay", "execution_timeout", "max_retry_delay"}:
             # Reuse existing timedelta deserialization logic
@@ -1741,9 +1743,7 @@ class DagSerialization(BaseSerialization):
                 default_args_dict = serialized_dag["default_args"][Encoding.VAR]
                 callbacks_to_remove = []
                 for k, v in list(default_args_dict.items()):
-                    if k in [
-                        f"on_{x}_callback" for x in ("execute", "failure", "success", "retry", "skipped")
-                    ]:
+                    if k in _OPERATOR_CALLBACK_FIELDS:
                         if bool(v):
                             default_args_dict[f"has_{k}"] = True
                         callbacks_to_remove.append(k)


### PR DESCRIPTION
## Summary

In `airflow-core/src/airflow/serialization/serialized_objects.py`, the same set of five callback type names (`execute, failure, success, retry, skipped`) was duplicated inline in four places — three of them as `[f"on_{x}_callback" for x in (...)]` list comprehensions used for `in` membership tests inside loops over operator/DAG fields.

This PR hoists them to three module-level constants:

```python
_CALLBACK_TYPES = ("execute", "failure", "success", "retry", "skipped")
_OPERATOR_CALLBACK_FIELDS = frozenset(f"on_{x}_callback" for x in _CALLBACK_TYPES)
_HAS_CALLBACK_FIELDS = frozenset(f"has_on_{x}_callback" for x in _CALLBACK_TYPES)
```
and replaces the four inline duplicates accordingly.

## Why
- Membership checks become O(1) instead of O(n) over a freshly-built list.
- The 5-element list and its f-string formatting were rebuilt on every iteration of the surrounding for k, v in ... loops; now they're built once at import.
- Single source of truth for the callback type names.


**Pure refactor — no behavior change.**