### PR TITLE
Fix Triggerer runner_health_check_threshold log formatting

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -656,7 +656,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             if not self._runner_comms_silence_logged:
                 log.error(
                     "TriggerRunner subprocess event loop appears deadlocked: no communication received "
-                    "for %.1fs (threshold: %ds). Skipping heartbeat so the triggerer appears unhealthy "
+                    "for %.1fs (threshold: %.1fs). Skipping heartbeat so the triggerer appears unhealthy "
                     "to the scheduler and its triggers are reassigned.",
                     elapsed,
                     self.runner_health_check_threshold,


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
Follow-up to #66412

Fix `runner_health_check_threshold` log formatting.

`runner_health_check_threshold` is read with `conf.getfloat(...)`, but the log message previously used integer formatting (`%ds`). Fractional values such as `0.5` are now displayed correctly with `%.1fs`.

- Changes:
  - Before: `TriggerRunner ... (threshold: 30s) ...`
  - After: `TriggerRunner ... (threshold: 30.5s) ...`

- Repro 
  - Run `airflow-core/tests/unit/jobs/test_triggerer_job.py::test_heartbeat_watchdog`
  - Temporarily patch the test with `mocker.patch.object(type(supervisor), "runner_health_check_threshold", new=30.5)` after the `supervisor = supervisor_builder()`

cc @jedcunningham @choo121600 


