### PR TITLE
Cache RevokedToken.is_revoked to avoid per-request DB roundtrip

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2101,6 +2101,30 @@ api_auth:
       default: "10"
       example: ~
       type: integer
+    revoked_token_cache_size:
+      description: |
+        Maximum number of JWT JTI lookups cached in process memory to avoid a database
+        roundtrip for every authenticated API request. See ``revoked_token_cache_ttl_seconds``
+        for the entry lifetime.
+
+        Set to 0 to disable caching and revert to a database query per request.
+      version_added: 3.2.1
+      type: integer
+      example: ~
+      default: "10000"
+    revoked_token_cache_ttl_seconds:
+      description: |
+        Time-to-live in seconds for cached JWT revocation lookups. Bounds the worst-case
+        window during which a token revoked on one API server worker can still be honored
+        as valid by another worker (uvicorn workers do not share memory).
+
+        Set to 0 to disable caching and revert to a database query per request. Operators
+        needing strict cross-worker logout consistency can lower this value at the cost
+        of more frequent database lookups.
+      version_added: 3.2.1
+      type: integer
+      example: ~
+      default: "60"
 execution_api:
   description: |
     Settings related to the Execution API server.

--- a/airflow-core/src/airflow/models/revoked_token.py
+++ b/airflow-core/src/airflow/models/revoked_token.py
@@ -17,14 +17,17 @@
 # under the License.
 from __future__ import annotations
 
+import threading
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, ClassVar
 
 import structlog
+from cachetools import TTLCache
 from sqlalchemy import String, delete, exists, select
 from sqlalchemy.orm import Mapped, mapped_column
 
+from airflow._shared.observability.metrics import stats
 from airflow.configuration import conf
 from airflow.models.base import Base
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -35,14 +38,53 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
+# Sentinel for cache-miss detection — a `None` value would clash with a valid bool.
+_CACHE_MISS = object()
+
 
 class RevokedToken(Base):
-    """Stores revoked JWT token JTIs to support token invalidation on logout."""
+    """Stores revoked JWT token JTIs to support token invalidation on logout.
+
+    The class also exposes a process-local TTL cache for ``is_revoked`` lookups.
+    Every authenticated API request goes through ``BaseAuthManager.get_user_from_token``,
+    which calls ``RevokedToken.is_revoked(jti)``. Without caching, that means a
+    SQLAlchemy roundtrip per request — at modest concurrency (UI polling, fan-out
+    DAGs) the connection pool exhausts and request handlers time out in
+    ``QueuePool._do_get``. Cache hit rate is ≈100% in practice (revocation only
+    happens on explicit logout), so an in-memory lookup keyed by ``jti`` collapses
+    the per-request DB roundtrip into a near-free check.
+
+    The cache is bounded by ``[api_auth] revoked_token_cache_size`` (default 10000)
+    and entries expire after ``[api_auth] revoked_token_cache_ttl_seconds``
+    (default 60). Setting either to 0 disables caching and reverts to the
+    per-request DB query behavior.
+
+    The cache is per-process. uvicorn API server workers do not share memory, so
+    ``revoke()`` populates only the local worker's cache. Other workers learn of
+    the revocation when their cached entry expires (worst case: the configured
+    TTL). Operators needing strict cross-worker logout consistency can set
+    ``revoked_token_cache_ttl_seconds = 0`` at the cost of restoring the
+    per-request DB roundtrip.
+
+    Implementation note: the cache assumes JWT ``exp`` validation rejects expired
+    tokens BEFORE this method runs (see ``BaseAuthManager.get_user_from_token``
+    -> ``JWTValidator.avalidated_claims``). A custom auth-manager subclass that
+    bypasses that validation must do its own ``exp`` check before relying on
+    the result here.
+    """
 
     __tablename__ = "revoked_token"
 
     # Track last cleanup time to avoid running cleanup on every request
     _last_cleanup_time: ClassVar[float] = 0.0
+
+    # In-process cache for ``is_revoked`` lookups, populated lazily on first use.
+    # ``None`` when caching is disabled (size or ttl is 0). Mutations are guarded
+    # by ``_cache_lock`` because cachetools is not internally thread-safe — its
+    # LRU/TTL bookkeeping mutates linked-list state on every access.
+    _cache: ClassVar[TTLCache | None] = None
+    _cache_lock: ClassVar[threading.RLock] = threading.RLock()
+    _cache_initialized: ClassVar[bool] = False
 
     jti: Mapped[str] = mapped_column(String(32), primary_key=True)
     exp: Mapped[datetime] = mapped_column(UtcDateTime, nullable=False, index=True)
