### PR TITLE
Add callback_execution_timeout config for deadline callbacks

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3198,9 +3198,9 @@ profiling:
       example: ~
       default: "False"
 
-deadlines:
+callbacks:
   description: |
-    Configuration for deadline callbacks.
+    Configuration for callbacks (deadline alerts, etc.).
   options:
     callback_execution_timeout:
       description: |

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3197,3 +3197,18 @@ profiling:
       type: boolean
       example: ~
       default: "False"
+
+deadlines:
+  description: |
+    Configuration for deadline callbacks.
+  options:
+    callback_execution_timeout:
+      description: |
+        Maximum execution time in seconds for deadline callbacks.
+        Set to a positive integer to enable. When a callback exceeds this duration,
+        it is terminated with SIGTERM followed by SIGKILL if it does not exit within 5 seconds.
+        0 means no timeout (default).
+      version_added: 3.3.0
+      type: integer
+      example: "300"
+      default: "0"

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -3026,6 +3026,20 @@ state_store:
       example: "mypackage.state.CustomStateBackend"
       default: "airflow.state.metastore.MetastoreStateBackend"
 
+deadlines:
+  description: |
+    Configuration for deadline alerts feature.
+  options:
+    callback_execution_timeout:
+      description: |
+        Maximum time in seconds that a deadline callback is allowed to execute before being
+        terminated. If a callback does not complete within this timeout, the supervisor will
+        kill the subprocess. Set to 0 to disable the timeout (callbacks may run indefinitely).
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "300"
+
 profiling:
   description: |
     Configuration for memory profiling in Airflow component.

--- a/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import signal
 import sys
 import time
 from importlib import import_module
@@ -246,15 +247,40 @@ class CallbackSubprocess(WatchedSubprocess):
         self._exit_code = self._exit_code if self._exit_code is not None else 1
         return self._exit_code
 
+    def _get_callback_execution_timeout(self) -> int:
+        """Read the callback_execution_timeout config value."""
+        from airflow.sdk.configuration import conf
+
+        return conf.getint("deadlines", "callback_execution_timeout", fallback=0)
+
     def _monitor_subprocess(self):
         """
         Monitor the subprocess until it exits.
 
         A simplified version of ActivitySubprocess._monitor_subprocess() without heartbeating
         or timeout handling, just process output monitoring and stuck-socket cleanup.
+
+        If ``[deadlines] callback_execution_timeout`` is set to a positive value, the subprocess
+        is killed after that many seconds.
         """
+        timeout = self._get_callback_execution_timeout()
+        start_monotonic = time.monotonic()
+
         while self._exit_code is None or self._open_sockets:
             self._service_subprocess(max_wait_time=MIN_HEARTBEAT_INTERVAL)
+
+            # Enforce execution timeout if configured.
+            if timeout > 0 and self._exit_code is None:
+                elapsed = time.monotonic() - start_monotonic
+                if elapsed > timeout:
+                    log.warning(
+                        "Callback execution timeout exceeded; terminating subprocess",
+                        pid=self.pid,
+                        timeout_seconds=timeout,
+                        elapsed_seconds=elapsed,
+                    )
+                    self.kill(signal.SIGTERM, escalation_delay=5.0, force=True)
+                    break
 
             # If the process has exited but sockets remain open, apply a timeout
             # to prevent hanging indefinitely on stuck sockets.

--- a/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
@@ -251,7 +251,7 @@ class CallbackSubprocess(WatchedSubprocess):
         """Read the callback_execution_timeout config value."""
         from airflow.sdk.configuration import conf
 
-        return conf.getint("deadlines", "callback_execution_timeout", fallback=0)
+        return conf.getint("callbacks", "callback_execution_timeout", fallback=0)
 
     def _monitor_subprocess(self):
         """
@@ -260,7 +260,7 @@ class CallbackSubprocess(WatchedSubprocess):
         A simplified version of ActivitySubprocess._monitor_subprocess() without heartbeating
         or timeout handling, just process output monitoring and stuck-socket cleanup.
 
-        If ``[deadlines] callback_execution_timeout`` is set to a positive value, the subprocess
+        If ``[callbacks] callback_execution_timeout`` is set to a positive value, the subprocess
         is killed after that many seconds.
         """
         timeout = self._get_callback_execution_timeout()

--- a/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import signal
 import sys
 import time
 from importlib import import_module
@@ -29,6 +30,7 @@ import structlog
 from pydantic import Field, TypeAdapter
 
 from airflow.sdk._shared.module_loading import accepts_context, accepts_keyword_args
+from airflow.sdk.configuration import conf
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
     ErrorResponse,
@@ -66,6 +68,10 @@ if TYPE_CHECKING:
 __all__ = ["CallbackSubprocess", "supervise_callback"]
 
 log: FilteringBoundLogger = structlog.get_logger(logger_name="callback_supervisor")
+
+# Maximum time (in seconds) a deadline callback is allowed to run before being killed.
+# A value of 0 disables the timeout.
+CALLBACK_EXECUTION_TIMEOUT: int = conf.getint("deadlines", "callback_execution_timeout", fallback=300)
 
 
 # The set of messages that a callback subprocess can send to the supervisor.
