### PR TITLE
Fix Alibaba OSS provider: configurable endpoint and task handler log …

### DIFF
--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -97,7 +97,8 @@ class OSSHook(BaseHook):
     def _get_client(self) -> oss.Client:
         config = oss.config.load_default()
         config.region = self.region
-        config.endpoint = f"oss-{self.region}.aliyuncs.com"
+        extra_config = self.oss_conn.extra_dejson
+        config.endpoint = extra_config.get("endpoint", f"oss-{self.region}.aliyuncs.com")
         config.credentials_provider = self.get_credential()
         return oss.Client(config)
 

--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -245,11 +245,11 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         log_relative_path = self._render_filename(ti, try_number)
         remote_loc = log_relative_path
 
-        if not self.oss_log_exists(remote_loc):
+        if not self.io.oss_log_exists(remote_loc):
             return super()._read(ti, try_number, metadata)
         # If OSS remote file exists, we do not fetch logs from task instance
         # local machine even if there are errors reading remote logs, as
         # returned remote_log will contain error messages.
-        remote_log = self.oss_read(remote_loc, return_error=True)
+        remote_log = self.io.oss_read(remote_loc, return_error=True)
         log = f"*** Reading remote log from {remote_loc}.\n{remote_log}\n"
         return log, {"end_of_log": True}

--- a/providers/alibaba/tests/unit/alibaba/cloud/hooks/test_oss.py
+++ b/providers/alibaba/tests/unit/alibaba/cloud/hooks/test_oss.py
@@ -210,24 +210,16 @@ class TestOSSHook:
 
     @mock.patch(OSS_STRING.format("oss.config.load_default"))
     def test_get_client_uses_custom_endpoint_from_connection(self, mock_load_default):
-        import json as json_mod
-
-        from airflow.models import Connection
-
         mock_config = mock.MagicMock()
         mock_load_default.return_value = mock_config
+
         custom_ep = "oss-eu-central-1-internal.aliyuncs.com"
-        self.hook.oss_conn = Connection(
-            extra=json_mod.dumps(
-                {
-                    "auth_type": "AK",
-                    "access_key_id": "mock_access_key_id",
-                    "access_key_secret": "mock_access_key_secret",
-                    "region": "mock_region",
-                    "endpoint": custom_ep,
-                }
-            )
-        )
+
+        mock_conn = mock.MagicMock()
+        mock_conn.extra_dejson = {"endpoint": custom_ep}
+
+        self.hook.oss_conn = mock_conn
+        self.hook.get_credential = mock.MagicMock()
 
         self.hook._get_client()
 

--- a/providers/alibaba/tests/unit/alibaba/cloud/hooks/test_oss.py
+++ b/providers/alibaba/tests/unit/alibaba/cloud/hooks/test_oss.py
@@ -198,3 +198,37 @@ class TestOSSHook:
 
     def test_get_default_region(self):
         assert self.hook.get_default_region() == "mock_region"
+
+    @mock.patch(OSS_STRING.format("oss.config.load_default"))
+    def test_get_client_uses_default_endpoint(self, mock_load_default):
+        mock_config = mock.MagicMock()
+        mock_load_default.return_value = mock_config
+
+        self.hook._get_client()
+
+        assert mock_config.endpoint == f"oss-{self.hook.region}.aliyuncs.com"
+
+    @mock.patch(OSS_STRING.format("oss.config.load_default"))
+    def test_get_client_uses_custom_endpoint_from_connection(self, mock_load_default):
+        import json as json_mod
+
+        from airflow.models import Connection
+
+        mock_config = mock.MagicMock()
+        mock_load_default.return_value = mock_config
+        custom_ep = "oss-eu-central-1-internal.aliyuncs.com"
+        self.hook.oss_conn = Connection(
+            extra=json_mod.dumps(
+                {
+                    "auth_type": "AK",
+                    "access_key_id": "mock_access_key_id",
+                    "access_key_secret": "mock_access_key_secret",
+                    "region": "mock_region",
+                    "endpoint": custom_ep,
+                }
+            )
+        )
+
+        self.hook._get_client()
+
+        assert mock_config.endpoint == custom_ep

--- a/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
+++ b/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
@@ -208,3 +208,24 @@ class TestOSSTaskHandler:
     def test_filename_template_for_backward_compatibility(self):
         # filename_template arg support for running the latest provider on airflow 2
         OSSTaskHandler(self.base_log_folder, self.oss_log_folder, filename_template=None)
+
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_read"))
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_log_exists"))
+    def test_read_calls_oss_methods_via_io(self, mock_log_exists, mock_oss_read):
+        mock_log_exists.return_value = True
+        mock_oss_read.return_value = "mock log content"
+
+        log, metadata = self.oss_task_handler._read(self.ti, self.ti.try_number)
+
+        mock_log_exists.assert_called_once()
+        mock_oss_read.assert_called_once()
+        assert "mock log content" in log
+        assert metadata == {"end_of_log": True}
+
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_log_exists"))
+    def test_read_falls_back_to_local_when_no_remote_log(self, mock_log_exists):
+        mock_log_exists.return_value = False
+
+        self.oss_task_handler._read(self.ti, self.ti.try_number)
+
+        mock_log_exists.assert_called_once()


### PR DESCRIPTION
## Summary

- **OSSHook._get_client()**: The endpoint was hardcoded to the public URL
  (`oss-{region}.aliyuncs.com`), making it impossible to use VPC/internal
  endpoints (e.g. `oss-eu-central-1-internal.aliyuncs.com`). Now reads from
  the connection's `extra` config with `endpoint` key, falling back to the
  public default.

- **OSSTaskHandler._read()**: Called `self.oss_log_exists()` and `self.oss_read()`
  which don't exist on `OSSTaskHandler`. These methods live on `OSSRemoteLogIO`
  and must be accessed via `self.io`. This caused the webserver to fail silently
  when reading logs from OSS.

## Test plan
- [x] Added `test_get_client_uses_default_endpoint` - verifies default endpoint behavior
- [x] Added `test_get_client_uses_custom_endpoint_from_connection` - verifies custom endpoint from extra config
- [x] Added `test_read_calls_oss_methods_via_io` - verifies _read() uses self.io
- [x] Added `test_read_falls_back_to_local_when_no_remote_log` - verifies local fallback

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes 

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.