### PR TITLE
Add session param to BaseStateBackend interface to fix custom backends

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_state.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_state.py
@@ -87,7 +87,7 @@ def get_asset_state_by_name(
 ) -> AssetStateResponse:
     """Get an asset state value by asset name."""
     asset_id = _resolve_asset_id_by_name(name, session)
-    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)
     if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -105,7 +105,7 @@ def set_asset_state_by_name(
 ) -> None:
     """Set an asset state value by asset name."""
     asset_id = _resolve_asset_id_by_name(name, session)
-    get_state_backend().set(AssetScope(asset_id=asset_id), key, body.value, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().set(AssetScope(asset_id=asset_id), key, body.value, session=session)
 
 
 @router.delete("/by-name/value", status_code=status.HTTP_204_NO_CONTENT)
@@ -116,7 +116,7 @@ def delete_asset_state_by_name(
 ) -> None:
     """Delete a single asset state key by asset name."""
     asset_id = _resolve_asset_id_by_name(name, session)
-    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)
 
 
 @router.delete("/by-name/clear", status_code=status.HTTP_204_NO_CONTENT)
@@ -126,7 +126,7 @@ def clear_asset_state_by_name(
 ) -> None:
     """Delete all state keys for an asset by asset name."""
     asset_id = _resolve_asset_id_by_name(name, session)
-    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)
 
 
 @router.get("/by-uri/value")
@@ -137,7 +137,7 @@ def get_asset_state_by_uri(
 ) -> AssetStateResponse:
     """Get an asset state value by asset URI."""
     asset_id = _resolve_asset_id_by_uri(uri, session)
-    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)
     if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -155,7 +155,7 @@ def set_asset_state_by_uri(
 ) -> None:
     """Set an asset state value by asset URI."""
     asset_id = _resolve_asset_id_by_uri(uri, session)
-    get_state_backend().set(AssetScope(asset_id=asset_id), key, body.value, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().set(AssetScope(asset_id=asset_id), key, body.value, session=session)
 
 
 @router.delete("/by-uri/value", status_code=status.HTTP_204_NO_CONTENT)
@@ -166,7 +166,7 @@ def delete_asset_state_by_uri(
 ) -> None:
     """Delete a single asset state key by asset URI."""
     asset_id = _resolve_asset_id_by_uri(uri, session)
-    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)
 
 
 @router.delete("/by-uri/clear", status_code=status.HTTP_204_NO_CONTENT)
@@ -176,4 +176,4 @@ def clear_asset_state_by_uri(
 ) -> None:
     """Delete all state keys for an asset by asset URI."""
     asset_id = _resolve_asset_id_by_uri(uri, session)
-    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_state.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_state.py
@@ -65,7 +65,7 @@ def get_task_state(
 ) -> TaskStateResponse:
     """Get value for a task state."""
     scope = _get_task_scope_for_ti(task_instance_id, session)
