### PR TITLE
Fix dag processor callback cleanup for versioned bundle files

### DIFF
--- a/airflow-core/newsfragments/66483.bugfix.rst
+++ b/airflow-core/newsfragments/66483.bugfix.rst
@@ -1,0 +1,1 @@
+Fix dag processor orphan cleanup for versioned callback files so DAG-level callbacks are not dropped when the scanned DAG file is present but the queued callback entry carries a bundle version.

--- a/airflow-core/newsfragments/66483.bugfix.rst
+++ b/airflow-core/newsfragments/66483.bugfix.rst
@@ -1,1 +1,0 @@
-Fix dag processor orphan cleanup for versioned callback files so DAG-level callbacks are not dropped when the scanned DAG file is present but the queued callback entry carries a bundle version.

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1014,22 +1014,34 @@ class DagFileProcessorManager(LoggingMixin):
             files_set |= v
 
         present_keys = {file.presence_key for file in files_set}
-        self.purge_removed_files_from_queue(present_keys=present_keys)
-        self.terminate_orphan_processes(present_keys=present_keys)
-        self.remove_orphaned_file_stats(present_keys=present_keys)
+        self._purge_removed_files_from_queue(present_keys=present_keys)
+        self._terminate_orphan_processes(present_keys=present_keys)
+        self._remove_orphaned_file_stats(present_keys=present_keys)
 
-    def purge_removed_files_from_queue(self, present_keys: set[tuple[str, Path]]):
+    def purge_removed_files_from_queue(self, present: set[DagFileInfo]):
+        """Remove from queue any files no longer observed locally."""
+        self._purge_removed_files_from_queue(present_keys={file.presence_key for file in present})
+
+    def _purge_removed_files_from_queue(self, present_keys: set[tuple[str, Path]]):
         """Remove from queue any files no longer observed locally."""
         self._file_queue = deque(x for x in self._file_queue if x.presence_key in present_keys)
         stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
 
-    def remove_orphaned_file_stats(self, present_keys: set[tuple[str, Path]]):
+    def remove_orphaned_file_stats(self, present: set[DagFileInfo]):
+        """Remove the stats for any dag files that don't exist anymore."""
+        self._remove_orphaned_file_stats(present_keys={file.presence_key for file in present})
+
+    def _remove_orphaned_file_stats(self, present_keys: set[tuple[str, Path]]):
         """Remove the stats for any dag files that don't exist anymore."""
         stats_to_remove = {file for file in self._file_stats if file.presence_key not in present_keys}
         for file in stats_to_remove:
             del self._file_stats[file]
 
-    def terminate_orphan_processes(self, present_keys: set[tuple[str, Path]]):
+    def terminate_orphan_processes(self, present: set[DagFileInfo]):
+        """Stop processors that are working on deleted files."""
+        self._terminate_orphan_processes(present_keys={file.presence_key for file in present})
+
+    def _terminate_orphan_processes(self, present_keys: set[tuple[str, Path]]):
         """Stop processors that are working on deleted files."""
         for file in list(self._processors.keys()):
             if file.presence_key not in present_keys:

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -129,6 +129,11 @@ class DagFileInfo:
             raise ValueError("bundle_path not set")
         return self.bundle_path / self.rel_path
 
+    @property
+    def presence_key(self) -> tuple[str, Path]:
+        """Return the stable file identity used for presence checks."""
+        return self.bundle_name, self.rel_path
+
 
 def _config_int_factory(section: str, key: str):
     return functools.partial(conf.getint, section, key)
@@ -1008,35 +1013,26 @@ class DagFileProcessorManager(LoggingMixin):
         for v in known_files.values():
             files_set |= v
 
-        self.purge_removed_files_from_queue(present=files_set)
-        self.terminate_orphan_processes(present=files_set)
-        self.remove_orphaned_file_stats(present=files_set)
+        present_keys = {file.presence_key for file in files_set}
+        self.purge_removed_files_from_queue(present_keys=present_keys)
+        self.terminate_orphan_processes(present_keys=present_keys)
+        self.remove_orphaned_file_stats(present_keys=present_keys)
 
-    @staticmethod
-    def _present_file_key(file: DagFileInfo) -> tuple[str, Path]:
-        """Return the stable file identity used for present/orphan checks."""
-        return file.bundle_name, file.rel_path
-
-    def purge_removed_files_from_queue(self, present: set[DagFileInfo]):
+    def purge_removed_files_from_queue(self, present_keys: set[tuple[str, Path]]):
         """Remove from queue any files no longer observed locally."""
-        present_keys = {self._present_file_key(file) for file in present}
-        self._file_queue = deque(x for x in self._file_queue if self._present_file_key(x) in present_keys)
+        self._file_queue = deque(x for x in self._file_queue if x.presence_key in present_keys)
         stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
 
-    def remove_orphaned_file_stats(self, present: set[DagFileInfo]):
+    def remove_orphaned_file_stats(self, present_keys: set[tuple[str, Path]]):
         """Remove the stats for any dag files that don't exist anymore."""
-        present_keys = {self._present_file_key(file) for file in present}
-        stats_to_remove = {
-            file for file in self._file_stats if self._present_file_key(file) not in present_keys
-        }
+        stats_to_remove = {file for file in self._file_stats if file.presence_key not in present_keys}
         for file in stats_to_remove:
             del self._file_stats[file]
 
-    def terminate_orphan_processes(self, present: set[DagFileInfo]):
+    def terminate_orphan_processes(self, present_keys: set[tuple[str, Path]]):
         """Stop processors that are working on deleted files."""
-        present_keys = {self._present_file_key(file) for file in present}
         for file in list(self._processors.keys()):
-            if self._present_file_key(file) not in present_keys:
+            if file.presence_key not in present_keys:
                 processor = self._processors.pop(file, None)
                 if not processor:
                     continue
@@ -1270,11 +1266,14 @@ class DagFileProcessorManager(LoggingMixin):
         A "new" file is a file that has not been processed yet and is not currently being processed.
         """
         new_files = []
+        tracked_presence_keys = {file.presence_key for file in self._file_queue}
+        tracked_presence_keys.update(file.presence_key for file in self._file_stats)
+        tracked_presence_keys.update(file.presence_key for file in self._processors)
         for files in known_files.values():
             for file in files:
-                # todo: store stats by bundle also?
-                if file not in self._file_stats and file not in self._processors:
+                if file.presence_key not in tracked_presence_keys:
                     new_files.append(file)
+                    tracked_presence_keys.add(file.presence_key)
 
         if new_files:
             self.log.info("Adding %d new files to the front of the queue", len(new_files))
@@ -1299,6 +1298,7 @@ class DagFileProcessorManager(LoggingMixin):
             self._file_queue = deque(callback_files + sorted_regular_files)
 
     def _sort_by_mtime(self, files: Iterable[DagFileInfo]):
+        file_stats_by_presence_key = {file.presence_key: stat for file, stat in self._file_stats.items()}
         files_with_mtime: dict[DagFileInfo, float] = {}
         changed_recently = set()
         for file in files:
@@ -1306,20 +1306,35 @@ class DagFileProcessorManager(LoggingMixin):
                 modified_timestamp = os.path.getmtime(file.absolute_path)
                 modified_datetime = datetime.fromtimestamp(modified_timestamp, tz=timezone.utc)
                 files_with_mtime[file] = modified_timestamp
-                last_time = self._file_stats[file].last_finish_time
+                stat = file_stats_by_presence_key.get(file.presence_key)
+                last_time = stat.last_finish_time if stat else None
                 if not last_time:
                     continue
                 if modified_datetime > last_time:
                     changed_recently.add(file)
             except FileNotFoundError:
                 self.log.warning("Skipping processing of missing file: %s", file)
-                self._file_stats.pop(file, None)
+                stats_to_remove = [
+                    tracked_file
+                    for tracked_file in self._file_stats
+                    if tracked_file.presence_key == file.presence_key
+                ]
+                for tracked_file in stats_to_remove:
+                    self._file_stats.pop(tracked_file, None)
                 continue
         file_infos = [info for info, ts in sorted(files_with_mtime.items(), key=itemgetter(1), reverse=True)]
         return file_infos, changed_recently
 
     def processed_recently(self, now, file):
-        last_time = self._file_stats[file].last_finish_time
+        stat = next(
+            (
+                stat
+                for tracked_file, stat in self._file_stats.items()
+                if tracked_file.presence_key == file.presence_key
+            ),
+            None,
+        )
+        last_time = stat.last_finish_time if stat else None
         if not last_time:
             return False
         elapsed_ss = (now - last_time).total_seconds()
@@ -1344,7 +1359,8 @@ class DagFileProcessorManager(LoggingMixin):
 
         # If the file path is already being processed, or if a file was
         # processed recently, wait until the next batch
-        in_progress = set(self._processors)
+        in_progress_keys = {file.presence_key for file in self._processors}
+        file_stats_by_presence_key = {file.presence_key: stat for file, stat in self._file_stats.items()}
         now = timezone.utcnow()
 
         # Sort the file paths by the parsing order mode
@@ -1367,15 +1383,19 @@ class DagFileProcessorManager(LoggingMixin):
             # set of files. Since we set the seed, the sort order will remain same per host
             random.Random(get_hostname()).shuffle(files)
 
-        at_run_limit = [info for info, stat in self._file_stats.items() if stat.run_count == self.max_runs]
-        to_exclude = in_progress.union(at_run_limit)
+        at_run_limit_keys = {
+            presence_key
+            for presence_key, stat in file_stats_by_presence_key.items()
+            if stat.run_count == self.max_runs
+        }
+        to_exclude = in_progress_keys.union(at_run_limit_keys)
 
         # exclude recently processed unless changed recently
-        to_exclude |= recently_processed - changed_recently
+        to_exclude |= {file.presence_key for file in recently_processed - changed_recently}
 
         # Do not convert the following list to set as set does not preserve the order
         # and we need to maintain the order of files for `[dag_processor] file_parsing_sort_mode`
-        to_queue = [x for x in files if x not in to_exclude]
+        to_queue = [x for x in files if x.presence_key not in to_exclude]
 
         if self.log.isEnabledFor(logging.DEBUG):
             for path, processor in self._processors.items():

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1013,36 +1013,26 @@ class DagFileProcessorManager(LoggingMixin):
         for v in known_files.values():
             files_set |= v
 
-        present_keys = {file.presence_key for file in files_set}
-        self._purge_removed_files_from_queue(present_keys=present_keys)
-        self._terminate_orphan_processes(present_keys=present_keys)
-        self._remove_orphaned_file_stats(present_keys=present_keys)
+        self.purge_removed_files_from_queue(present=files_set)
+        self.terminate_orphan_processes(present=files_set)
+        self.remove_orphaned_file_stats(present=files_set)
 
     def purge_removed_files_from_queue(self, present: set[DagFileInfo]):
         """Remove from queue any files no longer observed locally."""
-        self._purge_removed_files_from_queue(present_keys={file.presence_key for file in present})
-
-    def _purge_removed_files_from_queue(self, present_keys: set[tuple[str, Path]]):
-        """Remove from queue any files no longer observed locally."""
+        present_keys = {file.presence_key for file in present}
         self._file_queue = deque(x for x in self._file_queue if x.presence_key in present_keys)
         stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
 
     def remove_orphaned_file_stats(self, present: set[DagFileInfo]):
         """Remove the stats for any dag files that don't exist anymore."""
-        self._remove_orphaned_file_stats(present_keys={file.presence_key for file in present})
-
-    def _remove_orphaned_file_stats(self, present_keys: set[tuple[str, Path]]):
-        """Remove the stats for any dag files that don't exist anymore."""
+        present_keys = {file.presence_key for file in present}
         stats_to_remove = {file for file in self._file_stats if file.presence_key not in present_keys}
         for file in stats_to_remove:
             del self._file_stats[file]
 
     def terminate_orphan_processes(self, present: set[DagFileInfo]):
         """Stop processors that are working on deleted files."""
-        self._terminate_orphan_processes(present_keys={file.presence_key for file in present})
-
-    def _terminate_orphan_processes(self, present_keys: set[tuple[str, Path]]):
-        """Stop processors that are working on deleted files."""
+        present_keys = {file.presence_key for file in present}
         for file in list(self._processors.keys()):
             if file.presence_key not in present_keys:
                 processor = self._processors.pop(file, None)
@@ -1382,7 +1372,9 @@ class DagFileProcessorManager(LoggingMixin):
         for bundle_files in known_files.values():
             for file in bundle_files:
                 files.append(file)
-                if self.processed_recently(now, file):
+                stat = file_stats_by_presence_key.get(file.presence_key)
+                last_time = stat.last_finish_time if stat else None
+                if last_time and (now - last_time).total_seconds() < self._file_process_interval:
                     recently_processed.add(file)
 
         changed_recently: set[DagFileInfo] = set()

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1012,22 +1012,31 @@ class DagFileProcessorManager(LoggingMixin):
         self.terminate_orphan_processes(present=files_set)
         self.remove_orphaned_file_stats(present=files_set)
 
+    @staticmethod
+    def _present_file_key(file: DagFileInfo) -> tuple[str, Path]:
+        """Return the stable file identity used for present/orphan checks."""
+        return file.bundle_name, file.rel_path
+
     def purge_removed_files_from_queue(self, present: set[DagFileInfo]):
         """Remove from queue any files no longer observed locally."""
-        self._file_queue = deque(x for x in self._file_queue if x in present)
+        present_keys = {self._present_file_key(file) for file in present}
+        self._file_queue = deque(x for x in self._file_queue if self._present_file_key(x) in present_keys)
         stats.gauge("dag_processing.file_path_queue_size", len(self._file_queue))
 
     def remove_orphaned_file_stats(self, present: set[DagFileInfo]):
         """Remove the stats for any dag files that don't exist anymore."""
-        # todo: store stats by bundle also?
-        stats_to_remove = set(self._file_stats).difference(present)
+        present_keys = {self._present_file_key(file) for file in present}
+        stats_to_remove = {
+            file for file in self._file_stats if self._present_file_key(file) not in present_keys
+        }
         for file in stats_to_remove:
             del self._file_stats[file]
 
     def terminate_orphan_processes(self, present: set[DagFileInfo]):
         """Stop processors that are working on deleted files."""
+        present_keys = {self._present_file_key(file) for file in present}
         for file in list(self._processors.keys()):
-            if file not in present:
+            if self._present_file_key(file) not in present_keys:
                 processor = self._processors.pop(file, None)
                 if not processor:
                     continue

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -424,7 +424,7 @@ class TestDagFileProcessorManager:
 
         manager._file_queue = deque([versioned_file])
 
-        manager.purge_removed_files_from_queue(present_keys={present_file.presence_key})
+        manager.purge_removed_files_from_queue(present={present_file})
 
         assert manager._file_queue == deque([versioned_file])
 
@@ -434,7 +434,7 @@ class TestDagFileProcessorManager:
 
         manager._file_queue = deque([versioned_file])
 
-        manager.purge_removed_files_from_queue(present_keys=set())
+        manager.purge_removed_files_from_queue(present=set())
 
         assert manager._file_queue == deque()
 
@@ -448,7 +448,7 @@ class TestDagFileProcessorManager:
 
         manager._processors[versioned_file] = processor
 
-        manager.terminate_orphan_processes(present_keys={present_file.presence_key})
+        manager.terminate_orphan_processes(present={present_file})
 
         assert manager._processors == {versioned_file: processor}
         processor.kill.assert_not_called()
@@ -460,7 +460,7 @@ class TestDagFileProcessorManager:
 
         manager._processors[versioned_file] = processor
 
-        manager.terminate_orphan_processes(present_keys=set())
+        manager.terminate_orphan_processes(present=set())
 
         assert manager._processors == {}
         processor.kill.assert_called_once_with(signal.SIGKILL)
@@ -472,7 +472,7 @@ class TestDagFileProcessorManager:
 
         manager._file_stats[versioned_file] = DagFileStat()
 
-        manager.remove_orphaned_file_stats(present_keys={present_file.presence_key})
+        manager.remove_orphaned_file_stats(present={present_file})
 
         assert manager._file_stats == {versioned_file: DagFileStat()}
 
@@ -482,7 +482,7 @@ class TestDagFileProcessorManager:
 
         manager._file_stats[versioned_file] = DagFileStat()
 
-        manager.remove_orphaned_file_stats(present_keys=set())
+        manager.remove_orphaned_file_stats(present=set())
 
         assert manager._file_stats == {}
 

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -417,6 +417,22 @@ class TestDagFileProcessorManager:
         manager.handle_removed_files(known_files={bundle_name: {file}})
         assert manager._processors == {file: mock_processor}
 
+    def test_handle_removed_files_uses_public_extension_points(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        bundle_name = "testing"
+        file = DagFileInfo(bundle_name=bundle_name, rel_path=Path("abc.txt"), bundle_path=TEST_DAGS_FOLDER)
+
+        with (
+            mock.patch.object(manager, "purge_removed_files_from_queue") as purge_queue,
+            mock.patch.object(manager, "terminate_orphan_processes") as terminate_processors,
+            mock.patch.object(manager, "remove_orphaned_file_stats") as remove_stats,
+        ):
+            manager.handle_removed_files(known_files={bundle_name: {file}})
+
+        purge_queue.assert_called_once_with(present={file})
+        terminate_processors.assert_called_once_with(present={file})
+        remove_stats.assert_called_once_with(present={file})
+
     def test_purge_removed_files_keeps_versioned_callback_file_when_unversioned_file_is_present(self):
         manager = DagFileProcessorManager(max_runs=1)
         versioned_file = _get_versioned_file_info("callbacks.py")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -408,6 +408,70 @@ class TestDagFileProcessorManager:
         manager.handle_removed_files(known_files={bundle_name: {file}})
         assert manager._processors == {file: mock_processor}
 
+    def test_purge_removed_files_keeps_versioned_callback_file_when_unversioned_file_is_present(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+            bundle_version="v1",
+        )
+        present_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+        )
+
+        manager._file_queue = deque([versioned_file])
+
+        manager.purge_removed_files_from_queue(present={present_file})
+
+        assert manager._file_queue == deque([versioned_file])
+
+    def test_terminate_orphan_processes_keeps_versioned_callback_processor_when_unversioned_file_is_present(
+        self,
+    ):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+            bundle_version="v1",
+        )
+        present_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+        )
+        processor = MagicMock()
+
+        manager._processors[versioned_file] = processor
+
+        manager.terminate_orphan_processes(present={present_file})
+
+        assert manager._processors == {versioned_file: processor}
+        processor.kill.assert_not_called()
+
+    def test_remove_orphaned_file_stats_keeps_versioned_callback_stats_when_unversioned_file_is_present(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+            bundle_version="v1",
+        )
+        present_file = DagFileInfo(
+            bundle_name="testing",
+            rel_path=Path("callbacks.py"),
+            bundle_path=TEST_DAGS_FOLDER,
+        )
+
+        manager._file_stats[versioned_file] = DagFileStat()
+
+        manager.remove_orphaned_file_stats(present={present_file})
+
+        assert manager._file_stats == {versioned_file: DagFileStat()}
+
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
     def test_files_in_queue_sorted_alphabetically(self):
         """Test dag files are sorted alphabetically"""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -89,6 +89,15 @@ def _get_file_infos(files: list[str | Path]) -> list[DagFileInfo]:
     return [DagFileInfo(bundle_name="testing", bundle_path=TEST_DAGS_FOLDER, rel_path=Path(f)) for f in files]
 
 
+def _get_versioned_file_info(file: str | Path, bundle_version: str = "v1") -> DagFileInfo:
+    return DagFileInfo(
+        bundle_name="testing",
+        bundle_path=TEST_DAGS_FOLDER,
+        rel_path=Path(file),
+        bundle_version=bundle_version,
+    )
+
+
 def mock_get_mtime(file: Path):
     f = str(file)
     m = re.match(pattern=r".*ss=(.+?)\.\w+", string=f)
@@ -410,67 +419,72 @@ class TestDagFileProcessorManager:
 
     def test_purge_removed_files_keeps_versioned_callback_file_when_unversioned_file_is_present(self):
         manager = DagFileProcessorManager(max_runs=1)
-        versioned_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-            bundle_version="v1",
-        )
-        present_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-        )
+        versioned_file = _get_versioned_file_info("callbacks.py")
+        present_file = _get_file_infos(["callbacks.py"])[0]
 
         manager._file_queue = deque([versioned_file])
 
-        manager.purge_removed_files_from_queue(present={present_file})
+        manager.purge_removed_files_from_queue(present_keys={present_file.presence_key})
 
         assert manager._file_queue == deque([versioned_file])
+
+    def test_purge_removed_files_drops_versioned_callback_file_when_truly_absent(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("callbacks.py")
+
+        manager._file_queue = deque([versioned_file])
+
+        manager.purge_removed_files_from_queue(present_keys=set())
+
+        assert manager._file_queue == deque()
 
     def test_terminate_orphan_processes_keeps_versioned_callback_processor_when_unversioned_file_is_present(
         self,
     ):
         manager = DagFileProcessorManager(max_runs=1)
-        versioned_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-            bundle_version="v1",
-        )
-        present_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-        )
+        versioned_file = _get_versioned_file_info("callbacks.py")
+        present_file = _get_file_infos(["callbacks.py"])[0]
         processor = MagicMock()
 
         manager._processors[versioned_file] = processor
 
-        manager.terminate_orphan_processes(present={present_file})
+        manager.terminate_orphan_processes(present_keys={present_file.presence_key})
 
         assert manager._processors == {versioned_file: processor}
         processor.kill.assert_not_called()
 
+    def test_terminate_orphan_processes_kills_processor_when_file_is_truly_absent(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("callbacks.py")
+        processor = MagicMock()
+
+        manager._processors[versioned_file] = processor
+
+        manager.terminate_orphan_processes(present_keys=set())
+
+        assert manager._processors == {}
+        processor.kill.assert_called_once_with(signal.SIGKILL)
+
     def test_remove_orphaned_file_stats_keeps_versioned_callback_stats_when_unversioned_file_is_present(self):
         manager = DagFileProcessorManager(max_runs=1)
-        versioned_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-            bundle_version="v1",
-        )
-        present_file = DagFileInfo(
-            bundle_name="testing",
-            rel_path=Path("callbacks.py"),
-            bundle_path=TEST_DAGS_FOLDER,
-        )
+        versioned_file = _get_versioned_file_info("callbacks.py")
+        present_file = _get_file_infos(["callbacks.py"])[0]
 
         manager._file_stats[versioned_file] = DagFileStat()
 
-        manager.remove_orphaned_file_stats(present={present_file})
+        manager.remove_orphaned_file_stats(present_keys={present_file.presence_key})
 
         assert manager._file_stats == {versioned_file: DagFileStat()}
