### PR TITLE
Migrate BigQueryInsertJobTrigger to use on_kill() for user-initiated kills

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
@@ -26,14 +26,14 @@ from asgiref.sync import sync_to_async
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryAsyncHook, BigQueryTableAsyncHook
-from airflow.providers.google.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.google.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
-if not AIRFLOW_V_3_0_PLUS:
+if not AIRFLOW_V_3_3_PLUS:
     from sqlalchemy import select
 
     from airflow.models.taskinstance import TaskInstance
@@ -103,7 +103,20 @@ class BigQueryInsertJobTrigger(BaseTrigger):
             },
         )
 
-    if not AIRFLOW_V_3_0_PLUS:
+    async def on_kill(self) -> None:
+        """Cancel the BigQuery job when the task is killed by a user action."""
+        if self.job_id and self.cancel_on_kill:
+            self.log.info(
+                "Cancelling BigQuery job. Project ID: %s, Location: %s, Job ID: %s",
+                self.project_id,
+                self.location,
+                self.job_id,
+            )
+            hook = self._get_async_hook()
+            await hook.cancel_job(job_id=self.job_id, project_id=self.project_id, location=self.location)
+            self.log.info("BigQuery job %s cancelled successfully.", self.job_id)
+
+    if not AIRFLOW_V_3_3_PLUS:
 
         @provide_session
         def get_task_instance(self, session: Session) -> TaskInstance:
@@ -125,41 +138,41 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                 )
             return task_instance
 
-    async def get_task_state(self):
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+        async def get_task_state(self):
+            from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 
-        task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
-            dag_id=self.task_instance.dag_id,
-            task_ids=[self.task_instance.task_id],
-            run_ids=[self.task_instance.run_id],
-            map_index=self.task_instance.map_index,
-        )
-        try:
-            task_state = task_states_response[self.task_instance.run_id][self.task_instance.task_id]
-        except Exception:
-            raise AirflowException(
-                "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
-                self.task_instance.dag_id,
-                self.task_instance.task_id,
-                self.task_instance.run_id,
-                self.task_instance.map_index,
+            task_states_response = await sync_to_async(RuntimeTaskInstance.get_task_states)(
+                dag_id=self.task_instance.dag_id,
+                task_ids=[self.task_instance.task_id],
+                run_ids=[self.task_instance.run_id],
+                map_index=self.task_instance.map_index,
             )
-        return task_state
+            try:
+                task_state = task_states_response[self.task_instance.run_id][self.task_instance.task_id]
+            except Exception:
+                raise AirflowException(
+                    "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",
+                    self.task_instance.dag_id,
+                    self.task_instance.task_id,
+                    self.task_instance.run_id,
+                    self.task_instance.map_index,
+                )
+            return task_state
 
-    async def safe_to_cancel(self) -> bool:
-        """
-        Whether it is safe to cancel the external job which is being executed by this trigger.
+        async def safe_to_cancel(self) -> bool:
+            """
+            Whether it is safe to cancel the external job which is being executed by this trigger.
 
-        This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped.
-        Because in those cases, we should NOT cancel the external job.
-        """
-        if AIRFLOW_V_3_0_PLUS:
-            task_state = await self.get_task_state()
-        else:
-            # Database query is needed to get the latest state of the task instance.
-            task_instance = self.get_task_instance()  # type: ignore[call-arg]
-            task_state = task_instance.state
-        return task_state != TaskInstanceState.DEFERRED
+            This is to avoid the case that `asyncio.CancelledError` is called because the trigger itself is stopped.
+            Because in those cases, we should NOT cancel the external job.
+            """
+            if AIRFLOW_V_3_0_PLUS:
+                task_state = await self.get_task_state()
+            else:
+                # Database query is needed to get the latest state of the task instance.
+                task_instance = self.get_task_instance()  # type: ignore[call-arg]
+                task_state = task_instance.state
+            return task_state != TaskInstanceState.DEFERRED
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         """Get current job execution status and yields a TriggerEvent."""
@@ -196,25 +209,27 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                     )
                     await asyncio.sleep(self.poll_interval)
         except asyncio.CancelledError:
