### PR TITLE
Add S3TablesDeleteTableBucketPolicyOperator

### DIFF
--- a/providers/amazon/docs/operators/s3_tables.rst
+++ b/providers/amazon/docs/operators/s3_tables.rst
@@ -132,6 +132,20 @@ To set a resource policy on an Amazon S3 Tables table bucket, use
     :start-after: [START howto_operator_s3tables_put_table_bucket_policy]
     :end-before: [END howto_operator_s3tables_put_table_bucket_policy]
 
+.. _howto/operator:S3TablesDeleteTableBucketPolicyOperator:
+
+Delete a Table Bucket Policy
+----------------------------
+
+To delete the resource policy from an Amazon S3 Tables table bucket, use
+:class:`~airflow.providers.amazon.aws.operators.s3_tables.S3TablesDeleteTableBucketPolicyOperator`.
+
+.. exampleinclude:: /../../amazon/tests/system/amazon/aws/example_s3_tables.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_s3tables_delete_table_bucket_policy]
+    :end-before: [END howto_operator_s3tables_delete_table_bucket_policy]
+
 Reference
 ---------
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/s3_tables.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/s3_tables.py
@@ -419,3 +419,32 @@ class S3TablesPutTableBucketPolicyOperator(AwsBaseOperator[S3TablesHook]):
             resourcePolicy=self.resource_policy,
         )
         self.log.info("Policy set on table bucket %s", self.table_bucket_arn)
+
+
+class S3TablesDeleteTableBucketPolicyOperator(AwsBaseOperator[S3TablesHook]):
+    """
+    Delete the resource policy from an Amazon S3 Tables table bucket.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:S3TablesDeleteTableBucketPolicyOperator`
+
+    :param table_bucket_arn: The ARN of the table bucket. (templated)
+    """
+
+    aws_hook_class = S3TablesHook
+    template_fields: Sequence[str] = aws_template_fields("table_bucket_arn")
+
+    def __init__(
+        self,
+        *,
+        table_bucket_arn: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.table_bucket_arn = table_bucket_arn
+
+    def execute(self, context: Context) -> None:
+        self.log.info("Deleting policy from table bucket %s", self.table_bucket_arn)
+        self.hook.conn.delete_table_bucket_policy(tableBucketARN=self.table_bucket_arn)
+        self.log.info("Policy deleted from table bucket %s", self.table_bucket_arn)

--- a/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
@@ -24,6 +24,7 @@ from airflow.providers.amazon.aws.operators.s3_tables import (
     S3TablesCreateTableOperator,
     S3TablesDeleteNamespaceOperator,
     S3TablesDeleteTableBucketOperator,
+    S3TablesDeleteTableBucketPolicyOperator,
     S3TablesDeleteTableOperator,
     S3TablesPutTableBucketPolicyOperator,
     S3TablesRenameTableOperator,
@@ -94,6 +95,14 @@ with DAG(
     )
     # [END howto_operator_s3tables_put_table_bucket_policy]
 
+    # [START howto_operator_s3tables_delete_table_bucket_policy]
+    delete_policy = S3TablesDeleteTableBucketPolicyOperator(
+        task_id="delete_table_bucket_policy",
+        table_bucket_arn=create_table_bucket.output,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+    # [END howto_operator_s3tables_delete_table_bucket_policy]
+
     # [START howto_operator_s3tables_create_namespace]
     setup_namespace = S3TablesCreateNamespaceOperator(
         task_id="create_namespace",
@@ -154,6 +163,7 @@ with DAG(
         test_context,
         create_table_bucket,
         put_policy,
+        delete_policy,
         setup_namespace,
         # TEST BODY
         create_table,

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_s3_tables.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_s3_tables.py
@@ -30,6 +30,7 @@ from airflow.providers.amazon.aws.operators.s3_tables import (
     S3TablesCreateTableOperator,
     S3TablesDeleteNamespaceOperator,
     S3TablesDeleteTableBucketOperator,
+    S3TablesDeleteTableBucketPolicyOperator,
     S3TablesDeleteTableOperator,
     S3TablesPutTableBucketPolicyOperator,
     S3TablesRenameTableOperator,
@@ -417,6 +418,26 @@ class TestS3TablesPutTableBucketPolicyOperator:
             tableBucketARN=TABLE_BUCKET_ARN,
             resourcePolicy=POLICY,
         )
+
+    def test_template_fields(self):
+        validate_template_fields(self.operator)
+
+
+class TestS3TablesDeleteTableBucketPolicyOperator:
+    def setup_method(self):
+        self.operator = S3TablesDeleteTableBucketPolicyOperator(
+            task_id="delete_policy",
+            table_bucket_arn=TABLE_BUCKET_ARN,
+        )
+
+    @mock.patch.object(S3TablesHook, "conn", new_callable=mock.PropertyMock)
+    def test_execute(self, mock_conn):
+        mock_client = mock.MagicMock()
+        mock_conn.return_value = mock_client
+
+        self.operator.execute({})
+
+        mock_client.delete_table_bucket_policy.assert_called_once_with(tableBucketARN=TABLE_BUCKET_ARN)
 
     def test_template_fields(self):
         validate_template_fields(self.operator)


### PR DESCRIPTION
Adds operator to delete a resource policy from an S3 Tables table bucket (complement to S3TablesPutTableBucketPolicyOperator).

## Changes
- `S3TablesPutTableBucketPolicyOperator` — sets a resource policy on a table bucket
- `S3TablesDeleteTableBucketPolicyOperator` — deletes a resource policy from a table bucket
- Unit tests for both operators
- System test integration with `[START/END]` markers
- RST documentation sections

## Testing
- Ruff lint/format: ✅ passed
- Mypy: ✅ no new errors (only pre-existing import-untyped for boto3/botocore)
- Unit tests: pass locally (CI blocked on S3TablesHook not yet in base image)