### PR TITLE
Add `S3VectorsDeleteIndexOperator`

### DIFF
--- a/providers/amazon/docs/operators/s3_vectors.rst
+++ b/providers/amazon/docs/operators/s3_vectors.rst
@@ -50,6 +50,20 @@ To create an index in an Amazon S3 Vectors vector bucket, use
     :start-after: [START howto_operator_s3vectors_create_index]
     :end-before: [END howto_operator_s3vectors_create_index]
 
+.. _howto/operator:S3VectorsDeleteIndexOperator:
+
+Delete an Index
+---------------
+
+To delete an index from an Amazon S3 Vectors vector bucket, use
+:class:`~airflow.providers.amazon.aws.operators.s3_vectors.S3VectorsDeleteIndexOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_s3_vectors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_s3vectors_delete_index]
+    :end-before: [END howto_operator_s3vectors_delete_index]
+
 .. _howto/operator:S3VectorsDeleteVectorBucketOperator:
 
 Delete a Vector Bucket

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/s3_vectors.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/s3_vectors.py
@@ -209,3 +209,43 @@ class S3VectorsCreateIndexOperator(AwsBaseOperator[AwsBaseHook]):
                 raise
         self.log.info("Index %s: %s", self.index_name, index_arn)
         return index_arn
+
+
+class S3VectorsDeleteIndexOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Delete an index from an Amazon S3 Vectors vector bucket.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:S3VectorsDeleteIndexOperator`
+
+    :param vector_bucket_name: The name of the vector bucket. (templated)
+    :param index_name: The name of the index to delete. (templated)
+    """
+
+    aws_hook_class = AwsBaseHook
+    template_fields: tuple[str, ...] = (
+        *AwsBaseOperator.template_fields,
+        "vector_bucket_name",
+        "index_name",
+    )
+
+    def __init__(
+        self,
+        *,
+        vector_bucket_name: str,
+        index_name: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.vector_bucket_name = vector_bucket_name
+        self.index_name = index_name
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "s3vectors"}
+
+    def execute(self, context: Context) -> None:
+        self.log.info("Deleting index %s from vector bucket %s", self.index_name, self.vector_bucket_name)
+        self.hook.conn.delete_index(vectorBucketName=self.vector_bucket_name, indexName=self.index_name)
+        self.log.info("Deleted index %s", self.index_name)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_vectors.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_vectors.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from airflow.providers.amazon.aws.operators.s3_vectors import (
     S3VectorsCreateIndexOperator,
     S3VectorsCreateVectorBucketOperator,
+    S3VectorsDeleteIndexOperator,
     S3VectorsDeleteVectorBucketOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
@@ -29,22 +30,13 @@ from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import TriggerRule, task
+    from airflow.sdk import TriggerRule
 else:
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 DAG_ID = "example_s3_vectors"
 
 sys_test_context_task = SystemTestContextBuilder().build()
-
-
-@task(trigger_rule=TriggerRule.ALL_DONE)
-def delete_index(vector_bucket_name: str, index_name: str):
-    """Delete the index."""
-    import boto3
-
-    boto3.client("s3vectors").delete_index(vectorBucketName=vector_bucket_name, indexName=index_name)
 
 
 with DAG(
@@ -84,11 +76,20 @@ with DAG(
     )
     # [END howto_operator_s3vectors_delete_vector_bucket]
 
+    # [START howto_operator_s3vectors_delete_index]
+    delete_index = S3VectorsDeleteIndexOperator(
+        task_id="delete_index",
+        vector_bucket_name=bucket_name,
+        index_name=index_name,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_s3vectors_delete_index]
+
     chain(
         test_context,
         create_vector_bucket,
         create_index,
-        delete_index(vector_bucket_name=bucket_name, index_name=index_name),
+        delete_index,
         delete_vector_bucket,
     )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_s3_vectors.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_s3_vectors.py
@@ -24,6 +24,7 @@ from botocore.exceptions import ClientError
 from airflow.providers.amazon.aws.operators.s3_vectors import (
     S3VectorsCreateIndexOperator,
     S3VectorsCreateVectorBucketOperator,
+    S3VectorsDeleteIndexOperator,
     S3VectorsDeleteVectorBucketOperator,
 )
 
@@ -198,6 +199,26 @@ class TestS3VectorsCreateIndexOperator:
 
         with pytest.raises(ClientError):
             op.execute({})
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+class TestS3VectorsDeleteIndexOperator:
+    def setup_method(self):
+        self.operator = S3VectorsDeleteIndexOperator(
+            task_id="delete_index",
+            vector_bucket_name=BUCKET_NAME,
+            index_name=INDEX_NAME,
+        )
+
+    def test_execute(self):
+        mock_conn = MagicMock()
+        self.operator.hook.conn = mock_conn
+
+        self.operator.execute({})
+
+        mock_conn.delete_index.assert_called_once_with(vectorBucketName=BUCKET_NAME, indexName=INDEX_NAME)
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
## What
Add `S3VectorsDeleteIndexOperator` to delete indexes from Amazon S3 Vectors vector buckets.

## Why
Complements `S3VectorsCreateIndexOperator` to provide full index lifecycle management. The system test previously used a `@task` with raw boto3 for deletion.

## What was done
- **Operator**: `S3VectorsDeleteIndexOperator` added to existing `s3_vectors.py`
- **Unit tests**: Added to existing `test_s3_vectors.py` — happy path, template fields
- **System test**: Updated `example_s3_vectors.py` — replaced `@task delete_index` with operator
- **Docs**: Updated `s3_vectors.rst` with new section