### PR TITLE
Pass `schedule_timeout_seconds` through to `GKEStartPodTrigger` from `GKEStartPodOperator`

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -767,6 +767,7 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
                 ssl_ca_cert=self.ssl_ca_cert,
                 get_logs=self.get_logs,
                 startup_timeout=self.startup_timeout_seconds,
+                schedule_timeout=self.schedule_timeout_seconds,
                 cluster_context=self.cluster_context,
                 poll_interval=self.poll_interval,
                 in_cluster=self.in_cluster,

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -143,6 +143,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
                 "in_cluster": self.in_cluster,
                 "get_logs": self.get_logs,
                 "startup_timeout": self.startup_timeout,
+                "schedule_timeout": self.schedule_timeout,
                 "trigger_start_time": self.trigger_start_time,
                 "base_container_name": self.base_container_name,
                 "should_delete_pod": self.should_delete_pod,

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -801,6 +801,7 @@ class TestGKEStartPodOperator:
             on_finish_action=OnFinishAction.KEEP_POD,
             gcp_conn_id=TEST_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            schedule_timeout_seconds=60,
         )
 
     def test_template_fields(self):
@@ -891,6 +892,7 @@ class TestGKEStartPodOperator:
             ssl_ca_cert=GKE_SSL_CA_CERT,
             get_logs=mock_get_logs,
             startup_timeout=120,
+            schedule_timeout=60,  # issue-66352: schedule_timeout should now be passed into the trigger
             cluster_context=None,
             poll_interval=2,
             in_cluster=None,

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -55,6 +55,7 @@ IN_CLUSTER = False
 SHOULD_DELETE_POD = True
 GET_LOGS = True
 STARTUP_TIMEOUT_SECS = 120
+SCHEDULE_TIMEOUT_SECS = 60
 TRIGGER_START_TIME = datetime.datetime.now(tz=datetime.timezone.utc)
 CLUSTER_URL = "https://test-host"
 SSL_CA_CERT = "TEST_SSL_CA_CERT_CONTENT"
@@ -82,6 +83,7 @@ def trigger():
         in_cluster=IN_CLUSTER,
         get_logs=GET_LOGS,
         startup_timeout=STARTUP_TIMEOUT_SECS,
+        schedule_timeout=SCHEDULE_TIMEOUT_SECS,
         trigger_start_time=TRIGGER_START_TIME,
         cluster_url=CLUSTER_URL,
         ssl_ca_cert=SSL_CA_CERT,
@@ -131,6 +133,7 @@ class TestGKEStartPodTrigger:
             "in_cluster": IN_CLUSTER,
             "get_logs": GET_LOGS,
             "startup_timeout": STARTUP_TIMEOUT_SECS,
+            "schedule_timeout": SCHEDULE_TIMEOUT_SECS,  # issue-66352: schedule_timeout properly serialized
             "trigger_start_time": TRIGGER_START_TIME,
             "cluster_url": CLUSTER_URL,
             "ssl_ca_cert": SSL_CA_CERT,
@@ -266,7 +269,7 @@ class TestGKEStartPodTrigger:
 
         generator = trigger.run()
         await generator.asend(None)
-        assert "Waiting until 120s to get the POD scheduled..." in caplog.text
+        assert "Waiting until 60s to get the POD scheduled..." in caplog.text
 
     @pytest.mark.parametrize(
         ("container_state", "expected_state"),


### PR DESCRIPTION
## Description

Per #66352, the `schedule_timeout_seconds` parameter defined in the `KubernetesPodOperator` was not being properly handled when using a child class of KPO, `GKEStartPodOperator`, when running in deferrable mode. This was due to the `schedule_timeout_seconds` not being passed to the `GKEStartPodTrigger` when deferring. As a result, the default value of 120 seconds was always being used, even if that was not the value passed.

The changes made in this PR ensure that `schedule_timeout_seconds` is properly handled when using the `GKEStartPodOperator`.

closes: #66352

## Testing

The appropriate unit-tests were updated to ensure that `schedule_timeout_seconds` parameter was passed through the chain of execution when passed into the `GKEStartPodOperator`. Note that all other tests for the Operator and Trigger ran successfully; this is not a breaking change.

The following commands can be used to run the updated tests:

```bash
# Testing the changes to the Operator
breeze testing providers-tests providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py

# Testing the changes to the Trigger
breeze testing providers-tests providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
```


##### Was generative AI tooling used to co-author this PR?

No, generative AI was NOT used to co-author this PR.