### PR TITLE
Enable ruff PLE1205 to catch logging calls with too many arguments

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -855,7 +855,7 @@ class FileTaskHandler(logging.Handler):
             try:
                 os.chmod(full_path, new_file_permissions)
             except OSError as e:
-                logger.warning("OSError while changing ownership of the log file. ", e)
+                logger.warning("OSError while changing ownership of the log file. %s", e)
 
         return full_path
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -120,10 +120,7 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
         if poll_interval > 0:
             self.poll_interval = poll_interval
         else:
-            self.log.warning(
-                "Invalid poll_interval:",
-                poll_interval,
-            )
+            self.log.warning("Invalid poll_interval: %s", poll_interval)
         self.return_sql_result = return_sql_result
         self.deferrable = deferrable
         self.session_id = session_id

--- a/providers/amazon/src/airflow/providers/amazon/aws/sensors/ssm.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/sensors/ssm.py
@@ -108,11 +108,7 @@ class SsmRunCommandCompletedSensor(AwsBaseSensor[SsmHook]):
         command_invocations = response.get("CommandInvocations", [])
 
         if not command_invocations:
-            self.log.info(
-                "No command invocations found",
-                "command_id=%s yet, waiting...",
-                self.command_id,
-            )
+            self.log.info("No command invocations found, command_id=%s yet, waiting...", self.command_id)
             return False
 
         for invocation in command_invocations:

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/task_log_fetcher.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/task_log_fetcher.py
@@ -84,7 +84,7 @@ class AwsTaskLogFetcher(Thread):
             )
         except ClientError as error:
             if error.response["Error"]["Code"] != "ResourceNotFoundException":
-                self.logger.warning("Error on retrieving Cloudwatch log events", error)
+                self.logger.warning("Error on retrieving Cloudwatch log events: %s", error)
             else:
                 self.logger.info(
                     "Cannot find log stream yet, it can take a couple of seconds to show up. "
@@ -95,7 +95,7 @@ class AwsTaskLogFetcher(Thread):
                 )
             yield from ()
         except ConnectionClosedError as error:
-            self.logger.warning("ConnectionClosedError on retrieving Cloudwatch log events", error)
+            self.logger.warning("ConnectionClosedError on retrieving Cloudwatch log events: %s", error)
             yield from ()
 
     @staticmethod

--- a/providers/google/src/airflow/providers/google/cloud/operators/compute.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/compute.py
@@ -1042,7 +1042,7 @@ class ComputeEngineInsertInstanceTemplateOperator(ComputeEngineBaseOperator):
             request_id=self.request_id,
             project_id=self.project_id,
         )
-        self.log.info("The specified Instance Template has been created SUCCESSFULLY", self.body)
+        self.log.info("The specified Instance Template has been created SUCCESSFULLY: %s", self.body)
         new_template = hook.get_instance_template(
             resource_id=self.resource_id,
             project_id=self.project_id,
@@ -1611,7 +1611,7 @@ class ComputeEngineInsertInstanceGroupManagerOperator(ComputeEngineBaseOperator)
             project_id=self.project_id,
             zone=self.zone,
         )
