### PR TITLE
Make Pool model session parameter keyword-only

### DIFF
--- a/airflow-core/src/airflow/models/pool.py
+++ b/airflow-core/src/airflow/models/pool.py
@@ -128,6 +128,7 @@ class Pool(Base):
         slots: int,
         description: str,
         include_deferred: bool,
+        *,
         session: Session = NEW_SESSION,
     ) -> Pool:
         """Create a pool with given parameters or update it if it already exists."""
@@ -143,12 +144,11 @@ class Pool(Base):
             pool.description = description
             pool.include_deferred = include_deferred
 
-        session.commit()
         return pool
 
     @staticmethod
     @provide_session
-    def delete_pool(name: str, session: Session = NEW_SESSION) -> Pool:
+    def delete_pool(name: str, *, session: Session = NEW_SESSION) -> Pool:
         """Delete pool by a given name."""
         if name == Pool.DEFAULT_POOL_NAME:
             raise AirflowException(f"{Pool.DEFAULT_POOL_NAME} cannot be deleted")
@@ -158,7 +158,6 @@ class Pool(Base):
             raise PoolNotFound(f"Pool '{name}' doesn't exist")
 
         session.delete(pool)
-        session.commit()
 
         return pool
 


### PR DESCRIPTION
`Pool.create_or_update_pool()` and `Pool.delete_pool()` in `airflow-core/src/airflow/models/pool.py` declared `session` as a
positional parameter and called `session.commit()` explicitly. Both patterns violate the project convention stated in `CLAUDE.md`:

> In `airflow-core`, functions with a `session` parameter must not call
> `session.commit()`. Use keyword-only `session` parameters.

This PR fixed the violation.

## Test plan:
- [X] `breeze run pytest airflow-core/tests/unit/models/test_pool.py -v` — 22 passed
- [X] `breeze run uv run --project airflow-core mypy airflow-core/src/airflow/models/pool.py` — no issues
- [X] `uvx ruff format` + `uvx ruff check` — clean