### PR TITLE
Fix smtp connection test for noop tuple response

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
@@ -299,9 +299,10 @@ class SmtpHook(BaseHook):
         """Test SMTP connectivity from UI."""
         try:
             smtp_client = self.get_conn()._smtp_client
-            if smtp_client:
+            if smtp_client is not None:
+                smtp_client = cast("smtplib.SMTP_SSL | smtplib.SMTP", smtp_client)
                 status = smtp_client.noop()
-                if status == 250:
+                if status[0] == 250:
                     return True, "Connection successfully tested"
         except Exception as e:
             return False, str(e)

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -546,6 +546,29 @@ class TestSmtpHook:
         assert ehlo_call == call.ehlo()
         assert login_call == call.login(SMTP_LOGIN, SMTP_PASSWORD)
 
+    @pytest.mark.parametrize(
+        ("noop_response", "expected_result"),
+        [
+            pytest.param(
+                (250, b"2.0.0 Ok"),
+                (True, "Connection successfully tested"),
+                id="success",
+            ),
+            pytest.param(
+                (421, b"4.3.0 Service not available"),
+                (False, "Failed to establish connection"),
+                id="failure",
+            ),
+        ],
+    )
+    @patch(smtplib_string)
+    def test_test_connection_handles_noop_responses(self, mock_smtplib, noop_response, expected_result):
+        mock_conn = _create_fake_smtp(mock_smtplib)
+        mock_conn.noop.return_value = noop_response
+
+        assert SmtpHook().test_connection() == expected_result
+        mock_conn.noop.assert_called_once_with()
+
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Async support was added to BaseNotifier in 3.1.0")


### PR DESCRIPTION

closes: #66391 


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
