### PR TITLE
Use shared Zulu datetime formatter in remaining FastAPI tests

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -2246,7 +2246,7 @@ class TestTriggerDagRun:
     def test_should_response_409_for_duplicate_logical_date(self, test_client):
         RUN_ID_1 = "random_1"
         RUN_ID_2 = "random_2"
-        now = timezone.utcnow().isoformat().replace("+00:00", "Z")
+        now = from_datetime_to_zulu(timezone.utcnow())
         note = "duplicate logical date test"
         response_1 = test_client.post(
             f"/dags/{DAG1_ID}/dagRuns",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -629,7 +629,7 @@ class TestGetHITLDetailsEndpoint:
                     "multiple": False,
                     "params": {"input_1": {"value": 1, "schema": {}, "description": None}},
                     "assigned_users": [],
-                    "created_at": DEFAULT_CREATED_AT.isoformat().replace("+00:00", "Z"),
+                    "created_at": from_datetime_to_zulu_without_ms(DEFAULT_CREATED_AT),
                     "responded_by_user": None,
                     "responded_at": None,
                     "chosen_options": None,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_04_06/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_04_06/test_task_instances.py
@@ -24,6 +24,7 @@ from airflow.serialization.serialized_objects import BaseSerialization
 from airflow.utils.state import DagRunState, State
 
 from tests_common.test_utils.db import clear_db_runs
+from tests_common.test_utils.format_datetime import from_datetime_to_zulu_without_ms
 
 pytestmark = pytest.mark.db_test
 
@@ -125,7 +126,7 @@ class TestDagRunStartDateNullableBackwardCompat:
 
         assert response.status_code == 200
         assert dag_run["start_date"] is not None, "start_date should not be None when DagRun has started"
-        assert dag_run["start_date"] == TIMESTAMP.isoformat().replace("+00:00", "Z")
+        assert dag_run["start_date"] == from_datetime_to_zulu_without_ms(TIMESTAMP)
 
 
 class TestNextKwargsBackwardCompat:


### PR DESCRIPTION
## Summary

Closes #44033 by migrating the last three inline `dt.isoformat().replace("+00:00", "Z")` call sites in FastAPI public API tests to the shared helpers in [`tests_common.test_utils.format_datetime`](devel-common/src/tests_common/test_utils/format_datetime.py) (`from_datetime_to_zulu` / `from_datetime_to_zulu_without_ms`).

The helpers were introduced earlier under the AIP-84 cleanup; this PR closes the remaining gap. After this, no `isoformat().replace("+00:00", "Z")` strings remain anywhere in `airflow-core/tests/` or `task-sdk/`.

## Related

- #44108 — earlier attempt; reviewer requested helper to live under `tests_common` and cover multiple files.
- #52042 — second attempt; closed due to merge conflicts and a parallel landing of the helper module under a different name.