### PR TITLE
feat(cli): add `partitions clear` to reset DagRun partition fields

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import textwrap
 from collections.abc import Callable, Iterable
+from datetime import datetime
 from typing import NamedTuple
 
 import lazy_object_proxy
@@ -38,6 +40,15 @@ from airflow.utils.cli import ColorMode
 from airflow.utils.state import DagRunState
 
 BUILD_DOCS = "BUILDING_AIRFLOW_DOCS" in os.environ
+
+_PARTITION_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def _parse_partition_date_str(value: str) -> datetime:
+    """Strict YYYY-MM-DD parser shared by --start-date / --end-date / --date."""
+    if not _PARTITION_DATE_RE.fullmatch(value):
+        raise ValueError(f"expected date in YYYY-MM-DD format, got: {value!r}")
+    return parsedate(value)
 
 
 def lazy_load_command(import_path: str) -> Callable:
@@ -1056,13 +1067,13 @@ ARG_PARTITIONS_CLEAR_DAG_ID = Arg(
 )
 ARG_PARTITIONS_CLEAR_START_DATE = Arg(
     ("-s", "--start-date"),
-    help="Only clear DagRuns whose partition_date is on or after this date",
-    type=parsedate,
+    help="Only clear DagRuns whose partition_date is on or after this date (date must be YYYY-MM-DD)",
+    type=_parse_partition_date_str,
 )
 ARG_PARTITIONS_CLEAR_END_DATE = Arg(
     ("-e", "--end-date"),
-    help="Only clear DagRuns whose partition_date is on or before this date",
-    type=parsedate,
+    help="Only clear DagRuns whose partition_date is on or before this date (date must be YYYY-MM-DD)",
+    type=_parse_partition_date_str,
 )
 ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
     ("--dry-run",),
@@ -1079,7 +1090,8 @@ ARG_PARTITIONS_CLEAR_DATE_RANGE = Arg(
     type=str,
     help=(
         "Range expressed as `a~b` (e.g. `2026-01-01~2026-01-31`); equivalent to "
-        "`--start-date a --end-date b`. Mutually exclusive with `--start-date` / `--end-date`."
+        "`--start-date a --end-date b`. Mutually exclusive with `--start-date` / `--end-date`. "
+        "Both sides must be YYYY-MM-DD."
     ),
 )
 ARG_PARTITIONS_CLEAR_TASK_INSTANCES = Arg(

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1069,6 +1069,19 @@ ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
     help="Show which DagRuns would be cleared without modifying the database",
     action="store_true",
 )
