### PR TITLE
[v3-2-test] Add jobless_supervisor fixture for backported triggerer-FD test

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -402,6 +402,43 @@ def test_trigger_logger_fd_closed_when_removed(session):
     trigger_runner_supervisor.kill(force=False)
 
 
+@pytest.fixture
+def jobless_supervisor(mocker):
+    """Build a TriggerRunnerSupervisor with a mock Job, for testing request-handling paths
+    that don't depend on a real DB-backed Job.
+
+    Named ``jobless_supervisor`` for naming parity with main, where the supervisor's ``job``
+    parameter is genuinely optional (made optional in #66006 — not backported to v3-2-test).
+    The test that uses this fixture (``test_trigger_logger_fd_closed_when_upload_to_remote_raises``)
+    only exercises ``logger_cache``, ``running_triggers``, and ``_handle_request``, none of
+    which touch the ``job`` attribute, so a Mock(spec=Job) is sufficient.
+    """
+    import psutil
+
+    job = mocker.Mock(spec=Job)
+    job.id = 42
+    job.hostname = "test-host"
+
+    process = mocker.Mock(spec=psutil.Process, pid=42)
+    mock_stdin = mocker.Mock(spec=socket)
+    mock_stdin.write = mocker.Mock()
+    mock_stdin.sendall = mocker.Mock()
+
+    supervisor = TriggerRunnerSupervisor(
+        process_log=mocker.Mock(spec=FilteringBoundLogger),
+        id=uuid.uuid4(),
+        job=job,
+        pid=process.pid,
+        stdin=mock_stdin,
+        process=process,
+        capacity=10,
+    )
+    mock_selector = mocker.Mock(spec=selectors.DefaultSelector)
+    mock_selector.select.return_value = []
+    supervisor.selector = mock_selector
+    return supervisor
+
+
 def test_trigger_logger_fd_closed_when_upload_to_remote_raises(jobless_supervisor):
     """If upload_to_remote() raises during finished-trigger cleanup, the FD must still be closed.
 


### PR DESCRIPTION
## Summary

`v3-2-test` is currently red because `airflow-core/tests/unit/jobs/test_triggerer_job.py::test_trigger_logger_fd_closed_when_upload_to_remote_raises` fails at setup with `fixture 'jobless_supervisor' not found`.

## Root cause

The test was backported to v3-2-test by #66684 (auto-cherry-pick of #66675). But the `jobless_supervisor` fixture that the test consumes was added on `main` by a different, *earlier* PR — #66006 "Make TriggerRunnerSupervisor.job optional" — which was **not** backported to v3-2-test because it's a feature change, not a fix.

So the test cherry-pick brought a single test definition that references a fixture that doesn't exist on this branch. Setup error → 1 ERROR → all Core...Serialization jobs red across every DB/Python matrix cell.

## Why not cherry-pick #66006

Tried it; conflicts in 4 regions of `airflow-core/src/airflow/jobs/triggerer_job_runner.py` totalling ~150 lines (v3-2-test has diverged since 2026-04-30). Also: #66006 is a *feature* (makes `TriggerRunnerSupervisor.job` optional). v3-2-test should generally take only fix backports, so dragging the whole feature in just to satisfy a fixture name is the wrong shape.

## What this PR does

Adds a `jobless_supervisor` fixture to v3-2-test's `test_triggerer_job.py`, with the same name and shape as main's, but adapted for the fact that `TriggerRunnerSupervisor.job` is still required on this branch. Uses `mocker.Mock(spec=Job)` instead of `job=None`. The test that consumes it (`test_trigger_logger_fd_closed_when_upload_to_remote_raises`) only exercises `logger_cache`, `running_triggers`, and `_handle_request` — none of which touch `.job` — so the mock is sufficient.

## Test plan

- [x] `uv run --project airflow-core pytest airflow-core/tests/unit/jobs/test_triggerer_job.py::test_trigger_logger_fd_closed_when_upload_to_remote_raises -xvs` — PASSED on this branch.
- [x] No other test references `jobless_supervisor` on v3-2-test (would be unintended scope creep).
- [x] Fixture matches main's naming so a future full backport of #66006 will replace it cleanly without name churn.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)