### PR TITLE
Set SameSite=Lax on SimpleAuthManager all-admins login cookie

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -97,6 +97,7 @@ def login_all_admins(request: Request) -> RedirectResponse:
         path=get_cookie_path(),
         secure=secure,
         httponly=True,
+        samesite="lax",
     )
     return response
 

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -85,6 +85,7 @@ class TestLogin:
             assert response.status_code == 307
             assert "location" in response.headers
             assert response.cookies.get("_token") is not None
+            assert "samesite=lax" in response.headers["set-cookie"].lower()
 
     def test_login_all_admins_config_disabled(self, test_client):
         response = test_client.get("/auth/token/login", follow_redirects=False)


### PR DESCRIPTION
The all-admins login response set `Secure` (conditional on HTTPS) and `HttpOnly` on the JWT cookie but omitted `SameSite`. `JWTRefreshMiddleware` already sets `samesite="lax"` on the cookie it issues. Bring the login response in line so both code paths produce cookies with the same attributes.

The cookie's `Secure` flag was already set conditionally based on HTTPS or configured `ssl_cert` — only `SameSite` was missing.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)