+ARG_PARTITIONS_CLEAR_PARTITION_KEY = Arg(
+    ("-k", "--partition-key"),
+    type=str,
+    help="Only clear DagRuns whose `partition_key` equals this exact value",
+)
+ARG_PARTITIONS_CLEAR_DATE_RANGE = Arg(
+    ("--date",),
+    type=str,
+    help=(
+        "Range expressed as `a~b` (e.g. `2026-01-01~2026-01-31`); equivalent to "
+        "`--start-date a --end-date b`. Mutually exclusive with `--start-date` / `--end-date`."
+    ),
+)
 ARG_PARTITIONS_CLEAR_TASK_INSTANCES = Arg(
     ("--clear-task-instances",),
     help=(
@@ -1505,8 +1518,8 @@ PARTITIONS_COMMANDS = (
         help="Clear the partition_key and partition_date of one or more DagRuns",
         description=(
             "Clear the partition_key and partition_date columns on a Dag's DagRuns.\n"
-            "Either --run-id (single run) or a partition_date range "
-            "(--start-date and/or --end-date) is required.\n"
+            "Either --run-id (single run), --partition-key (exact match), or a partition_date range "
+            "(--start-date/--end-date or --date a~b) is required.\n"
             "Pass --clear-task-instances to additionally clear the matching DagRuns' "
             "task instances so finished runs go back to QUEUED and re-execute."
         ),
@@ -1516,6 +1529,8 @@ PARTITIONS_COMMANDS = (
             ARG_RUN_ID,
             ARG_PARTITIONS_CLEAR_START_DATE,
             ARG_PARTITIONS_CLEAR_END_DATE,
+            ARG_PARTITIONS_CLEAR_PARTITION_KEY,
+            ARG_PARTITIONS_CLEAR_DATE_RANGE,
             ARG_PARTITIONS_CLEAR_TASK_INSTANCES,
             ARG_PARTITIONS_CLEAR_DRY_RUN,
             ARG_VERBOSE,

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -23,10 +23,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import textwrap
 from collections.abc import Callable, Iterable
-from datetime import datetime
 from typing import NamedTuple
 
 import lazy_object_proxy
@@ -40,23 +38,6 @@ from airflow.utils.cli import ColorMode
 from airflow.utils.state import DagRunState
 
 BUILD_DOCS = "BUILDING_AIRFLOW_DOCS" in os.environ
-
-_PARTITION_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
-
-
-def _parse_partition_date_str(value: str) -> tuple[datetime, bool]:
-    """
-    Parse --start-date / --end-date / --date side; return (parsed, is_date_only).
-
-    Accepts YYYY-MM-DD or any ISO datetime pendulum understands. The is_date_only
-    flag is used by the caller to decide whether to clamp an end-date to end-of-day.
-    """
-    try:
-        parsed = parsedate(value)
-    except Exception as exc:
-        raise ValueError(f"could not parse {value!r} as a date or datetime") from exc
-    is_date_only = bool(_PARTITION_DATE_RE.fullmatch(value))
-    return parsed, is_date_only
 
 
 def lazy_load_command(import_path: str) -> Callable:
@@ -1075,19 +1056,13 @@ ARG_PARTITIONS_CLEAR_DAG_ID = Arg(
 )
 ARG_PARTITIONS_CLEAR_START_DATE = Arg(
     ("-s", "--start-date"),
-    help=(
-        "Only clear DagRuns whose partition_date is on or after this point "
-        "(YYYY-MM-DD or ISO datetime; date-only means 00:00:00)"
-    ),
-    type=str,
+    help="Inclusive lower bound of the partition_date window.",
+    type=parsedate,
 )
 ARG_PARTITIONS_CLEAR_END_DATE = Arg(
     ("-e", "--end-date"),
-    help=(
-        "Only clear DagRuns whose partition_date is on or before this point "
-        "(YYYY-MM-DD or ISO datetime; date-only is inclusive of the whole day)"
-    ),
-    type=str,
+    help="Inclusive upper bound of the partition_date window.",
+    type=parsedate,
 )
 ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
     ("--dry-run",),
@@ -1103,9 +1078,8 @@ ARG_PARTITIONS_CLEAR_DATE_RANGE = Arg(
     ("--date",),
     type=str,
     help=(
-        "Range expressed as 'a~b' (e.g. '2026-01-01~2026-01-31'); equivalent to --start-date a --end-date b. "
-        "Mutually exclusive with --start-date / --end-date. "
-        "Each side accepts YYYY-MM-DD or ISO datetime; date-only end side is inclusive of the whole day."
+        "Range expressed as 'a~b' (e.g. '2026-01-01~2026-01-31'); equivalent to "
+        "--start-date a --end-date b. Mutually exclusive with --start-date / --end-date."
     ),
 )
 ARG_PARTITIONS_CLEAR_TASK_INSTANCES = Arg(

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1048,6 +1048,28 @@ ARG_ASSET_NAME = Arg(("--name",), default="", help="Asset name")
 ARG_ASSET_URI = Arg(("--uri",), default="", help="Asset URI")
 ARG_ASSET_ALIAS = Arg(("--alias",), default=False, action="store_true", help="Show asset alias")
 
+# partitions clear
+ARG_PARTITIONS_CLEAR_DAG_ID = Arg(
+    ("-d", "--dag-id"),
+    help="The id of the dag whose DagRun partition fields should be cleared",
+    required=True,
+)
+ARG_PARTITIONS_CLEAR_START_DATE = Arg(
+    ("-s", "--start-date"),
+    help="Only clear DagRuns whose partition_date is on or after this date",
+    type=parsedate,
+)
+ARG_PARTITIONS_CLEAR_END_DATE = Arg(
+    ("-e", "--end-date"),
+    help="Only clear DagRuns whose partition_date is on or before this date",
+    type=parsedate,
+)
+ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
+    ("--dry-run",),
+    help="Show which DagRuns would be cleared without modifying the database",
+    action="store_true",
+)
+
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE,
     ARG_CONN_DESCRIPTION,
@@ -1467,6 +1489,26 @@ TASKS_COMMANDS = (
         help="Get the status of all task instances in a dag run",
         func=lazy_load_command("airflow.cli.commands.task_command.task_states_for_dag_run"),
         args=(ARG_DAG_ID, ARG_LOGICAL_DATE_OR_RUN_ID, ARG_OUTPUT, ARG_VERBOSE),
+    ),
+)
+PARTITIONS_COMMANDS = (
+    ActionCommand(
+        name="clear",
+        help="Clear the partition_key and partition_date of one or more DagRuns",
+        description=(
+            "Clear the partition_key and partition_date columns on a Dag's DagRuns.\n"
+            "Either --run-id (single run) or a partition_date range "
+            "(--start-date and/or --end-date) is required."
+        ),
+        func=lazy_load_command("airflow.cli.commands.partition_command.clear"),
+        args=(
+            ARG_PARTITIONS_CLEAR_DAG_ID,
+            ARG_RUN_ID,
+            ARG_PARTITIONS_CLEAR_START_DATE,
+            ARG_PARTITIONS_CLEAR_END_DATE,
+            ARG_PARTITIONS_CLEAR_DRY_RUN,
+            ARG_VERBOSE,
+        ),
     ),
 )
 POOLS_COMMANDS = (
@@ -2030,6 +2072,11 @@ core_commands: list[CLICommand] = [
         name="backfill",
         help="Manage backfills",
         subcommands=BACKFILL_COMMANDS,
+    ),
+    GroupCommand(
+        name="partitions",
+        help="Manage Dag run partition metadata",
+        subcommands=PARTITIONS_COMMANDS,
     ),
     GroupCommand(
         name="tasks",

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1051,7 +1051,7 @@ ARG_ASSET_ALIAS = Arg(("--alias",), default=False, action="store_true", help="Sh
 # partitions clear
 ARG_PARTITIONS_CLEAR_DAG_ID = Arg(
     ("-d", "--dag-id"),
-    help="The id of the dag whose DagRun partition fields should be cleared",
+    help="The id of the Dag whose DagRun partition fields should be cleared",
     required=True,
 )
 ARG_PARTITIONS_CLEAR_START_DATE = Arg(
@@ -1067,6 +1067,14 @@ ARG_PARTITIONS_CLEAR_END_DATE = Arg(
 ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
     ("--dry-run",),
     help="Show which DagRuns would be cleared without modifying the database",
+    action="store_true",
+)
+ARG_PARTITIONS_CLEAR_TASK_INSTANCES = Arg(
+    ("--clear-task-instances",),
+    help=(
+        "Also clear the matching DagRuns' task instances (resetting finished runs back to "
+        "QUEUED so they re-execute), in addition to clearing the partition fields."
+    ),
     action="store_true",
 )
 
@@ -1498,7 +1506,9 @@ PARTITIONS_COMMANDS = (
         description=(
             "Clear the partition_key and partition_date columns on a Dag's DagRuns.\n"
             "Either --run-id (single run) or a partition_date range "
-            "(--start-date and/or --end-date) is required."
+            "(--start-date and/or --end-date) is required.\n"
+            "Pass --clear-task-instances to additionally clear the matching DagRuns' "
+            "task instances so finished runs go back to QUEUED and re-execute."
         ),
         func=lazy_load_command("airflow.cli.commands.partition_command.clear"),
         args=(
@@ -1506,6 +1516,7 @@ PARTITIONS_COMMANDS = (
             ARG_RUN_ID,
             ARG_PARTITIONS_CLEAR_START_DATE,
             ARG_PARTITIONS_CLEAR_END_DATE,
+            ARG_PARTITIONS_CLEAR_TASK_INSTANCES,
             ARG_PARTITIONS_CLEAR_DRY_RUN,
             ARG_VERBOSE,
         ),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -44,11 +44,19 @@ BUILD_DOCS = "BUILDING_AIRFLOW_DOCS" in os.environ
 _PARTITION_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
-def _parse_partition_date_str(value: str) -> datetime:
-    """Strict YYYY-MM-DD parser shared by --start-date / --end-date / --date."""
-    if not _PARTITION_DATE_RE.fullmatch(value):
-        raise ValueError(f"expected date in YYYY-MM-DD format, got: {value!r}")
-    return parsedate(value)
+def _parse_partition_date_str(value: str) -> tuple[datetime, bool]:
+    """
+    Parse --start-date / --end-date / --date side; return (parsed, is_date_only).
+
+    Accepts YYYY-MM-DD or any ISO datetime pendulum understands. The is_date_only
+    flag is used by the caller to decide whether to clamp an end-date to end-of-day.
+    """
+    try:
+        parsed = parsedate(value)
+    except Exception as exc:
+        raise ValueError(f"could not parse {value!r} as a date or datetime") from exc
+    is_date_only = bool(_PARTITION_DATE_RE.fullmatch(value))
+    return parsed, is_date_only
 
 
 def lazy_load_command(import_path: str) -> Callable:
@@ -1067,13 +1075,19 @@ ARG_PARTITIONS_CLEAR_DAG_ID = Arg(
 )
 ARG_PARTITIONS_CLEAR_START_DATE = Arg(
     ("-s", "--start-date"),
-    help="Only clear DagRuns whose partition_date is on or after this date (date must be YYYY-MM-DD)",
-    type=_parse_partition_date_str,
+    help=(
+        "Only clear DagRuns whose partition_date is on or after this point "
+        "(YYYY-MM-DD or ISO datetime; date-only means 00:00:00)"
+    ),
+    type=str,
 )
 ARG_PARTITIONS_CLEAR_END_DATE = Arg(
     ("-e", "--end-date"),
-    help="Only clear DagRuns whose partition_date is on or before this date (date must be YYYY-MM-DD)",
-    type=_parse_partition_date_str,
+    help=(
+        "Only clear DagRuns whose partition_date is on or before this point "
+        "(YYYY-MM-DD or ISO datetime; date-only is inclusive of the whole day)"
+    ),
+    type=str,
 )
 ARG_PARTITIONS_CLEAR_DRY_RUN = Arg(
     ("--dry-run",),
@@ -1089,9 +1103,9 @@ ARG_PARTITIONS_CLEAR_DATE_RANGE = Arg(
     ("--date",),
     type=str,
     help=(
-        "Range expressed as `a~b` (e.g. `2026-01-01~2026-01-31`); equivalent to "
-        "`--start-date a --end-date b`. Mutually exclusive with `--start-date` / `--end-date`. "
-        "Both sides must be YYYY-MM-DD."
+        "Range expressed as 'a~b' (e.g. '2026-01-01~2026-01-31'); equivalent to --start-date a --end-date b. "
+        "Mutually exclusive with --start-date / --end-date. "
+        "Each side accepts YYYY-MM-DD or ISO datetime; date-only end side is inclusive of the whole day."
     ),
 )
 ARG_PARTITIONS_CLEAR_TASK_INSTANCES = Arg(

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select
 
+from airflow._shared.timezones.timezone import parse as parsedate
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.utils import cli as cli_utils
@@ -39,16 +40,31 @@ DR_CHUNK_SIZE = 500
 @provide_session
 def clear(args, *, session: Session = NEW_SESSION) -> None:
     """Clear the partition_key and partition_date of matching DagRuns."""
-    has_range = args.start_date is not None or args.end_date is not None
-    if not args.run_id and not has_range:
+    has_range = args.start_date is not None or args.end_date is not None or args.date is not None
+    selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])
+    if selectors_used == 0:
         raise SystemExit(
-            "Specify either --run-id for a single DagRun, or a partition_date range "
-            "via --start-date and/or --end-date."
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
         )
-    if args.run_id and has_range:
+    if selectors_used > 1:
         raise SystemExit(
-            "--run-id cannot be combined with a partition_date range (--start-date / --end-date)."
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
         )
+
+    if args.date is not None:
+        if args.start_date is not None or args.end_date is not None:
+            raise SystemExit("--date cannot be combined with --start-date / --end-date.")
+        raw = args.date
+        parts = raw.split("~", 1)
+        if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+            raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
+        try:
+            args.start_date = parsedate(parts[0].strip())
+            args.end_date = parsedate(parts[1].strip())
+        except ValueError:
+            raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
 
     if args.end_date is not None:
         args.end_date = args.end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
@@ -56,6 +72,8 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     stmt = select(DagRun).where(DagRun.dag_id == args.dag_id)
     if args.run_id:
         stmt = stmt.where(DagRun.run_id == args.run_id)
+    elif args.partition_key is not None:
+        stmt = stmt.where(DagRun.partition_key == args.partition_key)
     else:
         stmt = stmt.where(or_(DagRun.partition_key.is_not(None), DagRun.partition_date.is_not(None)))
         if args.start_date is not None:

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -23,12 +23,15 @@ from typing import TYPE_CHECKING
 from sqlalchemy import or_, select
 
 from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.utils import cli as cli_utils
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+DR_CHUNK_SIZE = 500
 
 
 @cli_utils.action_cli
@@ -39,11 +42,16 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     has_range = args.start_date is not None or args.end_date is not None
     if not args.run_id and not has_range:
         raise SystemExit(
-            "Specify either --run-id for a single DagRun or a partition_date range "
-            "via --start-date / --end-date."
+            "Specify either --run-id for a single DagRun, or a partition_date range "
+            "via --start-date and/or --end-date."
         )
     if args.run_id and has_range:
-        raise SystemExit("--run-id cannot be combined with --start-date / --end-date.")
+        raise SystemExit(
+            "--run-id cannot be combined with a partition_date range (--start-date / --end-date)."
+        )
+
+    if args.end_date is not None:
+        args.end_date = args.end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
     stmt = select(DagRun).where(DagRun.dag_id == args.dag_id)
     if args.run_id:
@@ -56,25 +64,75 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             stmt = stmt.where(DagRun.partition_date <= args.end_date)
     stmt = stmt.order_by(DagRun.partition_date, DagRun.run_id)
 
-    runs = session.scalars(stmt).all()
-    if not runs:
+    clear_tis = bool(args.clear_task_instances)
+    cleared = 0
+    processed_any = False
+
+    # For --clear-task-instances: buffer run_ids, flush in DR_CHUNK_SIZE batches.
+    # task_instances is a lazy-select relationship; avoid N+1 by issuing one explicit
+    # SELECT per chunk instead of accessing run.task_instances directly.
+    ti_buffer_run_ids: list[str] = []
+    tis_cleared_total = 0
+    runs_for_ti_total = 0
+    tis_dry_total = 0
+    runs_for_ti_dry = 0
+
+    for run in session.scalars(stmt).yield_per(100):
+        processed_any = True
+        fields_already_cleared = run.partition_key is None and run.partition_date is None
+        if fields_already_cleared and not clear_tis:
+            print(f"DagRun {run.run_id}: already cleared, skipping.")
+            continue
+        if not fields_already_cleared:
+            print(
+                f"DagRun {run.run_id}: "
+                f"partition_key={run.partition_key!r} -> None, "
+                f"partition_date={run.partition_date.isoformat() if run.partition_date else None} -> None"
+            )
+            if not args.dry_run:
+                run.partition_key = None
+                run.partition_date = None
+            cleared += 1
+        if clear_tis:
+            if args.dry_run:
+                run_tis = session.scalars(select(TaskInstance).where(TaskInstance.run_id == run.run_id)).all()
+                tis_dry_total += len(run_tis)
+                runs_for_ti_dry += 1
+            else:
+                ti_buffer_run_ids.append(run.run_id)
+                runs_for_ti_total += 1
+                if len(ti_buffer_run_ids) >= DR_CHUNK_SIZE:
+                    chunk_tis = list(
+                        session.scalars(
+                            select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids))
+                        )
+                    )
+                    clear_task_instances(chunk_tis, session=session)
+                    tis_cleared_total += len(chunk_tis)
+                    ti_buffer_run_ids.clear()
+
+    if not processed_any:
         print(f"No matching DagRuns found for dag_id={args.dag_id}.")
         return
 
-    cleared = 0
-    for run in runs:
-        if run.partition_key is None and run.partition_date is None:
-            print(f"DagRun {run.run_id}: already cleared, skipping.")
-            continue
-        print(
-            f"DagRun {run.run_id}: "
-            f"partition_key={run.partition_key!r} -> None, "
-            f"partition_date={run.partition_date.isoformat() if run.partition_date else None} -> None"
-        )
-        if not args.dry_run:
-            run.partition_key = None
-            run.partition_date = None
-        cleared += 1
+    # Flush the tail of the TI buffer after the loop.
+    if clear_tis:
+        if args.dry_run:
+            print(
+                f"Dry run: would clear task instances on {runs_for_ti_dry} "
+                f"DagRun(s) ({tis_dry_total} task instance(s))."
+            )
+        else:
+            if ti_buffer_run_ids:
+                chunk_tis = list(
+                    session.scalars(select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids)))
+                )
+                clear_task_instances(chunk_tis, session=session)
+                tis_cleared_total += len(chunk_tis)
+            print(
+                f"Cleared task instances on {runs_for_ti_total} "
+                f"DagRun(s) ({tis_cleared_total} task instance(s))."
+            )
 
     if args.dry_run:
         print(f"Dry run: would clear {cleared} DagRun(s). No changes written.")

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select
 
-from airflow._shared.timezones.timezone import parse as parsedate
+from airflow.cli.cli_config import _parse_partition_date_str
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.utils import cli as cli_utils
@@ -56,10 +56,10 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
             raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
         try:
-            args.start_date = parsedate(parts[0].strip())
-            args.end_date = parsedate(parts[1].strip())
+            args.start_date = _parse_partition_date_str(parts[0].strip())
+            args.end_date = _parse_partition_date_str(parts[1].strip())
         except ValueError:
-            raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
+            raise SystemExit("--date sides must be in YYYY-MM-DD format, e.g. '2026-01-01~2026-01-31'.")
 
     if args.end_date is not None:
         args.end_date = args.end_date.replace(hour=23, minute=59, second=59, microsecond=999999)

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -77,6 +77,10 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             "(--start-date/--end-date or --date)."
         )
 
+    start_date = None
+    end_date = None
+    end_is_date_only = False
+
     if args.date is not None:
         if args.start_date is not None or args.end_date is not None:
             raise SystemExit("--date cannot be combined with --start-date / --end-date.")
@@ -85,13 +89,24 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
             raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
         try:
-            args.start_date = _parse_partition_date_str(parts[0].strip())
-            args.end_date = _parse_partition_date_str(parts[1].strip())
+            start_date, _ = _parse_partition_date_str(parts[0].strip())
+            end_date, end_is_date_only = _parse_partition_date_str(parts[1].strip())
         except ValueError:
-            raise SystemExit("--date sides must be in YYYY-MM-DD format, e.g. '2026-01-01~2026-01-31'.")
+            raise SystemExit("--date sides must be parseable as YYYY-MM-DD or ISO datetime.")
+    else:
+        if args.start_date is not None:
+            try:
+                start_date, _ = _parse_partition_date_str(args.start_date)
+            except ValueError as exc:
+                raise SystemExit(str(exc)) from exc
+        if args.end_date is not None:
+            try:
+                end_date, end_is_date_only = _parse_partition_date_str(args.end_date)
+            except ValueError as exc:
+                raise SystemExit(str(exc)) from exc
 
-    if args.end_date is not None:
-        args.end_date = args.end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+    if end_date is not None and end_is_date_only:
+        end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
     stmt = select(DagRun).where(DagRun.dag_id == args.dag_id)
     if args.run_id:
@@ -100,10 +115,10 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         stmt = stmt.where(DagRun.partition_key == args.partition_key)
     else:
         stmt = stmt.where(or_(DagRun.partition_key.is_not(None), DagRun.partition_date.is_not(None)))
-        if args.start_date is not None:
-            stmt = stmt.where(DagRun.partition_date >= args.start_date)
-        if args.end_date is not None:
-            stmt = stmt.where(DagRun.partition_date <= args.end_date)
+        if start_date is not None:
+            stmt = stmt.where(DagRun.partition_date >= start_date)
+        if end_date is not None:
+            stmt = stmt.where(DagRun.partition_date <= end_date)
     stmt = stmt.order_by(DagRun.partition_date, DagRun.run_id)
 
     clear_tis = bool(args.clear_task_instances)

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -32,7 +32,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-DR_CHUNK_SIZE = 500
+TI_CHUNK_SIZE = 500
 
 
 @cli_utils.action_cli
@@ -81,10 +81,13 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     cleared = 0
     processed_any = False
 
-    # For --clear-task-instances: buffer run_ids, flush in DR_CHUNK_SIZE batches.
-    # task_instances is a lazy-select relationship; avoid N+1 by issuing one explicit
-    # SELECT per chunk instead of accessing run.task_instances directly.
+    # For --clear-task-instances: run_ids are buffered so that TIs are fetched with a single
+    # SELECT IN per chunk (avoiding N+1).  The fetched TIs are then flushed to
+    # clear_task_instances in slices of TI_CHUNK_SIZE, batched by TI count rather than
+    # DagRun count.  Any leftover TIs that do not fill a full slice are carried forward and
+    # combined with the next SELECT's results before the next set of slices is cut.
     ti_buffer_run_ids: list[str] = []
+    ti_carry: list[TaskInstance] = []
     tis_cleared_total = 0
     runs_for_ti_total = 0
     tis_dry_total = 0
@@ -114,21 +117,26 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             else:
                 ti_buffer_run_ids.append(run.run_id)
                 runs_for_ti_total += 1
-                if len(ti_buffer_run_ids) >= DR_CHUNK_SIZE:
+                if len(ti_buffer_run_ids) >= TI_CHUNK_SIZE:
                     chunk_tis = list(
                         session.scalars(
                             select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids))
                         )
                     )
-                    clear_task_instances(chunk_tis, session=session)
-                    tis_cleared_total += len(chunk_tis)
                     ti_buffer_run_ids.clear()
+                    ti_carry.extend(chunk_tis)
+                    while len(ti_carry) >= TI_CHUNK_SIZE:
+                        slice_tis = ti_carry[:TI_CHUNK_SIZE]
+                        ti_carry = ti_carry[TI_CHUNK_SIZE:]
+                        clear_task_instances(slice_tis, session=session)
+                        tis_cleared_total += len(slice_tis)
 
     if not processed_any:
         print(f"No matching DagRuns found for dag_id={args.dag_id}.")
         return
 
-    # Flush the tail of the TI buffer after the loop.
+    # Flush the tail: fetch any remaining buffered run_ids, combine with carry, then
+    # cut full slices and send the final partial slice.
     if clear_tis:
         if args.dry_run:
             print(
@@ -137,11 +145,18 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             )
         else:
             if ti_buffer_run_ids:
-                chunk_tis = list(
+                tail_tis = list(
                     session.scalars(select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids)))
                 )
-                clear_task_instances(chunk_tis, session=session)
-                tis_cleared_total += len(chunk_tis)
+                ti_carry.extend(tail_tis)
+            while len(ti_carry) >= TI_CHUNK_SIZE:
+                slice_tis = ti_carry[:TI_CHUNK_SIZE]
+                ti_carry = ti_carry[TI_CHUNK_SIZE:]
+                clear_task_instances(slice_tis, session=session)
+                tis_cleared_total += len(slice_tis)
+            if ti_carry:
+                clear_task_instances(ti_carry, session=session)
+                tis_cleared_total += len(ti_carry)
             print(
                 f"Cleared task instances on {runs_for_ti_total} "
                 f"DagRun(s) ({tis_cleared_total} task instance(s))."

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -42,12 +42,7 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     """Clear the partition_key and partition_date of matching DagRuns."""
     has_range = args.start_date is not None or args.end_date is not None or args.date is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])
-    if selectors_used == 0:
-        raise SystemExit(
-            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
-            "(--start-date/--end-date or --date)."
-        )
-    if selectors_used > 1:
+    if selectors_used != 1:
         raise SystemExit(
             "Specify exactly one of --run-id, --partition-key, or a partition_date range "
             "(--start-date/--end-date or --date)."

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Partitions sub-commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import or_, select
+
+from airflow.models.dagrun import DagRun
+from airflow.utils import cli as cli_utils
+from airflow.utils.providers_configuration_loader import providers_configuration_loaded
+from airflow.utils.session import NEW_SESSION, provide_session
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+@cli_utils.action_cli
+@providers_configuration_loaded
+@provide_session
+def clear(args, *, session: Session = NEW_SESSION) -> None:
+    """Clear the partition_key and partition_date of matching DagRuns."""
+    has_range = args.start_date is not None or args.end_date is not None
+    if not args.run_id and not has_range:
+        raise SystemExit(
+            "Specify either --run-id for a single DagRun or a partition_date range "
+            "via --start-date / --end-date."
+        )
+    if args.run_id and has_range:
+        raise SystemExit("--run-id cannot be combined with --start-date / --end-date.")
+
+    stmt = select(DagRun).where(DagRun.dag_id == args.dag_id)
+    if args.run_id:
+        stmt = stmt.where(DagRun.run_id == args.run_id)
+    else:
+        stmt = stmt.where(or_(DagRun.partition_key.is_not(None), DagRun.partition_date.is_not(None)))
+        if args.start_date is not None:
+            stmt = stmt.where(DagRun.partition_date >= args.start_date)
+        if args.end_date is not None:
+            stmt = stmt.where(DagRun.partition_date <= args.end_date)
+    stmt = stmt.order_by(DagRun.partition_date, DagRun.run_id)
+
+    runs = session.scalars(stmt).all()
+    if not runs:
+        print(f"No matching DagRuns found for dag_id={args.dag_id}.")
+        return
+
+    cleared = 0
+    for run in runs:
+        if run.partition_key is None and run.partition_date is None:
+            print(f"DagRun {run.run_id}: already cleared, skipping.")
+            continue
+        print(
+            f"DagRun {run.run_id}: "
+            f"partition_key={run.partition_key!r} -> None, "
+            f"partition_date={run.partition_date.isoformat() if run.partition_date else None} -> None"
+        )
+        if not args.dry_run:
+            run.partition_key = None
+            run.partition_date = None
+        cleared += 1
+
+    if args.dry_run:
+        print(f"Dry run: would clear {cleared} DagRun(s). No changes written.")
+    else:
+        print(f"Cleared partition fields on {cleared} DagRun(s).")

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -35,6 +35,35 @@ if TYPE_CHECKING:
 TI_CHUNK_SIZE = 500
 
 
+def _flush_buffer(
+    buffer: list[str],
+    carry: list[TaskInstance],
+    session: Session,
+    *,
+    drain: bool = False,
+) -> int:
+    """
+    Fetch TIs for buffered run_ids, extend carry, send full TI_CHUNK_SIZE slices.
+
+    If drain=True, also send the final partial slice (used at end of run).
+    Returns the total number of TIs sent to clear_task_instances by this call.
+    """
+    flushed = 0
+    if buffer:
+        chunk_tis = list(session.scalars(select(TaskInstance).where(TaskInstance.run_id.in_(buffer))))
+        buffer.clear()
+        carry.extend(chunk_tis)
+    while len(carry) >= TI_CHUNK_SIZE:
+        slice_tis = carry[:TI_CHUNK_SIZE]
+        del carry[:TI_CHUNK_SIZE]
+        clear_task_instances(slice_tis, session=session)
+        flushed += len(slice_tis)
+    if drain and carry:
+        clear_task_instances(carry, session=session)
+        flushed += len(carry)
+    return flushed
+
+
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -82,9 +111,9 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     processed_any = False
 
     # For --clear-task-instances: run_ids are buffered so that TIs are fetched with a single
-    # SELECT IN per chunk (avoiding N+1).  The fetched TIs are then flushed to
+    # SELECT IN per chunk (avoiding N+1). The fetched TIs are then flushed to
     # clear_task_instances in slices of TI_CHUNK_SIZE, batched by TI count rather than
-    # DagRun count.  Any leftover TIs that do not fill a full slice are carried forward and
+    # DagRun count. Any leftover TIs that do not fill a full slice are carried forward and
     # combined with the next SELECT's results before the next set of slices is cut.
     ti_buffer_run_ids: list[str] = []
     ti_carry: list[TaskInstance] = []
@@ -118,18 +147,7 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
                 ti_buffer_run_ids.append(run.run_id)
                 runs_for_ti_total += 1
                 if len(ti_buffer_run_ids) >= TI_CHUNK_SIZE:
-                    chunk_tis = list(
-                        session.scalars(
-                            select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids))
-                        )
-                    )
-                    ti_buffer_run_ids.clear()
-                    ti_carry.extend(chunk_tis)
-                    while len(ti_carry) >= TI_CHUNK_SIZE:
-                        slice_tis = ti_carry[:TI_CHUNK_SIZE]
-                        ti_carry = ti_carry[TI_CHUNK_SIZE:]
-                        clear_task_instances(slice_tis, session=session)
-                        tis_cleared_total += len(slice_tis)
+                    tis_cleared_total += _flush_buffer(ti_buffer_run_ids, ti_carry, session)
 
     if not processed_any:
         print(f"No matching DagRuns found for dag_id={args.dag_id}.")
