### PR TITLE
Fix BigQueryStreamingBufferEmptySensor failing against real BigQuery

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/bigquery.py
@@ -712,11 +712,12 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param project_id: The name of the project where we have the table
         :param dataset_id: The name of the dataset where we have the table
         :param table_id: The name of the table
-        :param rows: the rows to insert
+        :param rows: the rows to insert. Each row is a mapping of column name to
+            value, matching the table schema.
 
             .. code-block:: python
 
-                rows = [{"json": {"a_key": "a_value_0"}}, {"json": {"a_key": "a_value_1"}}]
+                rows = [{"a_key": "a_value_0"}, {"a_key": "a_value_1"}]
 
         :param ignore_unknown_values: [Optional] Accept rows that contain values
             that do not match the schema. The unknown values are ignored.

--- a/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
@@ -333,6 +333,14 @@ class BigQueryStreamingBufferEmptySensor(BaseSensorOperator):
     ``UPDATE/MERGE/DELETE statement over table ... would affect rows in the
     streaming buffer`` errors.
 
+    .. warning::
+        The sensor reads ``table.streaming_buffer`` from BigQuery's table
+        metadata, which is eventually consistent. For a short window right
+        after a streaming insert the buffer metadata is still absent, so the
+        sensor may report the buffer empty before it actually is. Known
+        limitation tracked at
+        https://github.com/apache/airflow/issues/66963
+
     :param project_id: Google Cloud project containing the table.
     :param dataset_id: Dataset of the table to monitor.
     :param table_id: Table to monitor.

--- a/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/bigquery.py
@@ -25,6 +25,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from google.api_core.exceptions import NotFound
+from google.cloud.bigquery import DatasetReference, TableReference
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator, conf
@@ -404,9 +405,17 @@ class BigQueryStreamingBufferEmptySensor(BaseSensorOperator):
         table_uri = f"{self.project_id}:{self.dataset_id}.{self.table_id}"
         self.log.info("Checking streaming buffer state for table: %s", table_uri)
 
+        # ``Client.get_table`` only accepts a ``TableReference`` or a standard-SQL
+        # ``project.dataset.table`` string -- not the legacy ``project:dataset.table``
+        # form -- so build an explicit reference here.
+        table_ref = TableReference(
+            dataset_ref=DatasetReference(self.project_id, self.dataset_id),
+            table_id=self.table_id,
+        )
+
         hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
         try:
-            table = hook.get_client(project_id=self.project_id).get_table(table_uri)
+            table = hook.get_client(project_id=self.project_id).get_table(table_ref)
         except NotFound as err:
             raise ValueError(f"Table {table_uri} not found") from err
         return table.streaming_buffer is None

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
@@ -22,6 +22,7 @@ Example Airflow DAG for Google BigQuery Sensors.
 from __future__ import annotations
 
 import os
+import time
 from datetime import datetime
 
 from airflow.models.dag import DAG
