### PR TITLE
Include endpoint_prefix in LivyTrigger serialization

### DIFF
--- a/providers/apache/livy/src/airflow/providers/apache/livy/triggers/livy.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/triggers/livy.py
@@ -42,6 +42,7 @@ class LivyTrigger(BaseTrigger):
         depends on the option that's being modified.
     :param extra_headers: A dictionary of headers passed to the HTTP request to livy.
     :param livy_hook_async: LivyAsyncHook object
+    :param endpoint_prefix: Optional URL prefix for the Livy API endpoint.
     """
 
     def __init__(
@@ -80,6 +81,7 @@ class LivyTrigger(BaseTrigger):
                 "extra_headers": self._extra_headers,
                 "livy_hook_async": self._livy_hook_async,
                 "execution_timeout": self._execution_timeout,
+                "endpoint_prefix": self._endpoint_prefix,
             },
         )
 

--- a/providers/apache/livy/tests/unit/apache/livy/triggers/test_livy.py
+++ b/providers/apache/livy/tests/unit/apache/livy/triggers/test_livy.py
@@ -48,7 +48,20 @@ class TestLivyTrigger:
             "extra_headers": None,
             "livy_hook_async": None,
             "execution_timeout": None,
+            "endpoint_prefix": None,
         }
+
+    def test_livy_trigger_serialize_round_trip_endpoint_prefix(self):
+        trigger = LivyTrigger(
+            batch_id=1,
+            spark_params={},
+            livy_conn_id=LivyHook.default_conn_name,
+            polling_interval=0,
+            endpoint_prefix="/custom",
+        )
+        _, kwargs = trigger.serialize()
+        restored = LivyTrigger(**kwargs)
+        assert restored._endpoint_prefix == "/custom"
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.apache.livy.triggers.livy.LivyTrigger.poll_for_termination")


### PR DESCRIPTION
`LivyTrigger` accepted `endpoint_prefix` for `LivyAsyncHook`, but `serialize()` omitted it, so the triggerer could not restore that value after a restart or handoff. Serialize `endpoint_prefix` with the other constructor kwargs, document it in the class docstring, and extend unit tests so the default payload includes `None` and a non-default value round-trips through `serialize()` -> `LivyTrigger(**kwargs)`.

related: #66961

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor

Generated-by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)