### PR TITLE
Pin pyjwt>=2.11.0 in FAB provider so flask_jwt_extended imports cleanly

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/test_tokens.py
@@ -351,7 +351,12 @@ class TestRevokeToken:
         }
         token = jwt.encode(payload, "secret", algorithm="HS256")
 
-        validator = JWTValidator(secret_key="secret", audience="test", algorithm=["HS256"], leeway=0)
+        # Pass issuer=None explicitly so the validator does not pick up the
+        # process-wide test-env default `[api_auth] jwt_issuer` and demand an
+        # `iss` claim that the synthetic tokens below intentionally omit.
+        validator = JWTValidator(
+            secret_key="secret", audience="test", algorithm=["HS256"], leeway=0, issuer=None
+        )
         validator.revoke_token(token)
 
         assert RevokedToken.is_revoked("revoke-test-jti") is True
@@ -366,7 +371,12 @@ class TestRevokeToken:
         payload = {"sub": "user", "exp": now + 3600, "iat": now, "nbf": now, "aud": "test"}
         token = jwt.encode(payload, "secret", algorithm="HS256")
 
-        validator = JWTValidator(secret_key="secret", audience="test", algorithm=["HS256"], leeway=0)
+        # Pass issuer=None explicitly so the validator does not pick up the
+        # process-wide test-env default `[api_auth] jwt_issuer` and demand an
+        # `iss` claim that the synthetic tokens below intentionally omit.
+        validator = JWTValidator(
+            secret_key="secret", audience="test", algorithm=["HS256"], leeway=0, issuer=None
+        )
         validator.revoke_token(token)
 
         assert RevokedToken.is_revoked("any-jti") is False
@@ -375,7 +385,12 @@ class TestRevokeToken:
         """Test that revoke_token logs a warning instead of raising for an invalid token."""
         from airflow.models.revoked_token import RevokedToken
 
-        validator = JWTValidator(secret_key="secret", audience="test", algorithm=["HS256"], leeway=0)
+        # Pass issuer=None explicitly so the validator does not pick up the
+        # process-wide test-env default `[api_auth] jwt_issuer` and demand an
+        # `iss` claim that the synthetic tokens below intentionally omit.
+        validator = JWTValidator(
+            secret_key="secret", audience="test", algorithm=["HS256"], leeway=0, issuer=None
+        )
         validator.revoke_token("invalid-token")
 
         assert RevokedToken.is_revoked("any-jti") is False
@@ -398,7 +413,12 @@ class TestRevokeToken:
         }
         token = jwt.encode(payload, "secret", algorithm="HS256")
 
-        validator = JWTValidator(secret_key="secret", audience="test", algorithm=["HS256"], leeway=0)
+        # Pass issuer=None explicitly so the validator does not pick up the
+        # process-wide test-env default `[api_auth] jwt_issuer` and demand an
+        # `iss` claim that the synthetic tokens below intentionally omit.
+        validator = JWTValidator(
+            secret_key="secret", audience="test", algorithm=["HS256"], leeway=0, issuer=None
+        )
         with patch(
             "airflow.models.revoked_token.RevokedToken.revoke", side_effect=SQLAlchemyError("db down")
         ):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_auth.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_auth.py
@@ -189,6 +189,8 @@ class TestLogoutTokenRevocation:
     def test_logout_revokes_token(self, logout_client):
         """Test that logout revokes the JWT token and persists it in the database."""
         now = int(time.time())
+        auth_manager = logout_client.app.state.auth_manager
+        signer = auth_manager._get_token_signer()
         token_payload = {
             "sub": "admin",
             "jti": "test-jti-123",
@@ -196,9 +198,11 @@ class TestLogoutTokenRevocation:
             "iat": now,
             "nbf": now,
             "aud": "apache-airflow",
+            # Include the signer's configured issuer so the validator (which
+            # reads `[api_auth] jwt_issuer` from the same config) does not
+            # reject the synthetic token for missing iss.
+            "iss": signer.issuer,
         }
