### PR TITLE
Fix Dag run scheduling after coarser schedule changes

### DIFF
--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -111,18 +111,12 @@ class _DataIntervalTimetable(Timetable):
                 # Data interval starts from the end of the previous interval.
                 start = align_last_data_interval_end
 
-            # CronTriggerTimetable stores its runs as point-in-time intervals
-            # (start == end == logical_date). After a switch to a
-            # CronDataIntervalTimetable the aligned `start` lands back on that
-            # same logical_date, so without this guard we'd propose a run
-            # identical to the existing one — which collides with the
-            # (dag_id, logical_date) unique constraint and leaves the scheduler
-            # looping on "run already exists; skipping dagrun creation" until
-            # the next period elapses. Advance one period to skip past it.
-            if (
-                last_automated_data_interval.start == last_automated_data_interval.end
-                and start == last_automated_data_interval.start
-            ):
+            # When the Dag has a new schedule, aligning the previous interval
+            # end can land on (or before) the previous logical date. Re-emitting
+            # that logical date collides with the existing Dag run and leaves
+            # the scheduler looping on "run already exists; skipping dagrun
+            # creation". Advance one period to skip past it.
+            if start <= last_automated_data_interval.start:
                 start = self._get_next(start)
         if restriction.latest is not None and start > restriction.latest:
             return None

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -91,6 +91,27 @@ def test_zero_length_last_interval_does_not_re_emit_logical_date(catchup: bool) 
 
 
 @pytest.mark.parametrize(
+    "catchup",
+    [pytest.param(True, id="catchup_true"), pytest.param(False, id="catchup_false")],
+)
+@time_machine.travel(pendulum.DateTime(2026, 5, 6, tzinfo=utc))
+def test_coarser_new_schedule_does_not_re_emit_previous_logical_date(catchup: bool) -> None:
+    """When a Dag moves from hourly to daily, don't re-emit the old logical date."""
+    timetable = CronDataIntervalTimetable("0 0 * * *", utc)
+    last = DataInterval(
+        start=pendulum.DateTime(2026, 5, 4, tzinfo=utc),
+        end=pendulum.DateTime(2026, 5, 4, 1, tzinfo=utc),
+    )
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=catchup),
+    )
+    expected_start = pendulum.DateTime(2026, 5, 5, tzinfo=utc)
+    expected_end = pendulum.DateTime(2026, 5, 6, tzinfo=utc)
+    assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+@pytest.mark.parametrize(
     "earliest",
     [pytest.param(None, id="none"), pytest.param(START_DATE, id="start_date")],
 )


### PR DESCRIPTION
## Summary

- prevent data-interval timetables from re-emitting an existing logical date after a Dag schedule changes to a coarser cadence
- keep the existing zero-length interval guard working while covering hourly-to-daily schedule changes
- add a regression test for the issue scenario

Fixes #66754

## Tests

- `uv run ruff format airflow-core/src/airflow/timetables/interval.py airflow-core/tests/unit/timetables/test_interval_timetable.py`
- `uv run ruff check --fix airflow-core/src/airflow/timetables/interval.py airflow-core/tests/unit/timetables/test_interval_timetable.py`
- `uv run --project airflow-core pytest airflow-core/tests/unit/timetables/test_interval_timetable.py -q`