### PR TITLE
docs(security): document supported deployment platforms

### DIFF
--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -833,7 +833,7 @@ Supported deployment platforms
 Apache Airflow officially supports Linux-based deployment environments only. The reference
 deployment, the CI matrix, and the official Docker image are all Linux-targeted (Debian Bookworm).
 macOS is supported for local development but is not a deployment platform. Windows is not supported
-for deployment or development.
+for deployment - except WSL2 for develop (buy only with POSIX filesystem which is the same as Linux).
 
 Vulnerability reports that only manifest on a non-Linux platform — behavior that depends on Windows
 path separators, macOS-specific filesystem semantics, etc. — are **out of scope** for the security

--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -826,3 +826,22 @@ significantly from typical web applications — many scanner findings (such as "
 code" or "database credentials accessible in configuration") are expected behavior. Reports must
 include a proof-of-concept that demonstrates how the finding violates the security model described
 in this document, including identifying the specific user role involved and the attack scenario.
+
+Supported deployment platforms
+..............................
+
+Apache Airflow officially supports Linux-based deployment environments only. The reference
+deployment, the CI matrix, and the official Docker image are all Linux-targeted (Debian Bookworm).
+macOS is supported for local development but is not a deployment platform. Windows is not supported
+for deployment or development.
+
+Vulnerability reports that only manifest on a non-Linux platform — behavior that depends on Windows
+path separators, macOS-specific filesystem semantics, etc. — are **out of scope** for the security
+process. We do not issue CVEs or advisories for platform-specific bugs in deployment configurations
+the project does not support.
+
+Reports where the bug affects both supported (Linux) and unsupported (Windows, macOS) platforms are
+judged on the Linux behavior; the non-Linux aspect is informational.
+
+Reporters who identify a non-Linux-only bug should still report it through the regular contribution
+process — fixes are welcome as defense-in-depth hardening, with no CVE or advisory.


### PR DESCRIPTION
## Summary

Adds an explicit out-of-scope section for non-Linux platforms to the Security Model. Bugs that only manifest on Windows / macOS / other non-Linux platforms are not eligible for CVE allocation because Airflow does not officially support those platforms as deployment targets.

## Motivation

Codifies what was already the security team's practice — most recently the disposition on a 2026-05-14 IMAP-attachment-path-traversal report ([GHSA-w72r-xvc9-jwgh](https://github.com/apache/airflow/security/advisories/GHSA-w72r-xvc9-jwgh)) that only manifested on Windows due to backslash path-separator handling, closed NOT-CVE-WORTHY on this basis.

Without an explicit Security Model section, reporters routinely submit Windows-only path-traversal / RCE reports that the team has to invalidate one-by-one with manual reasoning. Future Windows-only / macOS-only reports will be closed against this section, and reporters can read the rule upfront before submitting through `security@`.

The rule applies symmetrically: a bug that affects Linux is judged on the Linux behavior regardless of whether it also reaches Windows; non-Linux-only bugs are out of scope.

## Test plan

- [ ] Render the docs locally with `breeze build-docs apache-airflow --package-filter apache-airflow` and confirm the new section appears under the existing out-of-scope items in the Security Model page.
- [ ] Spot-check that the new anchor `#supported-deployment-platforms` is generated correctly (Sphinx generates anchor IDs from heading text via kebab-case).
