### PR TITLE
i18n(ko): Update deadline terminology and counter unit per community feedback

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -42,8 +42,8 @@
   },
   "deadlineAlerts": {
     "completionRule": "{{reference}} 기준 {{interval}} 이내에 완료되어야 합니다",
-    "count_one": "마감 {{count}}개",
-    "count_other": "마감 {{count}}개",
+    "count_one": "데드라인 {{count}}건",
+    "count_other": "데드라인 {{count}}건",
     "referenceType": {
       "AverageRuntimeDeadline": "평균 실행 시간",
       "DagRunLogicalDateDeadline": "논리적 날짜",
@@ -56,15 +56,15 @@
     "finishedEarly": "데드라인보다 {{duration}} 일찍 완료",
     "finishedLate": "데드라인보다 {{duration}} 늦게 완료",
     "label": "데드라인",
-    "met": "달성",
+    "met": "충족",
     "missed": "초과",
     "missedCount_one": "데드라인 초과 {{count}}건",
     "missedCount_other": "데드라인 초과 {{count}}건",
     "mixedCount": "데드라인 초과 {{missedCount}}건, 예정 {{upcomingCount}}건",
     "stillRunning": "실행 중",
     "upcoming": "예정",
-    "upcomingCount_one": "예정된 데드라인 {{count}}개",
-    "upcomingCount_other": "예정된 데드라인 {{count}}개"
+    "upcomingCount_one": "예정된 데드라인 {{count}}건",
+    "upcomingCount_other": "예정된 데드라인 {{count}}건"
   },
   "extraLinks": "추가 링크",
   "grid": {


### PR DESCRIPTION
## Summary
Updated Korean translations for deadline-related terms based on community vote and review feedback:
- **마감 → 데드라인**: Changed terminology based on community vote
- **달성 → 충족**: Changed terminology based on community vote
- **개 → 건**: Unified counter unit per reviewer suggestion (국립국어원 정의에 따름)

## Community Decision
This change was decided through:
- **Community vote**: https://discourse.airflow-kr.org/t/vs-deadline-alerts-5-5/566
  - Deadline → 데드라인
  - Met → 충족
- **Review feedback**: https://github.com/apache/airflow/pull/66272#issuecomment-4378302454
  - 건(의존명사): 사건, 서류, 안건 따위를 세는 단위
  - 개(의존명사): 낱으로 된 물건을 세는 단위

## Before
```json
"deadlineAlerts": {
  "count_one": "마감 {{count}}개",
  "count_other": "마감 {{count}}개"
},
"deadlineStatus": {
  "met": "달성",
  "upcomingCount_one": "예정된 데드라인 {{count}}개",
  "upcomingCount_other": "예정된 데드라인 {{count}}개"
}
```

## After
```json
"deadlineAlerts": {
  "count_one": "데드라인 {{count}}건",
  "count_other": "데드라인 {{count}}건"
},
"deadlineStatus": {
  "met": "충족",
  "upcomingCount_one": "예정된 데드라인 {{count}}건",
  "upcomingCount_other": "예정된 데드라인 {{count}}건"
}
```

## Changes
- Updated `airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenCode

Generated-by: OpenCode following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

## Review Request

Requesting review from Korean translation owners:
@choo121600 @onestn @noeunkim