### PR TITLE
Add Bundle documentation for Amazon S3 and Google GCS providers

### DIFF
--- a/providers/amazon/docs/bundles/index.rst
+++ b/providers/amazon/docs/bundles/index.rst
@@ -18,21 +18,21 @@
 Bundles
 #######
 
-A DAG bundle is a way to load DAGs into Airflow from an external source. For a general overview of
-DAG bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+A Dag bundle is a way to load Dags into Airflow from an external source. For a general overview of
+Dag bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
 
 S3DagBundle
 ===========
 
-Use the :class:`~airflow.providers.amazon.aws.bundles.s3.S3DagBundle` to load DAGs directly from
-an Amazon S3 bucket. Airflow will periodically sync DAG files from the specified S3 bucket and prefix
+Use the :class:`~airflow.providers.amazon.aws.bundles.s3.S3DagBundle` to load Dags directly from
+an Amazon S3 bucket. Airflow will periodically sync Dag files from the specified S3 bucket and prefix
 to a local directory and load them from there.
 
 Prerequisites
 -------------
 
 - An AWS connection configured in Airflow (see :doc:`/connections/aws`).
-- An S3 bucket containing your DAG Python files.
+- An S3 bucket containing your Dag Python files.
 
 Configuration
 -------------
@@ -75,6 +75,6 @@ Parameters
 ----------
 
 - ``aws_conn_id`` – Airflow connection ID for AWS. Defaults to ``aws_default``.
-- ``bucket_name`` – Name of the S3 bucket containing the DAG files.
-- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, DAGs are loaded from the root of the bucket.
-- ``refresh_interval`` – How often (in seconds) to sync DAGs from S3.
+- ``bucket_name`` – Name of the S3 bucket containing the Dag files.
+- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, Dags are loaded from the root of the bucket.
+- ``refresh_interval`` – How often (in seconds) to sync Dags from S3.

--- a/providers/amazon/docs/bundles/index.rst
+++ b/providers/amazon/docs/bundles/index.rst
@@ -18,43 +18,18 @@
 Bundles
 #######
 
-A Dag bundle is a way to load Dags into Airflow from an external source. For a general overview of
-Dag bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+Dag bundles allow Airflow to load Dags from external sources. For a general overview see
+:doc:`apache-airflow:administration-and-deployment/dag-bundles`.
 
 S3DagBundle
 ===========
 
-Use the :class:`~airflow.providers.amazon.aws.bundles.s3.S3DagBundle` to load Dags directly from
-an Amazon S3 bucket. Airflow will periodically sync Dag files from the specified S3 bucket and prefix
-to a local directory and load them from there.
+Use the :class:`~airflow.providers.amazon.aws.bundles.s3.S3DagBundle` to configure an S3 bundle in your Airflow's
+``[dag_processor] dag_bundle_config_list``.
 
-Prerequisites
--------------
+Example of using the S3DagBundle:
 
-- An AWS connection configured in Airflow (see :doc:`/connections/aws`).
-- An S3 bucket containing your Dag Python files.
-
-Configuration
--------------
-
-Add the bundle to your ``[dag_processor] dag_bundle_config_list`` configuration:
-
-.. code-block:: json
-
-    [
-      {
-        "name": "my-s3-dags",
-        "classpath": "airflow.providers.amazon.aws.bundles.s3.S3DagBundle",
-        "kwargs": {
-          "aws_conn_id": "aws_default",
-          "bucket_name": "my-airflow-bucket",
-          "prefix": "dags/",
-          "refresh_interval": 60
-        }
-      }
-    ]
-
-Or using an environment variable:
+**JSON format example**:
 
 .. code-block:: bash
 
@@ -70,11 +45,3 @@ Or using an environment variable:
         }
       }
     ]'
-
-Parameters
-----------
-
-- ``aws_conn_id`` – Airflow connection ID for AWS. Defaults to ``aws_default``.
-- ``bucket_name`` – Name of the S3 bucket containing the Dag files.
-- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, Dags are loaded from the root of the bucket.
-- ``refresh_interval`` – How often (in seconds) to sync Dags from S3.

