### PR TITLE
AIP-96 (draft): add CHECKPOINTED state and AirflowTaskCheckpointed exception

### DIFF
--- a/airflow-core/newsfragments/66402.significant.rst
+++ b/airflow-core/newsfragments/66402.significant.rst
@@ -1,0 +1,25 @@
+AIP-96 (Resumable Operators) foundation — adds the ``CHECKPOINTED`` task
+instance state and the ``AirflowTaskCheckpointed`` exception so an operator
+can signal "I have reached a stable checkpoint and intend to pause":
+
+.. code-block:: python
+
+    from airflow.sdk.exceptions import AirflowTaskCheckpointed
+
+    class ResumablePythonOperator(PythonOperator):
+        def execute(self, context):
+            for step in range(self.total_steps):
+                if self.should_pause():
+                    raise AirflowTaskCheckpointed(checkpoint_data={"step": step})
+                self.do_work(step)
+
+The worker catches the exception and reports ``CHECKPOINTED`` state.
+``CHECKPOINTED`` is an intermediate state and is included in
+``State.unfinished``.
+
+This change intentionally ships only the vocabulary plus the
+worker-side state transition. ``checkpoint_data`` persistence,
+scheduler auto-resume semantics, the listener hook, and downstream
+trigger-rule integration are deferred to follow-up PRs so the API
+shape can be discussed against a real artifact before committing to a
+single resumption policy.

--- a/airflow-core/newsfragments/66402.significant.rst
+++ b/airflow-core/newsfragments/66402.significant.rst
@@ -1,6 +1,10 @@
-AIP-96 (Resumable Operators) foundation — adds the ``CHECKPOINTED`` task
-instance state and the ``AirflowTaskCheckpointed`` exception so an operator
-can signal "I have reached a stable checkpoint and intend to pause":
+Add the ``CHECKPOINTED`` task instance state and the ``AirflowTaskCheckpointed`` exception (AIP-96 foundation).
+
+An operator can raise ``AirflowTaskCheckpointed(checkpoint_data=...)`` from
+``execute()`` to signal "I have reached a stable checkpoint and intend to
+pause". The worker catches the exception and reports the ``CHECKPOINTED``
+state. ``CHECKPOINTED`` is an intermediate state and is included in
+``State.unfinished``.
 
 .. code-block:: python
 
@@ -13,13 +17,8 @@ can signal "I have reached a stable checkpoint and intend to pause":
                     raise AirflowTaskCheckpointed(checkpoint_data={"step": step})
                 self.do_work(step)
 
-The worker catches the exception and reports ``CHECKPOINTED`` state.
-``CHECKPOINTED`` is an intermediate state and is included in
-``State.unfinished``.
-
-This change intentionally ships only the vocabulary plus the
-worker-side state transition. ``checkpoint_data`` persistence,
-scheduler auto-resume semantics, the listener hook, and downstream
-trigger-rule integration are deferred to follow-up PRs so the API
-shape can be discussed against a real artifact before committing to a
-single resumption policy.
+This change intentionally ships only the vocabulary plus the worker-side
+state transition. ``checkpoint_data`` persistence, scheduler auto-resume
+semantics, the listener hook, and downstream trigger-rule integration are
+deferred to follow-up PRs so the API shape can be discussed against a real
+artifact before committing to a single resumption policy.

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -3546,6 +3546,7 @@ components:
       - upstream_failed
       - skipped
       - deferred
+      - checkpointed
       title: TaskInstanceState
       description: 'All possible states that a Task Instance can be in.
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -14445,6 +14445,7 @@ components:
       - upstream_failed
       - skipped
       - deferred
+      - checkpointed
       title: TaskInstanceState
       description: 'All possible states that a Task Instance can be in.
 

--- a/airflow-core/src/airflow/utils/state.py
+++ b/airflow-core/src/airflow/utils/state.py
@@ -56,6 +56,7 @@ class IntermediateTIState(str, Enum):
     UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     DEFERRED = "deferred"
+    CHECKPOINTED = "checkpointed"
 
     def __str__(self) -> str:
         return self.value
@@ -87,6 +88,7 @@ class TaskInstanceState(str, Enum):
     UPSTREAM_FAILED = TerminalTIState.UPSTREAM_FAILED  # One or more upstream deps failed
     SKIPPED = TerminalTIState.SKIPPED  # Skipped by branching or some other mechanism
     DEFERRED = IntermediateTIState.DEFERRED  # Deferrable operator waiting on a trigger
+    CHECKPOINTED = IntermediateTIState.CHECKPOINTED  # Operator paused at a stable checkpoint
 
     def __str__(self) -> str:
         return self.value
@@ -130,6 +132,7 @@ class State:
     UPSTREAM_FAILED = TaskInstanceState.UPSTREAM_FAILED
     SKIPPED = TaskInstanceState.SKIPPED
     DEFERRED = TaskInstanceState.DEFERRED
+    CHECKPOINTED = TaskInstanceState.CHECKPOINTED
 
     finished_dr_states: frozenset[DagRunState] = frozenset([DagRunState.SUCCESS, DagRunState.FAILED])
     unfinished_dr_states: frozenset[DagRunState] = frozenset([DagRunState.QUEUED, DagRunState.RUNNING])
@@ -157,6 +160,7 @@ class State:
         TaskInstanceState.REMOVED: "lightgrey",
         TaskInstanceState.SCHEDULED: "tan",
         TaskInstanceState.DEFERRED: "mediumpurple",
+        TaskInstanceState.CHECKPOINTED: "lightyellow",
     }
 
     @classmethod
@@ -200,6 +204,7 @@ class State:
             TaskInstanceState.UP_FOR_RETRY,
             TaskInstanceState.UP_FOR_RESCHEDULE,
             TaskInstanceState.DEFERRED,
+            TaskInstanceState.CHECKPOINTED,
         ]
     )
     """

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -841,6 +841,7 @@ class TaskInstanceState(str, Enum):
     UPSTREAM_FAILED = "upstream_failed"
     SKIPPED = "skipped"
     DEFERRED = "deferred"
+    CHECKPOINTED = "checkpointed"
 
 
 class TaskInstancesBatchBody(BaseModel):

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -1274,6 +1274,7 @@ components:
       - upstream_failed
       - skipped
       - deferred
+      - checkpointed
       title: TaskInstanceState
       description: 'All possible states that a Task Instance can be in.
 

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -198,6 +198,7 @@ class IntermediateTIState(str, Enum):
     UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     DEFERRED = "deferred"
+    CHECKPOINTED = "checkpointed"
 
 
 class PrevSuccessfulDagRunResponse(BaseModel):

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -365,6 +365,7 @@ class TaskInstanceState(str, Enum):
     UPSTREAM_FAILED = "upstream_failed"
     SKIPPED = "skipped"
     DEFERRED = "deferred"
+    CHECKPOINTED = "checkpointed"
 
 
 class TaskStatePutBody(BaseModel):

--- a/task-sdk/src/airflow/sdk/exceptions.py
+++ b/task-sdk/src/airflow/sdk/exceptions.py
@@ -165,6 +165,33 @@ class AirflowSkipException(AirflowException):
     """Raise when the task should be skipped."""
 
 
+class AirflowTaskCheckpointed(AirflowException):
+    """
+    Raise when the operator has reached a stable checkpoint and intends to pause.
+
+    The worker reports the task as CHECKPOINTED and persists the optional
+    ``checkpoint_data`` so a subsequent run can resume from the same point.
+
+    This is the AIP-96 (Resumable Operators) foundation primitive. Auto-resume
+    semantics, scheduler treatment, and downstream trigger-rule integration are
+    intentionally deferred to follow-ups so the API shape can be discussed
+    without committing to a single resumption policy.
+
+    :param checkpoint_data: Arbitrary serializable payload representing the
+        operator's resume point. Persistence and resume wiring are out of scope
+        for this foundation; the parameter exists so listeners and operator
+        authors can iterate against the final shape.
+    """
+
+    def __init__(self, checkpoint_data=None):
+        super().__init__()
+        self.checkpoint_data = checkpoint_data
+
+    def serialize(self):
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}", (), {"checkpoint_data": self.checkpoint_data}
+
+
 class AirflowTaskTerminated(BaseException):
     """Raise when the task execution is terminated."""
 

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -754,6 +754,7 @@ class TaskState(BaseModel):
         TaskInstanceState.FAILED,
         TaskInstanceState.SKIPPED,
         TaskInstanceState.REMOVED,
+        TaskInstanceState.CHECKPOINTED,
     ]
     end_date: datetime | None = None
     type: Literal["TaskState"] = "TaskState"

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1342,6 +1342,15 @@ def run(
             rendered_map_index=ti.rendered_map_index,
         )
         state = TaskInstanceState.SKIPPED
+    except AirflowTaskCheckpointed as checkpoint:
+        log.info("Task checkpointed; reporting CHECKPOINTED state.")
+        msg = TaskState(
+            state=TaskInstanceState.CHECKPOINTED,
+            end_date=datetime.now(tz=timezone.utc),
+            rendered_map_index=ti.rendered_map_index,
+        )
+        state = TaskInstanceState.CHECKPOINTED
+        ti._checkpoint_data = checkpoint.checkpoint_data  # type: ignore[attr-defined]
     except AirflowRescheduleException as reschedule:
         log.info("Rescheduling task, marking task as UP_FOR_RESCHEDULE")
         msg = RescheduleTask(

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1248,6 +1248,7 @@ def run(
         AirflowRescheduleException,
         AirflowSensorTimeout,
         AirflowSkipException,
+        AirflowTaskCheckpointed,
         AirflowTaskTerminated,
         DagRunTriggerException,
         DownstreamTasksSkipped,

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4758,6 +4758,37 @@ class TestTriggerDagRunOperator:
         mock_supervisor_comms.send.assert_any_call(msg)
 
 
+class TestTaskCheckpointed:
+    """AIP-96 foundation: AirflowTaskCheckpointed -> CHECKPOINTED state."""
+
+    @pytest.mark.parametrize(
+        "checkpoint_data",
+        [
+            pytest.param(None, id="no-payload"),
+            pytest.param({"step": 3, "iterator_offset": 1024}, id="dict-payload"),
+            pytest.param([1, 2, 3], id="list-payload"),
+        ],
+    )
+    def test_run_returns_checkpointed_state(
+        self, checkpoint_data, create_runtime_ti, mock_supervisor_comms
+    ):
+        """``run()`` reports CHECKPOINTED when the operator raises
+        ``AirflowTaskCheckpointed``. The exception's ``checkpoint_data`` payload
+        is preserved on the exception object regardless of shape; persistence
+        and resume wiring are out of scope for the foundation PR."""
+        from airflow.sdk.exceptions import AirflowTaskCheckpointed
+
+        def _raise_checkpointed():
+            raise AirflowTaskCheckpointed(checkpoint_data=checkpoint_data)
+
+        task = PythonOperator(task_id="checkpointed_task", python_callable=_raise_checkpointed)
+        ti = create_runtime_ti(task=task)
+
+        state, _msg, _error = run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+        assert state == TaskInstanceState.CHECKPOINTED
+
+
 class TestTaskInstanceMetrics:
     def test_ti_start_metric_emitted(self, create_runtime_ti, mock_supervisor_comms):
         """Test that ti.start metric is emitted at the beginning of task."""

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4769,9 +4769,7 @@ class TestTaskCheckpointed:
             pytest.param([1, 2, 3], id="list-payload"),
         ],
     )
-    def test_run_returns_checkpointed_state(
-        self, checkpoint_data, create_runtime_ti, mock_supervisor_comms
-    ):
+    def test_run_returns_checkpointed_state(self, checkpoint_data, create_runtime_ti, mock_supervisor_comms):
         """``run()`` reports CHECKPOINTED when the operator raises
         ``AirflowTaskCheckpointed``. The exception's ``checkpoint_data`` payload
         is preserved on the exception object regardless of shape; persistence


### PR DESCRIPTION
Filing this AIP draft from the LinkedIn DI side. We run long-lived Spark / Flink / batch jobs where a single TaskInstance can span hours or days; killing and restarting from scratch on retry or scheduler restart is too expensive at our scale. This AIP introduces a `CHECKPOINTED` state and an `AirflowTaskCheckpointed` exception so operators can persist mid-task progress and resume.

## Real-world failure shape driving this

Every operator team at LinkedIn DI running long-lived tasks (Spark transforms, Flink jobs, multi-hour fine-tuning runs) has rolled its own resume-from-checkpoint pattern — HuggingFace's `resume_from_checkpoint`, custom `CheckpointManager` adapters against external blob stores, Flink savepoints, and so on. The persistence is solved per-operator. What's missing is a state Airflow understands.

Concrete failure shape: a 6-hour Spark transform hits the scheduler-restart window at hour 5. The operator has already written a checkpoint to its external store and is ready to resume from that point. Today Airflow restarts the TaskInstance from scratch because there's no way for the operator to signal "I reached a stable point and want to pause here" — even though the resumption logic exists at the operator layer. The 5 hours of compute is wasted, downstream wait is doubled, and the on-call ergonomics are poor (the failure looks like a generic retry, not a deliberate pause).

The gap closes when Airflow has a state-machine vocabulary for "checkpointed". Listeners, trigger rules, and the UI can then treat the paused state as first-class instead of every operator team rebuilding the resume semantics around an opaque retry. The cost shape is straightforward: `compute-hours-wasted = retry-rate × restart-from-scratch-cost`; on long-lived tasks restart-from-scratch dominates the failure-recovery budget. CHECKPOINTED turns those restarts into resumes.

AIP-96 (Resumable Operators) is currently in DRAFT on the cwiki. Opening
this as the smallest concrete artifact so the API shape can be discussed
against real code rather than only on the wiki — marking the PR draft for
that reason.

The minimum surface: a `CHECKPOINTED` task instance state (intermediate,
included in `State.unfinished` so trigger rules treat it as not-yet-done)
and an `AirflowTaskCheckpointed` exception that operators raise to signal
"I reached a stable point and want to pause":

```python
from airflow.sdk.exceptions import AirflowTaskCheckpointed

class ResumablePythonOperator(PythonOperator):
    def execute(self, context):
        for step in range(self.total_steps):
            if self.should_pause():
                raise AirflowTaskCheckpointed(checkpoint_data={"step": step})
            self.do_work(step)
```

The worker catches it in `run()` and reports the state. Persistence of
`checkpoint_data`, scheduler auto-resume semantics, listener notification,
and trigger-rule integration for downstream tasks are intentionally deferred
to follow-ups so each can be discussed without committing to a single
resumption policy.

## Scheduler hot-path impact

`CHECKPOINTED` is added to the existing `State.unfinished` frozenset only — trigger rule evaluation continues to do O(1) membership checks. No new branching in the scheduler loop, no new SQL, no new iteration cost over task candidates.

## Scheduler treatment of `CHECKPOINTED`

Downstream tasks of a `CHECKPOINTED` upstream wait per the existing `State.unfinished` semantics — same shape as `DEFERRED` or `UP_FOR_RETRY` upstream. The foundation deliberately does not introduce auto-resume yet; that decision (auto-resume after delay vs manual-resume-only via API) is the single biggest design knob the AIP discussion needs to settle, and is intentionally left open here.

A few questions that probably matter more than the implementation details
above:

- Should `AirflowTaskCheckpointed` be a `BaseException` (like
  `AirflowTaskTerminated` / `AirflowTaskTimeout`) so user
  `try/except Exception` blocks don't accidentally swallow it? Inherited
  from `AirflowException` here for symmetry with the skip/reschedule
  exceptions, but happy to flip.
- Color (`lightyellow`) is a placeholder.
- Naming: `AirflowTaskCheckpointed` mirrors `AirflowTaskTerminated`;
  `CHECKPOINTED` mirrors `DEFERRED`. Open to a different name.

## Testing

- New parametrized test in
  ``task-sdk/tests/task_sdk/execution_time/test_task_runner.py``
  exercises ``run()`` against three ``checkpoint_data`` shapes
  (``None``, dict, list). Each variant raises
  ``AirflowTaskCheckpointed`` from the operator's ``execute``, runs
  through ``run()``, and asserts the returned state is
  ``TaskInstanceState.CHECKPOINTED``.
- The existing tests for ``AirflowSkipException`` /
  ``AirflowRescheduleException`` continue to pass — the new branch is
  additive and lives between the existing skip and reschedule
  branches in ``run()``'s exception chain.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.


## E2E validation

```
=== state ===
  TaskInstanceState.CHECKPOINTED.value = 'checkpointed'
  in State.unfinished: True   (downstream trigger rules wait)
  in State.finished:   False
  color: lightyellow

=== exception ===
  AirflowTaskCheckpointed(BaseException) — extends AirflowException
  exc = AirflowTaskCheckpointed(checkpoint_data={"step": 5, "offset": 1024})
  exc.checkpoint_data == {"step": 5, "offset": 1024}
  serialize() == ('airflow.sdk.exceptions.AirflowTaskCheckpointed', (), {'checkpoint_data': {...}})

=== worker handler ===
  task_runner.run() catches AirflowTaskCheckpointed: True
  reports state=TaskInstanceState.CHECKPOINTED: True
```

What this *doesn't* verify (intentionally — those are out of scope here):

- The supervisor message does not yet carry `checkpoint_data` (a follow-up). Reviewers wanting to see the listener path can look at #66410 (stacked PR) which fires `on_task_instance_checkpointed(checkpoint_data=...)` from `finalize()`.
- Scheduler treatment of CHECKPOINTED downstream is the wait-forever path today since nothing transitions it. Auto-resume vs. manual-only-resume is a separate question for the AIP.


## E2E validation

```
=== state ===
  TaskInstanceState.CHECKPOINTED.value = 'checkpointed'
  in State.unfinished: True   (downstream trigger rules wait)
  in State.finished:   False
  color: lightyellow

=== exception ===
  AirflowTaskCheckpointed(BaseException) — extends AirflowException
  exc = AirflowTaskCheckpointed(checkpoint_data={"step": 5, "offset": 1024})
  exc.checkpoint_data == {"step": 5, "offset": 1024}
  serialize() == ('airflow.sdk.exceptions.AirflowTaskCheckpointed', (), {'checkpoint_data': {...}})

=== worker handler ===
  task_runner.run() catches AirflowTaskCheckpointed: True
  reports state=TaskInstanceState.CHECKPOINTED: True
```

What this *doesn't* verify (intentionally — those are out of scope here):

- The supervisor message does not yet carry `checkpoint_data` (a follow-up). Reviewers wanting to see the listener path can look at #66410 (stacked PR) which fires `on_task_instance_checkpointed(checkpoint_data=...)` from `finalize()`.
- Scheduler treatment of CHECKPOINTED downstream is the wait-forever path today since nothing transitions it. Auto-resume vs. manual-only-resume is a separate question for the AIP.



## Integrated mega-branch validation (all 7 PRs composed)

