### PR TITLE
Fix millisecond floating point duration bug

### DIFF
--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -16,11 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import dayjs from "dayjs";
+import dayjsDuration from "dayjs/plugin/duration";
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 
 import { getDuration, renderDuration, getRelativeTime } from "./datetimeUtils";
 
-describe("getDuration", () => {
+dayjs.extend(dayjsDuration);
+
+describe("getDuration & formatDuration", () => {
   it("handles durations less than 60 seconds", () => {
     const start = "2024-03-14T10:00:00.000Z";
     const end = "2024-03-14T10:00:05.5111111Z";
@@ -69,10 +73,23 @@ describe("getDuration", () => {
 
     const start = "2024-03-14T10:00:00.000Z";
 
-    expect(getDuration(start, null)).toBe("00:00:10.000");
-    expect(getDuration(start, undefined)).toBe("00:00:10.000");
+    expect(getDuration(start, null)).toBe("00:00:10");
+    expect(getDuration(start, undefined)).toBe("00:00:10");
 
     vi.useRealTimers();
+  });
+
+  it("handles both numbers and duration objects", () => {
+    expect(renderDuration(dayjs.duration(10, "seconds"))).toBe("00:00:10");
+    expect(renderDuration(10)).toBe("00:00:10");
+  });
+
+  it("handles floating point milliseconds", () => {
+    expect(renderDuration(dayjs.duration(10.000_499_738, "seconds"))).toBe("00:00:10");
+    expect(renderDuration(10.000_499_738)).toBe("00:00:10");
+
+    expect(renderDuration(dayjs.duration(10.838_999_738, "seconds"))).toBe("00:00:10.839");
+    expect(renderDuration(10.838_999_738)).toBe("00:00:10.839");
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.test.ts
@@ -87,7 +87,8 @@ describe("getDuration & formatDuration", () => {
   it("handles floating point milliseconds", () => {
     expect(renderDuration(dayjs.duration(10.000_499_738, "seconds"))).toBe("00:00:10");
     expect(renderDuration(10.000_499_738)).toBe("00:00:10");
-
+    expect(renderDuration(dayjs.duration(10.000_500, "seconds"))).toBe("00:00:10.001");
+    expect(renderDuration(10.000_500)).toBe("00:00:10.001");
     expect(renderDuration(dayjs.duration(10.838_999_738, "seconds"))).toBe("00:00:10.839");
     expect(renderDuration(10.838_999_738)).toBe("00:00:10.839");
   });

--- a/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
+++ b/airflow-core/src/airflow/ui/src/utils/datetimeUtils.ts
@@ -29,22 +29,29 @@ export const DEFAULT_DATETIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
 export const DEFAULT_DATETIME_FORMAT_WITH_TZ = `${DEFAULT_DATETIME_FORMAT} z`;
 
 export const renderDuration = (
-  durationSeconds: number | null | undefined,
+  durationSeconds: dayjsDuration.Duration | number | null | undefined,
   withMilliseconds: boolean = true,
 ): string | undefined => {
-  if (durationSeconds === null || durationSeconds === undefined || durationSeconds <= 0.01) {
+  if (durationSeconds === null || durationSeconds === undefined) {
+    return undefined;
+  }
+
+  // Handle floating point milliseconds
+  const duration = dayjs.isDuration(durationSeconds)
+    ? dayjs.duration(Math.round(durationSeconds.asMilliseconds()))
+    : dayjs.duration(Number(durationSeconds.toFixed(3)), "seconds");
+
+  if (duration.asMilliseconds() < 1) {
     return undefined;
   }
 
   // If under 60 seconds, render milliseconds
-  if (durationSeconds < 60 && withMilliseconds) {
-    return dayjs.duration(Number(durationSeconds.toFixed(3)), "seconds").format("HH:mm:ss.SSS");
+  if (duration.asSeconds() < 60 && duration.milliseconds() > 0 && withMilliseconds) {
+    return duration.format("HH:mm:ss.SSS");
   }
 
   // If under 1 day, render as HH:mm:ss otherwise include the number of days
-  return durationSeconds < 86_400
-    ? dayjs.duration(durationSeconds, "seconds").format("HH:mm:ss")
-    : dayjs.duration(durationSeconds, "seconds").format("D[d]HH:mm:ss");
+  return duration.asSeconds() < 86_400 ? duration.format("HH:mm:ss") : duration.format("D[d]HH:mm:ss");
 };
 
 export const getDuration = (
@@ -57,9 +64,9 @@ export const getDuration = (
   }
 
   const end = endDate ?? dayjs().toISOString();
-  const seconds = dayjs.duration(dayjs(end).diff(startDate)).asSeconds();
+  const milliseconds = dayjs.duration(dayjs(end).diff(startDate));
 
-  return renderDuration(seconds, withMilliseconds);
+  return renderDuration(milliseconds, withMilliseconds);
 };
 
 export const formatDate = (


### PR DESCRIPTION
Fix bug when rendering a duration with a floating point of milliseconds. To make sure we only ever show millisecond-level precision.


Before:
<img width="711" height="78" alt="Screenshot 2026-05-07 at 12 23 31 PM" src="https://github.com/user-attachments/assets/8f6aa71d-315a-4d46-b583-5c9b0ffea5f5" />



After:
<img width="508" height="76" alt="Screenshot 2026-05-07 at 12 23 16 PM" src="https://github.com/user-attachments/assets/449ad1e2-d22e-458d-a5bd-d8fd56a1e128" />





---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