@@ -50,15 +92,76 @@ class RevokedToken(Base):
     @classmethod
     @provide_session
     def revoke(cls, jti: str, exp: datetime, session: Session = NEW_SESSION) -> None:
-        """Add a token JTI to the revoked tokens."""
+        """Add a token JTI to the revoked tokens.
+
+        Also populates the local in-process cache so the same worker
+        immediately sees the revocation without a follow-up DB query. Other
+        workers' caches learn of the revocation when their cached entry
+        expires (worst case: ``revoked_token_cache_ttl_seconds``).
+
+        If ``session.merge`` raises, the cache is left untouched.
+        """
         session.merge(cls(jti=jti, exp=exp))
+        cls._ensure_cache_initialized()
+        if cls._cache is not None:
+            with cls._cache_lock:
+                cls._cache[jti] = True
 
     @classmethod
     @provide_session
     def is_revoked(cls, jti: str, session: Session = NEW_SESSION) -> bool:
-        """Check if a token JTI has been revoked."""
+        """Check if a token JTI has been revoked, using a process-local TTL cache."""
+        # Run cleanup BEFORE the cache lookup so periodic deletion of expired
+        # rows still fires when most calls are cache hits. ``_maybe_cleanup_expired``
+        # is self-throttled by ``_last_cleanup_time``, so the cost on hot paths
+        # is one ``time.monotonic()`` comparison.
         cls._maybe_cleanup_expired(session)
-        return bool(session.scalar(select(exists().where(cls.jti == jti))))
+        cls._ensure_cache_initialized()
+        cache = cls._cache
+        if cache is None:
+            # Caching disabled — original 3.2 behavior.
+            return bool(session.scalar(select(exists().where(cls.jti == jti))))
+
+        with cls._cache_lock:
+            cached = cache.get(jti, _CACHE_MISS)
+        if cached is not _CACHE_MISS:
+            stats.incr("api_auth.revoked_token.cache_hit")
+            return cached  # type: ignore[return-value]
+
+        # Cache miss — query DB.
+        db_result = bool(session.scalar(select(exists().where(cls.jti == jti))))
+
+        # Double-checked locking: another thread may have populated the entry
+        # while we were querying. Prefer their value and avoid double-counting
+        # the miss metric. (Cold-cache thundering herd is bounded by worker
+        # concurrency and self-corrects after the first populate.)
+        with cls._cache_lock:
+            re_cached = cache.get(jti, _CACHE_MISS)
+            if re_cached is not _CACHE_MISS:
+                stats.incr("api_auth.revoked_token.cache_hit")
+                return re_cached  # type: ignore[return-value]
+            cache[jti] = db_result
+            cache_size = len(cache)
+        stats.incr("api_auth.revoked_token.cache_miss")
+        stats.gauge("api_auth.revoked_token.cache_size", cache_size, rate=0.1)
+        return db_result
+
+    @classmethod
+    def clear_cache(cls) -> int:
+        """Clear the in-process cache and return the number of evicted entries.
+
+        No-op (returns 0) when caching is disabled. Useful for tests and for
+        operators wanting to force a refresh from the database after an
+        out-of-band revocation.
+        """
+        if cls._cache is None:
+            return 0
+        with cls._cache_lock:
+            count = len(cls._cache)
+            cls._cache.clear()
+        stats.incr("api_auth.revoked_token.cache_clear")
+        stats.gauge("api_auth.revoked_token.cache_size", 0)
+        return count
 
     @classmethod
     def _maybe_cleanup_expired(cls, session: Session) -> None:
@@ -77,3 +180,22 @@ class RevokedToken(Base):
                 session.execute(delete(cls).where(cls.exp < datetime.now(tz=timezone.utc)))
             except Exception:
                 log.exception("Failed to clean up expired revoked tokens")
+
+    @classmethod
+    def _ensure_cache_initialized(cls) -> None:
+        """Lazily build the in-process cache from config the first time it's needed.
+
+        Idempotent and thread-safe. If ``[api_auth] revoked_token_cache_size`` or
+        ``revoked_token_cache_ttl_seconds`` is 0, leaves ``_cache`` as ``None``
+        and every call falls through to the DB.
+        """
+        if cls._cache_initialized:
+            return
+        with cls._cache_lock:
+            if cls._cache_initialized:
+                return
+            cache_size = conf.getint("api_auth", "revoked_token_cache_size", fallback=10000)
+            cache_ttl = conf.getint("api_auth", "revoked_token_cache_ttl_seconds", fallback=60)
+            if cache_size > 0 and cache_ttl > 0:
+                cls._cache = TTLCache(maxsize=cache_size, ttl=cache_ttl)
+            cls._cache_initialized = True

