### PR TITLE
Avoid rebuilding option filter sets per iteration in update_config CLI ( O(N*M) to O(N+M) )

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -1003,6 +1003,11 @@ def update_config(args) -> None:
         include_secret=True,
         display_sensitive=True,
     )
+    update_sections_lower = {s.lower() for s in update_sections} if update_sections is not None else None
+    update_options_lower = {opt.lower() for opt in update_options} if update_options is not None else None
+    ignore_sections_lower = {s.lower() for s in ignore_sections}
+    ignore_options_lower = {opt.lower() for opt in ignore_options}
+
     for change in CONFIGS_CHANGES:
         if not include_all and not change.breaking:
             continue
@@ -1010,13 +1015,11 @@ def update_config(args) -> None:
         conf_option = change.config.option.lower()
         full_key = f"{conf_section}.{conf_option}"
 
-        if update_sections is not None and conf_section not in [s.lower() for s in update_sections]:
+        if update_sections_lower is not None and conf_section not in update_sections_lower:
             continue
-        if update_options is not None and full_key not in [opt.lower() for opt in update_options]:
+        if update_options_lower is not None and full_key not in update_options_lower:
             continue
-        if conf_section in [s.lower() for s in ignore_sections] or full_key in [
-            opt.lower() for opt in ignore_options
-        ]:
+        if conf_section in ignore_sections_lower or full_key in ignore_options_lower:
             continue
 
         if conf_section not in config_dict or conf_option not in config_dict[conf_section]:


### PR DESCRIPTION
## Summary

In `airflow.cli.commands.config_command.update_config`, the per-change loop rebuilt four lowercase list comprehensions on every iteration just to do `in` membership tests against user-provided filter args:

```python
for change in CONFIGS_CHANGES:
    ...
    if update_sections is not None and conf_section not in [s.lower() for s in update_sections]:
        continue
    if update_options is not None and full_key not in [opt.lower() for opt in update_options]:
        continue
    if conf_section in [s.lower() for s in ignore_sections] or full_key in [
        opt.lower() for opt in ignore_options
    ]:
        continue
```

This is O(N·M) (N = number of CONFIGS_CHANGES, M = filter list size), and on top of the linear scan, every .lower() call is repeated N times for the same input.

This PR hoists the four filters into pre-built lowercase sets before the loop, so:

- Membership lookups are O(1).
- Each input is .lower()'d once at setup time, not per iteration.

```python
update_sections_lower = (
    {s.lower() for s in update_sections} if update_sections is not None else None
)
update_options_lower = (
    {opt.lower() for opt in update_options} if update_options is not None else None
)
ignore_sections_lower = {s.lower() for s in ignore_sections}
ignore_options_lower = {opt.lower() for opt in ignore_options}
```

Overall, this chage can make time complexity $O(NM)$ to $O(N+M)$

**Pure refactor — no behavior change.**