### PR TITLE
Bugfix/make edge resilient against log errors

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -544,25 +544,30 @@ class EdgeWorker:
 
     async def _push_logs_in_chunks(self, job: Job):
         aio_logfile = anyio.Path(job.logfile)
-        if self.push_logs and await aio_logfile.exists() and (await aio_logfile.stat()).st_size > job.logsize:
-            async with aio_open(job.logfile, mode="rb") as logf:
-                await logf.seek(job.logsize, os.SEEK_SET)
-                read_data = await logf.read()
-                job.logsize += len(read_data)
-                # backslashreplace to keep not decoded characters and not raising exception
-                # replace null with question mark to fix issue during DB push
-                log_data = read_data.decode(errors="backslashreplace").replace("\x00", "\ufffd")
-                while True:
-                    chunk_data = log_data[: self.push_log_chunk_size]
-                    log_data = log_data[self.push_log_chunk_size :]
-                    if not chunk_data:
-                        break
+        try:
+            if self.push_logs and await aio_logfile.exists() and (await aio_logfile.stat()).st_size > job.logsize:
+                async with aio_open(job.logfile, mode="rb") as logf:
+                    await logf.seek(job.logsize, os.SEEK_SET)
+                    read_data = await logf.read()
+                    job.logsize += len(read_data)
+                    # backslashreplace to keep not decoded characters and not raising exception
+                    # replace null with question mark to fix issue during DB push
+                    log_data = read_data.decode(errors="backslashreplace").replace("\x00", "\ufffd")
+                    while True:
+                        chunk_data = log_data[: self.push_log_chunk_size]
+                        log_data = log_data[self.push_log_chunk_size :]
+                        if not chunk_data:
+                            break
 
-                    await logs_push(
-                        task=job.edge_job.key,
-                        log_chunk_time=timezone.utcnow(),
-                        log_chunk_data=chunk_data,
-                    )
+                        await logs_push(
+                            task=job.edge_job.key,
+                            log_chunk_time=timezone.utcnow(),
+                            log_chunk_data=chunk_data,
+                        )
+        except (FileNotFoundError, OSError):
+            logger.exception("Log file %s vanished while reading, ignoring.", job.logfile)
+            # Swallow the exception; the file may have been removed by log rotation or cleanup while we were reading it.
+            # We'll catch up on the next heartbeat/log push or file was uploaded by log integration in parallel.
 
     async def start(self):
         """Start the execution in a loop until terminated."""
@@ -670,39 +675,41 @@ class EdgeWorker:
         logfile = Path(self.base_log_folder, workload.log_path)
         job = self._launch_job(edge_job, workload, logfile)
         self.jobs.append(job)
-        await jobs_set_state(edge_job.key, TaskInstanceState.RUNNING)
+        try:
+            await jobs_set_state(edge_job.key, TaskInstanceState.RUNNING)
 
-        # As we got one job, directly fetch another one if possible
-        if self.free_concurrency > 0:
-            task = create_task(self.fetch_and_run_job())
-            self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
+            # As we got one job, directly fetch another one if possible
+            if self.free_concurrency > 0:
+                task = create_task(self.fetch_and_run_job())
+                self.background_tasks.add(task)
+                task.add_done_callback(self.background_tasks.discard)
 
-        while job.is_running:
+            while job.is_running:
+                await self._push_logs_in_chunks(job)
+                for _ in range(0, self.job_poll_interval * 10):
+                    await sleep(0.1)
+                    if not job.is_running:
+                        break
             await self._push_logs_in_chunks(job)
-            for _ in range(0, self.job_poll_interval * 10):
-                await sleep(0.1)
-                if not job.is_running:
-                    break
-        await self._push_logs_in_chunks(job)
 
-        self.jobs.remove(job)
-        if job.is_success:
-            logger.info("Job completed: %s", job.edge_job.identifier)
-            await jobs_set_state(job.edge_job.key, TaskInstanceState.SUCCESS)
-        else:
-            ex_txt = job.failure_details()
-            logger.error("Job failed: %s with:\n%s", job.edge_job.identifier, ex_txt)
+            if job.is_success:
+                logger.info("Job completed: %s", job.edge_job.identifier)
+                await jobs_set_state(job.edge_job.key, TaskInstanceState.SUCCESS)
+            else:
+                ex_txt = job.failure_details()
+                logger.error("Job failed: %s with:\n%s", job.edge_job.identifier, ex_txt)
 
-            # Push it upwards to logs for better diagnostic as well
-            await logs_push(
-                task=job.edge_job.key,
-                log_chunk_time=timezone.utcnow(),
-                log_chunk_data=f"Error executing job:\n{ex_txt}",
-            )
-            await jobs_set_state(job.edge_job.key, TaskInstanceState.FAILED)
-        # Cleanup temp files used for the job
-        job.cleanup()
+                # Push it upwards to logs for better diagnostic as well
+                await logs_push(
+                    task=job.edge_job.key,
+                    log_chunk_time=timezone.utcnow(),
+                    log_chunk_data=f"Error executing job:\n{ex_txt}",
+                )
+                await jobs_set_state(job.edge_job.key, TaskInstanceState.FAILED)
+        finally:
+            self.jobs.remove(job)
+            # Cleanup temp files used for the job
+            job.cleanup()
 
     async def heartbeat(self, new_maintenance_comments: str | None = None) -> bool:
         """Report liveness state of worker to central site with stats."""

--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -545,7 +545,11 @@ class EdgeWorker:
     async def _push_logs_in_chunks(self, job: Job):
         aio_logfile = anyio.Path(job.logfile)
         try:
-            if self.push_logs and await aio_logfile.exists() and (await aio_logfile.stat()).st_size > job.logsize:
+            if (
+                self.push_logs
+                and await aio_logfile.exists()
+                and (await aio_logfile.stat()).st_size > job.logsize
+            ):
                 async with aio_open(job.logfile, mode="rb") as logf:
                     await logf.seek(job.logsize, os.SEEK_SET)
                     read_data = await logf.read()

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -594,6 +594,44 @@ class TestEdgeWorker:
         assert "ModuleNotFoundError: No module named 'common'" in log_chunk_data
         assert not stderr_file_path.exists()
 
+    @patch("airflow.providers.edge3.cli.worker.jobs_set_state", side_effect=RuntimeError("set state failed"))
+    @patch("airflow.providers.edge3.cli.worker.jobs_fetch")
+    @pytest.mark.asyncio
+    async def test_fetch_and_run_job_cleans_up_when_mark_running_fails(
+        self,
+        mock_jobs_fetch,
+        _mock_jobs_set_state,
+        tmp_path: Path,
+        worker_with_job: EdgeWorker,
+    ):
+        edge_job = EdgeJobFetched(
+            dag_id="test",
+            task_id="test",
+            run_id="test",
+            map_index=-1,
+            try_number=1,
+            concurrency_slots=1,
+            command=MOCK_COMMAND,  # type: ignore[arg-type]
+        )
+        mock_jobs_fetch.return_value = edge_job
+        stderr_file_path = tmp_path / "cleanup-marker.log"
+        stderr_file_path.write_text("cleanup me")
+        launched_job = Job(
+            edge_job,
+            _MockProcess(returncode=None),
+            tmp_path / "mock.log",
+            stderr_file_path=stderr_file_path,
+        )
+
+        with (
+            patch.object(worker_with_job, "_launch_job", return_value=launched_job),
+            pytest.raises(RuntimeError, match="set state failed"),
+        ):
+            await worker_with_job.fetch_and_run_job()
+
+        assert launched_job not in worker_with_job.jobs
+        assert not stderr_file_path.exists()
+
     @time_machine.travel(datetime.now(), tick=False)
     @patch("airflow.providers.edge3.cli.worker.logs_push")
     @pytest.mark.asyncio
