### PR TITLE
Serialize poll_interval and impersonation_chain on DataFusionStartPipelineTrigger

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/datafusion.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/datafusion.py
@@ -82,6 +82,8 @@ class DataFusionStartPipelineTrigger(BaseTrigger):
                 "pipeline_name": self.pipeline_name,
                 "pipeline_id": self.pipeline_id,
                 "pipeline_type": self.pipeline_type,
+                "poll_interval": self.poll_interval,
+                "impersonation_chain": self.impersonation_chain,
                 "success_states": self.success_states,
             },
         )

--- a/providers/google/tests/unit/google/cloud/triggers/test_datafusion.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_datafusion.py
@@ -71,9 +71,27 @@ class TestDataFusionStartPipelineTrigger:
             "pipeline_name": PIPELINE_NAME,
             "pipeline_id": PIPELINE_ID,
             "pipeline_type": PIPELINE_TYPE,
+            "poll_interval": TEST_POLL_INTERVAL,
             "gcp_conn_id": TEST_GCP_PROJECT_ID,
+            "impersonation_chain": None,
             "success_states": None,
         }
+
+    def test_start_pipeline_trigger_serialize_round_trip_poll_and_impersonation(self):
+        trigger = DataFusionStartPipelineTrigger(
+            instance_url=INSTANCE_URL,
+            namespace=NAMESPACE,
+            pipeline_name=PIPELINE_NAME,
+            pipeline_id=PIPELINE_ID,
+            pipeline_type=PIPELINE_TYPE,
+            poll_interval=7.5,
+            gcp_conn_id=TEST_GCP_PROJECT_ID,
+            impersonation_chain="sa@project.iam.gserviceaccount.com",
+        )
+        _, kwargs = trigger.serialize()
+        restored = DataFusionStartPipelineTrigger(**kwargs)
+        assert restored.poll_interval == 7.5
+        assert restored.impersonation_chain == "sa@project.iam.gserviceaccount.com"
 
     @pytest.mark.asyncio
     @mock.patch(HOOK_STATUS_STR)


### PR DESCRIPTION
`DataFusionStartPipelineTrigger` stored `poll_interval` and `impersonation_chain` but omitted them from `serialize()`, so the triggerer could lose those values after restart or handoff. Include both in the serialized kwargs, update the serialization unit test, and add a round-trip test for non-default values.

related: #66961

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor

Generated-by: Cursor following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions.