### PR TITLE
Add checksum for api-server config in API server deployment

### DIFF
--- a/chart/newsfragments/66468.bugfix.rst
+++ b/chart/newsfragments/66468.bugfix.rst
@@ -1,0 +1,7 @@
+Roll api-server pods on ``apiServer.apiServerConfig`` change
+
+The api-server deployment template now carries a ``checksum/api-server-config``
+annotation. Changing ``apiServer.apiServerConfig`` (typically a custom
+``webserver_config.py``) bumps the pod template hash so ``helm upgrade`` rolls
+the api-server, instead of silently leaving running pods on the old config
+file.

--- a/chart/newsfragments/66468.bugfix.rst
+++ b/chart/newsfragments/66468.bugfix.rst
@@ -1,7 +1,0 @@
-Roll api-server pods on ``apiServer.apiServerConfig`` change
-
-The api-server deployment template now carries a ``checksum/api-server-config``
-annotation. Changing ``apiServer.apiServerConfig`` (typically a custom
-``webserver_config.py``) bumps the pod template hash so ``helm upgrade`` rolls
-the api-server, instead of silently leaving running pods on the old config
-file.

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -87,6 +87,9 @@ spec:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
+        {{- if and .Values.apiServer.apiServerConfig (not .Values.apiServer.apiServerConfigConfigMapName) }}
+        checksum/api-server-config: {{ include (print $.Template.BasePath "/configmaps/api-server-configmap.yaml") . | sha256sum }}
+        {{- end }}
         checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
         checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}
         {{- if not .Values.jwtSecretName }}


### PR DESCRIPTION
## Root cause

The api-server deployment template (`chart/templates/api-server/api-server-deployment.yaml`) has `checksum/...` annotations for several config sources — `airflow-config`, `extra-configmaps`, `extra-secrets`, `metadata-secret`, `pgbouncer-config-secret`, and (since #60111) `jwt-secret` — but is missing one for the api-server ConfigMap rendered from `apiServer.apiServerConfig`.

When users change `apiServer.apiServerConfig`:

- The `airflow-api-server-config` ConfigMap is updated.
- The api-server deployment's pod template hash is **not** bumped, so no rolling restart happens.
- The api-server pods keep running with the previous `webserver_config.py`. The mount uses `subPath`, so kubelet does not auto-refresh the file inside running pods either.

The user-visible symptom is that custom auth/security changes silently fail to take effect after `helm upgrade` until someone manually runs `kubectl rollout restart deploy/<release>-api-server`.

## Solution

Add a `checksum/api-server-config` annotation to `chart/templates/api-server/api-server-deployment.yaml`, guarded by the same condition that controls whether `chart/templates/configmaps/api-server-configmap.yaml` actually renders:

```yaml
{{- if and .Values.apiServer.apiServerConfig (not .Values.apiServer.apiServerConfigConfigMapName) }}
checksum/api-server-config: {{ include (print $.Template.BasePath "/configmaps/api-server-configmap.yaml") . | sha256sum }}
{{- end }}
```

This mirrors the pattern used in #60111 for `checksum/jwt-secret`. Same shape of bug, same shape of fix, +3/0 in one template.

## Changes

- Added `checksum/api-server-config` annotation to the api-server deployment template.
- Conditional matches the api-server ConfigMap render condition: only when `apiServer.apiServerConfig` is set and `apiServer.apiServerConfigConfigMapName` is not (i.e., when the chart manages the ConfigMap).

closes: #66467

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

<!-- Generated-by: Claude Code (Anthropic) following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions -->