### PR TITLE
fix(scheduler): clear identity map between _do_scheduling phases

### DIFF
--- a/airflow-core/newsfragments/66820.bugfix.rst
+++ b/airflow-core/newsfragments/66820.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cross-replica deadlocks in HA scheduler by clearing the SQLAlchemy identity map between the two phases of ``_do_scheduling``, preventing stale ``DagRun`` rows from phase 1 being re-dirtied and committed in an unpredictable lock order during phase 2.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1780,6 +1780,20 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             self._start_queued_dagruns(session)
             guard.commit()
 
+            # Detach phase 1's instances so phase 2 starts with an empty
+            # identity map. Without this, stale DagRun rows loaded by
+            # `_start_queued_dagruns` can be re-dirtied via `flush` / `merge`
+            # inside `_schedule_all_dag_runs` (a `merge` with the same primary
+            # key marks the existing identity-map entry dirty even when the
+            # values are unchanged) and end up in the final `guard.commit()`
+            # in a row-lock order that differs from what other scheduler
+            # replicas are taking, producing A-B / B-A deadlocks on `dag_run`
+            # and `task_instance` under HA scheduler deployments. `expire_all`
+            # is not enough: expired entries are still subject to `merge`-side
+            # re-dirtying. See
+            # https://github.com/apache/airflow/issues/66817.
+            session.expunge_all()
+
             # Bulk fetch the currently active dag runs for the dags we are
             # examining, rather than making one query per DagRun
             dag_runs = DagRun.get_running_dag_runs_to_examine(session=session)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -3789,6 +3789,14 @@ class TestSchedulerJob:
 
         self.job_runner._do_scheduling(session)
 
+        # `_do_scheduling` expunges the identity map between its phases so phase 2
+        # starts fresh (see `scheduler_job_runner.SchedulerJobRunner._do_scheduling`),
+        # which leaves the local `dr` / `ti` ORM references detached. Re-query both
+        # from the database so the expected payload matches the post-scheduling state
+        # captured in the actual callback.
+        dr = session.scalars(select(DagRun).where(DagRun.id == dr.id)).one()
+        ti = session.scalars(select(TaskInstance).where(TaskInstance.id == ti.id)).one()
+
         expected_callback = DagCallbackRequest(
             filepath=dag.relative_fileloc,
             dag_id=dr.dag_id,
@@ -3864,6 +3872,11 @@ class TestSchedulerJob:
         dr = dag_maker.create_dagrun(start_date=DEFAULT_DATE)
 
         self.job_runner._do_scheduling(session)
+
+        # `_do_scheduling` expunges the identity map between its phases so phase 2 starts fresh,
+        # leaving the local `dr` ORM reference detached. Re-query so the expected payload reflects
+        # the post-scheduling state captured in the stored callback.
+        dr = session.scalars(select(DagRun).where(DagRun.id == dr.id)).one()
 
         callback = (
             session.scalars(select(DbCallbackRequest).order_by(DbCallbackRequest.id.desc()))
@@ -5572,6 +5585,42 @@ class TestSchedulerJob:
                     )
 
             assert mock_schedule.call_count == 1
+
+    def test_do_scheduling_expunges_identity_map_between_phases(self, dag_maker, session):
+        """Phase 2 must start with a clean identity map, otherwise stale DagRun
+        objects loaded by phase 1 can be re-dirtied by `flush` / `merge` during
+        `_schedule_all_dag_runs` and committed in a row-lock order that conflicts
+        with other scheduler replicas, producing A-B / B-A deadlocks on
+        `dag_run` and `task_instance`. Regression test for #66817.
+
+        Exercises the real phase 1 (`_start_queued_dagruns`) instead of mocking
+        it: a `QUEUED` DagRun is created up front, the real phase 1 transitions
+        it to `RUNNING`, and we then capture the identity-map keys that phase 2
+        sees at its first query. Without the fix the queued-then-running
+        DagRun stays in the identity map; with the fix the identity map is
+        empty.
+        """
+        with dag_maker(dag_id="test_expunge_between_phases", schedule="@once"):
+            EmptyOperator(task_id="t")
+        dag_maker.create_dagrun(state=DagRunState.QUEUED)
+        session.flush()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        phase2_identity_map_keys: list = []
+
+        def capture_identity_map(*, session):
+            phase2_identity_map_keys.extend(session.identity_map.keys())
+            return []
+
+        with (
+            patch.object(DagRun, "get_running_dag_runs_to_examine", side_effect=capture_identity_map),
+            patch.object(self.job_runner, "_schedule_all_dag_runs", return_value=[]),
+        ):
+            self.job_runner._do_scheduling(session)
+
+        assert phase2_identity_map_keys == [], f"identity map leaked into phase 2: {phase2_identity_map_keys}"
 
     def test_bulk_write_to_db_external_trigger_dont_skip_scheduled_run(self, dag_maker, testing_dag_bundle):
         """


### PR DESCRIPTION
Proposed adding `session.expunge_all()` between the two phases of `_do_scheduling()`, on the theory that stale phase-1 `DagRun` objects get re-dirtied in phase 2 and committed in a lock order that deadlocks across schedulers on `dag_run` / `task_instance`.

**Withdrawing — I went back to reproduce that root cause on a live setup and couldn't.**

Both `get_queued_dag_runs_to_set_running` (phase 1) and `get_running_dag_runs_to_examine` (phase 2) already fetch their rows with `FOR UPDATE SKIP LOCKED`, so two schedulers don't contend on the same dag-run rows, and the before/after SQL is identical with vs without this change. Full repro in the closing comment.

Going to step back and benchmark this properly before pursuing it again. Thanks @ephraimbuddy and @potiuk for the reviews.