### PR TITLE
Add `BedrockUpdateGuardrailOperator`

### DIFF
--- a/providers/amazon/docs/operators/bedrock.rst
+++ b/providers/amazon/docs/operators/bedrock.rst
@@ -388,3 +388,17 @@ Reference
 * `AWS boto3 library documentation for Amazon Bedrock <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock.html>`__
 * `AWS boto3 library documentation for Amazon Bedrock Runtime <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime.html>`__
 * `AWS boto3 library documentation for Amazon Bedrock Agents <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agent.html>`__
+
+.. _howto/operator:BedrockUpdateGuardrailOperator:
+
+Update a Guardrail
+------------------
+
+To update an Amazon Bedrock guardrail configuration, use
+:class:`~airflow.providers.amazon.aws.operators.bedrock.BedrockUpdateGuardrailOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bedrock_update_guardrail]
+    :end-before: [END howto_operator_bedrock_update_guardrail]

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -1209,3 +1209,72 @@ class BedrockCreateGuardrailVersionOperator(AwsBaseOperator[BedrockHook]):
         version = response["version"]
         self.log.info("Guardrail %s version %s created.", response["guardrailId"], version)
         return version
+
+
+class BedrockUpdateGuardrailOperator(AwsBaseOperator[BedrockHook]):
+    """
+    Update an Amazon Bedrock guardrail configuration.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BedrockUpdateGuardrailOperator`
+
+    :param guardrail_identifier: The ID or ARN of the guardrail to update. (templated)
+    :param guardrail_name: The new name for the guardrail. (templated)
+    :param blocked_input_messaging: Message returned when input is blocked. (templated)
+    :param blocked_outputs_messaging: Message returned when output is blocked. (templated)
+    :param description: Optional description. (templated)
+    :param topic_policy_config: Optional topic policy configuration dict.
+    :param content_policy_config: Optional content filter policy configuration dict.
+    :param word_policy_config: Optional word filter policy configuration dict.
+    :param sensitive_information_policy_config: Optional sensitive information policy dict.
+    """
+
+    aws_hook_class = BedrockHook
+    template_fields: Sequence[str] = aws_template_fields(
+        "guardrail_identifier", "guardrail_name", "blocked_input_messaging", "blocked_outputs_messaging"
+    )
+
+    def __init__(
+        self,
+        *,
+        guardrail_identifier: str,
+        guardrail_name: str,
+        blocked_input_messaging: str,
+        blocked_outputs_messaging: str,
+        description: str | None = None,
+        topic_policy_config: dict[str, Any] | None = None,
+        content_policy_config: dict[str, Any] | None = None,
+        word_policy_config: dict[str, Any] | None = None,
+        sensitive_information_policy_config: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.guardrail_identifier = guardrail_identifier
+        self.guardrail_name = guardrail_name
+        self.blocked_input_messaging = blocked_input_messaging
+        self.blocked_outputs_messaging = blocked_outputs_messaging
+        self.description = description
+        self.topic_policy_config = topic_policy_config
+        self.content_policy_config = content_policy_config
+        self.word_policy_config = word_policy_config
+        self.sensitive_information_policy_config = sensitive_information_policy_config
+
+    def execute(self, context: Context) -> str:
+        self.log.info("Updating guardrail %s", self.guardrail_identifier)
+        kwargs: dict[str, Any] = prune_dict(
+            {
+                "guardrailIdentifier": self.guardrail_identifier,
+                "name": self.guardrail_name,
+                "blockedInputMessaging": self.blocked_input_messaging,
+                "blockedOutputsMessaging": self.blocked_outputs_messaging,
+                "description": self.description,
+                "topicPolicyConfig": self.topic_policy_config,
+                "contentPolicyConfig": self.content_policy_config,
+                "wordPolicyConfig": self.word_policy_config,
+                "sensitiveInformationPolicyConfig": self.sensitive_information_policy_config,
+            }
+        )
+        response = self.hook.conn.update_guardrail(**kwargs)
+        self.log.info("Updated guardrail %s version %s", response["guardrailId"], response["version"])
+        return response["guardrailId"]

--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
@@ -22,6 +22,7 @@ from airflow.providers.amazon.aws.operators.bedrock import (
     BedrockCreateGuardrailOperator,
     BedrockCreateGuardrailVersionOperator,
     BedrockDeleteGuardrailOperator,
+    BedrockUpdateGuardrailOperator,
 )
 from airflow.providers.common.compat.sdk import DAG, chain
 
@@ -76,9 +77,20 @@ with DAG(
     )
     # [END howto_operator_bedrock_create_guardrail_version]
 
+    # [START howto_operator_bedrock_update_guardrail]
+    update_guardrail = BedrockUpdateGuardrailOperator(
+        task_id="update_guardrail",
+        guardrail_identifier=create_guardrail.output,
+        guardrail_name=f"{env_id}-guardrail-updated",
+        blocked_input_messaging="Updated: input blocked.",
+        blocked_outputs_messaging="Updated: output blocked.",
+    )
+    # [END howto_operator_bedrock_update_guardrail]
+
     chain(
         test_context,
         create_guardrail,
+        update_guardrail,
         create_guardrail_version,
         delete_guardrail,
     )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_bedrock.py
@@ -39,6 +39,7 @@ from airflow.providers.amazon.aws.operators.bedrock import (
     BedrockIngestDataOperator,
     BedrockInvokeModelOperator,
     BedrockRaGOperator,
+    BedrockUpdateGuardrailOperator,
 )
 
 from unit.amazon.aws.utils.test_template_fields import validate_template_fields
@@ -957,6 +958,36 @@ class TestBedrockCreateGuardrailVersionOperator:
             guardrailIdentifier=GUARDRAIL_ID, description="Production version"
         )
         assert result == "2"
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+class TestBedrockUpdateGuardrailOperator:
+    def setup_method(self):
+        self.operator = BedrockUpdateGuardrailOperator(
+            task_id="update_guardrail",
+            guardrail_identifier=GUARDRAIL_ID,
+            guardrail_name="updated-guardrail",
+            blocked_input_messaging="Blocked.",
+            blocked_outputs_messaging="Blocked.",
+        )
+
+    @mock.patch.object(BedrockHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_client.update_guardrail.return_value = {
+            "guardrailId": GUARDRAIL_ID,
+            "guardrailArn": "arn",
+            "version": "DRAFT",
+            "updatedAt": "now",
+        }
+        mock_conn.return_value = mock_client
+
+        result = self.operator.execute({})
+
+        assert result == GUARDRAIL_ID
+        mock_client.update_guardrail.assert_called_once()
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
Adds `BedrockUpdateGuardrailOperator` to update an Amazon Bedrock guardrail configuration.

- Operator implementation with `prune_dict` for optional policy configs
- Unit tests with mock
- Docs (RST)