### PR TITLE
Fix TaskFlow context docs example

### DIFF
--- a/devel-common/src/docs/shared/template-examples/taskflow-kwargs.rst
+++ b/devel-common/src/docs/shared/template-examples/taskflow-kwargs.rst
@@ -17,15 +17,15 @@
 
  .. code-block:: python
 
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.models.dagrun import DagRun
+    from airflow.sdk import TaskInstance
+    from airflow.sdk.types import DagRunProtocol
 
 
     @task
     def print_ti_info(**kwargs):
         ti: TaskInstance = kwargs["task_instance"]
         print(f"Run ID: {ti.run_id}")  # Run ID: scheduled__2023-08-09T00:00:00+00:00
-        print(f"Duration: {ti.duration}")  # Duration: 0.972019
+        print(f"Task start date: {ti.start_date}")  # 2023-08-10 00:00:01+00:00
 
-        dr: DagRun = kwargs["dag_run"]
-        print(f"Dag Run queued at: {dr.queued_at}")  # 2023-08-10 00:00:01+02:20
+        dr: DagRunProtocol = kwargs["dag_run"]
+        print(f"Dag Run logical date: {dr.logical_date}")  # 2023-08-09 00:00:00+00:00

--- a/devel-common/src/docs/shared/template-examples/taskflow.rst
+++ b/devel-common/src/docs/shared/template-examples/taskflow.rst
@@ -17,12 +17,12 @@
 
  .. code-block:: python
 
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.models.dagrun import DagRun
+    from airflow.sdk import TaskInstance
+    from airflow.sdk.types import DagRunProtocol
 
 
     @task
-    def print_ti_info(task_instance: TaskInstance, dag_run: DagRun):
+    def print_ti_info(task_instance: TaskInstance, dag_run: DagRunProtocol):
         print(f"Run ID: {task_instance.run_id}")  # Run ID: scheduled__2023-08-09T00:00:00+00:00
-        print(f"Duration: {task_instance.duration}")  # Duration: 0.972019
-        print(f"Dag Run queued at: {dag_run.queued_at}")  # 2023-08-10 00:00:01+02:20
+        print(f"Task start date: {task_instance.start_date}")  # 2023-08-10 00:00:01+00:00
+        print(f"Dag Run logical date: {dag_run.logical_date}")  # 2023-08-09 00:00:00+00:00


### PR DESCRIPTION
## What

Fix the TaskFlow context examples so they use attributes available on the runtime context objects.

The current examples reference:

- `task_instance.duration`
- `dag_run.queued_at`

Those fields are not available on the Task SDK runtime `TaskInstance` / Dag Run context objects and can raise `AttributeError` when users copy the example.

## How

- Use `airflow.sdk.TaskInstance` and `airflow.sdk.types.DagRunProtocol` in the example type hints.
- Keep `task_instance.run_id`.
- Replace `task_instance.duration` with `task_instance.start_date`.
- Replace `dag_run.queued_at` with `dag_run.logical_date`.

Closes #53637.

## Tests

- `defuddle parse https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/taskflow.html --md -o /tmp/airflow-taskflow-doc.md`
- Extracted and compiled the Python code blocks from:
  - `devel-common/src/docs/shared/template-examples/taskflow.rst`
  - `devel-common/src/docs/shared/template-examples/taskflow-kwargs.rst`
- `grep -R "task_instance.duration\|dag_run.queued_at\|ti.duration\|dr.queued_at" -n devel-common/src/docs/shared/template-examples/taskflow*.rst airflow-core/docs/core-concepts/taskflow.rst airflow-core/docs/templates-ref.rst`
- `git diff --check`
- `prek run --files devel-common/src/docs/shared/template-examples/taskflow.rst devel-common/src/docs/shared/template-examples/taskflow-kwargs.rst`
- `breeze build-docs --docs-only --one-pass-only apache-airflow`

Result: documentation build finished successfully.
