### PR TITLE
feat: add code quality rule to flag new usage of AirflowException

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -32,6 +32,7 @@ Use these rules when reviewing pull requests to the Apache Airflow repository.
 - **Flag any `@lru_cache(maxsize=None)`.** This creates an unbounded cache — every unique argument set is cached forever. Note: `@lru_cache()` without arguments defaults to `maxsize=128` and is fine.
 - **Flag any heavy import** (e.g., `kubernetes.client`) in multi-process code paths that is not behind a `TYPE_CHECKING` guard.
 - **Flag any file, connection, or session opened without a context manager or `try/finally`.**
+- **Flag any new `raise AirflowException` usage.** The community has stopped adding new ones (enforced by the `check-no-new-airflow-exceptions` prek hook) — prefer Python's standard exceptions (`ValueError`, `TypeError`, `OSError`), or a dedicated class in the appropriate `exceptions.py`. **Do not suggest changing specific exceptions back to `AirflowException`.**
 
 ## Testing Requirements
 


### PR DESCRIPTION
Hi team,

I've noticed that GitHub Copilot keeps suggesting `AirflowException` in my recent PRs (e.g., #65991 and #66510).

However, the [contributing docs](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#don-t-raise-airflowexception-directly) and [`.pre-commit-config.yaml`](https://github.com/apache/airflow/blob/068d6db8e90b0ae156ce039ab0a66188c7e6efe7/.pre-commit-config.yaml#L1049) make it clear that new `raise AirflowException` usages should not be added.