### PR TITLE
Fix triggerer file handle leak when remote log upload fails

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -507,9 +507,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 self.running_triggers.discard(id)
                 self.cancelling_triggers.discard(id)
                 if factory := self.logger_cache.pop(id, None):
-                    factory.upload_to_remote()
-                    # Need to close the FD explicitly, as it is not closed when logger is removed.
-                    factory.close()
+                    try:
+                        factory.upload_to_remote()
+                    except Exception:
+                        log.exception("Failed to upload trigger logs to remote", trigger_id=id)
+                    finally:
+                        # Close the FD explicitly even if upload raised, otherwise the file
+                        # handle leaks for every failed upload.
+                        factory.close()
 
             response = messages.TriggerStateSync(
                 to_create=[],

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -612,6 +612,29 @@ def test_trigger_logger_fd_closed_when_removed(session):
     trigger_runner_supervisor.kill(force=False)
 
 
+def test_trigger_logger_fd_closed_when_upload_to_remote_raises(jobless_supervisor):
+    """If upload_to_remote() raises during finished-trigger cleanup, the FD must still be closed.
+
+    Regression test for the file handle leak referenced in
+    https://github.com/apache/airflow/discussions/65985 — without try/finally, a failed
+    remote-log upload would skip ``factory.close()`` and leak the underlying BufferedWriter
+    for every failed upload.
+    """
+    factory = MagicMock(spec=TriggerLoggingFactory)
+    factory.upload_to_remote.side_effect = RuntimeError("simulated remote-logging failure")
+
+    jobless_supervisor.logger_cache[42] = factory
+    jobless_supervisor.running_triggers.add(42)
+
+    msg = messages.TriggerStateChanges(finished=[42])
+    jobless_supervisor._handle_request(msg, log=MagicMock(spec=FilteringBoundLogger), req_id=0)
+
+    factory.upload_to_remote.assert_called_once()
+    factory.close.assert_called_once()
+    assert 42 not in jobless_supervisor.logger_cache
+    assert 42 not in jobless_supervisor.running_triggers
+
+
 class TestTriggerRunner:
     def test_blocked_main_thread_warning_threshold_decode(self) -> None:
         with conf_vars({("triggerer", "blocked_main_thread_warning_threshold"): "0.5"}):


### PR DESCRIPTION
## Summary

When a trigger finishes, `TriggerRunnerSupervisor._handle_request()`
uploads its log file to the remote store and then closes the local
file descriptor:

```python
if factory := self.logger_cache.pop(id, None):
    factory.upload_to_remote()
    # Need to close the FD explicitly, as it is not closed when logger is removed.
    factory.close()
```

If `factory.upload_to_remote()` raises (e.g. S3/GCS throttling, transient
network errors), `factory.close()` is never called. The factory has
already been popped from `logger_cache`, so nothing else will close the
underlying `BufferedWriter` — its 8 KiB buffer plus the open fd leak for
every failed upload, and the exception escapes into `handle_requests`
where it is not handled.

Wrap the cleanup in `try/except/finally` so the fd is always closed and
the failure is logged instead of propagating.

Surfaced in #65985.

## Test plan

- [x] New unit test `test_trigger_logger_fd_closed_when_upload_to_remote_raises`
      mocks `upload_to_remote()` to raise and asserts `close()` still
      runs and `logger_cache` / `running_triggers` are cleaned up.
- [x] Existing `test_trigger_logger_close` still passes.
- [x] `prek run` clean on changed files (ruff, mypy-airflow-core, bandit, etc.).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)