### PR TITLE
Go SDK: Refresh Bearer token from Execution API responses

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/security.py
@@ -25,8 +25,10 @@ Token types (``TokenType``):
     refreshed by ``JWTReissueMiddleware``.
 
 ``"workload"``
-    Restricted scope, only accepted on routes that opt in via
-    ``Security(require_auth, scopes=["token:workload"])``.
+    Restricted scope. Accepted on routes that declare ``token:workload`` in
+    ``Security(require_auth, scopes=[...])``, including routes that allow both
+    ``token:execution`` and ``token:workload`` (for example ``PATCH .../run``,
+    which exchanges a workload token for a short-lived execution token).
 
 Tokens without a ``scope`` claim default to ``"execution"`` for backwards
 compatibility (``claims.setdefault("scope", "execution")``).

--- a/go-sdk/pkg/api/client.go
+++ b/go-sdk/pkg/api/client.go
@@ -40,6 +40,18 @@ func correlationIdInjector(_ *resty.Client, req *resty.Request) error {
 	return nil
 }
 
+// applyRefreshedAPITokenBearer updates the client's default Bearer token when the Execution API
+// returns Refreshed-API-Token (workload→execution swap on PATCH /run, or JWTReissueMiddleware refresh).
+func applyRefreshedAPITokenBearer(c *resty.Client, res *resty.Response) error {
+	if res == nil {
+		return nil
+	}
+	if newToken := res.Header().Get("Refreshed-API-Token"); newToken != "" {
+		c.SetHeader("Authorization", fmt.Sprintf("Bearer %s", newToken))
+	}
+	return nil
+}
+
 func NewDefaultClient(server string, opts ...ClientOption) (ClientInterface, error) {
 	rc := resty.New()
 	rc.SetBaseURL(server)
@@ -63,6 +75,7 @@ func (c *Client) WithBearerToken(token string) (ClientInterface, error) {
 	// over HTTP: "Using sensitive credentials in HTTP mode is not secure." It's a time-limited-token though, so we
 	// can reasonably ignore that here and setting the header directly bypasses that
 	rc.SetHeader("Authorization", fmt.Sprintf("Bearer %s", token))
+	rc.AddResponseMiddleware(applyRefreshedAPITokenBearer)
 
 	opts := []ClientOption{
 		WithClient(rc),

--- a/go-sdk/pkg/api/client_test.go
+++ b/go-sdk/pkg/api/client_test.go
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithBearerToken_AppliesRefreshedAPITokenFromResponse(t *testing.T) {
+	var n int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		auth := r.Header.Get("Authorization")
+		switch n {
+		case 1:
+			if auth != "Bearer first-secret" {
+				t.Fatalf("first request: Authorization = %q, want Bearer first-secret", auth)
+			}
+			w.Header().Set("Refreshed-API-Token", "second-secret")
+		case 2:
+			if auth != "Bearer second-secret" {
+				t.Fatalf("second request: Authorization = %q, want Bearer second-secret", auth)
+			}
+		default:
+			t.Fatalf("unexpected extra request %d", n)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(ts.Close)
+
+	root, err := NewClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := root.(*Client)
+
+	withTok, err := base.WithBearerToken("first-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli := withTok.(*Client)
+
+	if _, err := cli.R().Get("/a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cli.R().Get("/b"); err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 requests, got %d", n)
+	}
+}


### PR DESCRIPTION
Problem
The Execution API uses a two-step token model: the scheduler issues a longer-lived workload JWT for queued work; when the worker calls PATCH …/run, the server returns a short-lived execution JWT in the Refreshed-API-Token response header. The Python Task SDK already updates its Authorization header from that header on every response.

The Go SDK’s WithBearerToken path set a static Authorization header and never applied Refreshed-API-Token, so after /run the client could keep sending the workload token on later calls (e.g. heartbeat, state updates), which does not match the server’s scope rules.

Solution

Register a Resty response middleware on the bearer-scoped client that, when Refreshed-API-Token is present, updates the default Authorization: Bearer … header for subsequent requests (same idea as the Task SDK’s _update_auth).
Add a small unit test that proves the second request uses the refreshed token after the first response sets the header.
Tighten the Execution API security.py module docstring so the workload scope description matches routes that allow both token:execution and token:workload (e.g. /run).
Testing
go test ./go-sdk/pkg/api/... (or from go-sdk: go test ./pkg/api/...)

Related
Aligns Go workers with the existing two-token / refresh behavior described for the Execution API and implemented for the Python client.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=a0770fd action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @sharan-s2k** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~30 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->