### PR TITLE
Registry: make tomllib fallback version-aware

### DIFF
--- a/dev/registry/extract_metadata.py
+++ b/dev/registry/extract_metadata.py
@@ -37,16 +37,17 @@ import json
 import re
 import shutil
 import subprocess
+import sys
 import urllib.request
 import zlib
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib  # Python 3.11+ stdlib
-except ModuleNotFoundError:  # pragma: no cover -- Python 3.10 fallback
-    import tomli as tomllib  # type: ignore[no-redef]
+else:  # pragma: no cover -- Python 3.10 fallback
+    import tomli as tomllib
 
 import yaml
 from registry_contract_models import validate_providers_catalog

--- a/dev/registry/extract_versions.py
+++ b/dev/registry/extract_versions.py
@@ -46,10 +46,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib  # Python 3.11+ stdlib
-except ModuleNotFoundError:  # pragma: no cover -- Python 3.10 fallback
-    import tomli as tomllib  # type: ignore[no-redef]
+else:  # pragma: no cover -- Python 3.10 fallback
+    import tomli as tomllib
 from registry_contract_models import validate_provider_version_metadata
 
 try:


### PR DESCRIPTION
Use explicit Python-version check for tomllib fallback in registry extract scripts.

Why:
- Make fallback path deterministic by Python version instead of exception-driven import flow.
- Keep registry scripts aligned and easier to read.

Changes:
1. dev/registry/extract_metadata.py
- Add sys import.
- Switch tomllib/tomli import to version-aware if/else.

2. dev/registry/extract_versions.py
- Switch tomllib/tomli import to version-aware if/else.

This PR was split from #66250 to keep scope focused.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (GPT-5.3-Codex)

Generated-by: GitHub Copilot (GPT-5.3-Codex) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: GitHub Copilot (GPT-5.3-Codex) (no human review before posting)
