### PR TITLE
Clarify HttpOperator response_filter XCom usage

### DIFF
--- a/providers/http/docs/operators.rst
+++ b/providers/http/docs/operators.rst
@@ -89,14 +89,15 @@ Here we are calling a ``GET`` request and pass params to it. The task will succe
     :end-before: [END howto_operator_http_task_get_op]
 
 HttpOperator returns the response body as text by default. If you want to modify the response before passing
-it on the next task downstream use ``response_filter``. This is useful if:
+it on to the next downstream task, use ``response_filter``. The value returned by ``response_filter`` becomes
+the task result, which can be pulled by downstream tasks with XCom. This is useful if:
 
 - the API you are consuming returns a large JSON payload and you're interested in a subset of the data
 - the API returns data in xml or csv and you want to convert it to JSON
 - you're interested in the headers of the response instead of the body
 
-Below is an example of retrieving data from a REST API and only returning a nested property instead of the full
-response body.
+Below is an example of retrieving data from a REST API and only returning the ``status`` query parameter from
+the response body.
 
 .. exampleinclude:: /../../http/tests/system/http/example_http.py
     :language: python

--- a/providers/http/tests/system/http/example_http.py
+++ b/providers/http/tests/system/http/example_http.py
@@ -77,7 +77,8 @@ task_get_op_response_filter = HttpOperator(
     task_id="get_op_response_filter",
     method="GET",
     endpoint="get",
-    response_filter=lambda response: response.json()["nested"]["property"],
+    data={"status": "ready"},
+    response_filter=lambda response: response.json()["args"]["status"],
     dag=dag,
 )
 # [END howto_operator_http_task_get_op_response_filter]


### PR DESCRIPTION
Clarify the HttpOperator `response_filter` documentation and system test example so the
  example matches the actual httpbin `/get` response.

  The example now filters the `args.status` value returned by httpbin. The docs also explain
  that the `response_filter` return value becomes the task result and can be read by
  downstream tasks through XCom.

  ---

  ##### Was generative AI tooling used to co-author this PR?

  - [x] Yes — OpenAI Codex (GPT-5)

  Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/
  airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

  cc @choo121600 @noeunkim