### PR TITLE
Trim Claude Code skill descriptions to cut per-turn token cost

### DIFF
--- a/.github/skills/maintainer-review/SKILL.md
+++ b/.github/skills/maintainer-review/SKILL.md
@@ -1,23 +1,16 @@
 ---
 name: maintainer-review
 description: |
-  Walk a maintainer through deep code review of open pull requests on `apache/airflow` (or another target repo). The
-  default working list — referred to throughout the docs as **"my reviews"** — is the union of five signals on the
-  authenticated maintainer: PRs where review is requested from them, PRs that touch files they recently modified, PRs
-  whose changed files they own per `CODEOWNERS`, PRs that `@`-mention them, and PRs they already submitted a real
-  review on (triage comments do not count). Filters can narrow by area label, collaborator status, or to a single PR.
-  For each PR the skill reads the diff, applies the project's review criteria
-  ([.github/instructions/code-review.instructions.md](../../../.github/instructions/code-review.instructions.md)
-  and [AGENTS.md](../../../AGENTS.md)), runs any locally-configured adversarial reviewer (e.g. the OpenAI
-  Codex plugin), surfaces findings, drafts an `approve` / `request-changes` / `comment` review with
-  inline comments proposed by default, and — on the maintainer's confirmation — posts it via the
-  `addPullRequestReview` mutation. This is the deep-review counterpart to the triage skill.
+  Deep code review of open PRs on apache/airflow one at a time — reads the diff,
+  applies the project's review criteria, drafts an approve / request-changes /
+  comment review with inline comments, and posts it on confirmation. Default
+  working list ("my reviews") is review-requested + CODEOWNERS + @-mentions +
+  recently-touched + already-reviewed PRs; can also filter by area label or a
+  single PR number.
 when_to_use: |
-  Invoke when a maintainer says "review my PRs", "go through the PRs assigned to me", "review my queue", "review the
-  area:scheduler PRs", "review PR NNN", "do my review pass", or any variation on "look over the code on PRs I'm
-  responsible for, one at a time." Distinct from `pr-triage`, which decides *whether* to engage with a PR. This skill is
-  invoked **after** triage has produced PRs marked `ready for maintainer review` (or any other curated selector) and a
-  human reviewer is doing the actual code review.
+  When a maintainer says "review my PRs", "review my queue", "review the area:X
+  PRs", "review PR NNN", or "do my review pass". Deep-review counterpart to
+  pr-triage.
 license: Apache-2.0
 ---
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.github/skills/pr-stats/SKILL.md
+++ b/.github/skills/pr-stats/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: pr-stats
 description: |
-  Produce maintainer-facing statistics about open pull requests on
-  `apache/airflow` (or another target repo). Successor to
-  `breeze pr stats`: read-only, no mutations — just two summary
-  tables grouped by `area:*` label (Triaged final-state, and
-  Triaged still-open) plus per-area age-bucket breakdowns so the
-  maintainer can see where queue pressure is sitting.
-
-  Invoke when the user says "how is the PR queue doing", "run PR
-  stats", "show the area breakdown", "how many PRs are still
-  waiting on authors after triage", or any variation on the "give
-  me numbers about the open PR backlog" theme. Also appropriate
-  as a quick health check before or after a triage sweep.
+  Read-only stats on the open-PR backlog of apache/airflow — two area-grouped
+  tables (triaged final-state and triaged still-open) with age buckets, so
+  maintainers can see where queue pressure sits.
+when_to_use: |
+  When the user asks "how is the PR queue doing", "run PR stats", "show the
+  area breakdown", or "how many PRs are still waiting on authors". Good as a
+  health check before or after a triage sweep.
 ---
 
 <!-- SPDX-License-Identifier: Apache-2.0

--- a/.github/skills/pr-triage/SKILL.md
+++ b/.github/skills/pr-triage/SKILL.md
@@ -1,27 +1,14 @@
 ---
 name: pr-triage
 description: |
-  Sweep open pull requests on `apache/airflow` (or another
-  target repo), classify each one against the project's quality
-  criteria, propose a disposition, and — on the maintainer's
-  confirmation — carry out the action via `gh`. Covers the
-  first-pass triage that used to live in `breeze pr auto-triage`
-  (triage mode): decide whether each PR should be converted to
-  draft with a quality-issues comment, commented on, closed,
-  rebased, have CI reruns triggered, have a first-time-contributor
-  workflow approved, be pinged to a stale reviewer, or marked
-  `ready for maintainer review`. Does **not** perform
-  code review (no LLM line comments, no approve/request-changes
-  submissions) — that lives in a separate skill.
+  First-pass triage of open PRs on apache/airflow — classify each against
+  project quality criteria and propose / carry out a disposition (draft,
+  comment, close, rebase, rerun CI, approve first-contributor workflow, ping
+  reviewer, or mark `ready for maintainer review`). Does not perform code review.
 when_to_use: |
-  Invoke when a maintainer says "triage the PR queue", "go through
-  new contributor PRs", "run the morning triage", "triage PR NNN",
-  "are there any stale PRs we should close", or any variation on
-  the "sweep the contributor PRs and tell me which ones need
-  action" theme. Also appropriate as a recurring morning sweep —
-  the skill is cheap against a one-page batch (default 20 PRs)
-  and is a no-op when every candidate is already triaged or inside
-  its grace window.
+  When a maintainer says "triage the PR queue", "morning triage", "triage PR
+  NNN", "go through new contributor PRs", or "are there stale PRs to close".
+  Cheap to run as a recurring sweep.
 license: Apache-2.0
 ---
 <!-- SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
The `description` and `when_to_use` frontmatter fields of every available `SKILL.md` are loaded into the Claude Code system prompt at the start of every turn so it can route to the right skill; the body of each skill only loads on invocation. So frontmatter is the lever for steady-state context cost.

Trims `maintainer-review`, `pr-triage`, and `pr-stats` to keep only what's useful for routing — what the skill does, how it picks its targets where that matters (`maintainer-review`'s "my reviews" working list, `pr-triage`'s `ready for maintainer review` label), and the trigger phrases. Drops file-path cross-refs, mutation names, "successor to breeze X" history, and verbose action enumerations — all still present in the SKILL.md bodies, which are unchanged.

Saves roughly 500 tokens off the available-skills listing loaded each turn:

```
maintainer-review: ~420 → ~170 tokens
pr-triage:         ~300 → ~125 tokens
pr-stats:          ~170 → ~105 tokens
```

The `maintainer-review` skill was spitting out an warning before as well in `/doctor`:

```
Some skill descriptions will be shortened
      1 description exceeds the per-entry cap: maintainer-review
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)