### PR TITLE
feat(e2e): add waitForAllDialogsClosed method to handle dialog backdrops

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
@@ -55,4 +55,15 @@ export class BasePage {
   public async navigateTo(path: string): Promise<void> {
     await this.page.goto(path, { waitUntil: "domcontentloaded" });
   }
+
+  // Chakra v3 / Ark UI keeps the backdrop in the DOM until the close animation
+  // ends. On WebKit the animationend/transitionend event is occasionally
+  // dropped under CI load, leaving a `data-state="closed"` backdrop attached
+  // that intercepts pointer events on subsequent actions. Wait for every
+  // dialog backdrop to be detached before continuing.
+  public async waitForAllDialogsClosed(timeout = 15_000): Promise<void> {
+    await expect(this.page.locator('[data-scope="dialog"][data-part="backdrop"]')).toHaveCount(0, {
+      timeout,
+    });
+  }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/ConnectionsPage.ts
@@ -146,15 +146,12 @@ export class ConnectionsPage extends BasePage {
 
     await expect(deleteButton).toBeVisible();
     await expect(deleteButton).toBeEnabled({ timeout: 5000 });
-
-    // Extended timeout: on resource-constrained CI runners, WebKit can take
-    // longer than the default 10s to release the previous dialog's backdrop
-    // pointer-events after close.
-    await deleteButton.click({ timeout: 30_000 });
+    await deleteButton.click();
 
     await expect(this.confirmDeleteButton).toBeVisible();
     await expect(this.confirmDeleteButton).toBeEnabled({ timeout: 5000 });
     await this.confirmDeleteButton.click();
+    await this.waitForAllDialogsClosed();
 
     await expect(this.emptyState).toBeVisible({ timeout: 5000 });
   }
@@ -316,6 +313,7 @@ export class ConnectionsPage extends BasePage {
 
     await this.saveButton.click();
     await responsePromise;
+    await this.waitForAllDialogsClosed();
   }
 
   public async searchConnections(searchTerm: string): Promise<void> {


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

The should delete a connection Playwright test was consistently failing on WebKit (passes on Chromium/Firefox).

The issue was not a timeout problem. The dialog backdrop never unmounts and remains in the DOM with data-state="closed", blocking pointer events.

## Root cause
Chakra v3 / Ark UI waits for animationend to unmount the backdrop, but WebKit drops this event when nested portals are present (combobox + Monaco editor in this dialog).

## Fix
Add BasePage.waitForAllDialogsClosed() to ensure no dialog backdrops remain Call it after save and delete actions Remove the 30s timeout workaround

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude opus 4.7
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