--- a/airflow-core/tests/unit/models/test_revoked_token.py
+++ b/airflow-core/tests/unit/models/test_revoked_token.py
@@ -19,7 +19,50 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from airflow.models.revoked_token import RevokedToken
+
+
+@pytest.fixture(autouse=True)
+def _reset_revoked_token_state():
+    """Reset class-level cache + cleanup state between tests so they don't leak through.
+
+    Existing tests pre-date the cache and explicitly manage ``_last_cleanup_time``;
+    this fixture is additive — it just guarantees a clean slate before each test
+    and restores the originals afterward.
+    """
+    original = (
+        RevokedToken._last_cleanup_time,
+        RevokedToken._cache,
+        RevokedToken._cache_initialized,
+    )
+    try:
+        RevokedToken._last_cleanup_time = 0.0
+        RevokedToken._cache = None
+        RevokedToken._cache_initialized = False
+        yield
+    finally:
+        (
+            RevokedToken._last_cleanup_time,
+            RevokedToken._cache,
+            RevokedToken._cache_initialized,
+        ) = original
+
+
+def _conf_getint_factory(*, cache_size: int = 10000, ttl: int = 60, jwt_exp: int = 3600):
+    """Side-effect for patching ``airflow.models.revoked_token.conf.getint``."""
+
+    def _impl(section: str, key: str, fallback: int = 0) -> int:
+        if key == "revoked_token_cache_size":
+            return cache_size
+        if key == "revoked_token_cache_ttl_seconds":
+            return ttl
+        if key == "jwt_expiration_time":
+            return jwt_exp
+        return fallback
+
+    return _impl
 
 
 class TestRevokedTokenModel:
@@ -27,7 +70,11 @@ class TestRevokedTokenModel:
         """Test that revoke calls session.merge with a RevokedToken instance."""
         mock_session = MagicMock()
         exp = datetime.now(tz=timezone.utc) + timedelta(hours=1)
-        RevokedToken.revoke("test-jti-123", exp, session=mock_session)
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=0),
+        ):
+            RevokedToken.revoke("test-jti-123", exp, session=mock_session)
         mock_session.merge.assert_called_once()
         arg = mock_session.merge.call_args[0][0]
         assert isinstance(arg, RevokedToken)
@@ -38,14 +85,22 @@ class TestRevokedTokenModel:
         """Test that a revoked JTI is detected."""
         mock_session = MagicMock()
         mock_session.scalar.return_value = True
-        result = RevokedToken.is_revoked("known-jti", session=mock_session)
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=0),
+        ):
+            result = RevokedToken.is_revoked("known-jti", session=mock_session)
         assert result is True
 
     def test_is_revoked_returns_false(self):
         """Test that an unknown JTI returns False."""
         mock_session = MagicMock()
         mock_session.scalar.return_value = False
-        result = RevokedToken.is_revoked("unknown-jti", session=mock_session)
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=0),
+        ):
+            result = RevokedToken.is_revoked("unknown-jti", session=mock_session)
         assert result is False
 
 
@@ -62,7 +117,10 @@ class TestRevokedTokenCleanup:
             RevokedToken._last_cleanup_time = 0.0
             with (
                 patch("airflow.models.revoked_token.time.monotonic", return_value=8000.0),
-                patch("airflow.models.revoked_token.conf.getint", return_value=3600),
+                patch(
+                    "airflow.models.revoked_token.conf.getint",
+                    side_effect=_conf_getint_factory(cache_size=0),
+                ),
             ):
                 RevokedToken.is_revoked("test-jti", session=mock_session)
 
@@ -82,7 +140,10 @@ class TestRevokedTokenCleanup:
             # cleanup_interval = 3600 * 2 = 7200, so 4500 - 4000 = 500 < 7200 skips cleanup
             with (
                 patch("airflow.models.revoked_token.time.monotonic", return_value=4500.0),
-                patch("airflow.models.revoked_token.conf.getint", return_value=3600),
+                patch(
+                    "airflow.models.revoked_token.conf.getint",
+                    side_effect=_conf_getint_factory(cache_size=0),
+                ),
             ):
                 RevokedToken.is_revoked("test-jti", session=mock_session)
 
@@ -90,3 +151,138 @@ class TestRevokedTokenCleanup:
             mock_session.execute.assert_not_called()
         finally:
             RevokedToken._last_cleanup_time = original_last_cleanup
