### PR TITLE
Add `GlueCatalogDeleteTableOperator`

### DIFF
--- a/providers/amazon/docs/operators/glue_catalog.rst
+++ b/providers/amazon/docs/operators/glue_catalog.rst
@@ -68,3 +68,17 @@ To delete a database from the AWS Glue Data Catalog, use
     :dedent: 4
     :start-after: [START howto_operator_glue_catalog_delete_database]
     :end-before: [END howto_operator_glue_catalog_delete_database]
+
+.. _howto/operator:GlueCatalogDeleteTableOperator:
+
+Delete a Table
+--------------
+
+To delete a table from an AWS Glue Data Catalog database, use
+:class:`~airflow.providers.amazon.aws.operators.glue_catalog.GlueCatalogDeleteTableOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_glue_catalog.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_glue_catalog_delete_table]
+    :end-before: [END howto_operator_glue_catalog_delete_table]

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
@@ -219,3 +219,54 @@ class GlueCatalogCreateTableOperator(AwsBaseOperator[AwsBaseHook]):
                 raise
         self.log.info("Table %s created.", self.table_name)
         return self.table_name
+
+
+class GlueCatalogDeleteTableOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Delete a table from an AWS Glue Data Catalog database.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GlueCatalogDeleteTableOperator`
+
+    :param database_name: The name of the database. (templated)
+    :param table_name: The name of the table to delete. (templated)
+    :param catalog_id: The ID of the Data Catalog. Defaults to the account ID. (templated)
+    """
+
+    aws_hook_class = AwsBaseHook
+    template_fields: tuple[str, ...] = (
+        *AwsBaseOperator.template_fields,
+        "database_name",
+        "table_name",
+        "catalog_id",
+    )
+
+    def __init__(
+        self,
+        *,
+        database_name: str,
+        table_name: str,
+        catalog_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.database_name = database_name
+        self.table_name = table_name
+        self.catalog_id = catalog_id
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "glue"}
+
+    def execute(self, context: Context) -> None:
+        self.log.info("Deleting Glue table %s from database %s", self.table_name, self.database_name)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "DatabaseName": self.database_name,
+                "Name": self.table_name,
+                "CatalogId": self.catalog_id,
+            }
+        )
+        self.hook.conn.delete_table(**kwargs)
+        self.log.info("Deleted table %s", self.table_name)

--- a/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
@@ -22,6 +22,7 @@ from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
     GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
+    GlueCatalogDeleteTableOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
 
@@ -29,22 +30,13 @@ from system.amazon.aws.utils import ENV_ID_KEY, SystemTestContextBuilder
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
-    from airflow.sdk import TriggerRule, task
+    from airflow.sdk import TriggerRule
 else:
-    from airflow.decorators import task  # type: ignore[attr-defined,no-redef]
     from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef,attr-defined]
 
 DAG_ID = "example_glue_catalog"
 
 sys_test_context_task = SystemTestContextBuilder().build()
-
-
-@task(trigger_rule=TriggerRule.ALL_DONE)
-def delete_table(database_name: str, table_name: str):
-    """Delete the Glue table."""
-    import boto3
-
-    boto3.client("glue").delete_table(DatabaseName=database_name, Name=table_name)
 
 
 with DAG(
@@ -94,11 +86,20 @@ with DAG(
     )
     # [END howto_operator_glue_catalog_create_table]
 
+    # [START howto_operator_glue_catalog_delete_table]
+    delete_table = GlueCatalogDeleteTableOperator(
+        task_id="delete_table",
+        database_name=db_name,
+        table_name=table_name,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_glue_catalog_delete_table]
+
     chain(
         test_context,
         create_database,
         create_table,
-        delete_table(database_name=db_name, table_name=table_name),
+        delete_table,
         delete_database,
     )
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
@@ -27,6 +27,7 @@ from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
     GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
+    GlueCatalogDeleteTableOperator,
 )
 
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
@@ -201,6 +202,27 @@ class TestGlueCatalogCreateTableOperator:
 
         with pytest.raises(ClientError):
             op.execute({})
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+class TestGlueCatalogDeleteTableOperator:
+    def setup_method(self):
+        self.operator = GlueCatalogDeleteTableOperator(
+            task_id="delete_table",
+            database_name=DB_NAME,
+            table_name=TABLE_NAME,
+        )
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        self.operator.execute({})
+
+        mock_client.delete_table.assert_called_once_with(DatabaseName=DB_NAME, Name=TABLE_NAME)
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
## What
Add `GlueCatalogDeleteTableOperator` to delete tables from AWS Glue Data Catalog databases.

## Why
Complements `GlueCatalogCreateTableOperator` to provide full table lifecycle management. The system test previously used a `@task` with raw boto3 for deletion — this operator replaces that workaround.

## What was done
- **Operator**: `GlueCatalogDeleteTableOperator` with `database_name`, `table_name`, optional `catalog_id`, using `prune_dict`. Added to existing `glue_catalog.py`.
- **Unit tests**: Added to existing `test_glue_catalog.py` — happy path, template fields
- **System test**: Updated `example_glue_catalog.py` — replaced `@task delete_table` with operator
- **Docs**: Updated `glue_catalog.rst` with new section