### PR TITLE
Warn against world-accessible Kerberos ccache default in docs

### DIFF
--- a/airflow-core/docs/security/kerberos.rst
+++ b/airflow-core/docs/security/kerberos.rst
@@ -91,6 +91,16 @@ If you need more granular options for your Kerberos ticket the following options
     # This is particularly useful if you use Airflow inside a VM NATted behind host system IP.
     include_ip = True
 
+.. warning::
+
+    The default ``ccache`` location ``/tmp/airflow_krb5_ccache`` is in a world-readable directory on most
+    Unix systems, which means other local users on the same host could read or modify the Kerberos
+    credential cache and impersonate the Airflow service principal. In production deployments, point
+    ``ccache`` at a directory only the Airflow service account can access — for example a per-service
+    runtime directory like ``/run/airflow/krb5_ccache`` (or ``/var/lib/airflow/krb5_ccache``) created
+    with mode ``0700`` and owned by the Airflow user. Apply the same principle as the keytab, which
+    should already be ``chmod 600``.
+
 Keep in mind that Kerberos ticket are generated via ``kinit`` and will your use your local ``krb5.conf`` by default.
 
 Launch the ticket renewer by


### PR DESCRIPTION
## Summary

The Kerberos integration docs ship a default ccache path of `/tmp/airflow_krb5_ccache`, which sits in a world-readable directory on most Unix systems and would let any other local user on the host read or modify the Airflow service principal's credential cache.

Add a warning recommending a non-world-accessible directory (a per-service runtime dir like `/run/airflow/krb5_ccache` or a private user-scoped location) and `chmod 0700` on the parent — mirroring the guidance the docs already give for the keytab.

Documentation-only change; no code paths affected.

## Reported by

L3 ASVS sweep — apache/tooling-agents#23 (FINDING-175).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)