@@ -144,19 +162,7 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
                 f"DagRun(s) ({tis_dry_total} task instance(s))."
             )
         else:
-            if ti_buffer_run_ids:
-                tail_tis = list(
-                    session.scalars(select(TaskInstance).where(TaskInstance.run_id.in_(ti_buffer_run_ids)))
-                )
-                ti_carry.extend(tail_tis)
-            while len(ti_carry) >= TI_CHUNK_SIZE:
-                slice_tis = ti_carry[:TI_CHUNK_SIZE]
-                ti_carry = ti_carry[TI_CHUNK_SIZE:]
-                clear_task_instances(slice_tis, session=session)
-                tis_cleared_total += len(slice_tis)
-            if ti_carry:
-                clear_task_instances(ti_carry, session=session)
-                tis_cleared_total += len(ti_carry)
+            tis_cleared_total += _flush_buffer(ti_buffer_run_ids, ti_carry, session, drain=True)
             print(
                 f"Cleared task instances on {runs_for_ti_total} "
                 f"DagRun(s) ({tis_cleared_total} task instance(s))."

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_, select
 
-from airflow.cli.cli_config import _parse_partition_date_str
+from airflow._shared.timezones.timezone import parse as parsedate
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.utils import cli as cli_utils
@@ -77,10 +77,6 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             "(--start-date/--end-date or --date)."
         )
 
-    start_date = None
-    end_date = None
-    end_is_date_only = False
-
     if args.date is not None:
         if args.start_date is not None or args.end_date is not None:
             raise SystemExit("--date cannot be combined with --start-date / --end-date.")
@@ -89,24 +85,10 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
             raise SystemExit("--date must be in the form 'a~b', e.g. '2026-01-01~2026-01-31'.")
         try:
-            start_date, _ = _parse_partition_date_str(parts[0].strip())
-            end_date, end_is_date_only = _parse_partition_date_str(parts[1].strip())
+            args.start_date = parsedate(parts[0].strip())
+            args.end_date = parsedate(parts[1].strip())
         except ValueError:
-            raise SystemExit("--date sides must be parseable as YYYY-MM-DD or ISO datetime.")
-    else:
-        if args.start_date is not None:
-            try:
-                start_date, _ = _parse_partition_date_str(args.start_date)
-            except ValueError as exc:
-                raise SystemExit(str(exc)) from exc
-        if args.end_date is not None:
-            try:
-                end_date, end_is_date_only = _parse_partition_date_str(args.end_date)
-            except ValueError as exc:
-                raise SystemExit(str(exc)) from exc
-
-    if end_date is not None and end_is_date_only:
-        end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+            raise SystemExit("--date sides must be parseable as a date or datetime.")
 
     stmt = select(DagRun).where(DagRun.dag_id == args.dag_id)
     if args.run_id:
@@ -115,10 +97,10 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         stmt = stmt.where(DagRun.partition_key == args.partition_key)
     else:
         stmt = stmt.where(or_(DagRun.partition_key.is_not(None), DagRun.partition_date.is_not(None)))
-        if start_date is not None:
-            stmt = stmt.where(DagRun.partition_date >= start_date)
-        if end_date is not None:
-            stmt = stmt.where(DagRun.partition_date <= end_date)
+        if args.start_date is not None:
+            stmt = stmt.where(DagRun.partition_date >= args.start_date)
+        if args.end_date is not None:
+            stmt = stmt.where(DagRun.partition_date <= args.end_date)
     stmt = stmt.order_by(DagRun.partition_date, DagRun.run_id)
 
     clear_tis = bool(args.clear_task_instances)

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -805,34 +805,6 @@ class TestPartitionsClear:
             )
         assert "--date must be in the form 'a~b'" in str(excinfo.value.code)
 
-    @pytest.mark.parametrize(
-        "bad_date",
-        [
-            "2026-01-02T01:00:00~2026-01-02T10:00:00",  # jason's original case
-            "2026-01-02~2026-01-02T10:00:00",  # mixed: date / datetime
-            "2026-1-2~2026-01-02",  # missing zero-pad
-            "2026-01-01~not-a-date",  # right side not YYYY-MM-DD
-        ],
-    )
-    def test_date_range_syntax_rejects_non_yyyy_mm_dd(self, parser, bad_date):
-        with pytest.raises(SystemExit) as excinfo:
-            partition_command.clear(
-                parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--date", bad_date])
-            )
-        assert "--date sides must be in YYYY-MM-DD format" in str(excinfo.value.code)
-
-    @pytest.mark.parametrize(
-        ("flag", "bad_value"),
-        [
-            ("--start-date", "2026-01-02T01:00:00"),
-            ("--end-date", "2026-01-02T10:00:00"),
-            ("--start-date", "2026-1-2"),
-        ],
-    )
-    def test_start_end_date_reject_non_yyyy_mm_dd(self, parser, flag, bad_value):
-        with pytest.raises(SystemExit):
-            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, flag, bad_value])
-
     def test_date_range_syntax_mutually_exclusive_with_start_end(self, parser):
         with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(
@@ -887,3 +859,171 @@ class TestPartitionsClear:
         assert run_1.partition_key == "2026-01-01T00:00:00"
         run_3 = _get_run("part_run_3")
         assert run_3.partition_key == "2026-01-03T00:00:00"
+
+    def test_clear_with_datetime_end_date_no_clamp(self, parser, dag_maker):
+        """--end-date with an ISO datetime is NOT clamped; runs after that point are excluded."""
+        dag_maker.create_dagrun(
+            run_id="part_run_h10",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 10, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T10:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_run_h15",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 15, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T15:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--end-date",
+                    "2026-01-02T10:00:00",
+                ]
+            )
+        )
+
+        # 10:00 is within the boundary (<=), must be cleared.
+        run_h10 = _get_run("part_run_h10")
+        assert run_h10.partition_key is None
+        assert run_h10.partition_date is None
+        # 15:00 exceeds the un-clamped 10:00 boundary, must be untouched.
+        run_h15 = _get_run("part_run_h15")
+        assert run_h15.partition_key == "2026-01-02T15:00:00"
+
+    def test_clear_with_date_only_end_date_clamps_to_end_of_day(self, parser, dag_maker):
+        """--end-date with a date-only value clamps to 23:59:59; mid-day runs are included."""
+        dag_maker.create_dagrun(
+            run_id="part_run_h11",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 11, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T11:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--end-date",
+                    "2026-01-02",
+                ]
+            )
+        )
+
+        # 11:00 on 2026-01-02 is within the clamped boundary (23:59:59.999999).
+        run_h11 = _get_run("part_run_h11")
+        assert run_h11.partition_key is None
+        assert run_h11.partition_date is None
+
+    def test_clear_hourly_window_via_start_end_date(self, parser, dag_maker):
+        """ISO datetime --start-date / --end-date selects only runs within the exact window."""
+        dag_maker.create_dagrun(
+            run_id="part_run_h02",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 2, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T02:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_run_h05",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 5, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T05:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_run_h11b",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 11, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T11:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--start-date",
+                    "2026-01-02T03:00:00",
+                    "--end-date",
+                    "2026-01-02T10:00:00",
+                ]
+            )
+        )
+
+        # 02:00 is before the window start — untouched.
+        run_h02 = _get_run("part_run_h02")
+        assert run_h02.partition_key == "2026-01-02T02:00:00"
+        # 05:00 is inside [03:00, 10:00] — cleared.
+        run_h05 = _get_run("part_run_h05")
+        assert run_h05.partition_key is None
+        assert run_h05.partition_date is None
+        # 11:00 is after the window end — untouched.
+        run_h11b = _get_run("part_run_h11b")
+        assert run_h11b.partition_key == "2026-01-02T11:00:00"
+
+    def test_clear_via_date_range_with_datetime_endpoints(self, parser, dag_maker):
+        """--date with ISO datetime endpoints does not clamp the right side."""
+        dag_maker.create_dagrun(
+            run_id="part_run_h02b",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 2, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T02:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_run_h05b",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 5, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T05:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="part_run_h11c",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 11, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T11:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--date",
+                    "2026-01-02T03:00:00~2026-01-02T10:00:00",
+                ]
+            )
+        )
+
+        # 02:00 is before window start — untouched.
+        run_h02b = _get_run("part_run_h02b")
+        assert run_h02b.partition_key == "2026-01-02T02:00:00"
+        # 05:00 is inside [03:00, 10:00] — cleared.
+        run_h05b = _get_run("part_run_h05b")
+        assert run_h05b.partition_key is None
+        assert run_h05b.partition_date is None
+        # 11:00 is after un-clamped 10:00 end — untouched.
+        run_h11c = _get_run("part_run_h11c")
+        assert run_h11c.partition_key == "2026-01-02T11:00:00"

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from unittest import mock
 
 import pendulum
 import pytest
