### PR TITLE
Add prek hooks for coordinator distributions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -541,11 +541,26 @@ repos:
         pass_filenames: true
         require_serial: true
       - id: check-airflow-bug-report-template
-        name: Sort airflow-bug-report provider list
+        name: Validate airflow bug report template lists
         language: python
-        files: ^\.github/ISSUE_TEMPLATE/1-airflow_bug_report\.yml$
+        files: >
+          (?x)
+          ^\.github/ISSUE_TEMPLATE/1-airflow_bug_report\.yml$|
+          ^sdk/coordinators/.*/pyproject\.toml$
         require_serial: true
         entry: ./scripts/ci/prek/check_airflow_bug_report_template.py
+      - id: check-coordinator-distributions
+        name: Validate coordinator distributions metadata and docs
+        language: python
+        entry: ./scripts/ci/prek/check_coordinator_distributions.py
+        pass_filenames: false
+        files: >
+          (?x)
+          ^sdk/coordinators/.*/pyproject\.toml$|
+          ^sdk/coordinators/.*/README\.rst$|
+          ^sdk/coordinators/.*/(LICENSE|NOTICE)$|
+          ^scripts/ci/prek/check_coordinator_distributions\.py$
+        require_serial: true
       - id: update-local-yml-file
         name: Update mounts in the local yml file
         entry: ./scripts/ci/prek/local_yml_mounts.py
@@ -1109,6 +1124,13 @@ repos:
         entry: ./scripts/ci/prek/check_shared_mypy_hooks.py
         pass_filenames: false
         files: ^shared/.*|^scripts/ci/prek/check_shared_mypy_hooks\.py$
+        require_serial: true
+      - id: check-coordinators-mypy-hooks
+        name: Every sdk/coordinators/<dist> has a mypy-coordinators-<dist> prek hook
+        language: python
+        entry: ./scripts/ci/prek/check_coordinators_mypy_hooks.py
+        pass_filenames: false
+        files: ^sdk/coordinators/.*|^scripts/ci/prek/check_coordinators_mypy_hooks\.py$
         require_serial: true
       - id: check-migration-patterns
         name: Check migration files for anti-patterns (MIG001/MIG002/MIG003)

--- a/scripts/ci/prek/check_airflow_bug_report_template.py
+++ b/scripts/ci/prek/check_airflow_bug_report_template.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import sys
 
 import yaml
-from common_prek_utils import AIRFLOW_ROOT_PATH, check_list_sorted, console
+from common_prek_utils import AIRFLOW_ROOT_PATH, check_list_sorted, console, coordinator_ids
 
 BUG_REPORT_TEMPLATE = AIRFLOW_ROOT_PATH / ".github" / "ISSUE_TEMPLATE" / "1-airflow_bug_report.yml"
 
@@ -37,6 +37,8 @@ DEPENDENCIES_JSON_FILE_PATH = AIRFLOW_ROOT_PATH / "generated" / "provider_depend
 
 if __name__ == "__main__":
     errors: list[str] = []
+    coordinator_template_field_found = False
+    all_coordinators = set(coordinator_ids())
     template = yaml.safe_load(BUG_REPORT_TEMPLATE.read_text())
     for field in template["body"]:
         attributes = field.get("attributes")
@@ -57,6 +59,20 @@ if __name__ == "__main__":
                         all_providers.remove(provider)
                 if all_providers:
                     errors.append(f"Not all providers are listed: {all_providers}")
+            elif attributes.get("label") == "Apache Airflow Coordinator(s)":
+                coordinator_template_field_found = True
+                check_list_sorted(attributes["options"], "Apache Airflow Coordinator(s)", errors)
+                missing_coordinators = all_coordinators.difference(attributes["options"])
+                unknown_coordinators = set(attributes["options"]).difference(all_coordinators)
+                if missing_coordinators:
+                    errors.append(f"Not all coordinators are listed: {missing_coordinators}")
+                if unknown_coordinators:
+                    errors.append(
+                        f"Coordinator(s) {unknown_coordinators} not found in sdk/coordinators "
+                        "and still present in the template.!"
+                    )
+    if all_coordinators and not coordinator_template_field_found:
+        errors.append("Apache Airflow Coordinator(s) field is missing from the bug report template")
     if errors:
         console.print("[red]Errors found in the bug report template[/]")
         for error in errors:

--- a/scripts/ci/prek/check_coordinator_distributions.py
+++ b/scripts/ci/prek/check_coordinator_distributions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "rich>=13.6.0",
+#   "tomli>=2.0.1; python_version < '3.11'",
+# ]
+# ///
+"""Validate sdk/coordinators distributions metadata and basic docs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from common_prek_utils import console, coordinator_distribution_dirs
+
+PACKAGE_PREFIX = "apache-airflow-coordinators-"
+
+
+def _load_pyproject(path: Path) -> dict:
+    return tomllib.loads(path.read_text())
+
+
+def check_coordinator_distribution(dist_dir: Path) -> list[str]:
+    errors: list[str] = []
+    coordinator_id = dist_dir.name
+    expected_package_name = f"{PACKAGE_PREFIX}{coordinator_id}"
+
+    pyproject_path = dist_dir / "pyproject.toml"
+    pyproject = _load_pyproject(pyproject_path)
+    project = pyproject.get("project", {})
+    package_name = project.get("name")
+    if package_name != expected_package_name:
+        errors.append(
+            f"{pyproject_path}: [project].name must be {expected_package_name!r}, got {package_name!r}"
+        )
+
+    for required_file in ("LICENSE", "NOTICE", "README.rst"):
+        if not (dist_dir / required_file).exists():
+            errors.append(f"{dist_dir}: missing required file {required_file}")
+
+    readme_path = dist_dir / "README.rst"
+    if readme_path.exists():
+        readme = readme_path.read_text()
+        if expected_package_name not in readme:
+            errors.append(f"{readme_path}: missing package name {expected_package_name!r}")
+        if "pip install" not in readme:
+            errors.append(f"{readme_path}: missing installation instructions")
+
+    source_dir = dist_dir / "src" / "airflow" / "sdk" / "coordinators" / coordinator_id
+    if not source_dir.exists():
+        errors.append(f"{dist_dir}: missing source package {source_dir.relative_to(dist_dir)}")
+
+    tests_dir = dist_dir / "tests"
+    if not tests_dir.exists():
+        errors.append(f"{dist_dir}: missing tests directory")
+
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for dist_dir in coordinator_distribution_dirs():
+        errors.extend(check_coordinator_distribution(dist_dir))
+
+    if errors:
+        console.print("[red]Errors found in coordinator distributions[/]")
+        for error in errors:
+            console.print(f"[red]{error}[/]")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/prek/check_coordinators_mypy_hooks.py
+++ b/scripts/ci/prek/check_coordinators_mypy_hooks.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Fail when any sdk/coordinators/<dist> workspace member is missing its mypy prek config."""
+
+from __future__ import annotations
+
+import sys
+
+from common_prek_utils import coordinator_distribution_dirs
+
+EXPECTED_TEMPLATE = """\
+# <license header>
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.3.4'
+default_language_version:
+  python: python3
+repos:
+  - repo: local
+    hooks:
+      - id: mypy-coordinators-{dist}
+        name: Run mypy for coordinators-{dist}
+        language: python
+        entry: >-
+          ../../../scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
+          sdk/coordinators/{dist}
+        pass_filenames: false
+        files: ^.*\\.py$
+        require_serial: true
+"""
+
+
+def missing_mypy_hook_distribution_ids() -> list[str]:
+    missing: list[str] = []
+    for dist_dir in coordinator_distribution_dirs():
+        dist = dist_dir.name
+        hook_id = f"mypy-coordinators-{dist}"
+        config = dist_dir / ".pre-commit-config.yaml"
+        if not config.exists() or hook_id not in config.read_text():
+            missing.append(dist)
+    return missing
+
+
+def main() -> int:
+    missing = missing_mypy_hook_distribution_ids()
+    if missing:
+        print(
+            "ERROR: The following sdk/coordinators/<dist> workspace members are missing their "
+            f"dedicated mypy prek hook: {', '.join(missing)}\n"
+        )
+        print(
+            "Every coordinator distribution must ship its own mypy-coordinators-<dist> hook so it is\n"
+            "type-checked in isolation (dedicated virtualenv + mypy cache under .build/).\n"
+        )
+        print(
+            "Create sdk/coordinators/<dist>/.pre-commit-config.yaml with the following contents\n"
+            "(add the ASF license header at the top) for each missing distribution:\n"
+        )
+        for dist in missing:
+            print(f"--- sdk/coordinators/{dist}/.pre-commit-config.yaml ---")
+            print(EXPECTED_TEMPLATE.format(dist=dist))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -39,6 +39,20 @@ AIRFLOW_BREEZE_SOURCES_PATH = AIRFLOW_ROOT_PATH / "dev" / "breeze"
 AIRFLOW_PROVIDERS_ROOT_PATH = AIRFLOW_ROOT_PATH / "providers"
 AIRFLOW_TASK_SDK_ROOT_PATH = AIRFLOW_ROOT_PATH / "task-sdk"
 AIRFLOW_TASK_SDK_SOURCES_PATH = AIRFLOW_TASK_SDK_ROOT_PATH / "src"
