### PR TITLE
Use cryptographically secure RNG for SimpleAuthManager passwords

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -21,7 +21,7 @@ import fcntl
 import json
 import logging
 import os
-import random
+import secrets
 from collections import namedtuple
 from enum import Enum
 from json import JSONDecodeError
@@ -440,7 +440,8 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
 
     @staticmethod
     def _generate_password() -> str:
-        return "".join(random.choices("abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789", k=16))
+        alphabet = "abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789"
+        return "".join(secrets.choice(alphabet) for _ in range(16))
 
     @staticmethod
     def _print_output(output: str):

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -31,6 +31,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
     TeamDetails,
     VariableDetails,
 )
+from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.common.types import MenuItem
 
@@ -377,3 +378,10 @@ class TestSimpleAuthManager:
         from airflow.api_fastapi.auth.managers.simple.middleware import SimpleAllAdminMiddleware
 
         assert auth_manager.get_fastapi_middlewares() == [(SimpleAllAdminMiddleware, {})]
+
+    def test_generate_password_uses_expected_alphabet_and_length(self):
+        alphabet = set("abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789")
+        for _ in range(50):
+            password = SimpleAuthManager._generate_password()
+            assert len(password) == 16
+            assert set(password).issubset(alphabet)


### PR DESCRIPTION
SimpleAuthManager generated initial passwords with `random.choices()` — a non-cryptographic PRNG. Switch to `secrets.choice()` so the generated passwords use a CSPRNG.

SimpleAuthManager is documented as dev-only and the password is printed once at startup, so the practical risk is low — but the fix is one line and removes a misleading signal in security audits.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)