### PR TITLE
Add doc_md to Python and LatestOnly example DAGs

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py
@@ -15,7 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example DAG demonstrating the LatestOnlyOperator.
+"""### LatestOnlyOperator
+
+Example DAG demonstrating the LatestOnlyOperator.
 
 The LatestOnlyOperator skips downstream tasks for all DAG runs except the
 most recent scheduled run. This is useful when downstream work should only run
@@ -23,7 +25,7 @@ for the latest interval, such as refreshing a dashboard or publishing a current
 snapshot.
 
 See also:
-https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/operators/datetime.html#latestonlyoperator
+https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/operators/latest_only.html
 """
 
 from __future__ import annotations

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py
@@ -15,7 +15,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example of the LatestOnlyOperator"""
+"""Example DAG demonstrating the LatestOnlyOperator.
+
+The LatestOnlyOperator skips downstream tasks for all DAG runs except the
+most recent scheduled run. This is useful when downstream work should only run
+for the latest interval, such as refreshing a dashboard or publishing a current
+snapshot.
+
+See also:
+https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/operators/datetime.html#latestonlyoperator
+"""
 
 from __future__ import annotations
 
@@ -31,6 +40,7 @@ with DAG(
     start_date=datetime.datetime(2021, 1, 1),
     catchup=False,
     tags=["example2", "example3"],
+    doc_md=__doc__,
 ) as dag:
     # [START howto_operator_latest_only]
     latest_only = LatestOnlyOperator(task_id="latest_only")

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py
@@ -15,9 +15,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Example DAG demonstrating the usage of the classic Python operators to execute Python functions natively and
-within a virtual environment.
+"""Example DAG demonstrating classic Python operators.
+
+This DAG shows several ways to execute Python callables in Airflow:
+PythonOperator for regular Python functions, PythonVirtualenvOperator for
+functions that need an isolated virtual environment, and ExternalPythonOperator
+for running a callable with a specific Python binary.
+
+It also demonstrates passing keyword arguments, rendering templated files, and
+using asynchronous Python callables.
+
+See also:
+https://airflow.apache.org/docs/apache-airflow-providers-standard/stable/operators/python.html
 """
 
 from __future__ import annotations
@@ -48,6 +57,7 @@ with DAG(
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
     tags=["example"],
+    doc_md=__doc__,
 ) as dag:
     # [START howto_operator_python]
     def print_context(ds=None, **kwargs):

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py
@@ -15,7 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example DAG demonstrating classic Python operators.
+"""### Python operators
+
+Example DAG demonstrating classic Python operators.
 
 This DAG shows several ways to execute Python callables in Airflow:
 PythonOperator for regular Python functions, PythonVirtualenvOperator for


### PR DESCRIPTION
Adds DAG-level documentation to two standard provider example DAGs:

- `example_latest_only`
- `example_python_operator`

The documentation is exposed in the Airflow UI Docs tab by wiring each module docstring into the DAG via `doc_md=__doc__`.

This is a documentation-only change and does not modify DAG runtime behavior, task dependencies, scheduling, or operator usage.

Part of #60128.

Validation:

- `python3 -m py_compile providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py`
- `git diff --check HEAD~1 HEAD`
- `prek run --files providers/standard/src/airflow/providers/standard/example_dags/example_latest_only.py providers/standard/src/airflow/providers/standard/example_dags/example_python_operator.py`
- `breeze testing core-tests airflow-core/tests/unit/always/test_example_dags.py -k 'example_latest_only or example_python_operator' --backend sqlite --python 3.10`\n\nFocused Breeze result:\n\n`9 passed, 1599 deselected, 1 warning in 23.89s`