### PR TITLE
Fix scheduler MySQL task instance index hint

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -618,7 +618,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Select only rows where row_number <= max_active_tasks.
             query = (
                 select(TI)
-                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
                 .select_from(ranked_query)
                 .join(
                     TI,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -37,6 +37,7 @@ import psutil
 import pytest
 import time_machine
 from sqlalchemy import delete, func, select, update
+from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import joinedload
 
 from airflow import settings
@@ -1231,6 +1232,34 @@ class TestSchedulerJob:
         assert len(queued_tis) == 2
         assert {x.key for x in queued_tis} == {ti_non_backfill.key, ti_backfill.key}
         session.rollback()
+
+    def test_find_executable_task_instances_mysql_hint_only_applies_to_inner_query(self, dag_maker, session):
+        dag_id = "SchedulerJobTest.test_find_executable_task_instances_mysql_hint_only_applies_to_inner_query"
+        task_id = "dummy"
+        with dag_maker(dag_id=dag_id, max_active_tasks=16):
+            task = EmptyOperator(task_id=task_id)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
+        ti = dag_run.get_task_instance(task.task_id)
+        ti.state = State.SCHEDULED
+        session.merge(ti)
+        session.flush()
+
+        captured_queries = []
+
+        def capture_locked_query(query, **kwargs):
+            captured_queries.append(query)
+            return query
+
+        with mock.patch("airflow.jobs.scheduler_job_runner.with_row_locks", side_effect=capture_locked_query):
+            queued_tis = self.job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
+
+        assert {queued_ti.key for queued_ti in queued_tis} == {ti.key}
+        compiled_query = str(captured_queries[0].compile(dialect=mysql.dialect()))
+        assert compiled_query.count("USE INDEX (ti_state)") == 1
 
     def test_find_executable_task_instances_pool(self, dag_maker):
         dag_id = "SchedulerJobTest.test_find_executable_task_instances_pool"


### PR DESCRIPTION
  closes: #66763

  ## Summary

  `SchedulerJobRunner._executable_task_instances_to_queued` applied `USE INDEX (ti_state)` twice on MySQL: once on the
  inner ranked query that filters by scheduled task instances, and once on the outer rejoin that looks up
  `task_instance` by `(dag_id, task_id, run_id, map_index)`.

  The outer query is an exact identity lookup, so forcing `ti_state` can prevent MySQL from using
  `task_instance_composite_key`. This PR removes only the outer hint and keeps the inner hint that was added for the
  original MySQL scheduler optimization.

  ## Regression Coverage

  Added a regression test that compiles the scheduler selection query with the MySQL dialect and verifies `USE INDEX
  (ti_state)` appears only once.

  ## Tests

  - `uv run --python 3.12 --group dev pytest airflow-core/tests/unit/jobs/ -xvs`
  - `prek run ruff --from-ref main`
  - `prek run ruff-format --from-ref main`

  ## Context

  - #25627 added the original MySQL `ti_state` hint for the scheduler state lookup.
  - #54103 reshaped this scheduler query into the ranked subquery plus outer rejoin form; that is where the hint was
  also applied to the outer rejoin.
  - #57210 touched the same scheduling path, but covers deferred-task priority rather than this MySQL hint placement.

  ---

  ##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — OpenAI Codex

  Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-
  docs/05_pull_requests.rst#gen-ai-assisted-contributions)