### PR TITLE
[v3-2-test] Fix Starlette 1.0.0 compatibility in TemplateResponse calls (#64116) (#64300)

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -96,9 +96,7 @@ dependencies = [
     "dill>=0.2.2",
     "fastapi[standard-no-fastapi-cloud-cli]>=0.129.0",
     "uvicorn>=0.37.0",
-    # Starlette 1.0.0 breaks the API server. Needs more investigation
-    # https://github.com/apache/airflow/issues/64116
-    "starlette>=0.45.0,<1",
+    "starlette>=0.45.0",
     "httpx>=0.25.0",
     'importlib_metadata>=6.5;python_version<"3.12"',
     'importlib_metadata>=7.0;python_version>="3.12"',

--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -354,8 +354,9 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
         @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
         def webapp(request: Request, rest_of_path: str):
             return templates.TemplateResponse(
+                request,
                 "/index.html",
-                {"request": request, "backend_server_base_url": request.base_url.path},
+                {"backend_server_base_url": request.base_url.path},
                 media_type="text/html",
             )
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -100,8 +100,9 @@ def init_views(app: FastAPI) -> None:
     @app.get("/{rest_of_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def webapp(request: Request, rest_of_path: str):
         return templates.TemplateResponse(
+            request,
             "/index.html",
-            {"request": request, "backend_server_base_url": request.base_url.path},
+            {"backend_server_base_url": request.base_url.path},
             media_type="text/html",
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -97,9 +97,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -1947,7 +1947,7 @@ requires-dist = [
     { name = "rich-argparse", specifier = ">=1.0.0" },
     { name = "setproctitle", specifier = ">=1.3.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
-    { name = "starlette", specifier = ">=0.45.0,<1" },
+    { name = "starlette", specifier = ">=0.45.0" },
     { name = "statsd", marker = "extra == 'statsd'", specifier = ">=3.3.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "svcs", specifier = ">=25.1.0" },


### PR DESCRIPTION
Backport of #64300 to `v3-2-test`.

Starlette 1.0.0 removed the deprecated `TemplateResponse(name, context)` signature where `request` was passed inside the context dict. This backport updates both call sites to use the new signature `TemplateResponse(request, name, context)` and removes the temporary `starlette<1` upper bound added in #64115.

Without this, dependabot's #66541 cannot raise the `starlette` cap on `v3-2-test` (I had to keep `<1` there until this backport lands).

closes #64116 on `v3-2-test`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)