--- a/providers/amazon/docs/bundles/index.rst
+++ b/providers/amazon/docs/bundles/index.rst
@@ -1,0 +1,80 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Bundles
+#######
+
+A DAG bundle is a way to load DAGs into Airflow from an external source. For a general overview of
+DAG bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+
+S3DagBundle
+===========
+
+Use the :class:`~airflow.providers.amazon.aws.bundles.s3.S3DagBundle` to load DAGs directly from
+an Amazon S3 bucket. Airflow will periodically sync DAG files from the specified S3 bucket and prefix
+to a local directory and load them from there.
+
+Prerequisites
+-------------
+
+- An AWS connection configured in Airflow (see :doc:`/connections/aws`).
+- An S3 bucket containing your DAG Python files.
+
+Configuration
+-------------
+
+Add the bundle to your ``[dag_processor] dag_bundle_config_list`` configuration:
+
+.. code-block:: json
+
+    [
+      {
+        "name": "my-s3-dags",
+        "classpath": "airflow.providers.amazon.aws.bundles.s3.S3DagBundle",
+        "kwargs": {
+          "aws_conn_id": "aws_default",
+          "bucket_name": "my-airflow-bucket",
+          "prefix": "dags/",
+          "refresh_interval": 60
+        }
+      }
+    ]
+
+Or using an environment variable:
+
+.. code-block:: bash
+
+    export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST='[
+      {
+        "name": "my-s3-dags",
+        "classpath": "airflow.providers.amazon.aws.bundles.s3.S3DagBundle",
+        "kwargs": {
+          "aws_conn_id": "aws_default",
+          "bucket_name": "my-airflow-bucket",
+          "prefix": "dags/",
+          "refresh_interval": 60
+        }
+      }
+    ]'
+
+Parameters
+----------
+
+- ``aws_conn_id`` – Airflow connection ID for AWS. Defaults to ``aws_default``.
+- ``bucket_name`` – Name of the S3 bucket containing the DAG files.
+- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, DAGs are loaded from the root of the bucket.
+- ``refresh_interval`` – How often (in seconds) to sync DAGs from S3.

--- a/providers/amazon/docs/index.rst
+++ b/providers/amazon/docs/index.rst
@@ -33,6 +33,7 @@
     :maxdepth: 1
     :caption: Guides
 
+    Bundles <bundles/index>
     Connection types <connections/index>
     Notifications <notifications/index>
     Operators <operators/index>

--- a/providers/google/docs/bundles/index.rst
+++ b/providers/google/docs/bundles/index.rst
@@ -18,43 +18,18 @@
 Bundles
 #######
 
-A Dag bundle is a way to load Dags into Airflow from an external source. For a general overview of
-Dag bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+Dag bundles allow Airflow to load Dags from external sources. For a general overview see
+:doc:`apache-airflow:administration-and-deployment/dag-bundles`.
 
 GCSDagBundle
 ============
 
-Use the :class:`~airflow.providers.google.cloud.bundles.gcs.GCSDagBundle` to load Dags directly from
-a Google Cloud Storage bucket. Airflow will periodically sync Dag files from the specified GCS bucket
-and prefix to a local directory and load them from there. This bundle does not support versioning.
+Use the :class:`~airflow.providers.google.cloud.bundles.gcs.GCSDagBundle` to configure a GCS bundle in your Airflow's
+``[dag_processor] dag_bundle_config_list``.
 
-Prerequisites
--------------
+Example of using the GCSDagBundle:
 
-- A Google Cloud connection configured in Airflow (see :doc:`/connections/gcp`).
-- A GCS bucket containing your Dag Python files.
-
-Configuration
--------------
-
-Add the bundle to your ``[dag_processor] dag_bundle_config_list`` configuration:
-
-.. code-block:: json
-
-    [
-      {
-        "name": "my-gcs-dags",
-        "classpath": "airflow.providers.google.cloud.bundles.gcs.GCSDagBundle",
-        "kwargs": {
-          "gcp_conn_id": "google_cloud_default",
-          "bucket_name": "my-airflow-bucket",
-          "prefix": "dags/",
-          "refresh_interval": 60
-        }
-      }
-    ]
-
-Or using an environment variable:
+**JSON format example**:
 
 .. code-block:: bash
 
@@ -70,11 +45,3 @@ Or using an environment variable:
         }
       }
     ]'
-
-Parameters
-----------
-
-- ``gcp_conn_id`` – Airflow connection ID for Google Cloud. Defaults to ``google_cloud_default``.
-- ``bucket_name`` – Name of the GCS bucket containing the Dag files.
-- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, Dags are loaded from the root of the bucket.
-- ``refresh_interval`` – How often (in seconds) to sync Dags from GCS.

