### PR TITLE
Extend DEFAULT_SENSITIVE_FIELDS with webhook_url, bearer, dsn, auth_header, service_key

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -54,8 +54,11 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
         "access_token",
         "api_key",
         "apikey",
+        "auth_header",
         "authorization",
+        "bearer",
         "connection_string",
+        "dsn",
         "passphrase",
         "passwd",
         "password",
@@ -64,9 +67,11 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
         "proxy_password",
         "proxies",
         "secret",
+        "service_account",
+        "service_key",
         "token",
         "keyfile_dict",
-        "service_account",
+        "webhook_url",
     }
 )
 """Names of fields (Connection extra, Variable key name etc.) that are deemed sensitive"""

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -779,6 +779,23 @@ class TestShouldHideValueForKey:
             ("GOOGLE_API_KEY", True),
             ("GOOGLE_APIKEY", True),
             (1, False),
+            # webhook_url / bearer / dsn / auth_header / service_key in DEFAULT_SENSITIVE_FIELDS.
+            # Matching is case-insensitive substring on the lowercased key, so
+            # snake_case variants (and underscore-bearing prefixes/suffixes) are
+            # covered; PascalCase / camelCase variants without underscores are not.
+            ("webhook_url", True),
+            ("WEBHOOK_URL", True),
+            ("slack_webhook_url", True),
+            ("bearer", True),
+            ("Bearer", True),
+            ("auth_bearer", True),
+            ("dsn", True),
+            ("DSN", True),
+            ("auth_header", True),
+            ("AUTH_HEADER", True),
+            ("custom_auth_header", True),
+            ("service_key", True),
+            ("my_service_key", True),
         ],
     )
     def test_hiding_defaults(self, key, expected_result):


### PR DESCRIPTION
`DEFAULT_SENSITIVE_FIELDS` is the allowlist used by the secrets masker for
masking Variables and Connection extras. Several common field names used by
official Airflow providers and standard HTTP/database configurations are
not in the allowlist.

This PR adds five field names commonly used in connection extras and
provider configurations:

- `webhook_url` — Slack provider webhook URL key
- `bearer` — HTTP bearer-token auth key
- `dsn` — database connection strings (which typically embed credentials, e.g. `postgres://user:pass@host/db`)
- `auth_header` — custom HTTP auth header values
- `service_key` — service-account-like keys

The matcher uses case-insensitive substring matching, so e.g. `bearer` covers
`Bearer`, `bearer_token`, `auth_bearer`, etc.

Related: https://github.com/airflow-s/airflow-s/issues/377

## Test plan

- [ ] `uv run --project shared/secrets_masker pytest shared/secrets_masker/tests/ -xvs` — secrets-masker tests pass
- [ ] New parametrised test asserts `should_hide_value_for_key(name)` returns `True` for each of the five new field names plus substring variants (`WEBHOOK_URL`, `slack_webhook_url`, `auth_bearer`, `AUTH_HEADER`, `custom_auth_header`, `my_service_key`)

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
