### PR TITLE
fix: report duplicate plugin names as import errors

### DIFF
--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -99,7 +99,10 @@ def _get_plugins() -> tuple[list[AirflowPlugin], dict[str, str]]:
     def __register_plugins(plugin_instances: list[AirflowPlugin], errors: dict[str, str]) -> None:
         for plugin_instance in plugin_instances:
             if plugin_instance.name in loaded_plugins:
-                log.warning("Plugin %r already registered, skipping", plugin_instance.name)
+                message = f"Plugin {plugin_instance.name!r} already registered, skipping"
+                log.warning(message)
+                name = str(plugin_instance.source) if plugin_instance.source else plugin_instance.name or ""
+                import_errors[name] = message
                 continue
 
             loaded_plugins.add(plugin_instance.name)

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -160,7 +160,34 @@ class TestPluginsManager:
         assert "plugin_b" in plugin_names
         assert "plugin_c" in plugin_names
         assert len(plugins) == 3
-        assert not import_errors
+
+    def test_duplicate_plugin_name_is_reported_as_import_error(self):
+        from airflow import plugins_manager
+
+        class PluginA(AirflowPlugin):
+            name = "plugin_a"
+
+        class PluginADuplicateName(AirflowPlugin):
+            name = "plugin_a"
+
+        plugin_a = PluginA()
+        plugin_a_dup = PluginADuplicateName()
+
+        with (
+            mock.patch(
+                "airflow.plugins_manager._load_plugins_from_plugin_directory",
+                return_value=([plugin_a], {}),
+            ),
+            mock.patch(
+                "airflow.plugins_manager._load_entrypoint_plugins",
+                return_value=([plugin_a_dup], {}),
+            ),
+            mock.patch("airflow.plugins_manager._load_providers_plugins", return_value=([], {})),
+        ):
+            plugins, import_errors = plugins_manager._get_plugins()
+
+        assert [p.name for p in plugins] == ["plugin_a"]
+        assert len(import_errors) == 1
 
     def test_should_warning_about_incompatible_plugins(self, caplog):
         class AirflowAdminViewsPlugin(AirflowPlugin):


### PR DESCRIPTION
## Description

Report duplicate Airflow plugin names as plugin import errors.

When multiple plugins define the same name, Airflow already skips the later duplicate plugin, but the conflict was only logged as a warning. This made the issue hard to discover from the UI/API because only one plugin appeared in the plugin list.

This change keeps the existing behavior of skipping duplicate plugin names and continuing to load subsequent plugins, but also records the duplicate as a plugin import error so it is visible from the plugin import errors endpoint/UI.

- closes: #55140

## Testing

sample plugin code
``` python
from airflow.plugins_manager import AirflowPlugin
from fastapi import FastAPI

my_app = FastAPI()

@my_app.get("/ping")
async def ping():
    return {"message": "pong"}

class MyFastAPIPlugin(AirflowPlugin):
    name = "my_fastapi_plugin"
    fastapi_apps = [
        {
            "name": "example_api",
            "app": my_app,
            "url_prefix": "/example"
        }
    ]

@my_app.get("/hello")
async def ping():
    return {"message": "Hello"}

class MyFastAPIPlugin2(AirflowPlugin):
    name = "my_fastapi_plugin"
    fastapi_apps = [
        {
            "name": "example_api",
            "app": my_app,
            "url_prefix": "/example"
        }
    ] 
```

- Before : Import error is not shown.

<img width="780" height="551" alt="image" src="https://github.com/user-attachments/assets/f4a646d1-ca41-4063-8da6-6d7c7326dc13" />

- After : Duplicate Airflow plugin names are shown as an import error.

<img width="1064" height="543" alt="image" src="https://github.com/user-attachments/assets/07d10c8e-7d88-41d0-bcf8-9231fa1843e9" />


---

Was generative AI tooling used to co-author this PR?
- [x] Yes — OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)