### PR TITLE
Update health endpoint in security docs

### DIFF
--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -92,9 +92,9 @@ Non-authenticated UI users
 
 Airflow doesn't support unauthenticated users by default. If allowed, potential vulnerabilities
 must be assessed and addressed by the Deployment Manager. However, there are exceptions to this.
-The ``/health`` endpoint responsible to get health check updates should be publicly accessible.
-This is because other systems would want to retrieve that information. Another exception is the
-``/login`` endpoint, as the users are expected to be unauthenticated to use it.
+The ``/api/v2/monitor/health`` endpoint responsible for health check updates should be publicly
+accessible. This is because other systems would want to retrieve that information. Another exception
+is the ``/login`` endpoint, as the users are expected to be unauthenticated to use it.
 
 Capabilities of authenticated UI users
 --------------------------------------


### PR DESCRIPTION
## What

Update the security model docs to reference the Airflow 3 health endpoint at `/api/v2/monitor/health` instead of the legacy `/health` path.

## Why

The issue reports that the security model still points readers to `/health`, while the current webserver health endpoint is documented elsewhere as `/api/v2/monitor/health`.

Closes #49683.

## How to test

```bash
defuddle parse https://airflow.apache.org/docs/apache-airflow/stable/security/security_model.html --md -o /tmp/airflow-security-model.md
grep -n '/health\|/api/v2/monitor/health' /tmp/airflow-security-model.md
grep -n '/health\|/api/v2/monitor/health' airflow-core/docs/security/security_model.rst
git diff --check
prek run --files airflow-core/docs/security/security_model.rst
breeze build-docs --docs-only --one-pass-only apache-airflow
```
