### PR TITLE
[v3-2-test] ci: also build ARM on pushes to release-prep / providers branches (#66668)

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -30,10 +30,6 @@ on:  # yamllint disable-line rule:truthy
     # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
     # canaries don't compete for runners at exactly the same minute.
     - cron: '58 1,7,13,19 * * *'
-  push:
-    branches:
-      - v[0-9]+-[0-9]+-test
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   pull_request:
     branches:
       - main
@@ -41,6 +37,15 @@ on:  # yamllint disable-line rule:truthy
       - v[0-9]+-[0-9]+-stable
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
     types: [opened, reopened, synchronize, ready_for_review]
+  push:
+    # Post-merge pushes to release-prep / providers branches run on both
+    # AMD and ARM (the matching block lives in the other wrapper too —
+    # `check-ci-workflows-in-sync` enforces they stay identical). `main` is
+    # intentionally NOT in this list: main pushes stay AMD-only via
+    # `ci-amd.yml`; ARM main coverage is the cron-driven canary above.
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   workflow_dispatch:
 permissions:
   # All other permissions are set to none by default

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -27,6 +27,15 @@ name: Tests (ARM)
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '28 1,3,7,9,13,15,19,21 * * *'
+  push:
+    # Post-merge pushes to release-prep / providers branches run on both
+    # AMD and ARM (the matching block lives in the other wrapper too —
+    # `check-ci-workflows-in-sync` enforces they stay identical). `main` is
+    # intentionally NOT in this list: main pushes stay AMD-only via
+    # `ci-amd.yml`; ARM main coverage is the cron-driven canary above.
+    branches:
+      - v[0-9]+-[0-9]+-test
+      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   workflow_dispatch:
 permissions:
   # All other permissions are set to none by default

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
-| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM 3.2](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
 
 
 

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -33,7 +33,7 @@ PROJECT BY THE `generate-pypi-readme` PREK HOOK. YOUR CHANGES HERE WILL BE AUTOM
 | Version | Build Status                                                                                                                                                    |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Main    | [![Tests AMD main](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM main](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
-| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) |
+| 3.x     | [![Tests AMD 3.2](https://github.com/apache/airflow/actions/workflows/ci-amd.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-amd.yml) [![Tests ARM 3.2](https://github.com/apache/airflow/actions/workflows/ci-arm.yml/badge.svg?branch=v3-2-test)](https://github.com/apache/airflow/actions/workflows/ci-arm.yml) |
 
 
 

--- a/scripts/ci/prek/check_ci_workflows_in_sync.py
+++ b/scripts/ci/prek/check_ci_workflows_in_sync.py
@@ -27,9 +27,12 @@ Documented divergences:
 
 1. Header intro comment (different prose explaining what each file is for)
 2. Workflow ``name:`` — ``Tests (ARM)`` vs ``Tests (AMD)``
-3. Triggers — ARM = schedule + workflow_dispatch only; AMD = its own
-   schedule (offset from ARM's cron) + pull_request + push (to release
-   branches) + workflow_dispatch
+3. Triggers — ARM = its own schedule + push (to release-prep /
+   providers branches) + workflow_dispatch; AMD = its own schedule
+   (offset from ARM's cron) + the same push branches + pull_request +
+   workflow_dispatch. Both wrappers run on post-merge pushes to
+   stable / providers branches; only AMD runs on PRs (per-PR ARM
+   coverage stays cron-driven via the canary).
 4. ``concurrency.group`` prefix — ``ci-arm-`` vs ``ci-amd-``
 5. ``build-info`` outputs ``platform`` and ``runner-type`` — hardcoded per
    architecture (and the surrounding comment naming the "ARM/AMD copy")
@@ -112,10 +115,6 @@ AMD_ONLY_BLOCK = """  schedule:
     # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
     # canaries don't compete for runners at exactly the same minute.
     - cron: '58 1,7,13,19 * * *'
-  push:
-    branches:
-      - v[0-9]+-[0-9]+-test
-      - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
   pull_request:
     branches:
       - main
@@ -124,6 +123,7 @@ AMD_ONLY_BLOCK = """  schedule:
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
     types: [opened, reopened, synchronize, ready_for_review]
 """
+
 
 # The header comment block (between the `---` document marker and the
 # `name:` line) is intentionally different between files — each describes


### PR DESCRIPTION
Cherry-pick of #66668 to `v3-2-test`.

Adds `push:` triggers on `v[0-9]+-[0-9]+-test` and
`providers-*/v*` branches to `ci-arm.yml` so ARM also builds on
release-prep / providers-branch merges (previously ARM coverage
on those branches was cron-canary only). Pure CI change — no
runtime code touched.