### PR TITLE
Bump flask-appbuilder to 5.2.1 and mirror new auth event hooks

### DIFF
--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -111,7 +111,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
-``flask-appbuilder``                        ``==5.2.0``
+``flask-appbuilder``                        ``==5.2.1``
 ``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/providers/fab/auth_manager/security_manager/override.py` with their upstream counterparts.
     # In particular, make sure any breaking changes, for example any new methods, are accounted for.
-    "flask-appbuilder==5.2.0",  # Whenever updating the version, run test_fab_alignment.py to verify.
+    "flask-appbuilder==5.2.1",  # Whenever updating the version, run test_fab_alignment.py to verify.
     # Transitive via flask-appbuilder -> flask-jwt-extended; pinned here so the FAB
     # provider keeps installing cleanly when paired with older airflow-core releases
     # (the compat-3.0.6 matrix job) whose own pyjwt floor predates `jwt.types.Options`

--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1544,6 +1544,36 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
     def get_all_users(self) -> list[User]:
         return self.session.scalars(select(self.user_model)).all()
 
+    def on_user_login(self, user) -> None:
+        """
+        Run after a successful user login.
+
+        Override to add custom logic (e.g. audit logging). Mirrors
+        ``BaseSecurityManager.on_user_login`` from FAB 5.2.1+.
+
+        :param user: The authenticated user model.
+        """
+
+    def on_user_login_failed(self, user) -> None:
+        """
+        Run after a failed user login attempt.
+
+        Override to add custom logic (e.g. audit logging). Mirrors
+        ``BaseSecurityManager.on_user_login_failed`` from FAB 5.2.1+.
+
+        :param user: The identified (but not authenticated) user model.
+        """
+
+    def on_user_logout(self, user) -> None:
+        """
+        Run when a user logs out.
+
+        Override to add custom logic (e.g. audit logging). Mirrors
+        ``BaseSecurityManager.on_user_logout`` from FAB 5.2.1+.
+
+        :param user: The user model that is logging out.
+        """
+
     def update_user_auth_stat(self, user, success=True) -> None:
         """
         Update user authentication stats.
@@ -1569,6 +1599,13 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         else:
             user.fail_login_count += 1
         self.update_user(user)
+        # Fire the auth event hooks added in FAB 5.2.1 (PR #2450) so subclasses
+        # can plug in audit logging / custom side effects without having to
+        # override update_user_auth_stat itself.
+        if success:
+            self.on_user_login(user)
+        else:
+            self.on_user_login_failed(user)
 
     """
     -------------

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
@@ -40,7 +40,7 @@ from airflow.providers.fab.auth_manager.models import Role
 from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 # The FAB version that override.py was last aligned with.
-EXPECTED_FAB_VERSION = "5.2.0"
+EXPECTED_FAB_VERSION = "5.2.1"
 
 # FAB public methods that override.py intentionally does NOT implement.
 # Every entry must have a comment explaining why it's excluded.

--- a/uv.lock
+++ b/uv.lock
@@ -4961,7 +4961,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.6.2" },
     { name = "cachetools", specifier = ">=6.0" },
     { name = "flask", specifier = ">=2.2.1" },
-    { name = "flask-appbuilder", specifier = "==5.2.0" },
+    { name = "flask-appbuilder", specifier = "==5.2.1" },
     { name = "flask-limiter", specifier = ">3,!=3.13" },
     { name = "flask-login", marker = "python_full_version < '3.14'", specifier = ">=0.6.2" },
     { name = "flask-login", marker = "python_full_version >= '3.14'", specifier = ">=0.6.3" },
@@ -11388,7 +11388,7 @@ wheels = [
 
 [[package]]
 name = "flask-appbuilder"
-version = "5.2.0"
+version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"] },
@@ -11413,9 +11413,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "wtforms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/ca/a617a4b39d6c1336a3dbc0b2e2ee24c2cbd3183174620de965affa355741/flask_appbuilder-5.2.0.tar.gz", hash = "sha256:dd153b4649f0cd127aeed056a409141299c6f491ecbe297960b37ace07117e72", size = 7060586, upload-time = "2026-03-02T14:42:08.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b2/ad1784b3393cda84fd68b90689b1d6db037c13a62a9726ef639068bf8a75/flask_appbuilder-5.2.1.tar.gz", hash = "sha256:a5f6f34aa4ae0092a9eeb5051dc210869d9360429a429b0be88416c2616e1281", size = 7077970, upload-time = "2026-04-09T11:06:35.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/33/c3c98b590f644fe80298e368401a2ad920c153210bc1ebb4cb60d6ed6478/flask_appbuilder-5.2.0-py3-none-any.whl", hash = "sha256:054b9372e2f3785c8b0012bac744a807c5740bf4dff1ed207473a696a6321ce8", size = 2216573, upload-time = "2026-03-02T14:42:05.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/af/bdfd96170b1159ddc0e8424dfebbbac93d7270a1a749b0857fdaf384f027/flask_appbuilder-5.2.1-py3-none-any.whl", hash = "sha256:c5a134870fc0b780ac8d9de15fea8c470613ebe44feeddf01a2c18d2c066e144", size = 2217302, upload-time = "2026-04-09T11:06:32.891Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upstream Flask-AppBuilder 5.2.1 was released to PyPI on **2026-04-09** (commit `5dae8164` titled "release: 5.2.1"). The maintainer did not cut a GitHub release / tag, which is why `gh api .../tags` still shows `v5.2.0` as the latest. The release has three changes that matter for our vendored `BaseSecurityManager`:

| Upstream change | Effect on Airflow |
|---|---|
| **PR #2450** — new `on_user_login` / `on_user_login_failed` / `on_user_logout` no-op hooks; `update_user_auth_stat` now calls `on_user_login{,_failed}`; `AuthView.logout` / SAML SLO call `on_user_logout` | **Vendored** — `update_user_auth_stat` is in `override.py`, so the hook calls must be mirrored or the hooks never fire in Airflow. This PR mirrors them. |
| **PR #2451** — `_is_user_detached` / `_get_safe_user` helpers; `has_access` rewrite handling `DetachedInstanceError` on `g.user` (LocalProxy or detached ORM) | Inherited automatically — `has_access` is not vendored in `override.py`. No mirror needed. |
| **PR #2440** — security log redactions: OAuth tokens / responses no longer logged at debug level | Inherited automatically — the redacted code paths are not vendored. |

## Changes

1. `providers/fab/pyproject.toml` — bump `flask-appbuilder==5.2.0` → `==5.2.1`
2. `providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py` — add no-op `on_user_login` / `on_user_login_failed` / `on_user_logout` mirroring FAB's defaults; append the hook dispatch at the end of `update_user_auth_stat` matching the upstream call order (after `update_user`, so counters and `last_login` are persisted before the hook runs).
3. `providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py` — bump `EXPECTED_FAB_VERSION` to `"5.2.1"`.
4. `uv.lock` — re-resolved.

`generated/provider_dependencies.json` and `providers/fab/docs/index.rst` regenerated by prek.

## Validation

- `test_fab_alignment.py` — all 7 alignment tests pass with `flask-appbuilder==5.2.1` installed (the test compares `FabAirflowSecurityManagerOverride` against `BaseSecurityManager` from FAB).
- `providers/fab/tests/unit/fab/auth_manager/security_manager/` — all 39 unit tests pass.

## Note on the upstream PyJWT root cause

This PR builds on #66840 (parent branch `pin-pyjwt-in-fab-provider`), which adds a defensive `pyjwt>=2.11.0` pin to `providers/fab/pyproject.toml` to keep the FAB provider installable against older `airflow-core` releases. The actual root cause is **in `flask-jwt-extended`, not FAB**:

- `flask_jwt_extended/tokens.py` does `from jwt.types import Options`, and `jwt.types.Options` was first added in PyJWT 2.11.0
- `flask-jwt-extended` 4.7.3 (2026-05-08) bumped `requirements.txt` to `PyJWT==2.12.1` but **did not** lift the floor in `setup.py::install_requires`, which still reads `PyJWT>=2.0,<3.0`
- That gap means downstream consumers can resolve `flask-jwt-extended` 4.7.3 with PyJWT 2.10.x and still hit the broken import

A follow-up issue against `vimalloc/flask-jwt-extended` to lift their distributed-package install_requires floor to `PyJWT>=2.11.0` would be the cleanest long-term fix; until then, FAB's `PyJWT>=2.0.0,<3.0.0` pin is also too permissive but matches `flask-jwt-extended`'s. Our airflow-side defensive pin (#66840) closes the loop without waiting on either upstream.

## Test plan

- [ ] CI green on this branch
- [ ] `test_fab_alignment.py` passes in CI (it was the canary test we were supposed to run on every FAB version bump per the comment at `pyproject.toml:80`)
- [ ] Compat-3.0.6 matrix job collects providers/fab tests cleanly (the original failure that motivated the parent PR)

related: #66840

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)