### PR TITLE
Fix SFTPHookAsync test fixture to return async context managers

### DIFF
--- a/providers/sftp/tests/conftest.py
+++ b/providers/sftp/tests/conftest.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from asyncssh import SFTPClient, SSHClientConnection
@@ -39,11 +39,20 @@ def sftp_hook_mocked() -> Generator[tuple[SFTPHookAsync, SFTPClient], Any, None]
 
     sftp_client_mock = AsyncMock(spec=SFTPClient)
     sftp_client_mock.readdir.return_value = []
+    # asyncssh's SFTPClient.open() is decorated to be both awaitable and async-context-
+    # manageable; the production code uses ``async with sftp.open(...) as remote_file``,
+    # so the mock must return a context manager from a *synchronous* call. The spec
+    # auto-makes it an AsyncMock (call → coroutine); override it with a sync MagicMock.
+    sftp_client_mock.open = MagicMock()
 
-    client_connection_mock = AsyncMock(spec=SSHClientConnection)
-    sftp_cm_mock = client_connection_mock.start_sftp_client.return_value
+    # asyncssh's start_sftp_client() has the same shape — production uses it as
+    # ``async with ssh_conn.start_sftp_client() as sftp:``. Same override pattern.
+    sftp_cm_mock = MagicMock()
     sftp_cm_mock.__aenter__ = AsyncMock(return_value=sftp_client_mock)
     sftp_cm_mock.__aexit__ = AsyncMock(return_value=None)
+
+    client_connection_mock = AsyncMock(spec=SSHClientConnection)
+    client_connection_mock.start_sftp_client = MagicMock(return_value=sftp_cm_mock)
 
     with patch("airflow.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn") as mock_get_conn:
         mock_get_conn.return_value.__aenter__.return_value = client_connection_mock


### PR DESCRIPTION
## Summary

PR #64465 (SFTP async refactor) changed the production code from
`await ssh_conn.start_sftp_client()` to
`async with ssh_conn.start_sftp_client() as sftp:` (same for
`sftp.open()`), but the `sftp_hook_mocked` fixture in
`providers/sftp/tests/conftest.py` was still set up as if those methods
were awaited.

`AsyncMock(spec=SSHClientConnection)` auto-makes `start_sftp_client` an
`AsyncMock` whose call returns a *coroutine* — not an async context
manager — so every `TestSFTPHookAsync` test in
`providers/sftp/tests/unit/sftp/hooks/test_sftp.py` blew up with:

```
TypeError: 'coroutine' object does not support the asynchronous context manager protocol
```

In real asyncssh, both `SSHClientConnection.start_sftp_client()` and
`SFTPClient.open()` are decorated so a call returns an object that is
both awaitable *and* async-context-manageable. The production code only
uses the context-manager half. Override the auto-spec'd AsyncMocks with
sync `MagicMock`s that return a context-manager mock with `__aenter__` /
`__aexit__` configured.

## Test plan

- [x] All 28 `TestSFTPHookAsync` tests in
      `providers/sftp/tests/unit/sftp/hooks/test_sftp.py` pass locally
      against `upstream/main`.
- [x] `prek run` clean on the changed file.

Blocking CI on unrelated PRs since #64465 merged — example failure:
https://github.com/apache/airflow/actions/runs/25638333348/job/75256444992?pr=65840
(PR #65840 only touches `docs-theme`/breeze; the SFTP failures are
purely fixture rot).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)