### PR TITLE
Fix missing Chakra UI license in airflow-core

### DIFF
--- a/airflow-core/3rd-party-licenses/LICENSE-chakra-ui.txt
+++ b/airflow-core/3rd-party-licenses/LICENSE-chakra-ui.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2019 Chakra Systems Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/airflow-core/LICENSE
+++ b/airflow-core/LICENSE
@@ -237,6 +237,7 @@ The text of each license is also included at 3rd-party-licenses/LICENSE-[project
     (MIT License) ElasticMock v1.3.2 (https://github.com/vrcmarcos/elasticmock)
     (MIT License) MomentJS v2.24.0 (http://momentjs.com/)
     (MIT License) eonasdan-bootstrap-datetimepicker v4.17.49 (https://github.com/eonasdan/bootstrap-datetimepicker/)
+    (MIT License) Chakra UI v3.35.0 (https://github.com/chakra-ui/chakra-ui)
 
 ========================================================================
 BSD 3-Clause licenses


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Found that the Chakra UI license was missing from airflow-core third-party licenses. 
Added the Chakra UI MIT license and listed it in airflow-core/LICENSE.

Supporting references:
- airflow-core/src/airflow/ui/package.json:29:  `"@chakra-ui/react": "^3.35.0"`
- airflow-core/src/airflow/ui/pnpm-lock.yaml:471: `'@chakra-ui/react@3.35.0'`
- airflow-core/src/airflow/ui/node_modules/@chakra-ui/react/package.json: `"version": "3.35.0"`

