### PR TITLE
UI: Fix relative React plugin bundle URLs in dev mode

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/ReactPlugin.tsx
@@ -35,7 +35,7 @@ type PluginComponentType = FC<PluginProps>;
 
 const loadPlugin = (reactApp: ReactAppResponse): Promise<{ default: PluginComponentType }> =>
   // We are assuming the plugin manager is trusted and the bundle_url is safe
-  import(/* @vite-ignore */ reactApp.bundle_url)
+  import(/* @vite-ignore */ new URL(reactApp.bundle_url, document.baseURI).href)
     .then(() => {
       // Store components in globalThis[reactApp.name] to avoid conflicts with the shared globalThis.AirflowPlugin
       // global variable.


### PR DESCRIPTION
## Description

Closes: #53378

React app plugins can register a relative `bundle_url`. In UI dev mode, the Airflow HTML document is served by the API server, while the React UI modules are loaded from the Vite dev server. Because of that, `import(reactApp.bundle_url)` resolved relative plugin bundle URLs against the Vite origin instead of the Airflow API server origin.

This changes the React plugin loader to resolve `bundle_url` against `document.baseURI` before dynamically importing it. Absolute bundle URLs are preserved, and relative bundle URLs now load from the Airflow document/API server base URL.

## Testing

Tested manually with an Astronomer-style React app plugin using a relative `bundle_url`.
( astronomer-style react app docs : https://www.astronomer.io/docs/learn/using-airflow-plugins )

I created a temporary test React app plugin (`/simple-react-app/my-app.js`) with a relative `bundle_url` and used it to verify the behavior in UI dev mode.

Before the change, `/simple-react-app/my-app.js` was requested from the Vite dev server at `http://localhost:5173/...` and returned the Vite fallback HTML instead of the plugin JavaScript bundle.
[before image]
<img width="792" height="297" alt="image" src="https://github.com/user-attachments/assets/a78dcf98-4c78-4f69-9671-9a50b193241c" />

After the change, the same relative URL was resolved against `document.baseURI` and requested from the Airflow API server at `http://localhost:28080/simple-react-app/my-app.js`. The plugin JavaScript loaded and the React plugin rendered successfully.
[after image]
<img width="1413" height="425" alt="image" src="https://github.com/user-attachments/assets/446d9267-4428-44f6-8c25-13474e190bdc" />

cc @choo121600

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] codex (gpt-5.5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

