### PR TITLE
`fix/issue-66592`: Respecting `unwrap_single` for non-deferrable execution

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -255,7 +255,7 @@ class KubernetesJobOperator(KubernetesPodOperator):
                     f"Kubernetes job '{self.job.metadata.name}' is failed with error '{error_message}'"
                 )
             if self.do_xcom_push:
-                return xcom_result
+                return xcom_result[0] if self.unwrap_single and len(xcom_result) == 1 else xcom_result
 
     def execute_deferrable(self):
         self.defer(

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
@@ -1119,6 +1119,48 @@ class TestKubernetesJobOperator:
         assert result == return_value
         assert mock_client.return_value.list_namespaced_pod.call_count == successful_try + 1
 
+    @pytest.mark.non_db_test_override
+    @pytest.mark.parametrize(
+        ("unwrap_single", "parallelism", "expected"),
+        [
+            (True, 1, "xcom-result"),
+            (True, 2, ["xcom-result", "xcom-result"]),
+            (False, 1, ["xcom-result"]),
+        ],
+    )
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.extract_xcom"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.get_pods"))
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"), mock.MagicMock())
+    @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.create_job"), mock.MagicMock())
+    @patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start", mock.MagicMock())
+    @patch(f"{POD_MANAGER_CLASS}.await_container_completion", mock.MagicMock())
+    @patch(HOOK_CLASS)
+    def test_execute_xcom_respects_unwrap_single(
+        self,
+        mock_hook,
+        mock_get_pods,
+        mock_extract_xcom,
+        unwrap_single,
+        parallelism,
+        expected,
+    ):
+        mock_hook.return_value.is_job_failed.return_value = None
+        mock_extract_xcom.return_value = "xcom-result"
+        mock_get_pods.return_value = [mock.MagicMock() for _ in range(parallelism)]
+
+        op = KubernetesJobOperator(
+            task_id="test_task_id",
+            wait_until_job_complete=True,
+            do_xcom_push=True,
+            get_logs=False,
+            parallelism=parallelism,
+            unwrap_single=unwrap_single,
+        )
+
+        result = op.execute(context=dict(ti=mock.MagicMock()))
+
+        assert result == expected
+
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.get_pods"))
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.build_job_request_obj"))
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.hook"), new_callable=mock.PropertyMock)


### PR DESCRIPTION
## Description

According to #66592:

> When using `KubernetesJobOperator` with `do_xcom_push=True`, the task returns the content of JSON file found at `/airflow/xcom/return.json` in k8s pod as a return_value XCom, but the data type of the returned XCom value varies depending on whether the deferrable paramter was set to `True` or `False`:
> 
> - When `deferrable=True` parameter is supplied, `KubernetesJobOperator` returns XCom value with data type of `dict`
> - When `deferrable=False` parameter is supplied, `KubernetesJobOperator` returns XCom value with data type of `list[dict]`

This PR remedies this issue by "unwrapping" the `xcom_result` if the following condition is met: `if self.unwrap_single and len(xcom_result) == 1`. This ensures that the behavior for non-deferrable execution matches that of deferrable execution, providing parity for users.

## Testing

These changes were testing using the newly-created `test_execute_xcom_respects_unwrap_single` unit test. This test can be run using the command below.

```bash
breeze testing providers-tests providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_job.py
```

* closes: #66592 

##### Was generative AI tooling used to co-author this PR?

No, generative AI was not used to co-author this PR.