### PR TITLE
Warn when SimpleAuthManager runs in a production-shaped deployment

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -119,11 +119,55 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         with open(password_file, "r+") as file:
             return SimpleAuthManager._get_passwords(file)
 
+    @staticmethod
+    def _looks_like_production() -> bool:
+        """
+        Best-effort heuristic for whether the Airflow deployment looks production-shaped.
+
+        Returns True if any of the following hold:
+
+        - The SQL backend is not sqlite (i.e. Postgres or MySQL is configured).
+        - The API host is bound to a non-local address.
+        - The configured executor is not Local-/Sequential-/Debug-/InProcessExecutor.
+
+        None of these are *definitive* — a developer can pick any combination locally
+        — but the cumulative signal is strong enough to justify a loud warning that
+        SimpleAuthManager (which is dev-only by design) is being used in a setup
+        that resembles production.
+        """
+        sql_conn = conf.get("database", "sql_alchemy_conn", fallback="")
+        if sql_conn and not sql_conn.startswith("sqlite:"):
+            return True
+        api_host = conf.get("api", "host", fallback="localhost").strip()
+        if api_host not in {"localhost", "127.0.0.1", "::1", "[::1]"}:
+            return True
+        executor = conf.get("core", "executor", fallback="LocalExecutor")
+        # Split on '.' to get the class name only (handles fully-qualified executor paths).
+        local_executors = {"LocalExecutor", "SequentialExecutor", "DebugExecutor", "InProcessExecutor"}
+        if executor.split(".")[-1] not in local_executors:
+            return True
+        return False
+
     def init(self) -> None:
         super().init()
         is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
         if is_simple_auth_manager_all_admins:
             return
+
+        # SimpleAuthManager is dev-only by design — it stores passwords in plaintext,
+        # prints generated passwords to stdout/logs on first init, and provides no
+        # rotation mechanism. Emit a loud warning when the deployment shape suggests
+        # production so it shows up in startup logs of misconfigured deployments.
+        if self._looks_like_production():
+            log.warning(
+                "SimpleAuthManager is active but the deployment shape looks like production "
+                "(non-sqlite backend, non-local API host, or a distributed executor). "
+                "SimpleAuthManager stores passwords in plaintext at %s and prints generated "
+                "passwords to stdout/logs on first init. Use a real auth manager "
+                "(e.g. FAB or Keycloak) for production deployments.",
+                self.get_generated_password_file(),
+            )
+
         users = self.get_users()
         password_file = self.get_generated_password_file()
 

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -120,7 +120,12 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
             return SimpleAuthManager._get_passwords(file)
 
     @staticmethod
-    def _looks_like_production() -> bool:
+    def _looks_like_production(
+        *,
+        sql_conn: str | None = None,
+        api_host: str | None = None,
+        executor: str | None = None,
+    ) -> bool:
         """
         Best-effort heuristic for whether the Airflow deployment looks production-shaped.
 
@@ -134,14 +139,22 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         — but the cumulative signal is strong enough to justify a loud warning that
         SimpleAuthManager (which is dev-only by design) is being used in a setup
         that resembles production.
+
+        Each axis can be passed in directly (kwargs) so unit tests can probe the
+        decision logic without touching the global ``conf`` state. ``None`` (the
+        default) reads the value from ``conf``.
         """
-        sql_conn = conf.get("database", "sql_alchemy_conn", fallback="")
+        if sql_conn is None:
+            sql_conn = conf.get("database", "sql_alchemy_conn", fallback="")
+        if api_host is None:
+            api_host = conf.get("api", "host", fallback="localhost")
+        if executor is None:
+            executor = conf.get("core", "executor", fallback="LocalExecutor")
+
         if sql_conn and not sql_conn.startswith("sqlite:"):
             return True
-        api_host = conf.get("api", "host", fallback="localhost").strip()
-        if api_host not in {"localhost", "127.0.0.1", "::1", "[::1]"}:
+        if api_host.strip() not in {"localhost", "127.0.0.1", "::1", "[::1]"}:
             return True
-        executor = conf.get("core", "executor", fallback="LocalExecutor")
         # Split on '.' to get the class name only (handles fully-qualified executor paths).
         local_executors = {"LocalExecutor", "SequentialExecutor", "DebugExecutor", "InProcessExecutor"}
         if executor.split(".")[-1] not in local_executors:

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -121,6 +121,84 @@ class TestSimpleAuthManager:
             auth_manager.init()
             assert not os.path.exists(auth_manager.get_generated_password_file())
 
