### PR TITLE
Fix airflow db clean IntegrityError when a dag_version is referenced by a task_instance

### DIFF
--- a/airflow-core/newsfragments/66350.bugfix.rst
+++ b/airflow-core/newsfragments/66350.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``airflow db clean`` failing with an ``IntegrityError`` when a ``dag_version`` row was still referenced by a ``task_instance`` created between the archive ``INSERT`` and the ``DELETE``.

--- a/airflow-core/newsfragments/71732.bugfix.rst
+++ b/airflow-core/newsfragments/71732.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``airflow db clean`` failing on the ``asset_event``, ``task_reschedule`` and ``deadline`` tables when ``--dag-ids`` or ``--exclude-dag-ids`` was used.

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -138,7 +138,9 @@ config_list: list[_TableConfig] = [
         keep_last_group_by=["dag_id"],
         dependent_tables=["task_instance", "deadline"],
     ),
-    _TableConfig(table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="dag_id"),
+    _TableConfig(
+        table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="source_dag_id"
+    ),
     _TableConfig(table_name="import_error", recency_column_name="timestamp"),
     _TableConfig(table_name="log", recency_column_name="dttm", dag_id_column_name="dag_id"),
     _TableConfig(table_name="sla_miss", recency_column_name="timestamp", dag_id_column_name="dag_id"),
@@ -151,7 +153,7 @@ config_list: list[_TableConfig] = [
     _TableConfig(
         table_name="task_instance_history", recency_column_name="start_date", dag_id_column_name="dag_id"
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="callback_request", recency_column_name="created_at"),
@@ -170,7 +172,7 @@ config_list: list[_TableConfig] = [
         keep_last=True,
         keep_last_group_by=["dag_id"],
     ),
-    _TableConfig(table_name="deadline", recency_column_name="deadline_time", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="deadline", recency_column_name="deadline_time"),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
 ]
 

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -184,7 +184,9 @@ config_list: list[_TableConfig] = [
         keep_last_group_by=["dag_id"],
         dependent_tables=["task_instance", "task_state_store", "deadline"],
     ),
-    _TableConfig(table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="dag_id"),
+    _TableConfig(
+        table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="source_dag_id"
+    ),
     _TableConfig(table_name="import_error", recency_column_name="timestamp"),
     _TableConfig(table_name="log", recency_column_name="dttm", dag_id_column_name="dag_id"),
     _TableConfig(table_name="sla_miss", recency_column_name="timestamp", dag_id_column_name="dag_id"),
@@ -202,7 +204,7 @@ config_list: list[_TableConfig] = [
         recency_column_name="expires_at",
         dag_id_column_name="dag_id",
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="callback_request", recency_column_name="created_at"),
@@ -227,7 +229,7 @@ config_list: list[_TableConfig] = [
         # and are cleaned. dag_run.created_dag_version_id is ON DELETE SET NULL, so it does not block.
         skip_if_referenced=[("task_instance", "dag_version_id")],
     ),
