### PR TITLE
[v3-2-test] fix(k8s): pre-load postgresql image to prevent Docker Hub rate-limit flakes (#66507)

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -716,6 +716,7 @@ def _upload_k8s_image(python: str, kubernetes_version: str, output: Output | Non
 # scripts/ci/prek/upgrade_important_versions.py.
 K8S_TEST_IMAGES_TO_PRELOAD: tuple[str, ...] = (
     "alpine:3.23",  # xcom_sidecar default in providers/cncf/kubernetes
+    "bitnamilegacy/postgresql:16.1.0-debian-11-r15",  # chart/values.yaml postgresql subchart
     "busybox:1.37",  # busybox-based system tests in kubernetes-tests/
     "ubuntu:24.04",  # ubuntu-based system tests in kubernetes-tests/
 )


### PR DESCRIPTION
Cherry-pick of #66507 to `v3-2-test`.

Adds `bitnamilegacy/postgresql:16.1.0-debian-11-r15` to
`K8S_TEST_IMAGES_TO_PRELOAD` so the chart's PostgreSQL subchart
image is pulled once on the host (with retry-on-429) and
`kind load`-ed into every node, instead of each pod racing Docker
Hub anonymous-pull rate limits.

## Conflict notes

The auto-merge fired on the alpine / busybox lines because main
has had auto-bumped patch versions (`alpine:3.23.4`, `busybox:1.37.0`)
that haven't reached v3-2-test yet. Kept v3-2-test's existing
versions (`alpine:3.23`, `busybox:1.37`) — patch-version bumps
belong in their own backport via `upgrade_important_versions.py`,
not in this cherry-pick. Only the postgresql line was added.

## Prerequisite chain

- #66685 (mypy plugin path fix) — merged
- #66687 (`[v3-2-test] Pin Docker Hub test images against K8s
  system-test rate-limit flakes (#66423)`) — merged
- this PR (#66507)