### PR TITLE
docs(edge3): clarify WorkerQueuesBase.team_name is an experimental hint, cross-ref workload.rst

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -108,9 +108,12 @@ run on the central Airflow instance:
 To kick off a worker, you need to setup Airflow and kick off the worker
 subcommand.
 
-If your Airflow deployment uses Multi-Team mode, assign the worker to its team with
-the ``--team-name`` option so it only picks up jobs for that team. See
-:ref:`edge_executor:multi_team` for setup details and security considerations.
+If your Airflow deployment uses the experimental Multi-Team mode, assign the worker
+to its team with the ``--team-name`` option so it only picks up jobs for that team.
+The flag is a UI/REST API-level hint — the Execution API does not currently enforce
+team-based access boundaries. See :ref:`edge_executor:multi_team` for setup details
+and :doc:`apache-airflow:security/workload` (section "No team-level isolation in
+Execution API") for the security boundary.
 
 .. code-block:: bash
 

--- a/providers/edge3/docs/edge_executor.rst
+++ b/providers/edge3/docs/edge_executor.rst
@@ -89,9 +89,18 @@ each worker only picks up jobs assigned to its team.
 
     airflow edge worker --team-name team_a -q queue1,queue2
 
-When ``--team-name`` is omitted, the worker operates without team isolation — the
+When ``--team-name`` is omitted, the worker operates as a default-team worker — the
 same behavior as a single-team deployment. Existing workers continue to work without
 any changes.
+
+.. note::
+
+    ``--team-name`` is an experimental UI/REST API-level hint. The Execution API
+    does not currently enforce team-based access boundaries — workloads from
+    different teams share the same Execution API, JWT signing keys, and access to
+    connections, variables, and XComs. See
+    :doc:`apache-airflow:security/workload` (section "No team-level isolation in
+    Execution API") for the full security boundary discussion.
 
 **Per-team configuration overrides:**
 

--- a/providers/edge3/src/airflow/providers/edge3/cli/definition.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/definition.py
@@ -40,7 +40,13 @@ ARG_TEAM_NAME = Arg(
         "-t",
         "--team-name",
     ),
-    help="Team name for multi-team setups. If not provided, worker operates without team isolation.",
+    help=(
+        "Team name for the experimental ``[core] multi_team`` feature. This is a "
+        "UI/REST API-level hint; the Execution API does not currently enforce "
+        "team-based access boundaries (see ``airflow-core/docs/security/workload.rst``, "
+        "section 'No team-level isolation in Execution API'). If omitted, the worker "
+        "operates as a default-team worker."
+    ),
 )
 ARG_EDGE_HOSTNAME = Arg(
     ("-H", "--edge-hostname"),

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/datamodels.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/datamodels.py
@@ -125,7 +125,14 @@ class WorkerQueuesBase(BaseModel):
         str | None,
         Field(
             None,
-            description="Team name for multi-team setups. If not provided, worker operates without team isolation.",
+            description=(
+                "Team name for the experimental ``[core] multi_team`` feature. "
+                "This is a UI/REST API-level hint; the Execution API does not "
+                "currently enforce team-based access boundaries -- see "
+                "``airflow-core/docs/security/workload.rst`` (section: "
+                "'No team-level isolation in Execution API'). Workers without "
+                "team_name behave as default-team workers."
+            ),
         ),
     ] = None
 

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -1321,8 +1321,11 @@ components:
           - type: string
           - type: 'null'
           title: Team Name
-          description: Team name for multi-team setups. If not provided, worker operates
-            without team isolation.
+          description: 'Team name for the experimental ``[core] multi_team`` feature.
+            This is a UI/REST API-level hint; the Execution API does not currently
+            enforce team-based access boundaries -- see ``airflow-core/docs/security/workload.rst``
+            (section: ''No team-level isolation in Execution API''). Workers without
+            team_name behave as default-team workers.'
         state:
           $ref: '#/components/schemas/EdgeWorkerState'
           description: State of the worker from the view of the worker.
@@ -1435,8 +1438,11 @@ components:
           - type: string
           - type: 'null'
           title: Team Name
-          description: Team name for multi-team setups. If not provided, worker operates
-            without team isolation.
+          description: 'Team name for the experimental ``[core] multi_team`` feature.
+            This is a UI/REST API-level hint; the Execution API does not currently
+            enforce team-based access boundaries -- see ``airflow-core/docs/security/workload.rst``
+            (section: ''No team-level isolation in Execution API''). Workers without
+            team_name behave as default-team workers.'
         free_concurrency:
           type: integer
           title: Free Concurrency
@@ -1523,8 +1529,11 @@ components:
           - type: string
           - type: 'null'
           title: Team Name
-          description: Team name for multi-team setups. If not provided, worker operates
-            without team isolation.
+          description: 'Team name for the experimental ``[core] multi_team`` feature.
+            This is a UI/REST API-level hint; the Execution API does not currently
+            enforce team-based access boundaries -- see ``airflow-core/docs/security/workload.rst``
+            (section: ''No team-level isolation in Execution API''). Workers without
+            team_name behave as default-team workers.'
         state:
           $ref: '#/components/schemas/EdgeWorkerState'
           description: State of the worker from the view of the worker.


### PR DESCRIPTION
The current `WorkerQueuesBase.team_name` field description implies the field provides team isolation when set. `workload.rst` documents the actual contract: `[core] multi_team` is experimental, and the Execution API does not enforce team boundaries today. This PR aligns the field description with that documented stance so operators reading only the API datamodel see the same caveats `workload.rst` already states.

No behavior change. No new APIs. Docs / docstring only.

**Before:**
```
Team name for multi-team setups. If not provided, worker operates without team isolation.
```

**After:**
```
Team name for the experimental ``[core] multi_team`` feature. This is a UI/REST API-level hint; the Execution API does not currently enforce team-based access boundaries -- see ``airflow-core/docs/security/workload.rst`` (section: 'No team-level isolation in Execution API'). Workers without team_name behave as default-team workers.
```

Cross-reference: `airflow-core/docs/security/workload.rst` section "No team-level isolation in Execution API (experimental multi-team feature)".