### PR TITLE
[v3-2-test] fix(dev): correct mypy plugin paths in dev/pyproject.toml

### DIFF
--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -74,8 +74,8 @@ no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = false
 plugins = [
-    "airflow_mypy/plugin/decorators.py",
-    "airflow_mypy/plugin/outputs.py",
+    "airflow_mypy.plugins.decorators",
+    "airflow_mypy.plugins.outputs",
 ]
 pretty = true
 show_error_codes = true


### PR DESCRIPTION
The `tool.mypy.plugins` entries on v3-2-test were written as
file paths with a typo'd directory name (`airflow_mypy/plugin/...`
where the directory is actually `plugins/` plural), and on the
file-path format which doesn't match `main`'s use of the
module-name format.

Result: the `mypy-dev` prek hook fails on every v3-2-test commit
that touches a `dev/` file with:

```
dev/pyproject.toml:1: error: Can't find plugin
"dev/airflow_mypy/plugin/decorators.py"  [misc]
```

Switched to the module-name format already used on `main`
(`airflow_mypy.plugins.decorators`). Same intent, plugin
discovery actually works.

`main` is unaffected — already correct there. v3-2-test only.