-    _TableConfig(table_name="deadline", recency_column_name="deadline_time", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="deadline", recency_column_name="deadline_time"),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
     _TableConfig(
         table_name="connection_test_request",

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -282,7 +282,14 @@ def _dump_table_to_file(*, target_table: str, file_path: str, export_format: str
 
 
 def _do_delete(
-    *, query: Select, orm_model: Base, skip_archive: bool, session: Session, batch_size: int | None
+    *,
+    query: Select,
+    orm_model: Base,
+    skip_archive: bool,
+    session: Session,
+    batch_size: int | None,
+    skip_if_referenced: list[tuple[str, str]] | None = None,
+    referenced_pk_column: str = "id",
 ) -> None:
     import itertools
     import re
@@ -353,6 +360,20 @@ def _do_delete(
                 delete = source_table.delete().where(
                     and_(*[col == target_table.c[col.name] for col in source_table.primary_key.columns])
                 )
+            # Re-apply skip_if_referenced on the DELETE to guard against a race where a new
+            # referencing row is created after the archive INSERT committed but before the DELETE
+            # runs. Without this the DELETE would violate the ON DELETE RESTRICT FK and fail.
+            if skip_if_referenced:
+                pk_col = source_table.c[referenced_pk_column]
+                for referencing_table_name, fk_column in skip_if_referenced:
+                    referencing = table(referencing_table_name, column(fk_column))
+                    delete = delete.where(
+                        ~select(literal(1))
+                        .select_from(referencing)
+                        .where(referencing.c[fk_column] == pk_col)
+                        .correlate(source_table)
+                        .exists()
+                    )
             logger.debug("delete statement:\n%s", delete.compile())
             session.execute(delete)
             session.commit()
@@ -551,6 +572,8 @@ def _cleanup_table(
             skip_archive=skip_archive,
             session=session,
             batch_size=batch_size,
+            skip_if_referenced=skip_if_referenced,
+            referenced_pk_column=referenced_pk_column,
         )
 
     session.commit()

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -323,7 +323,14 @@ def _dump_table_to_file(*, target_table: str, file_path: str, export_format: str
 
 
 def _do_delete(
-    *, query: Select, orm_model: Base, skip_archive: bool, session: Session, batch_size: int | None
+    *,
+    query: Select,
+    orm_model: Base,
+    skip_archive: bool,
+    session: Session,
+    batch_size: int | None,
+    skip_if_referenced: list[tuple[str, str]] | None = None,
+    referenced_pk_column: str = "id",
 ) -> None:
     import itertools
     import re
@@ -394,6 +401,20 @@ def _do_delete(
                 delete = source_table.delete().where(
                     and_(*[col == target_table.c[col.name] for col in source_table.primary_key.columns])
                 )
+            # Re-apply skip_if_referenced on the DELETE to guard against a race where a new
+            # referencing row is created after the archive INSERT committed but before the DELETE
+            # runs. Without this the DELETE would violate the ON DELETE RESTRICT FK and fail.
+            if skip_if_referenced:
+                pk_col = source_table.c[referenced_pk_column]
+                for referencing_table_name, fk_column in skip_if_referenced:
+                    referencing = table(referencing_table_name, column(fk_column))
+                    delete = delete.where(
+                        ~select(literal(1))
+                        .select_from(referencing)
+                        .where(referencing.c[fk_column] == pk_col)
+                        .correlate(source_table)
+                        .exists()
+                    )
             logger.debug("delete statement:\n%s", delete.compile())
             session.execute(delete)
             session.commit()
@@ -592,6 +613,8 @@ def _cleanup_table(
             skip_archive=skip_archive,
             session=session,
             batch_size=batch_size,
+            skip_if_referenced=skip_if_referenced,
+            referenced_pk_column=referenced_pk_column,
         )
 
     session.commit()

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -95,6 +95,9 @@ class _TableConfig:
         in the table.  to ignore certain records even if they are the latest in the table, you can
         supply additional filters here (e.g. externally triggered dag runs)
     :param keep_last_group_by: if keeping the last record, can keep the last record for each group
+    :param dag_id_via: for a table that has no dag id of its own, the ``(fk_column, parent_table,
+        parent_pk_column)`` through which one is reached. ``--dag-ids`` / ``--exclude-dag-ids`` then
+        filter on the parent's ``dag_id``. Mutually exclusive with ``dag_id_column_name``.
     :param dependent_tables: list of tables which have FK relationship with this table
     :param extra_filters: SQLAlchemy expressions ANDed with the recency filter; referenced columns must be in ``extra_columns``.
     :param skip_if_referenced: list of ``(referencing_table, fk_column)`` pairs whose FK points at this
@@ -109,6 +112,7 @@ class _TableConfig:
     recency_column_name: str
     extra_columns: list[str] | None = None
     dag_id_column_name: str | None = None
+    dag_id_via: tuple[str, str, str] | None = None
     keep_last: bool = False
     keep_last_filters: Any | None = None
     keep_last_group_by: Any | None = None
@@ -127,23 +131,23 @@ class _TableConfig:
     def __post_init__(self):
         self.schema_name, self.bare_table_name = _split_schema_table(self.table_name)
         self.recency_column = column(self.recency_column_name)
-        if self.dag_id_column_name is None:
-            self.dag_id_column = None
-            self.orm_model: Base = table(
-                self.bare_table_name,
-                *[column(x) for x in self.extra_columns or []],
-                self.recency_column,
-                schema=self.schema_name,
+        if self.dag_id_column_name and self.dag_id_via:
+            raise ValueError(
+                f"_TableConfig for table {self.table_name!r} sets both dag_id_column_name and "
+                "dag_id_via; a table reaches its dag id one way or the other, not both."
             )
-        else:
-            self.dag_id_column = column(self.dag_id_column_name)
-            self.orm_model: Base = table(
-                self.bare_table_name,
-                *[column(x) for x in self.extra_columns or []],
-                self.dag_id_column,
-                self.recency_column,
-                schema=self.schema_name,
-            )
+        self.dag_id_column = column(self.dag_id_column_name) if self.dag_id_column_name else None
+        column_names = list(self.extra_columns or [])
+        if self.dag_id_column_name:
+            column_names.append(self.dag_id_column_name)
+        if self.dag_id_via:
+            column_names.append(self.dag_id_via[0])
+        self.orm_model: Base = table(
+            self.bare_table_name,
+            *[column(name) for name in dict.fromkeys(column_names)],
+            self.recency_column,
+            schema=self.schema_name,
+        )
 
         # skip_if_referenced filters on referenced_pk_column, which must be a column of orm_model
         # (added via extra_columns). Fail fast with a clear message instead of a cryptic KeyError
@@ -163,7 +167,11 @@ class _TableConfig:
         return {
             "table": self.table_name,
             "recency_column": str(self.recency_column),
-            "dag_id_column": str(self.dag_id_column),
+            "dag_id_column": (
+                f"{self.dag_id_via[0]} -> {self.dag_id_via[1]}.dag_id"
+                if self.dag_id_via
+                else str(self.dag_id_column)
+            ),
             "keep_last": self.keep_last,
             "keep_last_filters": [str(x) for x in self.keep_last_filters] if self.keep_last_filters else None,
             "keep_last_group_by": str(self.keep_last_group_by),
@@ -221,7 +229,11 @@ config_list: list[_TableConfig] = [
         recency_column_name="expires_at",
         dag_id_column_name="dag_id",
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
+    _TableConfig(
+        table_name="task_reschedule",
+        recency_column_name="start_date",
+        dag_id_via=("ti_id", "task_instance", "id"),
+    ),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(
@@ -270,7 +282,11 @@ config_list: list[_TableConfig] = [
         # and are cleaned. dag_run.created_dag_version_id is ON DELETE SET NULL, so it does not block.
         skip_if_referenced=[("task_instance", "dag_version_id")],
     ),
-    _TableConfig(table_name="deadline", recency_column_name="deadline_time"),
+    _TableConfig(
+        table_name="deadline",
+        recency_column_name="deadline_time",
+        dag_id_via=("dagrun_id", "dag_run", "id"),
+    ),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
     _TableConfig(
         table_name="connection_test_request",
@@ -502,6 +518,7 @@ def _build_query(
     clean_before_timestamp: DateTime,
     session: Session,
     dag_id_column=None,
+    dag_id_via: tuple[str, str, str] | None = None,
     dag_ids: list[str] | None = None,
     exclude_dag_ids: list[str] | None = None,
     extra_filters: list[Any] | None = None,
@@ -542,6 +559,31 @@ def _build_query(
         if exclude_dag_ids:
             conditions.append(base_table_dag_id_col.not_in(exclude_dag_ids))
 
+    if (dag_ids or exclude_dag_ids) and dag_id_via is not None:
+        # EXISTS rather than a NOT IN subquery so that a row whose FK is NULL — a deadline not
+        # attached to any dag run, say — is treated as belonging to no dag: kept under --dag-ids
+        # and removed under --exclude-dag-ids, instead of NULL swallowing the comparison.
+        fk_column, parent_table_name, parent_pk_column = dag_id_via
+        parent_table = table(parent_table_name, column(parent_pk_column), column("dag_id"))
+        base_table_fk_col = base_table.c[fk_column]
+
+        def belongs_to_dags(wanted_dag_ids: list[str]) -> Any:
+            return (
+                select(literal(1))
+                .select_from(parent_table)
+                .where(
+                    parent_table.c[parent_pk_column] == base_table_fk_col,
+                    parent_table.c["dag_id"].in_(wanted_dag_ids),
+                )
+                .correlate(base_table)
+                .exists()
+            )
+
+        if dag_ids:
+            conditions.append(belongs_to_dags(dag_ids))
+        if exclude_dag_ids:
+            conditions.append(~belongs_to_dags(exclude_dag_ids))
+
     if keep_last:
         max_date_col_name = "max_date_per_group"
         group_by_columns: list[Any] = [column(x) for x in keep_last_group_by]
@@ -572,6 +614,7 @@ def _cleanup_table(
     keep_last_group_by,
     clean_before_timestamp: DateTime,
     dag_id_column=None,
+    dag_id_via: tuple[str, str, str] | None = None,
     dag_ids=None,
     exclude_dag_ids=None,
     dry_run: bool = True,
@@ -591,6 +634,7 @@ def _cleanup_table(
         orm_model=orm_model,
         recency_column=recency_column,
         dag_id_column=dag_id_column,
+        dag_id_via=dag_id_via,
         dag_ids=dag_ids,
         exclude_dag_ids=exclude_dag_ids,
         keep_last=keep_last,

--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -188,7 +188,9 @@ config_list: list[_TableConfig] = [
         keep_last_group_by=["dag_id"],
         dependent_tables=["task_instance", "task_state_store", "deadline"],
     ),
-    _TableConfig(table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="dag_id"),
+    _TableConfig(
+        table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="source_dag_id"
+    ),
     # Carries no foreign key, so rows are left behind when the partition Dag run they describe
     # is cascade-deleted with its dag_run. Only such orphans may be purged: rows whose partition
     # Dag run still exists are the evidence the scheduler evaluates to decide when that pending
@@ -219,7 +221,7 @@ config_list: list[_TableConfig] = [
         recency_column_name="expires_at",
         dag_id_column_name="dag_id",
     ),
-    _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="task_reschedule", recency_column_name="start_date"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="_xcom_archive", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(
@@ -268,7 +270,7 @@ config_list: list[_TableConfig] = [
         # and are cleaned. dag_run.created_dag_version_id is ON DELETE SET NULL, so it does not block.
         skip_if_referenced=[("task_instance", "dag_version_id")],
     ),
-    _TableConfig(table_name="deadline", recency_column_name="deadline_time", dag_id_column_name="dag_id"),
+    _TableConfig(table_name="deadline", recency_column_name="deadline_time"),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
     _TableConfig(
         table_name="connection_test_request",

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -551,6 +551,79 @@ class TestDBCleanup:
         assert latest_id in remaining  # kept by keep_last
         assert orphan_id not in remaining  # old and unreferenced -> pruned
 
+    def test_do_delete_skip_if_referenced_guards_against_race(self):
+        """_do_delete must not issue a DELETE that violates an ON DELETE RESTRICT FK.
+
+        Simulates a race where a dag_version row passes the SELECT filter (no TI
+        references it at archive-creation time) but a TI referencing it is inserted
+        before the DELETE runs.  The skip_if_referenced guard on the DELETE itself
+        must leave the row in place instead of failing with IntegrityError.
+        """
+        from airflow.utils.db import reflect_tables
+        from airflow.utils.db_cleanup import ARCHIVE_TABLE_PREFIX, _do_delete
+
+        base_date = pendulum.DateTime(2020, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        bundle_name = f"race-test-{uuid4()}"
+        dag_id = f"race_dag_{uuid4()}"
+
+        with create_session() as session:
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+            session.add(DagModel(dag_id=dag_id, bundle_name=bundle_name))
+            session.flush()
+
+            dv = DagVersion(
+                dag_id=dag_id,
+                version_number=1,
+                bundle_name=bundle_name,
+                created_at=base_date,
+                last_updated=base_date,
+            )
+            session.add(dv)
+            session.flush()
+            dv_id = dv.id
+
+            # Manually create an archive table containing this dag_version row,
+            # simulating the CTAS step that ran before the TI was inserted.
+            archive_name = f"{ARCHIVE_TABLE_PREFIX}dag_version__race_test"
+            session.execute(
+                text(f"CREATE TABLE {archive_name} AS SELECT * FROM dag_version WHERE id = '{dv_id}'")
+            )
+            session.commit()
+
+            # Now insert a TI referencing the dag_version (the "race").
+            dag_run = DagRun(dag_id, run_id="race-run", run_type=DagRunType.MANUAL, start_date=base_date)
+            ti = create_task_instance(
+                PythonOperator(task_id="dummy-task", python_callable=print),
+                run_id=dag_run.run_id,
+                dag_version_id=dv_id,
+            )
+            ti.dag_id = dag_id
+            ti.start_date = base_date
+            session.add_all([dag_run, ti])
+            session.commit()
+
+            # Build a select query that would return the row (simulating what _build_query
+            # returned before the TI was inserted).
+            metadata = reflect_tables([archive_name, "dag_version"], session)
+            archive_table = metadata.tables[archive_name]
+            query = select(archive_table)
+
+            # _do_delete must silently skip the row (FK guard on DELETE), not raise IntegrityError.
+            _do_delete(
+                query=query,
+                orm_model=config_dict["dag_version"].orm_model,
+                skip_archive=True,
+                session=session,
+                batch_size=None,
+                skip_if_referenced=[("task_instance", "dag_version_id")],
+                referenced_pk_column="id",
+            )
+
+            remaining = set(session.scalars(select(DagVersion.id).where(DagVersion.dag_id == dag_id)).all())
+
+        assert dv_id in remaining, "dag_version referenced by a task_instance must not be deleted"
+
     def test_table_config_skip_if_referenced_requires_pk_column(self):
         """A misconfigured skip_if_referenced (pk not in columns) must fail fast at construction."""
         with pytest.raises(ValueError, match="referenced_pk_column"):
@@ -877,6 +950,23 @@ class TestDBCleanup:
         print(f"excl+conf={exclusion_list.union(config_dict)}")
         assert set(all_models) - exclusion_list.union(config_dict) == set()
         assert exclusion_list.isdisjoint(config_dict)
+
+    def test_dag_id_column_name_matches_schema(self):
+        """
+        Regression guard: every dag_id_column_name in config_dict must be an actual column in its
+        database table, so that --dag-ids filtering never raises UndefinedColumn.
+        """
+        with create_session() as session:
+            insp = inspect(session.bind)
+            existing_tables = set(insp.get_table_names())
+            for table_name, cfg in config_dict.items():
+                if cfg.dag_id_column_name is None or table_name not in existing_tables:
+                    continue
+                db_columns = {col["name"] for col in insp.get_columns(table_name)}
+                assert cfg.dag_id_column_name in db_columns, (
+                    f"config_dict[{table_name!r}].dag_id_column_name={cfg.dag_id_column_name!r} "
+                    f"is not a column of table {table_name!r} in the database"
+                )
 
     def test_no_failure_warnings(self):
         """

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -560,7 +560,6 @@ class TestDBCleanup:
         must leave the row in place instead of failing with IntegrityError.
         """
         from airflow.utils.db import reflect_tables
-        from airflow.utils.db_cleanup import ARCHIVE_TABLE_PREFIX, _do_delete
 
         base_date = pendulum.DateTime(2020, 1, 1, tzinfo=pendulum.timezone("UTC"))
         bundle_name = f"race-test-{uuid4()}"

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -36,10 +36,12 @@ from airflow import DAG
 from airflow._shared.timezones import timezone
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun, TaskInstance
+from airflow.models.asset import AssetEvent
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.task_state_store import TaskStateStoreModel
+from airflow.models.taskreschedule import TaskReschedule
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.utils.db_cleanup import (
@@ -445,6 +447,108 @@ class TestDBCleanup:
 
             assert remaining_dag_ids == expected_remaining_dag_ids, (
                 f"Expected {expected_remaining_dag_ids} to remain, but got {remaining_dag_ids}"
+            )
+
+    @pytest.mark.parametrize(
+        ("dag_ids", "exclude_dag_ids"),
+        [
+            pytest.param(["dag1"], None, id="include"),
+            pytest.param(None, ["dag1"], id="exclude"),
+        ],
+    )
+    def test_cleanup_dag_filtering_on_tables_without_their_own_dag_id(self, dag_ids, exclude_dag_ids):
+        """asset_event, task_reschedule and deadline have no dag_id column of their own."""
+        with create_session() as session:
+            run_cleanup(
+                clean_before_timestamp=pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.timezone("UTC")),
+                table_names=["asset_event", "task_reschedule", "deadline"],
+                dag_ids=dag_ids,
+                exclude_dag_ids=exclude_dag_ids,
+                dry_run=False,
+                confirm=False,
+                error_on_cleanup_failure=True,
+                session=session,
+            )
+
+    @pytest.mark.parametrize(
+        "table_names",
+        [
+            pytest.param(["asset_event", "task_reschedule"], id="child_tables_only"),
+            pytest.param(
+                ["asset_event", "task_reschedule", "task_instance", "dag_run"],
+                id="with_parents_that_cascade",
+            ),
+        ],
+    )
+    def test_cleanup_dag_filtering_keeps_rows_of_other_dags(self, table_names):
+        base_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.timezone("UTC"))
+
+        with create_session() as session:
+            bundle_name = "testing"
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+
+            for asset_id, dag_id in enumerate(["dag1", "dag2"], start=1):
+                dag = DAG(dag_id=dag_id)
+                session.add(DagModel(dag_id=dag_id, bundle_name=bundle_name))
+                SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
+                dag_version = DagVersion.get_latest_version(dag_id)
+
+                dag_run = DagRun(
+                    dag_id,
+                    run_id=f"{dag_id}_run",
+                    run_type=DagRunType.MANUAL,
+                    start_date=base_date,
+                )
+                ti = create_task_instance(
+                    PythonOperator(task_id="dummy-task", python_callable=print),
+                    run_id=dag_run.run_id,
+                    dag_version_id=dag_version.id,
+                )
+                ti.dag_id = dag_id
+                ti.start_date = base_date
+                session.add(dag_run)
+                session.add(ti)
+                session.flush()
+
+                session.add(
+                    TaskReschedule(
+                        ti_id=ti.id,
+                        start_date=base_date,
+                        end_date=base_date.add(minutes=1),
+                        reschedule_date=base_date.add(minutes=5),
+                    )
+                )
+                session.add(
+                    AssetEvent(asset_id=asset_id, source_dag_id=dag_id, extra={}, timestamp=base_date)
+                )
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=10),
+                table_names=table_names,
+                dag_ids=["dag1"],
+                dry_run=False,
+                confirm=False,
+                error_on_cleanup_failure=True,
+                session=session,
+            )
+
+            remaining_reschedule_dag_ids = {
+                tr.task_instance.dag_id for tr in session.scalars(select(TaskReschedule)).all()
+            }
+            remaining_event_dag_ids = {e.source_dag_id for e in session.scalars(select(AssetEvent)).all()}
+
+            assert remaining_reschedule_dag_ids == {"dag2"}
+            assert remaining_event_dag_ids == {"dag2"}
+
+    def test_table_config_rejects_two_ways_to_reach_dag_id(self):
+        with pytest.raises(ValueError, match="one way or the other"):
+            _TableConfig(
+                table_name="task_reschedule",
+                recency_column_name="start_date",
+                dag_id_column_name="dag_id",
+                dag_id_via=("ti_id", "task_instance", "id"),
             )
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -551,6 +551,79 @@ class TestDBCleanup:
         assert latest_id in remaining  # kept by keep_last
         assert orphan_id not in remaining  # old and unreferenced -> pruned
 
+    def test_do_delete_skip_if_referenced_guards_against_race(self):
+        """_do_delete must not issue a DELETE that violates an ON DELETE RESTRICT FK.
+
+        Simulates a race where a dag_version row passes the SELECT filter (no TI
+        references it at archive-creation time) but a TI referencing it is inserted
+        before the DELETE runs.  The skip_if_referenced guard on the DELETE itself
+        must leave the row in place instead of failing with IntegrityError.
+        """
+        from airflow.utils.db import reflect_tables
+        from airflow.utils.db_cleanup import ARCHIVE_TABLE_PREFIX, _do_delete
+
+        base_date = pendulum.DateTime(2020, 1, 1, tzinfo=pendulum.timezone("UTC"))
+        bundle_name = f"race-test-{uuid4()}"
+        dag_id = f"race_dag_{uuid4()}"
+
+        with create_session() as session:
+            session.add(DagBundleModel(name=bundle_name))
+            session.flush()
+            session.add(DagModel(dag_id=dag_id, bundle_name=bundle_name))
+            session.flush()
+
+            dv = DagVersion(
+                dag_id=dag_id,
+                version_number=1,
+                bundle_name=bundle_name,
+                created_at=base_date,
+                last_updated=base_date,
+            )
+            session.add(dv)
+            session.flush()
+            dv_id = dv.id
+
+            # Manually create an archive table containing this dag_version row,
+            # simulating the CTAS step that ran before the TI was inserted.
+            archive_name = f"{ARCHIVE_TABLE_PREFIX}dag_version__race_test"
+            session.execute(
+                text(f"CREATE TABLE {archive_name} AS SELECT * FROM dag_version WHERE id = '{dv_id}'")
+            )
+            session.commit()
+
+            # Now insert a TI referencing the dag_version (the "race").
+            dag_run = DagRun(dag_id, run_id="race-run", run_type=DagRunType.MANUAL, start_date=base_date)
+            ti = create_task_instance(
+                PythonOperator(task_id="dummy-task", python_callable=print),
+                run_id=dag_run.run_id,
+                dag_version_id=dv_id,
+            )
+            ti.dag_id = dag_id
+            ti.start_date = base_date
+            session.add_all([dag_run, ti])
+            session.commit()
+
+            # Build a select query that would return the row (simulating what _build_query
+            # returned before the TI was inserted).
+            metadata = reflect_tables([archive_name, "dag_version"], session)
+            archive_table = metadata.tables[archive_name]
+            query = select(archive_table)
+
+            # _do_delete must silently skip the row (FK guard on DELETE), not raise IntegrityError.
+            _do_delete(
+                query=query,
+                orm_model=config_dict["dag_version"].orm_model,
+                skip_archive=True,
+                session=session,
+                batch_size=None,
+                skip_if_referenced=[("task_instance", "dag_version_id")],
+                referenced_pk_column="id",
+            )
+
+            remaining = set(session.scalars(select(DagVersion.id).where(DagVersion.dag_id == dag_id)).all())
+
+        assert dv_id in remaining, "dag_version referenced by a task_instance must not be deleted"
+
     def test_table_config_skip_if_referenced_requires_pk_column(self):
         """A misconfigured skip_if_referenced (pk not in columns) must fail fast at construction."""
         with pytest.raises(ValueError, match="referenced_pk_column"):
@@ -896,6 +969,23 @@ class TestDBCleanup:
         assert all_models, "discovered no models, so this check would pass vacuously"
         assert set(all_models) - exclusion_list.union(config_dict) == set()
         assert exclusion_list.isdisjoint(config_dict)
+
+    def test_dag_id_column_name_matches_schema(self):
+        """
+        Regression guard: every dag_id_column_name in config_dict must be an actual column in its
+        database table, so that --dag-ids filtering never raises UndefinedColumn.
+        """
+        with create_session() as session:
+            insp = inspect(session.bind)
+            existing_tables = set(insp.get_table_names())
+            for table_name, cfg in config_dict.items():
+                if cfg.dag_id_column_name is None or table_name not in existing_tables:
+                    continue
+                db_columns = {col["name"] for col in insp.get_columns(table_name)}
+                assert cfg.dag_id_column_name in db_columns, (
+                    f"config_dict[{table_name!r}].dag_id_column_name={cfg.dag_id_column_name!r} "
+                    f"is not a column of table {table_name!r} in the database"
+                )
 
     def test_no_failure_warnings(self):
         """


### PR DESCRIPTION

`airflow db clean` fails on `asset_event`, `deadline` and `task_reschedule` whenever `--dag-ids` or `--exclude-dag-ids` is passed, while the same command without a dag filter succeeds:

```
RuntimeError: airflow db clean encountered errors on the following tables and
did not clean them: ['asset_event', 'deadline', 'task_reschedule']
```

### Cause

All three are configured with `dag_id_column_name="dag_id"`, and none of them has a `dag_id` column:

| table | actual column |
|---|---|
| `asset_event` | `source_dag_id` |
| `task_reschedule` | `ti_id` → `task_instance.id` |
| `deadline` | `dagrun_id` → `dag_run.id` |

`_build_query` only reads `dag_id_column` when a dag filter is requested, which is why the failure appears solely with those two flags.

### Fix

**`asset_event`** filters on `source_dag_id`.

**`task_reschedule` and `deadline`** have no dag id of their own, so `_TableConfig` gains `dag_id_via=(fk_column, parent_table, parent_pk_column)` and filters through the parent's `dag_id` via a correlated `EXISTS` subquery — matching the `skip_if_referenced` guard already in the same function.

`EXISTS` rather than `IN` / `NOT IN` because `deadline.dagrun_id` is nullable: a deadline with no dag run belongs to no dag, so it is kept under `--dag-ids` and removed under `--exclude-dag-ids`; with `NOT IN`, the NULL would swallow the comparison and the row would survive a filter that does not name it.

Setting both `dag_id_column_name` and `dag_id_via` raises rather than silently ANDing two filters.

Dry-run output prints the resolved path (`ti_id -> task_instance.dag_id`) instead of `None`.

Also fixes a race between the archive INSERT and DELETE by re-applying `skip_if_referenced` on the DELETE.

### Tests

- Cleanup of the three tables under `--dag-ids` and `--exclude-dag-ids` — reproduces the reported `RuntimeError` verbatim.
- Rows for two dags in `task_reschedule` and `asset_event`, cleaned with `--dag-ids dag1`: only `dag2`'s rows survive. Parametrized to also run with `task_instance` and `dag_run` in the table list, covering the cascade path as well as the child's own filter.
- `test_dag_id_column_name_matches_schema` regression test ensuring all `dag_id_column_name` entries match the actual schema.
- `_TableConfig` guard rejecting both filter styles at once.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)