### PR TITLE
Require trust sentinel for state.user injection in get_user()

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/middlewares/refresh_token.py
@@ -25,7 +25,10 @@ from airflow.api_fastapi.app import get_auth_manager, get_cookie_path
 from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
 from airflow.api_fastapi.auth.managers.exceptions import AuthManagerRefreshTokenExpiredException
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
-from airflow.api_fastapi.core_api.security import resolve_user_from_token
+from airflow.api_fastapi.core_api.security import (
+    USER_INJECTED_BY_TRUSTED_MIDDLEWARE,
+    resolve_user_from_token,
+)
 from airflow.configuration import conf
 
 
@@ -48,7 +51,11 @@ class JWTRefreshMiddleware(BaseHTTPMiddleware):
                 try:
                     new_user, current_user = await self._refresh_user(current_token)
                     if user := (new_user or current_user):
+                        # Stamp the trust sentinel alongside the user so `get_user()`
+                        # can distinguish this trusted assignment from a stray write
+                        # by unrelated middleware.
                         request.state.user = user
+                        request.state.user_authenticated_via = USER_INJECTED_BY_TRUSTED_MIDDLEWARE
                     if new_user:
                         # If we created a new user, serialize it and set it as a cookie
                         new_token = get_auth_manager().generate_jwt(new_user)

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -125,14 +125,31 @@ async def resolve_user_from_token(token_str: str | None) -> BaseUser:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid JWT token")
 
 
+# Sentinel marker that designates a `request.state.user` value as having come from a
+# trusted, in-tree authentication code path (currently only `JWTRefreshMiddleware`).
+# `get_user()` only honours `request.state.user` when this sentinel is also present
+# at `request.state.user_authenticated_via`. This is defense-in-depth against an
+# accidental `request.state.user = ...` assignment in unrelated middleware (a typo,
+# a third-party plugin, a fixture leaked into production); it does NOT defend against
+# a malicious in-process plugin that imports the sentinel and sets it itself, since
+# plugins are trusted code in Airflow's security model — the goal is to keep an
+# accidental write from silently bypassing JWT validation.
+USER_INJECTED_BY_TRUSTED_MIDDLEWARE = object()
+
+
 async def get_user(
     request: Request,
     oauth_token: str | None = Depends(oauth2_scheme),
     bearer_credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> BaseUser:
-    # A user might have been already built by a middleware, if so, it is stored in `request.state.user`
+    # A user might have been already built by a trusted in-tree middleware (currently
+    # only `JWTRefreshMiddleware`); if so, it is stored in `request.state.user` AND
+    # `request.state.user_authenticated_via` is set to the trust sentinel above.
+    # Honour the cached user only when both are present, so a stray `state.user`
+    # assignment from unrelated middleware can't bypass JWT validation.
     user: BaseUser | None = getattr(request.state, "user", None)
-    if user:
+    trust_marker = getattr(request.state, "user_authenticated_via", None)
+    if user and trust_marker is USER_INJECTED_BY_TRUSTED_MIDDLEWARE:
         return user
 
     token_str: str | None

--- a/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/middlewares/test_refresh_token.py
@@ -123,7 +123,13 @@ class TestJWTRefreshMiddleware:
         call_next = AsyncMock(return_value=Response())
         response = await middleware.dispatch(mock_request, call_next)
 
+        from airflow.api_fastapi.core_api.security import USER_INJECTED_BY_TRUSTED_MIDDLEWARE
+
         assert mock_request.state.user == refreshed_user
+        # JWTRefreshMiddleware must stamp the trust sentinel so `get_user()` accepts
+        # the cached user. Without the marker, the auth dependency falls through
+        # to a fresh JWT validation, defeating the refresh.
+        assert mock_request.state.user_authenticated_via is USER_INJECTED_BY_TRUSTED_MIDDLEWARE
         call_next.assert_called_once_with(mock_request)
         mock_resolve_user_from_token.assert_called_once_with("valid_token")
         mock_auth_manager.refresh_user.assert_called_once_with(user=mock_user)

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -116,15 +116,42 @@ class TestFastApiSecurity:
             await resolve_user_from_token(None)
 
     @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
-    async def test_get_user_with_request_state(self, mock_resolve_user_from_token):
+    async def test_get_user_with_trusted_request_state(self, mock_resolve_user_from_token):
+        """A `request.state.user` paired with the trust sentinel is honoured."""
+        from airflow.api_fastapi.core_api.security import USER_INJECTED_BY_TRUSTED_MIDDLEWARE
+
         user = Mock()
         request = Mock()
         request.state.user = user
+        request.state.user_authenticated_via = USER_INJECTED_BY_TRUSTED_MIDDLEWARE
 
         result = await get_user(request, None, None)
 
         assert result == user
         mock_resolve_user_from_token.assert_not_called()
+
+    @patch("airflow.api_fastapi.core_api.security.resolve_user_from_token")
+    async def test_get_user_ignores_request_state_without_trust_marker(self, mock_resolve_user_from_token):
+        """An un-marked `request.state.user` is ignored — falls through to JWT.
+
+        Defends against unrelated middleware accidentally writing `state.user`
+        and silently bypassing JWT validation.
+        """
+        injected_user = Mock(name="injected_user")
+        resolved_user = Mock(name="resolved_user")
+        mock_resolve_user_from_token.return_value = resolved_user
+
+        request = Mock()
+        request.state.user = injected_user
+        # Trust marker deliberately not set — simulates a non-auth middleware
+        # that wrote `state.user` without going through the auth path.
+        request.state.user_authenticated_via = None
+        request.cookies = {COOKIE_NAME_JWT_TOKEN: "cookie_token"}
+
+        result = await get_user(request, None, None)
+
+        assert result == resolved_user
+        mock_resolve_user_from_token.assert_called_once_with("cookie_token")
 
     @pytest.mark.parametrize(
         ("oauth_token", "bearer_credentials_creds", "cookies", "expected"),


### PR DESCRIPTION
## Summary

The `get_user()` auth dependency in `core_api/security.py` accepted any value at `request.state.user` without verification, returning it before JWT signature/expiry/revocation checks. The only legitimate writer (`JWTRefreshMiddleware`) is one of many possible middlewares — any plugin or unrelated middleware that wrote `request.state.user`, accidentally or otherwise, would silently bypass JWT validation.

## Fix

Defense-in-depth: introduce a private module-level sentinel `USER_INJECTED_BY_TRUSTED_MIDDLEWARE` and require it to be set at `request.state.user_authenticated_via` for `get_user()` to honour the cached user. `JWTRefreshMiddleware` now stamps the marker alongside the user. Without the marker, `get_user()` falls through to fresh JWT validation, so a stray `state.user = ...` write no longer skips auth.

## Threat model

This does **not** defend against a *malicious* in-process plugin (which can import the sentinel and set it itself) — plugins are trusted code in Airflow's [security model](https://github.com/apache/airflow/blob/main/airflow-core/docs/security/security_model.rst). The goal is preventing accidental writes from unrelated middleware silently bypassing auth, which the audit flagged as an undocumented authentication pathway.

Tests cover both the marked-honoured path and the unmarked-fall-through path; the `JWTRefreshMiddleware` test asserts the marker is stamped.

## Reported by

L3 ASVS sweep — apache/tooling-agents#23 (FINDING-133).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)