### PR TITLE
KubernetesExecutor: scope periodic completed-pod adoption to dead schedulers

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -725,7 +725,7 @@ class KubernetesExecutor(BaseExecutor):
                 # Iterate the scalar cursor straight into the set so we never
                 # materialize an intermediate list — keeps the memory
                 # footprint flat regardless of how many sibling schedulers
-                # are alive (per @jscheffl review on #66400).
+                # are alive
                 return {
                     jid
                     for jid in session.scalars(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -681,22 +681,108 @@ class KubernetesExecutor(BaseExecutor):
         del tis_to_flush_by_key[ti_key]
         self.running.add(ti_key)
 
+    def _alive_other_scheduler_job_ids(self) -> set[int]:
+        """
+        Return job IDs of every SchedulerJob that is currently alive — excluding self.
+
+        "Alive" means ``Job.state == RUNNING`` AND its ``latest_heartbeat`` is
+        within ``[scheduler] scheduler_health_check_threshold``.
+
+        Used by ``_adopt_completed_pods`` to scope cross-scheduler pod
+        adoption to pods owned by no-longer-alive schedulers (#66396).
+        With a single scheduler the returned set is always empty — the
+        original "exclude self only" behavior is preserved. With multiple
+        schedulers each one only adopts pods whose owning scheduler is gone,
+        eliminating the relabel-thrash that PR #61839 introduced.
+
+        Returns an empty set on any DB error so the caller falls back to
+        the pre-#61839 "exclude self only" selector — a transient DB issue
+        must not break completed-pod cleanup.
+        """
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+
+        try:
+            self_id = int(self.scheduler_job_id)
+        except (TypeError, ValueError):
+            # Tests sometimes set scheduler_job_id to a non-numeric string.
+            # In production it's always Job.id (int), but be defensive.
+            return set()
+
+        try:
+            from datetime import timedelta
+
+            from sqlalchemy import select
+
+            from airflow.jobs.job import Job
+            from airflow.utils import timezone
+            from airflow.utils.session import create_session
+            from airflow.utils.state import JobState
+
+            timeout = conf.getint("scheduler", "scheduler_health_check_threshold")
+            cutoff = timezone.utcnow() - timedelta(seconds=timeout)
+            with create_session() as session:
+                rows = session.scalars(
+                    select(Job.id).where(
+                        Job.job_type == "SchedulerJob",
+                        Job.state == JobState.RUNNING,
+                        Job.latest_heartbeat >= cutoff,
+                        Job.id != self_id,
+                    )
+                ).all()
+            return set(rows)
+        except Exception as exc:
+            self.log.warning(
+                "Could not query alive SchedulerJobs for completed-pod adoption "
+                "scoping: %s. Falling back to exclude-self-only.",
+                exc,
+            )
+            return set()
+
     def _adopt_completed_pods(self, kube_client: client.CoreV1Api) -> None:
         """
-        Patch completed pods so that the KubernetesJobWatcher can delete them.
+        Patch completed pods owned by no-longer-alive schedulers so this scheduler's watcher can delete them.
+
+        Originally this method patched every Succeeded pod that did not carry
+        THIS scheduler's ``airflow-worker`` label. With multi-scheduler
+        deployments that caused thrashing — every scheduler relabeled every
+        other scheduler's completed pods on each interval tick, fighting over
+        ownership and burning kube-API and watcher cycles (see #66396).
+
+        The fix scopes the selector to also exclude pods owned by every
+        currently-alive sibling scheduler. With one scheduler, behavior is
+        unchanged (no siblings → original "exclude self only" selector). With
+        multiple schedulers, each one only adopts pods whose owning scheduler
+        is gone — preserving the original goal of #61839 (cleanup after a
+        scheduler restart) without the multi-scheduler regression.
 
         :param kube_client: kubernetes client for speaking to kube API
         """
         if TYPE_CHECKING:
             assert self.scheduler_job_id
 
-        new_worker_id_label = self._make_safe_label_value(self.scheduler_job_id)
+        self_label = self._make_safe_label_value(self.scheduler_job_id)
+        excluded_labels = sorted(
+            {
+                self_label,
+                *(self._make_safe_label_value(str(jid)) for jid in self._alive_other_scheduler_job_ids()),
+            }
+        )
+
+        if len(excluded_labels) == 1:
+            # Equality-based selector — preserves the pre-fix label_selector
+            # exactly when no sibling scheduler is alive, so single-scheduler
+            # deployments see no behavior change.
+            worker_filter = f"airflow-worker!={excluded_labels[0]}"
+        else:
+            # Set-based requirement: K8s parses `notin (a,b,c)` as "label
+            # value is none of these". Mixed with the surrounding
+            # equality-based requirements via comma separator.
+            worker_filter = f"airflow-worker notin ({','.join(excluded_labels)})"
+
         query_kwargs = {
             "field_selector": "status.phase=Succeeded",
-            "label_selector": (
-                "kubernetes_executor=True,"
-                f"airflow-worker!={new_worker_id_label},{POD_EXECUTOR_DONE_KEY}!=True"
-            ),
+            "label_selector": (f"kubernetes_executor=True,{worker_filter},{POD_EXECUTOR_DONE_KEY}!=True"),
         }
         pod_list = self._list_pods(query_kwargs)
         for pod in pod_list:
@@ -707,7 +793,7 @@ class KubernetesExecutor(BaseExecutor):
                 kube_client.patch_namespaced_pod(
                     name=pod.metadata.name,
                     namespace=pod.metadata.namespace,
-                    body={"metadata": {"labels": {"airflow-worker": new_worker_id_label}}},
+                    body={"metadata": {"labels": {"airflow-worker": self_label}}},
                 )
             except ApiException as e:
                 self.log.info("Failed to adopt pod %s. Reason: %s", pod.metadata.name, e)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -722,15 +722,21 @@ class KubernetesExecutor(BaseExecutor):
             timeout = conf.getint("scheduler", "scheduler_health_check_threshold")
             cutoff = timezone.utcnow() - timedelta(seconds=timeout)
             with create_session() as session:
-                rows = session.scalars(
-                    select(Job.id).where(
-                        Job.job_type == "SchedulerJob",
-                        Job.state == JobState.RUNNING,
-                        Job.latest_heartbeat >= cutoff,
-                        Job.id != self_id,
+                # Iterate the scalar cursor straight into the set so we never
+                # materialize an intermediate list — keeps the memory
+                # footprint flat regardless of how many sibling schedulers
+                # are alive (per @jscheffl review on #66400).
+                return {
+                    jid
+                    for jid in session.scalars(
+                        select(Job.id).where(
+                            Job.job_type == "SchedulerJob",
+                            Job.state == JobState.RUNNING,
+                            Job.latest_heartbeat >= cutoff,
+                            Job.id != self_id,
+                        )
                     )
-                ).all()
-            return set(rows)
+                }
         except Exception as exc:
             self.log.warning(
                 "Could not query alive SchedulerJobs for completed-pod adoption "

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1383,6 +1383,79 @@ class TestKubernetesExecutor:
         assert len(pod_names) == mock_kube_client.patch_namespaced_pod.call_count
         assert executor.running == set()
 
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor."
+        "KubernetesExecutor._alive_other_scheduler_job_ids"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.DynamicClient")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_adopt_completed_pods_excludes_alive_siblings(
+        self, mock_kube_client, mock_kube_dynamic_client, mock_alive_ids
+    ):
+        """
+        With multiple alive schedulers, the label selector must exclude pods owned
+        by every alive sibling — not just self — so the schedulers do not thrash
+        relabeling each other's completed pods (see #66396).
+        """
+        mock_alive_ids.return_value = {7, 9}
+        executor = self.kubernetes_executor
+        executor.scheduler_job_id = "5"
+        executor.kube_client = mock_kube_client
+        mock_kube_dynamic_client.return_value = mock.MagicMock()
+        mock_pod_resource = mock.MagicMock()
+        mock_kube_dynamic_client.return_value.resources.get.return_value = mock_pod_resource
+        mock_kube_dynamic_client.return_value.get.return_value.items = []
+        executor.kube_config.kube_namespace = "somens"
+
+        executor._adopt_completed_pods(mock_kube_client)
+
+        # Selector must use set-based `notin (...)` listing self + every alive sibling,
+        # sorted for determinism. Anything outside that set is a pod whose owning
+        # scheduler is gone and therefore safe for this scheduler to adopt.
+        mock_kube_dynamic_client.return_value.get.assert_called_once_with(
+            resource=mock_pod_resource,
+            namespace="somens",
+            field_selector="status.phase=Succeeded",
+            label_selector=(
+                "kubernetes_executor=True,airflow-worker notin (5,7,9),airflow_executor_done!=True"
+            ),
+            header_params={"Accept": "application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io"},
+        )
+
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor."
+        "KubernetesExecutor._alive_other_scheduler_job_ids"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.DynamicClient")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_adopt_completed_pods_single_scheduler_unchanged(
+        self, mock_kube_client, mock_kube_dynamic_client, mock_alive_ids
+    ):
+        """
+        With only one scheduler (no alive siblings), the selector must remain
+        identical to the pre-#66396-fix equality form so single-scheduler
+        deployments see no behavior change.
+        """
+        mock_alive_ids.return_value = set()
+        executor = self.kubernetes_executor
+        executor.scheduler_job_id = "modified"
+        executor.kube_client = mock_kube_client
+        mock_kube_dynamic_client.return_value = mock.MagicMock()
+        mock_pod_resource = mock.MagicMock()
+        mock_kube_dynamic_client.return_value.resources.get.return_value = mock_pod_resource
+        mock_kube_dynamic_client.return_value.get.return_value.items = []
+        executor.kube_config.kube_namespace = "somens"
+
+        executor._adopt_completed_pods(mock_kube_client)
+
+        mock_kube_dynamic_client.return_value.get.assert_called_once_with(
+            resource=mock_pod_resource,
+            namespace="somens",
+            field_selector="status.phase=Succeeded",
+            label_selector="kubernetes_executor=True,airflow-worker!=modified,airflow_executor_done!=True",
+            header_params={"Accept": "application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io"},
+        )
+
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     def test_not_adopt_unassigned_task(self, mock_kube_client):
         """


### PR DESCRIPTION
## Summary

Fix for [#66396](https://github.com/apache/airflow/issues/66396). PR #61839
(cncf-kubernetes 10.15.0) added a periodic call to `_adopt_completed_pods`
from inside `KubernetesExecutor.sync()`, gated by
`[scheduler] orphaned_tasks_check_interval` (default 300 s). The query
selects every Succeeded pod whose `airflow-worker` label is **not** the
current scheduler's label and PATCHes it with the current scheduler's label
so its `KubernetesJobWatcher` will see the change and DELETE the pod.

With multi-scheduler deployments that caused thrashing — every interval
tick each scheduler relabeled every other scheduler's completed pods,
fighting over ownership and burning kube-API + watcher cycles. See
[#66396](https://github.com/apache/airflow/issues/66396) for the full
walkthrough and a real user report on the mailing list (3 schedulers,
Airflow 3.2.1, 1000+ pods/min, tasks stalling in `scheduled` / `queued`,
`delete_worker_pods=False` not helping).

## What changed

- New helper **`_alive_other_scheduler_job_ids`** queries the `Job` table
  for `SchedulerJob`s whose `state == RUNNING` and whose
  `latest_heartbeat` is within
  `[scheduler] scheduler_health_check_threshold` — matching the
  alive-scheduler definition already used by
  `SchedulerJobRunner.adopt_or_reset_orphaned_tasks`. Returns an empty
  set on any DB error so the caller falls back to the pre-#61839
  "exclude self only" selector — a transient DB issue must not break
  completed-pod cleanup.
- **`_adopt_completed_pods`** now builds the label selector to exclude
  `self` + every alive sibling using K8s set-based syntax:
  `airflow-worker notin (a,b,c)`. With one scheduler the selector is
  identical to the pre-fix equality form, so single-scheduler
  deployments see no behavior change.

## Why this preserves the original #61839 goal

#61839 closed [#57553](https://github.com/apache/airflow/issues/57553):
"completed pods leaking after scheduler restart". The fix here keeps
that working — when a scheduler dies, its `Job` row's
`latest_heartbeat` ages out of the threshold, the helper stops
including its ID in the alive set, and the surviving schedulers will
adopt and clean up its completed pods on the next interval tick. The
only behavior removed is the steady-state cross-scheduler relabeling
that caused the thrash.

## Test plan

- [x] New `test_adopt_completed_pods_excludes_alive_siblings`: with
      `_alive_other_scheduler_job_ids` mocked to `{7, 9}` and
      `scheduler_job_id = "5"`, the selector emitted is
      `kubernetes_executor=True,airflow-worker notin (5,7,9),airflow_executor_done!=True`.
- [x] New `test_adopt_completed_pods_single_scheduler_unchanged`: with
      the helper returning an empty set, the selector is identical to
      the pre-fix string
      (`kubernetes_executor=True,airflow-worker!=modified,airflow_executor_done!=True`).
- [x] Existing `test_adopt_completed_pods` and
      `test_adopt_completed_pods_api_exception` still pass unchanged
      (the helper's fallback returns an empty set when
      `scheduler_job_id` is the tests' non-numeric string).
- [ ] Smoke test in CI on the AMD pipeline.
- [ ] (Manual) cluster-mode verification on a 3-scheduler
      KubernetesExecutor deployment — drop PATCH traffic should be
      visible immediately on the kube API server metrics. (Anyone
      affected by #66396 can apply this patch and report back; happy
      to coordinate.)

closes: #66396

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)