### PR TITLE
Support inline ignore marker for check-sdk-imports hook

### DIFF
--- a/scripts/ci/prek/check_sdk_imports.py
+++ b/scripts/ci/prek/check_sdk_imports.py
@@ -29,9 +29,9 @@ import ast
 import sys
 from pathlib import Path
 
-from common_prek_utils import console
+from common_prek_utils import console, has_nocheck_marker
 
-NOCHECK_MARKER = "# nocheck: sdk-imports"
+NOCHECK_MARKER = "# noqa: SDK001"
 
 
 def check_file_for_sdk_imports(file_path: Path) -> list[tuple[int, str]]:
@@ -49,23 +49,13 @@ def check_file_for_sdk_imports(file_path: Path) -> list[tuple[int, str]]:
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             if node.module and ("airflow.sdk" in node.module):
-                if _has_nocheck_marker(source_lines, node):
+                if has_nocheck_marker(source_lines, node, NOCHECK_MARKER):
                     continue
                 import_names = ", ".join(alias.name for alias in node.names)
                 statement = f"from {node.module} import {import_names}"
                 mismatches.append((node.lineno, statement))
 
     return mismatches
-
-
-def _has_nocheck_marker(source_lines: list[str], node: ast.Import | ast.ImportFrom) -> bool:
-    """Check if the import statement has the nocheck marker comment on any of its lines."""
-    start = node.lineno
-    end = node.end_lineno or start
-    for lineno in range(start, end + 1):
-        if lineno <= len(source_lines) and NOCHECK_MARKER in source_lines[lineno - 1]:
-            return True
-    return False
 
 
 def main():

--- a/scripts/ci/prek/check_sdk_imports.py
+++ b/scripts/ci/prek/check_sdk_imports.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 from common_prek_utils import console
 
+NOCHECK_MARKER = "# nocheck: sdk-imports"
+
 
 def check_file_for_sdk_imports(file_path: Path) -> list[tuple[int, str]]:
     """Check file for airflow.sdk imports. Returns list of (line_num, import_statement)."""
@@ -41,16 +43,29 @@ def check_file_for_sdk_imports(file_path: Path) -> list[tuple[int, str]]:
     except (OSError, UnicodeDecodeError, SyntaxError):
         return []
 
+    source_lines = source.splitlines()
     mismatches = []
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             if node.module and ("airflow.sdk" in node.module):
+                if _has_nocheck_marker(source_lines, node):
+                    continue
                 import_names = ", ".join(alias.name for alias in node.names)
                 statement = f"from {node.module} import {import_names}"
                 mismatches.append((node.lineno, statement))
 
     return mismatches
+
+
+def _has_nocheck_marker(source_lines: list[str], node: ast.Import | ast.ImportFrom) -> bool:
+    """Check if the import statement has the nocheck marker comment on any of its lines."""
+    start = node.lineno
+    end = node.end_lineno or start
+    for lineno in range(start, end + 1):
+        if lineno <= len(source_lines) and NOCHECK_MARKER in source_lines[lineno - 1]:
+            return True
+    return False
 
 
 def main():

--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -521,6 +521,16 @@ def get_all_provider_info_dicts() -> dict[str, dict]:
     return providers
 
 
+def has_nocheck_marker(source_lines: list[str], node: ast.ImportFrom, marker: str) -> bool:
+    """Check if the import statement has the given nocheck marker comment on any of its lines."""
+    start = node.lineno
+    end = node.end_lineno or start
+    for lineno in range(start, end + 1):
+        if lineno <= len(source_lines) and marker in source_lines[lineno - 1]:
+            return True
+    return False
+
+
 def get_imports_from_file(file_path: Path, *, only_top_level: bool) -> list[str]:
     """
     Returns list of all imports in file.

--- a/scripts/tests/ci/prek/test_check_sdk_imports.py
+++ b/scripts/tests/ci/prek/test_check_sdk_imports.py
@@ -65,17 +65,17 @@ class TestNocheckMarker:
         "code, expected",
         [
             pytest.param(
-                "from airflow.sdk import DAG  # nocheck: sdk-imports\n",
+                "from airflow.sdk import DAG  # noqa: SDK001\n",
                 [],
                 id="from-import-suppressed",
             ),
             pytest.param(
-                "from airflow.sdk.definitions import dag  # nocheck: sdk-imports\n",
+                "from airflow.sdk.definitions import dag  # noqa: SDK001\n",
                 [],
                 id="from-submodule-suppressed",
             ),
             pytest.param(
-                "from airflow.sdk import DAG  # nocheck: sdk-imports - needed for compat\n",
+                "from airflow.sdk import DAG  # noqa: SDK001 - needed for compat\n",
                 [],
                 id="marker-with-extra-text",
             ),
@@ -84,14 +84,14 @@ class TestNocheckMarker:
                     from airflow.sdk import (
                         DAG,
                         Variable,
-                    )  # nocheck: sdk-imports
+                    )  # noqa: SDK001
                 """),
                 [],
                 id="multiline-marker-on-closing-paren",
             ),
             pytest.param(
                 textwrap.dedent("""\
-                    from airflow.sdk import (  # nocheck: sdk-imports
+                    from airflow.sdk import (  # noqa: SDK001
                         DAG,
                         Variable,
                     )
@@ -102,7 +102,7 @@ class TestNocheckMarker:
             pytest.param(
                 textwrap.dedent("""\
                     from airflow.sdk import (
-                        DAG,  # nocheck: sdk-imports
+                        DAG,  # noqa: SDK001
                         Variable,
                     )
                 """),
@@ -126,7 +126,7 @@ class TestNocheckMarker:
             ),
             pytest.param(
                 textwrap.dedent("""\
-                    from airflow.sdk import DAG  # nocheck: sdk-imports
+                    from airflow.sdk import DAG  # noqa: SDK001
                     from airflow.sdk.definitions import dag
                 """),
                 [(2, "from airflow.sdk.definitions import dag")],

--- a/scripts/tests/ci/prek/test_check_sdk_imports.py
+++ b/scripts/tests/ci/prek/test_check_sdk_imports.py
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from check_sdk_imports import check_file_for_sdk_imports
+
+
+class TestCheckFileForSdkImports:
+    @pytest.mark.parametrize(
+        "code, expected",
+        [
+            pytest.param(
+                "from airflow.sdk import DAG\n",
+                [(1, "from airflow.sdk import DAG")],
+                id="from-sdk-import",
+            ),
+            pytest.param(
+                "from airflow.sdk.definitions import dag\n",
+                [(1, "from airflow.sdk.definitions import dag")],
+                id="from-sdk-submodule-import",
+            ),
+            pytest.param(
+                "from airflow.models import DagRun\n",
+                [],
+                id="core-import-allowed",
+            ),
+            pytest.param(
+                "import airflow.sdk\n",
+                [],
+                id="plain-import-not-checked",
+            ),
+            pytest.param(
+                "import os\nimport sys\n",
+                [],
+                id="stdlib-only",
+            ),
+        ],
+    )
+    def test_detects_sdk_imports(self, tmp_path: Path, code: str, expected: list[tuple[int, str]]):
+        f = tmp_path / "example.py"
+        f.write_text(code)
+        assert check_file_for_sdk_imports(f) == expected
+
+
+class TestNocheckMarker:
+    @pytest.mark.parametrize(
+        "code, expected",
+        [
+            pytest.param(
+                "from airflow.sdk import DAG  # nocheck: sdk-imports\n",
+                [],
+                id="from-import-suppressed",
+            ),
+            pytest.param(
+                "from airflow.sdk.definitions import dag  # nocheck: sdk-imports\n",
+                [],
+                id="from-submodule-suppressed",
+            ),
+            pytest.param(
+                "from airflow.sdk import DAG  # nocheck: sdk-imports - needed for compat\n",
+                [],
+                id="marker-with-extra-text",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    from airflow.sdk import (
+                        DAG,
+                        Variable,
+                    )  # nocheck: sdk-imports
+                """),
+                [],
+                id="multiline-marker-on-closing-paren",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    from airflow.sdk import (  # nocheck: sdk-imports
+                        DAG,
+                        Variable,
+                    )
+                """),
+                [],
+                id="multiline-marker-on-first-line",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    from airflow.sdk import (
+                        DAG,  # nocheck: sdk-imports
+                        Variable,
+                    )
+                """),
+                [],
+                id="multiline-marker-on-middle-line",
+            ),
+            pytest.param(
+                "from airflow.sdk import DAG  # noqa: E402\n",
+                [(1, "from airflow.sdk import DAG")],
+                id="wrong-marker-not-suppressed",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    from airflow.sdk import (
+                        DAG,
+                        Variable,
+                    )
+                """),
+                [(1, "from airflow.sdk import DAG, Variable")],
+                id="multiline-without-marker-detected",
+            ),
+            pytest.param(
+                textwrap.dedent("""\
+                    from airflow.sdk import DAG  # nocheck: sdk-imports
+                    from airflow.sdk.definitions import dag
+                """),
+                [(2, "from airflow.sdk.definitions import dag")],
+                id="only-marked-line-suppressed",
+            ),
+        ],
+    )
+    def test_nocheck_marker(self, tmp_path: Path, code: str, expected: list[tuple[int, str]]):
+        f = tmp_path / "example.py"
+        f.write_text(code)
+        assert check_file_for_sdk_imports(f) == expected


### PR DESCRIPTION

- related: #65358

## Why

There are cases where importing `airflow.sdk` modules in airflow-core is intentionally needed, but the `check-sdk-imports` prek hook has no way to suppress individual violations. Mirrors the `# nocheck: core-imports` support added for `check_core_imports_in_sdk` in #65358.

## What

- Add `# nocheck: sdk-imports` inline comment marker support to `check_sdk_imports.py`, allowing specific import lines to be excluded from the check.
- The marker works on both single-line and multi-line `from airflow.sdk import (...)` statements (on the first line, any middle line, or the closing paren line).
- Add tests for the `check_sdk_imports` hook covering both the existing detection behavior and the new nocheck marker.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
