### PR TITLE
docs: fix grammar issues in contributing-docs/README.rst

### DIFF
--- a/contributing-docs/README.rst
+++ b/contributing-docs/README.rst
@@ -24,7 +24,7 @@ and credit will always be given.
 This page aims to explain the basic concept of contributions. It contains links
 to detailed documents for the different aspects of contribution. We encourage both
 Open Source first timers as well as more experienced contributors to read and
-learn about this community's contribution guidelines as it support easy and efficient collaboration.
+learn about this community's contribution guidelines as it supports easy and efficient collaboration.
 
 Getting Started
 ----------------
@@ -47,7 +47,7 @@ community - mostly Airflow committers (maintainers). Mentoring new members of th
 maintainers job so do not be afraid to ask them to help you. You can do it
 via comments in your PR, asking on a devlist or via Slack. We also have a dedicated ``#new-contributors`` Slack channel where you can ask any questions
 about making your first Pull Request (PR) contribution to the Airflow codebase - it's a safe space
-where it is expected that people asking questions do not know a lot Airflow (yet!).
+where it is expected that people asking questions do not know a lot about Airflow (yet!).
 If you need help with Airflow see the Slack channel ``#user-troubleshooting``.
 
 To check on how mentoring works for the projects under Apache Software Foundation's


### PR DESCRIPTION
Two small grammar fixes in the Contributors' guide README: subject-verb agreement ('as it support' -> 'as it supports') and a missing preposition ('do not know a lot Airflow' -> 'do not know a lot about Airflow').

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---



* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
