### PR TITLE
Fix deprecated sentry scope function calls

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
+++ b/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
@@ -109,14 +109,14 @@ class ConfiguredSentry(NoopSentry):
     def add_tagging(self, dag_run: DagRunProtocol, task_instance: RuntimeTaskInstanceProtocol) -> None:
         """Add tagging for a task_instance."""
         task = task_instance.task
-        with sentry_sdk.configure_scope() as scope:
-            for tag_name in self.SCOPE_TASK_INSTANCE_TAGS:
-                attribute = getattr(task_instance, tag_name)
-                scope.set_tag(tag_name, attribute)
-            for tag_name in self.SCOPE_DAG_RUN_TAGS:
-                attribute = getattr(dag_run, tag_name)
-                scope.set_tag(tag_name, attribute)
-            scope.set_tag("operator", task.__class__.__name__)
+        scope = sentry_sdk.get_current_scope()
+        for tag_name in self.SCOPE_TASK_INSTANCE_TAGS:
+            attribute = getattr(task_instance, tag_name)
+            scope.set_tag(tag_name, attribute)
+        for tag_name in self.SCOPE_DAG_RUN_TAGS:
+            attribute = getattr(dag_run, tag_name)
+            scope.set_tag(tag_name, attribute)
+        scope.set_tag("operator", task.__class__.__name__)
 
     def add_breadcrumbs(self, task_instance: RuntimeTaskInstanceProtocol) -> None:
         """Add breadcrumbs inside of a task_instance."""
@@ -140,7 +140,7 @@ class ConfiguredSentry(NoopSentry):
         @functools.wraps(run)
         def wrapped_run(ti: RuntimeTaskInstance, context: Context, log: Logger) -> RunReturn:
             self.prepare_to_enrich_errors(ti.sentry_integration)
-            with sentry_sdk.push_scope():
+            with sentry_sdk.new_scope():
                 try:
                     self.add_tagging(context["dag_run"], ti)
                     self.add_breadcrumbs(ti)

--- a/task-sdk/tests/task_sdk/execution_time/test_sentry.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_sentry.py
@@ -121,7 +121,7 @@ class TestSentryHook:
         sentry_sdk = types.ModuleType("sentry_sdk")
         sentry_sdk.init = mock.MagicMock()
         sentry_sdk.integrations = mock.Mock(logging=sentry_sdk_integrations_logging)
-        sentry_sdk.configure_scope = mock.MagicMock()
+        sentry_sdk.get_current_scope = mock.MagicMock()
         sentry_sdk.add_breadcrumb = mock.MagicMock()
 
         sys.modules["sentry_sdk"] = sentry_sdk
@@ -135,7 +135,7 @@ class TestSentryHook:
         yield
         mock_sentry_sdk.integrations.logging.ignore_logger.reset_mock()
         mock_sentry_sdk.init.reset_mock()
-        mock_sentry_sdk.configure_scope.reset_mock()
+        mock_sentry_sdk.get_current_scope.reset_mock()
         mock_sentry_sdk.add_breadcrumb.reset_mock()
 
     @pytest.fixture
@@ -215,17 +215,15 @@ class TestSentryHook:
         Test adding tags.
         """
         sentry.add_tagging(dag_run=dag_run, task_instance=task_instance)
-        assert mock_sentry_sdk.configure_scope.mock_calls == [
+        assert mock_sentry_sdk.get_current_scope.mock_calls == [
             mock.call.__call__(),
-            mock.call.__call__().__enter__(),
-            mock.call.__call__().__enter__().set_tag("task_id", TASK_ID),
-            mock.call.__call__().__enter__().set_tag("dag_id", DAG_ID),
-            mock.call.__call__().__enter__().set_tag("try_number", TRY_NUMBER),
-            mock.call.__call__().__enter__().set_tag("data_interval_start", DATA_INTERVAL[0]),
-            mock.call.__call__().__enter__().set_tag("data_interval_end", DATA_INTERVAL[1]),
-            mock.call.__call__().__enter__().set_tag("logical_date", LOGICAL_DATE),
-            mock.call.__call__().__enter__().set_tag("operator", OPERATOR),
-            mock.call.__call__().__exit__(None, None, None),
+            mock.call.__call__().set_tag("task_id", TASK_ID),
+            mock.call.__call__().set_tag("dag_id", DAG_ID),
+            mock.call.__call__().set_tag("try_number", TRY_NUMBER),
+            mock.call.__call__().set_tag("data_interval_start", DATA_INTERVAL[0]),
+            mock.call.__call__().set_tag("data_interval_end", DATA_INTERVAL[1]),
+            mock.call.__call__().set_tag("logical_date", LOGICAL_DATE),
+            mock.call.__call__().set_tag("operator", OPERATOR),
         ]
 
     def test_add_breadcrumbs(self, mock_supervisor_comms, mock_sentry_sdk, sentry, task_instance):


### PR DESCRIPTION
Closes: #66585

Update sentry to use sentry 2.x APIs for scope-related function calls.