### PR TITLE
Fix IMAP hook not properly handling non-ASCII attachment filenames

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -28,6 +28,7 @@ import imaplib
 import os
 import re
 import ssl
+from email.header import decode_header
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -388,6 +389,21 @@ class MailPart:
         """
         return self.part.get_content_maintype() != "multipart" and self.part.get("Content-Disposition")
 
+    def _decode_filename(self, raw_filename: str | None) -> str:
+        """
+        Decode a filename that may be RFC 2047 encoded.
+
+        :param raw_filename: The raw filename from the email part (may be encoded or plain str).
+        :returns: A decoded Unicode string, or the original value if it cannot be decoded.
+        """
+        if raw_filename is None:
+            return ""
+        decoded_parts = decode_header(raw_filename)
+        return "".join(
+            part.decode(enc) if isinstance(part, bytes) else part
+            for part, enc in decoded_parts
+        )
+
     def has_matching_name(self, name: str) -> tuple[Any, Any] | None:
         """
         Check if the given name matches the part's name.
@@ -395,7 +411,7 @@ class MailPart:
         :param name: The name to look for.
         :returns: True if it matches the name (including regular expression).
         """
-        return re.match(name, self.part.get_filename())  # type: ignore
+        return re.match(name, self._decode_filename(self.part.get_filename()))  # type: ignore
 
     def has_equal_name(self, name: str) -> bool:
         """
@@ -404,12 +420,12 @@ class MailPart:
         :param name: The name to look for.
         :returns: True if it is equal to the given name.
         """
-        return self.part.get_filename() == name
+        return self._decode_filename(self.part.get_filename()) == name
 
     def get_file(self) -> tuple:
         """
         Get the file including name and payload.
 
-        :returns: the part's name and payload.
+        :returns: the part's decoded name and decoded payload.
         """
-        return self.part.get_filename(), self.part.get_payload(decode=True)
+        return self._decode_filename(self.part.get_filename()), self.part.get_payload(decode=True)

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -28,7 +28,7 @@ import imaplib
 import os
 import re
 import ssl
-from email.header import decode_header
+from email.header import decode_header, make_header
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -398,11 +398,7 @@ class MailPart:
         """
         if raw_filename is None:
             return ""
-        decoded_parts = decode_header(raw_filename)
-        return "".join(
-            part.decode(enc) if isinstance(part, bytes) else part
-            for part, enc in decoded_parts
-        )
+        return str(make_header(decode_header(raw_filename)))
 
     def has_matching_name(self, name: str) -> tuple[Any, Any] | None:
         """

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -458,3 +458,51 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(imaplib_string)
+    def test_retrieve_mail_attachments_with_rfc2047_encoded_filename(self, mock_imaplib):
+        """Test that non-ASCII (RFC 2047 encoded) attachment filenames are decoded to Unicode."""
+        # RFC 2047 encoded Cyrillic filename
+        # Decoded: "Перечень точек продаж_2026-04-21.xlsx"
+        encoded_filename = "=?UTF-8?B?0J/QtdGA0LXRh9C10L3RjCDRgtC+0YfQtdC6INC/0YDQvtC00LDQtl8yMDI2LTA0LTIxLnhsc3g=?="
+        expected_filename = "Перечень точек продаж_2026-04-21.xlsx"
+
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_filename)
+
+        with ImapHook() as imap_hook:
+            attachments = imap_hook.retrieve_mail_attachments(expected_filename)
+
+        assert len(attachments) == 1
+        assert attachments[0][0] == expected_filename
+
+    @patch(imaplib_string)
+    def test_has_mail_attachment_with_rfc2047_encoded_filename(self, mock_imaplib):
+        """Test that has_mail_attachment correctly matches RFC 2047 encoded filenames."""
+        # RFC 2047 encoded Cyrillic filename
+        # Decoded: "Перечень точек продаж_2026-04-21.xlsx"
+        encoded_filename = "=?UTF-8?B?0J/QtdGA0LXRh9C10L3RjCDRgtC+0YfQtdC6INC/0YDQvtC00LDQtl8yMDI2LTA0LTIxLnhsc3g=?="
+        expected_filename = "Перечень точек продаж_2026-04-21.xlsx"
+
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_filename)
+
+        with ImapHook() as imap_hook:
+            result = imap_hook.has_mail_attachment(name=expected_filename)
+
+        assert result is True
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_with_rfc2047_encoded_filename(self, mock_imaplib, mock_open_method):
+        """Test that download_mail_attachments correctly handles RFC 2047 encoded filenames."""
+        # RFC 2047 encoded Cyrillic filename
+        # Decoded: "Перечень точек продаж_2026-04-21.xlsx"
+        encoded_filename = "=?UTF-8?B?0J/QtdGA0LXRh9C10L3RjCDRgtC+0YfQtdC6INC/0YDQvtC00LDQtl8yMDI2LTA0LTIxLnhsc3g=?="
+        expected_filename = "Перечень точек продаж_2026-04-21.xlsx"
+
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_filename)
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(name=expected_filename, local_output_directory="test_directory")
+
+        mock_open_method.assert_called_once_with(f"test_directory/{expected_filename}", "wb")
+        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -506,3 +506,19 @@ class TestImapHook:
 
         mock_open_method.assert_called_once_with(f"test_directory/{expected_filename}", "wb")
         mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+
+    @patch(imaplib_string)
+    def test_retrieve_mail_attachments_with_mixed_plaintext_and_encoded_filename(self, mock_imaplib):
+        """Test mixed plaintext and RFC 2047 encoded filename (edge case)."""
+        # Mixed: plain text + encoded (e.g. 'bar =?utf-8?B?ZsOzbw==?=')
+        # Decoded: 'bar fóo'
+        encoded_filename = "bar =?utf-8?B?ZsOzbw==?="
+        expected_filename = "bar fóo"
+
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=encoded_filename)
+
+        with ImapHook() as imap_hook:
+            attachments = imap_hook.retrieve_mail_attachments(expected_filename)
+
+        assert len(attachments) == 1
+        assert attachments[0][0] == expected_filename


### PR DESCRIPTION
## What

Fixes IMAP hook returning raw RFC 2047 encoded filenames (e.g. `=?UTF-8?B?...?=`) instead of decoded Unicode for non-ASCII attachment filenames.

## How

Added `MailPart._decode_filename()` helper that uses `email.header.decode_header()` to properly decode RFC 2047 encoded filenames. Applied to `has_matching_name()`, `has_equal_name()`, and `get_file()` methods.

## Example

Before: `=?UTF-8?B?0J/QtdGA0LXRh9C10L3RjCDRgtC+0YfQtdC6INC/0YDQvtC00LDQtl8yMDI2LTA0LTIxLnhsc3g=?=`
After: `Перечень точек продаж_2026-04-21.xlsx`

Fixes #65871

---
**Gen-AI disclosure:** This PR was created with the assistance of an AI coding tool.