+    @pytest.mark.parametrize(
+        ("config_overrides", "expected"),
+        [
+            pytest.param(
+                {("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db"},
+                False,
+                id="sqlite-only-is-dev",
+            ),
+            pytest.param(
+                {("database", "sql_alchemy_conn"): "postgresql+psycopg2://airflow@db/airflow"},
+                True,
+                id="postgres-backend-is-prod-shape",
+            ),
+            pytest.param(
+                {("database", "sql_alchemy_conn"): "mysql://airflow@db/airflow"},
+                True,
+                id="mysql-backend-is-prod-shape",
+            ),
+            pytest.param(
+                {("api", "host"): "0.0.0.0"},
+                True,
+                id="non-local-bind-is-prod-shape",
+            ),
+            pytest.param(
+                {("api", "host"): "localhost"},
+                False,
+                id="localhost-bind-is-dev",
+            ),
+            pytest.param(
+                {("core", "executor"): "CeleryExecutor"},
+                True,
+                id="celery-executor-is-prod-shape",
+            ),
+            pytest.param(
+                {("core", "executor"): "airflow.executors.local_executor.LocalExecutor"},
+                False,
+                id="fully-qualified-local-executor-is-dev",
+            ),
+        ],
+    )
+    def test_looks_like_production(self, auth_manager, config_overrides, expected):
+        # Anchor every irrelevant axis to dev defaults so the parametrised override
+        # is the only signal under test.
+        base = {
+            ("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db",
+            ("api", "host"): "localhost",
+            ("core", "executor"): "LocalExecutor",
+        }
+        base.update(config_overrides)
+        with conf_vars(base):
+            assert SimpleAuthManager._looks_like_production() is expected
+
+    @mock.patch("airflow.api_fastapi.auth.managers.simple.simple_auth_manager.log")
+    def test_init_warns_when_production_shaped(self, mock_log, auth_manager):
+        """SimpleAuthManager.init() emits a loud warning in a production-shaped deployment."""
+        config = {
+            ("core", "simple_auth_manager_users"): "alice:admin",
+            ("database", "sql_alchemy_conn"): "postgresql+psycopg2://airflow@db/airflow",
+            ("api", "host"): "localhost",
+            ("core", "executor"): "LocalExecutor",
+        }
+        with conf_vars(config):
+            auth_manager.init()
+        mock_log.warning.assert_called_once()
+
+    @mock.patch("airflow.api_fastapi.auth.managers.simple.simple_auth_manager.log")
+    def test_init_does_not_warn_for_dev_shape(self, mock_log, auth_manager):
+        """No production warning when the deployment shape looks like local dev."""
+        config = {
+            ("core", "simple_auth_manager_users"): "alice:admin",
+            ("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db",
+            ("api", "host"): "localhost",
+            ("core", "executor"): "LocalExecutor",
+        }
+        with conf_vars(config):
+            auth_manager.init()
+        mock_log.warning.assert_not_called()
+
     def test_get_url_login(self, auth_manager):
         result = auth_manager.get_url_login()
         assert result == AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login"

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -122,81 +122,104 @@ class TestSimpleAuthManager:
             assert not os.path.exists(auth_manager.get_generated_password_file())
 
     @pytest.mark.parametrize(
-        ("config_overrides", "expected"),
+        ("kwargs", "expected"),
         [
             pytest.param(
-                {("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db"},
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "localhost",
+                    "executor": "LocalExecutor",
+                },
                 False,
-                id="sqlite-only-is-dev",
+                id="all-dev",
             ),
             pytest.param(
-                {("database", "sql_alchemy_conn"): "postgresql+psycopg2://airflow@db/airflow"},
+                {
+                    "sql_conn": "postgresql+psycopg2://airflow@db/airflow",
+                    "api_host": "localhost",
+                    "executor": "LocalExecutor",
+                },
                 True,
                 id="postgres-backend-is-prod-shape",
             ),
             pytest.param(
-                {("database", "sql_alchemy_conn"): "mysql://airflow@db/airflow"},
+                {
+                    "sql_conn": "mysql://airflow@db/airflow",
+                    "api_host": "localhost",
+                    "executor": "LocalExecutor",
+                },
                 True,
                 id="mysql-backend-is-prod-shape",
             ),
             pytest.param(
-                {("api", "host"): "0.0.0.0"},
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "0.0.0.0",
+                    "executor": "LocalExecutor",
+                },
                 True,
                 id="non-local-bind-is-prod-shape",
             ),
             pytest.param(
-                {("api", "host"): "localhost"},
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "127.0.0.1",
+                    "executor": "LocalExecutor",
+                },
                 False,
-                id="localhost-bind-is-dev",
+                id="loopback-bind-is-dev",
             ),
             pytest.param(
-                {("core", "executor"): "CeleryExecutor"},
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "localhost",
+                    "executor": "CeleryExecutor",
+                },
                 True,
                 id="celery-executor-is-prod-shape",
             ),
             pytest.param(
-                {("core", "executor"): "airflow.executors.local_executor.LocalExecutor"},
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "localhost",
+                    "executor": "airflow.executors.local_executor.LocalExecutor",
+                },
                 False,
                 id="fully-qualified-local-executor-is-dev",
             ),
+            pytest.param(
+                {
+                    "sql_conn": "sqlite:////tmp/airflow.db",
+                    "api_host": "  localhost  ",
+                    "executor": "LocalExecutor",
+                },
+                False,
+                id="api-host-is-stripped",
+            ),
         ],
     )
