### PR TITLE
Add ipFamilyPolicy and ipFamilies support to all Helm service templates

### DIFF
--- a/chart/templates/api-server/api-server-service.yaml
+++ b/chart/templates/api-server/api-server-service.yaml
@@ -56,4 +56,10 @@ spec:
   {{- if .Values.apiServer.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.apiServer.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.apiServer.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.apiServer.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.apiServer.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.apiServer.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/api-server/api-server-service.yaml
+++ b/chart/templates/api-server/api-server-service.yaml
@@ -56,10 +56,10 @@ spec:
   {{- if .Values.apiServer.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.apiServer.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
-  {{- if .Values.apiServer.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.apiServer.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.apiServer.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.apiServer.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -56,4 +56,10 @@ spec:
   {{- if .Values.flower.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.flower.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.flower.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.flower.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.flower.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.flower.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -56,10 +56,10 @@ spec:
   {{- if .Values.flower.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.flower.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
-  {{- if .Values.flower.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.flower.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.flower.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.flower.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/otel-collector/otel-collector-service.yaml
+++ b/chart/templates/otel-collector/otel-collector-service.yaml
@@ -52,4 +52,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.otelCollectorOtlpHttp }}
       targetPort: {{ .Values.ports.otelCollectorOtlpHttp }}
+  {{- if .Values.otelCollector.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.otelCollector.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.otelCollector.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.otelCollector.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/otel-collector/otel-collector-service.yaml
+++ b/chart/templates/otel-collector/otel-collector-service.yaml
@@ -52,10 +52,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.otelCollectorOtlpHttp }}
       targetPort: {{ .Values.ports.otelCollectorOtlpHttp }}
-  {{- if .Values.otelCollector.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.otelCollector.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.otelCollector.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.otelCollector.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -56,4 +56,10 @@ spec:
     - name: pgb-metrics
       protocol: TCP
       port: {{ .Values.ports.pgbouncerScrape }}
+  {{- if .Values.pgbouncer.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.pgbouncer.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.pgbouncer.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.pgbouncer.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/pgbouncer/pgbouncer-service.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-service.yaml
@@ -56,10 +56,10 @@ spec:
     - name: pgb-metrics
       protocol: TCP
       port: {{ .Values.ports.pgbouncerScrape }}
-  {{- if .Values.pgbouncer.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.pgbouncer.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.pgbouncer.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.pgbouncer.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -55,4 +55,10 @@ spec:
       {{- if and (eq .Values.redis.service.type "NodePort") (not (empty .Values.redis.service.nodePort)) }}
       nodePort: {{ .Values.redis.service.nodePort }}
       {{- end }}
+  {{- if .Values.redis.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.redis.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.redis.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.redis.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -55,10 +55,10 @@ spec:
       {{- if and (eq .Values.redis.service.type "NodePort") (not (empty .Values.redis.service.nodePort)) }}
       nodePort: {{ .Values.redis.service.nodePort }}
       {{- end }}
-  {{- if .Values.redis.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.redis.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.redis.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.redis.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -45,4 +45,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.workerLogs }}
       targetPort: {{ .Values.ports.workerLogs }}
+  {{- if .Values.scheduler.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.scheduler.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.scheduler.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.scheduler.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-service.yaml
+++ b/chart/templates/scheduler/scheduler-service.yaml
@@ -45,10 +45,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.workerLogs }}
       targetPort: {{ .Values.ports.workerLogs }}
-  {{- if .Values.scheduler.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.scheduler.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.scheduler.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.scheduler.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/statsd/statsd-service.yaml
+++ b/chart/templates/statsd/statsd-service.yaml
@@ -55,4 +55,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.statsdScrape }}
       targetPort: {{ .Values.ports.statsdScrape }}
+  {{- if .Values.statsd.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.statsd.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.statsd.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.statsd.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/statsd/statsd-service.yaml
+++ b/chart/templates/statsd/statsd-service.yaml
@@ -55,10 +55,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.statsdScrape }}
       targetPort: {{ .Values.ports.statsdScrape }}
-  {{- if .Values.statsd.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.statsd.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.statsd.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.statsd.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/triggerer/triggerer-service.yaml
+++ b/chart/templates/triggerer/triggerer-service.yaml
@@ -45,4 +45,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.triggererLogs }}
       targetPort: {{ .Values.ports.triggererLogs }}
+  {{- if .Values.triggerer.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.triggerer.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.triggerer.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.triggerer.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/triggerer/triggerer-service.yaml
+++ b/chart/templates/triggerer/triggerer-service.yaml
@@ -45,10 +45,10 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.triggererLogs }}
       targetPort: {{ .Values.ports.triggererLogs }}
-  {{- if .Values.triggerer.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.triggerer.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.triggerer.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.triggerer.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -61,6 +61,12 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.workerLogs }}
       targetPort: {{ .Values.ports.workerLogs }}
+  {{- if .Values.workers.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.workers.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.workers.service.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.workers.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-service.yaml
+++ b/chart/templates/workers/worker-service.yaml
@@ -61,11 +61,11 @@ spec:
       protocol: TCP
       port: {{ .Values.ports.workerLogs }}
       targetPort: {{ .Values.ports.workerLogs }}
-  {{- if .Values.workers.service.ipFamilyPolicy }}
-  ipFamilyPolicy: {{ .Values.workers.service.ipFamilyPolicy }}
+  {{- if .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ipFamilyPolicy }}
   {{- end }}
-  {{- if .Values.workers.service.ipFamilies }}
-  ipFamilies: {{- toYaml .Values.workers.service.ipFamilies | nindent 4 }}
+  {{- if .Values.ipFamilies }}
+  ipFamilies: {{- toYaml .Values.ipFamilies | nindent 4 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/tests/helm_tests/airflow_core/test_api_server.py
+++ b/chart/tests/helm_tests/airflow_core/test_api_server.py
@@ -741,6 +741,30 @@ class TestAPIServerService:
 
         assert len(docs) == 0
 
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "apiServer": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/api-server/api-server-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            show_only=["templates/api-server/api-server-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
 
 class TestAPIServerNetworkPolicy:
     """Tests api-server network policy."""

--- a/chart/tests/helm_tests/airflow_core/test_api_server.py
+++ b/chart/tests/helm_tests/airflow_core/test_api_server.py
@@ -744,12 +744,8 @@ class TestAPIServerService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "apiServer": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/api-server/api-server-service.yaml"],
         )

--- a/chart/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/chart/tests/helm_tests/airflow_core/test_scheduler.py
@@ -1089,6 +1089,32 @@ class TestSchedulerService:
         assert "executor" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["executor"] == expected_label
 
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "scheduler": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/scheduler/scheduler-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            values={"executor": "LocalExecutor"},
+            show_only=["templates/scheduler/scheduler-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
 
 class TestSchedulerServiceAccount:
     """Tests scheduler service account."""

--- a/chart/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/chart/tests/helm_tests/airflow_core/test_scheduler.py
@@ -1093,12 +1093,8 @@ class TestSchedulerService:
         docs = render_chart(
             values={
                 "executor": "LocalExecutor",
-                "scheduler": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/scheduler/scheduler-service.yaml"],
         )

--- a/chart/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/chart/tests/helm_tests/airflow_core/test_triggerer.py
@@ -746,12 +746,8 @@ class TestTriggererService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "triggerer": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/triggerer/triggerer-service.yaml"],
         )

--- a/chart/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/chart/tests/helm_tests/airflow_core/test_triggerer.py
@@ -740,6 +740,34 @@ class TestTriggerer:
         }
 
 
+class TestTriggererService:
+    """Tests triggerer service."""
+
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/triggerer/triggerer-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            show_only=["templates/triggerer/triggerer-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
+
 class TestTriggererServiceAccount:
     """Tests triggerer service account."""
 

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -2788,12 +2788,8 @@ class TestWorkerService:
         docs = render_chart(
             values={
                 "executor": "CeleryExecutor",
-                "workers": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/workers/worker-service.yaml"],
         )

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -2784,6 +2784,32 @@ class TestWorkerService:
         assert labels["test_label"] == "test_label_value"
         assert "key" not in labels
 
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/workers/worker-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            values={"executor": "CeleryExecutor"},
+            show_only=["templates/workers/worker-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
 
 class TestWorkerCeleryServiceAccount:
     @pytest.mark.parametrize(

--- a/chart/tests/helm_tests/otel_collector/test_otel_collector.py
+++ b/chart/tests/helm_tests/otel_collector/test_otel_collector.py
@@ -400,6 +400,28 @@ class TestOtelCollectorService:
         docs = render_chart(values={"otelCollector": {"tracesEnabled": True}}, show_only=[SERVICE_TEMPLATE])
         assert "annotations" not in jmespath.search("metadata", docs[0])
 
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "otelCollector": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=[SERVICE_TEMPLATE],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(show_only=[SERVICE_TEMPLATE])
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
 
 class TestOtelCollectorServiceAccount:
     def test_default_create(self):

--- a/chart/tests/helm_tests/otel_collector/test_otel_collector.py
+++ b/chart/tests/helm_tests/otel_collector/test_otel_collector.py
@@ -403,12 +403,8 @@ class TestOtelCollectorService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "otelCollector": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=[SERVICE_TEMPLATE],
         )

--- a/chart/tests/helm_tests/otel_collector/test_otel_collector.py
+++ b/chart/tests/helm_tests/otel_collector/test_otel_collector.py
@@ -403,6 +403,7 @@ class TestOtelCollectorService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
+                "otelCollector": {"tracesEnabled": True},
                 "ipFamilyPolicy": "PreferDualStack",
                 "ipFamilies": ["IPv4", "IPv6"],
             },
@@ -412,10 +413,10 @@ class TestOtelCollectorService:
         assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
         assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
 
-    def test_ip_family_policy_not_set_by_default(self):
-        docs = render_chart(show_only=[SERVICE_TEMPLATE])
-
-        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        docs = render_chart(
+            values={"otelCollector": {"tracesEnabled": True}},
+            show_only=[SERVICE_TEMPLATE],
+        )
         assert jmespath.search("spec.ipFamilies", docs[0]) is None
 
 

--- a/chart/tests/helm_tests/other/test_flower.py
+++ b/chart/tests/helm_tests/other/test_flower.py
@@ -573,6 +573,32 @@ class TestFlowerService:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "flower": {
+                    "enabled": True,
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/flower/flower-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            values={"flower": {"enabled": True}},
+            show_only=["templates/flower/flower-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
 
 class TestFlowerNetworkPolicy:
     """Tests flower network policy."""

--- a/chart/tests/helm_tests/other/test_flower.py
+++ b/chart/tests/helm_tests/other/test_flower.py
@@ -576,13 +576,9 @@ class TestFlowerService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "flower": {
-                    "enabled": True,
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "flower": {"enabled": True},
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/flower/flower-service.yaml"],
         )

--- a/chart/tests/helm_tests/other/test_pgbouncer.py
+++ b/chart/tests/helm_tests/other/test_pgbouncer.py
@@ -108,6 +108,32 @@ class TestPgbouncer:
 
         assert jmespath.search("spec.clusterIP", docs[0]) == "10.10.10.10"
 
+    def test_pgbouncer_service_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_pgbouncer_service_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            values={"pgbouncer": {"enabled": True}},
+            show_only=["templates/pgbouncer/pgbouncer-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
     @pytest.mark.parametrize(
         ("revision_history_limit", "global_revision_history_limit"),
         [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],

--- a/chart/tests/helm_tests/other/test_pgbouncer.py
+++ b/chart/tests/helm_tests/other/test_pgbouncer.py
@@ -111,13 +111,9 @@ class TestPgbouncer:
     def test_pgbouncer_service_ip_family_policy(self):
         docs = render_chart(
             values={
-                "pgbouncer": {
-                    "enabled": True,
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "pgbouncer": {"enabled": True},
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/pgbouncer/pgbouncer-service.yaml"],
         )

--- a/chart/tests/helm_tests/other/test_redis.py
+++ b/chart/tests/helm_tests/other/test_redis.py
@@ -576,3 +576,27 @@ class TestRedisService:
             show_only=["templates/redis/redis-service.yaml"],
         )
         assert jmespath.search("spec.clusterIP", docs[0]) == "127.0.0.1"
+
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/redis/redis-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            show_only=["templates/redis/redis-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None

--- a/chart/tests/helm_tests/other/test_redis.py
+++ b/chart/tests/helm_tests/other/test_redis.py
@@ -580,12 +580,8 @@ class TestRedisService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "redis": {
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/redis/redis-service.yaml"],
         )

--- a/chart/tests/helm_tests/other/test_statsd.py
+++ b/chart/tests/helm_tests/other/test_statsd.py
@@ -422,6 +422,36 @@ class TestStatsd:
         assert expected == jmespath.search("spec.template.spec.terminationGracePeriodSeconds", docs[0])
 
 
+class TestStatsdService:
+    """Tests statsd service."""
+
+    def test_ip_family_policy(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "enabled": True,
+                    "service": {
+                        "ipFamilyPolicy": "PreferDualStack",
+                        "ipFamilies": ["IPv4", "IPv6"],
+                    },
+                },
+            },
+            show_only=["templates/statsd/statsd-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) == "PreferDualStack"
+        assert jmespath.search("spec.ipFamilies", docs[0]) == ["IPv4", "IPv6"]
+
+    def test_ip_family_policy_not_set_by_default(self):
+        docs = render_chart(
+            values={"statsd": {"enabled": True}},
+            show_only=["templates/statsd/statsd-service.yaml"],
+        )
+
+        assert jmespath.search("spec.ipFamilyPolicy", docs[0]) is None
+        assert jmespath.search("spec.ipFamilies", docs[0]) is None
+
+
 class TestStatsdServiceAccount:
     """Tests statsd service account."""
 

--- a/chart/tests/helm_tests/other/test_statsd.py
+++ b/chart/tests/helm_tests/other/test_statsd.py
@@ -428,13 +428,9 @@ class TestStatsdService:
     def test_ip_family_policy(self):
         docs = render_chart(
             values={
-                "statsd": {
-                    "enabled": True,
-                    "service": {
-                        "ipFamilyPolicy": "PreferDualStack",
-                        "ipFamilies": ["IPv4", "IPv6"],
-                    },
-                },
+                "statsd": {"enabled": True},
+                "ipFamilyPolicy": "PreferDualStack",
+                "ipFamilies": ["IPv4", "IPv6"],
             },
             show_only=["templates/statsd/statsd-service.yaml"],
         )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4489,6 +4489,39 @@
                             "x-docsSection": "Common"
                         }
                     }
+                },
+                "service": {
+                    "description": "Headless service configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
+                        }
+                    }
                 }
             }
         },
@@ -5087,6 +5120,39 @@
                             }
                         ],
                         "additionalProperties": false
+                    }
+                },
+                "service": {
+                    "description": "Headless service configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
+                        }
                     }
                 }
             }
@@ -5726,6 +5792,39 @@
                             "description": "Whether to use PGBouncer to connect to the database or not when it is enabled. This configuration will be ignored if PGBouncer is not enabled.",
                             "type": "boolean",
                             "default": false
+                        }
+                    }
+                },
+                "service": {
+                    "description": "Headless service configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 }
@@ -7564,6 +7663,32 @@
                             "examples": [
                                 "10.123.0.0/16"
                             ]
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },
@@ -8058,6 +8183,32 @@
                             "examples": [
                                 "10.123.0.0/16"
                             ]
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },
@@ -8409,6 +8560,32 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },
@@ -8778,6 +8955,32 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },
@@ -9203,6 +9406,32 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },
@@ -9618,6 +9847,32 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "ipFamilyPolicy": {
+                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "enum": [
+                                "SingleStack",
+                                "PreferDualStack",
+                                "RequireDualStack",
+                                null
+                            ],
+                            "default": null
+                        },
+                        "ipFamilies": {
+                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "IPv4",
+                                    "IPv6"
+                                ]
+                            },
+                            "default": []
                         }
                     }
                 },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -232,6 +232,34 @@
             "default": false,
             "x-docsSection": "Kubernetes"
         },
+        "ipFamilyPolicy": {
+            "description": "Specify the ip family policy to configure dual-stack networking for all Services. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
+            "type": [
+                "string",
+                "null"
+            ],
+            "enum": [
+                "SingleStack",
+                "PreferDualStack",
+                "RequireDualStack",
+                null
+            ],
+            "default": null,
+            "x-docsSection": "Kubernetes"
+        },
+        "ipFamilies": {
+            "description": "List of IP families for all Services (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "IPv4",
+                    "IPv6"
+                ]
+            },
+            "default": [],
+            "x-docsSection": "Kubernetes"
+        },
         "imagePullSecrets": {
             "description": "List of existing Kubernetes secrets containing Base64 encoded credentials to connect to private registries (will get passed to imagePullSecrets).",
             "type": "array",
@@ -4489,39 +4517,6 @@
                             "x-docsSection": "Common"
                         }
                     }
-                },
-                "service": {
-                    "description": "Headless service configuration.",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
-                        }
-                    }
                 }
             }
         },
@@ -5120,39 +5115,6 @@
                             }
                         ],
                         "additionalProperties": false
-                    }
-                },
-                "service": {
-                    "description": "Headless service configuration.",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
-                        }
                     }
                 }
             }
@@ -5792,39 +5754,6 @@
                             "description": "Whether to use PGBouncer to connect to the database or not when it is enabled. This configuration will be ignored if PGBouncer is not enabled.",
                             "type": "boolean",
                             "default": false
-                        }
-                    }
-                },
-                "service": {
-                    "description": "Headless service configuration.",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 }
@@ -7663,32 +7592,6 @@
                             "examples": [
                                 "10.123.0.0/16"
                             ]
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },
@@ -8183,32 +8086,6 @@
                             "examples": [
                                 "10.123.0.0/16"
                             ]
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },
@@ -8560,32 +8437,6 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },
@@ -8955,32 +8806,6 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },
@@ -9406,32 +9231,6 @@
                                 "null"
                             ],
                             "default": null
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },
@@ -9847,32 +9646,6 @@
                                 "null"
                             ],
                             "default": null
-                        },
-                        "ipFamilyPolicy": {
-                            "description": "Specify the ip family policy to configure dual-stack. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
-                            "type": [
-                                "string",
-                                "null"
-                            ],
-                            "enum": [
-                                "SingleStack",
-                                "PreferDualStack",
-                                "RequireDualStack",
-                                null
-                            ],
-                            "default": null
-                        },
-                        "ipFamilies": {
-                            "description": "List of IP families for the Service (e.g. [\"IPv4\"] or [\"IPv6\"] or [\"IPv4\", \"IPv6\"]).",
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "IPv4",
-                                    "IPv6"
-                                ]
-                            },
-                            "default": []
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -139,6 +139,13 @@ labels: {}
 # Whenever service links should be added to each pod.
 enableServiceLinks: false
 
+# Specify the ip family policy to configure dual-stack networking for all Services.
+# See https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+ipFamilyPolicy: ~
+
+# List of IP families for all Services (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"]).
+ipFamilies: []
+
 # List of existing Kubernetes secrets containing Base64 encoded credentials to connect to private
 # registries. Items can be either strings or {name: secret} objects.
 imagePullSecrets: []
@@ -1105,15 +1112,6 @@ workers:
   # (deprecated, use `workers.celery.labels` and/or `workers.kubernetes.labels` instead)
   labels: {}
 
-  # Headless service configuration (used for internal log access with CeleryExecutor)
-  service:
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
-
   # Log groomer configuration for Airflow Celery workers
   # (deprecated, use `workers.celery.logGroomerSidecar` instead)
   logGroomerSidecar:
@@ -1935,15 +1933,6 @@ scheduler:
   # Labels specific to scheduler objects and pods
   labels: {}
 
-  # Headless service configuration (used for internal log access)
-  service:
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
-
   logGroomerSidecar:
     # Whether to deploy the Airflow scheduler log groomer sidecar.
     enabled: true
@@ -2316,12 +2305,6 @@ apiServer:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   podDisruptionBudget:
     enabled: false
@@ -2613,15 +2596,6 @@ triggerer:
 
   # Labels specific to triggerer objects and pods
   labels: {}
-
-  # Headless service configuration (used for internal log access)
-  service:
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   logGroomerSidecar:
     # Whether to deploy the Airflow triggerer log groomer sidecar.
@@ -3064,12 +3038,6 @@ flower:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   # Launch additional containers into the flower pods.
   extraContainers: []
@@ -3202,12 +3170,6 @@ statsd:
   service:
     extraAnnotations: {}
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   # Select certain nodes for StatsD pods.
   nodeSelector: {}
@@ -3308,12 +3270,6 @@ otelCollector:
   service:
     annotations: {}
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   nodeSelector: {}
   affinity: {}
@@ -3443,12 +3399,6 @@ pgbouncer:
     extraAnnotations: {}
     clusterIp: ~
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   # https://www.pgbouncer.org/config.html
   verbose: 0
@@ -3607,12 +3557,6 @@ redis:
     # If using NodePort service type, custom node port can be specified
     nodePort:
 
-    # Specify the ip family policy to configure dual-stack see `Type` in
-    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
-    ipFamilyPolicy: ~
-
-    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
-    ipFamilies: []
 
   persistence:
     # Enable persistent volumes

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2305,7 +2305,6 @@ apiServer:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
-
   podDisruptionBudget:
     enabled: false
 
@@ -3038,7 +3037,6 @@ flower:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
-
   # Launch additional containers into the flower pods.
   extraContainers: []
 
@@ -3170,7 +3168,6 @@ statsd:
   service:
     extraAnnotations: {}
 
-
   # Select certain nodes for StatsD pods.
   nodeSelector: {}
   affinity: {}
@@ -3269,7 +3266,6 @@ otelCollector:
 
   service:
     annotations: {}
-
 
   nodeSelector: {}
   affinity: {}
@@ -3398,7 +3394,6 @@ pgbouncer:
   service:
     extraAnnotations: {}
     clusterIp: ~
-
 
   # https://www.pgbouncer.org/config.html
   verbose: 0
@@ -3556,7 +3551,6 @@ redis:
 
     # If using NodePort service type, custom node port can be specified
     nodePort:
-
 
   persistence:
     # Enable persistent volumes

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1105,6 +1105,15 @@ workers:
   # (deprecated, use `workers.celery.labels` and/or `workers.kubernetes.labels` instead)
   labels: {}
 
+  # Headless service configuration (used for internal log access with CeleryExecutor)
+  service:
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
+
   # Log groomer configuration for Airflow Celery workers
   # (deprecated, use `workers.celery.logGroomerSidecar` instead)
   logGroomerSidecar:
@@ -1926,6 +1935,15 @@ scheduler:
   # Labels specific to scheduler objects and pods
   labels: {}
 
+  # Headless service configuration (used for internal log access)
+  service:
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
+
   logGroomerSidecar:
     # Whether to deploy the Airflow scheduler log groomer sidecar.
     enabled: true
@@ -2298,6 +2316,13 @@ apiServer:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
+
   podDisruptionBudget:
     enabled: false
 
@@ -2588,6 +2613,15 @@ triggerer:
 
   # Labels specific to triggerer objects and pods
   labels: {}
+
+  # Headless service configuration (used for internal log access)
+  service:
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
 
   logGroomerSidecar:
     # Whether to deploy the Airflow triggerer log groomer sidecar.
@@ -3030,6 +3064,13 @@ flower:
     # loadBalancerSourceRanges:
     #   - "10.123.0.0/16"
 
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
+
   # Launch additional containers into the flower pods.
   extraContainers: []
 
@@ -3161,6 +3202,13 @@ statsd:
   service:
     extraAnnotations: {}
 
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
+
   # Select certain nodes for StatsD pods.
   nodeSelector: {}
   affinity: {}
@@ -3259,6 +3307,13 @@ otelCollector:
 
   service:
     annotations: {}
+
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
 
   nodeSelector: {}
   affinity: {}
@@ -3387,6 +3442,13 @@ pgbouncer:
   service:
     extraAnnotations: {}
     clusterIp: ~
+
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
 
   # https://www.pgbouncer.org/config.html
   verbose: 0
@@ -3544,6 +3606,13 @@ redis:
 
     # If using NodePort service type, custom node port can be specified
     nodePort:
+
+    # Specify the ip family policy to configure dual-stack see `Type` in
+    # https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+    ipFamilyPolicy: ~
+
+    # List of IP families (e.g., ["IPv4"] or ["IPv6"] or ["IPv4","IPv6"])
+    ipFamilies: []
 
   persistence:
     # Enable persistent volumes


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/huynhsontung/airflow/sessions/be394b63-9852-4a0f-a4b9-6d9e14c14f29

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Summary

Adds `ipFamilyPolicy` and `ipFamilies` fields to all Airflow Helm chart service templates to support IPv6 and dual-stack networking configurations.

## Changes

### Service Templates Updated
All 9 service templates now conditionally include `ipFamilyPolicy` and `ipFamilies` when set:
- `api-server-service.yaml`
- `flower-service.yaml`
- `redis-service.yaml`
- `pgbouncer-service.yaml`
- `statsd-service.yaml`
- `otel-collector-service.yaml`
- `worker-service.yaml` (headless)
- `triggerer-service.yaml` (headless)
- `scheduler-service.yaml` (headless)

### `values.yaml`
- Add top-level `ipFamilyPolicy: ~` and `ipFamilies: []`
- Defaults are `null`/empty, preserving existing behavior unless explicitly set

### `values.schema.json`
- Added `ipFamilyPolicy` with enum validation (`SingleStack`, `PreferDualStack`, `RequireDualStack`, or `null`)
- Added `ipFamilies` with item enum validation (`IPv4`, `IPv6`)

### Tests
Added tests to all relevant test files verifying:
- `ipFamilyPolicy` and `ipFamilies` are rendered when configured
- Neither field is present by default (no breaking change)

## Usage Example

```yaml
# One setting applies to all Services:
ipFamilyPolicy: PreferDualStack
ipFamilies:
  - IPv4
  - IPv6
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
GitHub Copilot (Claude Sonnet 4.6)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
