### PR TITLE
Fix DAG owners filter matching unintended substrings

### DIFF
--- a/airflow-core/newsfragments/66775.bugfix.rst
+++ b/airflow-core/newsfragments/66775.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the ``owners`` filter on the public ``GET /dags`` endpoint to match whole comma-separated elements instead of any substring of the stored value. Previously a filter like ``owners=Admin`` also matched Dags whose owners were ``NotAnAdmin``; the filter now matches only when ``Admin`` is one of the listed owners.

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -770,7 +770,16 @@ class _TagsFilter(BaseParam[_TagFilterModel]):
 
 
 class _OwnersFilter(BaseParam[list[str]]):
-    """Filter on owners."""
+    """
+    Filter Dags by owner, matching whole comma-separated elements.
+
+    ``DagModel.owners`` is stored as a ``", "``-joined string of one or more owners
+    (see ``DAG.owner``). A naive substring match returns false positives whenever the
+    filter value is a substring of any stored owner — e.g. ``owners=Admin`` matched a
+    Dag whose owner was ``NotAnAdmin``. To get exact-element semantics while keeping
+    a single index-friendly ILIKE per term, we normalise the separator to ``,``, wrap
+    the column with sentinel commas, and search for ``,<owner>,``.
+    """
 
     def to_orm(self, select: Select) -> Select:
         if self.skip_none is False:
@@ -779,7 +788,18 @@ class _OwnersFilter(BaseParam[list[str]]):
         if not self.value:
             return select
 
-        conditions = [DagModel.owners.ilike(f"%{owner}%") for owner in self.value]
+        # Replace ``", "`` with ``","`` (the SDK joins owners with ``", "``), then wrap
+        # the column with leading and trailing commas. Comparing against ``,<owner>,``
+        # gives whole-element matching across SQLite / Postgres / MySQL. ``func.replace``
+        # returns a generic SQL function whose result type defaults to ``NullType``; we
+        # ``cast`` it to ``String`` so the ``||`` / ``+`` concatenation compiles to a
+        # string concat on every supported backend (``||`` on SQLite / Postgres,
+        # ``CONCAT()`` on MySQL via SQLAlchemy's string-type dispatch).
+        from sqlalchemy import String, cast
+
+        normalised = cast(func.replace(DagModel.owners, ", ", ","), String)
+        padded_owners = "," + normalised + ","
+        conditions = [padded_owners.ilike(f"%,{owner},%") for owner in self.value]
         return select.where(or_(*conditions))
 
     @classmethod

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from airflow.api_fastapi.common.parameters import (
     FilterParam,
     SortParam,
+    _OwnersFilter,
     _PrefixPatternParam,
     _PrefixSearchParam,
     _SearchParam,
@@ -335,3 +336,49 @@ class TestTaskDisplayNamePrefixPatternParam:
 
         sql = _compile(statement)
         assert "true" in sql or "1 = 1" in sql
+
+
+class TestOwnersFilter:
+    """
+    ``DagModel.owners`` is a ``", "``-joined string of one or more owners. The filter must
+    match a stored element as a whole — substring matches against an element are the bug
+    we are guarding against (e.g. ``owners=Admin`` returning a Dag with ``owners="NotAnAdmin"``).
+    """
+
+    def test_to_orm_empty_value_is_noop(self):
+        """An empty list leaves the statement unchanged."""
+        param = _OwnersFilter().set_value([])
+        statement = select(DagModel)
+        result = param.to_orm(statement)
+        assert result is statement
+
+    def test_to_orm_single_owner_uses_sentinel_wrapped_ilike(self):
+        """The compiled predicate wraps the column with sentinel commas, so the match is
+        on a whole element."""
+        param = _OwnersFilter().set_value(["airflow"])
+        statement = select(DagModel)
+        statement = param.to_orm(statement)
+
+        sql = _compile(statement)
+        # Whole-element pattern, not the naive ``'%airflow%'``.
+        assert "'%,airflow,%'" in sql
+        # The naive substring pattern (the bug) must not appear.
+        assert "'%airflow%'" not in sql
+
+    def test_to_orm_multiple_owners_or_together(self):
+        """Multiple owner values produce an OR of whole-element matches."""
+        param = _OwnersFilter().set_value(["airflow", "admin"])
+        statement = select(DagModel)
+        statement = param.to_orm(statement)
+
+        sql = _compile(statement)
+        assert " or " in sql
+        assert "'%,airflow,%'" in sql
+        assert "'%,admin,%'" in sql
+
+    def test_to_orm_skip_none_false_is_rejected(self):
+        """``skip_none=False`` is unsupported and surfaces loudly rather than silently
+        treating ``[]`` as a match-all."""
+        param = _OwnersFilter(skip_none=False).set_value(["airflow"])
+        with pytest.raises(ValueError, match="Cannot set 'skip_none' to False"):
+            param.to_orm(select(DagModel))

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -270,6 +270,19 @@ class TestGetDags(TestDagEndpoint):
                 [DAG1_ID, DAG2_ID],
             ),
             ({"owners": ["test_owner"], "exclude_stale": False}, 1, [DAG3_ID]),
