### PR TITLE
[v3-2-test] Pin ubuntu image in K8s basic_pod.yaml (follow-up to #66423) (#66527)

### DIFF
--- a/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
+++ b/kubernetes-tests/tests/kubernetes_tests/basic_pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: base
-      image: ubuntu
+      image: ubuntu:24.04
       command: ["/bin/bash"]
       args: ["-c", 'echo {\"hello\" : \"world\"} | cat > /airflow/xcom/return.json']
   restartPolicy: Never


### PR DESCRIPTION
Cherry-pick of #66527 to `v3-2-test`.

One-line follow-up to #66423: pins the ubuntu image in
`kubernetes-tests/.../basic_pod.yaml` to `ubuntu:24.04` so it
matches the entry in `K8S_TEST_IMAGES_TO_PRELOAD` and benefits
from the pre-pull + `kind load` path instead of hitting Docker
Hub at pod-start time.

Prerequisite: #66687 (the #66423 backport) — already merged.