### PR TITLE
Skip registry-derive in publish-docs for non-provider distributions

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -127,7 +127,39 @@ jobs:
         env:
           INCLUDE_DOCS: ${{ inputs.include-docs }}
           REF: ${{ inputs.ref }}
-        run: python3 dev/registry/derive_wave_providers.py
+        shell: bash
+        # The registry rebuild is provider-targeted. For non-provider
+        # distributions (apache-airflow, airflow-ctl, helm-chart, etc.) the
+        # update-registry job below is a no-op anyway, so skip the derive
+        # step — that lets release tags cut before
+        # `dev/registry/derive_wave_providers.py` was added (#66100) still
+        # publish docs without the workflow tripping on the missing file.
+        # Tracked at #66436.
+        run: |
+          # Keep the non-provider list in sync with NON_PROVIDER_TOKENS in
+          # dev/registry/derive_wave_providers.py.
+          NON_PROVIDER_TOKENS=("apache-airflow" "apache-airflow-ctl" "apache-airflow-task-sdk" "helm-chart" "docker-stack")
+          has_provider=false
+          for token in $INCLUDE_DOCS; do
+            is_non_provider=false
+            for np in "${NON_PROVIDER_TOKENS[@]}"; do
+              if [[ "$token" == "$np" ]]; then
+                is_non_provider=true
+                break
+              fi
+            done
+            if ! $is_non_provider; then
+              has_provider=true
+              break
+            fi
+          done
+          if ! $has_provider; then
+            echo "Non-provider distribution(s) only ('${INCLUDE_DOCS}') — skipping registry-derive."
+            echo "registry-providers=" >> "${GITHUB_OUTPUT}"
+            echo "registry-full-build=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          python3 dev/registry/derive_wave_providers.py
       - name: "Input parameters summary"
         shell: bash
         id: parameters


### PR DESCRIPTION
## Summary

The "Derive registry trigger inputs" step in
`publish-docs-to-s3.yml` runs
`python3 dev/registry/derive_wave_providers.py` unconditionally in
the Build Info job. The downstream `update-registry` job only runs
when `registry-providers != ''` or `registry-full-build == 'true'` —
so for non-provider distributions (`apache-airflow`,
`apache-airflow-ctl`, `apache-airflow-task-sdk`, `helm-chart`,
`docker-stack`) the script's output isn't consumed and the script
invocation is a no-op.

This PR skips the script invocation for those distributions:

- Both `registry-providers=` and `registry-full-build=false` are
  set so the `update-registry` job skips downstream as expected.
- Release tags cut before #66100 (when the script was added) can
  publish docs again without the workflow tripping on the missing
  file. Surfaced while publishing docs for `airflow-ctl/0.1.4`
  (cut from `0.1.4rc3` on 2026-04-22).

The non-provider list is kept in sync with `NON_PROVIDER_TOKENS` in
`dev/registry/derive_wave_providers.py`.

closes: #66436

## Test plan

- [x] `breeze workflow-run publish-docs --ref airflow-ctl/0.1.4 --workflow-branch airflow-ctl/0.1.4 apache-airflow-ctl` succeeded with the workflow YAML at the tag (workaround that exposed the issue): https://github.com/apache/airflow/actions/runs/25393124890
- [ ] After this PR lands: re-run publish-docs for airflow-ctl/0.1.4 against the workflow on `main` to verify the skip path works end-to-end with the new YAML.
- [ ] After this PR lands: re-run publish-docs for a wave-tag ref (e.g. `providers/2026-MM-DD`) to verify the provider path still invokes the script.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)