### PR TITLE
Restrict owner-link and extra-link href to safe schemes (http, https, mailto, relative)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next";
 import { Link as RouterLink } from "react-router-dom";
 
 import { LimitedItemsList } from "src/components/LimitedItemsList";
+import { getSafeExternalUrl } from "src/utils/links";
 
 const DEFAULT_OWNERS: Array<string> = [];
 const MAX_OWNERS = 3;
@@ -34,7 +35,8 @@ export const DagOwners = ({
 }) => {
   const { t: translate } = useTranslation("dags");
   const items = owners.map((owner) => {
-    const ownerLink = ownerLinks?.[owner];
+    const rawOwnerLink = ownerLinks?.[owner];
+    const ownerLink = rawOwnerLink === undefined ? undefined : getSafeExternalUrl(rawOwnerLink);
     const ownerFilterLink = `/dags?owners=${owner}`;
     const hasOwnerLink = ownerLink !== undefined;
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx
@@ -22,6 +22,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 
 import { useTaskInstanceServiceGetExtraLinks } from "openapi/queries";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { getSafeExternalUrl } from "src/utils/links";
 
 type ExtraLinksProps = {
   readonly refetchInterval: number | false;
@@ -67,11 +68,17 @@ export const ExtraLinks = ({ refetchInterval }: ExtraLinksProps) => {
             return undefined;
           }
 
-          const target = getTarget(url);
+          const safeUrl = getSafeExternalUrl(url);
+
+          if (safeUrl === undefined) {
+            return undefined;
+          }
+
+          const target = getTarget(safeUrl);
 
           return (
             <Button asChild colorPalette="brand" key={key} variant="surface">
-              <a href={url} rel="noopener noreferrer" target={target}>
+              <a href={safeUrl} rel="noopener noreferrer" target={target}>
                 {key}
               </a>
             </Button>

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -20,7 +20,12 @@ import { describe, it, expect } from "vitest";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
-import { buildTaskInstanceUrl, getTaskInstanceAdditionalPath, getTaskInstanceLink } from "./links";
+import {
+  buildTaskInstanceUrl,
+  getSafeExternalUrl,
+  getTaskInstanceAdditionalPath,
+  getTaskInstanceLink,
+} from "./links";
 
 describe("getTaskInstanceLink", () => {
   const testCases = [
@@ -282,5 +287,42 @@ describe("buildTaskInstanceUrl", () => {
         taskId: "new_task",
       }),
     ).toBe("/dags/new_dag/runs/new_run/tasks/new_task/mapped");
+  });
+});
+
+describe("getSafeExternalUrl", () => {
+  describe("allows", () => {
+    const safeCases = [
+      ["http URL", "http://example.com/path"],
+      ["https URL", "https://example.com/path?q=1#anchor"],
+      ["mailto URL", "mailto:ops@example.com"],
+      ["relative absolute path", "/dags/my_dag"],
+      ["relative same-document fragment", "#section"],
+      ["relative query string", "?owner=me"],
+      ["same-origin absolute URL", `${globalThis.location.origin}/dags`],
+      ["URL with surrounding whitespace", "  https://example.com/x  "],
+    ];
+
+    it.each(safeCases)("passes through a %s", (_description, input) => {
+      expect(getSafeExternalUrl(input)).toBe(input.trim());
+    });
+  });
+
+  describe("rejects", () => {
+    const unsafeCases = [
+      ["javascript: URL", "javascript:alert(1)"],
+      ["javascript: URL with mixed case", "JavaScript:alert(1)"],
+      ["javascript: URL with leading whitespace", " javascript:alert(1)"],
+      ["data: URL", "data:text/html,<script>alert(1)</script>"],
+      ["file: URL", "file:///etc/passwd"],
+      ["vbscript: URL", "vbscript:msgbox(1)"],
+      ["ftp: URL", "ftp://example.com/file"],
+      ["empty string", ""],
+      ["whitespace-only string", "   "],
+    ];
+
+    it.each(unsafeCases)("returns undefined for a %s", (_description, input) => {
+      expect(getSafeExternalUrl(input)).toBeUndefined();
+    });
   });
 });

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -73,6 +73,55 @@ export const getTaskInstanceAdditionalPath = (pathname: string): string => {
   return "";
 };
 
+const SAFE_EXTERNAL_URL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+/**
+ * Pass-through filter for href values that originate outside the application —
+ * for example DAG-author-supplied `owner_links`, or operator extra-link URLs
+ * read from task-pushed XCom.
+ *
+ * Returns the URL unchanged when it is either a same-origin / relative path or
+ * uses one of the allow-listed schemes (`http:`, `https:`, `mailto:`).
+ * Returns `undefined` for any other scheme (`javascript:`, `data:`, `file:`,
+ * `vbscript:`, etc.) and for unparsable input, matching the scheme-allowlist
+ * policy already applied to markdown links via react-markdown's default
+ * `urlTransform` and to log / XCom linkification (which is `https?://`-only).
+ *
+ * Callers should fall back to plain text or skip rendering when this returns
+ * `undefined`.
+ */
+export const getSafeExternalUrl = (url: string): string | undefined => {
+  const trimmed = url.trim();
+
+  if (trimmed === "") {
+    return undefined;
+  }
+
+  let parsed: URL;
+
+  try {
+    parsed = new URL(trimmed, globalThis.location.origin);
+  } catch {
+    return undefined;
+  }
+
+  // Same-origin URL (relative input, or absolute pointing at our own origin).
+  // We have to compare against `location.origin` rather than just looking at
+  // the protocol because `new URL("/foo", origin)` produces a URL whose
+  // protocol is the origin's protocol (typically `http(s):`), so a
+  // protocol-only check would let through any non-allow-listed scheme that
+  // happens to share the origin's protocol shape.
+  if (parsed.origin === globalThis.location.origin) {
+    return trimmed;
+  }
+
+  if (SAFE_EXTERNAL_URL_SCHEMES.has(parsed.protocol)) {
+    return trimmed;
+  }
+
+  return undefined;
+};
+
 export const buildTaskInstanceUrl = (params: {
   currentPathname: string;
   dagId: string;


### PR DESCRIPTION
## Summary

Bring DAG `owner_links` and operator extra-link rendering in line with the scheme-allowlist policy already applied to markdown links (react-markdown's default [`urlTransform`](https://github.com/remarkjs/react-markdown#urltransform)) and log / XCom linkification (which is `https?://`-only).

Before this change, both surfaces rendered DAG-author-supplied URLs (`dag.owner_links` set in the DAG file; operator extra-link URLs commonly read from task-pushed XCom) directly as `<a href={url} target="_blank">` with no scheme filter. `target="_blank"` blocks `javascript:` navigation on every modern browser, so the application itself provided no defense in depth on the rare legacy / embedded webview that still navigates `javascript:` in a new tab.

After this change, both surfaces consult a shared `getSafeExternalUrl(url)` helper that passes through `http:` / `https:` / `mailto:` / relative URLs and returns `undefined` for anything else. Unsafe URLs are silently skipped on the extra-links page; the owner-link surface falls back to the existing in-app `/dags?owners=X` filter link.

## Files changed

- `airflow-core/src/airflow/ui/src/utils/links.ts` — new `getSafeExternalUrl` helper.
- `airflow-core/src/airflow/ui/src/utils/links.test.ts` — new vitest cases for the allow / reject matrix.
- `airflow-core/src/airflow/ui/src/pages/TaskInstance/ExtraLinks.tsx` — wrap extra-link `url` with the helper; skip rendering when undefined.
- `airflow-core/src/airflow/ui/src/pages/DagsList/DagOwners.tsx` — wrap `owner_links[owner]` with the helper; fall back to the filter-link when unsafe.

## Test plan

- [ ] `pnpm vitest run src/utils/links.test.ts` — 34 / 34 tests pass (8 allow + 9 reject cases for `getSafeExternalUrl`, plus the existing tests)
- [ ] `pnpm lint` — eslint clean, `tsc --p tsconfig.app.json` clean
- [ ] `prek run --from-ref upstream/main --stage pre-commit` — clean

## Migration

DAG-author-supplied `owner_links` entries using non-allowlisted schemes (`javascript:`, `data:`, `file:`, etc.) are silently skipped on the UI and fall back to the in-app owner-filter link; same for operator extra-links carrying such schemes. No DAG-level API surface changes.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
