### PR TITLE
Feature/airflowctl tasks clear

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -57,6 +57,7 @@ from airflowctl.api.operations import (
     PoolsOperations,
     ProvidersOperations,
     ServerResponseError,
+    TasksOperations,
     VariablesOperations,
     VersionOperations,
     XComOperations,
@@ -448,6 +449,12 @@ class Client(httpx.Client):
     def providers(self):
         """Operations related to providers."""
         return ProvidersOperations(self)
+
+    @lru_cache()  # type: ignore[prop-decorator]
+    @property
+    def tasks(self):
+        """Operations related to task instances."""
+        return TasksOperations(self)
 
     @lru_cache()  # type: ignore[prop-decorator]
     @property

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -39,6 +39,7 @@ from airflowctl.api.datamodels.generated import (
     BulkBodyPoolBody,
     BulkBodyVariableBody,
     BulkResponse,
+    ClearTaskInstancesBody,  # add after BulkResponse
     Config,
     ConnectionBody,
     ConnectionCollectionResponse,
@@ -68,6 +69,8 @@ from airflowctl.api.datamodels.generated import (
     ProviderCollectionResponse,
     QueuedEventCollectionResponse,
     QueuedEventResponse,
+    TaskInstanceCollectionResponse,  # add after QueuedEventResponse
+    TaskInstanceResponse,  # add right after TaskInstanceCollectionResponse
     TriggerDAGRunPostBody,
     VariableBody,
     VariableCollectionResponse,
@@ -640,6 +643,66 @@ class DagRunOperations(BaseOperations):
         except ServerResponseError as e:
             raise e
 
+class TasksOperations(BaseOperations):
+    """Task instance operations."""
+
+    def get_ti_state(
+        self,
+        dag_id: str,
+        dag_run_id: str,
+        task_id: str,
+        map_index: int | None = None,
+    ) -> TaskInstanceResponse | ServerResponseError:
+        """
+        Get the state of a single task instance.
+
+        Used by ``airflowctl tasks state`` (issue #66174).
+        """
+        if map_index is not None and map_index >= 0:
+            path = f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/{map_index}"
+        else:
+            path = f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}"
+        try:
+            self.response = self.client.get(path)
+            return TaskInstanceResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
+
+    def list_states_for_dag_run(
+        self,
+        dag_id: str,
+        dag_run_id: str,
+        limit: int = 100,
+    ) -> TaskInstanceCollectionResponse | ServerResponseError:
+        """
+        List all task instances for a DAG run.
+
+        Used by ``airflowctl tasks states-for-dag-run`` (issue #66175).
+        """
+        return super().execute_list(
+            path=f"/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances",
+            data_model=TaskInstanceCollectionResponse,
+            limit=limit,
+        )
+
+    def clear_tis(
+        self,
+        dag_id: str,
+        body: ClearTaskInstancesBody,
+    ) -> TaskInstanceCollectionResponse | ServerResponseError:
+        """
+        Clear task instances matching the given filters.
+
+        Used by ``airflowctl tasks clear`` (issue #66176).
+        """
+        try:
+            self.response = self.client.post(
+                f"/dags/{dag_id}/clearTaskInstances",
+                json=body.model_dump(mode="json", exclude_none=True),
+            )
+            return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
+        except ServerResponseError as e:
+            raise e
 
 class JobsOperations(BaseOperations):
     """Job operations."""

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -976,6 +976,16 @@ TASKS_COMMANDS = (
             ARG_OUTPUT,
         ),
     ),
+    ActionCommand(
+        name="states-for-dag-run",
+        help="Get the states of all task instances in a DAG run",
+        func=lazy_load_command("airflowctl.ctl.commands.tasks_command.states_for_dag_run"),
+        args=(
+            ARG_DAG_ID,
+            ARG_DAG_RUN_ID,
+            ARG_OUTPUT,
+        ),
+    ),
 )
 
 VARIABLE_COMMANDS = (

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -268,6 +268,25 @@ ARG_DAG_ID = Arg(
     help="The Dag ID of the Dag to pause or unpause",
 )
 
+ARG_TASK_ID = Arg(
+    flags=("task_id",),
+    type=str,
+    help="The task ID",
+)
+
+ARG_DAG_RUN_ID = Arg(
+    flags=("dag_run_id",),
+    type=str,
+    help="The DAG run ID",
+)
+
+ARG_MAP_INDEX = Arg(
+    flags=("--map-index",),
+    type=int,
+    default=None,
+    help="Map index for a mapped task instance (omit for unmapped tasks)",
+)
+
 ARG_ACTION_ON_EXISTING_KEY = Arg(
     flags=("-a", "--action-on-existing-key"),
     type=str,
@@ -944,6 +963,21 @@ POOL_COMMANDS = (
     ),
 )
 
+TASKS_COMMANDS = (
+    ActionCommand(
+        name="state",
+        help="Get the state of a task instance",
+        func=lazy_load_command("airflowctl.ctl.commands.tasks_command.state"),
+        args=(
+            ARG_DAG_ID,
+            ARG_TASK_ID,
+            ARG_DAG_RUN_ID,
+            ARG_MAP_INDEX,
+            ARG_OUTPUT,
+        ),
+    ),
+)
+
 VARIABLE_COMMANDS = (
     ActionCommand(
         name="import",
@@ -979,6 +1013,11 @@ core_commands: list[CLICommand] = [
         name="pools",
         help="Manage Airflow pools",
         subcommands=POOL_COMMANDS,
+    ),
+    GroupCommand(
+        name="tasks",
+        help="Manage Airflow task instances",
+        subcommands=TASKS_COMMANDS,
     ),
     ActionCommand(
         name="version",

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -280,6 +280,83 @@ ARG_DAG_RUN_ID = Arg(
     help="The DAG run ID",
 )
 
+ARG_DRY_RUN = Arg(
+    flags=("--dry-run",),
+    action="store_true",
+    default=False,
+    help="Print which task instances would be cleared without clearing them",
+)
+
+ARG_ONLY_FAILED = Arg(
+    flags=("--only-failed",),
+    action="store_true",
+    default=False,
+    help="Only clear failed task instances",
+)
+
+ARG_ONLY_RUNNING = Arg(
+    flags=("--only-running",),
+    action="store_true",
+    default=False,
+    help="Only clear running task instances",
+)
+
+ARG_TASK_UPSTREAM = Arg(
+    flags=("--upstream",),
+    action="store_true",
+    default=False,
+    help="Include upstream tasks when clearing",
+)
+
+ARG_TASK_DOWNSTREAM = Arg(
+    flags=("--downstream",),
+    action="store_true",
+    default=False,
+    help="Include downstream tasks when clearing",
+)
+
+ARG_INCLUDE_PAST = Arg(
+    flags=("--include-past",),
+    action="store_true",
+    default=False,
+    help="Include past DAG runs when clearing",
+)
+
+ARG_INCLUDE_FUTURE = Arg(
+    flags=("--include-future",),
+    action="store_true",
+    default=False,
+    help="Include future DAG runs when clearing",
+)
+
+ARG_RESET_DAG_RUNS = Arg(
+    flags=("--reset-dag-runs",),
+    action="store_true",
+    default=False,
+    help="Reset the DAG runs to the queued state after clearing",
+)
+
+ARG_TASK_IDS = Arg(
+    flags=("--task-ids",),
+    nargs="*",
+    default=[],
+    help="Specific task IDs to clear (default: all tasks in the DAG run)",
+)
+
+ARG_TASK_START_DATE = Arg(
+    flags=("--start-date",),
+    type=str,
+    default=None,
+    help="Earliest logical date to consider when clearing (ISO 8601)",
+)
+
+ARG_TASK_END_DATE = Arg(
+    flags=("--end-date",),
+    type=str,
+    default=None,
+    help="Latest logical date to consider when clearing (ISO 8601)",
+)
+
 ARG_MAP_INDEX = Arg(
     flags=("--map-index",),
     type=int,
@@ -983,6 +1060,27 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_DAG_RUN_ID,
+            ARG_OUTPUT,
+        ),
+    ),
+    ActionCommand(
+        name="clear",
+        help="Clear task instances",
+        func=lazy_load_command("airflowctl.ctl.commands.tasks_command.clear"),
+        args=(
+            ARG_DAG_ID,
+            ARG_DAG_RUN_ID,
+            ARG_TASK_IDS,
+            ARG_DRY_RUN,
+            ARG_ONLY_FAILED,
+            ARG_ONLY_RUNNING,
+            ARG_TASK_UPSTREAM,
+            ARG_TASK_DOWNSTREAM,
+            ARG_INCLUDE_PAST,
+            ARG_INCLUDE_FUTURE,
+            ARG_RESET_DAG_RUNS,
+            ARG_TASK_START_DATE,
+            ARG_TASK_END_DATE,
             ARG_OUTPUT,
         ),
     ),

--- a/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
@@ -53,3 +53,32 @@ def state(args, api_client=NEW_API_CLIENT) -> None:
         data=[{"state": response.state.value if response.state else None, "task_id": response.task_id}],
         output=args.output,
     )
+
+@provide_api_client(kind=ClientKind.CLI)
+def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
+    """Get the states of all task instances in a DAG run.
+
+    Implements the `airflowctl tasks states-for-dag-run` command (issue #66175).
+    """
+    try:
+        response = api_client.tasks.list_states_for_dag_run(
+            dag_id=args.dag_id,
+            dag_run_id=args.dag_run_id,
+        )
+    except ServerResponseError as e:
+        rich.print(f"[red]Error fetching task states: {e}[/red]")
+        sys.exit(1)
+
+    rows = [
+        {
+            "dag_id": ti.dag_id,
+            "task_id": ti.task_id,
+            "run_id": ti.dag_run_id,
+            "state": ti.state.value if ti.state else "",
+            "start_date": ti.start_date.isoformat() if ti.start_date else "",
+            "end_date": ti.end_date.isoformat() if ti.end_date else "",
+            "map_index": ti.map_index,
+        }
+        for ti in response.task_instances
+    ]
+    AirflowConsole().print_as(data=rows, output=args.output)

--- a/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
@@ -22,6 +22,7 @@ import sys
 
 import rich
 
+from airflowctl.api.datamodels.generated import ClearTaskInstancesBody
 from airflowctl.api.client import (
     NEW_API_CLIENT,
     ClientKind,
@@ -82,3 +83,46 @@ def states_for_dag_run(args, api_client=NEW_API_CLIENT) -> None:
         for ti in response.task_instances
     ]
     AirflowConsole().print_as(data=rows, output=args.output)
+
+@provide_api_client(kind=ClientKind.CLI)
+def clear(args, api_client=NEW_API_CLIENT) -> None:
+    """Clear task instances matching the given filters.
+
+    Implements the `airflowctl tasks clear` command (issue #66176).
+    """
+    body = ClearTaskInstancesBody(
+        dry_run=args.dry_run,
+        only_failed=args.only_failed,
+        only_running=args.only_running,
+        include_upstream=args.upstream,
+        include_downstream=args.downstream,
+        include_past=args.include_past,
+        include_future=args.include_future,
+        reset_dag_runs=args.reset_dag_runs,
+        dag_run_id=args.dag_run_id,
+        task_ids=args.task_ids if args.task_ids else None,
+        start_date=args.start_date,
+        end_date=args.end_date,
+    )
+    try:
+        response = api_client.tasks.clear_tis(dag_id=args.dag_id, body=body)
+    except ServerResponseError as e:
+        rich.print(f"[red]Error clearing task instances: {e}[/red]")
+        sys.exit(1)
+
+    action_word = "Would clear" if args.dry_run else "Cleared"
+    rich.print(
+        f"[green]{action_word} {response.total_entries} task instance(s).[/green]"
+    )
+    if args.dry_run and response.task_instances:
+        AirflowConsole().print_as(
+            data=[
+                {
+                    "task_id": ti.task_id,
+                    "run_id": ti.dag_run_id,
+                    "state": ti.state.value if ti.state else "",
+                }
+                for ti in response.task_instances
+            ],
+            output=args.output,
+        )

--- a/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Command functions for managing Airflow task instances via airflowctl."""
+
+from __future__ import annotations
+
+import sys
+
+import rich
+
+from airflowctl.api.client import (
+    NEW_API_CLIENT,
+    ClientKind,
+    ServerResponseError,
+    provide_api_client,
+)
+from airflowctl.ctl.console_formatting import AirflowConsole
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def state(args, api_client=NEW_API_CLIENT) -> None:
+    """
+    Get the state of a single task instance.
+
+    Implements the `airflowctl tasks state` command (issue #66174).
+    """
+    try:
+        response = api_client.tasks.get_ti_state(
+            dag_id=args.dag_id,
+            dag_run_id=args.dag_run_id,
+            task_id=args.task_id,
+            map_index=args.map_index,
+        )
+    except ServerResponseError as e:
+        rich.print(f"[red]Error fetching task state: {e}[/red]")
+        sys.exit(1)
+
+    AirflowConsole().print_as(
+        data=[{"state": response.state.value if response.state else None, "task_id": response.task_id}],
+        output=args.output,
+    )

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
@@ -120,3 +120,23 @@ class TestTasksCommands:
                 ]),
                 api_client=api_client,
             )
+            
+    def test_tasks_clear_dry_run(self, api_client_maker):
+        collection = TaskInstanceCollectionResponse(
+            task_instances=[self.task_instance_response],
+            total_entries=1,
+            next_cursor=None,
+            previous_cursor=None,
+        )
+        api_client = api_client_maker(
+            path=f"/api/v2/dags/{self.dag_id}/clearTaskInstances",
+            response_json=collection.model_dump(mode="json"),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+        tasks_command.clear(
+            self.parser.parse_args([
+                "tasks", "clear", self.dag_id, self.dag_run_id, "--dry-run",
+            ]),
+            api_client=api_client,
+        )

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
@@ -27,6 +27,7 @@ import pytest
 
 from airflowctl.api.client import ClientKind
 from airflowctl.api.datamodels.generated import (
+    TaskInstanceCollectionResponse,
     TaskInstanceResponse,
     TaskInstanceState,
 )
@@ -92,6 +93,30 @@ class TestTasksCommands:
                 self.parser.parse_args([
                     "tasks", "state",
                     self.dag_id, self.task_id, self.dag_run_id,
+                ]),
+                api_client=api_client,
+            )
+
+    def test_tasks_states_for_dag_run(self, api_client_maker):
+            collection = TaskInstanceCollectionResponse(
+                task_instances=[self.task_instance_response],
+                total_entries=1,
+                next_cursor=None,
+                previous_cursor=None,
+            )
+            api_client = api_client_maker(
+                path=(
+                    f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}"
+                    f"/taskInstances"
+                ),
+                response_json=collection.model_dump(mode="json"),
+                expected_http_status_code=200,
+                kind=ClientKind.CLI,
+            )
+            tasks_command.states_for_dag_run(
+                self.parser.parse_args([
+                    "tasks", "states-for-dag-run",
+                    self.dag_id, self.dag_run_id,
                 ]),
                 api_client=api_client,
             )

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the airflowctl `tasks` command group.
+
+Implements tests for issues #66174, #66175, and #66176.
+"""
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import pytest
+
+from airflowctl.api.client import ClientKind
+from airflowctl.api.datamodels.generated import (
+    TaskInstanceResponse,
+    TaskInstanceState,
+)
+from airflowctl.ctl import cli_parser
+from airflowctl.ctl.commands import tasks_command
+
+
+class TestTasksCommands:
+    parser = cli_parser.get_parser()
+    dag_id = "test_dag"
+    task_id = "test_task"
+    dag_run_id = "manual__2025-01-01T00:00:00+00:00"
+
+    task_instance_response = TaskInstanceResponse(
+        id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        dag_id=dag_id,
+        task_id=task_id,
+        dag_run_id=dag_run_id,
+        map_index=-1,
+        run_after=datetime.datetime(2025, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        state=TaskInstanceState.SUCCESS,
+        start_date=datetime.datetime(2025, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        end_date=datetime.datetime(2025, 1, 1, 0, 5, 0, tzinfo=datetime.timezone.utc),
+        try_number=1,
+        max_tries=3,
+        task_display_name=task_id,
+        dag_display_name=dag_id,
+        pool="default_pool",
+        pool_slots=1,
+        executor_config="{}",
+    )
+
+    def test_tasks_state(self, api_client_maker):
+        api_client = api_client_maker(
+            path=(
+                f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}"
+                f"/taskInstances/{self.task_id}"
+            ),
+            response_json=self.task_instance_response.model_dump(mode="json"),
+            expected_http_status_code=200,
+            kind=ClientKind.CLI,
+        )
+        tasks_command.state(
+            self.parser.parse_args([
+                "tasks", "state",
+                self.dag_id, self.task_id, self.dag_run_id,
+            ]),
+            api_client=api_client,
+        )
+
+    def test_tasks_state_not_found(self, api_client_maker):
+        api_client = api_client_maker(
+            path=(
+                f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}"
+                f"/taskInstances/{self.task_id}"
+            ),
+            response_json={"detail": "Task instance not found"},
+            expected_http_status_code=404,
+            kind=ClientKind.CLI,
+        )
+        with pytest.raises(SystemExit):
+            tasks_command.state(
+                self.parser.parse_args([
+                    "tasks", "state",
+                    self.dag_id, self.task_id, self.dag_run_id,
+                ]),
+                api_client=api_client,
+            )


### PR DESCRIPTION
# Title
airflowctl: add `tasks clear` command (closes #66176)

# Body

Closes #66176.

Builds on top of #[66174](https://github.com/apache/airflow/pull/66384) (PR for #66174) and #[66175](https://github.com/apache/airflow/pull/66385) (PR for #66175).

## What this PR does

Adds the `airflowctl tasks clear` subcommand. Clears task instances in a DAG run with the same filtering options as the legacy `airflow tasks clear` command — only-failed, only-running, upstream, downstream, include-past, include-future, reset-dag-runs, and a `--dry-run` mode that previews what would be cleared without actually clearing.

## Implementation summary

- New `clear_tis` method on the `TasksOperations` class added in #______, wrapping `POST /dags/{dag_id}/clearTaskInstances`. The request body is constructed from the existing `ClearTaskInstancesBody` Pydantic model in the auto-generated datamodels.
- New `clear` command function in `airflow-ctl/src/airflowctl/ctl/commands/tasks_command.py`. In `--dry-run` mode, prints the list of task instances that would be cleared. Otherwise prints the count and exits.
- New CLI argument definitions in `cli_config.py`: `ARG_DRY_RUN`, `ARG_ONLY_FAILED`, `ARG_ONLY_RUNNING`, `ARG_TASK_UPSTREAM`, `ARG_TASK_DOWNSTREAM`, `ARG_INCLUDE_PAST`, `ARG_INCLUDE_FUTURE`, `ARG_RESET_DAG_RUNS`, `ARG_TASK_IDS`, `ARG_TASK_START_DATE`, `ARG_TASK_END_DATE`.
- New `ActionCommand` registered in `TASKS_COMMANDS` with `name="clear"`.
- Test for the `--dry-run` path in `test_tasks_command.py`.
- Newsfragment in `airflow-ctl/newsfragments/`.

## Testing

- `pytest airflow-ctl/tests/airflow_ctl/ctl/commands/test_tasks_command.py::TestTasksCommands::test_tasks_clear_dry_run -v` — passes.
- Manually verified `--dry-run` against a local Breeze-started Airflow:
  ```
  $ airflowctl tasks clear my_dag manual__2025-01-01T00:00:00+00:00 --dry-run --only-failed
  Would clear 1 task instance(s).
  [{"task_id": "transform", "run_id": "manual__2025-01-01T00:00:00+00:00", "state": "failed"}]
  ```
- Manually verified actual clearing (without `--dry-run`) and confirmed the affected task instance state was reset in the UI.

## AI-assistance disclosure

Per the project's contribution policy: this PR was developed with AI assistance for code drafting and analysis. All code has been reviewed, manually tested by the contributor, and the contributor can explain and defend the changes during review.