### PR TITLE
Adjust log message header for expandable sources

### DIFF
--- a/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
@@ -68,11 +68,10 @@ export const handlers: Array<HttpHandler> = [
   http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/generate/logs/1", () =>
     HttpResponse.json({
       content: [
+        { event: "::group::Log message source details" },
         {
-          event: "::group::Log message source details",
-          sources: [
+          event:
             "/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log",
-          ],
         },
         { event: "::endgroup::" },
         {
@@ -211,11 +210,10 @@ export const handlers: Array<HttpHandler> = [
   http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/ti_context/logs/1", () =>
     HttpResponse.json({
       content: [
+        { event: "::group::Log message source details" },
         {
-          event: "::group::Log message source details",
-          sources: [
+          event:
             "/home/airflow/logs/dag_id=log_grouping/run_id=manual__2025-02-18T12:19/task_id=ti_context/attempt=1.log",
-          ],
         },
         { event: "::endgroup::" },
         {
@@ -255,11 +253,10 @@ export const handlers: Array<HttpHandler> = [
   http.get("/api/v2/dags/log_grouping/dagRuns/manual__2025-02-18T12:19/taskInstances/log_source/logs/1", () =>
     HttpResponse.json({
       content: [
+        { event: "::group::Log message source details", timestamp: null },
         {
-          event: "::group::Log message source details",
-          sources: [
+          event:
             "/root/airflow/logs/dag_id=log_grouping/run_id=manual__2025-02-18T12:19/task_id=log_source/attempt=1.log",
-          ],
           timestamp: null,
         },
         { event: "::endgroup::", timestamp: null },

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -91,9 +91,7 @@ describe("Task log grouping", () => {
     await waitForLogs();
 
     // Group headers use the summary-{name} testid pattern and are always visible
-    const summarySource = screen.getByTestId(
-      'summary-Log message source details sources=["/home/airflow/logs/dag_id=tutorial_dag/run_id=manual__2025-02-28T05:18:54.249762+00:00/task_id=load/attempt=1.log"]',
-    );
+    const summarySource = screen.getByTestId("summary-Log message source details");
 
     expect(summarySource).toBeVisible();
 
@@ -190,9 +188,7 @@ describe("Task Identity preamble", () => {
 
     await waitForLogs();
 
-    const sourceGroup = screen.getByTestId(
-      'summary-Log message source details sources=["/home/airflow/logs/dag_id=log_grouping/run_id=manual__2025-02-18T12:19/task_id=ti_context/attempt=1.log"]',
-    );
+    const sourceGroup = screen.getByTestId("summary-Log message source details");
 
     expect(sourceGroup).toBeInTheDocument();
 
@@ -432,8 +428,8 @@ describe("Task log search", () => {
 
     fireEvent.click(summaryDependency);
 
-    await expectRenderedLineNumber(/dep_context=non-requeueable/iu, 0);
-    await expectRenderedLineNumber(/dep_context=requeueable/iu, 1);
-    await expectRenderedLineNumber(/starting attempt 1 of 3/iu, 2);
+    await expectRenderedLineNumber(/dep_context=non-requeueable/iu, 1);
+    await expectRenderedLineNumber(/dep_context=requeueable/iu, 2);
+    await expectRenderedLineNumber(/starting attempt 1 of 3/iu, 3);
   }, 10_000);
 });

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.test.ts
@@ -47,7 +47,9 @@ describe("getDownloadText", () => {
   it("places Task Identity preamble after the source details endgroup, before the first log line", () => {
     const fetchedData = {
       content: [
-        { event: "::group::Log message source details", sources: ["/logs/a.log", "/logs/b.log"] },
+        { event: "::group::Log message source details" },
+        { event: "/logs/a.log" },
+        { event: "/logs/b.log" },
         { event: "some source detail" },
         { event: "::endgroup::" },
         tiLine("First log line", "2026-01-01T00:00:00Z"),
@@ -68,7 +70,8 @@ describe("getDownloadText", () => {
   it("does not include TI context fields on individual log lines", () => {
     const fetchedData = {
       content: [
-        { event: "::group::Log message source details", sources: ["/logs/a.log"] },
+        { event: "::group::Log message source details" },
+        { event: "/logs/a.log" },
         { event: "::endgroup::" },
         tiLine("Task started", "2026-01-01T00:00:00Z"),
       ],
@@ -87,7 +90,8 @@ describe("getDownloadText", () => {
   it("omits the preamble when no TI context fields are present", () => {
     const fetchedData = {
       content: [
-        { event: "::group::Log message source details", sources: ["/logs/a.log"] },
+        { event: "::group::Log message source details" },
+        { event: "/logs/a.log" },
         { event: "::endgroup::" },
         { event: "plain log line", level: "info", timestamp: "2026-01-01T00:00:00Z" },
       ],

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -670,7 +670,8 @@ class FileTaskHandler(logging.Handler):
         # Log message source details are grouped: they are not relevant for most users and can
         # distract them from finding the root cause of their errors
         header = [
-            StructuredLogMessage(event="::group::Log message source details", sources=source_list),  # type: ignore[call-arg]
+            StructuredLogMessage(event="::group::Log message source details"),
+            *[StructuredLogMessage(event=source) for source in source_list],
             StructuredLogMessage(event="::endgroup::"),
         ]
         end_of_log = ti.try_number != try_number or ti.state not in (

--- a/airflow-core/src/airflow/utils/log/log_reader.py
+++ b/airflow-core/src/airflow/utils/log/log_reader.py
@@ -60,10 +60,7 @@ class TaskLogReader:
         else:
             msg = "No logs available for this task."
 
-        yield StructuredLogMessage(
-            timestamp=None,
-            event="::group::Log message source details",
-        )
+        yield StructuredLogMessage(timestamp=None, event="::group::Log message source details")
         yield StructuredLogMessage(timestamp=None, event="::endgroup::")
         yield StructuredLogMessage(
             timestamp=ti.updated_at or datetime.now(timezone.utc),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_log.py
@@ -172,9 +172,9 @@ class TestTaskInstancesLog:
         expected_filename = f"{self.log_dir}/dag_id={self.DAG_ID}/run_id={self.RUN_ID}/task_id={self.TASK_ID}/attempt={try_number}.log"
         log_content = "Log for testing." if try_number == 1 else "Log for testing 2."
         assert response.status_code == 200, response.json()
-        resp_contnt = response.json()["content"]
-        assert expected_filename in resp_contnt[0]["sources"]
-        assert log_content in resp_contnt[2]["event"]
+        resp_content = response.json()["content"]
+        assert expected_filename in resp_content[1]["event"]
+        assert log_content in resp_content[3]["event"]
 
         assert response.json()["continuation_token"] is None
         assert response.status_code == 200

--- a/airflow-core/tests/unit/utils/log/test_log_reader.py
+++ b/airflow-core/tests/unit/utils/log/test_log_reader.py
@@ -131,11 +131,11 @@ class TestLogView:
 
         logs = list(logs)
         assert logs[0].event == "::group::Log message source details"
-        assert logs[0].sources == [
-            f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log"
-        ]
-        assert logs[1].event == "::endgroup::"
-        assert logs[2].event == "try_number=1."
+        assert (
+            logs[1].event == f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log"
+        )
+        assert logs[2].event == "::endgroup::"
+        assert logs[3].event == "try_number=1."
         assert metadata == {"end_of_log": True, "log_pos": 1}
 
     def test_test_read_log_chunks_should_read_latest_files(self):
@@ -146,11 +146,11 @@ class TestLogView:
 
         logs = list(logs)
         assert logs[0].event == "::group::Log message source details"
-        assert logs[0].sources == [
-            f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log"
-        ]
-        assert logs[1].event == "::endgroup::"
-        assert logs[2].event == f"try_number={ti.try_number}."
+        assert (
+            logs[1].event == f"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log"
+        )
+        assert logs[2].event == "::endgroup::"
+        assert logs[3].event == f"try_number={ti.try_number}."
         assert metadata == {"end_of_log": True, "log_pos": 1}
 
     def test_test_test_read_log_stream_should_read_one_try(self):
@@ -160,10 +160,8 @@ class TestLogView:
         stream = task_log_reader.read_log_stream(ti=ti, try_number=1, metadata={})
 
         assert list(stream) == [
-            '{"timestamp":null,'
-            '"event":"::group::Log message source details",'
-            f'"sources":["{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log"]'
-            "}\n",
+            '{"timestamp":null,"event":"::group::Log message source details"}\n',
+            f'{{"timestamp":null,"event":"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/1.log"}}\n',
             '{"timestamp":null,"event":"::endgroup::"}\n',
             '{"timestamp":null,"event":"try_number=1."}\n',
         ]
@@ -174,10 +172,8 @@ class TestLogView:
         stream = task_log_reader.read_log_stream(ti=self.ti, try_number=None, metadata={})
 
         assert list(stream) == [
-            '{"timestamp":null,'
-            '"event":"::group::Log message source details",'
-            f'"sources":["{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log"]'
-            "}\n",
+            '{"timestamp":null,"event":"::group::Log message source details"}\n',
+            f'{{"timestamp":null,"event":"{self.log_dir}/dag_log_reader/task_log_reader/2017-09-01T00.00.00+00.00/3.log"}}\n',
             '{"timestamp":null,"event":"::endgroup::"}\n',
             '{"timestamp":null,"event":"try_number=3."}\n',
         ]

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -545,20 +545,20 @@ class TestFileTaskLogHandler:
             logical_date=DEFAULT_DATE,
         )
         ti.state = TaskInstanceState.SUCCESS  # we're testing scenario when task is done
-        expected_logs = ["::group::Log message source details", "::endgroup::"]
         with conf_vars({("core", "executor"): executor_name}):
             reload(executor_loader)
             fth = FileTaskHandler("")
             if remote_logs:
                 fth._read_remote_logs = mock.Mock()
                 fth._read_remote_logs.return_value = ["found remote logs"], ["remote\nlog\ncontent"]
-                expected_logs.extend(
-                    [
-                        "remote",
-                        "log",
-                        "content",
-                    ]
-                )
+                expected_logs = [
+                    "::group::Log message source details",
+                    "found remote logs",
+                    "::endgroup::",
+                    "remote",
+                    "log",
+                    "content",
+                ]
             if local_logs:
                 fth._read_from_local = mock.Mock()
                 fth._read_from_local.return_value = (
@@ -567,13 +567,14 @@ class TestFileTaskLogHandler:
                 )
                 # only when not read from remote and TI is unfinished will read from local
                 if not remote_logs:
-                    expected_logs.extend(
-                        [
-                            "local",
-                            "log",
-                            "content",
-                        ]
-                    )
+                    expected_logs = [
+                        "::group::Log message source details",
+                        "found local logs",
+                        "::endgroup::",
+                        "local",
+                        "log",
+                        "content",
+                    ]
             fth._read_from_logs_server = mock.Mock()
             fth._read_from_logs_server.return_value = (
                 ["this message"],
@@ -581,13 +582,14 @@ class TestFileTaskLogHandler:
             )
             # only when not read from remote and not read from local will read from logs server
             if served_logs_checked:
-                expected_logs.extend(
-                    [
-                        "this",
-                        "log",
-                        "content",
-                    ]
-                )
+                expected_logs = [
+                    "::group::Log message source details",
+                    "this message",
+                    "::endgroup::",
+                    "this",
+                    "log",
+                    "content",
+                ]
 
             logs, metadata = fth._read(ti=ti, try_number=1)
         if served_logs_checked:

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -77,7 +77,7 @@ class TestRemoteLogging:
         )
 
         task_log_sources = [
-            source for content in task_logs.get("content", [{}]) for source in content.get("sources", [])
+            source for content in task_logs.get("content", [{}]) for source in content.get("event", [])
         ]
         response = s3_client.list_objects_v2(Bucket=bucket_name)
 

--- a/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/remote_log_tests/test_remote_logging.py
@@ -76,9 +76,7 @@ class TestRemoteLogging:
             run_id=resp["dag_run_id"],
         )
 
-        task_log_sources = [
-            source for content in task_logs.get("content", [{}]) for source in content.get("event", [])
-        ]
+        task_log_sources = [content.get("event", []) for content in task_logs.get("content", [{}])]
         response = s3_client.list_objects_v2(Bucket=bucket_name)
 
         if "Contents" not in response:

--- a/devel-common/src/tests_common/test_utils/file_task_handler.py
+++ b/devel-common/src/tests_common/test_utils/file_task_handler.py
@@ -34,9 +34,15 @@ def extract_events(logs: Iterable[StructuredLogMessage], skip_source_info=True) 
     """Helper function to return just the event (a.k.a message) from a list of StructuredLogMessage"""
     logs = iter(logs)
     if skip_source_info:
+        in_source_group = False
 
         def is_source_group(log: StructuredLogMessage) -> bool:
-            return not hasattr(log, "timestamp") or log.event == "::endgroup::" or hasattr(log, "sources")
+            nonlocal in_source_group
+            if not in_source_group and log.event == "::group::Log message source details":
+                in_source_group = True
+            elif in_source_group and log.event == "::endgroup::":
+                in_source_group = False
+            return not hasattr(log, "timestamp") or log.event == "::endgroup::" or in_source_group
 
         logs = itertools.dropwhile(is_source_group, logs)
 

--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -40,6 +40,7 @@ AIRFLOW_V_3_1_3_PLUS = get_base_airflow_version_tuple() >= (3, 1, 3)
 AIRFLOW_V_3_1_7_PLUS = get_base_airflow_version_tuple() >= (3, 1, 7)
 AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_2_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 2)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 if AIRFLOW_V_3_1_PLUS:

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -38,7 +38,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.taskinstance import create_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
 
 try:
     from airflow.sdk.timezone import datetime
@@ -295,7 +295,7 @@ class TestS3TaskHandler:
 
         expected_s3_uri = f"s3://bucket/{self.remote_log_key}"
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_2_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
             assert expected_s3_uri in log[1].event
@@ -304,6 +304,16 @@ class TestS3TaskHandler:
             assert log[5].event == "Line 2"
             assert log[6].event == "Log line 3"
             assert log[7].event == "Line 4"
+            assert metadata == {"end_of_log": True, "log_pos": 4}
+        elif AIRFLOW_V_3_0_PLUS:
+            log = list(log)
+            assert log[0].event == "::group::Log message source details"
+            assert expected_s3_uri in log[0].sources
+            assert log[1].event == "::endgroup::"
+            assert log[2].event == "Log line"
+            assert log[3].event == "Line 2"
+            assert log[4].event == "Log line 3"
+            assert log[5].event == "Line 4"
             assert metadata == {"end_of_log": True, "log_pos": 4}
         else:
             actual = log[0][0][-1]

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -298,12 +298,12 @@ class TestS3TaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
-            assert expected_s3_uri in log[0].sources
-            assert log[1].event == "::endgroup::"
-            assert log[2].event == "Log line"
-            assert log[3].event == "Line 2"
-            assert log[4].event == "Log line 3"
-            assert log[5].event == "Line 4"
+            assert expected_s3_uri in log[1].event
+            assert log[3].event == "::endgroup::"
+            assert log[4].event == "Log line"
+            assert log[5].event == "Line 2"
+            assert log[6].event == "Log line 3"
+            assert log[7].event == "Line 4"
             assert metadata == {"end_of_log": True, "log_pos": 4}
         else:
             actual = log[0][0][-1]

--- a/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
+++ b/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
@@ -94,7 +94,7 @@ class TestFileTaskLogHandler:
 
         if AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
-            assert logs[0].sources == ["this message"]
+            assert logs[1].event == "this message"
             assert [x.event for x in logs[-3:]] == ["this", "log", "content"]
             assert metadata == {"end_of_log": False, "log_pos": 3}
         else:

--- a/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
+++ b/providers/celery/tests/unit/celery/log_handlers/test_log_handlers.py
@@ -39,7 +39,7 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.file_task_handler import (
     convert_list_to_stream,
 )
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
 
 pytestmark = pytest.mark.db_test
 
@@ -92,9 +92,14 @@ class TestFileTaskLogHandler:
             logs, metadata = fth._read(ti=ti, try_number=1)
             fth._read_from_logs_server.assert_called_once()
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_2_PLUS:
             logs = list(logs)
             assert logs[1].event == "this message"
+            assert [x.event for x in logs[-3:]] == ["this", "log", "content"]
+            assert metadata == {"end_of_log": False, "log_pos": 3}
+        elif AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
+            assert logs[0].sources == ["this message"]
             assert [x.event for x in logs[-3:]] == ["this", "log", "content"]
             assert metadata == {"end_of_log": False, "log_pos": 3}
         else:

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -428,10 +428,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
                 from airflow.utils.log.file_task_handler import StructuredLogMessage
 
                 header = [
-                    StructuredLogMessage(
-                        event="::group::Log message source details",
-                        sources=[host for host in logs_by_host.keys()],
-                    ),  # type: ignore[call-arg]
+                    StructuredLogMessage(event="::group::Log message source details"),
+                    *[StructuredLogMessage(event=host) for host in logs_by_host.keys()],
                     StructuredLogMessage(event="::endgroup::"),
                 ]
 

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -115,9 +115,10 @@ def _assert_log_events(logs, metadatas, *, expected_events: list[str], expected_
     if AIRFLOW_V_3_0_PLUS:
         logs = list(logs)
         assert logs[0].event == "::group::Log message source details"
-        assert logs[0].sources == expected_sources
-        assert logs[1].event == "::endgroup::"
-        assert [log.event for log in logs[2:]] == expected_events
+        for i, source in enumerate(expected_sources, start=1):
+            assert logs[i].event == source
+        assert logs[1 + len(expected_sources)].event == "::endgroup::"
+        assert [log.event for log in logs[(2 + len(expected_sources)) :]] == expected_events
     else:
         assert len(logs) == 1
         assert len(logs[0]) == 1

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -33,7 +33,7 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -369,12 +369,19 @@ class TestGCSTaskHandler:
 
         mock_blob.from_string.assert_called_once_with(expected_gs_uri, mock_client.return_value)
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_2_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[1].event == expected_gs_uri
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "CONTENT"
+            assert metadata == {"end_of_log": True, "log_pos": 1}
+        elif AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
+            assert logs[0].event == "::group::Log message source details"
+            assert logs[0].sources == [expected_gs_uri]
+            assert logs[1].event == "::endgroup::"
+            assert logs[2].event == "CONTENT"
             assert metadata == {"end_of_log": True, "log_pos": 1}
         else:
             assert f"*** Found remote logs:\n***   * {expected_gs_uri}\n" in logs
@@ -400,12 +407,21 @@ class TestGCSTaskHandler:
         log, metadata = self.gcs_task_handler._read(ti, self.ti.try_number)
         expected_gs_uri = f"gs://bucket/{blob_name}"
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_2_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
             assert log[1].event == expected_gs_uri
             assert log[2].event == f"{self.gcs_task_handler.local_base}/1.log"
             assert log[3].event == "::endgroup::"
+            assert metadata == {"end_of_log": True, "log_pos": 0}
+        elif AIRFLOW_V_3_0_PLUS:
+            log = list(log)
+            assert log[0].event == "::group::Log message source details"
+            assert log[0].sources == [
+                expected_gs_uri,
+                f"{self.gcs_task_handler.local_base}/1.log",
+            ]
+            assert log[1].event == "::endgroup::"
             assert metadata == {"end_of_log": True, "log_pos": 0}
         else:
             assert (

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -372,9 +372,9 @@ class TestGCSTaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
-            assert logs[0].sources == [expected_gs_uri]
-            assert logs[1].event == "::endgroup::"
-            assert logs[2].event == "CONTENT"
+            assert logs[1].event == expected_gs_uri
+            assert logs[2].event == "::endgroup::"
+            assert logs[3].event == "CONTENT"
             assert metadata == {"end_of_log": True, "log_pos": 1}
         else:
             assert f"*** Found remote logs:\n***   * {expected_gs_uri}\n" in logs
@@ -403,11 +403,9 @@ class TestGCSTaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
-            assert log[0].sources == [
-                expected_gs_uri,
-                f"{self.gcs_task_handler.local_base}/1.log",
-            ]
-            assert log[1].event == "::endgroup::"
+            assert log[1].event == expected_gs_uri
+            assert log[2].event == f"{self.gcs_task_handler.local_base}/1.log"
+            assert log[3].event == "::endgroup::"
             assert metadata == {"end_of_log": True, "log_pos": 0}
         else:
             assert (

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -33,7 +33,7 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
 
 pytestmark = pytest.mark.db_test
 
@@ -117,12 +117,19 @@ class TestWasbTaskHandler:
 
         logs, metadata = self.wasb_task_handler.read(ti)
 
-        if AIRFLOW_V_3_0_PLUS:
+        if AIRFLOW_V_3_2_2_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
             assert logs[1].event == "https://wasb-container.blob.core.windows.net/abc/hello.log"
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "Log line"
+            assert metadata == {"end_of_log": True, "log_pos": 1}
+        elif AIRFLOW_V_3_0_PLUS:
+            logs = list(logs)
+            assert logs[0].event == "::group::Log message source details"
+            assert logs[0].sources == ["https://wasb-container.blob.core.windows.net/abc/hello.log"]
+            assert logs[1].event == "::endgroup::"
+            assert logs[2].event == "Log line"
             assert metadata == {"end_of_log": True, "log_pos": 1}
         else:
             assert logs[0][0][0] == "localhost"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -120,9 +120,9 @@ class TestWasbTaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
-            assert logs[0].sources == ["https://wasb-container.blob.core.windows.net/abc/hello.log"]
-            assert logs[1].event == "::endgroup::"
-            assert logs[2].event == "Log line"
+            assert logs[1].event == "https://wasb-container.blob.core.windows.net/abc/hello.log"
+            assert logs[2].event == "::endgroup::"
+            assert logs[3].event == "Log line"
             assert metadata == {"end_of_log": True, "log_pos": 1}
         else:
             assert logs[0][0][0] == "localhost"

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py
@@ -593,10 +593,8 @@ class OpensearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin)
                 from airflow.utils.log.file_task_handler import StructuredLogMessage
 
                 header = [
-                    StructuredLogMessage(
-                        event="::group::Log message source details",
-                        sources=[host for host in logs_by_host.keys()],
-                    ),  # type: ignore[call-arg]
+                    StructuredLogMessage(event="::group::Log message source details"),
+                    *[StructuredLogMessage(event=host) for host in logs_by_host.keys()],
                     StructuredLogMessage(event="::endgroup::"),
                 ]
 

--- a/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
+++ b/providers/opensearch/tests/unit/opensearch/log/test_os_task_handler.py
@@ -111,9 +111,10 @@ def _assert_log_events(logs, metadatas, *, expected_events: list[str], expected_
     if AIRFLOW_V_3_0_PLUS:
         logs = list(logs)
         assert logs[0].event == "::group::Log message source details"
-        assert logs[0].sources == expected_sources
-        assert logs[1].event == "::endgroup::"
-        assert [log.event for log in logs[2:]] == expected_events
+        for i, source in enumerate(expected_sources, start=1):
+            assert logs[i].event == source
+        assert logs[1 + len(expected_sources)].event == "::endgroup::"
+        assert [log.event for log in logs[(2 + len(expected_sources)) :]] == expected_events
     else:
         assert len(logs) == 1
         assert len(logs[0]) == 1


### PR DESCRIPTION
Inspired by PR @ashb in https://github.com/apache/airflow/pull/66037 I am also bothered by the log source details. In our case this sometimes also contains HTTP errors of the endpoint e.g. Edge Worker not reachable to an internal Blob Storage URL which users attempt to open and then report errors. Comments already state the details might distract/confuse users but the kwargs are getting into the group and actually the log group is empty. So totally use-less.

With this PR the actual log source is hidden in the log group now, so exceptions from loading log files are not confusing users, looks like this now:

<img width="1031" height="196" alt="image" src="https://github.com/user-attachments/assets/6974f39d-028c-4f63-9fa5-78f83db9bdf3" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
