### PR TITLE
i18n(Ko): add missing translations in common.json (May 4)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -263,6 +263,8 @@
   "task_one": "작업",
   "task_other": "작업들",
   "taskGroup": "작업 그룹",
+  "taskGroup_one": "작업 그룹",
+  "taskGroup_other": "작업 그룹들",
   "taskId": "작업 ID",
   "taskInstance": {
     "dagVersion": "Dag 버전",


### PR DESCRIPTION
This PR adds missing Korean translations for `taskGroup_one` and `taskGroup_other` in common.json.

- `Task Group` → `작업 그룹`
- `Task Groups` → `작업 그룹들`

Note: `taskGroup_other` is a plural form key that could not be verified in the UI, but has been translated for consistency with `taskGroup_one`.

---
<img width="704" height="418" alt="image" src="https://github.com/user-attachments/assets/f5d3134f-c4f8-41e1-9273-d12fff322603" />


## Before
<img width="833" height="406" alt="image" src="https://github.com/user-attachments/assets/38d65ac4-f6d4-4153-8794-fd2e12bab2c3" />

## After
<img width="810" height="410" alt="image" src="https://github.com/user-attachments/assets/fa9ba8ff-1a7b-4b23-a431-e26162df2a13" />

Please review this translation.
/cc @choo121600 @onestn @noeunkim