@@ -25,12 +26,12 @@ from sqlalchemy import select
 from airflow.cli import cli_parser
 from airflow.cli.commands import partition_command
 from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import CronPartitionTimetable
 from airflow.utils.session import create_session
-from airflow.utils.state import DagRunState
+from airflow.utils.state import DagRunState, TaskInstanceState
 
-from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
 
 pytestmark = pytest.mark.db_test
@@ -91,20 +92,31 @@ def _get_run(run_id: str) -> DagRun:
     return run
 
 
-@pytest.fixture(autouse=True)
-def _disable_migration_check():
-    with conf_vars({("database", "check_migrations"): "False"}):
-        yield
+def _set_tis_state(run_id: str, state: TaskInstanceState) -> None:
+    with create_session() as session:
+        tis = session.scalars(select(TaskInstance).where(TaskInstance.run_id == run_id)).all()
+        for ti in tis:
+            ti.state = state
+        session.commit()
 
 
+def _get_tis(run_id: str) -> list[TaskInstance]:
+    with create_session() as session:
+        return list(session.scalars(select(TaskInstance).where(TaskInstance.run_id == run_id)))
+
+
+@pytest.mark.usefixtures("setup_partitioned_runs")
 class TestPartitionsClear:
-    def test_clear_single_run_id(self, parser, setup_partitioned_runs, capsys):
+    def test_clear_single_run_id(self, parser, capsys):
         partition_command.clear(
             parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_2"])
         )
         captured = capsys.readouterr()
-        assert "part_run_2" in captured.out
-        assert "Cleared partition fields on 1 DagRun(s)" in captured.out
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 1 DagRun(s).\n"
+        )
 
         run_2 = _get_run("part_run_2")
         assert run_2.partition_key is None
@@ -112,9 +124,9 @@ class TestPartitionsClear:
         # Other runs unchanged
         run_1 = _get_run("part_run_1")
         assert run_1.partition_key == "2026-01-01T00:00:00"
-        assert run_1.partition_date is not None
+        assert run_1.partition_date == datetime(2026, 1, 1, tzinfo=pendulum.UTC)
 
-    def test_clear_with_date_range(self, parser, setup_partitioned_runs, capsys):
+    def test_clear_with_date_range(self, parser, capsys):
         partition_command.clear(
             parser.parse_args(
                 [
@@ -130,7 +142,13 @@ class TestPartitionsClear:
             )
         )
         captured = capsys.readouterr()
-        assert "Cleared partition fields on 2 DagRun(s)" in captured.out
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "DagRun part_run_3: partition_key='2026-01-03T00:00:00' -> None, "
+            "partition_date=2026-01-03T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 2 DagRun(s).\n"
+        )
 
         # Out-of-range run untouched
         run_1 = _get_run("part_run_1")
@@ -141,7 +159,7 @@ class TestPartitionsClear:
             assert run.partition_key is None
             assert run.partition_date is None
 
-    def test_dry_run_does_not_modify(self, parser, setup_partitioned_runs, capsys):
+    def test_dry_run_does_not_modify(self, parser, capsys):
         partition_command.clear(
             parser.parse_args(
                 [
@@ -156,21 +174,34 @@ class TestPartitionsClear:
             )
         )
         captured = capsys.readouterr()
-        assert "Dry run: would clear 3 DagRun(s)" in captured.out
+        assert captured.out == (
+            "DagRun part_run_1: partition_key='2026-01-01T00:00:00' -> None, "
+            "partition_date=2026-01-01T00:00:00+00:00 -> None\n"
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "DagRun part_run_3: partition_key='2026-01-03T00:00:00' -> None, "
+            "partition_date=2026-01-03T00:00:00+00:00 -> None\n"
+            "Dry run: would clear 3 DagRun(s). No changes written.\n"
+        )
 
-        for run_id in ("part_run_1", "part_run_2", "part_run_3"):
+        expected = {
+            "part_run_1": ("2026-01-01T00:00:00", datetime(2026, 1, 1, tzinfo=pendulum.UTC)),
+            "part_run_2": ("2026-01-02T00:00:00", datetime(2026, 1, 2, tzinfo=pendulum.UTC)),
+            "part_run_3": ("2026-01-03T00:00:00", datetime(2026, 1, 3, tzinfo=pendulum.UTC)),
+        }
+        for run_id, (expected_key, expected_date) in expected.items():
             run = _get_run(run_id)
-            assert run.partition_key is not None
-            assert run.partition_date is not None
+            assert run.partition_key == expected_key
+            assert run.partition_date == expected_date
 
-    def test_no_match_prints_message(self, parser, setup_partitioned_runs, capsys):
+    def test_no_match_prints_message(self, parser, capsys):
         partition_command.clear(
             parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "does_not_exist"])
         )
         captured = capsys.readouterr()
-        assert "No matching DagRuns found" in captured.out
+        assert captured.out == f"No matching DagRuns found for dag_id={DAG_ID}.\n"
 
-    def test_already_cleared_run_is_skipped(self, parser, setup_partitioned_runs, capsys):
+    def test_already_cleared_run_is_skipped(self, parser, capsys):
         with create_session() as session:
             run = session.scalar(select(DagRun).where(DagRun.run_id == "part_run_1"))
             run.partition_key = None
@@ -181,15 +212,20 @@ class TestPartitionsClear:
             parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_1"])
         )
         captured = capsys.readouterr()
-        assert "already cleared" in captured.out
-        assert "Cleared partition fields on 0 DagRun(s)" in captured.out
+        assert captured.out == (
+            "DagRun part_run_1: already cleared, skipping.\nCleared partition fields on 0 DagRun(s).\n"
+        )
 
-    def test_requires_run_id_or_range(self, parser, setup_partitioned_runs):
-        with pytest.raises(SystemExit, match="Specify either --run-id"):
+    def test_requires_run_id_or_range(self, parser):
+        with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID]))
+        assert excinfo.value.code == (
+            "Specify either --run-id for a single DagRun, or a partition_date range "
+            "via --start-date and/or --end-date."
+        )
 
-    def test_run_id_and_range_mutually_exclusive(self, parser, setup_partitioned_runs):
-        with pytest.raises(SystemExit, match="cannot be combined"):
+    def test_run_id_and_range_mutually_exclusive(self, parser):
+        with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(
                 parser.parse_args(
                     [
@@ -204,11 +240,314 @@ class TestPartitionsClear:
                     ]
                 )
             )
+        assert excinfo.value.code == (
+            "--run-id cannot be combined with a partition_date range (--start-date / --end-date)."
+        )
 
-    def test_prints_before_values(self, parser, setup_partitioned_runs, capsys):
+    def test_prints_before_values(self, parser, capsys):
         partition_command.clear(
             parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_1"])
         )
         captured = capsys.readouterr()
