### PR TITLE
[v3-2-test] Restore AMD scheduled canary, split README badges, fix Slack-state collision (#66662)

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -25,6 +25,11 @@
 # Edit both files together when changing pipeline shape.
 name: Tests (AMD)
 on:  # yamllint disable-line rule:truthy
+  schedule:
+    # Mirror of the previous AMD canary cron from before the AMD/ARM split (PR #66348),
+    # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
+    # canaries don't compete for runners at exactly the same minute.
+    - cron: '58 1,7,13,19 * * *'
   push:
     branches:
       - v[0-9]+-[0-9]+-test
@@ -1054,13 +1059,13 @@ jobs:
           gh auth status || gh auth login --with-token <<< "${GITHUB_TOKEN}"
           python3 scripts/ci/slack_notification_state.py
         env:
-          ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}"
+          ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}-amd"
           CURRENT_FAILURES: "${{ steps.get-failures.outputs.failed-jobs }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Upload notification state"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "slack-state-tests-${{ github.ref_name }}"
+          name: "slack-state-tests-${{ github.ref_name }}-amd"
           path: ./slack-state/
           retention-days: 7
           overwrite: true

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1045,13 +1045,13 @@ jobs:
           gh auth status || gh auth login --with-token <<< "${GITHUB_TOKEN}"
           python3 scripts/ci/slack_notification_state.py
         env:
-          ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}"
+          ARTIFACT_NAME: "slack-state-tests-${{ github.ref_name }}-arm"
           CURRENT_FAILURES: "${{ steps.get-failures.outputs.failed-jobs }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Upload notification state"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "slack-state-tests-${{ github.ref_name }}"
+          name: "slack-state-tests-${{ github.ref_name }}-arm"
           path: ./slack-state/
           retention-days: 7
           overwrite: true

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -245,7 +245,8 @@ jobs:
         shell: bash
         run: python3 scripts/ci/slack_notification_state.py
         env:
-          ARTIFACT_NAME: "slack-state-inventory-${{ inputs.branch }}"
+          # yamllint disable-line rule:line-length
+          ARTIFACT_NAME: "slack-state-inventory-${{ inputs.branch }}-${{ contains(inputs.platform, 'arm') && 'arm' || 'amd' }}"
           CURRENT_FAILURES: "${{ steps.check-missing-inventories.outputs.packages }}"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Upload inventory notification state"
@@ -255,7 +256,8 @@ jobs:
           matrix.flag == '--docs-only'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: "slack-state-inventory-${{ inputs.branch }}"
+          # yamllint disable-line rule:line-length
+          name: "slack-state-inventory-${{ inputs.branch }}-${{ contains(inputs.platform, 'arm') && 'arm' || 'amd' }}"
           path: ./slack-state/
           retention-days: 7
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@
 
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions) |
-| 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
+| Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
 
 
 

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -32,9 +32,8 @@ PROJECT BY THE `generate-pypi-readme` PREK HOOK. YOUR CHANGES HERE WILL BE AUTOM
 
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Main    | [![GitHub Build main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions)                 |
-| 3.x     | [![GitHub Build 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions) |
-| 2.x     | [![GitHub Build 2.11](https://github.com/apache/airflow/actions/workflows/ci.yml/badge.svg?branch=v2-11-test)](https://github.com/apache/airflow/actions)       |
+| Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
 
 
 

--- a/scripts/ci/prek/check_ci_workflows_in_sync.py
+++ b/scripts/ci/prek/check_ci_workflows_in_sync.py
@@ -27,13 +27,18 @@ Documented divergences:
 
 1. Header intro comment (different prose explaining what each file is for)
 2. Workflow ``name:`` — ``Tests (ARM)`` vs ``Tests (AMD)``
-3. Triggers — ARM = schedule + workflow_dispatch only; AMD = pull_request +
-   push (to release branches) + workflow_dispatch
+3. Triggers — ARM = schedule + workflow_dispatch only; AMD = its own
+   schedule (offset from ARM's cron) + pull_request + push (to release
+   branches) + workflow_dispatch
 4. ``concurrency.group`` prefix — ``ci-arm-`` vs ``ci-amd-``
 5. ``build-info`` outputs ``platform`` and ``runner-type`` — hardcoded per
    architecture (and the surrounding comment naming the "ARM/AMD copy")
 6. ``print-platform`` job — ``name:`` and the architecture echoed to
    GITHUB_STEP_SUMMARY
+7. ``notify-slack`` Slack-state artifact name — ``slack-state-tests-…-arm``
+   vs ``slack-state-tests-…-amd``, so the de-dup tracker in
+   ``slack_notification_state.py`` keeps independent state for each
+   platform on the same branch
 
 Anything else differing between the two files is a drift bug. To
 intentionally introduce a new divergence, update the rules in this script
@@ -86,6 +91,12 @@ LINE_RULES: list[tuple[str, str]] = [
         r"^        run: \"echo '## Architecture: (?:ARM|AMD)' >> \$GITHUB_STEP_SUMMARY\"$",
         "        run: \"echo '## Architecture: PLACEHOLDER' >> $GITHUB_STEP_SUMMARY\"",
     ),
+    # Slack-state artifact name in the notify-slack job — suffixed `-amd` /
+    # `-arm` so each platform tracks its own de-dup state on the same branch.
+    (
+        r'^(?P<indent>\s+)(?P<key>ARTIFACT_NAME|name): "slack-state-tests-\$\{\{ github\.ref_name \}\}-(?:amd|arm)"$',
+        r'\g<indent>\g<key>: "slack-state-tests-${{ github.ref_name }}-PLACEHOLDER"',
+    ),
 ]
 
 # Whole sections that legitimately exist in only one file. Each entry is the
@@ -96,7 +107,12 @@ ARM_ONLY_BLOCK = """  schedule:
     - cron: '28 1,3,7,9,13,15,19,21 * * *'
 """
 
-AMD_ONLY_BLOCK = """  push:
+AMD_ONLY_BLOCK = """  schedule:
+    # Mirror of the previous AMD canary cron from before the AMD/ARM split (PR #66348),
+    # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
+    # canaries don't compete for runners at exactly the same minute.
+    - cron: '58 1,7,13,19 * * *'
+  push:
     branches:
       - v[0-9]+-[0-9]+-test
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+


### PR DESCRIPTION
## Summary

Backport of #66662 (merged 2026-05-10, commit [\`022e35d\`](https://github.com/apache/airflow/commit/022e35d9719b61e9d575f97750040faf9cc58e45)) to \`v3-2-test\`. Stacks cleanly on top of #66664 (the #66348 backport that already landed).

Cherry-pick was a clean \`-x\` apply — no conflicts, no manual fixes. See the source PR for full motivation.

## Test plan

- [x] Clean \`-x\` cherry-pick on top of latest \`v3-2-test\`
- [ ] Wait for CI on \`v3-2-test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context)