-            if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
-                self.log.info(
-                    "The job is safe to cancel the as airflow TaskInstance is not in deferred state."
-                )
-                self.log.info(
-                    "Cancelling job. Project ID: %s, Location: %s, Job ID: %s",
-                    self.project_id,
-                    self.location,
-                    self.job_id,
-                )
-                await hook.cancel_job(job_id=self.job_id, project_id=self.project_id, location=self.location)
-            else:
-                self.log.info(
-                    "Trigger may have shutdown. Skipping to cancel job because the airflow "
-                    "task is not cancelled yet: Project ID: %s, Location:%s, Job ID:%s",
-                    self.project_id,
-                    self.location,
-                    self.job_id,
-                )
+            # Legacy path for Airflow < 3.3.0
+            # On Airflow 3.3.0+, on_kill() handles user-initiated kills
+            if not AIRFLOW_V_3_3_PLUS:
+                if self.job_id and self.cancel_on_kill and await self.safe_to_cancel():
+                    self.log.info(
+                        "Cancelling job (legacy path). Project ID: %s, Location: %s, Job ID: %s",
+                        self.project_id,
+                        self.location,
+                        self.job_id,
+                    )
+                    await hook.cancel_job(
+                        job_id=self.job_id, project_id=self.project_id, location=self.location
+                    )
+                else:
+                    self.log.info(
+                        "Trigger may have shutdown. Skipping to cancel job because the airflow "
+                        "task is not cancelled yet: Project ID: %s, Location:%s, Job ID:%s",
+                        self.project_id,
+                        self.location,
+                        self.job_id,
+                    )
             raise
         except Exception as e:
             self.log.exception("Exception occurred while checking for query completion")

--- a/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
@@ -40,6 +40,8 @@ from airflow.providers.google.cloud.triggers.bigquery import (
 )
 from airflow.triggers.base import TriggerEvent
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
 TEST_CONN_ID = "bq_default"
 TEST_JOB_ID = "1234"
 TEST_GCP_PROJECT_ID = "test-project"
@@ -234,72 +236,81 @@ class TestBigQueryInsertJobTrigger:
         assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.cancel_job")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+    @pytest.mark.skipif(AIRFLOW_V_3_3_PLUS, reason="on_kill() handles cancellation for Airflow 3.3.0+")
+    @pytest.mark.parametrize("is_safe_to_cancel", [True, False])
+    @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger._get_async_hook")
     @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger.safe_to_cancel")