-    value = get_state_backend().get(scope, key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    value = get_state_backend().get(scope, key, session=session)
     if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -86,7 +86,7 @@ def set_task_state(
 ) -> None:
     """Set a task state key, creating or updating the row."""
     scope = _get_task_scope_for_ti(task_instance_id, session)
-    get_state_backend().set(scope, key, body.value, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().set(scope, key, body.value, session=session)
 
 
 @router.delete("/{task_instance_id}/{key}", status_code=status.HTTP_204_NO_CONTENT)
@@ -97,7 +97,7 @@ def delete_task_state(
 ) -> None:
     """Delete a single task state key."""
     scope = _get_task_scope_for_ti(task_instance_id, session)
-    get_state_backend().delete(scope, key, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().delete(scope, key, session=session)
 
 
 @router.delete("/{task_instance_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -125,4 +125,4 @@ def clear_task_state(
     accepted without error.
     """
     scope = _get_task_scope_for_ti(task_instance_id, session)
-    get_state_backend().clear(scope, all_map_indices=all_map_indices, session=session)  # type: ignore[call-arg]  # @provide_session adds session kwarg at runtime; BaseStateBackend signature omits it so mypy can't see it
+    get_state_backend().clear(scope, all_map_indices=all_map_indices, session=session)

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -37,6 +37,19 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.orm import Session
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def _async_session(session: AsyncSession | None) -> AsyncGenerator[AsyncSession, None]:
+    """Use provided async session or create a new one."""
+    if session is not None:
+        yield session
+    else:
+        async with create_session_async() as s:
+            yield s
+
 
 def _build_upsert_stmt(
     dialect: str | None,
@@ -122,43 +135,47 @@ class MetastoreStateBackend(BaseStateBackend):
             case _:
                 assert_never(scope)
 
-    async def aget(self, scope: StateScope, key: str) -> str | None:
-        async with create_session_async() as session:
+    async def aget(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> str | None:
+        async with _async_session(session) as s:
             match scope:
                 case TaskScope():
-                    return await self._aget_task_state(scope, key, session=session)
+                    return await self._aget_task_state(scope, key, session=s)
                 case AssetScope():
-                    return await self._aget_asset_state(scope, key, session=session)
+                    return await self._aget_asset_state(scope, key, session=s)
                 case _:
                     assert_never(scope)
 
-    async def aset(self, scope: StateScope, key: str, value: str) -> None:
-        async with create_session_async() as session:
+    async def aset(
+        self, scope: StateScope, key: str, value: str, *, session: AsyncSession | None = None
+    ) -> None:
+        async with _async_session(session) as s:
             match scope:
                 case TaskScope():
-                    await self._aset_task_state(scope, key, value, session=session)
+                    await self._aset_task_state(scope, key, value, session=s)
                 case AssetScope():
-                    await self._aset_asset_state(scope, key, value, session=session)
+                    await self._aset_asset_state(scope, key, value, session=s)
                 case _:
                     assert_never(scope)
 
-    async def adelete(self, scope: StateScope, key: str) -> None:
-        async with create_session_async() as session:
+    async def adelete(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> None:
+        async with _async_session(session) as s:
             match scope:
                 case TaskScope():
-                    await self._adelete_task_state(scope, key, session=session)
+                    await self._adelete_task_state(scope, key, session=s)
                 case AssetScope():
-                    await self._adelete_asset_state(scope, key, session=session)
+                    await self._adelete_asset_state(scope, key, session=s)
                 case _:
                     assert_never(scope)
 
-    async def aclear(self, scope: StateScope, *, all_map_indices: bool = False) -> None:
-        async with create_session_async() as session:
+    async def aclear(
+        self, scope: StateScope, *, all_map_indices: bool = False, session: AsyncSession | None = None
+    ) -> None:
+        async with _async_session(session) as s:
             match scope:
                 case TaskScope():
-                    await self._aclear_task_state(scope, all_map_indices=all_map_indices, session=session)
+                    await self._aclear_task_state(scope, all_map_indices=all_map_indices, session=s)
                 case AssetScope():
-                    await self._aclear_asset_state(scope, session=session)
+                    await self._aclear_asset_state(scope, session=s)
                 case _:
                     assert_never(scope)
 

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -69,7 +69,9 @@ class MetastoreStateBackend(BaseStateBackend):
     """Default state backend for tasks and assets. Stores task and asset state in the Airflow metadata database."""
 
     @provide_session
-    def get(self, scope: StateScope, key: str, *, session: Session = NEW_SESSION) -> str | None:
+    def get(self, scope: StateScope, key: str, *, session: Session | None = NEW_SESSION) -> str | None:
+        if TYPE_CHECKING:
+            assert session is not None
         match scope:
             case TaskScope():
                 return self._get_task_state(scope, key, session=session)
@@ -79,7 +81,9 @@ class MetastoreStateBackend(BaseStateBackend):
                 assert_never(scope)
 
     @provide_session
-    def set(self, scope: StateScope, key: str, value: str, *, session: Session = NEW_SESSION) -> None:
+    def set(self, scope: StateScope, key: str, value: str, *, session: Session | None = NEW_SESSION) -> None:
+        if TYPE_CHECKING:
+            assert session is not None
         match scope:
             case TaskScope():
                 self._set_task_state(scope, key, value, session=session)
@@ -89,7 +93,9 @@ class MetastoreStateBackend(BaseStateBackend):
                 assert_never(scope)
 
     @provide_session
-    def delete(self, scope: StateScope, key: str, *, session: Session = NEW_SESSION) -> None:
+    def delete(self, scope: StateScope, key: str, *, session: Session | None = NEW_SESSION) -> None:
+        if TYPE_CHECKING:
+            assert session is not None
         match scope:
             case TaskScope():
                 self._delete_task_state(scope, key, session=session)
@@ -104,8 +110,10 @@ class MetastoreStateBackend(BaseStateBackend):
         scope: StateScope,
         *,
         all_map_indices: bool = False,
-        session: Session = NEW_SESSION,
+        session: Session | None = NEW_SESSION,
     ) -> None:
+        if TYPE_CHECKING:
+            assert session is not None
         match scope:
             case TaskScope():
                 self._clear_task_state(scope, all_map_indices=all_map_indices, session=session)

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, select
@@ -36,9 +38,6 @@ if TYPE_CHECKING:
     from sqlalchemy.dialects.sqlite.dml import Insert as SQLiteInsert
     from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.orm import Session
-
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 
 
 @asynccontextmanager

--- a/airflow-core/tests/unit/state/test_metastore.py
+++ b/airflow-core/tests/unit/state/test_metastore.py
@@ -28,7 +28,7 @@ from airflow.models.dagrun import DagRun, DagRunType
 from airflow.models.task_state import TaskStateModel
 from airflow.state import AssetScope, TaskScope, resolve_state_backend
 from airflow.state.metastore import MetastoreStateBackend
-from airflow.utils.session import create_session
+from airflow.utils.session import create_session, create_session_async
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_assets, clear_db_dags, clear_db_runs
@@ -378,6 +378,16 @@ class TestMetastoreStateBackendAsync:
         scope = TaskScope(dag_id="nonexistent_dag", run_id="nonexistent_run", task_id=TASK_ID)
         with pytest.raises(ValueError, match="No DagRun found"):
             await backend.aset(scope, "job_id", "app_async")
+
+    async def test_aset_and_aget_with_provided_session(
+        self, backend: MetastoreStateBackend, dag_run_committed: DagRun
+    ):
+        """async methods use a provided AsyncSession when one is given."""
+        scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
+        async with create_session_async() as session:
+            await backend.aset(scope, "job_id", "app_with_session", session=session)
+            result = await backend.aget(scope, "job_id", session=session)
+        assert result == "app_with_session"
 
 
 class TestResolveStateBackend:

--- a/shared/state/src/airflow_shared/state/__init__.py
+++ b/shared/state/src/airflow_shared/state/__init__.py
@@ -119,7 +119,7 @@ class BaseStateBackend(ABC):
 
     @abstractmethod
     async def aset(
-        self, scope: StateScope, key: str, value: str, *, retention_days: int | None = None
+        self, scope: StateScope, key: str, value: str, *, session: Session | None = None
     ) -> None:
         """Async variant of set. Must handle both ``TaskScope`` and ``AssetScope``."""
 

--- a/shared/state/src/airflow_shared/state/__init__.py
+++ b/shared/state/src/airflow_shared/state/__init__.py
@@ -18,6 +18,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 @dataclass(frozen=True)
@@ -62,10 +66,16 @@ class BaseStateBackend(ABC):
                 ...  # asset-specific storage
 
     Custom backends are configured via ``[state_store] backend`` in ``airflow.cfg``.
+
+    **The ``session`` parameter on ``get``, ``set``, ``delete``, and ``clear``:**
+
+    The default ``MetastoreStateBackend`` passes a SQLAlchemy ``Session`` through
+    these methods. Custom backends that do not use SQLAlchemy should accept ``session`` as a
+    keyword argument and ignore it.
     """
 
     @abstractmethod
-    def get(self, scope: StateScope, key: str) -> str | None:
+    def get(self, scope: StateScope, key: str, *, session: Session | None = None) -> str | None:
         """
         Return the stored value, or None if the key does not exist.
 
@@ -73,7 +83,7 @@ class BaseStateBackend(ABC):
         """
 
     @abstractmethod
-    def set(self, scope: StateScope, key: str, value: str) -> None:
+    def set(self, scope: StateScope, key: str, value: str, *, session: Session | None = None) -> None:
         """
         Write or overwrite the value for the given key.
 
@@ -81,7 +91,7 @@ class BaseStateBackend(ABC):
         """
 
     @abstractmethod
-    def delete(self, scope: StateScope, key: str) -> None:
+    def delete(self, scope: StateScope, key: str, *, session: Session | None = None) -> None:
         """
         Delete a single key. No-op if the key does not exist.
 
@@ -89,7 +99,9 @@ class BaseStateBackend(ABC):
         """
 
     @abstractmethod
-    def clear(self, scope: StateScope, *, all_map_indices: bool = False) -> None:
+    def clear(
+        self, scope: StateScope, *, all_map_indices: bool = False, session: Session | None = None
+    ) -> None:
         """
         Delete all keys under the given scope.
 
@@ -106,7 +118,9 @@ class BaseStateBackend(ABC):
         """Async variant of get. Must handle both ``TaskScope`` and ``AssetScope``."""
 
     @abstractmethod
-    async def aset(self, scope: StateScope, key: str, value: str) -> None:
+    async def aset(
+        self, scope: StateScope, key: str, value: str, *, retention_days: int | None = None
+    ) -> None:
         """Async variant of set. Must handle both ``TaskScope`` and ``AssetScope``."""
 
     @abstractmethod

--- a/shared/state/src/airflow_shared/state/__init__.py
+++ b/shared/state/src/airflow_shared/state/__init__.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.orm import Session
 
 
@@ -114,29 +115,38 @@ class BaseStateBackend(ABC):
         """
 
     @abstractmethod
-    async def aget(self, scope: StateScope, key: str) -> str | None:
+    async def aget(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> str | None:
         """
         Async variant of get. Must handle both ``TaskScope`` and ``AssetScope``.
 
-        Async methods do not take a ``session`` argument — implementations are expected
-        to manage their own async sessions internally (e.g. via ``create_session_async``).
+        ``session`` is optional. If provided, implementations should use it directly.
+        If ``None``, implementations manage their own async session internally.
         """
 
     @abstractmethod
-    async def aset(self, scope: StateScope, key: str, value: str) -> None:
-        """Async variant of set. Must handle both ``TaskScope`` and ``AssetScope``."""
+    async def aset(
+        self, scope: StateScope, key: str, value: str, *, session: AsyncSession | None = None
+    ) -> None:
+        """
+        Async variant of set. Must handle both ``TaskScope`` and ``AssetScope``.
+
+        ``session`` is optional. If provided, implementations should use it directly.
+        If ``None``, implementations manage their own async session internally.
+        """
 
     @abstractmethod
-    async def adelete(self, scope: StateScope, key: str) -> None:
+    async def adelete(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> None:
         """
         Async variant of delete. Must handle both ``TaskScope`` and ``AssetScope``.
 
-        Async methods do not take a ``session`` argument — implementations manage their
-        own async sessions internally.
+        ``session`` is optional. If provided, implementations should use it directly.
+        If ``None``, implementations manage their own async session internally.
         """
 
     @abstractmethod
-    async def aclear(self, scope: StateScope, *, all_map_indices: bool = False) -> None:
+    async def aclear(
+        self, scope: StateScope, *, all_map_indices: bool = False, session: AsyncSession | None = None
+    ) -> None:
         """
         Async variant of clear. Must handle both ``TaskScope`` and ``AssetScope``.
 
@@ -144,6 +154,6 @@ class BaseStateBackend(ABC):
         scope are cleared. Pass ``all_map_indices=True`` to wipe state across every
         mapped instance of the task. For ``AssetScope`` the flag has no effect.
 
-        Async methods do not take a ``session`` argument — implementations manage their
-        own async sessions internally.
+        ``session`` is optional. If provided, implementations should use it directly.
+        If ``None``, implementations manage their own async session internally.
         """

--- a/shared/state/src/airflow_shared/state/__init__.py
+++ b/shared/state/src/airflow_shared/state/__init__.py
@@ -115,17 +115,25 @@ class BaseStateBackend(ABC):
 
     @abstractmethod
     async def aget(self, scope: StateScope, key: str) -> str | None:
-        """Async variant of get. Must handle both ``TaskScope`` and ``AssetScope``."""
+        """
+        Async variant of get. Must handle both ``TaskScope`` and ``AssetScope``.
+
+        Async methods do not take a ``session`` argument — implementations are expected
+        to manage their own async sessions internally (e.g. via ``create_session_async``).
+        """
 
     @abstractmethod
-    async def aset(
-        self, scope: StateScope, key: str, value: str, *, session: Session | None = None
-    ) -> None:
+    async def aset(self, scope: StateScope, key: str, value: str) -> None:
         """Async variant of set. Must handle both ``TaskScope`` and ``AssetScope``."""
 
     @abstractmethod
     async def adelete(self, scope: StateScope, key: str) -> None:
-        """Async variant of delete. Must handle both ``TaskScope`` and ``AssetScope``."""
+        """
+        Async variant of delete. Must handle both ``TaskScope`` and ``AssetScope``.
+
+        Async methods do not take a ``session`` argument — implementations manage their
+        own async sessions internally.
+        """
 
     @abstractmethod
     async def aclear(self, scope: StateScope, *, all_map_indices: bool = False) -> None:
@@ -135,4 +143,7 @@ class BaseStateBackend(ABC):
         For ``TaskScope``: by default, only keys for the exact ``map_index`` on the
         scope are cleared. Pass ``all_map_indices=True`` to wipe state across every
         mapped instance of the task. For ``AssetScope`` the flag has no effect.
+
+        Async methods do not take a ``session`` argument — implementations manage their
+        own async sessions internally.
         """


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Every call site in the execution API for task state and asset state passes `session=session` to `get_state_backend().get/set/delete/clear(...)`. This is required so the TI scope look-up and the state write share the same sqla transaction, avoiding a race condition where the TI could be deleted between the two operations (flagged in #66073). However, `BaseStateBackend` had no `session` parameter — the calls only worked at runtime because `@provide_session` on `MetastoreStateBackend` intercepts the kwarg. Any custom backend would crash with `TypeError: unexpected keyword argument 'session'`.

### Current behaviour

All twelve state backend call sites carry `# type: ignore[call-arg]` comments to silence mypy. A custom backend implementing `BaseStateBackend` would raise `TypeError` at runtime the moment any route called `get/set/delete/clear` on it.

### Proposed change

Adds `session: Session | None = None` to `get`, `set`, `delete`, and `clear` on `BaseStateBackend`. The `Session` type is imported under `TYPE_CHECKING` only, so there is no runtime SQLAlchemy dependency on the shared `airflow_shared.state` library. All twelve `# type: ignore[call-arg]` comments are removed.

**Alternatives considered:**

- *Remove `session=session` at call sites* — breaks transaction atomicity between scope look-up and write (Kaxil's concern in #66073).
- *`**kwargs`* — completely opaque; mypy cannot help and custom backend authors have no idea what can be passed.
- *`isinstance` check at every call site* — ugly, defeats the abstraction, requires importing `MetastoreStateBackend` into route layer.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
