### PR TITLE
[v3-2-test] Show dag run duration in grid tooltip (#65787)

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -84,6 +84,7 @@ export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
           alignItems="center"
           color="fg"
           dagId={dagId}
+          duration={run.duration}
           flexDir="column"
           height={`${(run.duration / max) * BAR_HEIGHT}px`}
           justifyContent="flex-end"

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.test.tsx
@@ -31,6 +31,7 @@ describe("GridButton", () => {
     render(
       <GridButton
         dagId="example_dag"
+        duration={3661}
         label="2026-04-21T00:00:00+00:00"
         runId="manual__2026-04-21T00:00:00+00:00"
         searchParams=""
@@ -49,6 +50,7 @@ describe("GridButton", () => {
     expect(screen.getByTestId("basic-tooltip")).toHaveTextContent(
       "common:runId: manual__2026-04-21T00:00:00+00:00",
     );
+    expect(screen.getByTestId("basic-tooltip")).toHaveTextContent("duration: 01:01:01");
 
     vi.useRealTimers();
   });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridButton.tsx
@@ -22,9 +22,11 @@ import { Link } from "react-router-dom";
 
 import type { DagRunState, TaskInstanceState } from "openapi/requests/types.gen";
 import { BasicTooltip } from "src/components/BasicTooltip";
+import { renderDuration } from "src/utils/datetimeUtils";
 
 type Props = {
   readonly dagId: string;
+  readonly duration?: number | null;
   readonly isGroup?: boolean;
   readonly label: string;
   readonly runId: string;
@@ -36,6 +38,7 @@ type Props = {
 export const GridButton = ({
   children,
   dagId,
+  duration,
   isGroup,
   label,
   runId,
@@ -54,6 +57,8 @@ export const GridButton = ({
       <br />
       {translate("state")}:{" "}
       {state ? translate(`common:states.${state}`) : translate("common:states.no_status")}
+      <br />
+      {translate("duration")}: {renderDuration(duration)}
     </>
   );
 


### PR DESCRIPTION
Cherry-pick of #65787 for the Airflow 3.2.2 patch release.

### Stacked PR

This PR is **stacked on top of #66871** (#65626 backport). #65787 modifies `GridButton.test.tsx` and `GridButton.tsx` — both of which were introduced by #65626. Since #66871 isn't merged yet, `backport-322-65787` is branched off `backport-322-65626` so the cherry-pick applies cleanly.

**Merge order:** merge #66871 first; this PR's diff will then collapse to only #65787's three-file change (no duplicate #65626 commit).


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)