### PR TITLE
Use hmac.compare_digest for SimpleAuthManager password compare (CWE-208)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/services/login.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import hmac
+
 from fastapi import HTTPException, status
 
 from airflow.api_fastapi.app import get_auth_manager
@@ -53,10 +55,17 @@ class SimpleAuthManagerLogin:
 
         users = SimpleAuthManager.get_users()
         passwords = SimpleAuthManager.get_passwords()
+        # Use hmac.compare_digest for constant-time password comparison (CWE-208).
+        # `passwords.get(..., "")` keeps the comparison constant-time against an
+        # empty string when the user record exists but the password entry is missing.
         found_users = [
             user
             for user in users
-            if user.username == body.username and passwords[user.username] == body.password
+            if user.username == body.username
+            and hmac.compare_digest(
+                passwords.get(user.username, "").encode("utf-8"),
+                body.password.encode("utf-8"),
+            )
         ]
 
         if len(found_users) == 0:

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/services/test_login.py
@@ -121,3 +121,29 @@ class TestLogin:
         with pytest.raises(HTTPException) as ex:
             SimpleAuthManagerLogin.create_token_all_admins()
         assert ex.value.status_code == 403
+
+    @pytest.mark.db_test
+    def test_create_token_wrong_password_rejected(self, auth_manager):
+        """Wrong password is rejected via constant-time comparison (CWE-208)."""
+        with conf_vars({("core", "simple_auth_manager_users"): f"{TEST_USER_1}:{TEST_ROLE_1}"}):
+            auth_manager.init()
+            with pytest.raises(HTTPException) as ex:
+                SimpleAuthManagerLogin.create_token(
+                    body=LoginBody(username=TEST_USER_1, password="wrong-password"),
+                    expiration_time_in_seconds=1,
+                )
+            assert ex.value.status_code == 401
+            assert "Invalid credentials" in ex.value.detail
+
+    @pytest.mark.db_test
+    def test_create_token_unknown_user_rejected(self, auth_manager):
+        """Unknown username is rejected without leaking timing info (CWE-208)."""
+        with conf_vars({("core", "simple_auth_manager_users"): f"{TEST_USER_1}:{TEST_ROLE_1}"}):
+            auth_manager.init()
+            with pytest.raises(HTTPException) as ex:
+                SimpleAuthManagerLogin.create_token(
+                    body=LoginBody(username="nonexistent", password="any-password"),
+                    expiration_time_in_seconds=1,
+                )
+            assert ex.value.status_code == 401
+            assert "Invalid credentials" in ex.value.detail


### PR DESCRIPTION
## Summary

The SimpleAuthManager login service compared submitted passwords against the stored value with `==`, which short-circuits on the first differing character and leaks password length / prefix information through timing analysis.

Switch to `hmac.compare_digest()` so the comparison runs in constant time regardless of where the strings diverge, and use `.get(user.username, "")` so a user record without a corresponding password entry compares against an empty string rather than raising `KeyError`.

SimpleAuthManager is dev-only, but the threat model the audit raised (timing analysis from a co-located process or local network) is plausible even in dev, and the fix is one line. ASVS L1/L2/L3 § 6.3.1 / CWE-208.

Tests added for wrong-password and unknown-username rejection.

## Reported by

L3 ASVS sweep — apache/tooling-agents#23 (FINDING-008).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)