### PR TITLE
fix: Pinecone compat tests raising error when project_id passed

### DIFF
--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -124,14 +124,12 @@ class PineconeHook(BaseHook):
         """Pinecone object to interact with Pinecone."""
         pinecone_host = self.conn.host
         extras = self.conn.extra_dejson
-        pinecone_project_id = extras.get("project_id")
         enable_curl_debug = extras.get("debug_curl")
         if enable_curl_debug:
             os.environ["PINECONE_DEBUG_CURL"] = "true"
         return Pinecone(
             api_key=self.api_key,
             host=pinecone_host,
-            project_id=pinecone_project_id,
             source_tag="apache_airflow",
         )
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

[Example run](https://github.com/pinecone-io/python-sdk/commit/3cbe3572896497211d7b373ab84960899f4a20d6#diff-bb805499729709343d9b1cd03010f78addd0d9f8090a99db86c99cd4b44aa9c1R48-R109). Pinecone client recently added [kwargs validation](https://github.com/pinecone-io/python-sdk/commit/3cbe3572896497211d7b373ab84960899f4a20d6#diff-bb805499729709343d9b1cd03010f78addd0d9f8090a99db86c99cd4b44aa9c1R109) and is raising ValueError for unkown kwargs. I believe this is causing test failures. I can't see project_id ever being accepted as a kwarg, maybe it was just silently skipped from the start, so I removed it. If anyone is more familiar with Pinecone, let me know if there is another way to pass project_id, I could not find any - what I found is that the API_KEY is used to identify the project, and we already pass that to Pinecone client.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
