### PR TITLE
Fix deferrable KPO trigger_reentry crash when pod is GC'd before re-entry

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -966,9 +966,30 @@ class KubernetesPodOperator(BaseOperator):
         pod_name = event["name"]
         pod_namespace = event["namespace"]
 
-        self.pod = self.hook.get_pod(pod_name, pod_namespace)
+        try:
+            self.pod = self.hook.get_pod(pod_name, pod_namespace)
+        except ApiException as e:
+            if e.status != 404:
+                raise
+            # Pod was GC'd between trigger firing and re-entry. This is common
+            # when the cluster reclaims completed pods aggressively or a
+            # higher-priority workload (e.g. daemonset) preempts the node.
+            self.log.warning(
+                "Pod %s/%s not found after resuming from deferral — already GC'd.",
+                pod_namespace,
+                pod_name,
+            )
+            if event["status"] == "success":
+                # Trigger already observed the pod completed successfully;
+                # logs/XCom are unrecoverable but the task itself succeeded.
+                return
+            raise PodNotFoundException(
+                f"Pod {pod_namespace}/{pod_name} not found after resuming from deferral"
+            ) from e
 
         if not self.pod:
+            # Defensive: get_pod is documented to raise on missing pods, but
+            # keep this for any subclass override that returns None instead.
             raise PodNotFoundException("Could not find pod after resuming from deferral")
 
         follow = self.logging_interval is None

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -3353,9 +3353,7 @@ class TestKubernetesPodOperatorAsync:
 
     @patch(POD_MANAGER_CLASS)
     @patch(HOOK_CLASS)
-    def test_async_trigger_reentry_returns_when_pod_gcd_on_success(
-        self, mocked_hook, mock_manager
-    ):
+    def test_async_trigger_reentry_returns_when_pod_gcd_on_success(self, mocked_hook, mock_manager):
         """Pod GC'd between trigger firing and reentry should not fail a successful task."""
         mocked_hook.return_value.get_pod.side_effect = ApiException(status=404, reason="Not Found")
         k = KubernetesPodOperator(task_id="task", deferrable=True)
@@ -3379,9 +3377,7 @@ class TestKubernetesPodOperatorAsync:
 
     @patch(POD_MANAGER_CLASS)
     @patch(HOOK_CLASS)
-    def test_async_trigger_reentry_raises_pod_not_found_on_failure(
-        self, mocked_hook, mock_manager
-    ):
+    def test_async_trigger_reentry_raises_pod_not_found_on_failure(self, mocked_hook, mock_manager):
         """Pod GC'd before reentry on a failed event surfaces as PodNotFoundException."""
         mocked_hook.return_value.get_pod.side_effect = ApiException(status=404, reason="Not Found")
         k = KubernetesPodOperator(task_id="task", deferrable=True)
@@ -3401,9 +3397,7 @@ class TestKubernetesPodOperatorAsync:
 
     @patch(POD_MANAGER_CLASS)
     @patch(HOOK_CLASS)
-    def test_async_trigger_reentry_propagates_non_404_api_exception(
-        self, mocked_hook, mock_manager
-    ):
+    def test_async_trigger_reentry_propagates_non_404_api_exception(self, mocked_hook, mock_manager):
         """Non-404 ApiException from get_pod should propagate unchanged."""
         mocked_hook.return_value.get_pod.side_effect = ApiException(status=500, reason="Server Error")
         k = KubernetesPodOperator(task_id="task", deferrable=True)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -39,7 +39,12 @@ from airflow.providers.cncf.kubernetes.operators.pod import (
 )
 from airflow.providers.cncf.kubernetes.secret import Secret
 from airflow.providers.cncf.kubernetes.triggers.pod import KubernetesPodTrigger
