### PR TITLE
[v3-2-test] fix(DagCalendarTab): improve background color retrieval and loading overlay handling (#64189)

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts
@@ -50,9 +50,35 @@ export class DagCalendarTab extends BasePage {
 
     for (let i = 0; i < count; i++) {
       const cell = this.activeCells.nth(i);
-      const bg = await cell.evaluate((el) => window.getComputedStyle(el).backgroundColor);
+      const computedColor = await cell.evaluate((el: Element) => {
+        const getRenderableColor = (element: Element): string => {
+          const color = window.getComputedStyle(element).backgroundColor;
 
-      colors.push(bg);
+          return color && color !== "rgba(0, 0, 0, 0)" && color !== "transparent" ? color : "";
+        };
+
+        const cellColor = getRenderableColor(el);
+
+        if (cellColor) {
+          return cellColor;
+        }
+
+        const children = [...el.querySelectorAll("*")];
+
+        for (const child of children) {
+          const childColor = getRenderableColor(child);
+
+          if (childColor) {
+            return childColor;
+          }
+        }
+
+        return "";
+      });
+
+      if (computedColor) {
+        colors.push(computedColor);
+      }
     }
 
     return colors;
@@ -97,7 +123,7 @@ export class DagCalendarTab extends BasePage {
   public async switchToHourly() {
     await this.hourlyToggle.click();
 
-    await this.page.getByTestId("calendar-hourly-view").waitFor({ state: "visible", timeout: 30_000 });
+    await expect(this.page.getByTestId("calendar-hourly-view")).toBeVisible({ timeout: 30_000 });
   }
 
   public async switchToTotalView() {
@@ -109,22 +135,16 @@ export class DagCalendarTab extends BasePage {
   }
 
   private async waitForCalendarReady(): Promise<void> {
-    await this.page.getByTestId("dag-calendar-root").waitFor({ state: "visible", timeout: 120_000 });
+    await expect(this.page.getByTestId("dag-calendar-root")).toBeVisible({ timeout: 120_000 });
 
-    await this.page.getByTestId("calendar-current-period").waitFor({ state: "visible", timeout: 120_000 });
+    await expect(this.page.getByTestId("calendar-current-period")).toBeVisible({ timeout: 120_000 });
+    await expect(this.page.getByTestId("calendar-grid")).toBeVisible({ timeout: 120_000 });
 
     const overlay = this.page.getByTestId("calendar-loading-overlay");
 
-    if (await overlay.isVisible().catch(() => false)) {
-      await overlay.waitFor({ state: "hidden", timeout: 120_000 });
-    }
+    await expect(overlay).toBeHidden({ timeout: 120_000 });
+    const cells = this.page.getByTestId("calendar-cell");
 
-    await this.page.getByTestId("calendar-grid").waitFor({ state: "visible", timeout: 120_000 });
-
-    await this.page.waitForFunction(() => {
-      const cells = document.querySelectorAll('[data-testid="calendar-cell"]');
-
-      return cells.length > 0;
-    });
+    await expect(cells.first()).toBeVisible({ timeout: 120_000 });
   }
 }


### PR DESCRIPTION
Cherry-pick of #64189 for the Airflow 3.2.2 patch release.

### Conflict resolution

One conflict in `airflow-core/src/airflow/ui/tests/e2e/pages/DagCalendarTab.ts::navigateToCalendar`. The PR side used a `this.safeGoto(...)` helper plus `expect(...).toBeVisible()`, while `v3-2-test`'s `BasePage` does not export `safeGoto`. Kept the `v3-2-test` style (`this.page.goto(...)` + `waitFor({ state: "visible" })`) to avoid introducing a runtime reference error. The remainder of #64189 (background-colour retrieval logic, loading-overlay handling, visibility checks) applied cleanly.