+AIRFLOW_COORDINATORS_ROOT_PATH = AIRFLOW_ROOT_PATH / "sdk" / "coordinators"
+
+
+def coordinator_distribution_dirs(root_path: Path = AIRFLOW_COORDINATORS_ROOT_PATH) -> list[Path]:
+    """Return coordinator distribution directories under ``sdk/coordinators``."""
+    if not root_path.exists():
+        return []
+    return sorted(path for path in root_path.iterdir() if (path / "pyproject.toml").exists())
+
+
+def coordinator_ids(root_path: Path = AIRFLOW_COORDINATORS_ROOT_PATH) -> list[str]:
+    """Return coordinator ids derived from ``sdk/coordinators/<id>`` directories."""
+    return [path.name for path in coordinator_distribution_dirs(root_path)]
+
 
 # Here we should add the second level paths that we want to have sub-packages in
 KNOWN_SECOND_LEVEL_PATHS = ["apache", "atlassian", "common", "cncf", "dbt", "microsoft"]

--- a/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
+++ b/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
@@ -25,7 +25,7 @@
 
 Used for non-provider projects: airflow-core, task-sdk, airflow-ctl, dev, scripts,
 devel-common, airflow-ctl-tests, chart/tests, airflow-e2e-tests,
-task-sdk-integration-tests, docker-tests, kubernetes-tests, shared.
+task-sdk-integration-tests, docker-tests, kubernetes-tests, shared, sdk/coordinators.
 """
 
 from __future__ import annotations
@@ -40,6 +40,7 @@ from pathlib import Path
 from common_prek_utils import (
     AIRFLOW_ROOT_PATH,
     check_uv_version,
+    coordinator_distribution_dirs,
 )
 
 CI = os.environ.get("CI")
@@ -78,7 +79,11 @@ _SHARED_DISTS = sorted(
     f"shared/{p.name}" for p in (AIRFLOW_ROOT_PATH / "shared").iterdir() if (p / "pyproject.toml").exists()
 )
 
-ALLOWED_FOLDERS = _TOP_LEVEL_ALLOWED_FOLDERS + _SHARED_DISTS
+# Each sdk/coordinators/<dist> workspace member is an allowed folder in its own right,
+# giving every coordinator distribution its own dedicated mypy hook / virtualenv / cache.
+_COORDINATOR_DISTS = [f"sdk/coordinators/{p.name}" for p in coordinator_distribution_dirs()]
+
+ALLOWED_FOLDERS = _TOP_LEVEL_ALLOWED_FOLDERS + _SHARED_DISTS + _COORDINATOR_DISTS
 
 # Map folder(s) to the uv project to use for running mypy.
 # When multiple folders are checked together, the first folder's project is used.

--- a/scripts/tests/ci/prek/test_check_coordinator_distributions.py
+++ b/scripts/tests/ci/prek/test_check_coordinator_distributions.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from check_coordinator_distributions import check_coordinator_distribution
+
+
+@pytest.fixture
+def coordinator_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "java"
+    (dist / "src" / "airflow" / "sdk" / "coordinators" / "java").mkdir(parents=True)
+    (dist / "tests").mkdir()
+    (dist / "LICENSE").write_text("license")
+    (dist / "NOTICE").write_text("notice")
+    (dist / "README.rst").write_text(
+        textwrap.dedent(
+            """\
+            apache-airflow-coordinators-java
+            =================================
+
+            Installation
+            ------------
+
+            .. code-block:: bash
+
+               pip install apache-airflow-coordinators-java
+            """
+        )
+    )
+    (dist / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "apache-airflow-coordinators-java"
+            """
+        )
+    )
+    return dist
+
+
+def test_check_coordinator_distribution_accepts_valid_distribution(coordinator_dist: Path):
+    assert check_coordinator_distribution(coordinator_dist) == []
+
+
+def test_check_coordinator_distribution_reports_metadata_and_docs_errors(coordinator_dist: Path):
+    (coordinator_dist / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "apache-airflow-coordinators-scala"
+            """
+        )
+    )
+    (coordinator_dist / "README.rst").write_text("apache-airflow-coordinators-java\n")
+    (coordinator_dist / "NOTICE").unlink()
+
+    errors = check_coordinator_distribution(coordinator_dist)
+
+    assert "[project].name must be 'apache-airflow-coordinators-java'" in "\n".join(errors)
+    assert "missing required file NOTICE" in "\n".join(errors)
+    assert "missing installation instructions" in "\n".join(errors)

--- a/scripts/tests/ci/prek/test_check_coordinators_mypy_hooks.py
+++ b/scripts/tests/ci/prek/test_check_coordinators_mypy_hooks.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+import check_coordinators_mypy_hooks
+
+
+def test_missing_mypy_hook_distribution_ids_returns_missing_distribution(tmp_path: Path, monkeypatch):
+    dist = tmp_path / "java"
+    dist.mkdir()
+    monkeypatch.setattr(check_coordinators_mypy_hooks, "coordinator_distribution_dirs", lambda: [dist])
+
+    assert check_coordinators_mypy_hooks.missing_mypy_hook_distribution_ids() == ["java"]
+
+
+def test_missing_mypy_hook_distribution_ids_accepts_matching_config(tmp_path: Path, monkeypatch):
+    dist = tmp_path / "java"
+    dist.mkdir()
+    (dist / ".pre-commit-config.yaml").write_text("id: mypy-coordinators-java\n")
+    monkeypatch.setattr(check_coordinators_mypy_hooks, "coordinator_distribution_dirs", lambda: [dist])
+
+    assert check_coordinators_mypy_hooks.missing_mypy_hook_distribution_ids() == []

--- a/scripts/tests/ci/prek/test_common_prek_utils_coordinators.py
+++ b/scripts/tests/ci/prek/test_common_prek_utils_coordinators.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+from common_prek_utils import coordinator_distribution_dirs, coordinator_ids
+
+
+def test_coordinator_distribution_dirs_returns_empty_when_root_is_missing(tmp_path: Path):
+    assert coordinator_distribution_dirs(tmp_path / "missing") == []
+
+
+def test_coordinator_distribution_dirs_discovers_pyproject_directories(tmp_path: Path):
+    java = tmp_path / "java"
+    python = tmp_path / "python"
+    docs = tmp_path / "docs"
+    java.mkdir()
+    python.mkdir()
+    docs.mkdir()
+    (java / "pyproject.toml").touch()
+    (python / "pyproject.toml").touch()
+
+    assert coordinator_distribution_dirs(tmp_path) == [java, python]
+    assert coordinator_ids(tmp_path) == ["java", "python"]


### PR DESCRIPTION
## Summary

- add common discovery helpers for `sdk/coordinators/<dist>` distributions
- add prek validation for coordinator distribution metadata/docs and dedicated mypy hook coverage
- wire coordinator distributions into the local mypy runner allow-list and bug report template validation
- add unit tests for coordinator discovery and the new coordinator prek checks

closes: #66515

## Tests

- `uv run --project scripts pytest scripts/tests/ci/prek -q`
- `uv run --project scripts python scripts/ci/prek/check_coordinator_distributions.py`
- `uv run --project scripts python scripts/ci/prek/check_coordinators_mypy_hooks.py`
- `uv run --project scripts python scripts/ci/prek/check_airflow_bug_report_template.py`
- `uv run prek run check-coordinator-distributions --all-files`
- `uv run prek run check-coordinators-mypy-hooks --all-files`
- `uv run prek run check-airflow-bug-report-template --all-files`
