### PR TITLE
[v3-2-test] UI: Fix Mark state as... buttons grayed out when task/DAGRun already in target state (#66198)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -46,7 +46,7 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
       setState("failed");
       onOpen();
     },
-    { enabled: isHotkeyEnabled && dagRun.state !== "failed" },
+    { enabled: isHotkeyEnabled },
   );
 
   useHotkeys(
@@ -55,7 +55,7 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
       setState("success");
       onOpen();
     },
-    { enabled: isHotkeyEnabled && dagRun.state !== "success" },
+    { enabled: isHotkeyEnabled },
   );
 
   return (
@@ -94,20 +94,18 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
               <Tooltip
                 closeDelay={100}
                 content={content}
-                disabled={!isHotkeyEnabled || dagRun.state === menuState}
+                disabled={!isHotkeyEnabled}
                 key={menuState}
                 openDelay={100}
               >
+                {/* Not disabled when state matches: re-applying lets users also flip upstream/downstream tasks */}
                 <Menu.Item
                   asChild
                   data-testid={`mark-run-as-${menuState}`}
-                  disabled={dagRun.state === menuState}
                   key={menuState}
                   onClick={() => {
-                    if (dagRun.state !== menuState) {
-                      setState(menuState);
-                      onOpen();
-                    }
+                    setState(menuState);
+                    onOpen();
                   }}
                   value={menuState}
                 >

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -47,7 +47,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
       setState("failed");
       onOpen();
     },
-    { enabled: isHotkeyEnabled && taskInstance.state !== "failed" },
+    { enabled: isHotkeyEnabled },
   );
 
   useHotkeys(
@@ -56,7 +56,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
       setState("success");
       onOpen();
     },
-    { enabled: isHotkeyEnabled && taskInstance.state !== "success" },
+    { enabled: isHotkeyEnabled },
   );
 
   return (
@@ -96,19 +96,17 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
               <Tooltip
                 closeDelay={100}
                 content={content}
-                disabled={!isHotkeyEnabled || taskInstance.state === menuState}
+                disabled={!isHotkeyEnabled}
                 key={menuState}
                 openDelay={100}
               >
+                {/* Not disabled when state matches: re-applying lets users also flip upstream/downstream tasks */}
                 <Menu.Item
                   asChild
-                  disabled={taskInstance.state === menuState}
                   key={menuState}
                   onClick={() => {
-                    if (taskInstance.state !== menuState) {
-                      setState(menuState);
-                      onOpen();
-                    }
+                    setState(menuState);
+                    onOpen();
                   }}
                   value={menuState}
                 >


### PR DESCRIPTION
Cherry-pick of #66198

### Conflict resolution

PR touches three files:
- \`MarkAs/Run/MarkRunAsButton.tsx\` — auto-merged
- \`MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx\` — auto-merged
- \`MarkAs/TaskGroup/MarkTaskGroupAsButton.tsx\` — **doesn't exist on v3-2-test** (whole \`MarkAs/TaskGroup/\` directory was introduced on main by a separate PR not in this backport set). No other UI file on v3-2-test imports it, so the PR's modified version would be orphaned dead code. **Dropped** the TaskGroup file; the user-visible fix lives in the two button components that do exist on v3-2-test (Run + TaskInstance).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)