+
+
+class TestRevokedTokenCache:
+    """Tests for the in-process ``is_revoked`` cache (3.2 perf-regression fix)."""
+
+    def test_caches_negative_result(self):
+        """First miss queries DB; second call within TTL is a cache hit."""
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = False
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            assert RevokedToken.is_revoked("jti-A", session=mock_session) is False
+            assert RevokedToken.is_revoked("jti-A", session=mock_session) is False
+        assert mock_session.scalar.call_count == 1
+
+    def test_caches_positive_result(self):
+        """Revoked tokens are cached too — short-circuits subsequent rejections."""
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = True
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            assert RevokedToken.is_revoked("jti-B", session=mock_session) is True
+            assert RevokedToken.is_revoked("jti-B", session=mock_session) is True
+        assert mock_session.scalar.call_count == 1
+
+    def test_revoke_populates_cache(self):
+        """``revoke()`` populates the cache so the same worker is immediately consistent."""
+        mock_session = MagicMock()
+        # If the cache is bypassed, the DB would say False — proves we hit the cache.
+        mock_session.scalar.return_value = False
+        exp = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            RevokedToken.revoke("jti-C", exp, session=mock_session)
+            assert RevokedToken.is_revoked("jti-C", session=mock_session) is True
+        mock_session.scalar.assert_not_called()
+
+    def test_cache_disabled_when_size_is_zero(self):
+        """Setting ``cache_size = 0`` falls through to the DB on every call."""
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = False
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=0),
+        ):
+            RevokedToken.is_revoked("jti-D", session=mock_session)
+            RevokedToken.is_revoked("jti-D", session=mock_session)
+        assert mock_session.scalar.call_count == 2
+        assert RevokedToken._cache is None
+
+    def test_cache_disabled_when_ttl_is_zero(self):
+        """Setting ``cache_ttl_seconds = 0`` falls through to the DB on every call."""
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = False
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(ttl=0),
+        ):
+            RevokedToken.is_revoked("jti-E", session=mock_session)
+            RevokedToken.is_revoked("jti-E", session=mock_session)
+        assert mock_session.scalar.call_count == 2
+        assert RevokedToken._cache is None
+
+    def test_cleanup_runs_even_on_cache_hit(self):
+        """``_maybe_cleanup_expired`` must fire on every call, not only on cache misses.
+
+        Locks in the design choice that cleanup runs before the cache lookup so a
+        future refactor that short-circuits earlier doesn't silently disable the
+        background TTL sweep.
+        """
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = False
+        with (
+            patch(
+                "airflow.models.revoked_token.conf.getint",
+                side_effect=_conf_getint_factory(cache_size=10),
+            ),
+            patch.object(RevokedToken, "_maybe_cleanup_expired") as cleanup,
+        ):
+            RevokedToken.is_revoked("jti-F", session=mock_session)  # miss
+            RevokedToken.is_revoked("jti-F", session=mock_session)  # hit
+        assert cleanup.call_count == 2
+
+    def test_clear_cache_returns_count_and_empties(self):
+        mock_session = MagicMock()
+        mock_session.scalar.return_value = False
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            RevokedToken.is_revoked("jti-G1", session=mock_session)
+            RevokedToken.is_revoked("jti-G2", session=mock_session)
+            assert RevokedToken.clear_cache() == 2
+            assert RevokedToken.clear_cache() == 0  # already empty
+
+    def test_clear_cache_is_noop_when_caching_disabled(self):
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=0),
+        ):
+            # Force lazy init so ``_cache_initialized`` flips to True.
+            RevokedToken._ensure_cache_initialized()
+            assert RevokedToken._cache is None
+            assert RevokedToken.clear_cache() == 0
+
+    def test_revoke_does_not_cache_on_db_failure(self):
+        """If ``session.merge`` raises, the cache must not be mutated."""
+        mock_session = MagicMock()
+        mock_session.merge.side_effect = RuntimeError("db down")
+        exp = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            with pytest.raises(RuntimeError):
+                RevokedToken.revoke("jti-H", exp, session=mock_session)
+        # Cache was either never initialized or initialized but empty.
+        assert RevokedToken._cache is None or "jti-H" not in RevokedToken._cache
+
+    def test_cache_lazy_init_is_idempotent(self):
+        """Repeat calls to ``_ensure_cache_initialized`` should not rebuild the cache."""
+        with patch(
+            "airflow.models.revoked_token.conf.getint",
+            side_effect=_conf_getint_factory(cache_size=10),
+        ):
+            RevokedToken._ensure_cache_initialized()
+            first_cache = RevokedToken._cache
+            RevokedToken._ensure_cache_initialized()
+            assert RevokedToken._cache is first_cache


### PR DESCRIPTION
Closes #66493

## What does this change?

Adds a process-local `cachetools.TTLCache` to `RevokedToken.is_revoked`. Every authenticated API request currently runs a synchronous `session.scalar(...)` to check whether the JWT's `jti` is in the `revoked_token` table — once the SQLAlchemy pool saturates, request handlers stall in `QueuePool._do_get` for the full `pool_timeout` (30 s by default) before failing 500.

Cache hit rate on `is_revoked` is ≈100% in practice (revocation only happens on explicit logout), so the cache collapses the per-request DB roundtrip into a near-free in-memory lookup.

The implementation mirrors the existing `DBDagBag` cache pattern at `airflow/models/dagbag.py` line-for-line: `TTLCache` + `RLock`, double-checked locking on miss, `Stats.cache_hit/cache_miss/cache_size` metrics, and a public `clear_cache()` for operators. `revoke()` populates the local cache on success so the worker that processes a logout is immediately consistent.

Two new `[api_auth]` config keys make the cache tunable:
- `revoked_token_cache_size` (default 10000) — bounded LRU+TTL cache size
- `revoked_token_cache_ttl_seconds` (default 60) — entry lifetime

Setting either to 0 disables caching and reverts to the per-request DB query behavior.

## Why?

3.2 introduced AIP-84 (commit b3306f15cd, PR #47952 / #61339) which added a per-request DB query to the auth path. Under modest concurrent load — UI multi-endpoint polling, fan-out DAG runs, or just a few users — the default pool of `5+10=15` (shared across api-server, scheduler, dag-processor, and triggerer) exhausts and the API server stops serving requests. See #66493 for the full repro and stacktrace.

## Trade-offs

- **Worker-local cache**. uvicorn workers don't share memory, so a logout on worker A is not immediately reflected on worker B — worker B serves the cached pre-logout result for up to `revoked_token_cache_ttl_seconds` seconds. Operators needing strict cross-worker logout consistency can lower or zero out the TTL.
- **Cached `True` cannot leak past JWT expiry**. `JWTValidator.avalidated_claims` (`auth/tokens.py:318-339`) enforces `exp` via PyJWT before `is_revoked` runs, so an expired token is rejected upstream regardless of cache state.
- **`_maybe_cleanup_expired` is called BEFORE the cache lookup** so the periodic TTL sweep keeps running even when most calls are cache hits — a future refactor that short-circuits earlier would silently break this and a regression test (`test_cleanup_runs_even_on_cache_hit`) locks the ordering.
- **Cold-cache thundering herd** is bounded by worker concurrency and self-corrects after the first DB populate; the implementation does not add `singleflight` coalescing (same pragmatic call as `DBDagBag._get_dag`).

## Local before/after

Stock 3.2.0 vs this PR, identical `pool_size=3, max_overflow=2`, 60 requests at concurrency 30 against `GET /api/v2/dags`:

| Metric | STOCK 3.2.0 | This PR | improvement |
|---|---|---|---|
| Wall time | 31.0 s | 1.04 s | ~30× |
| Success rate | 53/60 (88%) | 60/60 (100%) | +12pp |
| Pool timeouts (≥25 s + non-200) | 7/60 | 0 | gone |
| Latency p50 | 15.3 s | 0.51 s | ~30× |
| Latency p95 | 30.5 s | 0.57 s | ~53× |
| Latency p99 | 30.7 s | 0.60 s | ~51× |

## Tests

`airflow-core/tests/unit/models/test_revoked_token.py` adds 8 new tests:

- `test_caches_negative_result` / `test_caches_positive_result` — both polarities cached
- `test_revoke_populates_cache` — `revoke()` makes the local worker immediately consistent
- `test_cache_disabled_when_size_is_zero` / `test_cache_disabled_when_ttl_is_zero` — opt-out paths
- `test_cleanup_runs_even_on_cache_hit` — locks in the cleanup-ordering invariant
- `test_clear_cache_returns_count_and_empties` / `test_clear_cache_is_noop_when_caching_disabled`
- `test_revoke_does_not_cache_on_db_failure` — cache stays clean if `session.merge` raises
- `test_cache_lazy_init_is_idempotent`

Plus an autouse fixture that resets `_cache`, `_cache_initialized`, and `_last_cleanup_time` so existing tests don't leak class-level state through.

The 4 pre-existing tests in `TestRevokedTokenModel` and `TestRevokedTokenCleanup` are preserved with their assertions intact (just patched to point conf.getint at cache-disabled values for hermetic behavior).

---

^ Add a description of your Pull Request here. Try to keep it as short as possible while still describing all relevant changes.
^ Provide enough information about your change. Don't make reviewers work too much.