### PR TITLE
fix: preserve XCom multi-column sorting

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.test.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.test.ts
@@ -34,6 +34,21 @@ describe("searchParams", () => {
 
       expect(stateToSearchParams(state).toString()).toEqual("limit=20&offset=1&sort=name");
     });
+
+    it("preserves multiple sort entries", () => {
+      const state: TableState = {
+        pagination: {
+          pageIndex: 0,
+          pageSize: 20,
+        },
+        sorting: [
+          { desc: false, id: "name" },
+          { desc: true, id: "age" },
+        ],
+      };
+
+      expect(stateToSearchParams(state).toString()).toEqual("limit=20&sort=name&sort=-age");
+    });
   });
 
   describe("searchParamsToState", () => {

--- a/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.ts
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/searchParams.ts
@@ -50,17 +50,12 @@ export const stateToSearchParams = (state: TableState, defaultTableState?: Table
     queryParams.delete(CURSOR_PARAM);
   }
 
-  if (state.sorting.length) {
-    state.sorting.forEach(({ desc, id }) => {
-      if (defaultTableState?.sorting.find((sort) => sort.id === id && sort.desc === desc)) {
-        queryParams.delete(SORT_PARAM, `${desc ? "-" : ""}${id}`);
-      } else {
-        queryParams.set(SORT_PARAM, `${desc ? "-" : ""}${id}`);
-      }
-    });
-  } else {
-    queryParams.delete(SORT_PARAM);
-  }
+  queryParams.delete(SORT_PARAM);
+  state.sorting.forEach(({ desc, id }) => {
+    if (!defaultTableState?.sorting.find((sort) => sort.id === id && sort.desc === desc)) {
+      queryParams.append(SORT_PARAM, `${desc ? "-" : ""}${id}`);
+    }
+  });
 
   return queryParams;
 };

--- a/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/XCom.tsx
@@ -38,6 +38,7 @@ import DeleteXComButton from "./DeleteXComButton";
 import EditXComButton from "./EditXComButton";
 import { XComEntry } from "./XComEntry";
 import { XComFilters } from "./XComFilters";
+import { sortingToOrderBy } from "./orderBy";
 
 const {
   DAG_DISPLAY_NAME_PATTERN: DAG_DISPLAY_NAME_PATTERN_PARAM,
@@ -147,10 +148,7 @@ export const XCom = () => {
   const { t: translate } = useTranslation(["browse", "common"]);
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
-  const [sort] = sorting;
-  const orderBy = sort
-    ? [`${sort.desc ? "-" : ""}${sort.id === "task_display_name" ? "task_id" : sort.id}`]
-    : undefined;
+  const orderBy = sortingToOrderBy(sorting);
   const [searchParams] = useSearchParams();
   const { onClose, onOpen, open } = useDisclosure();
 

--- a/airflow-core/src/airflow/ui/src/pages/XCom/orderBy.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/orderBy.test.ts
@@ -1,0 +1,40 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, expect, it } from "vitest";
+
+import { sortingToOrderBy } from "./orderBy";
+
+describe("sortingToOrderBy", () => {
+  it("keeps every XCom sort entry in order", () => {
+    expect(
+      sortingToOrderBy([
+        { desc: false, id: "key" },
+        { desc: true, id: "timestamp" },
+      ]),
+    ).toEqual(["key", "-timestamp"]);
+  });
+
+  it("maps the task display column to the API field", () => {
+    expect(sortingToOrderBy([{ desc: false, id: "task_display_name" }])).toEqual(["task_id"]);
+  });
+
+  it("returns undefined without sorting", () => {
+    expect(sortingToOrderBy([])).toBeUndefined();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/XCom/orderBy.ts
+++ b/airflow-core/src/airflow/ui/src/pages/XCom/orderBy.ts
@@ -1,0 +1,26 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { SortingState } from "@tanstack/react-table";
+
+const xcomSortIdToOrderBy = (id: string) => (id === "task_display_name" ? "task_id" : id);
+
+export const sortingToOrderBy = (sorting: SortingState) =>
+  sorting.length
+    ? sorting.map((sort) => `${sort.desc ? "-" : ""}${xcomSortIdToOrderBy(sort.id)}`)
+    : undefined;


### PR DESCRIPTION
Preserve multi-column XCom sorting across the table URL state and API request.

Summary:
- keep repeated `sort` search params when serializing table state
- map every XCom sorting entry into the API `orderBy` list
- keep the existing `task_display_name` to `task_id` mapping for each sort entry

Tests:
- `./node_modules/.bin/vitest run src/components/DataTable/searchParams.test.ts src/pages/XCom/orderBy.test.ts`
- `./node_modules/.bin/eslint --quiet src/components/DataTable/searchParams.test.ts src/components/DataTable/searchParams.ts src/pages/XCom/XCom.tsx src/pages/XCom/orderBy.test.ts src/pages/XCom/orderBy.ts`
- `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- `git diff --check`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex, following the guidelines.
