### PR TITLE
Docs: doc_md + task docstrings for measurement correction example Dags

### DIFF
--- a/contributing-docs/28_example_dag_review_checklist.rst
+++ b/contributing-docs/28_example_dag_review_checklist.rst
@@ -94,3 +94,20 @@ Provider examples have slightly different expectations:
 - [ ] Provider dependencies are clearly documented in the docstring.
 - [ ] Example is not auto-loaded unless intended.
 - [ ] Example naming follows provider naming conventions.
+
+Reference Examples
+------------------
+
+The following example Dags are kept aligned with this checklist and are good
+templates for new tutorial-style examples. Both implement the same
+"measurement correction" storyline so the TaskFlow and ``PythonOperator``
+styles can be compared side by side:
+
+- `example_measurement_correction_decorator.py
+  <https://github.com/apache/airflow/blob/main/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py>`_ — TaskFlow version.
+- `example_measurement_correction_operator.py
+  <https://github.com/apache/airflow/blob/main/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py>`_ — classic ``PythonOperator`` version.
+
+When introducing a new tutorial-style example, prefer copying the shape of
+these two files (module docstring, ``doc_md``, per-task docstrings, no
+external dependencies) rather than starting from scratch.

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_decorator.py
@@ -14,14 +14,50 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+Tutorial example Dag: measurement correction storyline (TaskFlow).
 
