### PR TITLE
Fix calendar view showing queued runs as green, indistinguishable from success

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarLegend.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarLegend.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "react-i18next";
 
 import { Tooltip } from "src/components/ui";
 
-import { PLANNED_COLOR } from "./calendarUtils";
+import { PLANNED_COLOR, QUEUED_COLOR } from "./calendarUtils";
 import type { CalendarScale, CalendarColorMode } from "./types";
 
 type Props = {
@@ -87,6 +87,12 @@ export const CalendarLegend = ({ scale, vertical = false, viewMode }: Props) => 
             <Box bg={PLANNED_COLOR} borderRadius="2px" boxShadow="sm" height="14px" width="14px" />
             <Text color="fg.muted" fontSize="xs">
               {translate("common:states.planned")}
+            </Text>
+          </HStack>
+          <HStack gap={2}>
+            <Box bg={QUEUED_COLOR} borderRadius="2px" boxShadow="sm" height="14px" width="14px" />
+            <Text color="fg.muted" fontSize="xs">
+              {translate("common:states.queued")}
             </Text>
           </HStack>
           <HStack gap={2}>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -187,7 +187,10 @@ export const calculateDataBounds = (
 
   dataMap.forEach((runs) => {
     const runCounts = calculateRunCounts(runs);
-    const targetCount = viewMode === "total" ? runCounts.total : runCounts.failed;
+    const targetCount =
+      viewMode === "total"
+        ? runCounts.total - runCounts.planned - runCounts.queued
+        : runCounts.failed;
 
     if (targetCount > 0) {
       counts.push(targetCount);
@@ -281,8 +284,7 @@ export const createCalendarScale = (
         actual: string | { _dark: string; _light: string };
         planned: string | { _dark: string; _light: string };
       } => {
-    const actualCount =
-      viewMode === "total" ? counts.total - counts.planned - counts.queued : counts.failed;
+    const actualCount = viewMode === "total" ? counts.total - counts.planned - counts.queued : counts.failed;
     const hasPlanned = counts.planned > 0;
     const hasQueued = counts.queued > 0;
     const hasActual = actualCount > 0;

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -188,9 +188,7 @@ export const calculateDataBounds = (
   dataMap.forEach((runs) => {
     const runCounts = calculateRunCounts(runs);
     const targetCount =
-      viewMode === "total"
-        ? runCounts.total - runCounts.planned - runCounts.queued
-        : runCounts.failed;
+      viewMode === "total" ? runCounts.total - runCounts.planned - runCounts.queued : runCounts.failed;
 
     if (targetCount > 0) {
       counts.push(targetCount);

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -37,6 +37,7 @@ dayjs.extend(isSameOrBefore);
 
 // Calendar color constants
 export const PLANNED_COLOR = { _dark: "stone.600", _light: "stone.500" };
+export const QUEUED_COLOR = { _dark: "blue.700", _light: "blue.300" };
 const EMPTY_COLOR = { _dark: "gray.700", _light: "gray.100" };
 
 const TOTAL_COLOR_INTENSITIES = [
@@ -226,8 +227,10 @@ export const createCalendarScale = (
 
     return {
       getColor: (counts: RunCounts) => {
-        const actualCount = viewMode === "total" ? counts.total - counts.planned : counts.failed;
+        const actualCount =
+          viewMode === "total" ? counts.total - counts.planned - counts.queued : counts.failed;
         const hasPlanned = counts.planned > 0;
+        const hasQueued = counts.queued > 0;
         const hasActual = actualCount > 0;
 
         if (hasPlanned && hasActual) {
@@ -239,6 +242,10 @@ export const createCalendarScale = (
 
         if (hasPlanned && !hasActual) {
           return PLANNED_COLOR;
+        }
+
+        if (hasQueued && !hasActual) {
+          return QUEUED_COLOR;
         }
 
         return actualCount === 0 ? EMPTY_COLOR : singleColor;
@@ -274,8 +281,10 @@ export const createCalendarScale = (
         actual: string | { _dark: string; _light: string };
         planned: string | { _dark: string; _light: string };
       } => {
-    const actualCount = viewMode === "total" ? counts.total - counts.planned : counts.failed;
+    const actualCount =
+      viewMode === "total" ? counts.total - counts.planned - counts.queued : counts.failed;
     const hasPlanned = counts.planned > 0;
+    const hasQueued = counts.queued > 0;
     const hasActual = actualCount > 0;
 
     if (hasPlanned && hasActual) {
@@ -302,6 +311,10 @@ export const createCalendarScale = (
 
     if (hasPlanned && !hasActual) {
       return PLANNED_COLOR;
+    }
+
+    if (hasQueued && !hasActual) {
+      return QUEUED_COLOR;
     }
 
     const targetCount = actualCount;


### PR DESCRIPTION
Closes #66614
In the Calendar view (Total Runs), cells that have queued runs appear as solid green as those that have successful runs. It can be known via the tooltip.

The problem lies in calendarUtils.ts file where actualCount subtracts  planned but not queued from total hence treating queued runs as successful runs, which causes queued runs to display as green.

Solution:
- Subtract queued from actualCount like planned
- Return a unique blue color whenever there are only queued runs in 
  a particular cell.
- Include queued color swatch to legend
> I utilized Claude (claude.ai) as an AI assistant during this implementation process.
