### PR TITLE
[v3-2-test] Mark tests as fixme for asset details and connection deletion (#65487)

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/specs/asset.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/asset.spec.ts
@@ -101,7 +101,7 @@ test.describe("Assets Page", () => {
       .toBe(true);
   });
 
-  test("verify asset details and dependencies", async ({ page }) => {
+  test.fixme("verify asset details and dependencies", async ({ page }) => {
     const assetDetailPage = new AssetDetailPage(page);
     const assetName = testConfig.asset.name;
 

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/connections.spec.ts
@@ -191,7 +191,7 @@ test.describe("Connections Page - CRUD Operations", () => {
     expect(stillExists).toBeTruthy();
   });
 
-  test("should delete a connection", async () => {
+  test.fixme("should delete a connection", async () => {
     test.setTimeout(120_000);
 
     // Create a temporary connection for deletion test


### PR DESCRIPTION
Cherry-pick of #65487 

### Conflict resolution

One conflict in `airflow-core/src/airflow/ui/tests/e2e/specs/asset.spec.ts`. The PR side also refactored the test parameter to a fixture-style `({ assetDetailPage })` (from a separate PR not in this backport set). Kept v3-2-test's `({ page })` signature and the manual `const assetDetailPage = new AssetDetailPage(page)` line, and applied only #65487's intent — the `test.fixme(...)` skip change.