### PR TITLE
Fix scheduler dag-version refresh deadlock with PK-ordered locking

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -142,6 +142,9 @@ DM = DagModel
 TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 """:meta private:"""
 
+_DAG_VERSION_REFRESH_BATCH_SIZE = 1000
+"""Maximum number of task instances to lock per dag-version refresh batch."""
+
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
     """
@@ -2520,18 +2523,36 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
         if not dag_run.dag:
             return False
-        # Bulk update dag_version_id for unfinished TIs instead of loading all TIs into memory.
-        # Use synchronize_session=False since we handle cache coherence via session.expire() below.
-        session.execute(
-            update(TI)
-            .where(
-                TI.dag_id == dag_run.dag_id,
-                TI.run_id == dag_run.run_id,
-                TI.state.in_(State.unfinished),
+        # Lock TIs in PK order with SKIP LOCKED to match writers that lock by primary
+        # key (e.g. the api-server's ti_update_state path); the previous bulk UPDATE
+        # locked via the (dag_id, run_id) index and could deadlock with PK-ordered
+        # writers under concurrent task state updates. Filtering on dag_version_id
+        # ensures each batch advances past already-updated rows so the loop terminates.
+        while True:
+            candidates = (
+                select(TI.id)
+                .where(
+                    TI.dag_id == dag_run.dag_id,
+                    TI.run_id == dag_run.run_id,
+                    TI.state.in_(State.unfinished),
+                    or_(TI.dag_version_id.is_(None), TI.dag_version_id != latest_dag_version.id),
+                )
+                .order_by(TI.id)
+                .limit(_DAG_VERSION_REFRESH_BATCH_SIZE)
             )
-            .values(dag_version_id=latest_dag_version.id),
-            execution_options={"synchronize_session": False},
-        )
+            task_instance_ids = session.scalars(
+                with_row_locks(candidates, of=TI, session=session, skip_locked=True, key_share=False)
+            ).all()
+            if not task_instance_ids:
+                break
+            session.execute(
+                update(TI)
+                .where(TI.id.in_(task_instance_ids))
+                .values(dag_version_id=latest_dag_version.id)
+                .execution_options(synchronize_session=False)
+            )
+            if len(task_instance_ids) < _DAG_VERSION_REFRESH_BATCH_SIZE:
+                break
         # Expire task_instances relationship so next access fetches fresh data from DB
         session.expire(dag_run, ["task_instances"])
         # Verify integrity also takes care of session.flush

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4745,6 +4745,74 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    def test_verify_integrity_processes_more_than_one_batch(self, dag_maker, monkeypatch):
+        """Bulk dag_version_id refresh processes all TIs across multiple batches."""
+        dag_id = "test_verify_integrity_processes_more_than_one_batch"
+        with create_session() as session:
+            session.execute(
+                delete(SerializedDagModel).where(SerializedDagModel.dag_id == dag_id),
+                execution_options={"synchronize_session": False},
+            )
+
+        initial_task_ids = {f"dummy_{i}" for i in range(3)}
+        with dag_maker(dag_id=dag_id, serialized=False) as dag:
+            for task_id in sorted(initial_task_ids):
+                BashOperator(task_id=task_id, bash_command="echo hi")
+
+        session = settings.Session()
+        orm_dag = dag_maker.dag_model
+        assert orm_dag is not None
+        SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="testing")
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        self.job_runner._create_dag_runs([orm_dag], session)
+        drs = DagRun.find(dag_id=dag.dag_id, session=session)
+        assert len(drs) == 1
+        dr = drs[0]
+        assert dr.bundle_version is None
+
+        # Set explicit state because _create_dag_runs leaves TI.state NULL, and
+        # SQL three-valued logic excludes NULL from `state IN (State.unfinished)`,
+        # which would silently skip the batch UPDATE under test.
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.dag_id == dr.dag_id, TaskInstance.run_id == dr.run_id)
+            .values(state=State.SCHEDULED),
+            execution_options={"synchronize_session": False},
+        )
+
+        BashOperator(task_id="dummy_3", dag=dag, bash_command="echo hi")
+        SerializedDagModel.write_dag(
+            LazyDeserializedDAG.from_dag(dag), bundle_name="testing", session=session
+        )
+        session.commit()
+        dag_version_2 = DagVersion.get_latest_version(dr.dag_id, session=session)
+
+        # Force the multi-batch path: 3 initial TIs with batch_size=2 -> 2 + 1.
+        # Mock out the trailing verify_integrity call so this test focuses on the batch loop only;
+        # the missing-task creation path is already covered by test_verify_integrity_if_dag_changed.
+        monkeypatch.setattr("airflow.jobs.scheduler_job_runner._DAG_VERSION_REFRESH_BATCH_SIZE", 2)
+        with mock.patch("airflow.jobs.scheduler_job_runner.DagRun.verify_integrity"):
+            self.job_runner._verify_integrity_if_dag_changed(dag_run=dr, session=session)
+        session.commit()
+
+        session.expire_all()
+        initial_tis = session.scalars(
+            select(TaskInstance).where(
+                TaskInstance.dag_id == dr.dag_id,
+                TaskInstance.run_id == dr.run_id,
+                TaskInstance.task_id.in_(initial_task_ids),
+            )
+        ).all()
+        assert len(initial_tis) == 3
+        for ti in initial_tis:
+            assert ti.dag_version_id == dag_version_2.id
+
+        session.rollback()
+        session.close()
+
     def test_verify_integrity_not_called_for_versioned_bundles(self, dag_maker, session):
         with dag_maker("test_verify_integrity_if_dag_not_changed") as dag:
             BashOperator(task_id="dummy", bash_command="echo hi")


### PR DESCRIPTION
related: #66734

After upgrading to 3.2.1 we hit periodic Postgres deadlocks on `task_instance` between two writers that lock the same rows in different orders:

- scheduler's `_verify_integrity_if_dag_changed` issues `UPDATE task_instance ... WHERE dag_id=? AND run_id=? AND state IN (...)`, which the planner satisfies via the `(dag_id, run_id)` index
- api-server's `ti_update_state` does `SELECT FOR UPDATE` on the same rows by primary key

When the row sets overlap, PG aborts one of them with `deadlock detected`. Traceback and pg_stat_activity output are in #66734.

This PR replaces the bulk UPDATE with a `SELECT id ORDER BY id LIMIT N FOR UPDATE SKIP LOCKED` + `UPDATE WHERE id IN (...)` batch loop, so the scheduler also locks in PK order. Same approach #65920 takes for `check_trigger_timeouts`; #65818 tracks this family of bugs.

One thing that bit me on the way: the inner UPDATE only changes `dag_version_id`, not `state`, so a SELECT filtered solely on `state IN (State.unfinished)` keeps returning the same N ids on every iteration and the loop never terminates once the batch is full. The candidate SELECT also filters on `dag_version_id IS NULL OR != latest_dag_version.id` so each batch advances. The previous single bulk UPDATE never surfaced this; the batched form needs it.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)