### PR TITLE
Add doc_md to branch and short-circuit example DAGs

### DIFF
--- a/providers/standard/src/airflow/providers/standard/example_dags/example_branch_day_of_week_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_branch_day_of_week_operator.py
@@ -16,7 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Example DAG demonstrating the usage of BranchDayOfWeekOperator.
+### BranchDayOfWeekOperator
+
+This example demonstrates how to use the BranchDayOfWeekOperator to choose downstream tasks based on the day
+of the week. It shows both a single-day branch and a weekend branch using the WeekDay enum.
 """
 
 from __future__ import annotations
@@ -34,6 +37,7 @@ with DAG(
     catchup=False,
     tags=["example"],
     schedule="@daily",
+    doc_md=__doc__,
 ) as dag:
     # [START howto_operator_day_of_week_branch]
     empty_task_1 = EmptyOperator(task_id="branch_true")

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_short_circuit_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_short_circuit_operator.py
@@ -15,7 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example DAG demonstrating the usage of the ShortCircuitOperator."""
+"""
+### ShortCircuitOperator
+
+This example demonstrates how to use the ShortCircuitOperator to continue a workflow only when a condition
+is truthy. It also shows how `ignore_downstream_trigger_rules=False` lets later downstream tasks respect
+their trigger rules after the direct downstream tasks are skipped.
+"""
 
 from __future__ import annotations
 
@@ -32,6 +38,7 @@ with DAG(
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
     tags=["example"],
+    doc_md=__doc__,
 ) as dag:
     # [START howto_operator_short_circuit]
     cond_true = ShortCircuitOperator(


### PR DESCRIPTION
## What

Add DAG-level `doc_md` to two standard provider example DAGs:

- `example_branch_day_of_week_operator.py`
- `example_short_circuit_operator.py`

This exposes the examples' purpose in the Airflow UI Docs tab, following the same pattern used by other example DAG documentation updates.

Follows up #60128.

## How

- Expanded each module docstring with a concise Markdown heading and explanation.
- Passed `doc_md=__doc__` to each DAG constructor.

## Tests

- `python3 -m py_compile providers/standard/src/airflow/providers/standard/example_dags/example_branch_day_of_week_operator.py providers/standard/src/airflow/providers/standard/example_dags/example_short_circuit_operator.py`
- `git diff --check`
- `prek run --files providers/standard/src/airflow/providers/standard/example_dags/example_branch_day_of_week_operator.py providers/standard/src/airflow/providers/standard/example_dags/example_short_circuit_operator.py`
- `breeze testing core-tests airflow-core/tests/unit/always/test_example_dags.py -k 'example_weekday_branch_operator or example_short_circuit_operator' --backend sqlite --python 3.10`

Result: `3 passed, 1605 deselected, 1 warning in 23.87s`.
