### PR TITLE
UI: Handle Dags state filter overflow on mobile

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack } from "@chakra-ui/react";
+import { Box, HStack } from "@chakra-ui/react";
 import type { MultiValue } from "chakra-react-select";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -146,7 +146,9 @@ export const DagsFilters = () => {
 
   return (
     <HStack flexWrap="wrap" gap={2} justifyContent="space-between">
-      <StateFilters onChange={handleStateChange} value={stateValue} />
+      <Box overflowX="auto" pb={1}>
+        <StateFilters onChange={handleStateChange} value={stateValue} />
+      </Box>
       <RequiredActionFilter needsReview={needsReview === "true"} onToggle={handleNeedsReviewToggle} />
       <PausedFilter onChange={handlePausedChange} value={pausedValue} />
       <TagFilter

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -146,7 +146,7 @@ export const DagsFilters = () => {
 
   return (
     <HStack flexWrap="wrap" gap={2} justifyContent="space-between">
-      <Box overflowX="auto" pb={1}>
+      <Box overflowX="auto">
         <StateFilters onChange={handleStateChange} value={stateValue} />
       </Box>
       <RequiredActionFilter needsReview={needsReview === "true"} onToggle={handleNeedsReviewToggle} />


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

# Why
On mobile, the state filter on the Dags List page can overflow the viewport.
Related on #64846

<img width="412" height="456" alt="image" src="https://github.com/user-attachments/assets/d506ab78-6eeb-486c-ab24-61ab4dcd111e" />


# Fix
This change keeps the filter within the page width and allows horizontal scrolling when needed.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>

<tr>
<td><video src="https://github.com/user-attachments/assets/8ea30435-cf15-4349-89a0-cbc7515476b5" /> </td>
<td><video src="https://github.com/user-attachments/assets/c0d9acc5-97f2-45b0-9cf6-3abb85459fb0" /></td>
</tr>
</table>

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
