### PR TITLE
Forward Airflow Dag params to Databricks job parameters in CreateJobs/SubmitRun/RunNow

### DIFF
--- a/providers/databricks/docs/operators/jobs_create.rst
+++ b/providers/databricks/docs/operators/jobs_create.rst
@@ -58,6 +58,28 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
   - ``access_control_list``
 
 
+Forwarding Airflow Dag params as Databricks job parameters
+----------------------------------------------------------
+
+If ``parameters`` is not set in ``json`` and the operator's ``params`` dict is non-empty,
+the operator's ``params`` are automatically converted to job-level ``parameters`` (a list
+of ``{"name": k, "default": v}`` entries, the shape required by the
+``api/2.2/jobs/create`` endpoint) so that Airflow Dag params can be forwarded as
+Databricks job parameters without hardcoding them in ``json``. If ``json`` already
+contains ``parameters``, it is left untouched.
+
+.. code-block:: python
+
+  create_job = DatabricksCreateJobsOperator(
+      task_id="create_job",
+      json={"name": "my-job", "tasks": [...]},
+      params={"env": "prod", "batch_size": "100"},
+  )
+  # The created/reset job will have:
+  #   parameters=[{"name": "env", "default": "prod"},
+  #               {"name": "batch_size", "default": "100"}]
+
+
 Examples
 --------
 

--- a/providers/databricks/docs/operators/jobs_create.rst
+++ b/providers/databricks/docs/operators/jobs_create.rst
@@ -61,23 +61,36 @@ Currently the named parameters that ``DatabricksCreateJobsOperator`` supports ar
 Forwarding Airflow Dag params as Databricks job parameters
 ----------------------------------------------------------
 
+The Databricks ``api/2.2/jobs/create`` endpoint accepts a top-level ``parameters`` field
+that defines `job-level parameters
+<https://docs.databricks.com/api/workspace/jobs/create#parameters>`_ — a list of objects
+with a ``name`` (the parameter name) and a ``default`` (its default value), for example
+``[{"name": "env", "default": "prod"}]``.
+
 If ``parameters`` is not set in ``json`` and the operator's ``params`` dict is non-empty,
-the operator's ``params`` are automatically converted to job-level ``parameters`` (a list
-of ``{"name": k, "default": v}`` entries, the shape required by the
-``api/2.2/jobs/create`` endpoint) so that Airflow Dag params can be forwarded as
-Databricks job parameters without hardcoding them in ``json``. If ``json`` already
-contains ``parameters``, it is left untouched.
+each key/value pair in ``params`` is converted into one such ``{"name": key, "default":
+value}`` entry, so that Airflow Dag params can be forwarded as Databricks job parameters
+without hardcoding the API shape in ``json``. If ``json`` already contains ``parameters``,
+it is left untouched.
 
 .. code-block:: python
+
+  # Airflow Dag params (key/value pairs)
+  params = {"env": "prod", "batch_size": "100"}
 
   create_job = DatabricksCreateJobsOperator(
       task_id="create_job",
       json={"name": "my-job", "tasks": [...]},
-      params={"env": "prod", "batch_size": "100"},
+      params=params,
   )
-  # The created/reset job will have:
-  #   parameters=[{"name": "env", "default": "prod"},
-  #               {"name": "batch_size", "default": "100"}]
+
+  # The Databricks job created/reset by the operator will have:
+  #   parameters=[
+  #       {"name": "env",        "default": "prod"},
+  #       {"name": "batch_size", "default": "100"},
+  #   ]
+  # i.e. each "<key>: <value>" in params becomes one
+  # {"name": "<key>", "default": "<value>"} entry in the job definition.
 
 
 Examples

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -49,6 +49,26 @@ All other parameters are optional and described in documentation for ``Databrick
 * ``repair_run``
 * ``cancel_previous_runs``
 