-        assert "partition_key='2026-01-01T00:00:00' -> None" in captured.out
-        assert "partition_date=2026-01-01T00:00:00+00:00 -> None" in captured.out
+        assert captured.out == (
+            "DagRun part_run_1: partition_key='2026-01-01T00:00:00' -> None, "
+            "partition_date=2026-01-01T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 1 DagRun(s).\n"
+        )
+
+    def test_clear_task_instances_resets_run_and_tis(self, parser, capsys):
+        _set_tis_state("part_run_2", TaskInstanceState.SUCCESS)
+        before_clear_number = _get_run("part_run_2").clear_number
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--run-id",
+                    "part_run_2",
+                    "--clear-task-instances",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "Cleared task instances on 1 DagRun(s) (1 task instance(s)).\n"
+            "Cleared partition fields on 1 DagRun(s).\n"
+        )
+
+        run_2 = _get_run("part_run_2")
+        assert run_2.partition_key is None
+        assert run_2.partition_date is None
+        assert run_2.state == DagRunState.QUEUED
+        assert run_2.clear_number == before_clear_number + 1
+        assert all(ti.state is None for ti in _get_tis("part_run_2"))
+
+        # Untargeted run is unaffected.
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        assert run_1.state == DagRunState.SUCCESS
+
+    def test_clear_task_instances_dry_run_makes_no_changes(self, parser, capsys):
+        _set_tis_state("part_run_2", TaskInstanceState.SUCCESS)
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--run-id",
+                    "part_run_2",
+                    "--clear-task-instances",
+                    "--dry-run",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "Dry run: would clear task instances on 1 DagRun(s) (1 task instance(s)).\n"
+            "Dry run: would clear 1 DagRun(s). No changes written.\n"
+        )
+
+        run_2 = _get_run("part_run_2")
+        assert run_2.partition_key == "2026-01-02T00:00:00"
+        assert run_2.partition_date == datetime(2026, 1, 2, tzinfo=pendulum.UTC)
+        assert run_2.state == DagRunState.SUCCESS
+        assert all(ti.state == TaskInstanceState.SUCCESS for ti in _get_tis("part_run_2"))
+
+    def test_clear_task_instances_on_already_cleared_run(self, parser, capsys):
+        # Partition fields already None, but the user still wants to re-run the DagRun.
+        with create_session() as session:
+            run = session.scalar(select(DagRun).where(DagRun.run_id == "part_run_1"))
+            run.partition_key = None
+            run.partition_date = None
+            session.commit()
+        _set_tis_state("part_run_1", TaskInstanceState.SUCCESS)
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--run-id",
+                    "part_run_1",
+                    "--clear-task-instances",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "Cleared task instances on 1 DagRun(s) (1 task instance(s)).\n"
+            "Cleared partition fields on 0 DagRun(s).\n"
+        )
+
+        run_1 = _get_run("part_run_1")
+        assert run_1.state == DagRunState.QUEUED
+        assert all(ti.state is None for ti in _get_tis("part_run_1"))
+
+    def test_clear_end_date_includes_same_day_runs(self, parser, dag_maker):
+        """A run whose partition_date is mid-day on --end-date must be cleared (thread 4b fix)."""
+        # Insert a run with partition_date at 15:00 on 2026-01-02.  Without the end-of-day clamp,
+        # the filter is `partition_date <= 2026-01-02T00:00:00`, so 15:00 > midnight would NOT
+        # be matched.  With the clamp (<=  2026-01-02T23:59:59.999999) it must be cleared.
+        dag_maker.create_dagrun(
+            run_id="part_run_2_midday",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 15, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T15:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--start-date",
+                    "2026-01-02",
+                    "--end-date",
+                    "2026-01-02",
+                ]
+            )
+        )
+        run_midday = _get_run("part_run_2_midday")
+        assert run_midday.partition_key is None
+        assert run_midday.partition_date is None
+        # Runs outside the range are untouched.
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        run_3 = _get_run("part_run_3")
+        assert run_3.partition_key == "2026-01-03T00:00:00"
+
+    def test_clear_streams_runs_without_materialising(self, parser, dag_maker):
+        """Clearing 250 partitioned runs clears every one of them (streaming smoke test)."""
+        clear_db_runs()
+        clear_db_dags()
+        n = 250
+        with dag_maker(
+            "dag_stream_250",
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2024, 1, 1),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        for i in range(n):
+            dag_maker.create_dagrun(
+                run_id=f"stream_run_{i:04d}",
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
+                partition_key=f"2024-key-{i:04d}",
+            )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    "dag_stream_250",
+                    "--start-date",
+                    "2024-01-01",
+                    "--end-date",
+                    "2025-12-31",
+                ]
+            )
+        )
+
+        with create_session() as session:
+            runs = list(
+                session.scalars(
+                    select(DagRun).where(DagRun.dag_id == "dag_stream_250").order_by(DagRun.run_id)
+                )
+            )
+
+        cleared_run_ids = [r.run_id for r in runs if r.partition_key is None and r.partition_date is None]
+        expected_run_ids = [f"stream_run_{i:04d}" for i in range(n)]
+        assert cleared_run_ids == expected_run_ids
+
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_clear_task_instances_chunks_at_boundary(self, parser, dag_maker):
+        """Exactly DR_CHUNK_SIZE runs → clear_task_instances called once with all TIs."""
+        chunk_size = 3
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            "dag_chunk_boundary",
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2024, 1, 1),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        for i in range(chunk_size):
+            dag_maker.create_dagrun(
+                run_id=f"chunk_run_{i:04d}",
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
+                partition_key=f"chunk-key-{i:04d}",
+            )
+        dag_maker.sync_dagbag_to_db()
+
+        with (
+            mock.patch.object(partition_command, "DR_CHUNK_SIZE", chunk_size),
+            mock.patch(
+                "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
+            ) as mock_cti,
+        ):
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        "dag_chunk_boundary",
+                        "--start-date",
+                        "2024-01-01",
+                        "--end-date",
+                        "2025-12-31",
+                        "--clear-task-instances",
+                    ]
+                )
+            )
+
+        # Exactly one call: the flush at >= DR_CHUNK_SIZE triggers mid-loop.
+        assert len(mock_cti.mock_calls) == 1
+        first_call_tis = mock_cti.mock_calls[0].args[0]
+        assert len(first_call_tis) == chunk_size  # == 3 when patched
+
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_clear_task_instances_chunks_just_over_boundary(self, parser, dag_maker):
+        """DR_CHUNK_SIZE + 1 runs → two clear_task_instances calls (first full, second tail)."""
+        chunk_size = 3
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            "dag_chunk_over",
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2024, 1, 1),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        for i in range(chunk_size + 1):
+            dag_maker.create_dagrun(
+                run_id=f"over_run_{i:04d}",
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
+                partition_key=f"over-key-{i:04d}",
+            )
+        dag_maker.sync_dagbag_to_db()
+
+        with (
+            mock.patch.object(partition_command, "DR_CHUNK_SIZE", chunk_size),
+            mock.patch(
+                "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
+            ) as mock_cti,
+        ):
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        "dag_chunk_over",
+                        "--start-date",
+                        "2024-01-01",
+                        "--end-date",
+                        "2025-12-31",
+                        "--clear-task-instances",
+                    ]
+                )
+            )
+
+        # Two calls: first flush at DR_CHUNK_SIZE (3 TIs), tail flush with 1 TI.
+        assert len(mock_cti.mock_calls) == 2
+        first_call_tis = mock_cti.mock_calls[0].args[0]
+        second_call_tis = mock_cti.mock_calls[1].args[0]
+        assert len(first_call_tis) == chunk_size
+        assert len(second_call_tis) == 1
+
+        clear_db_runs()
+        clear_db_dags()

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -1,0 +1,214 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+import pendulum
+import pytest
+from sqlalchemy import select
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import partition_command
+from airflow.models.dagrun import DagRun
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import CronPartitionTimetable
+from airflow.utils.session import create_session
+from airflow.utils.state import DagRunState
+
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs
+
+pytestmark = pytest.mark.db_test
+
+
+DAG_ID = "test_partitions_clear_dag"
+
+
+@pytest.fixture
+def parser():
+    return cli_parser.get_parser()
+
+
+@pytest.fixture
+def setup_partitioned_runs(dag_maker):
+    clear_db_runs()
+    clear_db_dags()
+    with dag_maker(
+        DAG_ID,
+        schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+        start_date=datetime(2026, 1, 1),
+        catchup=True,
+        serialized=True,
+    ):
+        EmptyOperator(task_id="t1")
+    dag_maker.create_dagrun(
+        run_id="part_run_1",
+        state=DagRunState.SUCCESS,
+        logical_date=None,
+        partition_date=datetime(2026, 1, 1, tzinfo=pendulum.UTC),
+        partition_key="2026-01-01T00:00:00",
+    )
+    dag_maker.create_dagrun(
+        run_id="part_run_2",
+        state=DagRunState.SUCCESS,
+        logical_date=None,
+        partition_date=datetime(2026, 1, 2, tzinfo=pendulum.UTC),
+        partition_key="2026-01-02T00:00:00",
+    )
+    dag_maker.create_dagrun(
+        run_id="part_run_3",
+        state=DagRunState.SUCCESS,
+        logical_date=None,
+        partition_date=datetime(2026, 1, 3, tzinfo=pendulum.UTC),
+        partition_key="2026-01-03T00:00:00",
+    )
+    dag_maker.sync_dagbag_to_db()
+    yield
+    clear_db_runs()
+    clear_db_dags()
+
+
+def _get_run(run_id: str) -> DagRun:
+    with create_session() as session:
+        run = session.scalar(select(DagRun).where(DagRun.run_id == run_id))
+    if run is None:
+        raise AssertionError(f"DagRun {run_id} not found")
+    return run
+
+
+@pytest.fixture(autouse=True)
+def _disable_migration_check():
+    with conf_vars({("database", "check_migrations"): "False"}):
+        yield
+
+
+class TestPartitionsClear:
+    def test_clear_single_run_id(self, parser, setup_partitioned_runs, capsys):
+        partition_command.clear(
+            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_2"])
+        )
+        captured = capsys.readouterr()
+        assert "part_run_2" in captured.out
+        assert "Cleared partition fields on 1 DagRun(s)" in captured.out
+
+        run_2 = _get_run("part_run_2")
+        assert run_2.partition_key is None
+        assert run_2.partition_date is None
+        # Other runs unchanged
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        assert run_1.partition_date is not None
+
+    def test_clear_with_date_range(self, parser, setup_partitioned_runs, capsys):
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--start-date",
+                    "2026-01-02",
+                    "--end-date",
+                    "2026-01-03",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert "Cleared partition fields on 2 DagRun(s)" in captured.out
+
+        # Out-of-range run untouched
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        # In-range runs cleared
+        for run_id in ("part_run_2", "part_run_3"):
+            run = _get_run(run_id)
+            assert run.partition_key is None
+            assert run.partition_date is None
+
+    def test_dry_run_does_not_modify(self, parser, setup_partitioned_runs, capsys):
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--start-date",
+                    "2026-01-01",
+                    "--dry-run",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert "Dry run: would clear 3 DagRun(s)" in captured.out
+
+        for run_id in ("part_run_1", "part_run_2", "part_run_3"):
+            run = _get_run(run_id)
+            assert run.partition_key is not None
+            assert run.partition_date is not None
+
+    def test_no_match_prints_message(self, parser, setup_partitioned_runs, capsys):
+        partition_command.clear(
+            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "does_not_exist"])
+        )
+        captured = capsys.readouterr()
+        assert "No matching DagRuns found" in captured.out
+
+    def test_already_cleared_run_is_skipped(self, parser, setup_partitioned_runs, capsys):
+        with create_session() as session:
+            run = session.scalar(select(DagRun).where(DagRun.run_id == "part_run_1"))
+            run.partition_key = None
+            run.partition_date = None
+            session.commit()
+
+        partition_command.clear(
+            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_1"])
+        )
+        captured = capsys.readouterr()
+        assert "already cleared" in captured.out
+        assert "Cleared partition fields on 0 DagRun(s)" in captured.out
+
+    def test_requires_run_id_or_range(self, parser, setup_partitioned_runs):
+        with pytest.raises(SystemExit, match="Specify either --run-id"):
+            partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID]))
+
+    def test_run_id_and_range_mutually_exclusive(self, parser, setup_partitioned_runs):
+        with pytest.raises(SystemExit, match="cannot be combined"):
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        DAG_ID,
+                        "--run-id",
+                        "part_run_1",
+                        "--start-date",
+                        "2026-01-01",
+                    ]
+                )
+            )
+
+    def test_prints_before_values(self, parser, setup_partitioned_runs, capsys):
+        partition_command.clear(
+            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--run-id", "part_run_1"])
+        )
+        captured = capsys.readouterr()
+        assert "partition_key='2026-01-01T00:00:00' -> None" in captured.out
+        assert "partition_date=2026-01-01T00:00:00+00:00 -> None" in captured.out

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -220,8 +220,8 @@ class TestPartitionsClear:
         with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID]))
         assert excinfo.value.code == (
-            "Specify either --run-id for a single DagRun, or a partition_date range "
-            "via --start-date and/or --end-date."
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
         )
 
     def test_run_id_and_range_mutually_exclusive(self, parser):
@@ -241,7 +241,8 @@ class TestPartitionsClear:
                 )
             )
         assert excinfo.value.code == (
-            "--run-id cannot be combined with a partition_date range (--start-date / --end-date)."
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
         )
 
     def test_prints_before_values(self, parser, capsys):
@@ -551,3 +552,184 @@ class TestPartitionsClear:
 
         clear_db_runs()
         clear_db_dags()
+
+    # ------------------------------------------------------------------
+    # --partition-key tests
+    # ------------------------------------------------------------------
+
+    def test_clear_by_partition_key(self, parser, capsys):
+        partition_command.clear(
+            parser.parse_args(
+                ["partitions", "clear", "--dag-id", DAG_ID, "--partition-key", "2026-01-02T00:00:00"]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 1 DagRun(s).\n"
+        )
+
+        run_2 = _get_run("part_run_2")
+        assert run_2.partition_key is None
+        assert run_2.partition_date is None
+        # Other runs unchanged
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        assert run_1.partition_date == datetime(2026, 1, 1, tzinfo=pendulum.UTC)
+        run_3 = _get_run("part_run_3")
+        assert run_3.partition_key == "2026-01-03T00:00:00"
+        assert run_3.partition_date == datetime(2026, 1, 3, tzinfo=pendulum.UTC)
+
+    def test_clear_by_partition_key_no_match(self, parser, capsys):
+        partition_command.clear(
+            parser.parse_args(
+                ["partitions", "clear", "--dag-id", DAG_ID, "--partition-key", "nonexistent-key"]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == f"No matching DagRuns found for dag_id={DAG_ID}.\n"
+
+        # All runs unchanged
+        for run_id, expected_key in [
+            ("part_run_1", "2026-01-01T00:00:00"),
+            ("part_run_2", "2026-01-02T00:00:00"),
+            ("part_run_3", "2026-01-03T00:00:00"),
+        ]:
+            run = _get_run(run_id)
+            assert run.partition_key == expected_key
+
+    def test_partition_key_mutually_exclusive_with_run_id(self, parser):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        DAG_ID,
+                        "--run-id",
+                        "part_run_1",
+                        "--partition-key",
+                        "foo",
+                    ]
+                )
+            )
+        assert excinfo.value.code == (
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
+        )
+
+    def test_partition_key_mutually_exclusive_with_date_range(self, parser):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        DAG_ID,
+                        "--partition-key",
+                        "foo",
+                        "--start-date",
+                        "2026-01-01",
+                    ]
+                )
+            )
+        assert excinfo.value.code == (
+            "Specify exactly one of --run-id, --partition-key, or a partition_date range "
+            "(--start-date/--end-date or --date)."
+        )
+
+    # ------------------------------------------------------------------
+    # --date a~b tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "cli_args",
+        [
+            ["--start-date", "2026-01-02", "--end-date", "2026-01-03"],
+            ["--date", "2026-01-02~2026-01-03"],
+        ],
+    )
+    def test_date_range_syntax_equivalent_to_start_end(self, parser, capsys, cli_args):
+        partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, *cli_args]))
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "DagRun part_run_3: partition_key='2026-01-03T00:00:00' -> None, "
+            "partition_date=2026-01-03T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 2 DagRun(s).\n"
+        )
+
+    @pytest.mark.parametrize(
+        "bad_date",
+        [
+            "2026-01-01",  # no ~
+            "~2026-01-01",  # left side empty
+            "2026-01-01~",  # right side empty
+            "2026-01-01~not-a-date",  # right side parse failure
+        ],
+    )
+    def test_date_range_syntax_invalid_format(self, parser, bad_date):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--date", bad_date])
+            )
+        assert "--date must be in the form 'a~b'" in str(excinfo.value.code)
+
+    def test_date_range_syntax_mutually_exclusive_with_start_end(self, parser):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        DAG_ID,
+                        "--date",
+                        "2026-01-01~2026-01-02",
+                        "--start-date",
+                        "2026-01-01",
+                    ]
+                )
+            )
+        assert excinfo.value.code == "--date cannot be combined with --start-date / --end-date."
+
+    def test_date_range_end_of_day_clamp(self, parser, dag_maker):
+        """A run whose partition_date is mid-day on the --date right side must be cleared."""
+        dag_maker.create_dagrun(
+            run_id="part_run_2_midday_date",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 1, 2, 15, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-01-02T15:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--date",
+                    "2026-01-02~2026-01-02",
+                ]
+            )
+        )
+
+        run_midday = _get_run("part_run_2_midday_date")
+        assert run_midday.partition_key is None
+        assert run_midday.partition_date is None
+        # Midnight run on same date (start-boundary inclusive) is also cleared.
+        run_2 = _get_run("part_run_2")
+        assert run_2.partition_key is None
+        assert run_2.partition_date is None
+        # Runs outside the range are untouched.
+        run_1 = _get_run("part_run_1")
+        assert run_1.partition_key == "2026-01-01T00:00:00"
+        run_3 = _get_run("part_run_3")
+        assert run_3.partition_key == "2026-01-03T00:00:00"

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -796,7 +796,6 @@ class TestPartitionsClear:
             "2026-01-01",  # no ~
             "~2026-01-01",  # left side empty
             "2026-01-01~",  # right side empty
-            "2026-01-01~not-a-date",  # right side parse failure
         ],
     )
     def test_date_range_syntax_invalid_format(self, parser, bad_date):
@@ -805,6 +804,34 @@ class TestPartitionsClear:
                 parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--date", bad_date])
             )
         assert "--date must be in the form 'a~b'" in str(excinfo.value.code)
+
+    @pytest.mark.parametrize(
+        "bad_date",
+        [
+            "2026-01-02T01:00:00~2026-01-02T10:00:00",  # jason's original case
+            "2026-01-02~2026-01-02T10:00:00",  # mixed: date / datetime
+            "2026-1-2~2026-01-02",  # missing zero-pad
+            "2026-01-01~not-a-date",  # right side not YYYY-MM-DD
+        ],
+    )
+    def test_date_range_syntax_rejects_non_yyyy_mm_dd(self, parser, bad_date):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, "--date", bad_date])
+            )
+        assert "--date sides must be in YYYY-MM-DD format" in str(excinfo.value.code)
+
+    @pytest.mark.parametrize(
+        ("flag", "bad_value"),
+        [
+            ("--start-date", "2026-01-02T01:00:00"),
+            ("--end-date", "2026-01-02T10:00:00"),
+            ("--start-date", "2026-1-2"),
+        ],
+    )
+    def test_start_end_date_reject_non_yyyy_mm_dd(self, parser, flag, bad_value):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, flag, bad_value])
 
     def test_date_range_syntax_mutually_exclusive_with_start_end(self, parser):
         with pytest.raises(SystemExit) as excinfo:

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -445,31 +445,33 @@ class TestPartitionsClear:
         clear_db_runs()
         clear_db_dags()
 
-    def test_clear_task_instances_chunks_at_boundary(self, parser, dag_maker):
-        """Exactly DR_CHUNK_SIZE runs → clear_task_instances called once with all TIs."""
-        chunk_size = 3
+    def test_clear_task_instances_chunks_at_cap(self, parser, dag_maker):
+        """2 DRs × 3 TIs/DR = 6 TIs == TI_CHUNK_SIZE → clear_task_instances called once with all 6."""
+        ti_cap = 6
         clear_db_runs()
         clear_db_dags()
         with dag_maker(
-            "dag_chunk_boundary",
+            "dag_chunk_at_cap",
             schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
             start_date=datetime(2024, 1, 1),
             catchup=True,
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        for i in range(chunk_size):
+            EmptyOperator(task_id="t2")
+            EmptyOperator(task_id="t3")
+        for i in range(2):
             dag_maker.create_dagrun(
-                run_id=f"chunk_run_{i:04d}",
+                run_id=f"at_cap_run_{i:04d}",
                 state=DagRunState.SUCCESS,
                 logical_date=None,
                 partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
-                partition_key=f"chunk-key-{i:04d}",
+                partition_key=f"at-cap-key-{i:04d}",
             )
         dag_maker.sync_dagbag_to_db()
 
         with (
-            mock.patch.object(partition_command, "DR_CHUNK_SIZE", chunk_size),
+            mock.patch.object(partition_command, "TI_CHUNK_SIZE", ti_cap),
             mock.patch(
                 "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
             ) as mock_cti,
@@ -480,7 +482,7 @@ class TestPartitionsClear:
                         "partitions",
                         "clear",
                         "--dag-id",
-                        "dag_chunk_boundary",
+                        "dag_chunk_at_cap",
                         "--start-date",
                         "2024-01-01",
                         "--end-date",
@@ -490,39 +492,39 @@ class TestPartitionsClear:
                 )
             )
 
-        # Exactly one call: the flush at >= DR_CHUNK_SIZE triggers mid-loop.
-        assert len(mock_cti.mock_calls) == 1
-        first_call_tis = mock_cti.mock_calls[0].args[0]
-        assert len(first_call_tis) == chunk_size  # == 3 when patched
+        # Exactly one call: 6 TIs == cap, all flushed together in the tail.
+        assert [len(c.args[0]) for c in mock_cti.mock_calls] == [6]
 
         clear_db_runs()
         clear_db_dags()
 
-    def test_clear_task_instances_chunks_just_over_boundary(self, parser, dag_maker):
-        """DR_CHUNK_SIZE + 1 runs → two clear_task_instances calls (first full, second tail)."""
-        chunk_size = 3
+    def test_clear_task_instances_chunks_over_cap(self, parser, dag_maker):
+        """3 DRs × 3 TIs/DR = 9 TIs > TI_CHUNK_SIZE=6 → two calls: [6, 3]."""
+        ti_cap = 6
         clear_db_runs()
         clear_db_dags()
         with dag_maker(
-            "dag_chunk_over",
+            "dag_chunk_over_cap",
             schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
             start_date=datetime(2024, 1, 1),
             catchup=True,
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        for i in range(chunk_size + 1):
+            EmptyOperator(task_id="t2")
+            EmptyOperator(task_id="t3")
+        for i in range(3):
             dag_maker.create_dagrun(
-                run_id=f"over_run_{i:04d}",
+                run_id=f"over_cap_run_{i:04d}",
                 state=DagRunState.SUCCESS,
                 logical_date=None,
                 partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
-                partition_key=f"over-key-{i:04d}",
+                partition_key=f"over-cap-key-{i:04d}",
             )
         dag_maker.sync_dagbag_to_db()
 
         with (
-            mock.patch.object(partition_command, "DR_CHUNK_SIZE", chunk_size),
+            mock.patch.object(partition_command, "TI_CHUNK_SIZE", ti_cap),
             mock.patch(
                 "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
             ) as mock_cti,
@@ -533,7 +535,7 @@ class TestPartitionsClear:
                         "partitions",
                         "clear",
                         "--dag-id",
-                        "dag_chunk_over",
+                        "dag_chunk_over_cap",
                         "--start-date",
                         "2024-01-01",
                         "--end-date",
@@ -543,12 +545,137 @@ class TestPartitionsClear:
                 )
             )
 
-        # Two calls: first flush at DR_CHUNK_SIZE (3 TIs), tail flush with 1 TI.
-        assert len(mock_cti.mock_calls) == 2
-        first_call_tis = mock_cti.mock_calls[0].args[0]
-        second_call_tis = mock_cti.mock_calls[1].args[0]
-        assert len(first_call_tis) == chunk_size
-        assert len(second_call_tis) == 1
+        # First slice: 6 TIs at cap; tail: 3 remaining TIs.
+        assert [len(c.args[0]) for c in mock_cti.mock_calls] == [6, 3]
+
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_clear_task_instances_chunks_just_under_cap(self, parser, dag_maker):
+        """1 DR × 5 TIs = 5 TIs < TI_CHUNK_SIZE=6 → one tail call with all 5."""
+        ti_cap = 6
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            "dag_chunk_under_cap",
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2024, 1, 1),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+            EmptyOperator(task_id="t2")
+            EmptyOperator(task_id="t3")
+            EmptyOperator(task_id="t4")
+            EmptyOperator(task_id="t5")
+        dag_maker.create_dagrun(
+            run_id="under_cap_run_0000",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC),
+            partition_key="under-cap-key-0000",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        with (
+            mock.patch.object(partition_command, "TI_CHUNK_SIZE", ti_cap),
+            mock.patch(
+                "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
+            ) as mock_cti,
+        ):
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        "dag_chunk_under_cap",
+                        "--start-date",
+                        "2024-01-01",
+                        "--end-date",
+                        "2025-12-31",
+                        "--clear-task-instances",
+                    ]
+                )
+            )
+
+        # 5 TIs < cap of 6: no mid-loop flush triggered, tail sends all 5 in one call.
+        assert [len(c.args[0]) for c in mock_cti.mock_calls] == [5]
+
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_clear_task_instances_chunks_mid_loop_trigger(self, parser, dag_maker):
+        """Pin mid-loop SELECT IN + slice trigger (partition_command.py L120-132).
+
+        Design: TI_CHUNK_SIZE=3, 1 dag with 2 tasks, 3 DRs (6 TIs total).
+
+        Execution trace:
+        - DR0: ti_buffer=[r0], len=1 < 3 -- no mid-loop
+        - DR1: ti_buffer=[r0, r1], len=2 < 3 -- no mid-loop
+        - DR2: ti_buffer=[r0, r1, r2], len=3 >= 3 -- mid-loop FIRES:
+            SELECT IN(r0, r1, r2) -> 6 TIs
+            ti_buffer_run_ids.clear() -> []
+            ti_carry.extend(6 TIs) -> carry len=6
+            while len>=3: slice[3] -> call #1, carry len=3
+            while len>=3: slice[3] -> call #2, carry len=0
+            while exits
+        - tail: ti_buffer empty, carry empty -- no calls
+        Expected mock_calls sizes: [3, 3]
+
+        Note: carry-across-SELECT (mid-loop leftover surviving to the next outer
+        fetch) cannot arise in a single-dag CLI invocation.  When mid-loop triggers,
+        SELECT returns tasks_per_DR * TI_CHUNK_SIZE TIs -- always a TI_CHUNK_SIZE
+        multiple -- so there is never a leftover after the inner while loop.
+        Carry leftover only arises in the tail flush, which is pinned by
+        test_clear_task_instances_chunks_over_cap.
+        """
+        ti_cap = 3
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            "dag_chunk_mid_loop",
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2024, 1, 1),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+            EmptyOperator(task_id="t2")
+        for i in range(3):
+            dag_maker.create_dagrun(
+                run_id=f"mid_loop_run_{i:04d}",
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=datetime(2024, 1, 1, tzinfo=pendulum.UTC) + pendulum.duration(days=i),
+                partition_key=f"mid-loop-key-{i:04d}",
+            )
+        dag_maker.sync_dagbag_to_db()
+
+        with (
+            mock.patch.object(partition_command, "TI_CHUNK_SIZE", ti_cap),
+            mock.patch(
+                "airflow.cli.commands.partition_command.clear_task_instances", autospec=True
+            ) as mock_cti,
+        ):
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        "dag_chunk_mid_loop",
+                        "--start-date",
+                        "2024-01-01",
+                        "--end-date",
+                        "2025-12-31",
+                        "--clear-task-instances",
+                    ]
+                )
+            )
+
+        # Mid-loop fires on DR2: two slices of 3 each; tail is empty.
+        assert [len(c.args[0]) for c in mock_cti.mock_calls] == [3, 3]
 
         clear_db_runs()
         clear_db_dags()

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -356,43 +356,6 @@ class TestPartitionsClear:
         assert run_1.state == DagRunState.QUEUED
         assert all(ti.state is None for ti in _get_tis("part_run_1"))
 
-    def test_clear_end_date_includes_same_day_runs(self, parser, dag_maker):
-        """A run whose partition_date is mid-day on --end-date must be cleared (thread 4b fix)."""
-        # Insert a run with partition_date at 15:00 on 2026-01-02.  Without the end-of-day clamp,
-        # the filter is `partition_date <= 2026-01-02T00:00:00`, so 15:00 > midnight would NOT
-        # be matched.  With the clamp (<=  2026-01-02T23:59:59.999999) it must be cleared.
-        dag_maker.create_dagrun(
-            run_id="part_run_2_midday",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 1, 2, 15, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-01-02T15:00:00",
-        )
-        dag_maker.sync_dagbag_to_db()
-
-        partition_command.clear(
-            parser.parse_args(
-                [
-                    "partitions",
-                    "clear",
-                    "--dag-id",
-                    DAG_ID,
-                    "--start-date",
-                    "2026-01-02",
-                    "--end-date",
-                    "2026-01-02",
-                ]
-            )
-        )
-        run_midday = _get_run("part_run_2_midday")
-        assert run_midday.partition_key is None
-        assert run_midday.partition_date is None
-        # Runs outside the range are untouched.
-        run_1 = _get_run("part_run_1")
-        assert run_1.partition_key == "2026-01-01T00:00:00"
-        run_3 = _get_run("part_run_3")
-        assert run_3.partition_key == "2026-01-03T00:00:00"
-
     def test_clear_streams_runs_without_materialising(self, parser, dag_maker):
         """Clearing 250 partitioned runs clears every one of them (streaming smoke test)."""
         clear_db_runs()
@@ -823,8 +786,12 @@ class TestPartitionsClear:
             )
         assert excinfo.value.code == "--date cannot be combined with --start-date / --end-date."
 
-    def test_date_range_end_of_day_clamp(self, parser, dag_maker):
-        """A run whose partition_date is mid-day on the --date right side must be cleared."""
+    def test_date_range_end_date_is_literal(self, parser, dag_maker):
+        """Pin literal <= semantics: --date right side is used as-is (no end-of-day clamp).
+
+        '2026-01-02' parses to midnight 2026-01-02T00:00:00, so a run at 15:00 on
+        the same day has partition_date > the bound and must NOT be cleared.
+        """
         dag_maker.create_dagrun(
             run_id="part_run_2_midday_date",
             state=DagRunState.SUCCESS,
@@ -847,13 +814,14 @@ class TestPartitionsClear:
             )
         )
 
-        run_midday = _get_run("part_run_2_midday_date")
-        assert run_midday.partition_key is None
-        assert run_midday.partition_date is None
-        # Midnight run on same date (start-boundary inclusive) is also cleared.
+        # Midnight run on exact date is matched (partition_date == bound).
         run_2 = _get_run("part_run_2")
         assert run_2.partition_key is None
         assert run_2.partition_date is None
+        # 15:00 > midnight bound — NOT cleared.
+        run_midday = _get_run("part_run_2_midday_date")
+        assert run_midday.partition_key == "2026-01-02T15:00:00"
+        assert run_midday.partition_date == datetime(2026, 1, 2, 15, 0, 0, tzinfo=pendulum.UTC)
         # Runs outside the range are untouched.
         run_1 = _get_run("part_run_1")
         assert run_1.partition_key == "2026-01-01T00:00:00"
@@ -861,7 +829,7 @@ class TestPartitionsClear:
         assert run_3.partition_key == "2026-01-03T00:00:00"
 
     def test_clear_with_datetime_end_date_no_clamp(self, parser, dag_maker):
-        """--end-date with an ISO datetime is NOT clamped; runs after that point are excluded."""
+        """Pin literal <= semantics with a datetime endpoint: runs after the bound are excluded."""
         dag_maker.create_dagrun(
             run_id="part_run_h10",
             state=DagRunState.SUCCESS,
@@ -898,35 +866,6 @@ class TestPartitionsClear:
         # 15:00 exceeds the un-clamped 10:00 boundary, must be untouched.
         run_h15 = _get_run("part_run_h15")
         assert run_h15.partition_key == "2026-01-02T15:00:00"
-
-    def test_clear_with_date_only_end_date_clamps_to_end_of_day(self, parser, dag_maker):
-        """--end-date with a date-only value clamps to 23:59:59; mid-day runs are included."""
-        dag_maker.create_dagrun(
-            run_id="part_run_h11",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 1, 2, 11, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-01-02T11:00:00",
-        )
-        dag_maker.sync_dagbag_to_db()
-
-        partition_command.clear(
-            parser.parse_args(
-                [
-                    "partitions",
-                    "clear",
-                    "--dag-id",
-                    DAG_ID,
-                    "--end-date",
-                    "2026-01-02",
-                ]
-            )
-        )
-
-        # 11:00 on 2026-01-02 is within the clamped boundary (23:59:59.999999).
-        run_h11 = _get_run("part_run_h11")
-        assert run_h11.partition_key is None
-        assert run_h11.partition_date is None
 
     def test_clear_hourly_window_via_start_end_date(self, parser, dag_maker):
         """ISO datetime --start-date / --end-date selects only runs within the exact window."""


### PR DESCRIPTION
part of #65921

## Why

`airflow tasks clear --start-date / --end-date` filters by `logical_date`, so it cannot reach Dag runs whose `partition_date` / `partition_key` is what identifies them (rollup or offset partitions). Today the only ways to bulk-reprocess such runs are N API calls or N UI clicks.

## What

- Add `airflow dags clear <dag_id>` with three mutually-exclusive selectors:
    - `--run-id` (single run)
    - `--partition-key` (every run with that exact key)
    - `--partition-date-start` / `--partition-date-end` (inclusive `partition_date` window; runs with NULL `partition_date` are never matched;
inverted window is rejected)
- Reuse `Dag.clear()` per matched `run_id`, so TI reset + Dag run re-queue behave identically to every other clear path.
- Print a listing (`run_id`, `partition_key`, `partition_date`) before prompting; `--yes` skips the prompt.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
