### PR TITLE
Refactor Opensearch log formatter to use timezone.from_timestamp

### DIFF
--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
@@ -34,6 +34,7 @@ class OpensearchJSONFormatter(JSONFormatter):
 
             dt = timezone.from_timestamp(record.created, tz="local")
         else:
+            # TODO: Remove this fallback when the minimum Airflow version is 3.3.0
             from datetime import datetime
 
             import pendulum

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from airflow.providers.opensearch.version_compat import AIRFLOW_V_3_3_PLUS
 from airflow.sdk import timezone
 from airflow.utils.log.json_formatter import JSONFormatter
 
@@ -29,7 +30,15 @@ class OpensearchJSONFormatter(JSONFormatter):
 
     def formatTime(self, record, datefmt=None):
         """Return the creation time of the LogRecord in ISO 8601 date/time format in the local time zone."""
-        dt = timezone.from_timestamp(record.created, tz="local")
+        if AIRFLOW_V_3_3_PLUS:
+            dt = timezone.from_timestamp(record.created, tz="local")
+        else:
+            from datetime import datetime
+
+            import pendulum
+
+            dt = datetime.fromtimestamp(record.created, tz=pendulum.local_timezone())
+
         s = dt.strftime(datefmt or self.default_time_format)
         if self.default_msec_format:
             s = self.default_msec_format % (s, record.msecs)

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from airflow.providers.opensearch.version_compat import AIRFLOW_V_3_3_PLUS
-from airflow.sdk import timezone
 from airflow.utils.log.json_formatter import JSONFormatter
 
 
@@ -31,6 +30,8 @@ class OpensearchJSONFormatter(JSONFormatter):
     def formatTime(self, record, datefmt=None):
         """Return the creation time of the LogRecord in ISO 8601 date/time format in the local time zone."""
         if AIRFLOW_V_3_3_PLUS:
+            from airflow.sdk import timezone
+
             dt = timezone.from_timestamp(record.created, tz="local")
         else:
             from datetime import datetime

--- a/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/log/os_json_formatter.py
@@ -16,10 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from datetime import datetime
-
-import pendulum
-
+from airflow.sdk import timezone
 from airflow.utils.log.json_formatter import JSONFormatter
 
 
@@ -32,9 +29,7 @@ class OpensearchJSONFormatter(JSONFormatter):
 
     def formatTime(self, record, datefmt=None):
         """Return the creation time of the LogRecord in ISO 8601 date/time format in the local time zone."""
-        # TODO: Use airflow.utils.timezone.from_timestamp(record.created, tz="local")
-        #  as soon as min Airflow 2.9.0
-        dt = datetime.fromtimestamp(record.created, tz=pendulum.local_timezone())
+        dt = timezone.from_timestamp(record.created, tz="local")
         s = dt.strftime(datefmt or self.default_time_format)
         if self.default_msec_format:
             s = self.default_msec_format % (s, record.msecs)

--- a/providers/opensearch/src/airflow/providers/opensearch/version_compat.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/version_compat.py
@@ -35,9 +35,11 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS: bool = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_2_PLUS: bool = get_base_airflow_version_tuple() >= (3, 2, 0)
+AIRFLOW_V_3_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 3, 0)
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
 ]


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Description
This PR refactors the `OpensearchJSONFormatter` to use the standard Airflow `timezone.from_timestamp` utility, addressing a TODO in the codebase. 

> [!NOTE]
> The necessary Task SDK changes (exporting `from_timestamp` in `airflow.sdk.timezone`) have been extracted to a dedicated PR: #67321.

### Key changes
* **Compatibility logic**: Implemented version-based compatibility logic in the Opensearch provider. The formatter now uses the new `timezone.from_timestamp` on Airflow 3.3.0+ and maintains backward compatibility by falling back to the original pendulum/datetime logic on older Airflow 3.x releases.

### Verification Results
I have verified the changes using both `prek` (ruff) and `breeze` (standardized Docker environment).
- **Static Checks (Prek):** Passed
- **Unit Tests (Breeze):** Passed

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Please review this refactor.
/cc @choo121600 @noeunkim

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
