### PR TITLE
Preserve Databricks deferrable trigger caller across triggerer restarts

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -38,6 +38,8 @@ class DatabricksExecutionTrigger(BaseTrigger):
     :param retry_delay: The number of seconds to wait between retries.
     :param retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
     :param run_page_url: The run page url.
+    :param repair_run: Repair the databricks run in case of failure.
+    :param caller: The name of the operator that is calling the hook.
     """
 
     def __init__(
@@ -134,6 +136,7 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
     :param retry_limit: The number of times to retry the connection in case of service outages.
     :param retry_delay: The number of seconds to wait between retries.
     :param retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
+    :param caller: The name of the operator that is calling the hook.
     """
 
     def __init__(

--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -61,6 +61,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
         self.retry_args = retry_args
         self.run_page_url = run_page_url
         self.repair_run = repair_run
+        self.caller = caller
         self.hook = DatabricksHook(
             databricks_conn_id,
             retry_limit=self.retry_limit,
@@ -81,6 +82,7 @@ class DatabricksExecutionTrigger(BaseTrigger):
                 "retry_args": self.retry_args,
                 "run_page_url": self.run_page_url,
                 "repair_run": self.repair_run,
+                "caller": self.caller,
             },
         )
 
@@ -153,6 +155,7 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
         self.retry_limit = retry_limit
         self.retry_delay = retry_delay
         self.retry_args = retry_args
+        self.caller = caller
         self.hook = DatabricksHook(
             databricks_conn_id,
             retry_limit=self.retry_limit,
@@ -172,6 +175,7 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
                 "retry_limit": self.retry_limit,
                 "retry_delay": self.retry_delay,
                 "retry_args": self.retry_args,
+                "caller": self.caller,
             },
         )
 

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -50,6 +50,7 @@ TASK_RUN_ID3 = 33
 TASK_RUN_ID3_KEY = "third_task"
 JOB_ID = 42
 RUN_PAGE_URL = "https://XX.cloud.databricks.com/#jobs/1/runs/1"
+CALLER = "DatabricksSubmitRunOperator"
 ERROR_MESSAGE = "error message from databricks API"
 GET_RUN_OUTPUT_RESPONSE = {"metadata": {}, "error": ERROR_MESSAGE, "notebook_output": {}}
 
@@ -157,15 +158,14 @@ class TestDatabricksExecutionTrigger:
         )
 
     def test_serialize_round_trip_caller(self):
-        caller = "DatabricksSubmitRunOperator"
         trigger = DatabricksExecutionTrigger(
             run_id=RUN_ID,
             databricks_conn_id=DEFAULT_CONN_ID,
-            caller=caller,
+            caller=CALLER,
         )
         _, kwargs = trigger.serialize()
         restored = DatabricksExecutionTrigger(**kwargs)
-        assert restored.caller == caller
+        assert restored.caller == CALLER
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_output")
@@ -316,16 +316,15 @@ class TestDatabricksSQLStatementExecutionTrigger:
         )
 
     def test_serialize_round_trip_caller(self):
-        caller = "DatabricksSqlOperator"
         trigger = DatabricksSQLStatementExecutionTrigger(
             statement_id=STATEMENT_ID,
             databricks_conn_id=DEFAULT_CONN_ID,
             end_time=self.end_time,
-            caller=caller,
+            caller=CALLER,
         )
         _, kwargs = trigger.serialize()
         restored = DatabricksSQLStatementExecutionTrigger(**kwargs)
-        assert restored.caller == caller
+        assert restored.caller == CALLER
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_sql_statement_state")

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -152,8 +152,20 @@ class TestDatabricksExecutionTrigger:
                 "retry_args": None,
                 "run_page_url": RUN_PAGE_URL,
                 "repair_run": False,
+                "caller": "DatabricksExecutionTrigger",
             },
         )
+
+    def test_serialize_round_trip_caller(self):
+        caller = "DatabricksSubmitRunOperator"
+        trigger = DatabricksExecutionTrigger(
+            run_id=RUN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            caller=caller,
+        )
+        _, kwargs = trigger.serialize()
+        restored = DatabricksExecutionTrigger(**kwargs)
+        assert restored.caller == caller
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_output")
@@ -299,8 +311,21 @@ class TestDatabricksSQLStatementExecutionTrigger:
                 "retry_delay": 10,
                 "retry_limit": 3,
                 "retry_args": None,
+                "caller": "DatabricksSQLStatementExecutionTrigger",
             },
         )
+
+    def test_serialize_round_trip_caller(self):
+        caller = "DatabricksSqlOperator"
+        trigger = DatabricksSQLStatementExecutionTrigger(
+            statement_id=STATEMENT_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            end_time=self.end_time,
+            caller=caller,
+        )
+        _, kwargs = trigger.serialize()
+        restored = DatabricksSQLStatementExecutionTrigger(**kwargs)
+        assert restored.caller == caller
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_sql_statement_state")


### PR DESCRIPTION
`DatabricksExecutionTrigger` and `DatabricksSQLStatementExecutionTrigger` passed `caller` into `DatabricksHook` but omitted it from `serialize()`, so the triggerer lost the operator’s value after restart/handoff. Persist `caller` on the instance, include it in `serialize()`, and add tests for default serialization and round-trip.

related: #66961

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor

Generated-by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)