-    def test_looks_like_production(self, auth_manager, config_overrides, expected):
-        # Anchor every irrelevant axis to dev defaults so the parametrised override
-        # is the only signal under test.
-        base = {
-            ("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db",
-            ("api", "host"): "localhost",
-            ("core", "executor"): "LocalExecutor",
-        }
-        base.update(config_overrides)
-        with conf_vars(base):
-            assert SimpleAuthManager._looks_like_production() is expected
+    def test_looks_like_production(self, kwargs, expected):
+        # The function takes each axis as a keyword argument so the test fully
+        # controls the inputs and does not rely on conf state. Any axis left
+        # as None would fall through to conf.get(); we pass all three explicitly.
+        assert SimpleAuthManager._looks_like_production(**kwargs) is expected
 
+    @mock.patch.object(SimpleAuthManager, "_looks_like_production", return_value=True)
     @mock.patch("airflow.api_fastapi.auth.managers.simple.simple_auth_manager.log")
-    def test_init_warns_when_production_shaped(self, mock_log, auth_manager):
+    def test_init_warns_when_production_shaped(self, mock_log, mock_check, auth_manager):
         """SimpleAuthManager.init() emits a loud warning in a production-shaped deployment."""
-        config = {
-            ("core", "simple_auth_manager_users"): "alice:admin",
-            ("database", "sql_alchemy_conn"): "postgresql+psycopg2://airflow@db/airflow",
-            ("api", "host"): "localhost",
-            ("core", "executor"): "LocalExecutor",
-        }
-        with conf_vars(config):
+        with conf_vars({("core", "simple_auth_manager_users"): "alice:admin"}):
             auth_manager.init()
+        mock_check.assert_called_once_with()
         mock_log.warning.assert_called_once()
 
+    @mock.patch.object(SimpleAuthManager, "_looks_like_production", return_value=False)
     @mock.patch("airflow.api_fastapi.auth.managers.simple.simple_auth_manager.log")
-    def test_init_does_not_warn_for_dev_shape(self, mock_log, auth_manager):
+    def test_init_does_not_warn_for_dev_shape(self, mock_log, mock_check, auth_manager):
         """No production warning when the deployment shape looks like local dev."""
-        config = {
-            ("core", "simple_auth_manager_users"): "alice:admin",
-            ("database", "sql_alchemy_conn"): "sqlite:////tmp/airflow.db",
-            ("api", "host"): "localhost",
-            ("core", "executor"): "LocalExecutor",
-        }
-        with conf_vars(config):
+        with conf_vars({("core", "simple_auth_manager_users"): "alice:admin"}):
             auth_manager.init()
+        mock_check.assert_called_once_with()
         mock_log.warning.assert_not_called()
 
     def test_get_url_login(self, auth_manager):


### PR DESCRIPTION
## Summary

`SimpleAuthManager` is dev-only by design — it stores passwords in plaintext JSON, prints generated passwords to stdout/logs on first init, and provides no rotation mechanism. The class docstring says so, but nothing prevents an operator from configuring it (or leaving it as the default) in a production deployment, where the password leak becomes a real exposure.

Add a heuristic check at `init()` time: if any of the following are true, the deployment shape suggests production and we emit a `log.warning`:

- The SQL backend is not sqlite (Postgres or MySQL is configured).
- The API host is bound to a non-local address.
- The configured executor is not a Local-/Sequential-/Debug-/InProcessExecutor.

None of these are conclusive on their own — a developer can configure any combination locally — but the cumulative signal is strong enough that a loud warning in startup logs is worth the false-positive cost. The warning is non-blocking; it does not refuse to start.

Tests parametrise `_looks_like_production()` over each axis and assert the warning fires (or doesn't) end-to-end through `init()`.

## Reported by

L3 ASVS sweep — apache/tooling-agents#23 (FINDING-039).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)