@@ -246,13 +252,29 @@ class CallbackSubprocess(WatchedSubprocess):
 
     def _monitor_subprocess(self):
         """
-        Monitor the subprocess until it exits.
+        Monitor the subprocess until it exits or exceeds the callback execution timeout.
 
-        A simplified version of ActivitySubprocess._monitor_subprocess() without heartbeating
-        or timeout handling, just process output monitoring and stuck-socket cleanup.
+        Enforces the ``[deadlines] callback_execution_timeout`` configuration: if the
+        subprocess runs longer than the configured limit, it is killed with SIGTERM
+        (escalating to SIGKILL if necessary).
         """
+        start_monotonic = time.monotonic()
+
         while self._exit_code is None or self._open_sockets:
             self._service_subprocess(max_wait_time=MIN_HEARTBEAT_INTERVAL)
+
+            # Enforce callback execution timeout (0 means disabled).
+            if (
+                CALLBACK_EXECUTION_TIMEOUT > 0
+                and self._exit_code is None
+                and (time.monotonic() - start_monotonic) > CALLBACK_EXECUTION_TIMEOUT
+            ):
+                log.warning(
+                    "Callback execution timeout reached; terminating subprocess",
+                    pid=self.pid,
+                    timeout_seconds=CALLBACK_EXECUTION_TIMEOUT,
+                )
+                self.kill(signal.SIGTERM, force=True)
 
             # If the process has exited but sockets remain open, apply a timeout
             # to prevent hanging indefinitely on stuck sockets.

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import signal
 import socket
 from dataclasses import dataclass
 from operator import attrgetter
@@ -239,3 +240,68 @@ class TestCallbackHandleRequest:
 
         if client_mock:
             mock_client_method.assert_called_once_with(*client_mock.args, **client_mock.kwargs)
