### PR TITLE
Add `GlueCatalogCreateTableOperator`

### DIFF
--- a/providers/amazon/docs/operators/glue_catalog.rst
+++ b/providers/amazon/docs/operators/glue_catalog.rst
@@ -41,6 +41,20 @@ Reference
 
 * `AWS boto3 Library Documentation for Glue <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html>`__
 
+.. _howto/operator:GlueCatalogCreateTableOperator:
+
+Create a Table
+--------------
+
+To create a table in an AWS Glue Data Catalog database, use
+:class:`~airflow.providers.amazon.aws.operators.glue_catalog.GlueCatalogCreateTableOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_glue_catalog.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_glue_catalog_create_table]
+    :end-before: [END howto_operator_glue_catalog_create_table]
+
 .. _howto/operator:GlueCatalogDeleteDatabaseOperator:
 
 Delete a Catalog Database

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
@@ -151,3 +151,71 @@ class GlueCatalogDeleteDatabaseOperator(AwsBaseOperator[AwsBaseHook]):
         )
         self.hook.conn.delete_database(**kwargs)
         self.log.info("Deleted Glue Catalog database: %s", self.database_name)
+
+
+class GlueCatalogCreateTableOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Create a table in an AWS Glue Data Catalog database.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GlueCatalogCreateTableOperator`
+
+    :param database_name: The name of the database. (templated)
+    :param table_name: The name of the table. (templated)
+    :param table_input: The ``TableInput`` dict defining the table schema, storage, etc. (templated)
+    :param catalog_id: The ID of the Data Catalog. Defaults to the account ID. (templated)
+    :param if_exists: Behavior when the table already exists.
+        ``"fail"`` raises an error, ``"skip"`` logs and returns.
+    """
+
+    aws_hook_class = AwsBaseHook
+    template_fields: tuple[str, ...] = (
+        *AwsBaseOperator.template_fields,
+        "database_name",
+        "table_name",
+        "catalog_id",
+    )
+    template_fields_renderers = {"table_input": "json"}
+
+    def __init__(
+        self,
+        *,
+        database_name: str,
+        table_name: str,
+        table_input: dict[str, Any],
+        catalog_id: str | None = None,
+        if_exists: Literal["fail", "skip"] = "skip",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.database_name = database_name
+        self.table_name = table_name
+        self.table_input = table_input
+        self.catalog_id = catalog_id
+        self.if_exists = if_exists
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "glue"}
+
+    def execute(self, context: Context) -> str:
+        self.log.info("Creating Glue table %s in database %s", self.table_name, self.database_name)
+        # Ensure Name is set in TableInput
+        table_input = {**self.table_input, "Name": self.table_name}
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "DatabaseName": self.database_name,
+                "TableInput": table_input,
+                "CatalogId": self.catalog_id,
+            }
+        )
+        try:
+            self.hook.conn.create_table(**kwargs)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "AlreadyExistsException" and self.if_exists == "skip":
+                self.log.info("Table %s already exists, skipping.", self.table_name)
+            else:
+                raise
+        self.log.info("Table %s created.", self.table_name)
+        return self.table_name

--- a/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
+    GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
@@ -28,13 +29,23 @@ from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import TriggerRule
+    from airflow.sdk import TriggerRule, task
 else:
+    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 DAG_ID = "example_glue_catalog"
 
 sys_test_context_task = SystemTestContextBuilder().build()
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_table(database_name: str, table_name: str):
+    """Delete the Glue table."""
+    import boto3
+
+    boto3.client("glue").delete_table(DatabaseName=database_name, Name=table_name)
+
 
 with DAG(
     dag_id=DAG_ID,
@@ -62,9 +73,32 @@ with DAG(
     )
     # [END howto_operator_glue_catalog_delete_database]
 
+    table_name = f"{env_id}_tbl"
+    table_input = {
+        "StorageDescriptor": {
+            "Columns": [{"Name": "id", "Type": "int"}],
+            "Location": f"s3://{env_id}-glue/data/",
+            "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            "SerdeInfo": {"SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"},
+        },
+        "TableType": "EXTERNAL_TABLE",
+    }
+
+    # [START howto_operator_glue_catalog_create_table]
+    create_table = GlueCatalogCreateTableOperator(
+        task_id="create_table",
+        database_name=db_name,
+        table_name=table_name,
+        table_input=table_input,
+    )
+    # [END howto_operator_glue_catalog_create_table]
+
     chain(
         test_context,
         create_database,
+        create_table,
+        delete_table(database_name=db_name, table_name=table_name),
         delete_database,
     )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
@@ -16,12 +16,16 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
 from unittest.mock import MagicMock
 
+import pytest
 from botocore.exceptions import ClientError
 
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
+    GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
 )
 
@@ -131,3 +135,72 @@ class TestGlueCatalogDeleteDatabaseOperator:
             database_name=DB_NAME,
         )
         validate_template_fields(op)
+
+
+TABLE_NAME = "test_table"
+TABLE_INPUT = {
+    "StorageDescriptor": {
+        "Columns": [{"Name": "id", "Type": "int"}, {"Name": "name", "Type": "string"}],
+        "Location": "s3://bucket/path/",
+        "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+        "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+        "SerdeInfo": {"SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"},
+    },
+    "TableType": "EXTERNAL_TABLE",
+}
+
+
+class TestGlueCatalogCreateTableOperator:
+    def setup_method(self):
+        self.operator = GlueCatalogCreateTableOperator(
+            task_id="create_table",
+            database_name=DB_NAME,
+            table_name=TABLE_NAME,
+            table_input=TABLE_INPUT,
+        )
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        result = self.operator.execute({})
+
+        call_kwargs = mock_client.create_table.call_args[1]
+        assert call_kwargs["DatabaseName"] == DB_NAME
+        assert call_kwargs["TableInput"]["Name"] == TABLE_NAME
+        assert result == TABLE_NAME
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_skip_existing(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_client.create_table.side_effect = ClientError(
+            {"Error": {"Code": "AlreadyExistsException", "Message": "Already exists"}},
+            "CreateTable",
+        )
+        mock_conn.return_value = mock_client
+
+        result = self.operator.execute({})
+        assert result == TABLE_NAME
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_fail_on_conflict(self, mock_conn):
+        op = GlueCatalogCreateTableOperator(
+            task_id="create_table",
+            database_name=DB_NAME,
+            table_name=TABLE_NAME,
+            table_input=TABLE_INPUT,
+            if_exists="fail",
+        )
+        mock_client = mock.MagicMock()
+        mock_client.create_table.side_effect = ClientError(
+            {"Error": {"Code": "AlreadyExistsException", "Message": "Already exists"}},
+            "CreateTable",
+        )
+        mock_conn.return_value = mock_client
+
+        with pytest.raises(ClientError):
+            op.execute({})
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)


### PR DESCRIPTION
## What
Add `GlueCatalogCreateTableOperator` to create tables in AWS Glue Data Catalog databases.

## Why
Tables are the most commonly used Glue Catalog resource in data pipelines — defining schema for Athena queries, Spark jobs, and ETL workflows. This extends the existing database operators to cover the full catalog hierarchy (database → table).

## What was done
- **Operator**: `GlueCatalogCreateTableOperator` with `if_exists` idempotency, `table_input` for schema definition, optional `catalog_id`. Added to existing `glue_catalog.py`.
- **Unit tests**: Added to existing `test_glue_catalog.py` — happy path, skip-existing, fail-on-conflict, template fields
- **System test**: Updated `example_glue_catalog.py` — added table creation between database create/delete
- **Docs**: Updated `glue_catalog.rst` with new section