### PR TITLE
Fix DatabricksWorkflowTaskGroup leaking TaskGroupContext on internal exception

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -393,20 +393,21 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
             spark_submit_params=self.spark_submit_params,
         )
 
-        for task in tasks:
-            if not (
-                hasattr(task, "_convert_to_databricks_workflow_task")
-                and callable(task._convert_to_databricks_workflow_task)
-            ):
-                raise AirflowException(
-                    f"Task {task.task_id} does not support conversion to databricks workflow task."
-                )
+        try:
+            for task in tasks:
+                if not (
+                    hasattr(task, "_convert_to_databricks_workflow_task")
+                    and callable(task._convert_to_databricks_workflow_task)
+                ):
+                    raise AirflowException(
+                        f"Task {task.task_id} does not support conversion to databricks workflow task."
+                    )
 
-            task.workflow_run_metadata = create_databricks_workflow_task.output
-            create_databricks_workflow_task.relevant_upstreams.append(task.task_id)
-            create_databricks_workflow_task.add_task(task.task_id, task)
+                task.workflow_run_metadata = create_databricks_workflow_task.output
+                create_databricks_workflow_task.relevant_upstreams.append(task.task_id)
+                create_databricks_workflow_task.add_task(task.task_id, task)
 
-        for root_task in roots:
-            root_task.set_upstream(create_databricks_workflow_task)
-
-        super().__exit__(_type, _value, _tb)
+            for root_task in roots:
+                root_task.set_upstream(create_databricks_workflow_task)
+        finally:
+            super().__exit__(_type, _value, _tb)

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -288,7 +288,6 @@ def test_task_group_exception_super_exit():
                 ):
                     EmptyOperator(task_id="task1")
 
-    # Assert that super().__exit__ was called even with an exception
     mock_super_exit.assert_called_once()
 
 

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -279,7 +279,7 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
 def test_task_group_exception_super_exit():
     """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
 
-    with patch('airflow.utils.task_group.TaskGroup.__exit__') as mock_super_exit:
+    with patch('airflow.providers.common.compat.sdk.TaskGroup.__exit__') as mock_super_exit:
         with pytest.raises(AirflowException):
             with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
                      start_date=DEFAULT_DATE):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -276,6 +276,22 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
     )
 
 
+def test_task_group_exception_super_exit():
+    """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
+
+    with patch('airflow.utils.task_group.TaskGroup.__exit__') as mock_super_exit:
+        with pytest.raises(AirflowException):
+            with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
+                     start_date=DEFAULT_DATE):
+                with DatabricksWorkflowTaskGroup(
+                    group_id="test_databricks_workflow", databricks_conn_id="databricks_conn"
+                ):
+                    EmptyOperator(task_id="task1")
+
+    # Assert that super().__exit__ was called even with an exception
+    mock_super_exit.assert_called_once()
+
+
 def test_task_group_root_tasks_set_upstream_to_operator(mock_databricks_workflow_operator):
     """Test that tasks added to a DatabricksWorkflowTaskGroup are set upstream to the operator."""
     with DAG(dag_id="example_databricks_workflow_dag", schedule=None, start_date=DEFAULT_DATE):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -17,13 +17,11 @@
 
 from __future__ import annotations
 
-from functools import wraps
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.sdk import TaskGroup
-from airflow.sdk.definitions._internal.contextmanager import TaskGroupContext
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 # Do not run the tests when FAB / Flask is not installed
 pytest.importorskip("flask_session")
@@ -280,20 +278,30 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
     )
 
 
-def test_task_group_exception_super_exit():
-    """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Uses Airflow 3 task SDK TaskGroupContext layout")
+def test_task_group_context_cleaned_up_on_internal_exception():
+    """
+    Regression test for GH-42164.
 
-    with patch("airflow.providers.common.compat.sdk.TaskGroup.__exit__") as mock_super_exit:
-        with pytest.raises(AirflowException):
-            with DAG(dag_id="example_databricks_workflow_dag_err", schedule=None, start_date=DEFAULT_DATE):
-                with DatabricksWorkflowTaskGroup(
-                    group_id="test_databricks_workflow_err", databricks_conn_id="databricks_conn"
-                ):
-                    # Trigger the exception that prevents normal exit
-                    raise AirflowException("Force fail")
+    When DatabricksWorkflowTaskGroup.__exit__ raises (e.g. an added task does not
+    support conversion), super().__exit__ must still run so TaskGroupContext does
+    not leak the workflow group onto the global stack and break later DAGs with
+    "Cannot mix TaskGroups from different DAGs".
+    """
+    from airflow.sdk.definitions._internal.contextmanager import TaskGroupContext
 
-    mock_super_exit.assert_called_once()
     TaskGroupContext._context.clear()
+
+    with pytest.raises(AirflowException, match="does not support conversion"):  # noqa: PT012 raise happens on context exit
+        with DAG(dag_id="example_databricks_workflow_dag_err", schedule=None, start_date=DEFAULT_DATE):
+            with DatabricksWorkflowTaskGroup(
+                group_id="test_databricks_workflow_err", databricks_conn_id="databricks_conn"
+            ):
+                # EmptyOperator does not implement _convert_to_databricks_workflow_task,
+                # which makes DatabricksWorkflowTaskGroup.__exit__ raise mid-way.
+                EmptyOperator(task_id="not_convertible")
+
+    assert not TaskGroupContext._context, "TaskGroupContext leaked the workflow task group"
 
 
 def test_task_group_root_tasks_set_upstream_to_operator(mock_databricks_workflow_operator):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -17,9 +17,13 @@
 
 from __future__ import annotations
 
+from functools import wraps
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from airflow.sdk import TaskGroup
+from airflow.sdk.definitions._internal.contextmanager import TaskGroupContext
 
 # Do not run the tests when FAB / Flask is not installed
 pytest.importorskip("flask_session")
@@ -279,16 +283,17 @@ def test_task_group_exit_creates_operator(mock_databricks_workflow_operator):
 def test_task_group_exception_super_exit():
     """Test that DatabricksWorkflowTaskGroup execute super().__exit__ even with an exception."""
 
-    with patch('airflow.providers.common.compat.sdk.TaskGroup.__exit__') as mock_super_exit:
+    with patch("airflow.providers.common.compat.sdk.TaskGroup.__exit__") as mock_super_exit:
         with pytest.raises(AirflowException):
-            with DAG(dag_id="example_databricks_workflow_dag", schedule=None,
-                     start_date=DEFAULT_DATE):
+            with DAG(dag_id="example_databricks_workflow_dag_err", schedule=None, start_date=DEFAULT_DATE):
                 with DatabricksWorkflowTaskGroup(
-                    group_id="test_databricks_workflow", databricks_conn_id="databricks_conn"
+                    group_id="test_databricks_workflow_err", databricks_conn_id="databricks_conn"
                 ):
-                    EmptyOperator(task_id="task1")
+                    # Trigger the exception that prevents normal exit
+                    raise AirflowException("Force fail")
 
     mock_super_exit.assert_called_once()
+    TaskGroupContext._context.clear()
 
 
 def test_task_group_root_tasks_set_upstream_to_operator(mock_databricks_workflow_operator):


### PR DESCRIPTION
DatabricksWorkflowTaskGroup.__exit__ can raise mid-execution (for example when a child task does not implement `_convert_to_databricks_workflow_task`). Without try/finally, super().__exit__ never runs and the workflow group is left on the global TaskGroupContext stack, breaking later DAGs with `Cannot mix TaskGroups from different DAGs`.

Wrap the body of `__exit__` in try/finally so super().__exit__ is always invoked and the context stack is cleaned up.

Picks up @ayudovin's earlier work in #55891 (closed by author with explicit permission to take over) and adds a regression test that exercises the bug path directly: an EmptyOperator (which lacks `_convert_to_databricks_workflow_task`) is added inside the workflow body, which makes `__exit__` raise mid-way; the test then asserts that `TaskGroupContext._context` is empty, which fails on unfixed code and passes on fixed code.

closes: #42164

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.