### PR TITLE
 Fix ConnectionForm crashing when connection has invalid extra JSON

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -82,7 +82,11 @@ const ConnectionForm = ({
     setValue("conn_type", selectedConnType, {
       shouldDirty: true,
     });
-    setConf(JSON.stringify(JSON.parse(initialConnection.extra), undefined, 2));
+    try {
+      setConf(JSON.stringify(JSON.parse(initialConnection.extra), undefined, 2));
+    } catch {
+      setConf(initialConnection.extra);
+    }
   }, [selectedConnType, initialConnection, setConf, setValue]);
 
   // Automatically reset form when conf is fetched


### PR DESCRIPTION
Closes #66591
In 'ConnectionForm.tsx', line 85, 'JSON.parse(initialConnection.extra)' is invoked in a useEffect hook without any error handling. As a result, if any connection has some bad JSON in its extra property, that will throw an exception and stop Edit Connection form from opening.
This is done with a try-catch statement on lines 103-110 in the same file. Applied the exact same approach – in case the JSON parse failed, fall back to the string value so that the form can open successfully.
> I have used Claude (claude.ai) for this implementation part.