-from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction, PodLoggingStatus, PodPhase
+from airflow.providers.cncf.kubernetes.utils.pod_manager import (
+    OnFinishAction,
+    PodLoggingStatus,
+    PodNotFoundException,
+    PodPhase,
+)
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.providers.common.compat.sdk import (
     XCOM_RETURN_KEY,
@@ -3345,6 +3350,77 @@ class TestKubernetesPodOperatorAsync:
 
         k.execute(context)
         mocked_trigger_reentry.assert_called_once()
+
+    @patch(POD_MANAGER_CLASS)
+    @patch(HOOK_CLASS)
+    def test_async_trigger_reentry_returns_when_pod_gcd_on_success(
+        self, mocked_hook, mock_manager
+    ):
+        """Pod GC'd between trigger firing and reentry should not fail a successful task."""
+        mocked_hook.return_value.get_pod.side_effect = ApiException(status=404, reason="Not Found")
+        k = KubernetesPodOperator(task_id="task", deferrable=True)
+        context = create_context(k)
+        context["ti"] = MagicMock()
+
+        # Should return cleanly without raising
+        result = k.trigger_reentry(
+            context=context,
+            event={
+                "status": "success",
+                "message": TEST_SUCCESS_MESSAGE,
+                "name": TEST_NAME,
+                "namespace": TEST_NAMESPACE,
+            },
+        )
+
+        assert result is None
+        # await_pod_completion in _clean must not be called with self.pod=None
+        mock_manager.return_value.await_pod_completion.assert_not_called()
+
+    @patch(POD_MANAGER_CLASS)
+    @patch(HOOK_CLASS)
+    def test_async_trigger_reentry_raises_pod_not_found_on_failure(
+        self, mocked_hook, mock_manager
+    ):
+        """Pod GC'd before reentry on a failed event surfaces as PodNotFoundException."""
+        mocked_hook.return_value.get_pod.side_effect = ApiException(status=404, reason="Not Found")
+        k = KubernetesPodOperator(task_id="task", deferrable=True)
+        context = create_context(k)
+        context["ti"] = MagicMock()
+
+        with pytest.raises(PodNotFoundException):
+            k.trigger_reentry(
+                context=context,
+                event={
+                    "status": "failed",
+                    "message": "Some failure",
+                    "name": TEST_NAME,
+                    "namespace": TEST_NAMESPACE,
+                },
+            )
+
+    @patch(POD_MANAGER_CLASS)
+    @patch(HOOK_CLASS)
+    def test_async_trigger_reentry_propagates_non_404_api_exception(
+        self, mocked_hook, mock_manager
+    ):
+        """Non-404 ApiException from get_pod should propagate unchanged."""
+        mocked_hook.return_value.get_pod.side_effect = ApiException(status=500, reason="Server Error")
+        k = KubernetesPodOperator(task_id="task", deferrable=True)
+        context = create_context(k)
+        context["ti"] = MagicMock()
+
+        with pytest.raises(ApiException) as exc_info:
+            k.trigger_reentry(
+                context=context,
+                event={
+                    "status": "success",
+                    "message": TEST_SUCCESS_MESSAGE,
+                    "name": TEST_NAME,
+                    "namespace": TEST_NAMESPACE,
+                },
+            )
+        assert exc_info.value.status == 500
 
 
 @pytest.mark.parametrize("do_xcom_push", [True, False])


### PR DESCRIPTION
<!-- closes: #ISSUE -->
closes: #66715

## Problem

When `KubernetesPodOperator` runs in deferrable mode and the Kubernetes garbage collector deletes the pod in the window between the trigger firing a success/error/timeout event and the worker re-entering the task, `trigger_reentry` crashes.

The unguarded `self.pod = self.hook.get_pod(pod_name, pod_namespace)` raises `ApiException(404)` and escapes `trigger_reentry`. On provider versions before #56976 (which added `if self.pod is None: return` to `_clean`), the `finally` block additionally crashes with `AttributeError: 'NoneType' object has no attribute 'metadata'`, masking the original cause.

The existing dead-code branch right below the call:

```python
self.pod = self.hook.get_pod(pod_name, pod_namespace)

if not self.pod:
    raise PodNotFoundException("Could not find pod after resuming from deferral")
```

was clearly intended to handle this, but `hook.get_pod()` raises rather than returning `None`, so the translation never happens.

We hit this routinely on a Kubernetes cluster that aggressively reclaims completed pods:

```
File ".../operators/pod.py", line 834, in trigger_reentry
    self.pod = self.hook.get_pod(pod_name, pod_namespace)
kubernetes.client.exceptions.ApiException: (404) Not Found
{"message":"pods \"load-chiba-lotte-marines-player-tracking-bq-t0x42m45\" not found", ...}

During handling of the above exception, another exception occurred:
...
File ".../operators/pod.py", line 905, in _clean
    self.pod = self.pod_manager.await_pod_completion(...)
File ".../utils/pod_manager.py", line 808, in read_pod
    return self._client.read_namespaced_pod(pod.metadata.name, pod.metadata.namespace)
AttributeError: 'NoneType' object has no attribute 'metadata'
```

The trigger had already emitted `status: success` — the pod ran to completion successfully, was GC'd, and the worker resumed only to fail the task.

## Solution

Wrap the `get_pod` call so that:

- **Non-404 `ApiException`** re-raises unchanged.
- **404 + `event["status"] == "success"`** logs a warning and returns. The trigger already observed the pod completed successfully; logs/XCom are unrecoverable but the task itself succeeded, so retrying is wrong.
- **404 + non-success event** raises `PodNotFoundException`, matching the existing dead-code intent.

The pre-existing `if not self.pod:` branch is kept as a defensive guard for any subclass override that returns `None` instead of raising.

## Tests

Three new unit tests in `TestKubernetesPodOperatorAsync` covering the three branches:

- `test_async_trigger_reentry_returns_when_pod_gcd_on_success`
- `test_async_trigger_reentry_raises_pod_not_found_on_failure`
- `test_async_trigger_reentry_propagates_non_404_api_exception`

```
uv run --project providers/cncf/kubernetes pytest \
  providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py::TestKubernetesPodOperatorAsync \
  -k trigger_reentry -q
```

## Related prior work

- #39296 added `(HTTPError, ApiException)` handling around `_write_logs()` — runs after the unguarded `get_pod()`, doesn't help.
- #56976 added `if self.pod is None: return` to `_clean` — runs after, doesn't help.
- This PR closes the remaining gap at the unguarded `get_pod()` call itself.