### PR TITLE
feat(metrics): wrap executor.heartbeat() in a timer to localize loop slowdowns

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1665,7 +1665,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # either a no-op, or they will check-in on currently running tasks and send out new
                 # events to be processed below.
                 for executor in self.executors:
-                    executor.heartbeat()
+                    with stats.timer(
+                        "scheduler.executor_heartbeat_duration",
+                        tags={"executor": type(executor).__name__},
+                    ):
+                        executor.heartbeat()
 
                 with create_session() as session:
                     num_finished_events = 0

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1181,6 +1181,22 @@ class TestSchedulerJob:
             for executor in self.job_runner.executors:
                 executor.heartbeat.assert_called_once()
 
+    def test_executor_heartbeat_emits_timer(self, mock_executors, configure_testing_dag_bundle):
+        with configure_testing_dag_bundle(os.devnull):
+            scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            with patch("airflow.jobs.scheduler_job_runner.stats.timer") as mock_timer:
+                self.job_runner._execute()
+
+            heartbeat_calls = [
+                timer_call
+                for timer_call in mock_timer.call_args_list
+                if timer_call.args and timer_call.args[0] == "scheduler.executor_heartbeat_duration"
+            ]
+            assert len(heartbeat_calls) == len(self.job_runner.executors)
+            for executor, timer_call in zip(self.job_runner.executors, heartbeat_calls):
+                assert timer_call.kwargs.get("tags") == {"executor": type(executor).__name__}
+
     def test_executor_events_processed(self, mock_executors, configure_testing_dag_bundle):
         with configure_testing_dag_bundle(os.devnull):
             scheduler_job = Job()

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -604,6 +604,13 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "scheduler.executor_heartbeat_duration"
+    description: "Milliseconds spent in ``executor.heartbeat()`` per scheduler loop iteration, tagged
+      by executor class name so each configured executor is reported separately."
+    type: "timer"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "dagrun.first_task_scheduling_delay"
     description: "Milliseconds elapsed between first task start_date and dagrun expected start"
     type: "timer"


### PR DESCRIPTION
### Problem

`dag_processing.loop_duration` is aggregate. When the scheduler loop slows down, there's no signal pointing at the executor as the cause — `executor.heartbeat()` runs every iteration and can spike from Kubernetes API throttling, Celery broker lag, etc., but its wall time is folded into the loop total.

### Fix

Wrap `executor.heartbeat()` in `stats.timer("scheduler.executor_heartbeat_duration")`, tagged with `executor: <ClassName>` so each configured executor reports independently in multi-executor deployments.

### Tests

`test_executor_heartbeat_emits_timer` patches `stats.timer`, runs one scheduler loop iteration with the two-executor `mock_executors` fixture, and asserts the timer was opened once per executor with the right metric name and `tags={"executor": <class>}`.

### Note

I scoped this to `executor.heartbeat()` only, not `_process_executor_events`. The two calls are structurally separate — they live in different loops with a fresh `create_session()` block between them — and their cost characteristics differ (heartbeat is executor I/O; `_process_executor_events` is DB writes plus event-buffer drain). They look like two independent signals rather than a tight pair, so a separate timer for `_process_executor_events` makes sense as a follow-up if the same need surfaces there. Happy to roll it into this PR if reviewers would prefer.

Closes #66803