-"""Example Dag demonstrating a simple measurement correction workflow"""
+This Dag is part of the "Examples Refurbish" storyline and is meant to be a
+short, didactic walkthrough of a typical scientific or industrial data
+pipeline. It demonstrates the TaskFlow API on a self-contained workflow that:
+
+1. reads a raw measurement,
+2. validates it,
+3. applies a correction factor,
+4. stores the corrected result.
+
+The Dag has no external dependencies (no connections, no datasets, no hooks),
+so it parses and runs out of the box. Pair it with
+``example_measurement_correction_operator.py`` to compare TaskFlow and the
+classic ``PythonOperator`` style on the exact same storyline.
+"""
 
 from __future__ import annotations
 
 import pendulum
 
 from airflow.sdk import dag, task
+
+DAG_DOC_MD = """
+### Measurement correction (TaskFlow)
+
+Tutorial Dag showing a minimal "read, validate, correct, store" measurement
+pipeline implemented with the TaskFlow API.
+
+**Storyline**
+
+1. `read_measurement` produces a raw value coming from a fictional sensor.
+2. `validate_measurement` rejects negative values.
+3. `apply_correction` multiplies the value by a calibration factor.
+4. `store_result` logs the corrected value (the real Dag would persist it).
+
+**When to use this example**
+
+- Learning the TaskFlow API on a single, linear pipeline.
+- As a reference shape for new "tutorial" example Dags following the
+  [example Dag review checklist](
+  https://github.com/apache/airflow/blob/main/contributing-docs/28_example_dag_review_checklist.rst).
+"""
 
 
 # [START example_measurement_correction_decorator]
@@ -31,37 +67,52 @@ from airflow.sdk import dag, task
     schedule=None,
     catchup=False,
     tags=["example"],
+    doc_md=DAG_DOC_MD,
 )
 def measurement_correction_decorator():
-    """
-    A tutorial Dag showing how to:
-    1. Read a raw measurement
-    2. Validate the measurement
-    3. Apply a correction factor
-    4. Log the corrected result
-    """
+    """Tutorial Dag: read, validate, correct, and store a measurement."""
 
-    # Task 1: Read a raw measurement
     @task
     def read_measurement() -> int:
+        """Return the raw measurement coming from the source system.
+
+        In a real pipeline this would fetch the value from a sensor, an
+        external API, or an upstream dataset. For the tutorial it returns a
+        constant so the Dag is fully self-contained.
+        """
         return 100
 
-    # Task 2: Validate the measurement
     @task
     def validate_measurement(value: int) -> int:
+        """Reject obviously invalid measurements.
+
+        Raises ``ValueError`` when ``value`` is negative, so the failure is
+        visible as a failed task in the UI instead of silently corrupting
+        downstream data.
+        """
         if value < 0:
             raise ValueError("Measurement must be positive")
         return value
 
-    # Task 3: Apply a correction factor
     @task
     def apply_correction(value: int) -> float:
+        """Apply the calibration factor to a validated measurement.
+
+        The factor (``1.1``) is hard-coded here for brevity; a real pipeline
+        would read it from a Variable, a Connection extra, or a config file.
+        """
         correction_factor = 1.1
         return value * correction_factor
 
-    # Task 4: Log the final corrected result
     @task
     def store_result(value: float) -> None:
+        """Persist the corrected measurement.
+
+        The tutorial implementation logs the value via ``print`` so the
+        result is visible in the task logs. A production Dag would write it
+        to a database, an object store, or publish it to a downstream
+        system.
+        """
         print(f"Corrected measurement: {value}")
 
     raw_value = read_measurement()

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_measurement_correction_operator.py
@@ -15,8 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Example Dag demonstrating a simple measurement correction workflow
-using operator PythonOperator tasks.
+Tutorial example Dag: measurement correction storyline (PythonOperator).
+
+Classic, ``PythonOperator`` based counterpart of
+``example_measurement_correction_decorator.py``. It runs the same
+"read, validate, correct, store" pipeline so that learners can compare the
+TaskFlow API and the operator-based style on identical business logic.
+
+The Dag has no external dependencies (no connections, no datasets, no hooks),
+so it parses and runs out of the box and is suitable as a tutorial or as a
+documentation snippet.
 """
 
 from __future__ import annotations
@@ -26,28 +34,69 @@ import pendulum
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import DAG
 
+DAG_DOC_MD = """
+### Measurement correction (PythonOperator)
 
-# Task 1: Return a raw measurement value
+Tutorial Dag showing a minimal "read, validate, correct, store" measurement
+pipeline implemented with classic ``PythonOperator`` tasks and XCom for
+inter-task communication.
+
+**Storyline**
+
+1. `read_measurement` returns a raw value.
+2. `validate_measurement` pulls it from XCom and rejects negative values.
+3. `apply_correction` multiplies it by a calibration factor.
+4. `store_result` logs the corrected value.
+
+**When to use this example**
+
+- Comparing the TaskFlow API with the classic operator style on the same
+  storyline (see ``example_measurement_correction_decorator.py``).
+- As a reference shape for new "tutorial" example Dags following the
+  [example Dag review checklist](
+  https://github.com/apache/airflow/blob/main/contributing-docs/28_example_dag_review_checklist.rst).
+"""
+
+
 def read_measurement(**context):
+    """Return the raw measurement value pushed to XCom.
+
+    The returned value becomes the task's XCom payload so the downstream
+    tasks can pull it with ``ti.xcom_pull``.
+    """
     return 100
 
 
-# Task 2: Validate the measurement value
 def validate_measurement(**context):
+    """Validate the upstream measurement pulled from XCom.
+
+    Raises ``ValueError`` when the value is negative so the failure is
+    visible as a failed task in the UI instead of silently corrupting
+    downstream data.
+    """
     value = context["ti"].xcom_pull(task_ids="read_measurement")
     if value < 0:
         raise ValueError("Measurement must be positive")
     return value
 
 
-# Task 3: Apply correction factor
 def apply_correction(**context):
+    """Apply the calibration factor to a validated measurement.
+
+    The factor (``1.1``) is hard-coded for brevity; a production pipeline
+    would source it from a Variable, a Connection extra, or a config file.
+    """
     value = context["ti"].xcom_pull(task_ids="validate_measurement")
     return value * 1.1
 
 
-# Task 4: Log the corrected result
 def store_result(**context):
+    """Persist the corrected measurement.
+
+    The tutorial implementation logs the value via ``print`` so the result
+    is visible in the task logs. A production Dag would write it to a
+    database, an object store, or publish it to a downstream system.
+    """
     value = context["ti"].xcom_pull(task_ids="apply_correction")
     print(f"Corrected measurement: {value}")
 
@@ -59,6 +108,7 @@ with DAG(
     schedule=None,
     catchup=False,
     tags=["example"],
+    doc_md=DAG_DOC_MD,
 ) as dag:
     read = PythonOperator(
         task_id="read_measurement",
@@ -80,6 +130,5 @@ with DAG(
         python_callable=store_result,
     )
 
-    # Define execution order
     read >> validate >> correct >> store
 # [END example_measurement_correction_operator]


### PR DESCRIPTION
Follow-up to #66257 addressing the [post-merge review](https://github.com/apache/airflow/pull/66257#pullrequestreview-4259464331) from @jscheffl. His comment landed after the merge, so the items below were not part of the original PR. Drafting this for visibility while I wait on guidance for the consolidation item.

What this PR covers from Jens' list:

- **Dag Markdown Documentation**: both example Dags now define a ``doc_md`` block that renders in the UI with the storyline, the per-step description, and a link back to the example Dag review checklist.
- **Pydoc at the task level**: every task (TaskFlow and ``PythonOperator``) now has a docstring explaining what it does and how it would map to a production pipeline.
- **Take the new example into the docs**: the example Dag review checklist (``contributing-docs/28_example_dag_review_checklist.rst``) now references both files as the canonical templates for new tutorial-style example Dags.

What is **not** in this PR (need your input, @jscheffl):

- **Consolidating / removing pre-existing artificial examples**. The standard provider has ``example_python_decorator.py`` / ``example_python_operator.py`` that overlap conceptually with the measurement correction ones, but ``providers/standard/docs/operators/python.rst`` references them ~12 times as ``exampleinclude`` targets, so they are not free to delete. Could you point me at which pre-existing example(s) you had in mind so I can replace them in a separate commit on this branch?

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes