### PR TITLE
i18n(ko): Update deadline terms and counter unit per community vote

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dag.json
@@ -42,8 +42,8 @@
   },
   "deadlineAlerts": {
     "completionRule": "{{reference}} 기준 {{interval}} 이내에 완료되어야 합니다",
-    "count_one": "마감 {{count}}개",
-    "count_other": "마감 {{count}}개",
+    "count_one": "데드라인 {{count}}건",
+    "count_other": "데드라인 {{count}}건",
     "referenceType": {
       "AverageRuntimeDeadline": "평균 실행 시간",
       "DagRunLogicalDateDeadline": "논리적 날짜",
@@ -56,15 +56,15 @@
     "finishedEarly": "데드라인보다 {{duration}} 일찍 완료",
     "finishedLate": "데드라인보다 {{duration}} 늦게 완료",
     "label": "데드라인",
-    "met": "달성",
+    "met": "충족",
     "missed": "초과",
     "missedCount_one": "데드라인 초과 {{count}}건",
     "missedCount_other": "데드라인 초과 {{count}}건",
     "mixedCount": "데드라인 초과 {{missedCount}}건, 예정 {{upcomingCount}}건",
     "stillRunning": "실행 중",
     "upcoming": "예정",
-    "upcomingCount_one": "예정된 데드라인 {{count}}개",
-    "upcomingCount_other": "예정된 데드라인 {{count}}개"
+    "upcomingCount_one": "예정된 데드라인 {{count}}건",
+    "upcomingCount_other": "예정된 데드라인 {{count}}건"
   },
   "extraLinks": "추가 링크",
   "grid": {


### PR DESCRIPTION
Updates Korean translations for deadline-related terms and counter units following community consensus.

---
##### Was generative AI tooling used to co-author this PR?
- [ ] No