--- a/providers/google/docs/bundles/index.rst
+++ b/providers/google/docs/bundles/index.rst
@@ -1,0 +1,80 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Bundles
+#######
+
+A DAG bundle is a way to load DAGs into Airflow from an external source. For a general overview of
+DAG bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+
+GCSDagBundle
+============
+
+Use the :class:`~airflow.providers.google.cloud.bundles.gcs.GCSDagBundle` to load DAGs directly from
+a Google Cloud Storage bucket. Airflow will periodically sync DAG files from the specified GCS bucket
+and prefix to a local directory and load them from there.
+
+Prerequisites
+-------------
+
+- A Google Cloud connection configured in Airflow (see :doc:`/connections/gcp`).
+- A GCS bucket containing your DAG Python files.
+
+Configuration
+-------------
+
+Add the bundle to your ``[dag_processor] dag_bundle_config_list`` configuration:
+
+.. code-block:: json
+
+    [
+      {
+        "name": "my-gcs-dags",
+        "classpath": "airflow.providers.google.cloud.bundles.gcs.GCSDagBundle",
+        "kwargs": {
+          "gcp_conn_id": "google_cloud_default",
+          "bucket_name": "my-airflow-bucket",
+          "prefix": "dags/",
+          "refresh_interval": 60
+        }
+      }
+    ]
+
+Or using an environment variable:
+
+.. code-block:: bash
+
+    export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST='[
+      {
+        "name": "my-gcs-dags",
+        "classpath": "airflow.providers.google.cloud.bundles.gcs.GCSDagBundle",
+        "kwargs": {
+          "gcp_conn_id": "google_cloud_default",
+          "bucket_name": "my-airflow-bucket",
+          "prefix": "dags/",
+          "refresh_interval": 60
+        }
+      }
+    ]'
+
+Parameters
+----------
+
+- ``gcp_conn_id`` – Airflow connection ID for Google Cloud. Defaults to ``google_cloud_default``.
+- ``bucket_name`` – Name of the GCS bucket containing the DAG files.
+- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, DAGs are loaded from the root of the bucket.
+- ``refresh_interval`` – How often (in seconds) to sync DAGs from GCS.

--- a/providers/google/docs/bundles/index.rst
+++ b/providers/google/docs/bundles/index.rst
@@ -18,21 +18,21 @@
 Bundles
 #######
 
-A DAG bundle is a way to load DAGs into Airflow from an external source. For a general overview of
-DAG bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
+A Dag bundle is a way to load Dags into Airflow from an external source. For a general overview of
+Dag bundles, see :doc:`apache-airflow:administration-and-deployment/dag-bundles`.
 
 GCSDagBundle
 ============
 
-Use the :class:`~airflow.providers.google.cloud.bundles.gcs.GCSDagBundle` to load DAGs directly from
-a Google Cloud Storage bucket. Airflow will periodically sync DAG files from the specified GCS bucket
-and prefix to a local directory and load them from there.
+Use the :class:`~airflow.providers.google.cloud.bundles.gcs.GCSDagBundle` to load Dags directly from
+a Google Cloud Storage bucket. Airflow will periodically sync Dag files from the specified GCS bucket
+and prefix to a local directory and load them from there. This bundle does not support versioning.
 
 Prerequisites
 -------------
 
 - A Google Cloud connection configured in Airflow (see :doc:`/connections/gcp`).
-- A GCS bucket containing your DAG Python files.
+- A GCS bucket containing your Dag Python files.
 
 Configuration
 -------------
@@ -75,6 +75,6 @@ Parameters
 ----------
 
 - ``gcp_conn_id`` – Airflow connection ID for Google Cloud. Defaults to ``google_cloud_default``.
-- ``bucket_name`` – Name of the GCS bucket containing the DAG files.
-- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, DAGs are loaded from the root of the bucket.
-- ``refresh_interval`` – How often (in seconds) to sync DAGs from GCS.
+- ``bucket_name`` – Name of the GCS bucket containing the Dag files.
+- ``prefix`` – Optional subdirectory prefix within the bucket. If omitted, Dags are loaded from the root of the bucket.
+- ``refresh_interval`` – How often (in seconds) to sync Dags from GCS.

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -34,6 +34,7 @@
     :maxdepth: 1
     :caption: Guides
 
+    Bundles <bundles/index>
     Connection types <connections/index>
     Logging handlers <logging/index>
     Message queues <message-queues/index>


### PR DESCRIPTION
Closes #66986

Added a Bundles section to the Amazon and Google provider docs, following 
the same pattern as the existing Git provider bundle documentation.
Changes:
- providers/amazon/docs/bundles/index.rst — documents S3DagBundle with 
  configuration examples and parameter descriptions
- providers/google/docs/bundles/index.rst — documents GCSDagBundle with 
  configuration examples and parameter descriptions
- Added Bundles entry to the Guides section in both provider index files
I tried building the docs locally with Breeze but hit a Docker SIGBUS 
error during the CI image build. Will add rendered screenshots once 
resolved, or happy for a maintainer to verify the rendering.
> I used Claude (claude.ai) as an AI assistant for parts of this implementation.
