### PR TITLE
Fix config lint warnings for remove_if_equals rules

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/config_command.py
@@ -67,10 +67,10 @@ class ConfigChange:
     breaking: bool = False
     remove_if_equals: str | bool | int | float | None = None
 
-    def message(self, api_client=NEW_API_CLIENT) -> str | None:
+    def message(self, all_configs: Config) -> str | None:
         """Generate a message for this configuration change."""
         if self.default_change:
-            value = self._get_option_value(api_client.configs.list())
+            value = self._get_option_value(all_configs)
             if value != self.new_default:
                 return (
                     f"Changed default value of `{self.config.option}` in `{self.config.section}` "
@@ -86,14 +86,15 @@ class ConfigChange:
                 f"`{self.config.option}` configuration parameter renamed to `{self.renamed_to.option}` "
                 f"in the `{self.config.section}` section."
             )
-        if self.was_removed and not self.remove_if_equals:
-            return (
-                f"Removed{' deprecated' if self.was_deprecated else ''} `{self.config.option}` configuration parameter "
-                f"from `{self.config.section}` section."
-                f"{self.suggestion}"
-            )
+        if self.was_removed:
+            if self.remove_if_equals is None:
+                return self._removed_message
+
+            value = self._get_option_value(all_configs)
+            if value == str(self.remove_if_equals):
+                return self._removed_message
         if self.is_invalid_if is not None:
-            value = self._get_option_value(api_client.configs.list())
+            value = self._get_option_value(all_configs)
             if value == self.is_invalid_if:
                 return (
                     f"Invalid value `{self.is_invalid_if}` set for `{self.config.option}` configuration parameter "
@@ -108,6 +109,14 @@ class ConfigChange:
                     if option.key == self.config.option:
                         return option.value if isinstance(option.value, str) else str(option.value)
         return None
+
+    @property
+    def _removed_message(self) -> str:
+        return (
+            f"Removed{' deprecated' if self.was_deprecated else ''} `{self.config.option}` configuration parameter "
+            f"from `{self.config.section}` section."
+            f"{self.suggestion}"
+        )
 
 
 CONFIGS_CHANGES = [
@@ -805,8 +814,9 @@ def lint(args, api_client=NEW_API_CLIENT) -> None:
                     None,
                 )
                 if target_option:
-                    if configuration.message(api_client=api_client) is not None:
-                        lint_issues.append(configuration.message(api_client=api_client))
+                    msg = configuration.message(all_configs)
+                    if msg is not None:
+                        lint_issues.append(msg)
 
         if lint_issues:
             rich.print("[red]Found issues in your airflow.cfg:[/red]")

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_config_command.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import os
 from unittest.mock import patch
 
+import pytest
+
 from airflowctl.api.client import ClientKind
 from airflowctl.api.datamodels.generated import Config, ConfigOption, ConfigSection
 from airflowctl.ctl import cli_parser
@@ -157,6 +159,71 @@ class TestCliConfigCommands:
             "- [yellow]Removed deprecated `test_option` configuration parameter from `test_section` section.[/yellow]"
             in calls[1]
         )
+
+    @pytest.mark.parametrize(
+        ("remove_if_equals", "config_value", "expected_has_issue"),
+        [
+            pytest.param("matching_value", "matching_value", True, id="non-empty-match"),
+            pytest.param("", "", True, id="empty-string-match"),
+            pytest.param("", "non_matching_value", False, id="empty-string-no-match"),
+        ],
+    )
+    def test_lint_handles_remove_if_equals_rules(
+        self, api_client_maker, remove_if_equals, config_value, expected_has_issue
+    ):
+        with (
+            patch("airflowctl.api.client.Credentials.load"),
+            patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"}),
+            patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_CONFIG"}),
+            patch("rich.print") as mock_rich_print,
+            patch(
+                "airflowctl.ctl.commands.config_command.CONFIGS_CHANGES",
+                [
+                    ConfigChange(
+                        config=ConfigParameter("test_section", "test_option"),
+                        was_removed=True,
+                        remove_if_equals=remove_if_equals,
+                    ),
+                ],
+            ),
+        ):
+            response_config = Config(
+                sections=[
+                    ConfigSection(
+                        name="test_section",
+                        options=[
+                            ConfigOption(
+                                key="test_option",
+                                value=config_value,
+                            )
+                        ],
+                    )
+                ]
+            )
+
+            api_client = api_client_maker(
+                path="/api/v2/config",
+                response_json=response_config.model_dump(),
+                expected_http_status_code=200,
+                kind=ClientKind.CLI,
+            )
+
+            config_command.lint(
+                self.parser.parse_args(["config", "lint"]),
+                api_client=api_client,
+            )
+
+        calls = [call[0][0] for call in mock_rich_print.call_args_list]
+        if expected_has_issue:
+            assert "[red]Found issues in your airflow.cfg:[/red]" in calls[0]
+            assert (
+                "- [yellow]Removed deprecated `test_option` configuration parameter from `test_section` section.[/yellow]"
+                in calls[1]
+            )
+        else:
+            assert (
+                "[green]No issues found in your airflow.cfg. It is ready for Airflow 3![/green]" in calls[0]
+            )
 
     @patch("airflowctl.api.client.Credentials.load")
     @patch.dict(os.environ, {"AIRFLOW_CLI_TOKEN": "TEST_TOKEN"})


### PR DESCRIPTION
## Why

`airflowctl config lint` is meant to help users catch Airflow 3 migration
issues in their config. Right now, some migration rules exist in the rule
table but never actually fire, so users can get a misleading "no issues found"
result even when deprecated or removed settings should be flagged.

Also switch the check to` if self.remove_if_equals is None`, because the original implementation did not distinguish between an unset value and a falsey configured value.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
