### PR TITLE
Translations: add missing Polish translations for new UI keys

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -214,6 +214,12 @@
     },
     "tooltip": "Naciśnij {{hotkey}}, aby przewinąć do {{direction}}"
   },
+  "search": {
+    "advanced": {
+      "description": "Dopasuj w dowolnym miejscu wartości (wyszukiwanie podciągu). Wolniejsze w dużych wdrożeniach, ponieważ nie może użyć domyślnego indeksu B-drzewa. Szczegóły w sekcji dokumentacji o niestandardowych indeksach metadanych.",
+      "title": "Dopasuj w dowolnym miejscu"
+    }
+  },
   "security": {
     "actions": "Akcje",
     "permissions": "Uprawnienia",
@@ -284,6 +290,10 @@
   "task_one": "Zadanie",
   "task_other": "Zadania",
   "taskGroup": "Grupa zadań",
+  "taskGroup_few": "Grupy zadań",
+  "taskGroup_many": "Grup zadań",
+  "taskGroup_one": "Grupa zadań",
+  "taskGroup_other": "Grupy zadań",
   "taskId": "Identyfikator Zadania",
   "taskInstance": {
     "dagVersion": "Wersja Daga",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -12,6 +12,7 @@
     "maxRuns": "Maksymalna liczba aktywnych wykonań",
     "missingAndErroredRuns": "Brakujące i błędne wykonania",
     "missingRuns": "Brakujące wykonania",
+    "overrideExistingParams": "Nadpisz parametry istniejących wykonań",
     "permissionDenied": "Próba nieudana: Użytkownik nie ma uprawnień do tworzenia wypełnień wstecznych.",
     "reprocessBehavior": "Zachowanie ponownego przetwarzania",
     "run": "Uruchom ponowne przetwarzanie",
@@ -104,7 +105,8 @@
     "taskCount_many": "{{count}} Zadań",
     "taskCount_one": "{{count}} Zadanie",
     "taskCount_other": "{{count}} Zadań",
-    "taskGroup": "Grupa zadań"
+    "taskGroup": "Grupa zadań",
+    "zoomToTask": "Powiększ do wybranego zadania"
   },
   "limitedList": "+{{count}} więcej",
   "limitedList.allItems": "Wszystkie {{count}} elementy:",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -40,9 +40,43 @@
     "parseDuration": "Czas parsowania:",
     "parsedAt": "Przeanalizowano o:"
   },
+  "deadlineAlerts": {
+    "completionRule": "Musi zakończyć się w ciągu {{interval}} od momentu: {{reference}}",
+    "count_few": "{{count}} terminy",
+    "count_many": "{{count}} terminów",
+    "count_one": "{{count}} termin",
+    "count_other": "{{count}} terminów",
+    "referenceType": {
+      "AverageRuntimeDeadline": "średni czas wykonania",
+      "DagRunLogicalDateDeadline": "data logiczna",
+      "DagRunQueuedAtDeadline": "czas dodania do kolejki"
+    }
+  },
+  "deadlineStatus": {
+    "actual": "Rzeczywisty",
+    "expected": "Oczekiwany",
+    "finishedEarly": "Zakończono {{duration}} przed terminem",
+    "finishedLate": "Zakończono {{duration}} po terminie",
+    "label": "Termin",
+    "met": "Dotrzymany",
+    "missed": "Niedotrzymany",
+    "missedCount_few": "{{count}} Niedotrzymane terminy",
+    "missedCount_many": "{{count}} Niedotrzymanych terminów",
+    "missedCount_one": "{{count}} Niedotrzymany termin",
+    "missedCount_other": "{{count}} Niedotrzymanych terminów",
+    "mixedCount": "Niedotrzymane: {{missedCount}}, Nadchodzące: {{upcomingCount}}",
+    "stillRunning": "Nadal w trakcie",
+    "upcoming": "Nadchodzący",
+    "upcomingCount_few": "{{count}} Nadchodzące terminy",
+    "upcomingCount_many": "{{count}} Nadchodzących terminów",
+    "upcomingCount_one": "{{count}} Nadchodzący termin",
+    "upcomingCount_other": "{{count}} Nadchodzących terminów"
+  },
   "extraLinks": "Dodatkowe linki",
   "grid": {
     "buttons": {
+      "newerRuns": "Nowsze wykonania",
+      "olderRuns": "Starsze wykonania",
       "resetToLatest": "Przywróć do najnowszego",
       "toggleGroup": "Przełącz grupę"
     },
@@ -80,6 +114,7 @@
   },
   "navigation": {
     "navigation": "Przewiń: {{arrow}}",
+    "openGraphFilters": "Filtry zadań: Ctrl+Shift+F",
     "toggleGroup": "Przełącz grupę: Space"
   },
   "notFound": {
@@ -109,6 +144,10 @@
       "assetEvent_one": "Utworzone zdarzenie zasobu",
       "assetEvent_other": "Utworzone zdarzenia zasobów"
     },
