### PR TITLE
Replace deprecated typer-slim with typer in devel-common

### DIFF
--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "rich>=13.6.0",
     "ruff==0.15.11",
     "semver>=3.0.2",
-    "typer-slim>=0.15.1",
+    "typer>=0.22.0",
     "time-machine[dateutil]>=3.0.0",
     "wheel>=0.42.0",
     "yamllint>=1.33.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2172,7 +2172,7 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlalchemy-utils" },
     { name = "time-machine", extra = ["dateutil"] },
-    { name = "typer-slim" },
+    { name = "typer" },
     { name = "types-aiofiles" },
     { name = "types-cachetools" },
     { name = "types-certifi" },
@@ -2534,7 +2534,7 @@ requires-dist = [
     { name = "time-machine", extras = ["dateutil"], specifier = ">=3.0.0" },
     { name = "towncrier", marker = "extra == 'devscripts'", specifier = ">=23.11.0" },
     { name = "twine", marker = "extra == 'devscripts'", specifier = ">=4.0.2" },
-    { name = "typer-slim", specifier = ">=0.15.1" },
+    { name = "typer", specifier = ">=0.22.0" },
     { name = "types-aiofiles", marker = "extra == 'mypy'", specifier = ">=23.2.0.20240403" },
     { name = "types-cachetools", marker = "extra == 'mypy'", specifier = ">=6.2.0.20251022" },
     { name = "types-certifi", marker = "extra == 'mypy'", specifier = ">=2021.10.8.3" },
@@ -21838,18 +21838,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`devel-common/pyproject.toml` previously pinned `typer-slim>=0.15.1`. Under
`uv --resolution lowest-direct`, this resolved to `typer-slim==0.15.1` — the
OLD standalone slim package that ships its own `typer/` module. `fastapi-cli`
transitively pulled `typer==0.24.2`, so both packages wrote to the same
`typer/` site-packages directory and produced a corrupted install. `import
fastapi_cli.cli` then raised `ImportError`, and the 23
`mock.patch("fastapi_cli.cli._run")` calls in
`airflow-core/tests/unit/cli/commands/test_api_server_command.py` surfaced
this as `AttributeError: module 'fastapi_cli' has no attribute 'cli'` from
`pkgutil.resolve_name` (Python 3.13 `mock.patch` uses `pkgutil.resolve_name`,
which only falls back to `getattr` after an `ImportError`).

`typer-slim` 0.22.0+ is a [deprecated meta-package](https://pypi.org/project/typer-slim/)
that just depends on `typer`, and upstream explicitly warns against installing
it. Switch to `typer` directly (`>=0.22.0`) so nothing in the dep graph can
reintroduce a pre-0.22 slim `typer-slim`, and the full `typer` cleanly owns
the `typer/` namespace.

Observed CI failure: https://github.com/apache/airflow/actions/runs/25956999745/job/76306005054

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)