### PR TITLE
Add `BedrockCreateGuardrailVersionOperator`

### DIFF
--- a/providers/amazon/docs/operators/bedrock.rst
+++ b/providers/amazon/docs/operators/bedrock.rst
@@ -353,6 +353,20 @@ To create an Amazon Bedrock guardrail, use
     :start-after: [START howto_operator_bedrock_create_guardrail]
     :end-before: [END howto_operator_bedrock_create_guardrail]
 
+.. _howto/operator:BedrockCreateGuardrailVersionOperator:
+
+Create a Guardrail Version
+--------------------------
+
+To create a versioned snapshot of an Amazon Bedrock guardrail, use
+:class:`~airflow.providers.amazon.aws.operators.bedrock.BedrockCreateGuardrailVersionOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bedrock_create_guardrail_version]
+    :end-before: [END howto_operator_bedrock_create_guardrail_version]
+
 .. _howto/operator:BedrockDeleteGuardrailOperator:
 
 Delete a Guardrail

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -1166,3 +1166,46 @@ class BedrockDeleteGuardrailOperator(AwsBaseOperator[BedrockHook]):
         )
         self.hook.conn.delete_guardrail(**kwargs)
         self.log.info("Deleted guardrail %s", self.guardrail_identifier)
+
+
+class BedrockCreateGuardrailVersionOperator(AwsBaseOperator[BedrockHook]):
+    """
+    Create a version of an Amazon Bedrock guardrail.
+
+    Guardrails are created as DRAFT. This operator publishes a numbered version
+    that can be referenced in production workloads.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BedrockCreateGuardrailVersionOperator`
+
+    :param guardrail_identifier: The ID or ARN of the guardrail to version. (templated)
+    :param description: Optional description for this version. (templated)
+    """
+
+    aws_hook_class = BedrockHook
+    template_fields: Sequence[str] = aws_template_fields("guardrail_identifier", "description")
+
+    def __init__(
+        self,
+        *,
+        guardrail_identifier: str,
+        description: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.guardrail_identifier = guardrail_identifier
+        self.description = description
+
+    def execute(self, context: Context) -> str:
+        self.log.info("Creating version for guardrail %s", self.guardrail_identifier)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "guardrailIdentifier": self.guardrail_identifier,
+                "description": self.description,
+            }
+        )
+        response = self.hook.conn.create_guardrail_version(**kwargs)
+        version = response["version"]
+        self.log.info("Guardrail %s version %s created.", response["guardrailId"], version)
+        return version

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.bedrock import (
     BedrockCreateGuardrailOperator,
+    BedrockCreateGuardrailVersionOperator,
     BedrockDeleteGuardrailOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
@@ -68,9 +69,17 @@ with DAG(
     )
     # [END howto_operator_bedrock_delete_guardrail]
 
+    # [START howto_operator_bedrock_create_guardrail_version]
+    create_guardrail_version = BedrockCreateGuardrailVersionOperator(
+        task_id="create_guardrail_version",
+        guardrail_identifier=create_guardrail.output,
+    )
+    # [END howto_operator_bedrock_create_guardrail_version]
+
     chain(
         test_context,
         create_guardrail,
+        create_guardrail_version,
         delete_guardrail,
     )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
@@ -31,6 +31,7 @@ from airflow.providers.amazon.aws.operators.bedrock import (
     BedrockBatchInferenceOperator,
     BedrockCreateDataSourceOperator,
     BedrockCreateGuardrailOperator,
+    BedrockCreateGuardrailVersionOperator,
     BedrockCreateKnowledgeBaseOperator,
     BedrockCreateProvisionedModelThroughputOperator,
     BedrockCustomizeModelOperator,
@@ -910,6 +911,52 @@ class TestBedrockDeleteGuardrailOperator:
         mock_client.delete_guardrail.assert_called_once_with(
             guardrailIdentifier=GUARDRAIL_ID, guardrailVersion="1"
         )
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+class TestBedrockCreateGuardrailVersionOperator:
+    def setup_method(self):
+        self.operator = BedrockCreateGuardrailVersionOperator(
+            task_id="create_guardrail_version",
+            guardrail_identifier=GUARDRAIL_ID,
+        )
+
+    @mock.patch.object(BedrockHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_client.create_guardrail_version.return_value = {
+            "guardrailId": GUARDRAIL_ID,
+            "version": "1",
+        }
+        mock_conn.return_value = mock_client
+
+        result = self.operator.execute({})
+
+        mock_client.create_guardrail_version.assert_called_once_with(guardrailIdentifier=GUARDRAIL_ID)
+        assert result == "1"
+
+    @mock.patch.object(BedrockHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_with_description(self, mock_conn):
+        op = BedrockCreateGuardrailVersionOperator(
+            task_id="create_guardrail_version",
+            guardrail_identifier=GUARDRAIL_ID,
+            description="Production version",
+        )
+        mock_client = mock.MagicMock()
+        mock_client.create_guardrail_version.return_value = {
+            "guardrailId": GUARDRAIL_ID,
+            "version": "2",
+        }
+        mock_conn.return_value = mock_client
+
+        result = op.execute({})
+
+        mock_client.create_guardrail_version.assert_called_once_with(
+            guardrailIdentifier=GUARDRAIL_ID, description="Production version"
+        )
+        assert result == "2"
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
## What
Add `BedrockCreateGuardrailVersionOperator` to create versioned snapshots of Amazon Bedrock guardrails.

## Why
Guardrails are created as DRAFT. To use a guardrail in production, you need to publish a numbered version. This operator enables that step in a pipeline, complementing the existing `BedrockCreateGuardrailOperator` and `BedrockDeleteGuardrailOperator`.

## What was done
- **Operator**: `BedrockCreateGuardrailVersionOperator` with `guardrail_identifier` and optional `description`, using `prune_dict`. Added to existing `bedrock.py`.
- **Unit tests**: Added to existing `test_bedrock.py` — happy path, with description, template fields
- **System test**: Updated `example_bedrock_guardrail.py` — added version creation between create and delete
- **Docs**: Updated `bedrock.rst` with new section before Reference