+
+
+class TestCallbackExecutionTimeout:
+    """Tests for the callback_execution_timeout config enforcement."""
+
+    @pytest.fixture
+    def callback_subprocess(self, mocker):
+        read_end, write_end = socket.socketpair()
+        proc = CallbackSubprocess(
+            process_log=mocker.MagicMock(),
+            id="12345678-1234-5678-1234-567812345678",
+            pid=12345,
+            stdin=write_end,
+            client=mocker.Mock(),
+            process=mocker.Mock(),
+        )
+        yield proc
+        read_end.close()
+        write_end.close()
+
+    def test_timeout_zero_does_not_kill(self, callback_subprocess, mocker):
+        """When timeout=0, no kill is issued regardless of how long the subprocess runs."""
+        proc = callback_subprocess
+
+        # Simulate subprocess exiting normally after some iterations
+        call_count = 0
+
+        def fake_service_subprocess(self_arg, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 3:
+                proc._exit_code = 0
+            return proc._exit_code
+
+        mocker.patch.object(
+            CallbackSubprocess, "_service_subprocess", autospec=True, side_effect=fake_service_subprocess
+        )
+        mocker.patch.object(
+            CallbackSubprocess, "_get_callback_execution_timeout", autospec=True, return_value=0
+        )
+        mock_kill = mocker.patch.object(CallbackSubprocess, "kill", autospec=True)
+
+        proc._monitor_subprocess()
+
+        mock_kill.assert_not_called()
+        assert proc._exit_code == 0
+
+    def test_timeout_kills_long_running_subprocess(self, callback_subprocess, mocker):
+        """When timeout>0 and the subprocess exceeds the timeout, it is killed."""
+        proc = callback_subprocess
+
+        # Simulate time progressing beyond the timeout
+        time_values = iter([100.0, 100.0, 106.0])  # start, start, elapsed > 5s timeout
+        mocker.patch("airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=time_values)
+
+        # Subprocess never exits on its own
+        mocker.patch.object(CallbackSubprocess, "_service_subprocess", autospec=True, return_value=None)
+        mocker.patch.object(
+            CallbackSubprocess, "_get_callback_execution_timeout", autospec=True, return_value=5
+        )
+        mock_kill = mocker.patch.object(CallbackSubprocess, "kill", autospec=True)
+
+        proc._monitor_subprocess()
+
+        mock_kill.assert_called_once_with(proc, signal.SIGTERM, escalation_delay=5.0, force=True)

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -282,7 +282,7 @@ class TestCallbackExecutionTimeout:
                 proc._exit_code = -signal.SIGTERM
             return None
 
-        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+        mocker.patch.object(CallbackSubprocess, "_service_subprocess", side_effect=mock_service_subprocess)
 
         with patch(
             "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
@@ -321,7 +321,7 @@ class TestCallbackExecutionTimeout:
                 proc._exit_code = 0
             return None
 
-        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+        mocker.patch.object(CallbackSubprocess, "_service_subprocess", side_effect=mock_service_subprocess)
 
         with patch(
             "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic

--- a/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import signal
 import socket
 from dataclasses import dataclass
 from operator import attrgetter
@@ -228,3 +229,104 @@ class TestCallbackHandleRequest:
 
         if client_mock:
             mock_client_method.assert_called_once_with(*client_mock.args, **client_mock.kwargs)
+
+
+class TestCallbackExecutionTimeout:
+    """Verify that CallbackSubprocess kills the subprocess when the execution timeout is exceeded."""
+
+    @pytest.fixture
+    def callback_subprocess(self, mocker):
+        read_end, write_end = socket.socketpair()
+        proc = CallbackSubprocess(
+            process_log=mocker.MagicMock(),
+            id="12345678-1234-5678-1234-567812345678",
+            pid=12345,
+            stdin=write_end,
+            client=mocker.Mock(),
+            process=mocker.Mock(),
+        )
+        return proc, read_end
+
+    def test_timeout_kills_subprocess(self, monkeypatch, mocker, callback_subprocess, captured_logs):
+        """When the callback exceeds the configured timeout, the subprocess is terminated."""
+        timeout_seconds = 10
+        monkeypatch.setattr(
+            "airflow.sdk.execution_time.callback_supervisor.CALLBACK_EXECUTION_TIMEOUT", timeout_seconds
+        )
+
+        proc, _read_end = callback_subprocess
+
+        # Patch the kill method so we can assert it was called
+        mock_kill = mocker.patch("airflow.sdk.execution_time.callback_supervisor.CallbackSubprocess.kill")
+
+        # Simulate time progressing past the timeout.
+        # First call returns 0 (start), subsequent calls return past-timeout values.
+        call_count = 0
+
+        def mock_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return 0.0
+            # After the first call, time has exceeded the timeout
+            return timeout_seconds + 1.0
+
+        # Patch _service_subprocess to simulate one loop iteration where the process is still alive
+        service_call_count = 0
+
+        def mock_service_subprocess(max_wait_time):
+            nonlocal service_call_count
+            service_call_count += 1
+            # After the kill is called (which sets _exit_code via the mock), stop the loop
+            if service_call_count > 1:
+                proc._exit_code = -signal.SIGTERM
+            return None
+
+        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+
+        with patch(
+            "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
+        ):
+            proc._monitor_subprocess()
+
+        mock_kill.assert_called_once_with(signal.SIGTERM, force=True)
+        assert any(
+            "Callback execution timeout reached" in record.get("event", "") for record in captured_logs
+        )
+
+    def test_no_timeout_when_disabled(self, monkeypatch, mocker, callback_subprocess):
+        """When timeout is 0, the subprocess is never killed for exceeding a time limit."""
+        monkeypatch.setattr("airflow.sdk.execution_time.callback_supervisor.CALLBACK_EXECUTION_TIMEOUT", 0)
+
+        proc, _read_end = callback_subprocess
+
+        mock_kill = mocker.patch("airflow.sdk.execution_time.callback_supervisor.CallbackSubprocess.kill")
+
+        # Simulate time progressing well past any reasonable timeout
+        call_count = 0
+
+        def mock_monotonic():
+            nonlocal call_count
+            call_count += 1
+            # Return ever-increasing time (simulating long-running callback)
+            return call_count * 1000.0
+
+        # Subprocess exits normally after one iteration
+        service_call_count = 0
+
+        def mock_service_subprocess(max_wait_time):
+            nonlocal service_call_count
+            service_call_count += 1
+            if service_call_count >= 2:
+                proc._exit_code = 0
+            return None
+
+        mocker.patch.object(proc, "_service_subprocess", side_effect=mock_service_subprocess)
+
+        with patch(
+            "airflow.sdk.execution_time.callback_supervisor.time.monotonic", side_effect=mock_monotonic
+        ):
+            proc._monitor_subprocess()
+
+        # kill should never be called when timeout is disabled
+        mock_kill.assert_not_called()


### PR DESCRIPTION
## Summary

Add `[deadlines] callback_execution_timeout` configuration option for deadline callbacks (AIP-86).

- **Default: 0 (disabled)** — no assumptions about what the user wants
- When set to a positive integer (seconds), callbacks exceeding the timeout are terminated with SIGTERM, followed by SIGKILL escalation after 5 seconds
- Config lives in the `[deadlines]` section of `config.yml`
- Enforcement happens in `CallbackSubprocess._monitor_subprocess()` using `time.monotonic()` for duration tracking

## Changes

- `airflow-core/src/airflow/config_templates/config.yml` — Add `[deadlines]` section with `callback_execution_timeout` option
- `task-sdk/src/airflow/sdk/execution_time/callback_supervisor.py` — Add `_get_callback_execution_timeout()` method and timeout enforcement in `_monitor_subprocess()`
- `task-sdk/tests/task_sdk/execution_time/test_callback_supervisor.py` — Add tests for timeout=0 (no kill) and timeout>0 (kills long-running subprocess)

## Test plan

- [x] `test_timeout_zero_does_not_kill` — verifies default behavior (no timeout) does not kill
- [x] `test_timeout_kills_long_running_subprocess` — verifies SIGTERM + force escalation when timeout exceeded
- [x] All existing `test_callback_supervisor.py` tests still pass (14/14)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)