### PR TITLE
Re-defer KubernetesPodOperator when pod is still running after trigger error

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -67,7 +67,10 @@ from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.providers.cncf.kubernetes.triggers.pod import ContainerState, KubernetesPodTrigger
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar
 from airflow.providers.cncf.kubernetes.utils.container import (
+    container_is_completed,
+    container_is_running,
     container_is_succeeded,
+    container_is_wait,
     get_container_termination_message,
 )
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
@@ -78,9 +81,10 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodManager,
     PodNotFoundException,
     PodPhase,
+    detect_pod_terminate_early_issues,
 )
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_1_PLUS
-from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY, AirflowSkipException, TaskDeferred, conf
+from airflow.providers.common.compat.sdk import XCOM_RETURN_KEY, AirflowSkipException, conf
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import BaseHook, BaseOperator
@@ -268,6 +272,7 @@ class KubernetesPodOperator(BaseOperator):
     KILL_ISTIO_PROXY_SUCCESS_MSG = "HTTP/1.1 200"
     POD_CHECKED_KEY = "already_checked"
     POST_TERMINATION_TIMEOUT = 120
+    MAX_REDEFER_ATTEMPTS = 3
 
     template_fields: Sequence[str] = (
         "image",
@@ -958,18 +963,54 @@ class KubernetesPodOperator(BaseOperator):
         """
         self.pod = None
         xcom_sidecar_output = None
+        pod_name = event["name"]
+        pod_namespace = event["namespace"]
+
+        self.pod = self.hook.get_pod(pod_name, pod_namespace)
+
+        if not self.pod:
+            raise PodNotFoundException("Could not find pod after resuming from deferral")
+
+        follow = self.logging_interval is None
+        last_log_time = event.get("last_log_time")
+
+        pod_is_not_done = (
+            not container_is_completed(self.pod, self.base_container_name)
+            and (
+                container_is_running(self.pod, self.base_container_name)
+                or container_is_wait(self.pod, self.base_container_name)
+                or (self.pod.status and self.pod.status.phase == "Pending")
+            )
+            and not detect_pod_terminate_early_issues(self.pod)
+        )
+        redefer_count = event.get("_redefer_count", 0)
+
+        if event["status"] == "error" and pod_is_not_done and redefer_count < self.MAX_REDEFER_ATTEMPTS:
+            self.log.warning(
+                "Trigger returned but pod %s is still in phase %s. "
+                "Re-deferring to continue monitoring (attempt %d/%d). Trigger event: %s",
+                event["name"],
+                self.pod.status.phase if self.pod.status else "Unknown",
+                redefer_count + 1,
+                self.MAX_REDEFER_ATTEMPTS,
+                event,
+            )
+            self.trigger_kwargs = dict(self.trigger_kwargs or {})
+            self.trigger_kwargs["_redefer_count"] = redefer_count + 1
+            self.invoke_defer_method(
+                last_log_time=last_log_time,
+            )
+            # invoke_defer_method raises TaskDeferred, execution does not continue here
+
+        if event["status"] == "error" and pod_is_not_done:
+            self.log.error(
+                "Pod %s is still in phase %s but maximum re-defer attempts (%d) exceeded.",
+                event["name"],
+                self.pod.status.phase if self.pod.status else "Unknown",
+                self.MAX_REDEFER_ATTEMPTS,
+            )
+
         try:
-            pod_name = event["name"]
-            pod_namespace = event["namespace"]
-
-            self.pod = self.hook.get_pod(pod_name, pod_namespace)
-
-            if not self.pod:
-                raise PodNotFoundException("Could not find pod after resuming from deferral")
-
-            follow = self.logging_interval is None
-            last_log_time = event.get("last_log_time")
-
             if event["status"] in ("error", "failed", "timeout", "success"):
                 if self.get_logs:
                     try:
@@ -1000,14 +1041,19 @@ class KubernetesPodOperator(BaseOperator):
 
                 xcom_sidecar_output = self.extract_xcom(pod=self.pod) if self.do_xcom_push else None
 
-                if event["status"] != "success":
+                if event["status"] == "error" and container_is_succeeded(self.pod, self.base_container_name):
+                    self.log.warning(
+                        "Base container terminated successfully but trigger emitted an error event. "
+                        "Treating as success. Event: %s, Message: %s",
+                        event.get("status"),
+                        event.get("message"),
+                    )
+                elif event["status"] != "success":
                     self.log.error(
                         "Trigger emitted an %s event, failing the task: %s", event["status"], event["message"]
                     )
                     message = event.get("stack_trace", event["message"])
                     raise AirflowException(message)
-        except TaskDeferred:
-            raise
         finally:
             self._clean(event=event, context=context, result=xcom_sidecar_output)
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -3007,6 +3007,229 @@ class TestKubernetesPodOperatorAsync:
                 },
             )
 
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_redefer_when_pod_still_running(self, mocked_hook, mock_invoke_defer):
+        """When trigger returns error but pod container is still running, re-defer the task."""
+        mock_invoke_defer.side_effect = TaskDeferred(trigger=MagicMock(), method_name="trigger_reentry")
+
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.running = MagicMock()
+        base_container.state.terminated = None
+        base_container.state.waiting = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Running"
+        remote_pod.status.container_statuses = [base_container]
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "some transient error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+        }
+
+        with pytest.raises(TaskDeferred):
+            op.trigger_reentry(context, event)
+
+        mock_invoke_defer.assert_called_once()
+        assert op.trigger_kwargs["_redefer_count"] == 1
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_redefer_when_pod_pending(self, mocked_hook, mock_invoke_defer):
+        """When trigger returns error but pod is still Pending (no container status yet), re-defer."""
+        mock_invoke_defer.side_effect = TaskDeferred(trigger=MagicMock(), method_name="trigger_reentry")
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Pending"
+        remote_pod.status.container_statuses = None
+        remote_pod.status.init_container_statuses = None
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "some transient error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+        }
+
+        with pytest.raises(TaskDeferred):
+            op.trigger_reentry(context, event)
+
+        mock_invoke_defer.assert_called_once()
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_redefer_when_pod_waiting(self, mocked_hook, mock_invoke_defer):
+        """When trigger returns error but container is in waiting state, re-defer."""
+        mock_invoke_defer.side_effect = TaskDeferred(trigger=MagicMock(), method_name="trigger_reentry")
+
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.running = None
+        base_container.state.terminated = None
+        base_container.state.waiting = MagicMock()
+        base_container.state.waiting.reason = "ContainerCreating"
+        base_container.state.waiting.message = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Pending"
+        remote_pod.status.container_statuses = [base_container]
+        remote_pod.status.init_container_statuses = None
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "some transient error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+        }
+
+        with pytest.raises(TaskDeferred):
+            op.trigger_reentry(context, event)
+
+        mock_invoke_defer.assert_called_once()
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_no_redefer_when_detect_pod_terminate_early_issues(self, mocked_hook, mock_invoke_defer):
+        """When pod has fatal image pull error, do not re-defer even if container is waiting."""
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.running = None
+        base_container.state.terminated = None
+        base_container.state.waiting = MagicMock()
+        base_container.state.waiting.reason = "InvalidImageName"
+        base_container.state.waiting.message = "invalid image"
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Pending"
+        remote_pod.status.container_statuses = [base_container]
+        remote_pod.status.init_container_statuses = None
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "some error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+        }
+
+        with pytest.raises(AirflowException):
+            op.trigger_reentry(context, event)
+
+        mock_invoke_defer.assert_not_called()
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_no_redefer_when_max_attempts_exceeded(self, mocked_hook, mock_invoke_defer):
+        """When re-defer attempts are exhausted, fail the task instead of re-deferring."""
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.running = MagicMock()
+        base_container.state.terminated = None
+        base_container.state.waiting = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Running"
+        remote_pod.status.container_statuses = [base_container]
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "some transient error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+            "_redefer_count": op.MAX_REDEFER_ATTEMPTS,
+        }
+
+        with pytest.raises(AirflowException):
+            op.trigger_reentry(context, event)
+
+        mock_invoke_defer.assert_not_called()
+
+    @patch(KUB_OP_PATH.format("invoke_defer_method"))
+    @patch(HOOK_CLASS)
+    def test_redefer_increments_count(self, mocked_hook, mock_invoke_defer):
+        """Re-defer count is incremented in trigger_kwargs for each re-defer."""
+        mock_invoke_defer.side_effect = TaskDeferred(trigger=MagicMock(), method_name="trigger_reentry")
+
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.running = MagicMock()
+        base_container.state.terminated = None
+        base_container.state.waiting = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Running"
+        remote_pod.status.container_statuses = [base_container]
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True)
+        context = create_context(op)
+        event = {
+            "status": "error",
+            "message": "transient error",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+            "_redefer_count": 2,
+        }
+
+        with pytest.raises(TaskDeferred):
+            op.trigger_reentry(context, event)
+
+        assert op.trigger_kwargs["_redefer_count"] == 3
+        mock_invoke_defer.assert_called_once()
+
+    @patch(KUB_OP_PATH.format("post_complete_action"))
+    @patch(KUB_OP_PATH.format("pod_manager"))
+    @patch(HOOK_CLASS)
+    def test_error_event_treated_as_success_when_container_succeeded(
+        self, mocked_hook, mock_manager, mock_post_complete
+    ):
+        """When trigger emits error but container actually exited 0, treat as success."""
+        base_container = MagicMock()
+        base_container.name = "base"
+        base_container.state.terminated = MagicMock()
+        base_container.state.terminated.exit_code = 0
+        base_container.state.running = None
+        base_container.state.waiting = None
+
+        remote_pod = MagicMock()
+        remote_pod.status.phase = "Succeeded"
+        remote_pod.status.container_statuses = [base_container]
+        remote_pod.status.init_container_statuses = None
+        mocked_hook.return_value.get_pod.return_value = remote_pod
+        mock_manager.await_pod_completion.return_value = remote_pod
+
+        op = KubernetesPodOperator(task_id="test_task", name="test-pod", deferrable=True, get_logs=False)
+        context = create_context(op)
+        context["ti"] = MagicMock()
+        event = {
+            "status": "error",
+            "message": "API timeout",
+            "name": TEST_NAME,
+            "namespace": TEST_NAMESPACE,
+        }
+
+        # Should NOT raise — treated as success
+        op.trigger_reentry(context, event)
+
+        mock_post_complete.assert_called_once()
+
     @patch(HOOK_CLASS)
     def test_execute_async_callbacks(self, mocked_hook):
         from airflow.providers.cncf.kubernetes.callbacks import ExecutionMode


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Problem

When running Kubernetes Pods in deferred mode, the triggerer can return an `error` event due to transient communication issues with the Kubernetes API (e.g. timeouts, connection resets), even though the pod is still running normally. In the current implementation, this causes the task to fail immediately — even though the pod is healthy and still executing.

Additionally, if the trigger emits an `error` event but the base container has actually completed successfully (exit code 0), the task is unnecessarily marked as failed.

## Solution

### 1. Re-defer on transient errors when pod is still alive

When `trigger_reentry` receives an `error` event, it now checks the actual pod state before failing the task. If the pod's base container is still running, waiting, or the pod is pending (and there are no fatal issues like `InvalidImageName`), the task is re-deferred to the triggerer to continue monitoring.

A `MAX_REDEFER_ATTEMPTS = 3` limit prevents infinite re-defer loops if the Kubernetes API is persistently unreachable. The re-defer count is tracked via `trigger_kwargs` which round-trips through the trigger's emitted events.

Re-deferring is scoped to `"error"` events only. `"timeout"` and `"failed"` events represent deliberate decisions by the trigger (pod launch timeout, container failure) and are not retried.

### 2. Treat error as success when container actually succeeded

If the trigger emits an `error` event but the base container has already terminated with exit code 0, the task is now treated as successful instead of failing.

### 3. Remove misleading `except TaskDeferred: raise`

The old code had `except TaskDeferred: raise` before the `finally` block, which appeared to prevent `_clean()` from running during re-deferral. In reality, Python's `finally` always executes — even after a re-raised exception — so this guard was ineffective. The re-defer logic is now placed **before** the `try/finally` block, ensuring `_clean()` (which may delete the still-running pod) does not execute on re-deferral.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  GitHub Copilot - Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
