### PR TITLE
feat(ui-i18n): complete zh-TW translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -193,6 +193,12 @@
     },
     "tooltip": "按 {{hotkey}} 捲動到{{direction}}"
   },
+  "search": {
+    "advanced": {
+      "description": "在值中任意位置進行匹配 (子字串搜尋)。在大型部署上會較慢，因為無法使用預設的 B-tree 索引。詳情請參閱文件中關於自訂中繼資料索引的章節。",
+      "title": "任意位置匹配"
+    }
+  },
   "security": {
     "actions": "操作",
     "permissions": "權限",
@@ -257,6 +263,8 @@
   "task_one": "任務",
   "task_other": "任務",
   "taskGroup": "任務群組",
+  "taskGroup_one": "任務群組",
+  "taskGroup_other": "任務群組",
   "taskId": "任務 ID",
   "taskInstance": {
     "dagVersion": "Dag 版本",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -10,9 +10,11 @@
     "maxRuns": "活躍執行數上限",
     "missingAndErroredRuns": "遺漏和錯誤的執行",
     "missingRuns": "遺漏的執行",
+    "overrideExistingParams": "覆寫既有執行的參數",
     "permissionDenied": "試執行失敗：使用者沒有建立回填的權限。",
     "reprocessBehavior": "重新處理行為",
     "run": "執行回填",
+    "scheduleNotBackfillable": "此 Dag 的排程不支援回填",
     "selectDescription": "為指定的日期範圍補上 Dag 執行",
     "selectLabel": "回填",
     "title": "執行回填",
@@ -90,7 +92,8 @@
     "otherDagRuns": "+ 其他 Dag 執行",
     "taskCount_one": "1 個任務",
     "taskCount_other": "{{count}} 個任務",
-    "taskGroup": "任務群組"
+    "taskGroup": "任務群組",
+    "zoomToTask": "縮放至選定任務"
   },
   "limitedList": "+ 其他 {{count}} 項",
   "limitedList.allItems": "所有 {{count}} 個項目：",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
@@ -41,9 +41,9 @@
     "parsedAt": "解析時間："
   },
   "deadlineAlerts": {
-    "completionRule": "必須在 {{reference}}的 {{interval}} 內完成",
-    "count_one": "{{count}} 個截止時間",
-    "count_other": "{{count}} 個截止時間",
+    "completionRule": "必須在 {{reference}}後 {{interval}} 內完成",
+    "count_one": "{{count}} 個期限",
+    "count_other": "{{count}} 個期限",
     "referenceType": {
       "AverageRuntimeDeadline": "平均執行時間",
       "DagRunLogicalDateDeadline": "邏輯日期",
@@ -53,18 +53,18 @@
   "deadlineStatus": {
     "actual": "實際",
     "expected": "預期",
-    "finishedEarly": "比截止時間提前 {{duration}} 完成",
-    "finishedLate": "比截止時間延後 {{duration}} 完成",
-    "label": "截止時間",
-    "met": "達成",
-    "missed": "未達成",
-    "missedCount_one": "{{count}} 個未達成的截止時間",
-    "missedCount_other": "{{count}} 個未達成的截止時間",
-    "mixedCount": "{{missedCount}} 個未達成，{{upcomingCount}} 個即將到期",
+    "finishedEarly": "提前 {{duration}} 達成期限",
+    "finishedLate": "逾期 {{duration}} 完成",
+    "label": "期限",
+    "met": "已達成",
+    "missed": "已逾期",
+    "missedCount_one": "{{count}} 個已逾期的期限",
+    "missedCount_other": "{{count}} 個已逾期的期限",
+    "mixedCount": "{{missedCount}} 個已逾期，{{upcomingCount}} 個即將到期",
     "stillRunning": "仍在執行中",
     "upcoming": "即將到期",
-    "upcomingCount_one": "{{count}} 個即將到期的截止時間",
-    "upcomingCount_other": "{{count}} 個即將到期的截止時間"
+    "upcomingCount_one": "{{count}} 個即將到期的期限",
+    "upcomingCount_other": "{{count}} 個即將到期的期限"
   },
   "extraLinks": "額外連結",
   "grid": {
@@ -132,7 +132,7 @@
     },
     "deadlines": {
       "showAll": "顯示全部",
-      "title": "截止時間"
+      "title": "期限"
     },
     "failedLogs": {
       "hideLogs": "隱藏日誌",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
@@ -40,9 +40,37 @@
     "parseDuration": "解析時長：",
     "parsedAt": "解析時間："
   },
+  "deadlineAlerts": {
+    "completionRule": "必須在 {{reference}}的 {{interval}} 內完成",
+    "count_one": "{{count}} 個截止時間",
+    "count_other": "{{count}} 個截止時間",
+    "referenceType": {
+      "AverageRuntimeDeadline": "平均執行時間",
+      "DagRunLogicalDateDeadline": "邏輯日期",
+      "DagRunQueuedAtDeadline": "排隊時間"
+    }
+  },
+  "deadlineStatus": {
+    "actual": "實際",
+    "expected": "預期",
+    "finishedEarly": "比截止時間提前 {{duration}} 完成",
+    "finishedLate": "比截止時間延後 {{duration}} 完成",
+    "label": "截止時間",
+    "met": "達成",
+    "missed": "未達成",
+    "missedCount_one": "{{count}} 個未達成的截止時間",
+    "missedCount_other": "{{count}} 個未達成的截止時間",
+    "mixedCount": "{{missedCount}} 個未達成，{{upcomingCount}} 個即將到期",
+    "stillRunning": "仍在執行中",
+    "upcoming": "即將到期",
+    "upcomingCount_one": "{{count}} 個即將到期的截止時間",
+    "upcomingCount_other": "{{count}} 個即將到期的截止時間"
+  },
   "extraLinks": "額外連結",
   "grid": {
     "buttons": {
+      "newerRuns": "較新的執行",
+      "olderRuns": "較舊的執行",
       "resetToLatest": "重設為最新",
       "toggleGroup": "切換群組狀態"
     },
@@ -52,6 +80,9 @@
     "buttons": {
       "advanced": "進階功能",
       "dagDocs": "Dag 文件"
+    },
+    "status": {
+      "deactivated": "已停用"
     }
   },
   "logs": {
@@ -66,12 +97,18 @@
     },
     "info": "INFO",
     "noTryNumber": "無嘗試次數",
+    "search": {
+      "matchCount": "{{total}} 中第 {{current}} 筆",
+      "noMatches": "無符合結果",
+      "placeholder": "搜尋日誌..."
+    },
     "settings": "日誌設定",
     "viewInExternal": "在 {{name}} 中檢視日誌(嘗試 {{attempt}})",
     "warning": "WARNING"
   },
   "navigation": {
     "navigation": "導航: {{arrow}}",
+    "openGraphFilters": "任務篩選條件: Ctrl+Shift+F",
     "toggleGroup": "展開/收合群組: 空白鍵"
   },
   "notFound": {
@@ -92,6 +129,10 @@
     "charts": {
       "assetEvent_one": "已建立資源事件",
       "assetEvent_other": "已建立資源事件"
+    },
+    "deadlines": {
+      "showAll": "顯示全部",
+      "title": "截止時間"
     },
     "failedLogs": {
       "hideLogs": "隱藏日誌",
@@ -125,7 +166,9 @@
     "graphFilters": {
       "clearFilters": "清除篩選條件",
       "durationGte": "最短持續時間 (秒)",
+      "durationGteHint": "對於映射任務，會計算所有實例的總時間範圍",
       "mapIndex": "映射索引",
+      "mapIndexHint": "至少展開到此索引的映射任務",
       "selectStatus": "選擇狀態",
       "selectTaskGroup": "選擇任務群組",
       "title": "任務篩選條件"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
@@ -34,6 +34,11 @@
       "error": "清除 {{type}} 時發生錯誤",
       "title": "清除 {{type}}"
     },
+    "clearAllMapped": {
+      "button": "清除所有映射任務",
+      "buttonTooltip": "按下 shift+c 清除所有映射任務實例",
+      "title": "清除所有映射任務實例"
+    },
     "confirmationDialog": {
       "description": "此任務目前處於 {{state}} 狀態，由使用者 {{user}} 於 {{time}} 啟動。\n除非任務執行完畢，或是在清除任務對話框中取消勾選「防止重新執行執行中的任務」選項，否則無法清除此任務。",
       "title": "無法清除任務實例"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

## Why
zh-TW UI coverage was 95.2% with 41 missing keys — mostly the AIP-86 Deadline strings, log search, and graph filter hints.

## What
- Translate Deadline strings (`deadlineStatus.*`, `deadlineAlerts.*`, `overview.deadlines.*`) using 期限 / 已達成 / 已逾期 / 即將到期.
- Translate log search, graph filter hints, grid newer/older runs, deactivated header, clear-all-mapped, advanced search, and a few backfill /
  taskGroup keys.
- zh-TW coverage: 95.2% → 100%.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
