### PR TITLE
Pin ubuntu image in K8s basic_pod.yaml (follow-up to #66423)

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
+++ b/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: base
-      image: ubuntu
+      image: ubuntu:24.04
       command: ["/bin/bash"]
       args: ["-c", 'echo {\"hello\" : \"world\"} | cat > /airflow/xcom/return.json']
   restartPolicy: Never


### PR DESCRIPTION
## Summary

PR #66423 pinned bare `ubuntu` references across the `kubernetes-tests` Python sources to `ubuntu:24.04` (which is in the pre-pulled image set the K8s test infra now caches), but missed `basic_pod.yaml` — the pod-template file used by `test_pod_template_file_system` and the related parametrised tests.

The bare `ubuntu` image in that YAML still resolves to `docker.io/library/ubuntu:latest` at pod-pull time and hits Docker Hub anonymous-rate-limit timeouts on scheduled runs:

```
Failed to pull image "ubuntu": rpc error: code = DeadlineExceeded
desc = failed to pull and unpack image "docker.io/library/ubuntu:latest":
failed to authorize: failed to fetch anonymous token:
Get "https://auth.docker.io/token?...": dial tcp 104.18.43.178:443: i/o timeout
```

Failure: https://github.com/apache/airflow/actions/runs/25472151635/job/74749280411

related: #66423

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)