### PR TITLE
Migrate stable branch protection from protected_branches to Rulesets

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,8 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+# `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
+# See its documentation for details: https://github.com/apache/infrastructure-asfyaml
 ---
+#
+# Additional non-standard features
+#
+meta:
+  environments:
+    - github_rulesets
+
 github:
   description: "Apache Airflow - A platform to programmatically author, schedule, and monitor workflows"
   homepage: https://airflow.apache.org/
@@ -70,6 +78,17 @@ github:
     # auto-delete head branches after being merged
     del_branch_on_merge: true
 
+  # Legacy branch protection is being migrated to Rulesets below.
+  #
+  # `main` keeps the proven configuration here until the new ruleset is validated on other branches.
+  # We cannot test the new ruleset on `main` itself: ruleset settings are only applied from the default branch,
+  # so a broken config there would block fixing this file.
+  #
+  # Once the new ruleset is validated, `main` should be moved under the ruleset
+  # and removed from the legacy `protected_branches` section.
+  # This section should be kept empty to properly delete the legacy branch protection rules that are currently in place:
+  #
+  # protected_branches: ~
   protected_branches:
     main:
       required_pull_request_reviews:
@@ -77,96 +96,27 @@ github:
       required_linear_history: true
       required_conversation_resolution: true
       required_signatures: false
-    v1-10-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_signatures: false
-    v2-0-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-1-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-2-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-3-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-4-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-5-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-6-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-7-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-8-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-9-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-10-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v2-11-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v3-0-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v3-1-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    v3-2-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
-    providers-fab/v1-5:
+
+  rulesets:
+    - name: "Branch protection"
+      type: branch
+      branches:
+        includes:
+          # `main` stays under `protected_branches` above until this ruleset is validated on the branches below.
+          # We cannot test the new ruleset on `main` itself: ruleset settings are only applied from the default branch,
+          # so a broken config there would block fixing this file.
+          #
+          # Uncomment once the configuration is proven on the other branches.
+          # - "~DEFAULT_BRANCH"
+          - "v*-stable"
+          - "providers-fab/v*"
+          - "airflow-ctl/v*-stable"
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true
       required_conversation_resolution: true
       required_signatures: false
-    airflow-ctl/v0-1-stable:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-      required_linear_history: true
-      required_signatures: false
+
   collaborators:
     # Max 10 collaborators allowed
     # https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#assigning-the-github-triage-role-to-external-collaborators

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
+# `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features
+# such as notifications, GitHub settings, etc.
 # See its documentation for details: https://github.com/apache/infrastructure-asfyaml
 ---
 #
@@ -80,13 +81,14 @@ github:
 
   # Legacy branch protection is being migrated to Rulesets below.
   #
-  # `main` keeps the proven configuration here until the new ruleset is validated on other branches.
-  # We cannot test the new ruleset on `main` itself: ruleset settings are only applied from the default branch,
-  # so a broken config there would block fixing this file.
+  # `main` keeps the proven configuration here until the new ruleset is validated on other
+  # branches. We cannot test the new ruleset on `main` itself: ruleset settings are only applied
+  # from the default branch, so a broken config there would block fixing this file.
   #
   # Once the new ruleset is validated, `main` should be moved under the ruleset
   # and removed from the legacy `protected_branches` section.
-  # This section should be kept empty to properly delete the legacy branch protection rules that are currently in place:
+  # This section should be kept empty to properly delete the legacy branch protection rules that
+  # are currently in place:
   #
   # protected_branches: ~
   protected_branches:
@@ -102,9 +104,10 @@ github:
       type: branch
       branches:
         includes:
-          # `main` stays under `protected_branches` above until this ruleset is validated on the branches below.
-          # We cannot test the new ruleset on `main` itself: ruleset settings are only applied from the default branch,
-          # so a broken config there would block fixing this file.
+          # `main` stays under `protected_branches` above until this ruleset is validated on the
+          # branches below. We cannot test the new ruleset on `main` itself: ruleset settings are
+          # only applied from the default branch, so a broken config there would block fixing
+          # this file.
           #
           # Uncomment once the configuration is proven on the other branches.
           # - "~DEFAULT_BRANCH"


### PR DESCRIPTION
Replace the per-branch entries under `protected_branches` for stable, providers-fab and airflow-ctl release branches with a single GitHub Rulesets entry that uses glob patterns (`v*-stable`, `providers-fab/v*`, `airflow-ctl/v*-stable`).

> [!IMPORTANT]
> `main` is intentionally kept under the legacy `protected_branches` block until the new ruleset is proven on the other branches.
> We cannot experiment on `main` directly because `.asf.yaml` ruleset settings are only applied from the default branch, so a broken configuration there would block updates to this file.

Also refresh the documentation link at the top of the file from the retired Confluence wiki page to the current `apache/infrastructure-asfyaml` README.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes: Claude Code was used to generate comments, PR description and double-checking the configuration syntax. The bulk of the changes was already tested in apache/logging-parent#477 and previous attempts.

