### PR TITLE
fix(alibaba): call self.io.oss_log_exists in OSSTaskHandler._read

### DIFF
--- a/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -245,11 +245,11 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         log_relative_path = self._render_filename(ti, try_number)
         remote_loc = log_relative_path
 
-        if not self.oss_log_exists(remote_loc):
+        if not self.io.oss_log_exists(remote_loc):
             return super()._read(ti, try_number, metadata)
         # If OSS remote file exists, we do not fetch logs from task instance
         # local machine even if there are errors reading remote logs, as
         # returned remote_log will contain error messages.
-        remote_log = self.oss_read(remote_loc, return_error=True)
+        remote_log = self.io.oss_read(remote_loc, return_error=True)
         log = f"*** Reading remote log from {remote_loc}.\n{remote_log}\n"
         return log, {"end_of_log": True}

--- a/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
+++ b/providers/alibaba/tests/unit/alibaba/cloud/log/test_oss_task_handler.py
@@ -205,6 +205,18 @@ class TestOSSTaskHandler:
         handler.io.upload(str(log_file), self.ti)
         mock_oss_write.assert_called_once_with("test log content", relative_path)
 
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_read"))
+    @mock.patch(OSS_TASK_HANDLER_STRING.format("OSSRemoteLogIO.oss_log_exists"))
+    def test_read_calls_io_oss_log_exists_and_io_oss_read(self, mock_io_log_exists, mock_io_read):
+        """Test that _read calls self.io.oss_log_exists and self.io.oss_read."""
+        mock_io_log_exists.return_value = True
+        mock_io_read.return_value = "log content"
+
+        self.oss_task_handler._read(self.ti, try_number=1)
+
+        mock_io_log_exists.assert_called_once()
+        mock_io_read.assert_called_once()
+
     def test_filename_template_for_backward_compatibility(self):
         # filename_template arg support for running the latest provider on airflow 2
         OSSTaskHandler(self.base_log_folder, self.oss_log_folder, filename_template=None)


### PR DESCRIPTION
## Summary

OSSTaskHandler._read() calls self.oss_log_exists() and self.oss_read(), but these methods are only defined in OSSRemoteLogIO, not in OSSTaskHandler itself. This causes AttributeError when the Airflow UI reads task logs from OSS after task completion.

Fix: change the calls in _read() to use self.io.oss_log_exists() and self.io.oss_read() directly.

🤖 Generated with [Claude Code](https://claude.ai/code)