### PR TITLE
ci: also build ARM on pushes to release-prep / providers branches

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -30,10 +30,6 @@ on:  # yamllint disable-line rule:truthy
     # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
     # canaries don't compete for runners at exactly the same minute.
     - cron: '58 1,7,13,19 * * *'
-  push:
-    branches:
-      - v[0-9]+-[0-9]+-test
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   pull_request:
     branches:
       - main
@@ -41,6 +37,15 @@ on:  # yamllint disable-line rule:truthy
       - v[0-9]+-[0-9]+-stable
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
     types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    # Post-merge pushes to release-prep / providers branches run on both
+    # AMD and ARM (the matching block lives in the other wrapper too —
+    # `check-ci-workflows-in-sync` enforces they stay identical). `main` is
+    # intentionally NOT in this list: main pushes stay AMD-only via
+    # `ci-amd.yml`; ARM main coverage is the cron-driven canary above.
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   workflow_dispatch:
 permissions:
   # All other permissions are set to none by default

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -27,6 +27,15 @@ name: Tests (ARM)
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '28 1,3,7,9,13,15,19,21 * * *'
+  push:
+    # Post-merge pushes to release-prep / providers branches run on both
+    # AMD and ARM (the matching block lives in the other wrapper too —
+    # `check-ci-workflows-in-sync` enforces they stay identical). `main` is
+    # intentionally NOT in this list: main pushes stay AMD-only via
+    # `ci-amd.yml`; ARM main coverage is the cron-driven canary above.
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   workflow_dispatch:
 permissions:
   # All other permissions are set to none by default

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
-| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM 3.2](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
 
 
 

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -33,7 +33,7 @@ PROJECT BY THE `generate-pypi-readme` PREK HOOK. YOUR CHANGES HERE WILL BE AUTOM
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
-| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM 3.2](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
 
 
 

--- a/scripts/ci/prek/check_ci_workflows_in_sync.py
+++ b/scripts/ci/prek/check_ci_workflows_in_sync.py
@@ -27,9 +27,12 @@ Documented divergences:
 
 1. Header intro comment (different prose explaining what each file is for)
 2. Workflow ``name:`` — ``Tests (ARM)`` vs ``Tests (AMD)``
-3. Triggers — ARM = schedule + workflow_dispatch only; AMD = its own
-   schedule (offset from ARM's cron) + pull_request + push (to release
-   branches) + workflow_dispatch
+3. Triggers — ARM = its own schedule + push (to release-prep /
+   providers branches) + workflow_dispatch; AMD = its own schedule
+   (offset from ARM's cron) + the same push branches + pull_request +
+   workflow_dispatch. Both wrappers run on post-merge pushes to
+   stable / providers branches; only AMD runs on PRs (per-PR ARM
+   coverage stays cron-driven via the canary).
 4. ``concurrency.group`` prefix — ``ci-arm-`` vs ``ci-amd-``
 5. ``build-info`` outputs ``platform`` and ``runner-type`` — hardcoded per
    architecture (and the surrounding comment naming the "ARM/AMD copy")
@@ -112,10 +115,6 @@ AMD_ONLY_BLOCK = """  schedule:
     # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
     # canaries don't compete for runners at exactly the same minute.
     - cron: '58 1,7,13,19 * * *'
-  push:
-    branches:
-      - v[0-9]+-[0-9]+-test
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   pull_request:
     branches:
       - main
@@ -124,6 +123,7 @@ AMD_ONLY_BLOCK = """  schedule:
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
     types: [opened, reopened, synchronize, ready_for_review]
 """
+
 
 # The header comment block (between the `---` document marker and the
 # `name:` line) is intentionally different between files — each describes


### PR DESCRIPTION
## Summary

Until now, post-merge pushes to \`v[0-9]+-[0-9]+-test\` and \`providers-*/v*\` branches only triggered the AMD wrapper (\`ci-amd.yml\`); ARM coverage on those branches was limited to the cron-driven canary. Adds the same \`push:\` block to \`ci-arm.yml\` so both architectures build whenever a release-prep / providers branch advances.

\`main\` is intentionally **NOT** in the ARM push list — main pushes stay AMD-only via \`ci-amd.yml\` and ARM main coverage continues to come from the canary cron. Avoids doubling ARM runner load on the high-traffic main branch while still surfacing ARM regressions on every release-prep / providers commit.

## Knock-on changes

- **\`ci-amd.yml\`**: reordered \`pull_request:\` to come before \`push:\` so the AMD-only \`schedule + pull_request\` stays a contiguous block for the strip mechanism in \`check-ci-workflows-in-sync\`. Same comment text added to its \`push:\` block as ci-arm.yml's so the two read identically.
- **\`scripts/ci/prek/check_ci_workflows_in_sync.py\`**: drop the \`push:\` block from \`AMD_ONLY_BLOCK\` (push is now shared between both wrappers and therefore must NOT be stripped from either side). Updated docstring item 3 to reflect the new trigger split.
- **\`README.md\` and \`generated/PYPI_README.md\`**: add the ARM badge to the 3.x row alongside AMD (Main row already had both).

## Test plan

- [x] \`scripts/ci/prek/check_ci_workflows_in_sync.py\` exits 0 locally
- [x] All other prek hooks pass (skipping the pre-existing-broken \`mypy-dev\` hook locally — \`dev/airflow_mypy/\` is provisioned by \`uv sync\` in CI but not on a vanilla worktree)
- [ ] Wait for CI on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context)