### PR TITLE
Fix s3_tables system test: use valid bucket policy

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_tables.py
@@ -87,7 +87,7 @@ with DAG(
     put_policy = S3TablesPutTableBucketPolicyOperator(
         task_id="put_table_bucket_policy",
         table_bucket_arn=create_table_bucket.output,
-        resource_policy='{"Version":"2012-10-17","Statement":[]}',
+        resource_policy='{"Version":"2012-10-17","Statement":[{"Sid":"TestPolicy","Effect":"Allow","Principal":{"AWS":"558120655471"},"Action":"s3tables:GetTable","Resource":"*"}]}',
     )
     # [END howto_operator_s3tables_put_table_bucket_policy]
 


### PR DESCRIPTION
## Summary
Fix the `example_s3_tables` system test by replacing the empty policy statement with a valid one.

The S3 Tables API rejects policies with empty `Statement` arrays as malformed, and also rejects public policies (`Principal: *`). Use an account-specific principal instead.

## Test plan
- [x] Ran system test against this branch — passes (build `7fe776b1`)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)