### PR TITLE
Google: Harden GKE extra-link deferrable tests

### DIFF
--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -1033,10 +1033,7 @@ class TestGKEStartPodOperator:
     ):
         mock_trigger_start_time = mock_utcnow.return_value
 
-        mock_metadata = mock.MagicMock()
-        mock_metadata.name = K8S_POD_NAME
-        mock_metadata.namespace = K8S_NAMESPACE
-        self.operator.pod = mock.MagicMock(metadata=mock_metadata)
+        self.operator.pod = make_pod()
         mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
         mock_get_logs = mock.MagicMock()
         self.operator.get_logs = mock_get_logs
@@ -1287,17 +1284,8 @@ class TestGKEStartJobOperator:
     @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
     @mock.patch(GKE_OPERATORS_PATH.format("GKEJobTrigger"))
     def test_execute_deferrable(self, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer):
-        mock_pod_metadata = mock.MagicMock()
-        mock_pod_metadata.name = K8S_POD_NAME
-        mock_pod_metadata.namespace = K8S_NAMESPACE
-        self.operator.pods = [
-            mock.MagicMock(metadata=mock_pod_metadata),
-        ]
-
-        mock_job_metadata = mock.MagicMock()
-        mock_job_metadata.name = K8S_JOB_NAME
-        mock_job_metadata.namespace = K8S_NAMESPACE
-        self.operator.job = mock.MagicMock(metadata=mock_job_metadata)
+        self.operator.pods = [make_pod()]
+        self.operator.job = make_job()
 
         mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
         mock_get_logs = mock.MagicMock()
@@ -1347,20 +1335,9 @@ class TestGKEStartJobOperator:
             parallelism=2,
         )
         mock_pod_name_1 = K8S_POD_NAME + "-1"
-        mock_pod_metadata_1 = mock.MagicMock()
-        mock_pod_metadata_1.name = mock_pod_name_1
-        mock_pod_metadata_1.namespace = K8S_NAMESPACE
-
         mock_pod_name_2 = K8S_POD_NAME + "-2"
-        mock_pod_metadata_2 = mock.MagicMock()
-        mock_pod_metadata_2.name = mock_pod_name_2
-        mock_pod_metadata_2.namespace = K8S_NAMESPACE
-        op.pods = [mock.MagicMock(metadata=mock_pod_metadata_1), mock.MagicMock(metadata=mock_pod_metadata_2)]
-
-        mock_job_metadata = mock.MagicMock()
-        mock_job_metadata.name = K8S_JOB_NAME
-        mock_job_metadata.namespace = K8S_NAMESPACE
-        op.job = mock.MagicMock(metadata=mock_job_metadata)
+        op.pods = [make_pod(name=mock_pod_name_1), make_pod(name=mock_pod_name_2)]
+        op.job = make_job()
 
         mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
         mock_get_logs = mock.MagicMock()


### PR DESCRIPTION
Replace the deferrable GKE extra-link tests that build loose `MagicMock(metadata=...)` objects with the existing Kubernetes model helpers used elsewhere in the file.

Why this was made:
The current deferrable-path tests accept arbitrary attribute access through unspecced mocks. That weakens the regression coverage around `GKEStartPodOperator` and `GKEStartJobOperator` extra-link behavior because invalid metadata shapes can slip through without failing the test.

Impact:
The production code is unchanged. This only hardens the test suite so the deferrable extra-link tests exercise real `V1Pod` and `V1Job` metadata shapes, making future regressions easier to catch and aligning these tests with the repository’s mocking guidance.

related: #46658

Validation:
- `uv run ruff format providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py`
- `uv run ruff check --fix providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py`
- `breeze run pytest providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py -xvs`
- `prek run --from-ref main --stage pre-commit`
- `prek run --from-ref main --stage manual` (`mypy-providers` still reports unrelated failures in `providers/pinecone/src/airflow/providers/pinecone/hooks/pinecone.py:190` and `providers/pinecone/src/airflow/providers/pinecone/operators/pinecone.py:88`)
- `breeze ci selective-check --commit-ref HEAD`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)