### PR TITLE
Fix Kubernetes worker service account values

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -224,7 +224,7 @@ spec:
   terminationGracePeriodSeconds: {{ .Values.workers.kubernetes.terminationGracePeriodSeconds | default .Values.workers.terminationGracePeriodSeconds }}
   tolerations: {{- toYaml $tolerations | nindent 4 }}
   topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 4 }}
-  {{- if .Values.workers.kubernetes.serviceAccount.create }}
+  {{- if has .Values.workers.kubernetes.serviceAccount.create (list true false) }}
   serviceAccountName: {{ include "worker.kubernetes.serviceAccountName" . }}
   {{- else }}
   serviceAccountName: {{ include "worker.serviceAccountName" . }}

--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -32,7 +32,8 @@
   {{- $workers := (include "workersMergeValues" (list $mergedWorkers $workerSet "" list) | fromYaml) -}}
   {{- $_ := set $globals.Values "workers" $workers -}}
   {{- with $globals -}}
-{{- if and .Values.workers.serviceAccount.create (include "airflow.podLaunchingExecutor" .) }}
+{{- $useKubernetesServiceAccount := and (contains "KubernetesExecutor" .Values.executor) (has .Values.workers.kubernetes.serviceAccount.create (list true false)) -}}
+{{- if and .Values.workers.serviceAccount.create (include "airflow.podLaunchingExecutor" .) (or (contains "CeleryExecutor" .Values.executor) (not $useKubernetesServiceAccount)) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -2107,3 +2107,22 @@ class TestPodTemplateFile:
         )
 
         assert jmespath.search("spec.serviceAccountName", docs[0]) == "test-release-airflow-worker-kubernetes"
+
+    def test_dedicated_service_account_name_when_creation_disabled(self):
+        docs = render_chart(
+            name="test-release",
+            values={
+                "workers": {
+                    "kubernetes": {
+                        "serviceAccount": {
+                            "create": False,
+                            "name": "airflow",
+                        }
+                    }
+                }
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert jmespath.search("spec.serviceAccountName", docs[0]) == "airflow"

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -263,9 +263,9 @@ class TestWorker:
             "spec.template.spec.initContainers[?name=='wait-for-airflow-migrations'] | [0].volumeMounts",
             docs[0],
         )
-        assert (
-            mounts is not None
-        ), "wait-for-airflow-migrations initContainer not found or has no volumeMounts"
+        assert mounts is not None, (
+            "wait-for-airflow-migrations initContainer not found or has no volumeMounts"
+        )
         assert any(m.get("name") == "logs" and m.get("mountPath") == "/opt/airflow/logs" for m in mounts)
         if expect_sub_path is not None:
             assert any(
@@ -2007,9 +2007,9 @@ class TestWorker:
             (t for t in volume_claim_templates if t.get("metadata", {}).get("name") == "logs"),
             None,
         )
-        assert (
-            logs_template is None
-        ), "Logs should not be in volumeClaimTemplates when logs.persistence.enabled is true"
+        assert logs_template is None, (
+            "Logs should not be in volumeClaimTemplates when logs.persistence.enabled is true"
+        )
 
     @pytest.mark.parametrize(
         (
@@ -2102,9 +2102,9 @@ class TestWorker:
                     (t for t in volume_claim_templates if t.get("metadata", {}).get("name") == "logs"),
                     None,
                 )
-                assert (
-                    logs_template is not None
-                ), "Logs should be in volumeClaimTemplates when logs.persistence.enabled is false"
+                assert logs_template is not None, (
+                    "Logs should be in volumeClaimTemplates when logs.persistence.enabled is false"
+                )
 
             # If custom templates provided, they should be in volumeClaimTemplates
             if custom_templates:
@@ -2118,9 +2118,9 @@ class TestWorker:
                         ),
                         None,
                     )
-                    assert (
-                        found_template is not None
-                    ), f"Custom template '{template_name}' should be in volumeClaimTemplates"
+                    assert found_template is not None, (
+                        f"Custom template '{template_name}' should be in volumeClaimTemplates"
+                    )
         else:
             assert volume_claim_templates is None or len(volume_claim_templates) == 0
 

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -263,9 +263,9 @@ class TestWorker:
             "spec.template.spec.initContainers[?name=='wait-for-airflow-migrations'] | [0].volumeMounts",
             docs[0],
         )
-        assert mounts is not None, (
-            "wait-for-airflow-migrations initContainer not found or has no volumeMounts"
-        )
+        assert (
+            mounts is not None
+        ), "wait-for-airflow-migrations initContainer not found or has no volumeMounts"
         assert any(m.get("name") == "logs" and m.get("mountPath") == "/opt/airflow/logs" for m in mounts)
         if expect_sub_path is not None:
             assert any(
@@ -2007,9 +2007,9 @@ class TestWorker:
             (t for t in volume_claim_templates if t.get("metadata", {}).get("name") == "logs"),
             None,
         )
-        assert logs_template is None, (
-            "Logs should not be in volumeClaimTemplates when logs.persistence.enabled is true"
-        )
+        assert (
+            logs_template is None
+        ), "Logs should not be in volumeClaimTemplates when logs.persistence.enabled is true"
 
     @pytest.mark.parametrize(
         (
@@ -2102,9 +2102,9 @@ class TestWorker:
                     (t for t in volume_claim_templates if t.get("metadata", {}).get("name") == "logs"),
                     None,
                 )
-                assert logs_template is not None, (
-                    "Logs should be in volumeClaimTemplates when logs.persistence.enabled is false"
-                )
+                assert (
+                    logs_template is not None
+                ), "Logs should be in volumeClaimTemplates when logs.persistence.enabled is false"
 
             # If custom templates provided, they should be in volumeClaimTemplates
             if custom_templates:
@@ -2118,9 +2118,9 @@ class TestWorker:
                         ),
                         None,
                     )
-                    assert found_template is not None, (
-                        f"Custom template '{template_name}' should be in volumeClaimTemplates"
-                    )
+                    assert (
+                        found_template is not None
+                    ), f"Custom template '{template_name}' should be in volumeClaimTemplates"
         else:
             assert volume_claim_templates is None or len(volume_claim_templates) == 0
 
@@ -2981,6 +2981,24 @@ class TestWorkerKubernetesServiceAccount:
         )
 
         assert len(docs) == 1
+
+    def test_should_not_create_legacy_service_account_when_k8s_service_account_disabled(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "workers": {
+                    "kubernetes": {
+                        "serviceAccount": {
+                            "create": False,
+                            "name": "airflow",
+                        }
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-serviceaccount.yaml"],
+        )
+
+        assert len(docs) == 0
 
     @pytest.mark.parametrize(
         "executor",


### PR DESCRIPTION
Fixes #66579.

When `workers.kubernetes.serviceAccount.create` is explicitly set to `false`, the pod template should still use the Kubernetes worker service account name from `workers.kubernetes.serviceAccount.name` instead of falling back to the deprecated `workers.serviceAccount` values. For a pure `KubernetesExecutor` deployment, the legacy worker ServiceAccount should also not be rendered in that explicit Kubernetes service account path.

This keeps the existing default fallback when the Kubernetes worker service account section is not explicitly configured.

Tests:
- `PYTHONPATH=chart/tests python -m pytest chart/tests/helm_tests/airflow_aux/test_pod_template_file.py::TestPodTemplateFile::test_dedicated_service_account_name_when_creation_disabled chart/tests/helm_tests/airflow_core/test_worker.py::TestWorkerKubernetesServiceAccount::test_should_not_create_legacy_service_account_when_k8s_service_account_disabled -q`
- `PYTHONPATH=chart/tests python -m pytest chart/tests/helm_tests/airflow_aux/test_pod_template_file.py::TestPodTemplateFile::test_service_account_name_default chart/tests/helm_tests/airflow_aux/test_pod_template_file.py::TestPodTemplateFile::test_dedicated_service_account_name_default chart/tests/helm_tests/airflow_core/test_worker.py::TestWorkerKubernetesServiceAccount::test_should_create_service_account_when_enabled -q`
- `python -m black --check --target-version py312 chart/tests/helm_tests/airflow_aux/test_pod_template_file.py chart/tests/helm_tests/airflow_core/test_worker.py`
- `python -m ruff check chart/tests/helm_tests/airflow_aux/test_pod_template_file.py chart/tests/helm_tests/airflow_core/test_worker.py`
- `git diff --check`