### PR TITLE
IMAP: Add overwrite option to ImapHook.download_mail_attachments

### DIFF
--- a/providers/imap/docs/changelog.rst
+++ b/providers/imap/docs/changelog.rst
@@ -26,6 +26,8 @@
 Changelog
 ---------
 
+* ``IMAP: Add 'overwrite' option to ImapHook.download_mail_attachments (#65870)``
+
 3.11.2
 ......
 

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,8 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite: If True (default), overwrite the file if it already exists.
+            If False, rename the file by appending a numeric suffix if it already exists.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +222,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite=overwrite)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +290,16 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, overwrite: bool = True
+    ) -> None:
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(name, payload, local_output_directory, overwrite=overwrite)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,11 +316,33 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(
+        self, name: str, payload: Any, local_output_directory: str, overwrite: bool = True
+    ) -> None:
         file_path = self._correct_path(name, local_output_directory)
+
+        if not overwrite:
+            file_path = self._resolve_non_conflicting_path(file_path)
 
         with open(file_path, "wb") as file:
             file.write(payload)
+
+    def _resolve_non_conflicting_path(self, file_path: str) -> str:
+        if not os.path.exists(file_path):
+            return file_path
+
+        base_path, extension = os.path.splitext(file_path)
+        counter = 1
+        while os.path.exists(f"{base_path} ({counter}){extension}"):
+            counter += 1
+            if counter > 10000:
+                raise AirflowException(
+                    f"Could not find a unique filename for {file_path} after 10000 attempts."
+                )
+
+        resolved_path = f"{base_path} ({counter}){extension}"
+        self.log.info("File %s already exists, saving to %s instead.", file_path, resolved_path)
+        return resolved_path
 
 
 class Mail(LoggingMixin):

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -509,3 +509,96 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_true(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        local_output_directory = tmp_path / "test_directory"
+        local_output_directory.mkdir()
+        file_path = local_output_directory / "test1.csv"
+        file_path.write_bytes(b"OLD_CONTENT")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", str(local_output_directory), overwrite=True)
+
+        assert file_path.read_bytes() == b"SWQsTmFtZQoxLEZlbGl4"
+        assert len(list(local_output_directory.iterdir())) == 1
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_false(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        local_output_directory = tmp_path / "test_directory"
+        local_output_directory.mkdir()
+        file_path = local_output_directory / "test1.csv"
+        file_path.write_bytes(b"OLD_CONTENT")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", str(local_output_directory), overwrite=False)
+
+        assert file_path.read_bytes() == b"OLD_CONTENT"
+        new_file_path = local_output_directory / "test1 (1).csv"
+        assert new_file_path.read_bytes() == b"SWQsTmFtZQoxLEZlbGl4"
+        assert len(list(local_output_directory.iterdir())) == 2
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_multiple_collisions(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        local_output_directory = tmp_path / "test_directory"
+        local_output_directory.mkdir()
+        (local_output_directory / "test1.csv").write_bytes(b"CONTENT_0")
+        (local_output_directory / "test1 (1).csv").write_bytes(b"CONTENT_1")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", str(local_output_directory), overwrite=False)
+
+        assert (local_output_directory / "test1.csv").read_bytes() == b"CONTENT_0"
+        assert (local_output_directory / "test1 (1).csv").read_bytes() == b"CONTENT_1"
+        assert (local_output_directory / "test1 (2).csv").read_bytes() == b"SWQsTmFtZQoxLEZlbGl4"
+        assert len(list(local_output_directory.iterdir())) == 3
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_with_directory_collision(self, mock_imaplib, tmp_path):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        local_output_directory = tmp_path / "test_directory"
+        local_output_directory.mkdir()
+        (local_output_directory / "test1.csv").mkdir()
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", str(local_output_directory), overwrite=False)
+
+        assert (local_output_directory / "test1.csv").is_dir()
+        assert (local_output_directory / "test1 (1).csv").read_bytes() == b"SWQsTmFtZQoxLEZlbGl4"
+
+    def test_resolve_non_conflicting_path_exhaustion(self):
+        hook = ImapHook()
+        with patch("os.path.exists", return_value=True):
+            with pytest.raises(AirflowException, match="Could not find a unique filename"):
+                hook._resolve_non_conflicting_path("test.csv")
+
+    @patch(imaplib_string)
+    def test_download_mail_attachments_multiple_attachments_same_name(self, mock_imaplib, tmp_path):
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True)
+        # Create a mail with two attachments with the same name
+        mail_string = (
+            "Content-Type: multipart/mixed; boundary=123\r\n"
+            "--123\r\n"
+            'Content-Disposition: attachment; filename="test1.csv";\r\n'
+            "Content-Transfer-Encoding: base64\r\n"
+            "SWQsTmFtZQoxLEZlbGl4\r\n"  # Payload 1
+            "--123\r\n"
+            'Content-Disposition: attachment; filename="test1.csv";\r\n'
+            "Content-Transfer-Encoding: base64\r\n"
+            "SWQsTmFtZQoyLEJhcm5leQ==\r\n"  # Payload 2
+            "--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        local_output_directory = tmp_path / "test_directory"
+        local_output_directory.mkdir()
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", str(local_output_directory), overwrite=False)
+
+        assert (local_output_directory / "test1.csv").read_bytes() == b"Id,Name\n1,Felix"
+        assert (local_output_directory / "test1 (1).csv").read_bytes() == b"Id,Name\n2,Barney"
+        assert len(list(local_output_directory.iterdir())) == 2


### PR DESCRIPTION
The current implementation of `download_mail_attachments` in `ImapHook` silently overwrites files if they already exist in the target directory. This can lead to data loss when multiple emails have attachments with the same filename.

This PR adds a configurable `overwrite` parameter (defaulting to `True` for backward compatibility) to `download_mail_attachments`. When set to `False`, the hook will automatically rename files by appending a numeric suffix (e.g., `report (1).csv`) if a collision is detected.

Summary:
- Added `overwrite` parameter to `download_mail_attachments`.
- Implemented `_resolve_non_conflicting_path` helper to handle filename collisions.
- Added comprehensive unit tests for both overwrite and collision-avoidance scenarios.
- Updated the IMAP provider changelog.

closes: #65870

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — gemini-3-flash-preview

Generated-by: gemini-3-flash-preview following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)