### PR TITLE
Validate DAG trigger conf as JSON object or null

### DIFF
--- a/airflow-core/src/airflow/api/common/trigger_dag.py
+++ b/airflow-core/src/airflow/api/common/trigger_dag.py
@@ -26,6 +26,7 @@ from airflow._shared.timezones import timezone
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagModel, DagRun
 from airflow.models.dagbag import DBDagBag
+from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -38,6 +39,14 @@ if TYPE_CHECKING:
     from airflow.timetables.base import DataInterval
 
 
+def _normalize_conf(conf: dict | str | None) -> dict | None:
+    if isinstance(conf, str):
+        conf = json.loads(conf)
+    if conf is not None and not isinstance(conf, dict):
+        raise ValueError("DagRun conf must be a JSON object or null")
+    return conf
+
+
 @provide_session
 def _trigger_dag(
     dag_id: str,
@@ -48,7 +57,7 @@ def _trigger_dag(
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,
-    conf: dict | str | None = None,
+    conf: dict | str | None | ArgNotSet = NOTSET,
     logical_date: datetime | None = None,
     replace_microseconds: bool = True,
     note: str | None = None,
@@ -110,8 +119,8 @@ def _trigger_dag(
         raise DagRunAlreadyExists(dag_run)
 
     run_conf = None
-    if conf:
-        run_conf = conf if isinstance(conf, dict) else json.loads(conf)
+    if is_arg_set(conf):
+        run_conf = _normalize_conf(conf)
     dag_run = dag.create_dagrun(
         run_id=run_id,
         logical_date=coerced_logical_date,
@@ -139,7 +148,7 @@ def trigger_dag(
     triggering_user_name: str | None = None,
     run_after: datetime | None = None,
     run_id: str | None = None,
-    conf: dict | str | None = None,
+    conf: dict | str | None | ArgNotSet = NOTSET,
     logical_date: datetime | None = None,
     replace_microseconds: bool = True,
     note: str | None = None,

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -580,6 +580,44 @@ class TestCliDags:
         assert dagrun.data_interval_start is None
         assert dagrun.data_interval_end is None
 
+    def test_trigger_dag_empty_object_conf(self):
+        dag_command.dag_trigger(
+            self.parser.parse_args(
+                [
+                    "dags",
+                    "trigger",
+                    "example_bash_operator",
+                    "--run-id=test_trigger_dag_empty_object_conf",
+                    "--conf={}",
+                ],
+            ),
+        )
+        with create_session() as session:
+            dagrun = session.scalars(
+                select(DagRun).where(DagRun.run_id == "test_trigger_dag_empty_object_conf")
+            ).one()
+
+        assert dagrun.conf == {}
+
+    def test_trigger_dag_json_null_conf(self):
+        dag_command.dag_trigger(
+            self.parser.parse_args(
+                [
+                    "dags",
+                    "trigger",
+                    "example_bash_operator",
+                    "--run-id=test_trigger_dag_json_null_conf",
+                    "--conf=null",
+                ],
+            ),
+        )
+        with create_session() as session:
+            dagrun = session.scalars(
+                select(DagRun).where(DagRun.run_id == "test_trigger_dag_json_null_conf")
+            ).one()
+
+        assert dagrun.conf == {}
+
     def test_trigger_dag_with_microseconds(self):
         dag_command.dag_trigger(
             self.parser.parse_args(
@@ -603,7 +641,8 @@ class TestCliDags:
         assert dagrun.run_type == DagRunType.MANUAL
         assert dagrun.logical_date.isoformat(timespec="microseconds") == "2021-06-04T01:00:00.000001+00:00"
 
-    def test_trigger_dag_invalid_conf(self):
+    @pytest.mark.parametrize("conf", ["NOT JSON", ""])
+    def test_trigger_dag_invalid_conf(self, conf):
         with pytest.raises(ValueError, match=r"Expecting value: line \d+ column \d+ \(char \d+\)"):
             dag_command.dag_trigger(
                 self.parser.parse_args(
@@ -614,7 +653,24 @@ class TestCliDags:
                         "--run-id",
                         "trigger_dag_xxx",
                         "--conf",
-                        "NOT JSON",
+                        conf,
+                    ]
+                ),
+            )
+
+    @pytest.mark.parametrize("conf", ["[]", '"str"', "1", "false"])
+    def test_trigger_dag_rejects_non_object_conf(self, conf):
+        with pytest.raises(ValueError, match="DagRun conf must be a JSON object or null"):
+            dag_command.dag_trigger(
+                self.parser.parse_args(
+                    [
+                        "dags",
+                        "trigger",
+                        "example_bash_operator",
+                        "--run-id",
+                        "trigger_dag_xxx",
+                        "--conf",
+                        conf,
                     ]
                 ),
             )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Problem

`airflow dags trigger --conf` currently accepts any value that is valid JSON.

This means values such as arrays, strings, numbers, and booleans can be accepted by the CLI:

```bash
airflow dags trigger example --conf='[1]'
airflow dags trigger example --conf='"value"'
airflow dags trigger example --conf='1'
```
This is inconsistent with the REST API, where `conf` is validated as `dict | None`.

Allowing non-object JSON values into `DagRun.conf` can cause runtime issues later, because downstream code commonly treats `dag_run.conf` as a mapping, for example: `dag_run.conf.get(...)`

## Problematic Code

The issue was in `airflow.api.common.trigger_dag._trigger_dag()`.

The previous logic used a truthiness check:
```Python
run_conf = None
if conf:
    run_conf = conf if isinstance(conf, dict) else json.loads(conf)
```
This made it hard to distinguish between:
- `conf` not being provided
- an empty JSON object: `{}`
- an explicit JSON `null`
- invalid JSON
- valid JSON with the wrong type, such as `[]`, `"str"`, `1`, or `false`

It also parsed JSON strings without validating that the parsed value was a JSON object or `null`.

## Solution

This PR updates the common Dag trigger path to normalize and validate conf explicitly.

The new behavior is:
- omitted `conf` keeps the existing default behavior
- `{}` is accepted
- JSON `null` is accepted
- invalid JSON is rejected
- valid JSON values that are not objects or `null` are rejected with a clear error

The implementation uses Airflow’s existing `NOTSET` sentinel pattern to distinguish an omitted `conf` argument from an explicitly provided value. After parsing string input with `json.loads()`, the result is validated so only `dict` or `None` is accepted.

CLI tests were added to cover:
- empty object `conf`
- JSON `null` `conf`
- invalid JSON
- non-object JSON values such as arrays, strings, numbers, and booleans

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: [GPT 5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
