### PR TITLE
Fix system test bugs in bedrock_guardrail, glue_catalog, and s3_vectors

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_guardrail.py
@@ -84,6 +84,12 @@ with DAG(
         guardrail_name=f"{env_id}-guardrail-updated",
         blocked_input_messaging="Updated: input blocked.",
         blocked_outputs_messaging="Updated: output blocked.",
+        content_policy_config={
+            "filtersConfig": [
+                {"type": "HATE", "inputStrength": "HIGH", "outputStrength": "HIGH"},
+                {"type": "VIOLENCE", "inputStrength": "HIGH", "outputStrength": "HIGH"},
+            ]
+        },
     )
     # [END howto_operator_bedrock_update_guardrail]
 

--- a/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
+++ b/providers/amazon/tests/system/amazon/aws/example_glue_catalog.py
@@ -75,6 +75,7 @@ with DAG(
             "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
             "SerdeInfo": {"SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"},
         },
+        "PartitionKeys": [{"Name": "dt", "Type": "string"}],
         "TableType": "EXTERNAL_TABLE",
     }
 

--- a/providers/amazon/tests/system/amazon/aws/example_s3_vectors.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_vectors.py
@@ -64,7 +64,7 @@ with DAG(
         vector_bucket_name=bucket_name,
         index_name=index_name,
         data_type="float32",
-        dimension=128,
+        dimension=4,
         distance_metric="cosine",
     )
     # [END howto_operator_s3vectors_create_index]


### PR DESCRIPTION
## Summary
- **bedrock_guardrail**: Add content policy to UpdateGuardrail call (API now requires at least one policy)
- **glue_catalog**: Add partition keys to table creation so CreatePartition succeeds
- **s3_vectors**: Fix vector dimension mismatch between index (128) and test data (4)

## Test plan
- [ ] Run each system test end-to-end via CodeBuild
- [ ] Verify no regressions in other system tests

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)