### PR TITLE
[v3-2-test] Translations: add missing Polish translations for new UI keys

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -34,6 +34,7 @@
   },
   "collapseAllExtra": "Zwiń wszystkie dodatkowe dane JSON",
   "collapseDetailsPanel": "Zwiń panel szczegółów",
+  "consumingAsset": "Zabierający zasób",
   "createdAssetEvent_few": "Utworzone zdarzenia zasobów",
   "createdAssetEvent_many": "Utworzonych zdarzeń zasobów",
   "createdAssetEvent_one": "Utworzone zdarzenie zasobu",
@@ -143,6 +144,7 @@
     "logicalDateTo": "Data logiczna do",
     "runAfterFrom": "Uruchom po (od)",
     "runAfterTo": "Uruchom po (do)",
+    "searchAsset": "Szukaj zasobu",
     "selectDateRange": "Wybierz zakres dat",
     "startTime": "Czas rozpoczęcia"
   },
@@ -206,6 +208,12 @@
       "top": "góra"
     },
     "tooltip": "Naciśnij {{hotkey}}, aby przewinąć do {{direction}}"
+  },
+  "search": {
+    "advanced": {
+      "description": "Dopasuj w dowolnym miejscu wartości (wyszukiwanie podciągu). Wolniejsze w dużych wdrożeniach, ponieważ nie może użyć domyślnego indeksu B-drzewa. Szczegóły w sekcji dokumentacji o niestandardowych indeksach metadanych.",
+      "title": "Dopasuj w dowolnym miejscu"
+    }
   },
   "security": {
     "actions": "Akcje",
@@ -375,6 +383,10 @@
   "triggered": "Uruchomiony",
   "tryNumber": "Numer próby",
   "user": "Profil",
+  "validation": {
+    "mustBeAtLeast": "Musi wynosić co najmniej {{min}}.",
+    "mustBeValidNumber": "Musi być prawidłową liczbą."
+  },
   "wrap": {
     "hotkey": "w",
     "tooltip": "Wybierz {{hotkey}} aby przełączyć zawijanie",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -12,6 +12,7 @@
     "maxRuns": "Maksymalna liczba aktywnych wykonań",
     "missingAndErroredRuns": "Brakujące i błędne wykonania",
     "missingRuns": "Brakujące wykonania",
+    "overrideExistingParams": "Nadpisz parametry istniejących wykonań",
     "permissionDenied": "Próba nieudana: Użytkownik nie ma uprawnień do tworzenia wypełnień wstecznych.",
     "reprocessBehavior": "Zachowanie ponownego przetwarzania",
     "run": "Uruchom ponowne przetwarzanie",
@@ -104,7 +105,8 @@
     "taskCount_many": "{{count}} Zadań",
     "taskCount_one": "{{count}} Zadanie",
     "taskCount_other": "{{count}} Zadań",
-    "taskGroup": "Grupa zadań"
+    "taskGroup": "Grupa zadań",
+    "zoomToTask": "Powiększ do wybranego zadania"
   },
   "limitedList": "+{{count}} więcej",
   "limitedList.allItems": "Wszystkie {{count}} elementy:",


### PR DESCRIPTION
## Summary

Backports the Polish translation gaps on `v3-2-test`. Fills the 8 missing keys flagged by `breeze ui check-translation-completeness --language pl`:

- `common.json`
  - `consumingAsset` → "Zabierający zasób" (per locale glossary)
  - `filters.searchAsset` → "Szukaj zasobu"
  - `search.advanced.{description,title}` → "Dopasuj w dowolnym miejscu"
  - `validation.mustBeAtLeast` → "Musi wynosić co najmniej {{min}}."
  - `validation.mustBeValidNumber` → "Musi być prawidłową liczbą."
- `components.json`
  - `backfill.overrideExistingParams` → "Nadpisz parametry istniejących wykonań"
  - `graph.zoomToTask` → "Powiększ do wybranego zadania"

All terminology choices match the established translations on `main` for consistency.

## Test plan

- [ ] `breeze ui check-translation-completeness --language pl` shows 0 missing
- [ ] `prek run check-i18n-json` passes

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)