### PR TITLE
Remove airflow-core session and serialization imports from _run_task

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -442,8 +442,8 @@ def task_test(args, dag: DAG | None = None) -> None:
         # TODO: move bulk of this logic into the SDK: http://github.com/apache/airflow/issues/54658
         from airflow.sdk._shared.secrets_masker import RedactedIO
 
-        with redirect_stdout(RedactedIO()):
-            _run_task(ti=ti, task=sdk_task, run_triggerer=True)
+        with redirect_stdout(RedactedIO()), create_session() as session:
+            _run_task(ti=ti, task=sdk_task, run_triggerer=True, session=session)
         if ti.state == State.FAILED and args.post_mortem:
             debugger = _guess_debugger()
             debugger.set_trace()

--- a/devel-common/src/tests_common/test_utils/taskinstance.py
+++ b/devel-common/src/tests_common/test_utils/taskinstance.py
@@ -22,7 +22,7 @@ import copy
 from typing import TYPE_CHECKING
 
 from airflow.models.taskinstance import TaskInstance
-from airflow.utils.session import NEW_SESSION
+from airflow.utils.session import NEW_SESSION, create_session
 
 from tests_common.test_utils.compat import SerializedBaseOperator, SerializedMappedOperator
 from tests_common.test_utils.dag import create_scheduler_dag
@@ -141,7 +141,13 @@ def run_task_instance(
         **session_kwargs,
     )
     # Some tests don't even save the ti at all, in which case new_ti is None.
-    taskrun_result = _run_task(ti=new_ti or ti, task=task)
+    # ``_run_task`` requires a real session for the inline DEFERRED → SCHEDULED
+    # transition (AIP-72: task-sdk does not open its own DB session).
+    if session is not None:
+        taskrun_result = _run_task(ti=new_ti or ti, task=task, session=session)
+    else:
+        with create_session() as run_task_session:
+            taskrun_result = _run_task(ti=new_ti or ti, task=task, session=run_task_session)
     ti.refresh_from_db(**session_kwargs)  # Some tests expect side effects.
     if not taskrun_result:
         raise RuntimeError("task failed to finish with a result")

--- a/devel-common/src/tests_common/test_utils/taskinstance.py
+++ b/devel-common/src/tests_common/test_utils/taskinstance.py
@@ -26,7 +26,11 @@ from airflow.utils.session import NEW_SESSION, create_session
 
 from tests_common.test_utils.compat import SerializedBaseOperator, SerializedMappedOperator
 from tests_common.test_utils.dag import create_scheduler_dag
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
 
 try:
     from airflow.serialization.serialized_objects import create_scheduler_operator
@@ -141,13 +145,21 @@ def run_task_instance(
         **session_kwargs,
     )
     # Some tests don't even save the ti at all, in which case new_ti is None.
-    # ``_run_task`` requires a real session for the inline DEFERRED → SCHEDULED
-    # transition (AIP-72: task-sdk does not open its own DB session).
-    if session is not None:
-        taskrun_result = _run_task(ti=new_ti or ti, task=task, session=session)
+    if AIRFLOW_V_3_3_PLUS:
+        # On 3.3+, ``_run_task`` requires a real session for the inline
+        # DEFERRED → SCHEDULED transition (AIP-72: task-sdk does not open
+        # its own DB session).
+        if session is not None:
+            taskrun_result = _run_task(ti=new_ti or ti, task=task, session=session)
+        else:
+            with create_session() as run_task_session:
+                taskrun_result = _run_task(ti=new_ti or ti, task=task, session=run_task_session)
     else:
-        with create_session() as run_task_session:
-            taskrun_result = _run_task(ti=new_ti or ti, task=task, session=run_task_session)
+        # 3.2.x ``_run_task`` opens its own session internally and doesn't
+        # accept a ``session`` kwarg. mypy types against current main where
+        # ``session`` is required, so suppress the call-arg error for this
+        # backwards-compatible branch.
+        taskrun_result = _run_task(ti=new_ti or ti, task=task)  # type: ignore[call-arg]
     ti.refresh_from_db(**session_kwargs)  # Some tests expect side effects.
     if not taskrun_result:
         raise RuntimeError("task failed to finish with a result")

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from typing import TypeAlias, TypeVar
 
     from pendulum.tz.timezone import FixedTimezone, Timezone
+    from sqlalchemy.orm import Session
     from typing_extensions import Self, TypeIs
 
     from airflow.models.taskinstance import TaskInstance as SchedulerTaskInstance
@@ -1444,7 +1445,7 @@ class DAG:
                                 ti.set_state(TaskInstanceState.SUCCESS)
                                 log.info("[DAG TEST] Marking success for %s on %s", task, ti.logical_date)
                             else:
-                                _run_task(ti=ti, task=task, run_triggerer=True)
+                                _run_task(ti=ti, task=task, run_triggerer=True, session=session)
                         except Exception:
                             log.exception("Task failed; ti=%s", ti)
                 if use_executor:
