### PR TITLE
fix(k8s-executor): add latency + status metrics around pod API calls

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -45,7 +45,7 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     create_unique_id,
 )
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, workload_to_command_args
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
 
@@ -494,11 +494,18 @@ class AirflowKubernetesScheduler(LoggingMixin):
 
         self.log.debug("Pod Creation Request: \n%s", json_pod)
         try:
-            resp = self.kube_client.create_namespaced_pod(
-                body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
-            )
+            with Stats.timer("kubernetes_executor.pod_creation"):
+                resp = self.kube_client.create_namespaced_pod(
+                    body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
+                )
+            Stats.incr("kubernetes_executor.pod_creation_status", tags={"status": "200"})
             self.log.debug("Pod Creation Response: %s", resp)
+        except ApiException as e:
+            Stats.incr("kubernetes_executor.pod_creation_status", tags={"status": str(e.status)})
+            self.log.exception("Exception when attempting to create Namespaced Pod: %s", json_pod)
+            raise
         except Exception as e:
+            Stats.incr("kubernetes_executor.pod_creation_status", tags={"status": "error"})
             self.log.exception("Exception when attempting to create Namespaced Pod: %s", json_pod)
             raise e
         return resp
@@ -608,13 +615,16 @@ class AirflowKubernetesScheduler(LoggingMixin):
         """Delete Pod from a namespace; does not raise if it does not exist."""
         try:
             self.log.info("Deleting pod %s in namespace %s", pod_name, namespace)
-            self.kube_client.delete_namespaced_pod(
-                pod_name,
-                namespace,
-                body=client.V1DeleteOptions(**self.kube_config.delete_option_kwargs),
-                **self.kube_config.kube_client_request_args,
-            )
+            with Stats.timer("kubernetes_executor.pod_deletion"):
+                self.kube_client.delete_namespaced_pod(
+                    pod_name,
+                    namespace,
+                    body=client.V1DeleteOptions(**self.kube_config.delete_option_kwargs),
+                    **self.kube_config.kube_client_request_args,
+                )
+            Stats.incr("kubernetes_executor.pod_deletion_status", tags={"status": "200"})
         except ApiException as e:
+            Stats.incr("kubernetes_executor.pod_deletion_status", tags={"status": str(e.status)})
             # If the pod is already deleted
             if str(e.status) != "404":
                 raise
@@ -631,24 +641,30 @@ class AirflowKubernetesScheduler(LoggingMixin):
             namespace,
         )
         try:
-            self.kube_client.patch_namespaced_pod(
-                name=pod_name,
-                namespace=namespace,
-                body={"metadata": {"labels": {POD_REVOKED_KEY: "True"}}},
-            )
-        except ApiException:
+            with Stats.timer("kubernetes_executor.pod_patching"):
+                self.kube_client.patch_namespaced_pod(
+                    name=pod_name,
+                    namespace=namespace,
+                    body={"metadata": {"labels": {POD_REVOKED_KEY: "True"}}},
+                )
+            Stats.incr("kubernetes_executor.pod_patching_status", tags={"status": "200"})
+        except ApiException as e:
+            Stats.incr("kubernetes_executor.pod_patching_status", tags={"status": str(e.status)})
             self.log.warning("Failed to patch pod %s with pod revoked key.", pod_name, exc_info=True)
 
     def patch_pod_executor_done(self, *, pod_name: str, namespace: str):
         """Add a "done" annotation to ensure we don't continually adopt pods."""
         self.log.debug("Patching pod %s in namespace %s to mark it as done", pod_name, namespace)
         try:
-            self.kube_client.patch_namespaced_pod(
-                name=pod_name,
-                namespace=namespace,
-                body={"metadata": {"labels": {POD_EXECUTOR_DONE_KEY: "True"}}},
-            )
+            with Stats.timer("kubernetes_executor.pod_patching"):
+                self.kube_client.patch_namespaced_pod(
+                    name=pod_name,
+                    namespace=namespace,
+                    body={"metadata": {"labels": {POD_EXECUTOR_DONE_KEY: "True"}}},
+                )
+            Stats.incr("kubernetes_executor.pod_patching_status", tags={"status": "200"})
         except ApiException as e:
+            Stats.incr("kubernetes_executor.pod_patching_status", tags={"status": str(e.status)})
             self.log.info("Failed to patch pod %s with done annotation. Reason: %s", pod_name, e)
 
     def sync(self) -> None:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -244,6 +244,55 @@ class TestAirflowKubernetesScheduler:
         finally:
             kube_executor.end()
 
