### PR TITLE
Stop passing `project_id` to the Pinecone client constructor

### DIFF
--- a/providers/pinecone/provider.yaml
+++ b/providers/pinecone/provider.yaml
@@ -94,12 +94,6 @@ connection-types:
             - boolean
             - 'null'
           default: false
-      project_id:
-        label: Project ID
-        schema:
-          type:
-            - string
-            - 'null'
 
 operators:
   - integration-name: Pinecone

--- a/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
@@ -57,7 +57,6 @@ def get_provider_info():
                         "label": "PINECONE_DEBUG_CURL",
                         "schema": {"type": ["boolean", "null"], "default": False},
                     },
-                    "project_id": {"label": "Project ID", "schema": {"type": ["string", "null"]}},
                 },
             }
         ],

--- a/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py
@@ -69,10 +69,6 @@ class PineconeHook(BaseHook):
         return {
             "region": StringField(lazy_gettext("Pinecone Region"), widget=BS3TextFieldWidget(), default=None),
             "debug_curl": BooleanField(lazy_gettext("PINECONE_DEBUG_CURL"), default=False),
-            "project_id": StringField(
-                lazy_gettext("Project ID"),
-                widget=BS3TextFieldWidget(),
-            ),
         }
 
     @classmethod
@@ -124,14 +120,19 @@ class PineconeHook(BaseHook):
         """Pinecone object to interact with Pinecone."""
         pinecone_host = self.conn.host
         extras = self.conn.extra_dejson
-        pinecone_project_id = extras.get("project_id")
         enable_curl_debug = extras.get("debug_curl")
         if enable_curl_debug:
             os.environ["PINECONE_DEBUG_CURL"] = "true"
+        # Note: `project_id` was a constructor kwarg of the legacy Pinecone
+        # client; it has been removed in the v6+ SDK that this provider
+        # depends on (`pinecone>=7.0.0`). Passing it — even as `None` —
+        # raises `TypeError` from the new client's strict kwargs check.
+        # The connection-extras "project_id" field is therefore ignored;
+        # it's still accepted on existing connections so the provider does
+        # not break for users who saved one, but it has no effect.
         return Pinecone(
             api_key=self.api_key,
             host=pinecone_host,
-            project_id=pinecone_project_id,
             source_tag="apache_airflow",
         )
 


### PR DESCRIPTION
The provider's compat job
([`Compat 3.0.6:P3.10:`](https://github.com/apache/airflow/actions/runs/25560261904/job/75031753808))
fails on `main` with:

```
TypeError: Pinecone() got unexpected keyword arguments: ['project_id']
```

`pinecone>=7.0.0` (the floor declared in
`providers/pinecone/pyproject.toml`) removed `project_id` from the
`Pinecone()` constructor and now does strict kwarg validation, so
even `project_id=None` raises. The provider's `PineconeHook` was still
unconditionally passing the kwarg, which broke

* `providers/pinecone/tests/unit/pinecone/hooks/test_pinecone.py::TestPineconeHook::test_upsert`
* `providers/pinecone/tests/unit/pinecone/hooks/test_pinecone.py::TestPineconeHook::test_debug_curl_setting`

This PR drops the kwarg from the `Pinecone(...)` call, removes the
unused local extras lookup, and removes the `project_id` connection
form field + `provider.yaml` extra so new connections don't expose a
field that has no effect on the SDK any more. Existing connections
keep the saved value untouched (it's now silently ignored).

## Test plan

- [X] `uv run --project providers/pinecone pytest providers/pinecone/tests/unit/pinecone/hooks/test_pinecone.py -xvs` — 17 / 17 pass.
- [ ] CI `Compat 3.0.6:P3.10` job goes green on this PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)