-        self.log.info("The specified Instance Group Manager has been created SUCCESSFULLY", self.body)
+        self.log.info("The specified Instance Group Manager has been created SUCCESSFULLY: %s", self.body)
         new_instance_group_manager = hook.get_instance_group_manager(
             resource_id=self.resource_id,
             project_id=self.project_id,

--- a/providers/google/src/airflow/providers/google/suite/hooks/drive.py
+++ b/providers/google/src/airflow/providers/google/suite/hooks/drive.py
@@ -304,7 +304,7 @@ class GoogleDriveHook(GoogleBaseHook):
             try:
                 upload_location = self._resolve_file_path(folder_id)
             except GoogleApiClientError as e:
-                self.log.warning("A problem has been encountered when trying to resolve file path: %s", e)
+                self.log.exception("A problem has been encountered when trying to resolve file path:")
 
         if show_full_target_path:
             self.log.info("File %s uploaded to gdrive://%s.", local_location, upload_location)

--- a/providers/google/src/airflow/providers/google/suite/hooks/drive.py
+++ b/providers/google/src/airflow/providers/google/suite/hooks/drive.py
@@ -304,7 +304,7 @@ class GoogleDriveHook(GoogleBaseHook):
             try:
                 upload_location = self._resolve_file_path(folder_id)
             except GoogleApiClientError as e:
-                self.log.exception("A problem has been encountered when trying to resolve file path:")
+                self.log.exception("A problem has been encountered when trying to resolve file path: %s", e)
 
         if show_full_target_path:
             self.log.info("File %s uploaded to gdrive://%s.", local_location, upload_location)

--- a/providers/google/src/airflow/providers/google/suite/hooks/drive.py
+++ b/providers/google/src/airflow/providers/google/suite/hooks/drive.py
@@ -304,7 +304,7 @@ class GoogleDriveHook(GoogleBaseHook):
             try:
                 upload_location = self._resolve_file_path(folder_id)
             except GoogleApiClientError as e:
-                self.log.warning("A problem has been encountered when trying to resolve file path: ", e)
+                self.log.warning("A problem has been encountered when trying to resolve file path: %s", e)
 
         if show_full_target_path:
             self.log.info("File %s uploaded to gdrive://%s.", local_location, upload_location)

--- a/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gdrive.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gcs_to_gdrive.py
@@ -170,7 +170,7 @@ with DAG(
         if files := root_path["files"]:
             batch = service.new_batch_http_request()
             for file in files:
-                log.info("Preparing to remove file: {}", file)
+                log.info("Preparing to remove file: %s", file)
                 batch.add(service.files().delete(fileId=file["id"]))
             batch.execute()
             log.info("Selected files removed.")

--- a/providers/google/tests/system/google/cloud/gcs/example_gdrive_to_gcs.py
+++ b/providers/google/tests/system/google/cloud/gcs/example_gdrive_to_gcs.py
@@ -136,7 +136,7 @@ with DAG(
         response = service.files().list(q=f"name = '{DRIVE_FILE_NAME}'").execute()
         if files := response["files"]:
             file = files[0]
-            log.info("Deleting file {}...", file)
+            log.info("Deleting file %s...", file)
             service.files().delete(fileId=file["id"])
             log.info("Done.")
 

--- a/providers/google/tests/system/google/cloud/transfers/example_gdrive_to_local.py
+++ b/providers/google/tests/system/google/cloud/transfers/example_gdrive_to_local.py
@@ -137,7 +137,7 @@ with DAG(
         response = service.files().list(q=f"name = '{DRIVE_FILE_NAME}'").execute()
         if files := response["files"]:
             file = files[0]
-            log.info("Deleting file {}...", file)
+            log.info("Deleting file %s...", file)
             service.files().delete(fileId=file["id"])
             log.info("Done.")
 

--- a/providers/google/tests/system/google/suite/example_local_to_drive.py
+++ b/providers/google/tests/system/google/suite/example_local_to_drive.py
@@ -121,7 +121,7 @@ with DAG(
         if files := root_path["files"]:
             batch = service.new_batch_http_request()
             for file in files:
-                log.info("Preparing to remove file: {}", file)
+                log.info("Preparing to remove file: %s", file)
                 batch.add(service.files().delete(fileId=file["id"]))
             batch.execute()
             log.info("Selected files removed.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -628,6 +628,7 @@ extend-select = [
     "PLW2101", # Threading lock directly created in with statement has no effect
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
     "PLW3301", # Nested {func} calls can be flattened
+    "PLE1205", # Logging format string has too many arguments (extra args are silently dropped)
     # Per rule enables
     "RUF006", # Checks for asyncio dangling task
     "RUF015", # Checks for unnecessary iterable allocation for first element


### PR DESCRIPTION
When a `logging` call has more positional arguments than the format string has `%`-placeholders, the extra arguments are silently dropped and the intended information never appears in the log. Enable `PLE1205` (`logging-too-many-args`) to make this a lint error, and fix all 12 existing instances.

## Changes

- **\`pyproject.toml\`**: add `PLE1205` to `extend-select`.
- **\`airflow-core\`** (1): add missing `%s` placeholder for the caught `OSError` in `file_task_handler.py`.
- **\`provider:amazon\`** (4):
  - `redshift_data.py`: collapse two-string call into `"Invalid poll_interval: %s", poll_interval`
  - `ssm.py`: merge accidentally split message strings into one format string with `%s`
  - `task_log_fetcher.py` (×2): add `%s` for the captured exception
- **\`provider:google\`** (7):
  - `compute.py` (×2): add `%s` so `self.body` is actually logged
  - `drive.py`: add `%s` for the `GoogleApiClientError`
  - Four system-test example files using `{}` placeholders (logging uses `%s`, not `.format()` syntax)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)