### PR TITLE
Fix broken GKEStartPodOperator extra link

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -182,6 +182,20 @@ class GKEOperatorMixin:
     def ssl_ca_cert(self) -> str:
         return self.cluster_info[1]
 
+    def _get_resource_name_and_namespace(
+        self, *, resource: Any, resource_type: str
+    ) -> tuple[str, str] | None:
+        metadata = getattr(resource, "metadata", None)
+        resource_name = getattr(metadata, "name", None)
+        namespace = getattr(metadata, "namespace", None)
+        if not resource_name or not namespace:
+            self.log.debug(
+                "Skipping Kubernetes %s extra link persistence because metadata is incomplete.",
+                resource_type,
+            )
+            return None
+        return resource_name, namespace
+
 
 class GKEDeleteClusterOperator(GKEOperatorMixin, GoogleCloudBaseOperator):
     """
@@ -757,35 +771,30 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
         if self.config_file:
             raise AirflowException("config_file is not an allowed parameter for the GKEStartPodOperator.")
 
-    def _persist_pod_link(self, context: Context | None) -> None:
-        if context is None or self.pod is None or self.pod.metadata is None:
+    def _persist_pod_link(self, *, context: Context, pod: k8s.V1Pod | None) -> None:
+        metadata = self._get_resource_name_and_namespace(resource=pod, resource_type="Pod")
+        if metadata is None:
             return
 
-        pod_name = self.pod.metadata.name
-        pod_namespace = self.pod.metadata.namespace
-        if pod_name is None or pod_namespace is None:
-            return
-
+        pod_name, namespace = metadata
         KubernetesEnginePodLink.persist(
             context=context,
+            project_id=self.project_id,
             location=self.location,
             cluster_name=self.cluster_name,
-            namespace=pod_namespace,
+            namespace=namespace,
             pod_name=pod_name,
-            project_id=self.project_id,
         )
 
-    def execute_sync(self, context: Context):
-        try:
-            return super().execute_sync(context)
-        finally:
-            self._persist_pod_link(context)
+    def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: Context) -> k8s.V1Pod:
+        pod = super().get_or_create_pod(pod_request_obj=pod_request_obj, context=context)
+        self._persist_pod_link(context=context, pod=pod)
+        return pod
 
     def invoke_defer_method(
         self, last_log_time: DateTime | None = None, context: Context | None = None
     ) -> None:
         """Redefine triggers which are being used in child classes."""
-        self._persist_pod_link(context)
         trigger_start_time = timezone.utcnow()
         on_finish_action = self.on_finish_action
         if type(on_finish_action) is str and self.on_finish_action not in [i.value for i in OnFinishAction]:
@@ -887,26 +896,52 @@ class GKEStartJobOperator(GKEOperatorMixin, KubernetesJobOperator):
         self.use_internal_ip = use_internal_ip
         self.use_dns_endpoint = use_dns_endpoint
         self.impersonation_chain = impersonation_chain
+        self._job_link_context: Context | None = None
 
         # There is no need to manage the kube_config file, as it will be generated automatically.
         # All Kubernetes parameters (except config_file) are also valid for the GKEStartJobOperator.
         if self.config_file:
             raise AirflowException("config_file is not an allowed parameter for the GKEStartJobOperator.")
 
+    def _persist_job_link(self, *, context: Context, job: k8s.V1Job | None) -> None:
+        metadata = self._get_resource_name_and_namespace(resource=job, resource_type="Job")
+        if metadata is None:
+            return
+
+        job_name, namespace = metadata
+        KubernetesEngineJobLink.persist(
+            context=context,
+            project_id=self.project_id,
+            location=self.location,
+            cluster_name=self.cluster_name,
+            namespace=namespace,
+            job_name=job_name,
+        )
+
+    def create_job(self, job_request_obj: k8s.V1Job) -> k8s.V1Job:
+        job = super().create_job(job_request_obj=job_request_obj)
+        if self._job_link_context is not None:
+            self._persist_job_link(context=self._job_link_context, job=job)
+        return job
+
     def execute(self, context: Context):
         """Execute process of creating Job."""
-        if self.deferrable:
-            kubernetes_provider = ProvidersManager().providers["apache-airflow-providers-cncf-kubernetes"]
-            kubernetes_provider_name = kubernetes_provider.data["package-name"]
-            kubernetes_provider_version = kubernetes_provider.version
-            min_version = "8.0.1"
-            if parse_version(kubernetes_provider_version) <= parse_version(min_version):
-                raise AirflowException(
-                    "You are trying to use `GKEStartJobOperator` in deferrable mode with the provider "
-                    f"package {kubernetes_provider_name}=={kubernetes_provider_version} which doesn't "
-                    f"support this feature. Please upgrade it to version higher than {min_version}."
-                )
-        return super().execute(context)
+        self._job_link_context = context
+        try:
+            if self.deferrable:
+                kubernetes_provider = ProvidersManager().providers["apache-airflow-providers-cncf-kubernetes"]
+                kubernetes_provider_name = kubernetes_provider.data["package-name"]
+                kubernetes_provider_version = kubernetes_provider.version
+                min_version = "8.0.1"
+                if parse_version(kubernetes_provider_version) <= parse_version(min_version):
+                    raise AirflowException(
+                        "You are trying to use `GKEStartJobOperator` in deferrable mode with the provider "
+                        f"package {kubernetes_provider_name}=={kubernetes_provider_version} which doesn't "
+                        f"support this feature. Please upgrade it to version higher than {min_version}."
+                    )
+            return super().execute(context)
+        finally:
+            self._job_link_context = None
 
     def execute_deferrable(self):
         self.defer(

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -757,10 +757,35 @@ class GKEStartPodOperator(GKEOperatorMixin, KubernetesPodOperator):
         if self.config_file:
             raise AirflowException("config_file is not an allowed parameter for the GKEStartPodOperator.")
 
+    def _persist_pod_link(self, context: Context | None) -> None:
+        if context is None or self.pod is None or self.pod.metadata is None:
+            return
+
+        pod_name = self.pod.metadata.name
+        pod_namespace = self.pod.metadata.namespace
+        if pod_name is None or pod_namespace is None:
+            return
+
+        KubernetesEnginePodLink.persist(
+            context=context,
+            location=self.location,
+            cluster_name=self.cluster_name,
+            namespace=pod_namespace,
+            pod_name=pod_name,
+            project_id=self.project_id,
+        )
+
+    def execute_sync(self, context: Context):
+        try:
+            return super().execute_sync(context)
+        finally:
+            self._persist_pod_link(context)
+
     def invoke_defer_method(
         self, last_log_time: DateTime | None = None, context: Context | None = None
     ) -> None:
         """Redefine triggers which are being used in child classes."""
+        self._persist_pod_link(context)
         trigger_start_time = timezone.utcnow()
         on_finish_action = self.on_finish_action
         if type(on_finish_action) is str and self.on_finish_action not in [i.value for i in OnFinishAction]:

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -189,7 +189,7 @@ class GKEOperatorMixin:
         resource_name = getattr(metadata, "name", None)
         namespace = getattr(metadata, "namespace", None)
         if not resource_name or not namespace:
-            self.log.debug(
+            self.log.debug(  # type: ignore[attr-defined]
                 "Skipping Kubernetes %s extra link persistence because metadata is incomplete.",
                 resource_type,
             )

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -41,6 +41,7 @@ from airflow.providers.cncf.kubernetes.operators.resource import (
 )
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
 from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.google.cloud.links.kubernetes_engine import KubernetesEnginePodLink
 from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEClusterAuthDetails,
     GKECreateClusterOperator,
@@ -98,6 +99,13 @@ K8S_POD_NAME = "test-pod"
 K8S_NAMESPACE = "default"
 
 GKE_OPERATORS_PATH = "airflow.providers.google.cloud.operators.kubernetes_engine.{}"
+
+
+def make_mock_pod(name: str = K8S_POD_NAME, namespace: str = K8S_NAMESPACE):
+    metadata = mock.MagicMock()
+    metadata.name = name
+    metadata.namespace = namespace
+    return mock.MagicMock(metadata=metadata)
 
 
 class TestGKEClusterAuthDetails:
@@ -865,26 +873,28 @@ class TestGKEStartPodOperator:
             for expected_attr in expected_attributes:
                 assert op.__getattribute__(expected_attr) == expected_attributes[expected_attr]
 
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
     @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
-    def test_invoke_defer_method(
-        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    def test_invoke_defer_method_persists_pod_link(
+        self, mock_defer, mock_persist, mock_fetch_cluster_info, mock_cluster_hook, mock_utcnow, mock_trigger
     ):
         mock_trigger_start_time = mock_utcnow.return_value
+        mock_context = {"ti": mock.MagicMock()}
+        call_manager = mock.MagicMock()
+        call_manager.attach_mock(mock_persist, "persist")
+        call_manager.attach_mock(mock_defer, "defer")
 
-        mock_metadata = mock.MagicMock()
-        mock_metadata.name = K8S_POD_NAME
-        mock_metadata.namespace = K8S_NAMESPACE
-        self.operator.pod = mock.MagicMock(metadata=mock_metadata)
+        self.operator.pod = make_mock_pod()
         mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
         mock_get_logs = mock.MagicMock()
         self.operator.get_logs = mock_get_logs
         mock_last_log_time = mock.MagicMock()
 
-        self.operator.invoke_defer_method(last_log_time=mock_last_log_time)
+        self.operator.invoke_defer_method(last_log_time=mock_last_log_time, context=mock_context)
 
         mock_trigger.assert_called_once_with(
             pod_name=K8S_POD_NAME,
@@ -906,9 +916,114 @@ class TestGKEStartPodOperator:
             last_log_time=mock_last_log_time,
             use_dns_endpoint=False,
         )
+        assert call_manager.mock_calls == [
+            call.persist(
+                context=mock_context,
+                location=TEST_LOCATION,
+                cluster_name=GKE_CLUSTER_NAME,
+                namespace=K8S_NAMESPACE,
+                pod_name=K8S_POD_NAME,
+                project_id=TEST_PROJECT_ID,
+            ),
+            call.defer(
+                trigger=mock_trigger.return_value,
+                method_name="trigger_reentry",
+            ),
+        ]
+
+    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
+    def test_execute_sync_persists_pod_link_on_success(self, mock_persist, mock_execute_sync):
+        context = {"ti": mock.MagicMock()}
+
+        def execute_sync_side_effect(operator, current_context):
+            operator.pod = make_mock_pod()
+            return "result"
+
+        mock_execute_sync.side_effect = execute_sync_side_effect
+
+        result = self.operator.execute_sync(context)
+
+        assert result == "result"
+        mock_execute_sync.assert_called_once_with(self.operator, context)
+        mock_persist.assert_called_once_with(
+            context=context,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            pod_name=K8S_POD_NAME,
+            project_id=TEST_PROJECT_ID,
+        )
+
+    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
+    def test_execute_sync_persists_pod_link_on_pod_failure(self, mock_persist, mock_execute_sync):
+        context = {"ti": mock.MagicMock()}
+
+        def execute_sync_side_effect(operator, current_context):
+            operator.pod = make_mock_pod()
+            raise RuntimeError("Pod failed")
+
+        mock_execute_sync.side_effect = execute_sync_side_effect
+
+        with pytest.raises(RuntimeError, match="Pod failed"):
+            self.operator.execute_sync(context)
+
+        mock_execute_sync.assert_called_once_with(self.operator, context)
+        mock_persist.assert_called_once_with(
+            context=context,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            pod_name=K8S_POD_NAME,
+            project_id=TEST_PROJECT_ID,
+        )
+
+    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
+    def test_execute_sync_skips_persist_when_pod_not_created(self, mock_persist, mock_execute_sync):
+        context = {"ti": mock.MagicMock()}
+        mock_execute_sync.side_effect = RuntimeError("Pod failed")
+
+        with pytest.raises(RuntimeError, match="Pod failed"):
+            self.operator.execute_sync(context)
+
+        mock_execute_sync.assert_called_once_with(self.operator, context)
+        mock_persist.assert_not_called()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
+    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
+    def test_invoke_defer_method_skips_persist_without_context(
+        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_persist, mock_defer
+    ):
+        self.operator.pod = make_mock_pod()
+        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
+
+        self.operator.invoke_defer_method()
+
+        mock_persist.assert_not_called()
         mock_defer.assert_called_once_with(
             trigger=mock_trigger.return_value,
             method_name="trigger_reentry",
+        )
+
+    def test_pod_link_url_format(self):
+        pod_link = KubernetesEnginePodLink()
+
+        assert pod_link._format_link(
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            pod_name=K8S_POD_NAME,
+            project_id=TEST_PROJECT_ID,
+        ) == (
+            "https://console.cloud.google.com"
+            f"/kubernetes/pod/{TEST_LOCATION}/{GKE_CLUSTER_NAME}/{K8S_NAMESPACE}/{K8S_POD_NAME}"
+            f"/details?project={TEST_PROJECT_ID}"
         )
 
 

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -24,6 +24,7 @@ from unittest.mock import PropertyMock, call
 import pytest
 from google.api_core.exceptions import AlreadyExists, FailedPrecondition, PermissionDenied
 from google.cloud.container_v1.types import Cluster, NodePool
+from kubernetes.client import models as k8s
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.cncf.kubernetes.operators.job import (
@@ -41,7 +42,13 @@ from airflow.providers.cncf.kubernetes.operators.resource import (
 )
 from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction
 from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.google.cloud.links.kubernetes_engine import KubernetesEnginePodLink
+from airflow.providers.google.cloud.links.base import BASE_LINK
+from airflow.providers.google.cloud.links.kubernetes_engine import (
+    KUBERNETES_JOB_LINK,
+    KUBERNETES_POD_LINK,
+    KubernetesEngineJobLink,
+    KubernetesEnginePodLink,
+)
 from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEClusterAuthDetails,
     GKECreateClusterOperator,
@@ -59,6 +66,11 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEStartPodOperator,
     GKESuspendJobOperator,
 )
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
+if AIRFLOW_V_3_0_PLUS:
+    from airflow.sdk.execution_time.comms import XComResult
 
 pytestmark = pytest.mark.filterwarnings("error::airflow.exceptions.AirflowProviderDeprecationWarning")
 
@@ -101,11 +113,26 @@ K8S_NAMESPACE = "default"
 GKE_OPERATORS_PATH = "airflow.providers.google.cloud.operators.kubernetes_engine.{}"
 
 
-def make_mock_pod(name: str = K8S_POD_NAME, namespace: str = K8S_NAMESPACE):
-    metadata = mock.MagicMock()
-    metadata.name = name
-    metadata.namespace = namespace
-    return mock.MagicMock(metadata=metadata)
+def make_pod(
+    *,
+    name: str | None = K8S_POD_NAME,
+    namespace: str | None = K8S_NAMESPACE,
+    metadata: k8s.V1ObjectMeta | None = None,
+) -> k8s.V1Pod:
+    if metadata is None:
+        metadata = k8s.V1ObjectMeta(name=name, namespace=namespace)
+    return k8s.V1Pod(metadata=metadata)
+
+
+def make_job(
+    *,
+    name: str | None = K8S_JOB_NAME,
+    namespace: str | None = K8S_NAMESPACE,
+    metadata: k8s.V1ObjectMeta | None = None,
+) -> k8s.V1Job:
+    if metadata is None:
+        metadata = k8s.V1ObjectMeta(name=name, namespace=namespace)
+    return k8s.V1Job(metadata=metadata)
 
 
 class TestGKEClusterAuthDetails:
@@ -873,28 +900,149 @@ class TestGKEStartPodOperator:
             for expected_attr in expected_attributes:
                 assert op.__getattribute__(expected_attr) == expected_attributes[expected_attr]
 
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesPodOperator.get_or_create_pod"))
+    def test_get_or_create_pod_persists_link(self, mock_get_or_create_pod, mock_link):
+        pod = make_pod()
+        mock_get_or_create_pod.return_value = pod
+        context = {"ti": mock.Mock()}
+
+        result = self.operator.get_or_create_pod(pod_request_obj=make_pod(), context=context)
+
+        assert result == pod
+        mock_link.persist.assert_called_once_with(
+            context=context,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            pod_name=K8S_POD_NAME,
+        )
+
+    @pytest.mark.parametrize(
+        "pod",
+        [
+            k8s.V1Pod(),
+            make_pod(metadata=k8s.V1ObjectMeta(name=None, namespace=K8S_NAMESPACE)),
+            make_pod(metadata=k8s.V1ObjectMeta(name=K8S_POD_NAME, namespace=None)),
+        ],
+    )
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesPodOperator.get_or_create_pod"))
+    def test_get_or_create_pod_skips_link_when_metadata_is_incomplete(
+        self, mock_get_or_create_pod, mock_link, pod
+    ):
+        mock_get_or_create_pod.return_value = pod
+
+        result = self.operator.get_or_create_pod(pod_request_obj=make_pod(), context={"ti": mock.Mock()})
+
+        assert result == pod
+        mock_link.persist.assert_not_called()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.post_complete_action"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.is_istio_enabled"), return_value=False)
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.await_pod_completion"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.await_pod_start"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.await_init_containers_completion"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.find_pod"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesPodOperator.get_or_create_pod"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.build_pod_request_obj"))
+    def test_execute_sync_persists_link_when_follow_up_step_fails(
+        self,
+        mock_build_pod_request_obj,
+        mock_get_or_create_pod,
+        mock_link,
+        mock_find_pod,
+        mock_await_init_containers_completion,
+        mock_await_pod_start,
+        mock_await_pod_completion,
+        mock_is_istio_enabled,
+        mock_post_complete_action,
+    ):
+        pod = make_pod()
+        context = {"ti": mock.Mock()}
+        self.operator.pod_manager = mock.Mock()
+        self.operator.pod_manager.await_pod_completion.return_value = pod
+        mock_build_pod_request_obj.return_value = make_pod()
+        mock_get_or_create_pod.return_value = pod
+        mock_find_pod.return_value = pod
+        mock_await_init_containers_completion.side_effect = AirflowException("pod startup failed")
+
+        with pytest.raises(AirflowException, match="pod startup failed"):
+            self.operator.execute_sync(context=context)
+
+        mock_link.persist.assert_called_once_with(
+            context=context,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            pod_name=K8S_POD_NAME,
+        )
+        mock_post_complete_action.assert_called_once()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.post_complete_action"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesPodOperator.get_or_create_pod"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.build_pod_request_obj"))
+    def test_execute_sync_does_not_persist_link_when_pod_creation_fails(
+        self, mock_build_pod_request_obj, mock_get_or_create_pod, mock_link, mock_post_complete_action
+    ):
+        context = {"ti": mock.Mock()}
+        mock_build_pod_request_obj.return_value = make_pod()
+        mock_get_or_create_pod.side_effect = AirflowException("pod creation failed")
+
+        with pytest.raises(AirflowException, match="pod creation failed"):
+            self.operator.execute_sync(context=context)
+
+        mock_link.persist.assert_not_called()
+        mock_post_complete_action.assert_called_once()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesPodOperator.get_or_create_pod"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.build_pod_request_obj"))
+    def test_execute_async_persists_link_before_deferral(
+        self, mock_build_pod_request_obj, mock_get_or_create_pod, mock_link
+    ):
+        order: list[str] = []
+        pod = make_pod()
+        context = {"ti": mock.Mock()}
+        mock_build_pod_request_obj.return_value = make_pod()
+        mock_get_or_create_pod.return_value = pod
+        mock_link.persist.side_effect = lambda **_: order.append("persist")
+
+        with mock.patch.object(
+            GKEStartPodOperator,
+            "invoke_defer_method",
+            autospec=True,
+            side_effect=lambda _operator, last_log_time=None, context=None: order.append("defer"),
+        ) as mock_invoke_defer_method:
+            self.operator.execute_async(context=context)
+
+        assert order == ["persist", "defer"]
+        mock_invoke_defer_method.assert_called_once_with(self.operator, context=context)
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
     @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
-    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
-    def test_invoke_defer_method_persists_pod_link(
-        self, mock_defer, mock_persist, mock_fetch_cluster_info, mock_cluster_hook, mock_utcnow, mock_trigger
+    def test_invoke_defer_method(
+        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
     ):
         mock_trigger_start_time = mock_utcnow.return_value
-        mock_context = {"ti": mock.MagicMock()}
-        call_manager = mock.MagicMock()
-        call_manager.attach_mock(mock_persist, "persist")
-        call_manager.attach_mock(mock_defer, "defer")
 
-        self.operator.pod = make_mock_pod()
+        mock_metadata = mock.MagicMock()
+        mock_metadata.name = K8S_POD_NAME
+        mock_metadata.namespace = K8S_NAMESPACE
+        self.operator.pod = mock.MagicMock(metadata=mock_metadata)
         mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
         mock_get_logs = mock.MagicMock()
         self.operator.get_logs = mock_get_logs
         mock_last_log_time = mock.MagicMock()
 
-        self.operator.invoke_defer_method(last_log_time=mock_last_log_time, context=mock_context)
+        self.operator.invoke_defer_method(last_log_time=mock_last_log_time)
 
         mock_trigger.assert_called_once_with(
             pod_name=K8S_POD_NAME,
@@ -916,114 +1064,9 @@ class TestGKEStartPodOperator:
             last_log_time=mock_last_log_time,
             use_dns_endpoint=False,
         )
-        assert call_manager.mock_calls == [
-            call.persist(
-                context=mock_context,
-                location=TEST_LOCATION,
-                cluster_name=GKE_CLUSTER_NAME,
-                namespace=K8S_NAMESPACE,
-                pod_name=K8S_POD_NAME,
-                project_id=TEST_PROJECT_ID,
-            ),
-            call.defer(
-                trigger=mock_trigger.return_value,
-                method_name="trigger_reentry",
-            ),
-        ]
-
-    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
-    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
-    def test_execute_sync_persists_pod_link_on_success(self, mock_persist, mock_execute_sync):
-        context = {"ti": mock.MagicMock()}
-
-        def execute_sync_side_effect(operator, current_context):
-            operator.pod = make_mock_pod()
-            return "result"
-
-        mock_execute_sync.side_effect = execute_sync_side_effect
-
-        result = self.operator.execute_sync(context)
-
-        assert result == "result"
-        mock_execute_sync.assert_called_once_with(self.operator, context)
-        mock_persist.assert_called_once_with(
-            context=context,
-            location=TEST_LOCATION,
-            cluster_name=GKE_CLUSTER_NAME,
-            namespace=K8S_NAMESPACE,
-            pod_name=K8S_POD_NAME,
-            project_id=TEST_PROJECT_ID,
-        )
-
-    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
-    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
-    def test_execute_sync_persists_pod_link_on_pod_failure(self, mock_persist, mock_execute_sync):
-        context = {"ti": mock.MagicMock()}
-
-        def execute_sync_side_effect(operator, current_context):
-            operator.pod = make_mock_pod()
-            raise RuntimeError("Pod failed")
-
-        mock_execute_sync.side_effect = execute_sync_side_effect
-
-        with pytest.raises(RuntimeError, match="Pod failed"):
-            self.operator.execute_sync(context)
-
-        mock_execute_sync.assert_called_once_with(self.operator, context)
-        mock_persist.assert_called_once_with(
-            context=context,
-            location=TEST_LOCATION,
-            cluster_name=GKE_CLUSTER_NAME,
-            namespace=K8S_NAMESPACE,
-            pod_name=K8S_POD_NAME,
-            project_id=TEST_PROJECT_ID,
-        )
-
-    @mock.patch.object(KubernetesPodOperator, "execute_sync", autospec=True)
-    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
-    def test_execute_sync_skips_persist_when_pod_not_created(self, mock_persist, mock_execute_sync):
-        context = {"ti": mock.MagicMock()}
-        mock_execute_sync.side_effect = RuntimeError("Pod failed")
-
-        with pytest.raises(RuntimeError, match="Pod failed"):
-            self.operator.execute_sync(context)
-
-        mock_execute_sync.assert_called_once_with(self.operator, context)
-        mock_persist.assert_not_called()
-
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodOperator.defer"))
-    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEnginePodLink.persist"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
-    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartPodTrigger"))
-    @mock.patch(GKE_OPERATORS_PATH.format("timezone.utcnow"))
-    def test_invoke_defer_method_skips_persist_without_context(
-        self, mock_utcnow, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_persist, mock_defer
-    ):
-        self.operator.pod = make_mock_pod()
-        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
-
-        self.operator.invoke_defer_method()
-
-        mock_persist.assert_not_called()
         mock_defer.assert_called_once_with(
             trigger=mock_trigger.return_value,
             method_name="trigger_reentry",
-        )
-
-    def test_pod_link_url_format(self):
-        pod_link = KubernetesEnginePodLink()
-
-        assert pod_link._format_link(
-            location=TEST_LOCATION,
-            cluster_name=GKE_CLUSTER_NAME,
-            namespace=K8S_NAMESPACE,
-            pod_name=K8S_POD_NAME,
-            project_id=TEST_PROJECT_ID,
-        ) == (
-            "https://console.cloud.google.com"
-            f"/kubernetes/pod/{TEST_LOCATION}/{GKE_CLUSTER_NAME}/{K8S_NAMESPACE}/{K8S_POD_NAME}"
-            f"/details?project={TEST_PROJECT_ID}"
         )
 
 
@@ -1112,6 +1155,132 @@ class TestGKEStartJobOperator:
         mock_providers_manager.assert_called_once()
         mock_super.assert_not_called()
         mock_super.return_value.execute.assert_not_called()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEngineJobLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.build_job_request_obj"))
+    def test_execute_persists_link(self, mock_build_job_request_obj, mock_create_job, mock_link):
+        context = {"ti": mock.Mock()}
+        mock_build_job_request_obj.return_value = mock.Mock()
+        mock_create_job.return_value = make_job()
+
+        self.operator.execute(context=context)
+
+        mock_link.persist.assert_called_once_with(
+            context=context,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            job_name=K8S_JOB_NAME,
+        )
+
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEngineJobLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.get_pods"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.build_job_request_obj"))
+    def test_execute_persists_link_when_follow_up_step_fails(
+        self,
+        mock_build_job_request_obj,
+        mock_create_job,
+        mock_get_pods,
+        mock_link,
+    ):
+        context = {"ti": mock.Mock()}
+        self.operator.wait_until_job_complete = True
+        mock_build_job_request_obj.return_value = mock.Mock()
+        mock_create_job.return_value = make_job()
+        mock_get_pods.side_effect = AirflowException("pod discovery failed")
+
+        with pytest.raises(AirflowException, match="pod discovery failed"):
+            self.operator.execute(context=context)
+
+        mock_link.persist.assert_called_once_with(
+            context=context,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            namespace=K8S_NAMESPACE,
+            job_name=K8S_JOB_NAME,
+        )
+
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEngineJobLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.build_job_request_obj"))
+    def test_execute_does_not_persist_link_when_job_creation_fails(
+        self,
+        mock_build_job_request_obj,
+        mock_create_job,
+        mock_link,
+    ):
+        context = {"ti": mock.Mock()}
+        mock_build_job_request_obj.return_value = mock.Mock()
+        mock_create_job.side_effect = AirflowException("job creation failed")
+
+        with pytest.raises(AirflowException, match="job creation failed"):
+            self.operator.execute(context=context)
+
+        mock_link.persist.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "job",
+        [
+            k8s.V1Job(),
+            make_job(metadata=k8s.V1ObjectMeta(name=None, namespace=K8S_NAMESPACE)),
+            make_job(metadata=k8s.V1ObjectMeta(name=K8S_JOB_NAME, namespace=None)),
+        ],
+    )
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEngineJobLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    def test_create_job_skips_link_when_metadata_is_incomplete(self, mock_create_job, mock_link, job):
+        context = {"ti": mock.Mock()}
+        mock_create_job.return_value = job
+        self.operator._job_link_context = context
+
+        result = self.operator.create_job(job_request_obj=mock.Mock())
+
+        assert result == job
+        mock_link.persist.assert_not_called()
+
+    @mock.patch(GKE_OPERATORS_PATH.format("ProvidersManager"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesEngineJobLink"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.get_pods"))
+    @mock.patch(GKE_OPERATORS_PATH.format("KubernetesJobOperator.create_job"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.build_job_request_obj"))
+    def test_execute_deferrable_persists_link_before_deferral(
+        self,
+        mock_build_job_request_obj,
+        mock_create_job,
+        mock_get_pods,
+        mock_link,
+        mock_providers_manager,
+    ):
+        order: list[str] = []
+        context = {"ti": mock.Mock()}
+        self.operator.wait_until_job_complete = True
+        self.operator.deferrable = True
+        self.operator.pod_request_obj = make_pod()
+        mock_build_job_request_obj.return_value = mock.Mock()
+        mock_create_job.return_value = make_job()
+        mock_get_pods.return_value = [make_pod()]
+        mock_link.persist.side_effect = lambda **_: order.append("persist")
+        kubernetes_package_name = "apache-airflow-providers-cncf-kubernetes"
+        mock_providers_manager.return_value.providers = {
+            kubernetes_package_name: mock.MagicMock(
+                data={"package-name": kubernetes_package_name},
+                version="8.0.2",
+            )
+        }
+
+        with mock.patch.object(
+            self.operator,
+            "execute_deferrable",
+            side_effect=lambda: order.append("defer"),
+        ) as mock_execute_deferrable:
+            self.operator.execute(context=context)
+
+        assert order == ["persist", "defer"]
+        mock_execute_deferrable.assert_called_once_with()
 
     @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.defer"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
@@ -1217,6 +1386,80 @@ class TestGKEStartJobOperator:
         mock_defer.assert_called_once_with(
             trigger=mock_trigger.return_value,
             method_name="execute_complete",
+        )
+
+
+class TestGKEStartOperatorExtraLinks:
+    @pytest.mark.db_test
+    def test_start_pod_operator_get_link(
+        self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms
+    ):
+        ti = create_task_instance_of_operator(
+            GKEStartPodOperator,
+            dag_id="test_gke_start_pod_link_dag",
+            task_id=TEST_TASK_ID,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            name=K8S_POD_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+        )
+        task = dag_maker.dag.get_task(ti.task_id)
+        link_payload = {
+            "project_id": TEST_PROJECT_ID,
+            "location": TEST_LOCATION,
+            "cluster_name": GKE_CLUSTER_NAME,
+            "namespace": K8S_NAMESPACE,
+            "pod_name": K8S_POD_NAME,
+        }
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key=KubernetesEnginePodLink.key,
+                value=link_payload,
+            )
+
+        ti.xcom_push(key=KubernetesEnginePodLink.key, value=link_payload)
+
+        assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == BASE_LINK + (
+            KUBERNETES_POD_LINK.format(**link_payload)
+        )
+
+    @pytest.mark.db_test
+    def test_start_job_operator_get_link(
+        self, dag_maker, create_task_instance_of_operator, session, mock_supervisor_comms
+    ):
+        ti = create_task_instance_of_operator(
+            GKEStartJobOperator,
+            dag_id="test_gke_start_job_link_dag",
+            task_id=TEST_TASK_ID,
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            name=K8S_JOB_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+        )
+        task = dag_maker.dag.get_task(ti.task_id)
+        link_payload = {
+            "project_id": TEST_PROJECT_ID,
+            "location": TEST_LOCATION,
+            "cluster_name": GKE_CLUSTER_NAME,
+            "namespace": K8S_NAMESPACE,
+            "job_name": K8S_JOB_NAME,
+        }
+
+        if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
+            mock_supervisor_comms.send.return_value = XComResult(
+                key=KubernetesEngineJobLink.key,
+                value=link_payload,
+            )
+
+        ti.xcom_push(key=KubernetesEngineJobLink.key, value=link_payload)
+
+        assert task.operator_extra_links[0].get_link(operator=task, ti_key=ti.key) == BASE_LINK + (
+            KUBERNETES_JOB_LINK.format(**link_payload)
         )
 
 


### PR DESCRIPTION
This fixes the broken "Kubernetes Pod" extra link on `GKEStartPodOperator` task instances.

What this changes:
- persist the pod link payload after pod creation in the synchronous execution path, including cases where execution later fails
- persist the same payload before deferring in the deferrable execution path so the link is available consistently across both modes
- add regression tests covering sync success and failure, deferrable persistence, skip cases when no pod or context is available, and the final GKE console URL format

Impact:
- the "Kubernetes Pod" extra link now resolves to the live GKE pod details page instead of rendering a dead link
- failed `GKEStartPodOperator` tasks remain debuggable from the UI because the pod link is preserved once the pod exists
- sync and deferrable runs now expose the same extra-link behavior

Validation:
- `prek run --from-ref upstream/main --stage pre-commit`
- `.venv/bin/uv run --project providers/google pytest providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py::TestGKEStartPodOperator -xvs`

closes: #46658

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
