### PR TITLE
Fix None-valued OTel span attributes in triggerer

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -30,7 +30,7 @@ from contextlib import contextmanager, suppress
 from datetime import datetime
 from socket import socket
 from traceback import format_exception
-from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, ClassVar, Literal, TextIO, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, ClassVar, Literal, TextIO, TypedDict, cast
 from uuid import uuid4
 
 import anyio
@@ -131,11 +131,17 @@ def _make_trigger_span(
             span_name += f"_{ti.map_index}"
         attributes = {
             **attributes,
-            "airflow.dag_id": ti.dag_id,
-            "airflow.task_id": ti.task_id,
-            "airflow.dag_run.run_id": ti.run_id,
-            "airflow.task_instance.try_number": ti.try_number,
-            "airflow.task_instance.map_index": ti.map_index,
+            **{
+                k: cast("str | int", v)
+                for k, v in {
+                    "airflow.dag_id": ti.dag_id,
+                    "airflow.task_id": ti.task_id,
+                    "airflow.dag_run.run_id": ti.run_id,
+                    "airflow.task_instance.try_number": ti.try_number,
+                    "airflow.task_instance.map_index": ti.map_index,
+                }.items()
+                if v is not None
+            },
         }
     else:
         span_name = f"trigger.{name}"

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -32,7 +32,7 @@ from contextlib import contextmanager, suppress
 from datetime import datetime
 from socket import socket
 from traceback import format_exception
-from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, ClassVar, Literal, NamedTuple, TextIO, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, BinaryIO, ClassVar, Literal, NamedTuple, TextIO, TypedDict, cast
 from uuid import uuid4
 
 import anyio
@@ -168,11 +168,17 @@ def _make_trigger_span(
             span_name += f"_{ti.map_index}"
         attributes = {
             **attributes,
-            "airflow.dag_id": ti.dag_id,
-            "airflow.task_id": ti.task_id,
-            "airflow.dag_run.run_id": ti.run_id,
-            "airflow.task_instance.try_number": ti.try_number,
-            "airflow.task_instance.map_index": ti.map_index,
+            **{
+                k: cast("str | int", v)
+                for k, v in {
+                    "airflow.dag_id": ti.dag_id,
+                    "airflow.task_id": ti.task_id,
+                    "airflow.dag_run.run_id": ti.run_id,
+                    "airflow.task_instance.try_number": ti.try_number,
+                    "airflow.task_instance.map_index": ti.map_index,
+                }.items()
+                if v is not None
+            },
         }
     else:
         span_name = f"trigger.{name}"


### PR DESCRIPTION
Noticed following error in triggerer logs:
```
[2026-05-05T08:02:00.644020Z] {{__init__.py:149}} ERROR - Failed to encode key result: Invalid type <class 'NoneType'> of value None
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.13/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py", line 146, in _encode_attributes
    _encode_key_value(key, value, allow_null=allow_null)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.13/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py", line 107, in _encode_key_value
    key=key, value=_encode_value(value, allow_null=allow_null)
                   ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.13/site-packages/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py", line 100, in _encode_value
    raise Exception(f"Invalid type {type(value)} of value {value}")
Exception: Invalid type <class 'NoneType'> of value None
```
I've compared implementation of `_make_trigger_span`[*](https://github.com/apache/airflow/blob/209c815bc91d4f537c191af7e27c31a2c2f48c73/airflow-core/src/airflow/jobs/triggerer_job_runner.py#L138) with `_make_task_span`[*](https://github.com/apache/airflow/blob/209c815bc91d4f537c191af7e27c31a2c2f48c73/task-sdk/src/airflow/sdk/execution_time/task_runner.py#L163) and my guess is that it failed due to `map_index` being `None`.
Proposed fix filters out `None` values before building the attributes dict.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T16:21:07Z head=a29dd13 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @jakubmatyszewski** · by `@potiuk` · 2026-07-28 16:21 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **606 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
