### PR TITLE
Add `GlueCatalogCreatePartitionOperator`

### DIFF
--- a/providers/amazon/docs/operators/glue_catalog.rst
+++ b/providers/amazon/docs/operators/glue_catalog.rst
@@ -82,3 +82,17 @@ To delete a table from an AWS Glue Data Catalog database, use
     :dedent: 4
     :start-after: [START howto_operator_glue_catalog_delete_table]
     :end-before: [END howto_operator_glue_catalog_delete_table]
+
+.. _howto/operator:GlueCatalogCreatePartitionOperator:
+
+Create a Partition
+------------------
+
+To create a partition in an AWS Glue Data Catalog table, use
+:class:`~airflow.providers.amazon.aws.operators.glue_catalog.GlueCatalogCreatePartitionOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_glue_catalog.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_glue_catalog_create_partition]
+    :end-before: [END howto_operator_glue_catalog_create_partition]

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/glue_catalog.py
@@ -270,3 +270,69 @@ class GlueCatalogDeleteTableOperator(AwsBaseOperator[AwsBaseHook]):
         )
         self.hook.conn.delete_table(**kwargs)
         self.log.info("Deleted table %s", self.table_name)
+
+
+class GlueCatalogCreatePartitionOperator(AwsBaseOperator[AwsBaseHook]):
+    """
+    Create a partition in an AWS Glue Data Catalog table.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GlueCatalogCreatePartitionOperator`
+
+    :param database_name: The name of the database. (templated)
+    :param table_name: The name of the table. (templated)
+    :param partition_input: The ``PartitionInput`` dict defining the partition. (templated)
+    :param catalog_id: The ID of the Data Catalog. Defaults to the account ID. (templated)
+    :param if_exists: Behavior when the partition already exists.
+        ``"fail"`` raises an error, ``"skip"`` logs and returns.
+    """
+
+    aws_hook_class = AwsBaseHook
+    template_fields: tuple[str, ...] = (
+        *AwsBaseOperator.template_fields,
+        "database_name",
+        "table_name",
+        "catalog_id",
+    )
+    template_fields_renderers = {"partition_input": "json"}
+
+    def __init__(
+        self,
+        *,
+        database_name: str,
+        table_name: str,
+        partition_input: dict[str, Any],
+        catalog_id: str | None = None,
+        if_exists: Literal["fail", "skip"] = "skip",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.database_name = database_name
+        self.table_name = table_name
+        self.partition_input = partition_input
+        self.catalog_id = catalog_id
+        self.if_exists = if_exists
+
+    @property
+    def _hook_parameters(self) -> dict[str, Any]:
+        return {**super()._hook_parameters, "client_type": "glue"}
+
+    def execute(self, context: Context) -> None:
+        self.log.info("Creating partition in table %s.%s", self.database_name, self.table_name)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "DatabaseName": self.database_name,
+                "TableName": self.table_name,
+                "PartitionInput": self.partition_input,
+                "CatalogId": self.catalog_id,
+            }
+        )
+        try:
+            self.hook.conn.create_partition(**kwargs)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "AlreadyExistsException" and self.if_exists == "skip":
+                self.log.info("Partition already exists, skipping.")
+            else:
+                raise
+        self.log.info("Partition created.")

--- a/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
+    GlueCatalogCreatePartitionOperator,
     GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
     GlueCatalogDeleteTableOperator,
@@ -86,6 +87,24 @@ with DAG(
     )
     # [END howto_operator_glue_catalog_create_table]
 
+    # [START howto_operator_glue_catalog_create_partition]
+    create_partition = GlueCatalogCreatePartitionOperator(
+        task_id="create_partition",
+        database_name=db_name,
+        table_name=table_name,
+        partition_input={
+            "Values": ["2024-01-01"],
+            "StorageDescriptor": {
+                "Columns": [{"Name": "id", "Type": "int"}],
+                "Location": "s3://test-bucket/dt=2024-01-01/",
+                "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "SerdeInfo": {"SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"},
+            },
+        },
+    )
+    # [END howto_operator_glue_catalog_create_partition]
+
     # [START howto_operator_glue_catalog_delete_table]
     delete_table = GlueCatalogDeleteTableOperator(
         task_id="delete_table",
@@ -99,6 +118,7 @@ with DAG(
         test_context,
         create_database,
         create_table,
+        create_partition,
         delete_table,
         delete_database,
     )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue_catalog.py
@@ -25,6 +25,7 @@ from botocore.exceptions import ClientError
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.operators.glue_catalog import (
     GlueCatalogCreateDatabaseOperator,
+    GlueCatalogCreatePartitionOperator,
     GlueCatalogCreateTableOperator,
     GlueCatalogDeleteDatabaseOperator,
     GlueCatalogDeleteTableOperator,
@@ -223,6 +224,43 @@ class TestGlueCatalogDeleteTableOperator:
         self.operator.execute({})
 
         mock_client.delete_table.assert_called_once_with(DatabaseName=DB_NAME, Name=TABLE_NAME)
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+PARTITION_INPUT = {"Values": ["2024-01-01"], "StorageDescriptor": {"Location": "s3://bucket/dt=2024-01-01/"}}
+
+
+class TestGlueCatalogCreatePartitionOperator:
+    def setup_method(self):
+        self.operator = GlueCatalogCreatePartitionOperator(
+            task_id="create_partition",
+            database_name=DB_NAME,
+            table_name=TABLE_NAME,
+            partition_input=PARTITION_INPUT,
+        )
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        self.operator.execute({})
+
+        mock_client.create_partition.assert_called_once_with(
+            DatabaseName=DB_NAME, TableName=TABLE_NAME, PartitionInput=PARTITION_INPUT
+        )
+
+    @mock.patch.object(AwsBaseHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute_skip_existing(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_client.create_partition.side_effect = ClientError(
+            {"Error": {"Code": "AlreadyExistsException", "Message": "exists"}}, "CreatePartition"
+        )
+        mock_conn.return_value = mock_client
+
+        self.operator.execute({})  # Should not raise
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
Adds `GlueCatalogCreatePartitionOperator` to create a partition in an AWS Glue Data Catalog table.

- Operator implementation with `if_exists="skip"` support
- Unit tests with mock (including skip-existing behavior)
- Docs (RST)