### PR TITLE
Harden _collect_teams_to_check / requires_access_backfill against malformed bodies

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -338,7 +338,15 @@ def requires_access_backfill(
         if dag_id is None:
             # Not a json body, ignore
             with suppress(JSONDecodeError):
-                dag_id = (await request.json()).get("dag_id")
+                body = await request.json()
+                if isinstance(body, dict):
+                    dag_id = body.get("dag_id")
+            if dag_id is not None and not isinstance(dag_id, str):
+                # Fail closed: reject non-string dag_id before authz decision.
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="'dag_id' must be a string",
+                )
 
         requires_access_dag(method, DagAccessEntity.RUN, dag_id)(
             request,
@@ -758,17 +766,26 @@ async def _collect_teams_to_check(
         teams.add(get_existing_team(resource_id) if resource_id else None)
     if method in ("POST", "PUT"):
         try:
-            raw = (await request.json()).get("team_name")
+            body = await request.json()
         except JSONDecodeError:
-            # Fail closed: ensure auth callback still runs when team can't be determined.
-            teams.add(None)
-        else:
-            if raw and not Team.get_name_if_exists(raw):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Team {raw!r} does not exist",
-                )
-            teams.add(raw)
+            # Fail closed: reject unparsable bodies before any authz decision.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Request body is not valid JSON",
+            )
+        raw = body.get("team_name") if isinstance(body, dict) else None
+        if raw is not None and not isinstance(raw, str):
+            # Fail closed: reject non-string team_name before authz / DB lookup.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="'team_name' must be a string",
+            )
+        if raw and not Team.get_name_if_exists(raw):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Team {raw!r} does not exist",
+            )
+        teams.add(raw)
     return teams
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -757,8 +757,12 @@ async def _collect_teams_to_check(
     if method != "POST":
         teams.add(get_existing_team(resource_id) if resource_id else None)
     if method in ("POST", "PUT"):
-        with suppress(JSONDecodeError):
+        try:
             raw = (await request.json()).get("team_name")
+        except JSONDecodeError:
+            # Fail closed: ensure auth callback still runs when team can't be determined.
+            teams.add(None)
+        else:
             if raw and not Team.get_name_if_exists(raw):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -587,6 +587,37 @@ class TestFastApiSecurity:
         assert exc_info.value.status_code == 400
         assert "nonexistent" in exc_info.value.detail
 
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("method", ["POST", "PUT"])
+    @patch.object(Team, "get_name_if_exists")
+    @patch.object(Connection, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_connection_body_parse_failure_fails_closed(
+        self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists, method
+    ):
+        """If the request body cannot be parsed, the auth callback must still run with team=None."""
+        from json import JSONDecodeError
+
+        auth_manager = Mock()
+        auth_manager.is_authorized_connection.return_value = False
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = None
+        fastapi_request = Mock()
+        fastapi_request.path_params = {"connection_id": "conn_id"}
+        fastapi_request.json = AsyncMock(side_effect=JSONDecodeError("expecting value", "", 0))
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await requires_access_connection(method)(fastapi_request, user)
+
+        assert exc_info.value.status_code == 403
+        auth_manager.is_authorized_connection.assert_any_call(
+            method=method,
+            details=ConnectionDetails(conn_id="conn_id", team_name=None),
+            user=user,
+        )
+
     @patch.object(Connection, "get_conn_id_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
     def test_requires_access_connection_bulk(

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from json import JSONDecodeError
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -592,12 +593,10 @@ class TestFastApiSecurity:
     @patch.object(Team, "get_name_if_exists")
     @patch.object(Connection, "get_team_name")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
-    async def test_requires_access_connection_body_parse_failure_fails_closed(
+    async def test_requires_access_connection_body_parse_failure_returns_400(
         self, mock_get_auth_manager, mock_get_team_name, mock_get_name_if_exists, method
     ):
-        """If the request body cannot be parsed, the auth callback must still run with team=None."""
-        from json import JSONDecodeError
-
+        """If the request body cannot be parsed, fail closed with 400 before any authz check."""
         auth_manager = Mock()
         auth_manager.is_authorized_connection.return_value = False
         mock_get_auth_manager.return_value = auth_manager
@@ -611,12 +610,61 @@ class TestFastApiSecurity:
             with pytest.raises(HTTPException) as exc_info:
                 await requires_access_connection(method)(fastapi_request, user)
 
-        assert exc_info.value.status_code == 403
-        auth_manager.is_authorized_connection.assert_any_call(
-            method=method,
-            details=ConnectionDetails(conn_id="conn_id", team_name=None),
-            user=user,
-        )
+        assert exc_info.value.status_code == 400
+        auth_manager.is_authorized_connection.assert_not_called()
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("method", ["POST", "PUT"])
+    @pytest.mark.parametrize("bad_team_name", [123, ["x"], {"name": "x"}, True])
+    @patch.object(Team, "get_name_if_exists")
+    @patch.object(Connection, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_connection_non_string_team_name_returns_400(
+        self,
+        mock_get_auth_manager,
+        mock_get_team_name,
+        mock_get_name_if_exists,
+        bad_team_name,
+        method,
+    ):
+        """Non-string team_name in the body must be rejected with 400 before authz / DB lookup."""
+        auth_manager = Mock()
+        auth_manager.is_authorized_connection.return_value = False
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = None
+        fastapi_request = Mock()
+        fastapi_request.path_params = {"connection_id": "conn_id"}
+        fastapi_request.json = AsyncMock(return_value={"team_name": bad_team_name})
+        user = Mock()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with pytest.raises(HTTPException) as exc_info:
+                await requires_access_connection(method)(fastapi_request, user)
+
+        assert exc_info.value.status_code == 400
+        assert "team_name" in exc_info.value.detail
+        auth_manager.is_authorized_connection.assert_not_called()
+        mock_get_name_if_exists.assert_not_called()
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize("bad_dag_id", [123, ["x"], {"name": "x"}, True])
+    @patch("airflow.api_fastapi.core_api.security.requires_access_dag")
+    async def test_requires_access_backfill_non_string_dag_id_returns_400(
+        self, mock_requires_access_dag, bad_dag_id
+    ):
+        """Non-string dag_id in the body must be rejected with 400 before authz."""
+        fastapi_request = Mock()
+        fastapi_request.path_params = {}
+        fastapi_request.json = AsyncMock(return_value={"dag_id": bad_dag_id})
+        user = Mock()
+        session = Mock()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await requires_access_backfill("POST")(fastapi_request, user, session)
+
+        assert exc_info.value.status_code == 400
+        assert "dag_id" in exc_info.value.detail
+        mock_requires_access_dag.assert_not_called()
 
     @patch.object(Connection, "get_conn_id_to_team_name_mapping")
     @patch("airflow.api_fastapi.core_api.security.get_auth_manager")


### PR DESCRIPTION
The authorization helpers in `core_api/security.py` read fields directly from the raw request JSON body before Pydantic body-validation runs on the actual endpoint handler. Two related defects that share the same fix pattern:

## Commit 1: Fail closed on JSON parse failure (FINDING-008 from L1 sweep)

For POST/PUT in multi-team mode, `_collect_teams_to_check` used `with suppress(JSONDecodeError)` around `await request.json()`. If the body was unparseable, the suppress swallowed the exception, `teams.add(raw)` never ran, and the calling `requires_access_*` dependency iterated over an empty set — silently skipping the authorization callback entirely.

Replace the bare `suppress` with an explicit `try/except` that adds `None` to `teams` on parse failure, so the auth callback always runs at least once.

## Commit 2: Reject non-string `dag_id` / `team_name` from raw body before authz (FINDING-060 from L3 sweep)

`_collect_teams_to_check` reads `team_name`, and `requires_access_backfill` reads `dag_id`, from the raw JSON body before Pydantic validation runs on the actual endpoint handler. If a body contains a non-string value (list, dict, integer, …) those values would otherwise flow into `Team.get_name_if_exists` / the authz callback / the existence lookup, producing undefined behaviour or type-confused authz decisions.

Raise `400 Bad Request` on a non-string `team_name` / `dag_id` before any auth check runs. Tests parametrised on integer / list / dict / bool inputs assert the 400 + that the authz callback is never consulted.

## Reachability today

Both defects are unreachable in current `core_api` routes because every POST/PUT route uses a Pydantic body model, so FastAPI returns 422 before the auth dependency runs on a malformed body. The patterns would silently bypass team-scoped authz if a future route used a raw `Request` instead — both fixes are defense-in-depth, not exploitable today.

## Reported by

- Airflow-side audit triage — apache/tooling-agents#23 (FINDING-008 from L1, FINDING-060 from L3)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