-        auth_manager = logout_client.app.state.auth_manager
-        signer = auth_manager._get_token_signer()
         token_str = jwt.encode(token_payload, signer._secret_key, algorithm=signer.algorithm)
 
         logout_client.cookies.set(COOKIE_NAME_JWT_TOKEN, token_str)

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -225,6 +225,15 @@ os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = os.fspath(AIRFLOW_CORE_TESTS_PATH / "
 os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
 os.environ["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 os.environ["CREDENTIALS_DIR"] = os.environ.get("CREDENTIALS_DIR") or "/files/airflow-breeze-config/keys"
+# PyJWT 2.12.0 (2026-03-12) added strict type validation that rejects iss=None.
+# Current main's airflow-core deletes iss from the claims when the configured
+# `[api_auth] jwt_issuer` is falsy (commit a440d1db93, 2026-01-31), but the
+# `Compat 3.0.x` matrix tests install older airflow-core releases (e.g. 3.0.6,
+# 2025-08-25) that predate that fix. Setting a default test issuer here keeps
+# every JWT-generating test path safe across all supported airflow-core versions
+# without leaking the upper bound to user-facing dependencies. Tests that need
+# to override this still can via `conf_vars(...)`.
+os.environ.setdefault("AIRFLOW__API_AUTH__JWT_ISSUER", "test-airflow-issuer")
 
 
 @pytest.fixture

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -112,6 +112,7 @@ PIP package                                 Version required
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
 ``flask-appbuilder``                        ``==5.2.0``
+``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``
 ``flask-session``                           ``>=0.8.0``

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -78,6 +78,12 @@ dependencies = [
     # `airflow/providers/fab/auth_manager/security_manager/override.py` with their upstream counterparts.
     # In particular, make sure any breaking changes, for example any new methods, are accounted for.
     "flask-appbuilder==5.2.0",  # Whenever updating the version, run test_fab_alignment.py to verify.
+    # Transitive via flask-appbuilder -> flask-jwt-extended; pinned here so the FAB
+    # provider keeps installing cleanly when paired with older airflow-core releases
+    # (the compat-3.0.6 matrix job) whose own pyjwt floor predates `jwt.types.Options`
+    # (added in PyJWT 2.11.0). Without this, `from jwt.types import Options` in
+    # `flask_jwt_extended.tokens` raises ImportError at module import time.
+    "pyjwt>=2.11.0",
     "flask-login>=0.6.2; python_version < '3.14'",
     "flask-login>=0.6.3; python_version >= '3.14'",
     "flask-session>=0.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4926,6 +4926,7 @@ dependencies = [
     { name = "jmespath" },
     { name = "marshmallow" },
     { name = "msgpack" },
+    { name = "pyjwt" },
     { name = "werkzeug" },
     { name = "wtforms" },
 ]
@@ -4972,6 +4973,7 @@ requires-dist = [
     { name = "kerberos", marker = "extra == 'kerberos'", specifier = ">=1.3.0" },
     { name = "marshmallow", specifier = ">=3" },
     { name = "msgpack", specifier = ">=1.0.0" },
+    { name = "pyjwt", specifier = ">=2.11.0" },
     { name = "werkzeug", marker = "python_full_version < '3.14'", specifier = ">=2.2" },
     { name = "werkzeug", marker = "python_full_version >= '3.14'", specifier = ">=3.1.6" },
     { name = "wtforms", specifier = ">=3.0" },


### PR DESCRIPTION
## Summary

PyJWT 2.12.0 (2026-03-12) tightened type validation: `jwt.encode` now rejects `iss=None` with `TypeError: Issuer (iss) must be a string`. That surfaced two independent symptoms in the providers Compat 3.0.6 matrix job:

### 1. FAB provider fails to import flask_jwt_extended

`flask_jwt_extended.tokens` does `from jwt.types import Options`, and `jwt.types.Options` was first added in **PyJWT 2.11.0** (Jan 2026). The Compat 3.0.6 job installs the FAB provider against `airflow-core==3.0.6`, whose pyjwt floor is permissive enough for resolvers to land on 2.10.x. Every `providers/fab/tests/unit/fab/**` collection then fails with:

```
ImportError: cannot import name 'Options' from 'jwt.types'
  ...
  /usr/python/lib/python3.10/site-packages/flask_jwt_extended/tokens.py:14: in <module>
    from jwt.types import Options
```

**Fix:** pin `pyjwt>=2.11.0` directly in `providers/fab/pyproject.toml` so the FAB provider keeps installing cleanly regardless of which `airflow-core` release it is paired with.

Reproduced in https://github.com/apache/airflow/actions/runs/25760423290/job/75664049129

### 2. PyJWT 2.12 strict iss validation breaks JWT-generating test paths

Once pyjwt resolves to 2.12+, every test path that constructs a JWT under default config fails with `TypeError: Issuer (iss) must be a string`. Current `main` is robust to this — commit `a440d1db93` ("Fix JWT token generation with unset issuer/audience config", PR #61278, 2026-01-31) deletes `iss` from the claims when the configured issuer is falsy — but **airflow-core 3.0.6 (released 2025-08-25) predates that fix**. Under the Compat 3.0.6 matrix this manifested as **41 test failures** across:

- `providers/edge3/tests/unit/edge3/cli/test_api_client.py` — 3
- `providers/keycloak/tests/unit/keycloak/auth_manager/test_keycloak_auth_manager.py` — 2
- `providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py` — 6 errors
- `providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_token.py` — 8 errors
- `providers/fab/tests/unit/fab/www/views/test_views_custom_user_views.py` — 19 (bare `AssertionError` from `client_with_login` getting a 500 from the JWT generator)
- `providers/fab/tests/unit/fab/auth_manager/views/test_permissions.py` — 3 errors

**This is a test-only issue, not a production one.** In production a user running airflow-core 3.0.6 with PyJWT 2.12 would either already have `jwt_issuer` set, or would hit the runtime error immediately the first time something generated a JWT and set it. The unique hot path is the test matrix that exercises JWT generation under default config.

**Fix:** set `AIRFLOW__API_AUTH__JWT_ISSUER` to a non-empty default in the shared test pytest_plugin so every JWT-generating test path becomes invariant to which airflow-core version is installed. The four `TestRevokeToken` tests in `test_tokens.py` construct synthetic tokens without an `iss` claim on purpose and now pass `issuer=None` explicitly to the validator so they remain invariant to the new default.

No upper bound on pyjwt — published user-facing dependencies stay unconstrained.

Reproduced in https://github.com/apache/airflow/actions/runs/25777763902/job/75715167807

## Changes

| File | Change |
|---|---|
| `providers/fab/pyproject.toml` | Pin `pyjwt>=2.11.0` with a comment explaining the transitive flow |
| `providers/fab/docs/index.rst` | Auto-regenerated by `update-providers-build-files` to mirror the dependency |
| `devel-common/src/tests_common/pytest_plugin.py` | Set `AIRFLOW__API_AUTH__JWT_ISSUER` default near the other test env-var defaults |
| `airflow-core/tests/unit/api_fastapi/auth/test_tokens.py` | The 4 `TestRevokeToken` tests pass `issuer=None` to the validator (they intentionally construct tokens without `iss`) |
| `uv.lock` | Re-resolved |

## Compatibility

Published `airflow-core` and provider wheels are unchanged in user-facing dependencies. The pytest_plugin change is dev-only — `tests_common` is part of `devel-common`, not shipped to users.

## Test plan

- [x] `airflow-core/tests/unit/api_fastapi/auth/test_tokens.py` passes (20 passed, including the four `TestRevokeToken` tests after the `issuer=None` fix)
- [x] `providers/edge3/tests/unit/edge3/cli/test_api_client.py::test_make_generic_request_success` passes (verified locally)
- [ ] Compat 3.0.6 matrix job collects providers/fab tests cleanly (the original failure)
- [ ] Compat 3.0.6 matrix job no longer hits `Issuer (iss) must be a string` on edge3/keycloak/FAB tests

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
