### PR TITLE
Add on_audit_log_created listener hookspec

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -28,6 +28,7 @@ from pendulum.parsing.exceptions import ParserError
 from airflow._shared.secrets_masker import secrets_masker
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.security import GetUserDep
+from airflow.listeners.listener import get_listener_manager
 from airflow.models import Log
 
 logger = logging.getLogger(__name__)
@@ -170,5 +171,6 @@ def action_logging(event: str | None = None):
         # Explicit commit to persist the access log independently if the path operation fails or not.
         # Also it cannot be deferred to a 'function' scoped dependency because of the `request` parameter.
         session.commit()
+        get_listener_manager().hook.on_audit_log_created(log=log)
 
     return log_action

--- a/airflow-core/src/airflow/listeners/listener.py
+++ b/airflow-core/src/airflow/listeners/listener.py
@@ -21,7 +21,7 @@ from functools import cache
 
 from airflow._shared.listeners.listener import ListenerManager
 from airflow._shared.listeners.spec import lifecycle, taskinstance
-from airflow.listeners.spec import asset, dagrun, importerrors
+from airflow.listeners.spec import asset, audit_log, dagrun, importerrors
 from airflow.plugins_manager import integrate_listener_plugins
 
 
@@ -40,6 +40,7 @@ def get_listener_manager() -> ListenerManager:
     _listener_manager = ListenerManager()
 
     _listener_manager.add_hookspecs(lifecycle)
+    _listener_manager.add_hookspecs(audit_log)
     _listener_manager.add_hookspecs(dagrun)
     _listener_manager.add_hookspecs(taskinstance)
     _listener_manager.add_hookspecs(asset)

--- a/airflow-core/src/airflow/listeners/spec/audit_log.py
+++ b/airflow-core/src/airflow/listeners/spec/audit_log.py
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pluggy import HookspecMarker
+
+if TYPE_CHECKING:
+    from airflow.models.log import Log
+
+hookspec = HookspecMarker("airflow")
+
+
+@hookspec
+def on_audit_log_created(log: Log):
+    """Execute when an audit log record is created."""

--- a/airflow-core/tests/unit/listeners/audit_log_listener.py
+++ b/airflow-core/tests/unit/listeners/audit_log_listener.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.listeners import hookimpl
+
+if TYPE_CHECKING:
+    from airflow.models.log import Log
+
+audit_logs: list[Log] = []
+
+
+@hookimpl
+def on_audit_log_created(log: Log):
+    audit_logs.append(log)
+
+
+def clear():
+    audit_logs.clear()

--- a/airflow-core/tests/unit/listeners/test_audit_log_listener.py
+++ b/airflow-core/tests/unit/listeners/test_audit_log_listener.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.listeners.listener import get_listener_manager
+from airflow.models.log import Log
+
+from unit.listeners import audit_log_listener
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture(autouse=True)
+def clean_listener_state():
+    yield
+    audit_log_listener.clear()
+
+
+def test_audit_log_hookspec_registered():
+    """Verify the on_audit_log_created hookspec is registered in the listener manager."""
+    lm = get_listener_manager()
+    assert hasattr(lm.hook, "on_audit_log_created")
+
+
+def test_audit_log_listener_receives_event(listener_manager):
+    """Verify a registered listener receives audit log events."""
+    listener_manager(audit_log_listener)
+
+    log = Log(event="test_event", owner="test_user")
+    get_listener_manager().hook.on_audit_log_created(log=log)
+
+    assert len(audit_log_listener.audit_logs) == 1
+    assert audit_log_listener.audit_logs[0].event == "test_event"
+    assert audit_log_listener.audit_logs[0].owner == "test_user"
+
+
+def test_audit_log_listener_no_event_without_registration():
+    """Verify no error when hook fires with no listeners registered."""
+    log = Log(event="test_event", owner="test_user")
+    # Should not raise
+    get_listener_manager().hook.on_audit_log_created(log=log)
+    assert len(audit_log_listener.audit_logs) == 0


### PR DESCRIPTION
### Description

