### PR TITLE
fix: connection dialog state handling in BasePage to avoid flaky tests

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
@@ -56,13 +56,13 @@ export class BasePage {
     await this.page.goto(path, { waitUntil: "domcontentloaded" });
   }
 
-  // Chakra v3 / Ark UI keeps the backdrop in the DOM until the close animation
-  // ends. On WebKit the animationend/transitionend event is occasionally
-  // dropped under CI load, leaving a `data-state="closed"` backdrop attached
-  // that intercepts pointer events on subsequent actions. Wait for every
-  // dialog backdrop to be detached before continuing.
+  // Ark UI sets `data-state="closed"` synchronously on the close flag flip,
+  // but unmount only fires after `animationend`/`transitionend` — which WebKit
+  // occasionally drops under CI load. Wait on the dialog state, not on DOM
+  // detachment, so the test does not depend on the animation event firing.
+  // Any dialog part still in `data-state="open"` means a modal is active.
   public async waitForAllDialogsClosed(timeout = 15_000): Promise<void> {
-    await expect(this.page.locator('[data-scope="dialog"][data-part="backdrop"]')).toHaveCount(0, {
+    await expect(this.page.locator('[data-scope="dialog"][data-state="open"]')).toHaveCount(0, {
       timeout,
     });
   }


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## why
`waitForAllDialogsClosed` waits for the backdrop DOM to be detached, which only happens after Ark UI's presence machine receives an `animationend` event. 
However, WebKit drops this event under CI load when the close action coincides with a portalled toast and a TanStack Query refetch, which can leave a stuck backdrop for the full 15s timeout.

https://github.com/apache/airflow/actions/runs/25938538473

## after
Instead, wait on `data-state="open"` instead. Ark sets this synchronously when transitioning out of the open state, so the helper no longer depends on a fragile DOM event.



<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude opus 4.7
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
