### PR TITLE
Fix API server OOMKill: release row lock before asset event emission under high concurrency

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -459,11 +459,26 @@ def ti_update_state(
                 extra=json.dumps({"host_name": hostname}) if hostname else None,
             )
         )
+        session.commit()
     except SQLAlchemyError as e:
         log.error("Error updating Task Instance state", error=str(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
         )
+
+    if isinstance(ti_patch_payload, TISuccessStatePayload):
+        try:
+            ti = session.get(TI, task_instance_id)
+            if ti is not None:
+                TI.register_asset_changes_in_db(
+                    ti,
+                    ti_patch_payload.task_outlets,
+                    ti_patch_payload.outlet_events,
+                    session,
+                )
+                session.commit()
+        except Exception:
+            log.exception("Error registering asset changes. The task state is already saved as SUCCESS.")
 
     if updated_state == TaskInstanceState.SUCCESS:
         if conf.getboolean("state_store", "clear_on_success"):
@@ -577,14 +592,6 @@ def _create_ti_state_update_query_and_update_state(
                 retry_delay_override=ti_patch_payload.retry_delay_seconds,
                 retry_reason=(ti_patch_payload.retry_reason[:500] if ti_patch_payload.retry_reason else None),
             )
-        elif isinstance(ti_patch_payload, TISuccessStatePayload):
-            if ti is not None:
-                TI.register_asset_changes_in_db(
-                    ti,
-                    ti_patch_payload.task_outlets,
-                    ti_patch_payload.outlet_events,
-                    session,
-                )
         _emit_task_span(ti, state=updated_state)
     elif isinstance(ti_patch_payload, TIDeferredStatePayload):
         # Calculate timeout if it was passed

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -17,12 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable
+from collections.abc import Collection
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import structlog
-from sqlalchemy import exc, or_, select
+from sqlalchemy import exc, insert, or_, select
 from sqlalchemy.orm import joinedload
 
 from airflow._shared.observability.metrics import stats
@@ -40,6 +40,7 @@ from airflow.models.asset import (
     DagScheduleAssetReference,
     DagScheduleAssetUriReference,
     PartitionedAssetKeyLog,
+    asset_alias_asset_event_association_table,
 )
 from airflow.models.log import Log
 from airflow.utils.helpers import is_container
@@ -314,18 +315,22 @@ class AssetManager(LoggingMixin):
 
         dags_to_queue_from_asset_alias = set()
         if source_alias_names:
-            asset_alias_models: Iterable[AssetAliasModel] = session.scalars(
+            asset_alias_models: list[AssetAliasModel] = session.scalars(
                 select(AssetAliasModel)
                 .where(AssetAliasModel.name.in_(source_alias_names))
                 .options(
                     joinedload(AssetAliasModel.scheduled_dags).joinedload(DagScheduleAssetAliasReference.dag)
                 )
-            ).unique()
+            ).unique().all()
+
+            if asset_alias_models:
+                session.execute(
+                    insert(asset_alias_asset_event_association_table).values(
+                        [{"alias_id": aam.id, "event_id": asset_event.id} for aam in asset_alias_models]
+                    )
+                )
 
             for asset_alias_model in asset_alias_models:
-                asset_alias_model.asset_events.append(asset_event)
-                session.add(asset_alias_model)
-
                 dags_to_queue_from_asset_alias |= {
                     alias_ref.dag
                     for alias_ref in asset_alias_model.scheduled_dags

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1331,6 +1331,35 @@ class TestTIUpdateState:
             assert events[0].asset == AssetModel(name="my-task", uri="s3://bucket/my-task", extra={})
             assert events[0].extra == expected_extra
 
+    def test_ti_update_state_to_success_asset_registration_failure_returns_204(
+        self, client, session, create_task_instance
+    ):
+        ti = create_task_instance(
+            task_id="test_ti_update_state_to_success_asset_registration_failure_returns_204",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        with mock.patch("airflow.models.taskinstance.TaskInstance.register_asset_changes_in_db") as mock_register:
+            mock_register.side_effect = Exception("Asset registration failed")
+
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/state",
+                json={
+                    "state": "success",
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                    "task_outlets": [{"name": "my-task", "uri": "s3://bucket/my-task", "type": "Asset"}],
+                },
+            )
+
+        assert response.status_code == 204
+        assert response.text == ""
+
+        session.expire_all()
+        ti = session.get(TaskInstance, ti.id)
+        assert ti.state == State.SUCCESS
+
     def test_ti_update_state_not_found(self, client, session):
         """
         Test that a 404 error is returned when the Task Instance does not exist.

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, event, func, insert, select
 from sqlalchemy.orm import Session
 
 from airflow import settings
@@ -38,6 +38,7 @@ from airflow.models.asset import (
     AssetPartitionDagRun,
     DagScheduleAssetAliasReference,
     DagScheduleAssetReference,
+    asset_alias_asset_event_association_table,
 )
 from airflow.models.dag import DAG, DagModel
 from airflow.sdk.definitions.asset import Asset
@@ -161,6 +162,76 @@ class TestAssetManager:
             == 1
         )
         assert session.scalar(select(func.count()).select_from(AssetDagRunQueue)) == 2
+
+    @pytest.mark.usefixtures("clear_assets")
+    def test_register_asset_change_with_alias_no_lazy_load(
+        self, session, dag_maker, mock_task_instance, testing_dag_bundle
+    ):
+        bundle_name = "testing"
+
+        consumer_dag_1 = DagModel(
+            dag_id="consumer_1", bundle_name=bundle_name, is_stale=False, fileloc="dag1.py"
+        )
+        session.add(consumer_dag_1)
+
+        asm = AssetModel(uri="test://asset1/", name="test_asset_uri", group="asset")
+        session.add(asm)
+
+        asam = AssetAliasModel(name="test_alias_name", group="test")
+        session.add(asam)
+        asam.scheduled_dags = [
+            DagScheduleAssetAliasReference(alias_id=asam.id, dag_id=consumer_dag_1.dag_id)
+        ]
+        session.execute(delete(AssetDagRunQueue))
+        session.flush()
+
+        # Add a bunch of preexisting asset events for the alias
+        pre_existing_events = []
+        for _ in range(5):
+            ev = AssetEvent(asset_id=asm.id)
+            session.add(ev)
+            pre_existing_events.append(ev)
+        session.flush()
+
+        session.execute(
+            insert(asset_alias_asset_event_association_table).values(
+                [{"alias_id": asam.id, "event_id": ev.id} for ev in pre_existing_events]
+            )
+        )
+        session.commit()
+
+        asset = Asset(uri="test://asset1", name="test_asset_uri")
+        asset_manager = AssetManager()
+
+        query_count = 0
+
+        def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            nonlocal query_count
+            if "asset_alias_asset_event" in statement and "SELECT" in statement.upper():
+                query_count += 1
+
+        event.listen(session.bind, "before_cursor_execute", before_cursor_execute)
+
+        asset_manager.register_asset_change(
+            task_instance=mock_task_instance,
+            asset=asset,
+            source_alias_names=["test_alias_name"],
+            session=session,
+        )
+        session.flush()
+
+        event.remove(session.bind, "before_cursor_execute", before_cursor_execute)
+
+        # Ensure no SELECTs were made to the association table (no lazy loading)
+        assert query_count == 0
+
+        # Ensure we've created the new asset event and it is associated
+        # Total events should be 5 pre-existing + 1 new = 6
+        assert (
+            session.scalar(select(func.count()).select_from(AssetEvent).where(AssetEvent.asset_id == asm.id))
+            == 6
+        )
+        assert session.scalar(select(func.count()).select_from(AssetDagRunQueue)) == 1
 
     def test_register_asset_change_no_downstreams(self, session, mock_task_instance):
         asset_manager = AssetManager()


### PR DESCRIPTION
Closes #66853.

## Problem

Under high concurrency (80+ simultaneous task completions emitting asset events), the API server dies with OOMKill. The root cause is a DB lock contention chain:

1. `ti_update_state()` acquires `SELECT task_instance ... WITH FOR UPDATE`, holding a PostgreSQL row lock.
2. While holding that lock, `register_asset_changes_in_db()` runs multiple slow queries including `asset_alias_model.asset_events.append(asset_event)`. This ORM `.append()` lazy-loads the **entire** `asset_events` collection for the alias.
3. Each slow query leaves the connection `idle in transaction` while Python processes results. New workers needing `SELECT task_instance FOR UPDATE` on the same row queue up, each holding a FastAPI threadpool thread.
4. With 80+ concurrent completions, thread count grows unbounded until OOMKill.

## Fix

Two changes:

**1. `AssetManager.register_asset_change()` (`assets/manager.py`)**: Replace `asset_alias_model.asset_events.append(asset_event)` + `session.add(asset_alias_model)` with a direct `INSERT INTO asset_alias_asset_event (alias_id, event_id)`. This eliminates the lazy-load of the existing events collection (which can be thousands of rows) while the task_instance row lock is held.

**2. `ti_update_state()` (`execution_api/routes/task_instances.py`)**: Add `session.commit()` after the TI state UPDATE and Log writes to release the `task_instance` row lock before running asset registration. Asset registration then runs in a fresh implicit transaction. Registration failures are logged and swallowed -- the task state is already durable at that point.

## Testing

- New: `test_register_asset_change_with_alias_no_lazy_load` -- confirms no SELECT on `asset_alias_asset_event` collection during registration when pre-existing rows exist
- New: `test_ti_update_state_to_success_asset_registration_failure_returns_204` -- confirms 204 + TI SUCCESS when asset registration raises after commit

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=75ec588 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Bishesh-Shahi** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->