@@ -173,13 +174,27 @@ with DAG(
 
     @task(task_id="streaming_insert")
     def streaming_insert(ds: str | None = None) -> None:
-        BigQueryHook().insert_all(
+        hook = BigQueryHook()
+        hook.insert_all(
             project_id=PROJECT_ID,
             dataset_id=DATASET_NAME,
             table_id=TABLE_NAME,
             rows=[{"value": 100, "ds": ds}],
             fail_on_error=True,
         )
+        # BigQuery's streamingBuffer table metadata is eventually consistent: for
+        # a few seconds after a streaming insert the row is in the buffer but
+        # table.streaming_buffer is still None. Wait for the metadata to catch up
+        # so check_streaming_buffer_empty does not falsely report "empty" before
+        # the buffer is reported at all. Remove once the sensor handles this
+        # itself; tracked at https://github.com/apache/airflow/issues/66963
+        client = hook.get_client(project_id=PROJECT_ID)
+        table_uri = f"{PROJECT_ID}.{DATASET_NAME}.{TABLE_NAME}"
+        for _ in range(30):
+            if client.get_table(table_uri).streaming_buffer is not None:
+                return
+            time.sleep(2)
+        raise RuntimeError("BigQuery streaming buffer metadata did not appear within 60s")
 
     streaming_insert_task = streaming_insert()
 

--- a/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
+++ b/providers/google/tests/system/google/cloud/bigquery/example_bigquery_sensors.py
@@ -177,7 +177,8 @@ with DAG(
             project_id=PROJECT_ID,
             dataset_id=DATASET_NAME,
             table_id=TABLE_NAME,
-            rows=[{"json": {"value": 100, "ds": ds}}],
+            rows=[{"value": 100, "ds": ds}],
+            fail_on_error=True,
         )
 
     streaming_insert_task = streaming_insert()

--- a/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_bigquery.py
@@ -600,7 +600,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_insert_all_succeed(self, mock_client):
-        rows = [{"json": {"a_key": "a_value_0"}}]
+        rows = [{"a_key": "a_value_0"}]
 
         self.hook.insert_all(
             project_id=PROJECT_ID,
@@ -620,7 +620,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_insert_all_fail(self, mock_client):
-        rows = [{"json": {"a_key": "a_value_0"}}]
+        rows = [{"a_key": "a_value_0"}]
 
         mock_client.return_value.insert_rows.return_value = ["some", "errors"]
         with pytest.raises(AirflowException, match="insert error"):
@@ -2204,7 +2204,7 @@ class TestHookLevelLineage(_BigQueryBaseTestClass):
             project_id=PROJECT_ID,
             dataset_id=DATASET_ID,
             table_id=TABLE_ID,
-            rows=[{"json": {"a_key": "a_value"}}],
+            rows=[{"a_key": "a_value"}],
         )
 
         assert len(hook_lineage_collector.collected_assets.inputs) == 0

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigquery.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pytest
 from google.api_core.exceptions import NotFound
+from google.cloud.bigquery import TableReference
 
 from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 from airflow.providers.google.cloud.sensors.bigquery import (
@@ -323,9 +324,15 @@ class TestBigQueryStreamingBufferEmptySensor:
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         mock_hook.return_value.get_client.assert_called_once_with(project_id=TEST_PROJECT_ID)
-        mock_hook.return_value.get_client.return_value.get_table.assert_called_once_with(
-            f"{TEST_PROJECT_ID}:{TEST_DATASET_ID}.{TEST_TABLE_ID}"
-        )
+        get_table_call = mock_hook.return_value.get_client.return_value.get_table
+        get_table_call.assert_called_once()
+        # ``Client.get_table`` is given a ``TableReference``, never the legacy
+        # ``project:dataset.table`` string, which the BigQuery client rejects.
+        table_ref = get_table_call.call_args.args[0]
+        assert isinstance(table_ref, TableReference)
+        assert table_ref.project == TEST_PROJECT_ID
+        assert table_ref.dataset_id == TEST_DATASET_ID
+        assert table_ref.table_id == TEST_TABLE_ID
 
     @mock.patch("airflow.providers.google.cloud.sensors.bigquery.BigQueryHook")
     def test_poke_returns_false_when_buffer_present(self, mock_hook):


### PR DESCRIPTION
PR #66652 added `BigQueryStreamingBufferEmptySensor` and a system test exercising it. Running the system test against a real GCP project surfaces three problems — two are plain bugs (fixed here), the third is a sensor design limitation (worked around here, tracked in #66963).

### 1. `BigQueryStreamingBufferEmptySensor.poke()` always raised `NotFound`

`poke()` passed the legacy `project:dataset.table` string (colon separator) to `Client.get_table`. The BigQuery client only accepts a `TableReference` or a standard-SQL `project.dataset.table` string, so against real BigQuery every poke raised `NotFound` → `ValueError`, and the system test could never get past `check_streaming_buffer_empty`.

Fixed by building an explicit `TableReference`, mirroring `BigQueryHook.insert_all`. The colon form is kept only for log/error messages, where it is the conventional BigQuery display format. The unit test previously asserted the colon string was passed to `get_table` (the mock accepted anything, masking the bug) — it now asserts a proper `TableReference`.

### 2. `streaming_insert` task never streamed a row

The system test's `streaming_insert` task passed rows in the `{"json": {...}}` REST-API envelope to `BigQueryHook.insert_all`, which feeds them to the client library's `insert_rows` — that expects plain row dicts. The insert failed with `no such field: json`, so no row was streamed. The misleading `{"json": {...}}` format came straight from the `insert_all` docstring (stale since the 2020 refactor from the discovery API to `insert_rows`), so that — and its unit-test fixtures — is corrected too.

Fixed by passing plain row dicts and setting `fail_on_error=True` so a broken streaming insert fails the task loudly.

### 3. Sensor can falsely report an empty buffer (metadata lag) — worked around, tracked in #66963

BigQuery's `streamingBuffer` table metadata is eventually consistent: for ~10–12s after a streaming insert (measured against real BigQuery) the row is in the buffer but `table.streaming_buffer` is still `None`, so the sensor reports "empty" prematurely. With the simulated executor the sensor's first poke lands inside that window, so `stream_update` would run against still-buffered rows and fail.

This is a limitation of the sensor itself, not just the test. As a **workaround** the `streaming_insert` task now waits for the buffer metadata to appear before completing, making the system test deterministic. The underlying sensor limitation is documented in the sensor docstring and tracked in #66963 — the workaround comment in the test links back to it.

### Verification

All three were verified against a real GCP project: dataset + partitioned table created, one row streamed via `insert_all` (succeeds with plain dicts, fails with `{"json": ...}`), `poke()` called against the live table (returns cleanly, no exception), and the streaming-buffer metadata timing measured (`None` for ~11.6s post-insert, then `estimated_rows=1`).

related: #66652
tracking: #66963

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)