@@ -1466,6 +1467,7 @@ def _run_task(
     *,
     ti: SchedulerTaskInstance,
     task: Operator,
+    session: Session,
     run_triggerer: bool = False,
 ) -> TaskRunResult | None:
     """
@@ -1473,10 +1475,13 @@ def _run_task(
 
     Bypasses a lot of extra steps used in `task.run` to keep our local running as fast as
     possible.  This function is only meant for the `dag.test` function as a helper function.
+
+    The DEFERRED → SCHEDULED transition needed to resume a task after running its
+    trigger inline writes through the caller-supplied ``session`` — task-sdk must not
+    open its own DB session (AIP-72 server-client boundary).
     """
     from airflow.sdk._shared.module_loading import import_string
     from airflow.sdk.serde import deserialize, serialize
-    from airflow.utils.session import create_session
 
     taskrun_result: TaskRunResult | None
     log.info("[DAG TEST] starting task_id=%s map_index=%s", ti.task_id, ti.map_index)
@@ -1487,7 +1492,6 @@ def _run_task(
             from airflow.sdk.api.datamodels._generated import TaskInstance as TaskInstanceSDK
             from airflow.sdk.execution_time.comms import DeferTask
             from airflow.sdk.execution_time.supervisor import run_task_in_process
-            from airflow.serialization.serialized_objects import create_scheduler_operator
 
             # The API Server expects the task instance to be in QUEUED state before
             # it is run.
@@ -1505,7 +1509,6 @@ def _run_task(
             taskrun_result = run_task_in_process(ti=task_sdk_ti, task=task)
             msg = taskrun_result.msg
             ti.set_state(taskrun_result.ti.state)
-            ti.task = create_scheduler_operator(taskrun_result.ti.task)
 
             if ti.state == TaskInstanceState.DEFERRED and isinstance(msg, DeferTask) and run_triggerer:
                 # API Server expects the task instance to be in QUEUED state before
@@ -1526,10 +1529,12 @@ def _run_task(
                 ti.next_kwargs = {"event": serialize(event.payload)} if event else msg.next_kwargs
                 log.info("[DAG TEST] Trigger completed")
 
-                # Set the state to SCHEDULED so that the task can be resumed.
-                with create_session() as session:
-                    ti.state = TaskInstanceState.SCHEDULED
-                    session.add(ti)
+                # Set the state to SCHEDULED so that the task can be resumed. The
+                # next iteration's run_task_in_process reads ti.state via the API
+                # server, so this must be committed before the loop continues.
+                ti.state = TaskInstanceState.SCHEDULED
+                session.add(ti)
+                session.commit()
                 continue
 
             break


### PR DESCRIPTION
## Summary

Removes two `airflow-core` imports from `_run_task` in `task-sdk/src/airflow/sdk/definitions/dag.py`:

- `airflow.utils.session.create_session` (L1473) — sub-issue #54710. `_run_task` now
  takes a `session` keyword argument supplied by its caller (`dag.test`), and uses it
  for the inline `DEFERRED → SCHEDULED` transition after the trigger runs. The write
  is always performed; missing the session now fails loudly with `TypeError` (no
  silent skip — addresses the failure mode of the previous attempt at #54933).
- `airflow.serialization.serialized_objects.create_scheduler_operator` (L1484). The
  single use site (`ti.task = create_scheduler_operator(...)`) mutates a non-SQLAlchemy
  Python attribute that nothing downstream reads (the caller re-resolves the task via
  `self.task_dict[ti.task_id]`). Confirmed dead by full test sweep — removed along
  with the import.

The test helper `run_task_instance` in `devel-common/.../test_utils/taskinstance.py`
also calls `_run_task` directly, so it's updated to thread (or open) a session
the same way.

## Scope clarification

The issue comment proposed moving "DB-write responsibility from `_run_task` up to
its caller". This PR moves the **session ownership** to the caller while keeping
the actual `session.add(ti) + session.commit()` inside `_run_task`. Hoisting the
write itself (so `_run_task` becomes a pure single-attempt function and the caller
drives the deferred-resume loop) is a larger refactor I'd like to keep as a
follow-up — happy to take that on if the design direction is preferred.

## Verification

- `breeze run pytest airflow-core/tests/unit/models/test_dag.py airflow-core/tests/unit/cli/commands/test_dag_command.py airflow-core/tests/unit/models/test_mappedoperator.py airflow-core/tests/unit/models/test_xcom_arg.py` — 323 passed.
- DEFERRED → SCHEDULED resume specifically covered by `test_dag_test_no_triggerer_running`.
- `prek run --from-ref upstream/main --stage pre-commit` — all checks pass.
- `prek run mypy-task-sdk` — pass.

closes: #54710
related: #61803

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)