### PR TITLE
Include dataset_id, table_id, poll_interval in BigQueryIntervalCheckTrigger serialization

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/bigquery.py
@@ -484,6 +484,9 @@ class BigQueryIntervalCheckTrigger(BigQueryInsertJobTrigger):
                 "days_back": self.days_back,
                 "ratio_formula": self.ratio_formula,
                 "ignore_zero": self.ignore_zero,
+                "dataset_id": self.dataset_id,
+                "table_id": self.table_id,
+                "poll_interval": self.poll_interval,
                 "impersonation_chain": self.impersonation_chain,
             },
         )

--- a/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_bigquery.py
@@ -618,7 +618,17 @@ class TestBigQueryIntervalCheckTrigger:
             "days_back": TEST_DAYS_BACK,
             "ratio_formula": TEST_RATIO_FORMULA,
             "ignore_zero": TEST_IGNORE_ZERO,
+            "dataset_id": TEST_DATASET_ID,
+            "table_id": TEST_TABLE_ID,
+            "poll_interval": POLLING_PERIOD_SECONDS,
         }
+
+    def test_interval_check_trigger_serialize_round_trip(self, interval_check_trigger):
+        _, kwargs = interval_check_trigger.serialize()
+        restored = BigQueryIntervalCheckTrigger(**kwargs)
+        assert restored.dataset_id == TEST_DATASET_ID
+        assert restored.table_id == TEST_TABLE_ID
+        assert restored.poll_interval == POLLING_PERIOD_SECONDS
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_sync_hook")


### PR DESCRIPTION
`BigQueryIntervalCheckTrigger.__init__` accepts `dataset_id`, `table_id`, and `poll_interval` and stores them via the parent `BigQueryInsertJobTrigger.__init__`, but `serialize()` omitted all three. After a triggerer restart the trigger was reinstantiated with defaults (`dataset_id=None`, `table_id=None`, `poll_interval=4.0`), silently changing polling cadence and dropping the templated table identity for any task that customised them.

This PR adds the three fields to the `serialize()` payload so the trigger round-trips through `serialize()` -> `BigQueryIntervalCheckTrigger(**kwargs)` cleanly. The existing serialization test gains the three new keys, and a round-trip test mirrors the pattern used by the sibling fixes in #66965 / #66966 / #66968.

This is the last of the five triggers called out in #66961; the static check that flags this class of bug is being introduced in #66960.

related: #66961
related: #66960

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes