### PR TITLE
Fix flaky FileTrigger/FileDeleteTrigger tests by awaiting the task

### DIFF
--- a/providers/standard/tests/unit/standard/triggers/test_file.py
+++ b/providers/standard/tests/unit/standard/triggers/test_file.py
@@ -60,11 +60,10 @@ class TestFileTrigger:
 
         p.touch()
 
-        await asyncio.sleep(0.5)
+        # Await the task directly so the assertion can't race the trigger's
+        # detect → yield cycle on slow runners (ARM, Pendulum2 special job).
+        await asyncio.wait_for(task, timeout=5.0)
         assert task.done() is True
-
-        # Prevents error when task is destroyed while in "pending" state
-        asyncio.get_event_loop().stop()
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Skip on Airflow < 3.0")
@@ -101,8 +100,9 @@ class TestFileDeleteTrigger:
 
         p.touch()
 
-        await asyncio.sleep(0.5)
+        # Await the task directly so the assertion can't race the trigger's
+        # detect → unlink → yield cycle on slow runners (ARM, Pendulum2
+        # special job). The trigger only yields after `await filepath.unlink()`
+        # returns, so once the task is done, the file is guaranteed gone.
+        await asyncio.wait_for(task, timeout=5.0)
         assert await anyio.Path(p).exists() is False
-
-        # Prevents error when task is destroyed while in "pending" state
-        asyncio.get_event_loop().stop()


### PR DESCRIPTION
## Summary

`test_task_file_trigger` and `test_file_delete_trigger` in `providers/standard/tests/unit/standard/triggers/test_file.py` waited a fixed `asyncio.sleep(0.5)` after `p.touch()` and then asserted on the trigger's effect. On the Pendulum2 ARM scheduled job ([failing run](https://github.com/apache/airflow/actions/runs/25740213806/job/75591017736)) the `test_file_delete_trigger` race fires: captured stdout shows `Found file …` but the unlink hasn't returned by the time the assertion runs, so `await anyio.Path(p).exists() is False` fails with `assert True is False`.

The trigger has to wake from its `poke_interval=0.2` sleep, run `is_file()`, `stat()`, `unlink()`, log, and yield — all anyio thread-pool-backed file ops. 0.5s isn't always enough on slow runners.

## Fix

Switch to `await asyncio.wait_for(task, timeout=5.0)` so the assertion can't race the trigger's detect → (unlink) → yield cycle. Once the task is done, the trigger has completed all its work, so the file-existence assertion (for the delete variant) and `task.done() is True` (for the wait variant) are deterministic.

Also drop the trailing `asyncio.get_event_loop().stop()` cleanup line. It was a workaround for the pending task left behind by the fixed-sleep pattern; with `wait_for`, there's no pending task and pytest-asyncio's own teardown handles loop lifecycle.

## Test plan

- [x] Local: `uv run --project providers/standard pytest providers/standard/tests/unit/standard/triggers/test_file.py -xvs` (both tests pass)
- [ ] CI: Pendulum2 ARM scheduled job becomes deterministic

related: #61616 (the anyio conversion that made the unlink path async)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)