+
+    def test_remove_orphaned_file_stats_drops_versioned_callback_stats_when_truly_absent(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("callbacks.py")
+
+        manager._file_stats[versioned_file] = DagFileStat()
+
+        manager.remove_orphaned_file_stats(present_keys=set())
+
+        assert manager._file_stats == {}
 
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
     def test_files_in_queue_sorted_alphabetically(self):
@@ -604,6 +618,30 @@ class TestDagFileProcessorManager:
         # file_1 should remain (already in queue)
         assert list(manager._file_queue) == [file_2, file_1]
 
+    def test_add_new_files_to_queue_skips_versioned_files_already_represented(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        queued_versioned_file = _get_versioned_file_info("file_1.py")
+        processed_versioned_file = _get_versioned_file_info("file_3.py")
+        parsed_versioned_file = _get_versioned_file_info("file_4.py")
+        new_file = _get_file_infos(["file_2.py"])[0]
+
+        manager._file_queue = deque([queued_versioned_file])
+        manager._processors[processed_versioned_file] = MagicMock()
+        manager._file_stats[parsed_versioned_file] = DagFileStat(num_dags=1)
+
+        known_files = {
+            "testing": {
+                _get_file_infos(["file_1.py"])[0],
+                new_file,
+                _get_file_infos(["file_3.py"])[0],
+                _get_file_infos(["file_4.py"])[0],
+            }
+        }
+
+        manager._add_new_files_to_queue(known_files)
+
+        assert list(manager._file_queue) == [new_file, queued_versioned_file]
+
     @conf_vars({("dag_processor", "file_parsing_sort_mode"): "modified_time"})
     @mock.patch("airflow.utils.file.os.path.getmtime", new=mock_get_mtime)
     def test_resort_file_queue_by_mtime(self):
@@ -729,6 +767,69 @@ class TestDagFileProcessorManager:
                 manager._file_process_interval
                 > (freezed_base_time - manager._file_stats[dag_file].last_finish_time).total_seconds()
             )
+
+    @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
+    def test_prepare_file_queue_skips_file_when_versioned_processor_is_in_progress(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("file_1.py")
+        known_file = _get_file_infos(["file_1.py"])[0]
+
+        manager._processors[versioned_file] = MagicMock()
+
+        manager.prepare_file_queue(known_files={"testing": {known_file}})
+
+        assert manager._file_queue == deque()
+
+    @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
+    def test_prepare_file_queue_skips_file_when_versioned_stat_is_at_run_limit(self):
+        manager = DagFileProcessorManager(max_runs=1)
+        versioned_file = _get_versioned_file_info("file_1.py")
+        known_file = _get_file_infos(["file_1.py"])[0]
+
+        manager._file_stats[versioned_file] = DagFileStat(run_count=1)
+
+        manager.prepare_file_queue(known_files={"testing": {known_file}})
+
+        assert manager._file_queue == deque()
+
+    @conf_vars({("dag_processor", "file_parsing_sort_mode"): "alphabetical"})
+    def test_prepare_file_queue_skips_recently_processed_file_with_versioned_stats(self):
+        manager = DagFileProcessorManager(max_runs=3)
+        versioned_file = _get_versioned_file_info("file_1.py")
+        known_file = _get_file_infos(["file_1.py"])[0]
+
+        manager._file_stats[versioned_file] = DagFileStat(
+            last_finish_time=timezone.utcnow() - timedelta(seconds=10),
+            run_count=1,
+        )
+
+        manager.prepare_file_queue(known_files={"testing": {known_file}})
+
+        assert manager._file_queue == deque()
+
+    @conf_vars({("dag_processor", "file_parsing_sort_mode"): "modified_time"})
+    @mock.patch("airflow.utils.file.os.path.getmtime")
+    def test_recently_modified_file_uses_versioned_stats_without_creating_duplicate_entries(
+        self, mock_getmtime
+    ):
+        freezed_base_time = timezone.datetime(2020, 1, 5, 0, 0, 0)
+        versioned_file = _get_versioned_file_info("file_1.py")
+        known_file = _get_file_infos(["file_1.py"])[0]
+        known_files = {"testing": {known_file}}
+        last_finish_time = freezed_base_time - timedelta(seconds=10)
+
+        manager = DagFileProcessorManager(max_runs=3)
+        manager._file_stats = {
+            versioned_file: DagFileStat(1, 0, last_finish_time, 1.0, 1, 1),
+        }
+
+        with time_machine.travel(freezed_base_time):
+            mock_getmtime.side_effect = [(freezed_base_time - timedelta(seconds=5)).timestamp()]
+            manager.prepare_file_queue(known_files=known_files)
+
+        assert manager._file_queue == deque([known_file])
+        assert known_file not in manager._file_stats
+        assert versioned_file in manager._file_stats
 
     def test_file_paths_in_queue_sorted_by_priority(self):
         from airflow.models.dagbag import DagPriorityParsingRequest


### PR DESCRIPTION
Fix dag-processor presence/orphan checks so versioned bundle files are not treated as removed or new solely because the queued/tracked `DagFileInfo` carries a `bundle_version`.

This is distinct from #66301 / #66474. Those changes addressed stale serialized DAG metadata when only the bundle version changed. This fix is later in the callback pipeline: scheduler-emitted DAG-level and task-level callback requests are fetched and queued correctly, but manager-side presence checks must not purge, orphan, or re-queue the same file just because the scanned DAG file is represented without `bundle_version`.

The change keeps `DagFileInfo` equality and hashing version-aware, but adds a `presence_key` on `DagFileInfo` and uses that for manager-side “is this file already present / already represented?” checks. This is intentionally narrower than changing global `DagFileInfo` equality with `bundle_version=field(compare=False)`, because callback requests are tied to a specific bundle version and we do not want to collapse queue/process identity semantics outside these presence checks.

That is now applied in:
- `purge_removed_files_from_queue`
- `terminate_orphan_processes`
- `remove_orphaned_file_stats`
- `_add_new_files_to_queue`
- `prepare_file_queue`
- `_sort_by_mtime` / `processed_recently`

Tests added:
- preserve a versioned queued file, processor, and stats entry when the same unversioned file is still present
- purge/kill/remove those entries when the file is truly absent
- avoid re-adding a scanned unversioned file when the same path is already represented in queue/processors/stats under a versioned key
- avoid duplicate queue/stats behavior in `prepare_file_queue()` and modified-time mode when versioned entries already exist

Validation:
- `pytest airflow-core/tests/unit/dag_processing/test_manager.py -q`
- `breeze testing core-tests --backend postgres --python 3.10 --db-reset -- airflow-core/tests/unit/dag_processing/test_manager.py -q`
- `breeze testing core-tests --backend postgres --python 3.10 --downgrade-pendulum --db-reset -- airflow-core/tests/unit/dag_processing/test_manager.py -q`
- `breeze testing core-tests --backend sqlite --python 3.10 --force-lowest-dependencies --db-reset -- airflow-core/tests/unit/dag_processing/test_manager.py -q`

closes: #66483

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Codex)

Generated-by: Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
