### PR TITLE
Surface LogStreamAccumulator temp-file removal failures as warnings

### DIFF
--- a/airflow-core/src/airflow/utils/log/log_stream_accumulator.py
+++ b/airflow-core/src/airflow/utils/log/log_stream_accumulator.py
@@ -49,7 +49,7 @@ def _safe_remove(path: str) -> None:
     except FileNotFoundError:
         pass
     except OSError as exc:
-        logger.debug("LogStreamAccumulator: could not remove temp file %s: %s", path, exc)
+        logger.warning("LogStreamAccumulator: could not remove temp file %s: %s", path, exc)
 
 
 class LogStreamAccumulator:


### PR DESCRIPTION
Failure to remove the spill file is the exact failure mode that caused the prior /tmp leak (~39 GB on a single host), so operators need it visible in their logs rather than buried at debug level.

Follow-up to #66450.