Adds a new listener hookspec `on_audit_log_created` that fires whenever an audit log record is persisted via the API action logging system. This enables plugins and providers to react to audit events such forwarding to external logging/SIEM systems, triggering alerts, or enriching observability pipelines, without polling the REST API.

Ref: #66018

### Motivation

Airflow's listener system currently covers task instances, DAG runs, assets, and lifecycle events. Audit logs, i.e. the records of *who did what* (paused a DAG, modified a variable, deleted a connection), are the notable gap. Today the only way to consume these externally is to poll the `/eventLogs` API endpoint, which introduces latency, requires dedicated infrastructure (Lambda, cron job, etc.), and doesn't scale well for real-time compliance requirements.

This is a recurring community request:

- **#66018** — Request to push audit logs to CloudWatch for Splunk integration; currently requires an external Lambda polling the API.
- **[Discussion #34142](https://github.com/apache/airflow/discussions/34142)** — User attempted to read audit logs from within a Listener plugin but had to query the database directly, which caused HA lock errors. Maintainer (@Taragolis) confirmed the only option is the REST API.
- **[Discussion #24648](https://github.com/apache/airflow/discussions/24648)** — User seeking to forward Airflow logs to Splunk without FluentD.
- **#23880 / #24079** — Added `action_logging` to connection/variable endpoints, solving *what* gets audited but not *how to forward* those events externally.

This change brings audit logs to parity with other first-class Airflow events by exposing them through the same pluggy-based listener mechanism that providers and plugins already use.

### Scope

This PR fires the hook **only from the `action_logging` decorator** i.e., user-initiated API actions (pause/unpause DAGs, create/delete connections, modify variables, trigger DAG runs, clear task instances, etc.). It does **not** fire for high-frequency system-generated log entries (task state transitions, scheduler state mismatches), which are operational telemetry rather than audit events and already have dedicated hooks (`on_task_instance_running`, `on_task_instance_failed`, etc.).

### Changes

- New hookspec: `airflow/listeners/spec/audit_log.py`
- Register it in `airflow/listeners/listener.py`
- Fire the hook from `api_fastapi/logging/decorators.py` after the DB commit
- Unit tests

---

### FAQ

**Q: Why not handle this in a provider package without a core change?**

A: The only current integration point is the REST API, which requires external polling infrastructure and introduces latency. As demonstrated in [Discussion #34142](https://github.com/apache/airflow/discussions/34142), even attempting to read audit logs from within a Listener plugin today requires querying the database directly — which causes HA lock errors and is fragile across version upgrades. The listener system is Airflow's intended extension mechanism for cross-cutting event-driven concerns. Assets, DAG runs, and task instances all have listener hooks; audit logs are the missing piece.

**Q: What about performance? This runs on every API mutation.**

A: The hook fires *after* the DB commit, so it cannot affect the persistence of the audit record itself. If no listeners are registered, the cost is a single no-op function call. API mutations are human-rate operations — orders of magnitude less frequent than task heartbeats or scheduler loops.

**Q: Why not use a SQLAlchemy `after_insert` event on the `Log` model instead?**

A: SQLAlchemy ORM events run inside the active transaction. A slow or failing listener would block the commit or cause deadlocks -- exactly the "HA lock errors" reported in [Discussion #34142](https://github.com/apache/airflow/discussions/34142). The pluggy listener system runs outside the transaction boundary.

**Q: Why not just emit to a standard Python `logging.Logger`?**

A: A Python log record is an unstructured string. The `Log` model object carries structured fields (`event`, `dag_id`, `task_id`, `owner`, `extra`, `dttm`) that consumers need for filtering, routing, and compliance reporting.

**Q: Why not also fire for task state changes and scheduler events?**

A: Those are high-frequency system-generated events with dedicated hooks already. This PR scopes to user-initiated actions i.e. the events that answer "who changed what and when" for compliance purposes.

**Q: Who would consume this?**

A: CloudWatch, Datadog, Splunk, Elasticsearch/OpenSearch, Azure Monitor, GCP Cloud Logging, OpenTelemetry collectors, custom compliance webhooks, Kafka-based audit pipelines.

**Q: Is this a breaking change?**

A: No. Purely additive. Existing deployments are unaffected unless they register a listener for the new hook.