### PR TITLE
Fix uv.lock-conflict notifier hitting GitHub GraphQL with trailing slash

### DIFF
--- a/scripts/ci/notify_uv_lock_conflicts.py
+++ b/scripts/ci/notify_uv_lock_conflicts.py
@@ -145,8 +145,11 @@ class Stats:
 
 class GitHubGraphQL:
     def __init__(self, token: str) -> None:
+        # NOTE: do not use `base_url=GRAPHQL_URL` — httpx normalises base_url to
+        # end with `/`, so a relative POST to `""` resolves to
+        # https://api.github.com/graphql/ (trailing slash), which GitHub
+        # rejects with 404. Pass the full URL to .post() directly instead.
         self._http = httpx.Client(
-            base_url=GRAPHQL_URL,
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
@@ -161,7 +164,7 @@ class GitHubGraphQL:
         self._http.close()
 
     def call(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
-        r = self._http.post("", json={"query": query, "variables": variables})
+        r = self._http.post(GRAPHQL_URL, json={"query": query, "variables": variables})
         r.raise_for_status()
         data = r.json()
         if "errors" in data:


### PR DESCRIPTION
## Summary

`scripts/ci/notify_uv_lock_conflicts.py` constructs the GitHub GraphQL client as:

```python
self._http = httpx.Client(base_url=GRAPHQL_URL, ...)
...
r = self._http.post("", json=...)
```

`httpx` normalises `base_url` to end with `/`, so `base_url="https://api.github.com/graphql"` plus a relative path of `""` resolves to `https://api.github.com/graphql/` (trailing slash) — which GitHub's GraphQL API rejects with `404 Not Found`. This breaks the `Notify uv.lock conflicts` workflow on every main-branch push.

```
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://api.github.com/graphql/'
```

Failure: https://github.com/apache/airflow/actions/runs/25492428820/job/74803563077

## Fix

Drop the `base_url=` kwarg and pass the full `GRAPHQL_URL` to `.post()` directly so httpx never adds the trailing slash. Comment in the code records why so the next person who is tempted to "clean it up" doesn't reintroduce the bug.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)