### PR TITLE
fix(metrics/otel): bracket IPv6 host literals in exporter endpoint URL

### DIFF
--- a/shared/observability/src/airflow_shared/observability/common.py
+++ b/shared/observability/src/airflow_shared/observability/common.py
@@ -30,6 +30,21 @@ if TYPE_CHECKING:
 log = structlog.getLogger(__name__)
 
 
+def _format_url_host(host: str | None) -> str | None:
+    """
+    Bracket IPv6 host literals for embedding in a URL authority.
+
+    Per RFC 3986 §3.2.2, IPv6 hosts in a URI must be enclosed in square
+    brackets so the ``:`` separators do not conflict with the ``host:port``
+    delimiter. Hostnames, IPv4 literals, and already-bracketed v6 literals
+    are returned unchanged. ``None`` is passed through so existing
+    error-logging paths keep their shape.
+    """
+    if host is not None and ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def get_otel_data_exporter(
     *,
     otel_env_config: OtelEnvConfig,
@@ -106,7 +121,7 @@ def get_otel_data_exporter(
 
         endpoint_suffix = "traces" if otel_env_config.data_type == OtelDataType.TRACES else "metrics"
 
-        endpoint_str = f"{protocol}://{host}:{port}/v1/{endpoint_suffix}"
+        endpoint_str = f"{protocol}://{_format_url_host(host)}:{port}/v1/{endpoint_suffix}"
         if otel_env_config.data_type == OtelDataType.TRACES:
             exporter = OTLPSpanExporter(endpoint=endpoint_str)
         else:

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -394,6 +394,38 @@ class TestOtelMetrics:
                 "grpc",
                 id="type_specific_vars_take_precedence",
             ),
+            pytest.param(
+                {},
+                "::1",
+                "4318",
+                "http://[::1]:4318/v1/metrics",
+                "http",
+                id="airflow_config_ipv6_loopback_is_bracketed",
+            ),
+            pytest.param(
+                {},
+                "2001:db8::1",
+                "4318",
+                "http://[2001:db8::1]:4318/v1/metrics",
+                "http",
+                id="airflow_config_ipv6_literal_is_bracketed",
+            ),
+            pytest.param(
+                {},
+                "[::1]",
+                "4318",
+                "http://[::1]:4318/v1/metrics",
+                "http",
+                id="airflow_config_already_bracketed_ipv6_is_preserved",
+            ),
+            pytest.param(
+                {},
+                "10.0.0.1",
+                "4318",
+                "http://10.0.0.1:4318/v1/metrics",
+                "http",
+                id="airflow_config_ipv4_literal_passes_through_unchanged",
+            ),
         ],
     )
     def test_config_priorities(


### PR DESCRIPTION
### Problem

`get_otel_data_exporter()` builds the OTLP exporter endpoint URL with a raw f-string:

```python
endpoint_str = f"{protocol}://{host}:{port}/v1/{endpoint_suffix}"
```

When `host` is an IPv6 literal (e.g. `::1`, `2001:db8::1`), the resulting URL is invalid per RFC 3986 §3.2.2 — the v6 host has to be enclosed in `[...]` so the `:` separators don't conflict with the `host:port` delimiter:

```
http://::1:4318/v1/metrics              # invalid
http://2001:db8::1:4318/v1/metrics      # invalid
```

The OTLP exporter then either fails to parse the URL or interprets the trailing port digits as part of the v6 address.

### Fix

Add a small `_format_url_host()` helper in `shared/observability/.../common.py` that brackets bare IPv6 literals and leaves hostnames, IPv4 literals, and already-bracketed v6 strings unchanged. The helper accepts `str | None` so the existing error-logging path (where the deprecated airflow host/port config can resolve to `None`) keeps its shape.

### Tests

Extended `test_config_priorities` with four new parametrised cases:

- `::1` → `http://[::1]:4318/v1/metrics`
- `2001:db8::1` → `http://[2001:db8::1]:4318/v1/metrics`
- `[::1]` (already bracketed) → preserved
- `10.0.0.1` (v4) → passes through unchanged

Closes #66811
