### PR TITLE
Fix unhashable dict tag crashing triggerer metrics (#66353)

### DIFF
--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -149,7 +149,12 @@ class Callback(Base, BaseWorkload):
 
         if "kwargs" in tags:
             # Remove the context (if exists) to keep the tags simple
-            tags["kwargs"] = {k: v for k, v in tags["kwargs"].items() if k != "context"}
+            filtered_kwargs = {k: v for k, v in tags["kwargs"].items() if k != "context"}
+            if filtered_kwargs:
+                # OTel requires hashable tag values; serialize the dict to a string
+                tags["kwargs"] = str(filtered_kwargs)
+            else:
+                del tags["kwargs"]
 
         prefix = self.data.get("prefix", "")
         name = f"{prefix}.callback_{status}" if prefix else f"callback_{status}"

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -112,7 +112,7 @@ class TestCallback:
         assert metric_info["tags"] == {
             "result": "0",
             "path": TEST_ASYNC_CALLBACK.path,
-            "kwargs": {"email": "test@example.com"},
+            "kwargs": "{'email': 'test@example.com'}",
             "dag_id": TEST_DAG_ID,
         }
 


### PR DESCRIPTION
* closes: #66353

The triggerer crashes with a `TypeError: unhashable type: 'dict'` when OpenTelemetry metrics are enabled.

Root cause
---
The crash occurs because `Callback.get_metric_info()` in `airflow/models/callback.py` can return a tags dict containing a nested dict as a value (the "kwargs" key). OpenTelemetry's `_view_instrument_match.py` later calls `frozenset(attributes.items())` to build an aggregation key, which fails because dict values are not hashable.

Fix
---
Serialize the remaining kwargs to a string, or drop them if empty.

How to reproduce
---
1. Start Airflow with OTeL enabled (the OTel endpoint doesn't need to be reachable - the crash happens before any export).
2. Spawn task that will trigger DeadlineAlert.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