+    @pytest.mark.skipif(
+        AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.Stats")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.client")
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    def test_delete_pod_emits_metrics_on_success(
+        self, mock_watcher, mock_client, mock_kube_client, mock_stats
+    ):
+        pod_name = "my-pod-1"
+        namespace = "my-namespace-1"
+        mock_kube_client.return_value.delete_namespaced_pod = mock.MagicMock()
+
+        kube_executor = KubernetesExecutor()
+        kube_executor.job_id = 1
+        kube_executor.start()
+        try:
+            kube_executor.kube_scheduler.delete_pod(pod_name, namespace)
+            mock_stats.timer.assert_any_call("kubernetes_executor.pod_deletion")
+            mock_stats.incr.assert_any_call("kubernetes_executor.pod_deletion_status", tags={"status": "200"})
+        finally:
+            kube_executor.end()
+
+    @pytest.mark.skipif(
+        AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.Stats")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.client")
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    def test_delete_pod_emits_metrics_on_failure(
+        self, mock_watcher, mock_client, mock_kube_client, mock_stats
+    ):
+        pod_name = "my-pod-1"
+        namespace = "my-namespace-2"
+        mock_kube_client.return_value.delete_namespaced_pod.side_effect = ApiException(status=429)
+
+        kube_executor = KubernetesExecutor()
+        kube_executor.job_id = 1
+        kube_executor.start()
+        try:
+            with pytest.raises(ApiException):
+                kube_executor.kube_scheduler.delete_pod(pod_name, namespace)
+            mock_stats.timer.assert_any_call("kubernetes_executor.pod_deletion")
+            mock_stats.incr.assert_any_call("kubernetes_executor.pod_deletion_status", tags={"status": "429"})
+        finally:
+            kube_executor.end()
+
     def test_running_pod_log_lines(self):
         # default behaviour
         kube_executor = KubernetesExecutor()

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -534,6 +534,28 @@ metrics:
     legacy_name: "edge_worker.ti.finish.{queue}.{state}.{dag_id}.{task_id}"
     name_variables: ["queue", "state", "dag_id", "task_id"]
 
+  - name: "kubernetes_executor.pod_creation_status"
+    description: "Number of Kubernetes create_namespaced_pod calls from the Kubernetes Executor,
+    tagged by HTTP response status (``200`` on success, the ``ApiException`` status code on
+    failure, ``error`` for non-API exceptions)."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: ["status"]
+
+  - name: "kubernetes_executor.pod_deletion_status"
+    description: "Number of Kubernetes delete_namespaced_pod calls from the Kubernetes Executor,
+    tagged by HTTP response status (``200`` on success, the ``ApiException`` status code on failure)."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: ["status"]
+
+  - name: "kubernetes_executor.pod_patching_status"
+    description: "Number of Kubernetes patch_namespaced_pod calls from the Kubernetes Executor,
+    tagged by HTTP response status (``200`` on success, the ``ApiException`` status code on failure)."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: ["status"]
+
   # ==========
   # Timers
   # ==========
@@ -637,6 +659,24 @@ metrics:
 
   - name: "kubernetes_executor.adopt_task_instances.duration"
     description: "Milliseconds taken to adopt the task instances in Kubernetes Executor"
+    type: "timer"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "kubernetes_executor.pod_creation"
+    description: "Milliseconds taken for a Kubernetes create_namespaced_pod call from the Kubernetes Executor"
+    type: "timer"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "kubernetes_executor.pod_deletion"
+    description: "Milliseconds taken for a Kubernetes delete_namespaced_pod call from the Kubernetes Executor"
+    type: "timer"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "kubernetes_executor.pod_patching"
+    description: "Milliseconds taken for a Kubernetes patch_namespaced_pod call from the Kubernetes Executor"
     type: "timer"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
### Problem

The `KubernetesExecutor` calls `create_namespaced_pod`, `delete_namespaced_pod`, and `patch_namespaced_pod` against the API server on every task lifecycle event, but emits no metrics around those calls. When a cluster's control plane is slow, throttling (HTTP 429), or returning 5xx, the only signal today is scheduler log noise — there's no way to alert on latency drift or error-rate spikes without scraping logs.

Grafana Dashboard graphing these metrics from our internal fork 

<img width="621" height="512" alt="Image" src="https://github.com/user-attachments/assets/4d54398d-baf1-4762-a65c-42fd2d5ce77c" />

<img width="620" height="517" alt="Image" src="https://github.com/user-attachments/assets/056f1e2e-fda0-440d-b83b-e4da2a0f62d9" />

<img width="618" height="514" alt="Image" src="https://github.com/user-attachments/assets/bd8e0d29-4e9a-4985-bd02-9ecebe880184" />

<img width="924" height="763" alt="Image" src="https://github.com/user-attachments/assets/fbb8dadb-ac96-4a98-b0ec-4e03688f5e5b" />

### Fix

Wrap each of the three pod API call sites in `kubernetes_executor_utils.py` with `Stats.timer` for latency (`kubernetes_executor.pod_creation` / `pod_deletion` / `pod_patching`) and a paired `Stats.incr` tagged by status (`pod_creation_status` / `pod_deletion_status` / `pod_patching_status`). The counter is tagged `status="200"` on success and with the `ApiException.status` value on failure, so operators can chart per-status-code rates. The 404-is-fine branch in `delete_pod` and the swallow-on-failure branches in the two patch methods still behave as before — they just emit a counter on the way out.

The three new timers and three new counters are registered in `shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml` so they pass the metrics-registry pre-commit hook and show up in the published metrics docs.

### Tests

New unit tests in `test_kubernetes_executor.py` mock the `Stats` module and assert the timer + tagged counter fire on both the success path and an `ApiException(status=429)` failure path for `delete_pod`.

Closes #66799
