### PR TITLE
Add overwrite parameter to IMAP hook download_mail_attachments

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,10 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite: If set to True, files with the same name will be overwritten.
+            If set to False, unique filenames will be generated for duplicate filenames
+            by appending a suffix (e.g. ``report_1.csv``, ``report_2.csv``).
+            Defaults to True for backwards compatibility.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +224,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite=overwrite)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +292,54 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, *, overwrite: bool = True
+    ) -> None:
+        seen: dict[str, int] = {}
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                if not overwrite:
+                    file_name = self._unique_name(name, seen, local_output_directory)
+                    file_path = self._correct_path(file_name, local_output_directory)
+                    while True:
+                        try:
+                            with open(file_path, "xb") as f:
+                                f.write(payload)
+                            break
+                        except FileExistsError:
+                            seen[file_name] = 0
+                            file_name = self._unique_name(name, seen, local_output_directory)
+                            file_path = self._correct_path(file_name, local_output_directory)
+                else:
+                    file_name = name
+                    self._create_file(file_name, payload, local_output_directory)
+
+    def _unique_name(self, name: str, seen: dict[str, int], local_output_directory: str) -> str:
+        """
+        Generate a unique filename by appending a suffix when duplicates exist.
+
+        Checks both the in-memory ``seen`` dict and the filesystem so that
+        files left over from previous runs are never overwritten.
+        """
+        base, ext = os.path.splitext(name)
+        if name not in seen and not os.path.exists(self._correct_path(name, local_output_directory)):
+            seen[name] = 0
+            return name
+        if name not in seen:
+            seen[name] = 0
+        candidate: str
+        while True:
+            seen[name] += 1
+            candidate = f"{base}_{seen[name]}{ext}"
+            if candidate not in seen and not os.path.exists(
+                self._correct_path(candidate, local_output_directory)
+            ):
+                seen[candidate] = 0
+                return candidate
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -623,3 +623,28 @@ class TestImapHook:
                     imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
 
         mock_open_method.assert_called_once_with("test_directory/report_1.csv", "xb")
+
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false_file_exists_error_retries(self, mock_imaplib):
+        """Retry with the next generated name when exclusive create raises FileExistsError."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [("report.csv", b"data1")]
+        successful_open = mock_open()
+
+        def open_side_effect(path, mode, *args, **kwargs):
+            if path == "test_directory/report.csv" and mode == "xb":
+                raise FileExistsError(path)
+            return successful_open(path, mode)
+
+        mock_open_wrapper = Mock(side_effect=open_side_effect)
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                with patch(open_string, mock_open_wrapper):
+                    imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        assert mock_open_wrapper.call_count == 2
+        mock_open_wrapper.assert_any_call("test_directory/report.csv", "xb")
+        mock_open_wrapper.assert_any_call("test_directory/report_1.csv", "xb")
+        successful_open.assert_called_once_with("test_directory/report_1.csv", "xb")

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -509,3 +509,117 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_default(self, mock_imaplib, mock_open_method):
+        """Default overwrite=True overwrites duplicate filenames."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [("report.csv", b"data1"), ("report.csv", b"data2")]
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                imap_hook.download_mail_attachments("report.csv", "test_directory")
+
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/report.csv", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false(self, mock_imaplib, mock_open_method):
+        """overwrite=False generates unique filenames for duplicates."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [("report.csv", b"data1"), ("report.csv", b"data2"), ("report.csv", b"data3")]
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        assert mock_open_method.call_count == 3
+        mock_open_method.assert_any_call("test_directory/report.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_1.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_2.csv", "xb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false_generated_name_collision(
+        self, mock_imaplib, mock_open_method
+    ):
+        """overwrite=False avoids collision between generated name and original attachment name."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [
+            ("report.csv", b"data1"),
+            ("report.csv", b"data2"),
+            ("report_1.csv", b"data3"),
+        ]
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        assert mock_open_method.call_count == 3
+        mock_open_method.assert_any_call("test_directory/report.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_1.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_1_1.csv", "xb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false_generated_name_reuse(self, mock_imaplib, mock_open_method):
+        """overwrite=False probes until finding an unused name."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [
+            ("report.csv", b"data1"),
+            ("report_1.csv", b"data2"),
+            ("report.csv", b"data3"),
+        ]
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        assert mock_open_method.call_count == 3
+        mock_open_method.assert_any_call("test_directory/report.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_1.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_2.csv", "xb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false_filesystem_collision(self, mock_imaplib, mock_open_method):
+        """overwrite=False avoids suffixed names already on disk from previous runs."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [("report.csv", b"data1"), ("report.csv", b"data2")]
+
+        def exists(path):
+            return path == "test_directory/report_1.csv"
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                with patch("os.path.exists", side_effect=exists):
+                    imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/report.csv", "xb")
+        mock_open_method.assert_any_call("test_directory/report_2.csv", "xb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_attachments_overwrite_false_original_on_disk(self, mock_imaplib, mock_open_method):
+        """overwrite=False generates suffix when original filename exists on disk."""
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        duplicates = [("report.csv", b"data1")]
+
+        def exists(path):
+            return path == "test_directory/report.csv"
+
+        with ImapHook() as imap_hook:
+            with patch.object(imap_hook, "_retrieve_mails_attachments_by_name", return_value=duplicates):
+                with patch("os.path.exists", side_effect=exists):
+                    imap_hook.download_mail_attachments("report.csv", "test_directory", overwrite=False)
+
+        mock_open_method.assert_called_once_with("test_directory/report_1.csv", "xb")


### PR DESCRIPTION
Add an `overwrite` parameter to the IMAP hook's `download_mail_attachments()` method.

When `overwrite=True` (default), duplicate filenames are overwritten (current behavior).  
When `overwrite=False`, unique filenames are generated by appending a suffix (e.g. `report_1.csv`, `report_2.csv`).

The non-overwrite path uses exclusive create mode (`"xb"`) to avoid TOCTOU races, and checks both in-memory state and the filesystem to handle files left over from previous runs.

closes: #65870

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=b69c2b6 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @kyupark** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@shahar1` is waiting on you:
> - 2 unresolved review thread(s) from `@shahar1` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->