+    "deadlines": {
+      "showAll": "Pokaż wszystkie",
+      "title": "Terminy"
+    },
     "failedLogs": {
       "hideLogs": "Ukryj logi",
       "showLogs": "🐌 🐌 Pokaż logi",
@@ -137,6 +176,16 @@
     },
     "graphDirection": {
       "label": "Kierunek grafu"
+    },
+    "graphFilters": {
+      "clearFilters": "Wyczyść filtry",
+      "durationGte": "Min. czas trwania (s)",
+      "durationGteHint": "Dla zmapowanych zadań mierzy łączny czas wszystkich instancji",
+      "mapIndex": "Min. indeks mapowania",
+      "mapIndexHint": "Pokazuje zmapowane zadania rozszerzone co najmniej do tego indeksu",
+      "selectStatus": "Wybierz status",
+      "selectTaskGroup": "Wybierz grupę zadań",
+      "title": "Filtry zadań"
     },
     "showVersionIndicator": {
       "label": "Pokaż wskaźnik wersji",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
@@ -34,6 +34,11 @@
       "error": "Nie udało się wyczyścić {{type}}",
       "title": "Wyczyść {{type}}"
     },
+    "clearAllMapped": {
+      "button": "Wyczyść wszystkie zmapowane zadania",
+      "buttonTooltip": "Użyj shift+c żeby wyczyścić wszystkie zmapowane instancje zadań",
+      "title": "Wyczyść wszystkie zmapowane instancje zadań"
+    },
     "confirmationDialog": {
       "description": "Zadanie jest obecnie w stanie {{state}} uruchomionym przez użytkownika {{user}} o {{time}}. \nUżytkownik nie może wyczyścić tego zadania, dopóki nie zakończy się jego działanie lub użytkownik nie odznaczy opcji 'Zapobiegaj ponownemu uruchomieniu uruchomionych zadań' w oknie dialogowym czyszczenia zadań.",
       "title": "Nie można wyczyścić instancji zadania"


### PR DESCRIPTION
## Summary

Fills the 42 missing Polish translation keys flagged by `breeze ui check-translation-completeness --language pl`:

- `common.json` — `search.advanced.{description,title}` and the `taskGroup_one/few/many/other` plural forms
- `components.json` — `backfill.overrideExistingParams`, `graph.zoomToTask`
- `dag.json` — full `deadlineAlerts` and `deadlineStatus` blocks (deadline / termin terminology, mixedCount, finishedEarly/Late, upcoming, met, missed); `grid.buttons.newerRuns/olderRuns`; `navigation.openGraphFilters`; `overview.deadlines.{showAll,title}`; complete `panel.graphFilters` block
- `dags.json` — `runAndTaskActions.clearAllMapped.{button,buttonTooltip,title}`

Polish requires 4 plural forms (`_one`/`_few`/`_many`/`_other`) per the locale guideline in `.github/skills/airflow-translations/locales/pl.md`, so the new count/missedCount/upcomingCount/taskGroup keys include all four forms.

Terminology choices follow the existing pl/ conventions ("Nadpisz" for override, "Wyczyść" for clear, "termin" for deadline, "Grupa zadań" for task group).

## Test plan

- [ ] `breeze ui check-translation-completeness --language pl` shows 0 missing
- [ ] `prek run check-i18n-json` passes
- [ ] Visual check of the new strings in the UI for the Polish locale

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)