### PR TITLE
docs(agents): document Dag naming convention

### DIFF
--- a/.github/skills/airflow-translations/locales/th.md
+++ b/.github/skills/airflow-translations/locales/th.md
@@ -13,8 +13,8 @@ The following technical terms should **remain in English** in Thai translations:
 
 ### Core Technical Terms (คำศัพท์ทางเทคนิค)
 
-- **DAG** (Directed Acyclic Graph) - Keep as "DAG"
-- **DAG Run** - Keep as "DAG Run"
+- **Dag** - Keep as "Dag" (Airflow convention; never write "DAG")
+- **Dag Run** - Keep as "Dag Run"
 - **Task Instance** - Keep as "Task Instance"
 - **XCom** - Keep as "XCom"
 - **Asset** - Keep as "Asset"
@@ -24,7 +24,7 @@ The following technical terms should **remain in English** in Thai translations:
 - **Sensor** - Keep as "Sensor"
 - **Hook** - Keep as "Hook"
 - **Operator** - Keep as "Operator" (โอเปอเรเตอร์) or in English
-- **DAGBag** - Keep as "DAGBag"
+- **DagBag** - Keep as "DagBag"
 
 ### UI Components (ส่วนประกอบของอินเทอร์เฟซ)
 
@@ -123,14 +123,14 @@ In Airflow UI and messages, numerals are typically formatted as:
 Example:
 
 ```text
-งาน DAG รันสำเร็จ (DAG run successful)
+งาน Dag รันสำเร็จ (Dag run successful)
 ```
 
 ## Translation Style Guidelines
 
 ### 1. Technical Terminology
 
-Keep technical terms like DAG, XCom, Operator in English when:
+Keep technical terms like Dag, XCom, Operator in English when:
 
 - They appear in code or configuration examples
 - No clear Thai equivalent exists
@@ -181,8 +181,8 @@ Prefer translation for:
 
 ### 1. "Run" Context
 
-- "Run DAG" → "รัน DAG" or "ดำเนินการ DAG"
-- "DAG run" (noun) → "การรัน DAG" or "DAG Run"
+- "Run Dag" → "รัน Dag" or "ดำเนินการ Dag"
+- "Dag run" (noun) → "การรัน Dag" or "Dag Run"
 - "Run ID" → "รันไอดี" or "Run ID"
 
 ### 2. "Task" Context
@@ -191,11 +191,11 @@ Prefer translation for:
 - "Task instance" → "Task Instance" or "อินสแตนซ์งาน"
 - "Task ID" → "Task ID" or "ไอดีงาน"
 
-### 3. "DAG" Context
+### 3. "Dag" Context
 
-- "DAG run" → "การรัน DAG" or "DAG Run"
-- "DAG ID" → "DAG ID" or "ไอดี DAG"
-- "Sub DAG" → "DAG ย่อย" or "Sub DAG"
+- "Dag run" → "การรัน Dag" or "Dag Run"
+- "Dag ID" → "Dag ID" or "ไอดี Dag"
+- "Sub Dag" → "Dag ย่อย" or "Sub Dag"
 
 ### 4. Configuration
 
@@ -252,14 +252,14 @@ However, these are typically omitted in technical documentation to maintain conc
 "Tree View" → "มุมมองต้นไม้" or "Tree View"
 "Graph View" → "มุมมองกราฟ" or "Graph View"
 "Task Instances" → "Task Instances" or "อินสแตนซ์งาน"
-"DAG Runs" → "DAG Runs" or "การรัน DAG"
+"Dag Runs" → "Dag Runs" or "การรัน Dag"
 ```
 
 ### Message Examples
 
 ```text
 "Task failed" → "งานล้มเหลว"
-"DAG run successful" → "การรัน DAG สำเร็จ"
+"Dag run successful" → "การรัน Dag สำเร็จ"
 "XCom pushed" → "ดัน XCom แล้ว" or "XCom pushed"
 "Connection test failed" → "การทดสอบการเชื่อมต่อล้มเหลว"
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,12 @@ issue bodies, and chat replies. Never write "DAG" (all caps) or "dag"
 
 Exceptions where the literal form is required and must be preserved as-is:
 
-- **Python source code** where a legacy class or variable is literally named
-  `DAG` (e.g., `from airflow.sdk import DAG`, `dag = DAG("my_dag", ...)`). The
-  class is spelt `DAG`; that token cannot be renamed in documentation that
-  shows it. Same applies to lowercase identifiers like `dag_id`, `dag`,
-  `my_dag`.
+- **Python source code** where a class or variable is literally named `DAG`
+  (e.g., `from airflow.sdk import DAG`, `dag = DAG("my_dag", ...)`). The `DAG`
+  class itself is current and stays as-is in code; only its appearance in
+  prose moves to "Dag". The token `DAG` in code cannot be rewritten in
+  documentation that shows the code. Same applies to lowercase identifiers
+  like `dag_id`, `dag`, `my_dag`.
 - **CLI subcommands** that are literally named `dags` (e.g.,
   `airflow dags list`, `airflow dags test`). Lowercase is the actual command
   name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,33 @@
 
 # AGENTS instructions
 
+## Naming
+
+Always write **Dag** (title case) in prose — documentation, markdown, comments,
+docstrings, commit messages, PR titles and descriptions, code review comments,
+issue bodies, and chat replies. Never write "DAG" (all caps) or "dag"
+(lowercase) outside of literal code tokens.
+
+Exceptions where the literal form is required and must be preserved as-is:
+
+- **Python source code** where a legacy class or variable is literally named
+  `DAG` (e.g., `from airflow.sdk import DAG`, `dag = DAG("my_dag", ...)`). The
+  class is spelt `DAG`; that token cannot be renamed in documentation that
+  shows it. Same applies to lowercase identifiers like `dag_id`, `dag`,
+  `my_dag`.
+- **CLI subcommands** that are literally named `dags` (e.g.,
+  `airflow dags list`, `airflow dags test`). Lowercase is the actual command
+  name.
+- **File / directory / config tokens** that are literally those identifiers
+  (`dag_processing/`, `dagprocessor`, `get_dag`, etc.).
+- **Anti-pattern callouts** that quote the wrong form to teach the rule (e.g.,
+  `Use "DAG" — always write "Dag"`). The literal `DAG` is required to convey
+  what to avoid; this is the rule's spirit, not a violation.
+
+Do not write **Directed Acyclic Graph** in documentation. The only exception is
+when describing what the term originally meant (historical / etymological
+context). In current prose, just use "Dag".
+
 ## Environment Setup
 
 - Install prek: `uv tool install prek`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,31 +5,18 @@
 
 ## Naming
 
-Always write **Dag** (title case) in prose — documentation, markdown, comments,
-docstrings, commit messages, PR titles and descriptions, code review comments,
-issue bodies, and chat replies. Never write "DAG" (all caps) or "dag"
-(lowercase) outside of literal code tokens.
+Write **Dag** (title case) in all prose. Keep the all-caps or lowercase
+spelling only when reproducing a literal code token — never rewrite these,
+even inside fenced code blocks:
 
-Exceptions where the literal form is required and must be preserved as-is:
+- Python: the SDK class `DAG` (`from airflow.sdk import DAG`,
+  `dag = DAG("my_dag", ...)`); identifiers like `dag_id`, `dag`, `my_dag`.
+- CLI: `airflow dags list`, `airflow dags test`, etc.
+- Paths and config keys: `dag_processing/`, `dagprocessor`, `get_dag`, etc.
+- Anti-pattern quotes that show the wrong form to teach the rule itself
+  (e.g., `Use "DAG" — always write "Dag"`).
 
-- **Python source code** where a class or variable is literally named `DAG`
-  (e.g., `from airflow.sdk import DAG`, `dag = DAG("my_dag", ...)`). The `DAG`
-  class itself is current and stays as-is in code; only its appearance in
-  prose moves to "Dag". The token `DAG` in code cannot be rewritten in
-  documentation that shows the code. Same applies to lowercase identifiers
-  like `dag_id`, `dag`, `my_dag`.
-- **CLI subcommands** that are literally named `dags` (e.g.,
-  `airflow dags list`, `airflow dags test`). Lowercase is the actual command
-  name.
-- **File / directory / config tokens** that are literally those identifiers
-  (`dag_processing/`, `dagprocessor`, `get_dag`, etc.).
-- **Anti-pattern callouts** that quote the wrong form to teach the rule (e.g.,
-  `Use "DAG" — always write "Dag"`). The literal `DAG` is required to convey
-  what to avoid; this is the rule's spirit, not a violation.
-
-Do not write **Directed Acyclic Graph** in documentation. The only exception is
-when describing what the term originally meant (historical / etymological
-context). In current prose, just use "Dag".
+Don't spell out **Directed Acyclic Graph** except for historical context.
 
 ## Environment Setup
 

--- a/providers/AGENTS.md
+++ b/providers/AGENTS.md
@@ -46,14 +46,14 @@ Airflow has two distinct user roles with different trust levels:
 - **Connection editors** — UI/API users with permission to create or edit
   Connections. They control the host, login, password, and the `extra` JSON
   blob.
-- **DAG authors** — users who write the Python code that constructs hooks
+- **Dag authors** — users who write the Python code that constructs hooks
   and operators. They control which arguments are passed at call sites.
 
 These are *not* the same population, and the security model treats them
 differently. A Connection editor is trusted to supply credentials for a target
 system; they are **not** trusted to alter how the worker process behaves, load
 arbitrary Python code, change file paths the worker reads, or pass options
-into client libraries that the DAG author did not opt into.
+into client libraries that the Dag author did not opt into.
 
 ### What goes wrong when extras are forwarded blindly
 
@@ -90,7 +90,7 @@ model does not grant them.
 - When adding support for a new extra key, treat it like any other public
   argument: review what the underlying library does with it, and document
   it in the provider's connection docs.
-- If a DAG author genuinely needs to pass a non-allowlisted option, that
+- If a Dag author genuinely needs to pass a non-allowlisted option, that
   option should be a **Dag-author-supplied argument** on the operator or
   hook (with its own review), not something a Connection editor can set.
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

## Why
Codify the project-wide convention that "Dag" (title case) is the only correct form in prose, comments, commit messages, and PR text. "DAG" (all caps) appearing in documentation is the legacy form to be replaced; the `DAG` Python class itself is current and stays as-is in code. Without an explicit rule in the agent instructions, AI-assisted contributions repeatedly reintroduce the all-caps form.

## What
- Add a top-level **Naming** section to `AGENTS.md` covering Dag usage, the legitimate exceptions (Python code tokens, CLI subcommands like `airflow dags list`, file/directory tokens, anti-pattern callouts that quote the wrong form to teach the rule), and the rule that "Directed Acyclic Graph" should not appear except as historical context.
- Fix 3 prose mentions of "DAG authors" → "Dag authors" in `providers/AGENTS.md`.
- Update Thai translator locale guidance in `.github/skills/airflow-translations/locales/th.md` so its "Keep in English" entries and translation pattern examples use "Dag" instead of "DAG".

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