-    async def test_bigquery_insert_job_trigger_cancellation(
-        self, mock_get_task_instance, mock_get_job_status, mock_cancel_job, caplog, insert_job_trigger
+    async def test_insert_job_trigger_run_cancelled(
+        self, mock_safe_to_cancel, mock_get_async_hook, insert_job_trigger, is_safe_to_cancel
     ):
-        """
-        Test that BigQueryInsertJobTrigger handles cancellation correctly, logs the appropriate message,
-        and conditionally cancels the job based on the `cancel_on_kill` attribute.
-        """
-        mock_get_task_instance.return_value = True
-        insert_job_trigger.cancel_on_kill = True
-        insert_job_trigger.job_id = "1234"
+        """Test CancelledError handling for Airflow < 3.3.0."""
+        mock_safe_to_cancel.return_value = is_safe_to_cancel
+        mock_hook = mock_get_async_hook.return_value
+        mock_hook.get_job_status = AsyncMock()
+        mock_hook.get_job_status.side_effect = asyncio.CancelledError
+        mock_hook.cancel_job = AsyncMock()
 
-        mock_get_job_status.side_effect = [
-            {"status": "running", "message": "Job is still running"},
-            asyncio.CancelledError(),
-        ]
+        async_gen = insert_job_trigger.run()
+        try:
+            await async_gen.asend(None)
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
+        except Exception as e:
+            pytest.fail(f"Unexpected exception raised: {e}")
 
-        mock_cancel_job.return_value = asyncio.Future()
-        mock_cancel_job.return_value.set_result(None)
+        if insert_job_trigger.cancel_on_kill and is_safe_to_cancel:
+            mock_hook.cancel_job.assert_awaited_once_with(
+                job_id=insert_job_trigger.job_id,
+                project_id=insert_job_trigger.project_id,
+                location=insert_job_trigger.location,
+            )
+        else:
+            mock_hook.cancel_job.assert_not_awaited()
 
-        caplog.set_level(logging.INFO)
-
-        with pytest.raises(asyncio.CancelledError):
-            async for _ in insert_job_trigger.run():
-                pass
-
-        assert (
-            "Task was killed" in caplog.text
-            or "Bigquery job status is running. Sleeping for 4.0 seconds." in caplog.text
-        ), "Expected messages about task status or cancellation not found in log."
-        mock_cancel_job.assert_awaited_once()
+        await async_gen.aclose()
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.cancel_job")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
-    @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger.safe_to_cancel")
-    async def test_bigquery_insert_job_trigger_cancellation_unsafe_cancellation(
-        self, mock_safe_to_cancel, mock_get_job_status, mock_cancel_job, caplog, insert_job_trigger
-    ):
-        """
-        Test that BigQueryInsertJobTrigger logs the appropriate message and does not cancel the job
-        if safe_to_cancel returns False even when the task is cancelled.
-        """
-        mock_safe_to_cancel.return_value = False
+    @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger._get_async_hook")
+    async def test_on_kill_cancels_job(self, mock_get_async_hook, insert_job_trigger):
+        """Test that on_kill cancels the BigQuery job."""
+        mock_hook = mock_get_async_hook.return_value
+        mock_hook.cancel_job = AsyncMock()
+        insert_job_trigger.job_id = TEST_JOB_ID
         insert_job_trigger.cancel_on_kill = True
-        insert_job_trigger.job_id = "1234"
 
-        # Simulate the initial job status as running
-        mock_get_job_status.side_effect = [
-            {"status": "running", "message": "Job is still running"},
-            asyncio.CancelledError(),
-            {"status": "running", "message": "Job is still running after cancellation"},
-        ]
+        await insert_job_trigger.on_kill()
 
-        caplog.set_level(logging.INFO)
-
-        with pytest.raises(asyncio.CancelledError):
-            async for _ in insert_job_trigger.run():
-                pass
-
-        assert "Skipping to cancel job" in caplog.text, (
-            "Expected message about skipping cancellation not found in log."
+        mock_hook.cancel_job.assert_awaited_once_with(
+            job_id=TEST_JOB_ID,
+            project_id=TEST_GCP_PROJECT_ID,
+            location=TEST_LOCATION,
         )
-        assert mock_get_job_status.call_count == 2, "Job status should be checked multiple times"
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger._get_async_hook")
+    async def test_on_kill_respects_cancel_on_kill_false(self, mock_get_async_hook, insert_job_trigger):
+        """Test that on_kill does not cancel the job when cancel_on_kill is False."""
+        mock_hook = mock_get_async_hook.return_value
+        mock_hook.cancel_job = AsyncMock()
+        insert_job_trigger.job_id = TEST_JOB_ID
+        insert_job_trigger.cancel_on_kill = False
+
+        await insert_job_trigger.on_kill()
+
+        mock_hook.cancel_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger._get_async_hook")
+    async def test_on_kill_no_job_id_does_not_cancel(self, mock_get_async_hook, insert_job_trigger):
+        """Test that on_kill does not attempt to cancel when job_id is not set."""
+        mock_hook = mock_get_async_hook.return_value
+        mock_hook.cancel_job = AsyncMock()
+        insert_job_trigger.job_id = None
+        insert_job_trigger.cancel_on_kill = True
+
+        await insert_job_trigger.on_kill()
+
+        mock_hook.cancel_job.assert_not_called()
 
 
 class TestBigQueryGetDataTrigger:


### PR DESCRIPTION
## What

Migrates `BigQueryInsertJobTrigger` from the `asyncio.CancelledError + safe_to_cancel()` cancellation pattern to the `BaseTrigger.on_kill()` hook introduced in #65590, as tracked in #65733.

- Added `on_kill()` that cancels the BigQuery job via `await hook.cancel_job()`
- Kept backward-compat helpers under `if not AIRFLOW_V_3_3_PLUS:` guards
- Since `BigQueryInsertJobTrigger` is a base class, 4 inheriting triggers get `on_kill()` automatically
- Added focused `on_kill` tests; preserved CancelledError tests under `skipif` guards

## Why

The old `CancelledError + safe_to_cancel()` pattern requires a task-instance state query (DB or RuntimeTaskInstance API) on every trigger cancellation to distinguish user-initiated kills from triggerer restarts/rolling deploys. This adds unnecessary DB access and can incorrectly cancel jobs during infrastructure events.

`on_kill()` makes this distinction at the framework level — it fires only on explicit user kills — eliminating the DB query and ensuring external jobs survive triggerer restarts.

## Manual E2E Test

1. Created a long-running BigQuery query using WHILE loop scripting

<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/1480844a-8014-4e58-bc2f-00db288b8aa9" />


2. 2. Triggered the DAG with two tasks:
   - `long_running_cancel_true` (cancel_on_kill=True)
   - `long_running_cancel_false` (cancel_on_kill=False) 
   -> Waited for both tasks to enter deferred state (triggerer polling)

<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/3068a000-3d8a-4cdf-bbcf-22f8ab4d80c2" />


3. Marked long_running_cancel_true/false as failed from UI
<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/1a9bb43b-ef8a-468b-81f7-20941d28b03c" />



4. Verified on BigQuery: 
   - cancel_on_kill=True job → CANCELLED; 
   - cancel_on_kill=False job → NOT cancelled. 
   -> on_kill() correctly respects the flag.

<img width="595" height="52" alt="image" src="https://github.com/user-attachments/assets/effeb5a7-5b82-4476-85b8-b5d5e4a5b651" />


related: #65733

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — opencode (GLM-5.1)

Generated-by: opencode (GLM-5.1) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)