### PR TITLE
Keep Named*Logger.name working across structlog releases

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -203,24 +203,38 @@ def make_filtering_logger() -> Callable[..., BindableLogger]:
     return maker
 
 
+# structlog >= 26.1.0 added a `name` slot + kwarg to BytesLogger
+# (hynek/structlog#786). Detect it once so we can avoid a redundant slot and
+# forward `name` through the parent init. The same detection is applied to
+# WriteLogger so the analogous upstream change lands without a regression.
+_BYTES_LOGGER_HAS_NAME = "name" in getattr(structlog.BytesLogger, "__slots__", ())
+_WRITE_LOGGER_HAS_NAME = "name" in getattr(structlog.WriteLogger, "__slots__", ())
+
+
 class NamedBytesLogger(structlog.BytesLogger):
-    __slots__ = ("name",)
+    __slots__ = () if _BYTES_LOGGER_HAS_NAME else ("name",)
 
     def __init__(self, name: str | None = None, file: BinaryIO | None = None):
-        self.name = name
         if file is not None:
             file = make_file_io_non_caching(file)
-        super().__init__(file)
+        if _BYTES_LOGGER_HAS_NAME:
+            super().__init__(file, name=name)  # type: ignore[call-arg]
+        else:
+            super().__init__(file)
+            self.name = name
 
 
 class NamedWriteLogger(structlog.WriteLogger):
-    __slots__ = ("name",)
+    __slots__ = () if _WRITE_LOGGER_HAS_NAME else ("name",)
 
     def __init__(self, name: str | None = None, file: TextIO | None = None):
-        self.name = name
         if file is not None:
             file = make_file_io_non_caching(file)
-        super().__init__(file)
+        if _WRITE_LOGGER_HAS_NAME:
+            super().__init__(file, name=name)  # type: ignore[call-arg]
+        else:
+            super().__init__(file)
+            self.name = name
 
 
 LogOutputType = TypeVar("LogOutputType", bound=TextIO | BinaryIO)

--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -707,3 +707,24 @@ def test_dict_positional_arg_formatting(structlog_config, get_logger, message, a
 
     written = json.load(bio)
     assert written["event"] == expected_event
+
+
+def test_named_bytes_logger_preserves_name():
+    """
+    structlog 26.1.0 (hynek/structlog#786) gives ``BytesLogger`` its own ``name``
+    slot and sets ``self.name`` in ``__init__``; older releases do not. This test
+    runs against whichever version is installed and pins the contract that the
+    supplied name survives construction on both.
+    """
+    from airflow_shared.logging.structlog import NamedBytesLogger
+
+    assert NamedBytesLogger("my.logger").name == "my.logger"
+    assert NamedBytesLogger().name is None
+
+
+def test_named_write_logger_preserves_name():
+    """Same contract for NamedWriteLogger in case structlog mirrors #786 for WriteLogger."""
+    from airflow_shared.logging.structlog import NamedWriteLogger
+
+    assert NamedWriteLogger("my.logger").name == "my.logger"
+    assert NamedWriteLogger().name is None


### PR DESCRIPTION
Pre-emptive change to support - structlog 26.1.0 (most likely version - merged in hynek/structlog#786) adds a `name` slot and a kwarg-only
`name` argument to `BytesLogger`, and its `__init__` now assigns
`self.name = name`.

In NamedBytesLogger we were setting `self.name` *before* calling
`super().__init__`, so on the new release the parent would overwrite the
caller-supplied name with `None`, breaking the per-logger level lookup in
`make_filtering_logger` and any other consumer that reads `logger.name`.

Since this is ont yet released, I can't be certain if it will be in 26.1.0 or
something else, but it's merged to structlog's main, so lets cope with it
when ever it lands

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
