### PR TITLE
fix(k8s): pre-load postgresql image to prevent Docker Hub rate-limit flakes

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -716,6 +716,7 @@ def _upload_k8s_image(python: str, kubernetes_version: str, output: Output | Non
 # scripts/ci/prek/upgrade_important_versions.py.
 K8S_TEST_IMAGES_TO_PRELOAD: tuple[str, ...] = (
     "alpine:3.23.4",  # xcom_sidecar default in providers/cncf/kubernetes
+    "bitnamilegacy/postgresql:16.1.0-debian-11-r15",  # chart/values.yaml postgresql subchart
     "busybox:1.37.0",  # busybox-based system tests in kubernetes-tests/
     "ubuntu:24.04",  # ubuntu-based system tests in kubernetes-tests/
 )


### PR DESCRIPTION
## Description

Add `bitnamilegacy/postgresql:16.1.0-debian-11-r15` to `K8S_TEST_IMAGES_TO_PRELOAD` so the Helm chart's postgresql subchart image is pre-loaded into Kind nodes before tests run.

## Root Cause

K8S system tests fail intermittently when Docker Hub anonymous-pull rate limits (100 pulls/6h per IP) are exhausted. The postgresql image is pulled by containerd inside Kind at pod scheduling time — unauthenticated and without retry. When rate-limited, PostgreSQL never starts and all Airflow pods enter CrashLoopBackOff waiting for DB migrations.

## Changes

One-line addition to `K8S_TEST_IMAGES_TO_PRELOAD` tuple in `dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py`. The existing `_docker_pull_with_429_retry` + `kind load docker-image` mechanism (PR #66423) handles the rest.

## Testing

All 6 K8S system test jobs pass on this PR:
- KubernetesExecutor-3.10-v1.30.13-true ✓
- KubernetesExecutor-3.10-v1.30.13-false ✓
- CeleryExecutor-3.10-v1.30.13-true ✓
- CeleryExecutor-3.10-v1.30.13-false ✓
- LocalExecutor-3.10-v1.30.13-true ✓
- LocalExecutor-3.10-v1.30.13-false ✓

closes #66511

---

- [x] I think this PR should be tested with Breeze
- [x] In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed. In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] I have considered the AI disclosure below.

**AI disclosure:** AI-assisted development (Claude Code) — human-reviewed and tested.