### PR TITLE
Render Jinja templates in CloudBatchSubmitJobOperator job field

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -77,9 +77,11 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.region = region
         self.job_name = job_name
+        self.job = job
         # Normalize Job protobuf to dict so Airflow's template renderer can descend
         # into nested fields (e.g. runnable.container.commands). See #37217.
-        self.job = Job.to_dict(job) if isinstance(job, Job) else job
+        if isinstance(job, Job):
+            self.job = Job.to_dict(job)
         self.polling_period_seconds = polling_period_seconds
         self.timeout_seconds = timeout_seconds
         self.gcp_conn_id = gcp_conn_id

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -57,7 +57,8 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
 
     """
 
-    template_fields = ("project_id", "region", "gcp_conn_id", "impersonation_chain", "job_name")
+    template_fields = ("project_id", "region", "gcp_conn_id", "impersonation_chain", "job_name", "job")
+    template_fields_renderers = {"job": "json"}
 
     def __init__(
         self,
@@ -76,7 +77,9 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         self.project_id = project_id
         self.region = region
         self.job_name = job_name
-        self.job = job
+        # Normalize Job protobuf to dict so Airflow's template renderer can descend
+        # into nested fields (e.g. runnable.container.commands). See #37217.
+        self.job = Job.to_dict(job) if isinstance(job, Job) else job
         self.polling_period_seconds = polling_period_seconds
         self.timeout_seconds = timeout_seconds
         self.gcp_conn_id = gcp_conn_id

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import json
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -52,7 +54,7 @@ class TestCloudBatchSubmitJobOperator:
         assert completed_job["name"] == JOB_NAME
 
         mock.return_value.submit_batch_job.assert_called_with(
-            job_name=JOB_NAME, job=JOB, region=REGION, project_id=PROJECT_ID
+            job_name=JOB_NAME, job=batch_v1.Job.to_dict(JOB), region=REGION, project_id=PROJECT_ID
         )
         mock.return_value.wait_for_job.assert_called()
 
@@ -90,6 +92,59 @@ class TestCloudBatchSubmitJobOperator:
             expected_exception=AirflowException, match="Unexpected error in the operation: test error"
         ):
             operator.execute_complete(context=mock.MagicMock(), event=event)
+
+
+def _job_dict_with_template() -> dict:
+    return {
+        "task_groups": [
+            {
+                "task_spec": {
+                    "runnables": [
+                        {
+                            "container": {
+                                "image_uri": "gcr.io/google-containers/busybox",
+                                "entrypoint": "/bin/sh",
+                                "commands": ["-c", "echo {{ ds }}"],
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "labels": {"run_id": "{{ run_id }}"},
+    }
+
+
+class TestCloudBatchSubmitJobOperatorTemplating:
+    def test_template_fields_includes_job(self):
+        assert "job" in CloudBatchSubmitJobOperator.template_fields
+
+    @pytest.mark.db_test
+    @pytest.mark.parametrize(
+        "job_input_factory",
+        [
+            pytest.param(lambda d: d, id="dict"),
+            pytest.param(lambda d: batch_v1.Job.from_json(json.dumps(d)), id="protobuf-Job"),
+        ],
+    )
+    def test_jinja_in_job_commands_is_rendered(self, create_task_instance_of_operator, job_input_factory):
+        ti = create_task_instance_of_operator(
+            CloudBatchSubmitJobOperator,
+            dag_id="test_cloud_batch_render",
+            task_id=TASK_ID,
+            project_id=PROJECT_ID,
+            region=REGION,
+            job_name=JOB_NAME,
+            job=job_input_factory(_job_dict_with_template()),
+            logical_date=datetime(2026, 1, 15),
+        )
+        task = ti.render_templates()
+
+        assert isinstance(task.job, dict)
+        rendered_cmd = task.job["task_groups"][0]["task_spec"]["runnables"][0]["container"]["commands"][1]
+        assert rendered_cmd == "echo 2026-01-15"
+        # dag_maker's default run_id is "test"; the point is {{ run_id }} got substituted at all.
+        assert task.job["labels"]["run_id"] == "test"
 
 
 class TestCloudBatchDeleteJobOperator:


### PR DESCRIPTION
closes: #37217

# How

1. Add `job` to `template_fields`.
2. Normalize `Job` protobuf to `dict` in `__init__`
    + the official example DAG passes a `batch_v1.Job`, which Airflow's renderer skips because it only descends into `dict / list / str / tuple / set`.
    + This is the critical step that previous attempts missed.
3. Add a unit test for template rendering to prevent regression in the future.

+ Reproduction Dag
```python
from datetime import datetime
import os

from google.cloud import batch_v1

from airflow.models.dag import DAG
from airflow.providers.google.cloud.operators.cloud_batch import (
    CloudBatchSubmitJobOperator,
)

PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "<my-project-id>")
REGION = "us-central1"


def _build_job_with_template() -> batch_v1.Job:
    runnable = batch_v1.Runnable()
    runnable.container = batch_v1.Runnable.Container()
    runnable.container.image_uri = "gcr.io/google-containers/busybox"
    runnable.container.entrypoint = "/bin/sh"
    runnable.container.commands = [
        "-c",
        "echo logical_date={{ ds }} run_id={{ run_id }}",
    ]

    task = batch_v1.TaskSpec()
    task.runnables = [runnable]
    resources = batch_v1.ComputeResource()
    resources.cpu_milli = 2000
    resources.memory_mib = 16
    task.compute_resource = resources
    task.max_retry_count = 1

    group = batch_v1.TaskGroup()
    group.task_count = 1
    group.task_spec = task

    policy = batch_v1.AllocationPolicy.InstancePolicy()
    policy.machine_type = "e2-small"
    instances = batch_v1.AllocationPolicy.InstancePolicyOrTemplate()
    instances.policy = policy
    allocation_policy = batch_v1.AllocationPolicy()
    allocation_policy.instances = [instances]

    job = batch_v1.Job()
    job.task_groups = [group]
    job.allocation_policy = allocation_policy
    job.logs_policy = batch_v1.LogsPolicy()
    job.logs_policy.destination = batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
    return job


with DAG(
    dag_id="repro_37217",
    start_date=datetime(2026, 1, 1),
    schedule=None,
    catchup=False,
) as dag:
    CloudBatchSubmitJobOperator(
        task_id="submit_with_template",
        project_id=PROJECT_ID,
        region=REGION,
        job_name="repro-37217-{{ ts_nodash | lower }}",
        job=_build_job_with_template(),
    )

```

# What

### Before the fix

GCP Batch logs:

<img width="1419" height="809" alt="37217_repro_gcp_batch_before_fix" src="https://github.com/user-attachments/assets/d7ad0fa0-2260-4661-8c30-49694a6ea848" />

### After the fix

<img width="1436" height="809" alt="37217_repro_gcp_batch_after_fix" src="https://github.com/user-attachments/assets/8379708e-23ed-41e1-99e0-44be560fe4c8" />


<br><br>

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