+            # Comma-separated owners stored on DAG3 ("test_owner,another_test_owner") must
+            # match the second element exactly, not via substring of the first.
+            ({"owners": ["another_test_owner"], "exclude_stale": False}, 1, [DAG3_ID]),
+            # Substrings of any stored owner must NOT match — the filter is exact-element.
+            ({"owners": ["owner"], "exclude_stale": False}, 0, []),
+            ({"owners": ["another_test"], "exclude_stale": False}, 0, []),
+            ({"owners": ["air"], "exclude_stale": False}, 0, []),
+            # Multiple values OR together, each matching exact elements.
+            (
+                {"owners": ["airflow", "another_test_owner"], "exclude_stale": False},
+                3,
+                [DAG1_ID, DAG2_ID, DAG3_ID],
+            ),
             ({"last_dag_run_state": "success", "exclude_stale": False}, 1, [DAG3_ID]),
             ({"last_dag_run_state": "failed", "exclude_stale": False}, 1, [DAG1_ID]),
             ({"dag_run_state": "failed"}, 1, [DAG1_ID]),


### PR DESCRIPTION
`GET /dags` filters by `owners` using a substring match against `DagModel.owners`, which stores team owners as a comma-joined string. Filtering for `team_a` therefore also matches Dags owned by `team_a_legacy` or `team_a_archive`. This PR switches to a whole-element match so the filter only returns Dags whose owners list actually contains the requested value.

Hundreds of Dags on our cluster at LinkedIn Data Infrastructure are grouped by team owner — internal tooling filters the public `GET /dags` by `owners` to drive per-team views and route alerts. We hit a confusing case where filtering for `team_a` quietly also picked up `team_a_legacy` and `team_a_archive`. Tracked it down to a substring scan against the comma-joined `DagModel.owners`; this PR makes the match whole-element.

Closes #42790.

`_OwnersFilter` (in `airflow-core/src/airflow/api_fastapi/common/parameters.py`) filters `DagModel.owners` with `ilike(f"%{owner}%")`. Because `DagModel.owners` is the comma-joined list of all task owners for a DAG, filtering for `Admin` returns DAGs whose owner is `NotAnAdmin` — `%Admin%` substring-matches anywhere in the joined string.

The fix normalises the column to `,owner1,owner2,...,owner_n,` and ILIKEs against `'%,<owner>,%'`. `func.replace` returns a generic SQL function whose default result type is `NullType`, so we wrap it in `cast(..., String)` and concatenate the leading/trailing commas with `+` — SQLAlchemy compiles that to `||` on SQLite/Postgres and `CONCAT()` on MySQL. Single ILIKE per term, cross-dialect, index-friendly enough that the existing pagination plan doesn't regress.

Affects `GET /dags`, `GET /ui/dags`, and any endpoint sharing `_OwnersFilter`.

## Tests

- `airflow-core/tests/unit/api_fastapi/common/test_parameters.py::TestOwnersFilter` — compiles the statements and asserts the rendered SQL contains `'%,airflow,%'` rather than `'%airflow%'`.
- `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py::TestGetDags` — parametrized integration cases including the canonical collision (filter `owner` against stored `test_owner,another_test_owner` returns 0 results; filter `another_test_owner` returns the DAG; multi-value OR works).

The new tests fail on `main` (wrong row counts under the substring predicate) and pass with this PR.

## Reproducer

Standalone SQLAlchemy script that builds an in-memory SQLite `dag` table, seeds it with overlapping owners (`team_a`, `team_a, team_b`, `team_a_legacy`, `not_team_a`, `team_admin`, …), then runs `_OwnersFilter`-shaped predicates compiled both ways against the same data:

```python
from sqlalchemy import Column, String, create_engine, func, or_, select
from sqlalchemy.orm import DeclarativeBase, Session


class Base(DeclarativeBase):
    pass


class DagModel(Base):
    __tablename__ = "dag"
    dag_id: str = Column(String(250), primary_key=True)
    owners: str = Column(String(2000), nullable=True)


def filter_fixed(stmt, values):
    from sqlalchemy import cast

    normalised = cast(func.replace(DagModel.owners, ", ", ","), String)
    padded = "," + normalised + ","
    conditions = [padded.ilike(f"%,{owner},%") for owner in values]
    return stmt.where(or_(*conditions))


def filter_main(stmt, values):
    conditions = [DagModel.owners.ilike(f"%{owner}%") for owner in values]
    return stmt.where(or_(*conditions))


def run(label, filter_fn):
    print(f"--- {label} — owners=team_a ---")
    with Session(engine) as session:
        stmt = filter_fn(select(DagModel.dag_id, DagModel.owners), ["team_a"])
        rows = session.execute(stmt).all()
        for dag_id, owners in rows:
            print(f"  {dag_id:<22} owners={owners!r}")
        print(f"  ({len(rows)} row{'s' if len(rows) != 1 else ''})")
    print()


engine = create_engine("sqlite:///:memory:")
Base.metadata.create_all(engine)

with Session(engine) as session:
    session.add_all(
        [
            DagModel(dag_id="dag_owned_by_team_a",        owners="team_a"),
            DagModel(dag_id="dag_owned_by_team_a_and_b",  owners="team_a, team_b"),
            DagModel(dag_id="dag_owned_by_b_then_team_a", owners="team_b, team_a"),
            DagModel(dag_id="dag_owned_by_team_a_legacy", owners="team_a_legacy"),
            DagModel(dag_id="dag_owned_by_not_team_a",    owners="not_team_a"),
            DagModel(dag_id="dag_owned_by_team_admin",    owners="team_admin"),
            DagModel(dag_id="dag_owned_by_unrelated",     owners="team_b, team_c"),
        ]
    )
    session.commit()

run("main (substring match — bug)", filter_main)
run("this PR (whole-element match)", filter_fixed)
```

### Before (on `main` — substring-match)

`?owners=team_a` returns six rows, including three false positives (`team_a_legacy`, `not_team_a`, `team_admin`):

```
--- main (substring match — bug) — owners=team_a ---
  dag_owned_by_team_a    owners='team_a'
  dag_owned_by_team_a_and_b owners='team_a, team_b'
  dag_owned_by_b_then_team_a owners='team_b, team_a'
  dag_owned_by_team_a_legacy owners='team_a_legacy'
  dag_owned_by_not_team_a owners='not_team_a'
  dag_owned_by_team_admin owners='team_admin'
  (6 rows)
```

### After (with this PR — whole-element match)

`?owners=team_a` returns only the three Dags that actually have `team_a` as a whole element of their owner list:

```
--- this PR (whole-element match) — owners=team_a ---
  dag_owned_by_team_a    owners='team_a'
  dag_owned_by_team_a_and_b owners='team_a, team_b'
  dag_owned_by_b_then_team_a owners='team_b, team_a'
  (3 rows)
```

The same FAILED → PASSED transition is reproducible via the included unit tests: `git checkout upstream/main -- airflow-core/src/airflow/api_fastapi/common/parameters.py` and re-run `pytest airflow-core/tests/unit/api_fastapi/common/test_parameters.py::TestOwnersFilter` — `test_to_orm_single_owner_uses_sentinel_wrapped_ilike` fails with the compiled `lower(dag.owners) like lower('%airflow%')` predicate; restoring the fix flips it back to PASSED.