+Forwarding Airflow Dag params as Databricks job parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If ``job_parameters`` is not set in ``json`` and the operator's ``params`` dict is
+non-empty, the operator's ``params`` are automatically forwarded as ``job_parameters``
+(a ``Dict[str, str]``, the shape required by the ``api/2.2/jobs/run-now`` endpoint) so
+that Airflow Dag params can be passed dynamically to Databricks runs without hardcoding
+them in ``json``. If ``json`` already contains ``job_parameters``, it is left untouched.
+
+.. code-block:: python
+
+  run_now = DatabricksRunNowOperator(
+      task_id="run_now",
+      job_id=123,
+      params={"env": "staging", "batch_size": "42"},
+  )
+  # The triggered run receives:
+  #   job_parameters={"env": "staging", "batch_size": "42"}
+
+
 DatabricksRunNowDeferrableOperator
 ==================================
 

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -52,11 +52,15 @@ All other parameters are optional and described in documentation for ``Databrick
 Forwarding Airflow Dag params as Databricks job parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The Databricks ``api/2.2/jobs/run-now`` endpoint accepts a top-level `job_parameters
+<https://docs.databricks.com/api/workspace/jobs/runnow#job_parameters>`_ field — a plain
+``Dict[str, str]`` mapping parameter name to value — that overrides the job's defaults
+for this run.
+
 If ``job_parameters`` is not set in ``json`` and the operator's ``params`` dict is
-non-empty, the operator's ``params`` are automatically forwarded as ``job_parameters``
-(a ``Dict[str, str]``, the shape required by the ``api/2.2/jobs/run-now`` endpoint) so
-that Airflow Dag params can be passed dynamically to Databricks runs without hardcoding
-them in ``json``. If ``json`` already contains ``job_parameters``, it is left untouched.
+non-empty, ``params`` is forwarded as ``job_parameters`` as-is, so Airflow Dag params can
+be passed dynamically to a run without hardcoding them in ``json``. If ``json`` already
+contains ``job_parameters``, it is left untouched.
 
 .. code-block:: python
 
@@ -67,6 +71,7 @@ them in ``json``. If ``json`` already contains ``job_parameters``, it is left un
   )
   # The triggered run receives:
   #   job_parameters={"env": "staging", "batch_size": "42"}
+  # i.e. the same dict, passed straight through to the run-now request body.
 
 
 DatabricksRunNowDeferrableOperator

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -104,6 +104,35 @@ Another way to do is use the param tasks to pass array of objects to instantiate
   notebook_run = DatabricksSubmitRunOperator(task_id="notebook_run", tasks=tasks)
 
 
+Forwarding Airflow Dag params as task parameters
+------------------------------------------------
+
+The ``api/2.2/jobs/runs/submit`` endpoint has no top-level parameter slot — each task in
+``tasks`` carries its own parameters whose shape depends on the task type. If the
+operator's ``params`` dict is non-empty, it is automatically forwarded into the
+dict-shaped parameter slot of every task in ``json`` whose corresponding field is empty:
+
+* ``notebook_task.base_parameters``
+* ``python_wheel_task.named_parameters``
+* ``sql_task.parameters``
+* ``run_job_task.job_parameters``
+
+Tasks whose only parameter slot is ``List[str]`` (``spark_jar_task``, ``spark_python_task``,
+``spark_submit_task``) are skipped because there is no canonical mapping from a key/value
+dict to a positional argument list — pass those parameters explicitly via the ``json``
+or ``tasks`` argument.
+
+.. code-block:: python
+
+  notebook_run = DatabricksSubmitRunOperator(
+      task_id="notebook_run",
+      notebook_task={"notebook_path": "/Users/airflow@example.com/PrepareData"},
+      new_cluster={"spark_version": "15.4.x-scala2.12", "num_workers": 2},
+      params={"env": "dev", "shard": "1"},
+  )
+  # The submitted run's notebook_task.base_parameters becomes:
+  #   {"env": "dev", "shard": "1"}
+
 
 Examples
 --------

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -107,12 +107,14 @@ Another way to do is use the param tasks to pass array of objects to instantiate
 Forwarding Airflow Dag params as task parameters
 ------------------------------------------------
 
-The ``api/2.2/jobs/runs/submit`` endpoint has no top-level parameter slot — each task in
-``tasks`` carries its own parameters whose shape depends on the task type. If the
-operator's ``params`` dict is non-empty, it is automatically forwarded into the
+Unlike ``api/2.2/jobs/create`` and ``api/2.2/jobs/run-now``, the
+``api/2.2/jobs/runs/submit`` endpoint has no top-level parameter slot — each task in
+``tasks`` carries its own parameters whose shape depends on the task type.
+
+If the operator's ``params`` dict is non-empty, it is forwarded as-is into the
 dict-shaped parameter slot of every task in ``json`` whose corresponding field is empty:
 
-* ``notebook_task.base_parameters``
+* ``notebook_task.base_parameters`` (e.g. for ``notebook_task``)
 * ``python_wheel_task.named_parameters``
 * ``sql_task.parameters``
 * ``run_job_task.job_parameters``
@@ -132,6 +134,7 @@ or ``tasks`` argument.
   )
   # The submitted run's notebook_task.base_parameters becomes:
   #   {"env": "dev", "shard": "1"}
+  # i.e. the same dict, copied into the task's dict-shaped parameter slot.
 
 
 Examples

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -258,6 +258,27 @@ def _handle_deferrable_databricks_operator_completion(event: dict, log: Logger) 
     raise AirflowException(error_message)
 
 
+# Mapping of task definition keys (in the runs/submit JSON) to the dict-shaped
+# parameter sub-key into which Airflow ``self.params`` will be auto-injected.
+# Tasks whose only parameter field is ``List[str]`` (e.g. spark_python_task,
+# spark_jar_task, spark_submit_task) are intentionally omitted because there is
+# no canonical way to convert a key/value dict to positional/CLI arguments.
+_DICT_PARAM_FIELD_BY_TASK = {
+    "notebook_task": "base_parameters",
+    "python_wheel_task": "named_parameters",
+    "sql_task": "parameters",
+    "run_job_task": "job_parameters",
+}
+
+
+def _inject_airflow_params_into_task(task: dict, params: dict) -> None:
+    """Set dict-shaped per-task parameter fields from ``params`` if they are not already set."""
+    for task_key, field in _DICT_PARAM_FIELD_BY_TASK.items():
+        task_def = task.get(task_key)
+        if isinstance(task_def, dict) and not task_def.get(field):
+            task_def[field] = dict(params)
+
+
 class DatabricksJobRunLink(BaseOperatorLink):
     """Constructs a link to monitor a Databricks Job Run."""
 
@@ -320,6 +341,12 @@ class DatabricksCreateJobsOperator(BaseOperator):
     :param databricks_retry_delay: Number of seconds to wait between retries (it
             might be a floating point number).
     :param databricks_retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
+
+    .. note::
+        If ``parameters`` is not set in ``json`` and the operator's ``params`` dict is non-empty,
+        the operator's ``params`` are automatically converted to job-level ``parameters`` (a list
+        of ``{"name": k, "default": v}`` entries) so that Airflow Dag params can be forwarded as
+        Databricks job parameters without hardcoding them in ``json``.
 
     """
 
@@ -405,11 +432,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
         if not self.json.get("parameters") and self.params:
-            job_params = self.params.items() if self.params.items() else {}
-            param_list = []
-            for k, v in job_params:
-                param_list.append({"name": k, "default": v})
-            self.json["parameters"] = param_list
+            self.json["parameters"] = [{"name": k, "default": v} for k, v in self.params.dump().items()]
         if job_id is None:
             return self._hook.create_job(self.json)
         self._hook.reset_job(str(job_id), self.json)
@@ -535,6 +558,15 @@ class DatabricksSubmitRunOperator(BaseOperator):
 
         .. seealso::
             https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit
+
+    .. note::
+        If the operator's ``params`` dict is non-empty, it is automatically forwarded into the
+        dict-shaped parameter slot of every task in ``json`` whose corresponding field is empty:
+        ``notebook_task.base_parameters``, ``python_wheel_task.named_parameters``,
+        ``sql_task.parameters``, ``run_job_task.job_parameters``. Tasks whose only parameter
+        field is ``List[str]`` (``spark_jar_task``, ``spark_python_task``, ``spark_submit_task``)
+        are skipped because there is no canonical mapping from a key/value dict to a positional
+        argument list.
     """
 
     # Used in airflow.models.BaseOperator
@@ -649,6 +681,17 @@ class DatabricksSubmitRunOperator(BaseOperator):
             pipeline_name = self.json["pipeline_task"]["pipeline_name"]
             self.json["pipeline_task"]["pipeline_id"] = self._hook.find_pipeline_id_by_name(pipeline_name)
             del self.json["pipeline_task"]["pipeline_name"]
+
+        if self.params:
+            params_dump = self.params.dump()
+            tasks = self.json.get("tasks")
+            if isinstance(tasks, list):
+                for task in tasks:
+                    if isinstance(task, dict):
+                        _inject_airflow_params_into_task(task, params_dump)
+            else:
+                _inject_airflow_params_into_task(self.json, params_dump)
+
         json_normalised = normalise_json_content(self.json)
         self.run_id = self._hook.submit_run(json_normalised)
         if self.deferrable:
@@ -848,6 +891,12 @@ class DatabricksRunNowOperator(BaseOperator):
             (https://docs.databricks.com/api/workspace/jobs/update). If nothing is matched, then repair
             will not get triggered.
     :param cancel_previous_runs: Cancel all existing running jobs before submitting new one.
+
+    .. note::
+        If ``job_parameters`` is not set in ``json`` and the operator's ``params`` dict is
+        non-empty, the operator's ``params`` are automatically forwarded as ``job_parameters``
+        so that Airflow Dag params can be passed dynamically to Databricks runs without
+        hardcoding them in ``json``.
     """
 
     # Used in airflow.models.BaseOperator
@@ -956,6 +1005,9 @@ class DatabricksRunNowOperator(BaseOperator):
                 )
 
             hook.cancel_all_runs(job_id)
+
+        if not self.json.get("job_parameters") and self.params:
+            self.json["job_parameters"] = self.params.dump()
 
         self.run_id = hook.run_now(self.json)
         if self.deferrable:

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -404,6 +404,12 @@ class DatabricksCreateJobsOperator(BaseOperator):
         if "name" not in self.json:
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
+        if not self.json.get("parameters") and self.params:
+            job_params = self.params.items() if self.params.items() else {}
+            param_list = []
+            for k, v in job_params:
+                param_list.append({"name": k, "default": v})
+            self.json["parameters"] = param_list
         if job_id is None:
             return self._hook.create_job(self.json)
         self._hook.reset_job(str(job_id), self.json)

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -432,7 +432,7 @@ class DatabricksCreateJobsOperator(BaseOperator):
             raise AirflowException("Missing required parameter: name")
         job_id = self._hook.find_job_id_by_name(self.json["name"])
         if not self.json.get("parameters") and self.params:
-            self.json["parameters"] = [{"name": k, "default": v} for k, v in self.params.dump().items()]
+            self.json["parameters"] = [{"name": k, "default": v} for k, v in dict(self.params).items()]
         if job_id is None:
             return self._hook.create_job(self.json)
         self._hook.reset_job(str(job_id), self.json)
@@ -683,7 +683,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
             del self.json["pipeline_task"]["pipeline_name"]
 
         if self.params:
-            params_dump = self.params.dump()
+            params_dump = dict(self.params)
             tasks = self.json.get("tasks")
             if isinstance(tasks, list):
                 for task in tasks:
@@ -1007,7 +1007,7 @@ class DatabricksRunNowOperator(BaseOperator):
             hook.cancel_all_runs(job_id)
 
         if not self.json.get("job_parameters") and self.params:
-            self.json["job_parameters"] = self.params.dump()
+            self.json["job_parameters"] = dict(self.params)
 
         self.run_id = hook.run_now(self.json)
         if self.deferrable:

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -611,9 +611,7 @@ class TestDatabricksCreateJobsOperator:
         ],
     )
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
-    def test_injects_airflow_params_when_parameters_missing(
-        self, db_mock_class, found_job_id, hook_method
-    ):
+    def test_injects_airflow_params_when_parameters_missing(self, db_mock_class, found_job_id, hook_method):
         """
         When ``parameters`` is not set in ``json`` and the operator's ``params`` dict is
         non-empty, the operator's ``params`` should be forwarded as job-level

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -503,7 +503,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -558,7 +557,6 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -605,57 +603,68 @@ class TestDatabricksCreateJobsOperator:
 
         db_mock.update_job_permission.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "found_job_id, hook_method",
+        [
+            pytest.param(None, "create_job", id="create-path"),
+            pytest.param(JOB_ID, "reset_job", id="reset-path"),
+        ],
+    )
     @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
-    def test_create_job_with_job_parameter(self, db_mock_class):
+    def test_injects_airflow_params_when_parameters_missing(
+        self, db_mock_class, found_job_id, hook_method
+    ):
         """
-        Test create job with job parameters.
+        When ``parameters`` is not set in ``json`` and the operator's ``params`` dict is
+        non-empty, the operator's ``params`` should be forwarded as job-level
+        ``parameters`` on both the create and reset paths (regression test for
+        GH-39002).
         """
-        json = {
-            "name": JOB_NAME,
-            "tags": TAGS,
-            "tasks": TASKS,
-            "job_clusters": JOB_CLUSTERS,
-            "email_notifications": EMAIL_NOTIFICATIONS,
-            "webhook_notifications": WEBHOOK_NOTIFICATIONS,
-            "timeout_seconds": TIMEOUT_SECONDS,
-            "schedule": SCHEDULE,
-            "max_concurrent_runs": MAX_CONCURRENT_RUNS,
-            "git_source": GIT_SOURCE,
-            "access_control_list": ACCESS_CONTROL_LIST,
-            "parameters": JOB_PARAMS,
-        }
-        op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
+        op = DatabricksCreateJobsOperator(
+            task_id=TASK_ID,
+            json={"name": JOB_NAME, "tasks": TASKS},
+            params={"env": "prod", "batch_size": 100},
+        )
         db_mock = db_mock_class.return_value
-        db_mock.find_job_id_by_name.return_value = None
+        db_mock.find_job_id_by_name.return_value = found_job_id
 
         op.execute({})
 
-        expected = utils.normalise_json_content(
-            {
-                "name": JOB_NAME,
-                "tags": TAGS,
-                "tasks": TASKS,
-                "job_clusters": JOB_CLUSTERS,
-                "email_notifications": EMAIL_NOTIFICATIONS,
-                "webhook_notifications": WEBHOOK_NOTIFICATIONS,
-                "timeout_seconds": TIMEOUT_SECONDS,
-                "schedule": SCHEDULE,
-                "max_concurrent_runs": MAX_CONCURRENT_RUNS,
-                "git_source": GIT_SOURCE,
-                "access_control_list": ACCESS_CONTROL_LIST,
-                "parameters": JOB_PARAMS,
-            }
-        )
+        # The create-path passes the settings dict directly; the reset-path passes
+        # (job_id, settings) — pull the settings out in either case.
+        call_args = getattr(db_mock, hook_method).call_args.args
+        settings = call_args[0] if hook_method == "create_job" else call_args[1]
+        assert settings["parameters"] == [
+            {"name": "env", "default": "prod"},
+            {"name": "batch_size", "default": 100},
+        ]
 
-        db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID,
-            retry_limit=op.databricks_retry_limit,
-            retry_delay=op.databricks_retry_delay,
-            retry_args=None,
-            caller="DatabricksCreateJobsOperator",
+    @pytest.mark.parametrize(
+        "found_job_id, hook_method",
+        [
+            pytest.param(None, "create_job", id="create-path"),
+            pytest.param(JOB_ID, "reset_job", id="reset-path"),
+        ],
+    )
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_does_not_override_existing_parameters(self, db_mock_class, found_job_id, hook_method):
+        """
+        When ``parameters`` is already set in ``json``, the operator's ``params`` must
+        not override it on either the create or reset paths.
+        """
+        op = DatabricksCreateJobsOperator(
+            task_id=TASK_ID,
+            json={"name": JOB_NAME, "tasks": TASKS, "parameters": JOB_PARAMS},
+            params={"env": "prod"},
         )
+        db_mock = db_mock_class.return_value
+        db_mock.find_job_id_by_name.return_value = found_job_id
 
-        db_mock.create_job.assert_called_once_with(expected)
+        op.execute({})
+
+        call_args = getattr(db_mock, hook_method).call_args.args
+        settings = call_args[0] if hook_method == "create_job" else call_args[1]
+        assert settings["parameters"] == JOB_PARAMS
 
 
 class TestDatabricksSubmitRunOperator:
@@ -1195,6 +1204,76 @@ class TestDatabricksSubmitRunOperator:
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         assert op.run_id == RUN_ID
         assert not mock_defer.called
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_submit_run_injects_airflow_params_into_notebook_task(self, db_mock_class):
+        """
+        For a single notebook_task, ``self.params`` should be injected into
+        ``notebook_task.base_parameters`` (regression test for GH-39002).
+        """
+        op = DatabricksSubmitRunOperator(
+            task_id=TASK_ID,
+            notebook_task={"notebook_path": "/Users/me/notebook"},
+            new_cluster=NEW_CLUSTER,
+            params={"env": "prod", "batch_size": "100"},
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        op.execute(None)
+
+        actual = db_mock.submit_run.call_args.args[0]
+        assert actual["notebook_task"]["base_parameters"] == {"env": "prod", "batch_size": "100"}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_submit_run_injects_airflow_params_into_each_task_in_tasks_list(self, db_mock_class):
+        """
+        For multiple ``tasks``, dict-shaped per-task params should be filled in for
+        each task that supports them.
+        """
+        op = DatabricksSubmitRunOperator(
+            task_id=TASK_ID,
+            tasks=[
+                {"task_key": "t1", "notebook_task": {"notebook_path": "/n1"}},
+                {"task_key": "t2", "spark_jar_task": {"main_class_name": "Foo"}},
+            ],
+            params={"env": "prod"},
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        op.execute(None)
+
+        actual = db_mock.submit_run.call_args.args[0]
+        assert actual["tasks"][0]["notebook_task"]["base_parameters"] == {"env": "prod"}
+        # spark_jar_task only accepts List[str] parameters; skip auto-injection.
+        assert "parameters" not in actual["tasks"][1]["spark_jar_task"]
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_submit_run_does_not_override_existing_task_parameters(self, db_mock_class):
+        """
+        If a dict-shaped per-task parameter field is already populated, ``self.params``
+        should not override it.
+        """
+        op = DatabricksSubmitRunOperator(
+            task_id=TASK_ID,
+            notebook_task={
+                "notebook_path": "/Users/me/notebook",
+                "base_parameters": {"explicit": "value"},
+            },
+            new_cluster=NEW_CLUSTER,
+            params={"env": "prod"},
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        op.execute(None)
+
+        actual = db_mock.submit_run.call_args.args[0]
+        assert actual["notebook_task"]["base_parameters"] == {"explicit": "value"}
 
 
 class TestDatabricksRunNowOperator:
@@ -2011,6 +2090,48 @@ class TestDatabricksRunNowOperator:
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         assert op.run_id == RUN_ID
         assert not mock_defer.called
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_run_now_injects_airflow_params_when_job_parameters_missing(self, db_mock_class):
+        """
+        When ``job_parameters`` is not set in ``json`` and the operator's ``params`` dict is
+        non-empty, the operator's ``params`` should be forwarded as ``job_parameters``
+        (regression test for GH-39002).
+        """
+        op = DatabricksRunNowOperator(
+            task_id=TASK_ID,
+            job_id=JOB_ID,
+            params={"env": "prod", "batch_size": 100},
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        op.execute(None)
+
+        actual = db_mock.run_now.call_args.args[0]
+        assert actual["job_parameters"] == {"env": "prod", "batch_size": 100}
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_run_now_does_not_override_existing_job_parameters(self, db_mock_class):
+        """
+        When ``job_parameters`` is already set in ``json``, the operator's ``params`` should
+        not override it.
+        """
+        op = DatabricksRunNowOperator(
+            task_id=TASK_ID,
+            job_id=JOB_ID,
+            json={"job_parameters": {"explicit": "value"}},
+            params={"env": "prod"},
+        )
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = RUN_ID
+        db_mock.get_run = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        op.execute(None)
+
+        actual = db_mock.run_now.call_args.args[0]
+        assert actual["job_parameters"] == {"explicit": "value"}
 
 
 class TestDatabricksSQLStatementsOperator:

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -277,6 +277,7 @@ ACCESS_CONTROL_LIST = [
         "permission_level": "CAN_MANAGE",
     }
 ]
+JOB_PARAMS = [{"name": "param1", "default": "value1"}]
 
 
 def mock_dict(d: dict):
@@ -502,6 +503,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -556,6 +558,7 @@ class TestDatabricksCreateJobsOperator:
                 "max_concurrent_runs": MAX_CONCURRENT_RUNS,
                 "git_source": GIT_SOURCE,
                 "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": [],
             }
         )
         db_mock_class.assert_called_once_with(
@@ -601,6 +604,58 @@ class TestDatabricksCreateJobsOperator:
         )
 
         db_mock.update_job_permission.assert_not_called()
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksHook")
+    def test_create_job_with_job_parameter(self, db_mock_class):
+        """
+        Test create job with job parameters.
+        """
+        json = {
+            "name": JOB_NAME,
+            "tags": TAGS,
+            "tasks": TASKS,
+            "job_clusters": JOB_CLUSTERS,
+            "email_notifications": EMAIL_NOTIFICATIONS,
+            "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+            "timeout_seconds": TIMEOUT_SECONDS,
+            "schedule": SCHEDULE,
+            "max_concurrent_runs": MAX_CONCURRENT_RUNS,
+            "git_source": GIT_SOURCE,
+            "access_control_list": ACCESS_CONTROL_LIST,
+            "parameters": JOB_PARAMS,
+        }
+        op = DatabricksCreateJobsOperator(task_id=TASK_ID, json=json)
+        db_mock = db_mock_class.return_value
+        db_mock.find_job_id_by_name.return_value = None
+
+        op.execute({})
+
+        expected = utils.normalise_json_content(
+            {
+                "name": JOB_NAME,
+                "tags": TAGS,
+                "tasks": TASKS,
+                "job_clusters": JOB_CLUSTERS,
+                "email_notifications": EMAIL_NOTIFICATIONS,
+                "webhook_notifications": WEBHOOK_NOTIFICATIONS,
+                "timeout_seconds": TIMEOUT_SECONDS,
+                "schedule": SCHEDULE,
+                "max_concurrent_runs": MAX_CONCURRENT_RUNS,
+                "git_source": GIT_SOURCE,
+                "access_control_list": ACCESS_CONTROL_LIST,
+                "parameters": JOB_PARAMS,
+            }
+        )
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            retry_args=None,
+            caller="DatabricksCreateJobsOperator",
+        )
+
+        db_mock.create_job.assert_called_once_with(expected)
 
 
 class TestDatabricksSubmitRunOperator:

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -604,7 +604,7 @@ class TestDatabricksCreateJobsOperator:
         db_mock.update_job_permission.assert_not_called()
 
     @pytest.mark.parametrize(
-        "found_job_id, hook_method",
+        ("found_job_id", "hook_method"),
         [
             pytest.param(None, "create_job", id="create-path"),
             pytest.param(JOB_ID, "reset_job", id="reset-path"),
@@ -638,7 +638,7 @@ class TestDatabricksCreateJobsOperator:
         ]
 
     @pytest.mark.parametrize(
-        "found_job_id, hook_method",
+        ("found_job_id", "hook_method"),
         [
             pytest.param(None, "create_job", id="create-path"),
             pytest.param(JOB_ID, "reset_job", id="reset-path"),


### PR DESCRIPTION
The Databricks operators currently require job-level parameters to be hardcoded inside `json`. This forwards the operator's `self.params` (Airflow Dag / task / dag_run.conf params) into the corresponding Databricks parameter slot when the user has not explicitly populated it:

* `DatabricksCreateJobsOperator` -> top-level `parameters` list (`[{"name": k, "default": v}, ...]`).
* `DatabricksRunNowOperator` -> top-level `job_parameters` dict.
* `DatabricksSubmitRunOperator` -> dict-shaped per-task fields: `notebook_task.base_parameters`, `python_wheel_task.named_parameters`, `sql_task.parameters`, `run_job_task.job_parameters`. Tasks whose only parameter slot is `List[str]` (`spark_jar_task`, `spark_python_task`, `spark_submit_task`) are skipped because there is no canonical mapping from a key/value dict to positional CLI arguments.

The injection only fires when the corresponding slot is empty, so users who explicitly pass parameters in `json` keep their existing behaviour.

Builds on @SubhamSinghal's earlier work in #39007 (closed as stale). Picks up @dirrao's and @Lee-W's review feedback (list-comprehension refactor) and @galafis's request to extend the feature to RunNow / SubmitRun.

closes: #39002

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.