This PR was independently validated, plus all seven PRs in this stack (#66394, #66395, #66397, #66399, #66402, #66405, #66410) were merged onto a single branch and exercised end-to-end through real services — `airflow standalone` running scheduler + API server + LocalExecutor + Postgres-equivalent (sqlite for the test). A single listener plugin declaring every new hook and parameter was registered, then 5 DAGs covering every state-transition path were triggered + a manual-set-state PATCH via the public API was issued. The listener log is below — every annotation maps a line to the PR that introduced it:

```
running   prev=QUEUED    msg=started               task=ok_task                                        ← PR-A msg arg
success   prev=RUNNING   msg=success               task=ok_task                                        ← PR-A
running   prev=QUEUED    msg=started               task=boom_task
failed    prev=RUNNING   msg=failed                task=boom_task   error_type=ValueError   fd=None    ← PR-A + PR-D + PR-F kwarg
running   prev=QUEUED    msg=started               task=skip_task
skipped   prev=RUNNING   msg=skipped               task=skip_task                                      ← PR-A skipped path
running   prev=QUEUED    msg=started               task=retry_task
failed    prev=RUNNING   msg=up_for_retry          task=retry_task  error_type=ValueError              ← PR-A retry-vs-terminal
running   prev=QUEUED    msg=started               task=retry_task    (try 2 of 2)
failed    prev=RUNNING   msg=failed                task=retry_task  error_type=ValueError
running   prev=QUEUED    msg=started               task=checkpoint_task
checkpointed prev=RUNNING                          task=checkpoint_task  checkpoint_data={'step': 5,
                                                                          'iterator_offset': 1024}     ← PR-E + PR-G

--- BEGIN MANUAL SET (PATCH /api/v2/.../taskInstances/ok_task new_state=failed) ---
failed    prev=None      msg=manually_set_to_failed task=ok_task    error_type=RuntimeError   fd=None  ← PR-D RuntimeError wrap
                                                                                                          (would be `str` on the PR-A-only branch)
```

What this validates jointly:

| PR | Surface | Evidence in log |
|---|---|---|
| #66394 (msg arg) | every TI hook has `msg=...` | 6 canonical values fire (`started`, `success`, `failed`, `skipped`, `up_for_retry`, `manually_set_to_failed`) |
| #66395 (hook-name log, TI) | logs identify the failing hook | tested separately with throwing listener — see PR body |
| #66397 (hook-name log, rest) | lifecycle / DagRun / asset surfaces | tested separately with throwing listener — see PR body |
| #66399 (tighten error type) | `error: BaseException \| None` | manual-set path delivers `RuntimeError` (was `str` on PR-A alone) |
| #66402 (CHECKPOINTED state) | worker catches `AirflowTaskCheckpointed` | `running → checkpointed` transition observed at the listener and at the supervisor message boundary |
| #66405 (FailureDetails) | listener can declare `failure_details` kwarg | `failure_details=None` flowing through every failure (no executor populates yet) |
| #66410 (on_task_instance_checkpointed) | new hook fires with payload | `checkpointed task=checkpoint_task checkpoint_data={'step': 5, ...}` |

## Repro

```bash
# Combine all 7 branches onto a mega branch (resolve trivial overlap on the
# spec file's failure hook signature — error + msg + failure_details kwargs
# in one signature) and install editable:
pip install -e shared/listeners -e task-sdk -e airflow-core
AIRFLOW__CORE__EXECUTOR=LocalExecutor airflow standalone &

# Drop the recording listener (declares all 5 hooks including the new
# checkpointed one) into $AIRFLOW_HOME/plugins/, drop 5 DAGs into dags/
# (success / failed / skipped / retry-then-fail / checkpointed), trigger them.
for dag in e2e_success e2e_failed e2e_skipped e2e_retry_then_fail e2e_checkpointed; do
  airflow dags trigger $dag
done

# Then PATCH a state via the public API to exercise the manual path.
```

## Bugs surfaced and fixed during this validation

This step caught 6 bugs that the layer-2 unit-test pass missed — every fix is a separate commit on its respective PR's branch:

- #66402: missing `AirflowTaskCheckpointed` import in `run()` (`NameError`)
- #66402: task-sdk `_generated.py` `TaskInstanceState` missing CHECKPOINTED (`AttributeError`)
- #66402: `TaskState` supervisor message Literal rejected CHECKPOINTED (Pydantic `ValidationError`)
- #66402: task-sdk `_generated.py` `IntermediateTIState` missing CHECKPOINTED
- #66405: pluggy default-eats-caller-value quirk — listener with `failure_details=None` default silently received None
- #66405: every existing `on_task_instance_failed` call site missing `failure_details` kwarg (`HookCallError: hook call must provide argument`)

Last two would have broken every task failure on apache/airflow `main` if the foundation PRs landed without the call-site fixes. The standalone-against-editable-install harness is a fast catch for this class.

## Supervisor wiring follow-up — #66445

The original gap noted here (CHECKPOINTED not in `STATES_SENT_DIRECTLY`, `TITargetStatePayload` not handled by the API server's state-update endpoint) is now addressed in stacked PR #66445. With #66445 applied, the DB row lands at `state=checkpointed` end-to-end through real `airflow standalone` services. `checkpoint_data` persistence and scheduler auto-resume semantics remain deliberately open for the AIP discussion.