### PR TITLE
UI:  Hide the `Next Run` timestamp for paused Dags.

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -61,4 +61,15 @@ describe("Header", () => {
     expect(screen.queryByText(i18n.t("dag:dagDetails.nextRun"))).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Reparse Dag" })).not.toBeInTheDocument();
   });
+
+  it("does not render next run timestamp for a paused Dag", () => {
+    render(
+      <Wrapper>
+        <Header dag={{ ...mockDag, is_paused: true, is_stale: false }} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(i18n.t("common:dagDetails.nextRun"))).toBeInTheDocument();
+    expect(screen.queryByText("2024-08-22 19:00:00")).not.toBeInTheDocument();
+  });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -69,7 +69,7 @@ describe("Header", () => {
       </Wrapper>,
     );
 
-    expect(screen.getByText(i18n.t("common:dagDetails.nextRun"))).toBeInTheDocument();
+    expect(screen.getByText(i18n.t("dag:dagDetails.nextRun"))).toBeInTheDocument();
     expect(screen.queryByText("2024-08-22 19:00:00")).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -65,12 +65,13 @@ export const Header = ({
     : [
         {
           label: translate("dagDetails.nextRun"),
-          value: Boolean(dag?.next_dagrun_run_after) ? (
-            <DagRunInfo
-              logicalDate={dag?.next_dagrun_logical_date}
-              runAfter={dag?.next_dagrun_run_after as string}
-            />
-          ) : undefined,
+          value:
+            !dag?.is_paused && Boolean(dag?.next_dagrun_run_after) ? (
+              <DagRunInfo
+                logicalDate={dag?.next_dagrun_logical_date}
+                runAfter={dag?.next_dagrun_run_after as string}
+              />
+            ) : undefined,
         },
       ];
 

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -209,6 +209,14 @@ describe("DagCard", () => {
     expect(nextRunElement).toHaveTextContent("2024-08-22 19:00:00");
   });
 
+  it("DagCard should not render next run timestamp for a paused Dag", () => {
+    render(<DagCard dag={{ ...mockDag, is_paused: true }} />, { wrapper: GMTWrapper });
+    const nextRunElement = screen.getByTestId("next-run");
+
+    expect(nextRunElement).toBeInTheDocument();
+    expect(nextRunElement).not.toHaveTextContent("2024-08-22 19:00:00");
+  });
+
   it("DagCard should render StateBadge as success", () => {
     render(<DagCard dag={mockDag} />, { wrapper: GMTWrapper });
     const stateBadge = screen.getByTestId("state-badge");

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -100,7 +100,7 @@ export const DagCard = ({ dag }: Props) => {
           ) : undefined}
         </Stat>
         <Stat data-testid="next-run" label={translate("dagDetails.nextRun")}>
-          {Boolean(dag.next_dagrun_run_after) ? (
+          {!dag.is_paused && Boolean(dag.next_dagrun_run_after) ? (
             <DagRunInfo
               logicalDate={dag.next_dagrun_logical_date}
               runAfter={dag.next_dagrun_run_after as string}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -101,7 +101,7 @@ const createColumns = (
   {
     accessorKey: "next_dagrun",
     cell: ({ row: { original } }) =>
-      Boolean(original.next_dagrun_run_after) ? (
+      !original.is_paused && Boolean(original.next_dagrun_run_after) ? (
         <DagRunInfo
           logicalDate={original.next_dagrun_logical_date}
           runAfter={original.next_dagrun_run_after as string}


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

#66462 The issue is that a paused Dag can show Next Run in the past, making it look stuck or broken even though it is only paused.

<!-- 
<img width="1184" height="249" alt="image" src="https://github.com/user-attachments/assets/d9efb1cb-a257-41c9-8fdf-411a5c688f78" />
-->
<img width="593" height="126" alt="image" src="https://github.com/user-attachments/assets/49fa5a70-657a-437b-b516-2cf7a23da2cd" />

## Cause

The UI still renders Next Run for paused Dags, which can surface a past timestamp and make the Dag look stuck.

Example:
- Current time: 10:03
- Dag state: paused
- Next Run: 10:02

<details> 
<summary> repro description </summary>

- Create a Dag with schedule
- Open /dags
- Wait for one scheduled run to succeed and note the next Next Run time.
- Pause the Dag.
- Wait until that Next Run time passes, then refresh /dags.

```py
import pendulum

from airflow.sdk import DAG, task

with DAG(
    dag_id="repro_paused_next_run_drift",
    start_date=pendulum.datetime(2026, 1, 1, tz="UTC"),
    schedule="*/2 * * * *",
    catchup=False,
    tags=["repro"],
):
    @task
    def noop():
        print("ok")

    noop()

```

</details>

## Fix

 Hide the `Next Run` timestamp for paused Dags.
  Changed areas:
  - Dag list: card view, table view
  - Dag detail: header

Dag list card view
<img width="1307" height="198" alt="image" src="https://github.com/user-attachments/assets/1d9cda31-cb80-4b31-a420-0ee589da0766" />

Dag list table view
<img width="1306" height="206" alt="image" src="https://github.com/user-attachments/assets/93b4f484-effd-4f3a-88d7-898424ab1dac" />

Dag detail header
<img width="1028" height="122" alt="image" src="https://github.com/user-attachments/assets/98dba17b-751b-4df5-886d-8b5054d06830" />

* closes: #66462

cc @choo121600 

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Codex(gpt-5.5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