@@ -650,6 +688,25 @@ class TestEdgeWorker:
         assert calls[3] == call(
             task=job.edge_job.key, log_chunk_time=timezone.utcnow(), log_chunk_data="log3"
         )
+
+    @patch("airflow.providers.edge3.cli.worker.logger")
+    @patch("airflow.providers.edge3.cli.worker.logs_push")
+    @patch("airflow.providers.edge3.cli.worker.aio_open", side_effect=FileNotFoundError)
+    @pytest.mark.asyncio
+    async def test_push_logs_in_chunks_swallow_file_not_found_during_read(
+        self,
+        _mock_aio_open,
+        mock_logs_push,
+        mock_logger,
+        worker_with_job: EdgeWorker,
+    ):
+        job = EdgeWorker.jobs[0]
+        await anyio.Path(job.logfile).write_text("some log content")
+        with conf_vars({("edge", "api_url"): "https://invalid-api-test-endpoint"}):
+            await worker_with_job._push_logs_in_chunks(job)
+
+        mock_logs_push.assert_not_called()
+        mock_logger.exception.assert_called_once()
 
     @pytest.mark.parametrize(
         ("drain", "maintenance_mode", "jobs", "expected_state"),


### PR DESCRIPTION
In our farm we have seen a race in push_logs function that after `aio_logfile.exists()` the call to `aio_logfile.stat()` failed because file vanished in between. What had been a defensive programming turned out to be a concurrency race in very low probability.

Adding more resiliency to prevent exception being raised when log file dis-appears while check and open() call if the logging back-end makes uploads and deletes local copy.

Exception trace we saw:
```
2026-05-11T19:23:23.857132Z [info     ] No new job to process, 1 still running [airflow.providers.edge3.cli.worker] loc=worker.py:339
2026-05-11T19:23:27.045974Z [info     ] Environment is configured for ClientSecretCredential [azure.identity._credentials.environment] loc=environment.py:99
2026-05-11T19:23:27.046413Z [info     ] ManagedIdentityCredential will use IMDS with client_id: (uuid) [azure.identity._credentials.managed_identity] loc=managed_identity.py:151
2026-05-11T19:23:27.257091Z [info     ] DefaultAzureCredential acquired a token from EnvironmentCredential [azure.identity._credentials.chained] loc=chained.py:196
2026-05-11T19:23:27.593540Z [info     ] Task finished                  [supervisor] duration=515.2834468549117 exit_code=0 final_state=success loc=supervisor.py:2109 task_instance_id=(uuid)
2026-05-11T19:23:27.592357Z [error    ] Task exception was never retrieved
future: <Task finished name='Task-3141' coro=<EdgeWorker.fetch_and_run_job() done, defined at /home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/worker.py:334> exception=FileNotFoundError(2, 'N
o such file or directory')> [asyncio] loc=base_events.py:1833
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/worker.py", line 363, in fetch_and_run_job
    await self._push_logs_in_chunks(job)
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/edge3/cli/worker.py", line 243, in _push_logs_in_chunks
    if push_logs and await aio_logfile.exists() and (await aio_logfile.stat()).st_size > job.logsize:
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/anyio/_core/_fileio.py", line 727, in stat
    return await to_thread.run_sync(func, self._path, abandon_on_cancel=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/opt/airflow/logs/dag_id=my_dag_id/run_id=my_run_id/task_id=my_task_id/map_index=2/attempt=1.log'
2026-05-11T19:23:28.988671Z [info     ] No new job to process, 1 still running [airflow.providers.edge3.cli.worker] loc=worker.py:339
```

Additionally alongside realized that any kind of exception then will raise an exception in `fetch_and_run_job()` which potentially causes to skip the call to `self.jobs.remove(job)` which then makes the worker believe the job is still active but it actually had terminated. Then worker will never cleanly shut down (except if a drain timeout is set) and also might not pick new jobs if capacity is calculated wrongly.

FYI @AutomationDev85 @wolfdn @renat-sagut 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
