### PR TITLE
Move Task Identity line into Pre Execution block in logs

### DIFF
--- a/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
+++ b/airflow-core/src/airflow/ui/src/mocks/handlers/log.ts
@@ -227,9 +227,21 @@ export const handlers: Array<HttpHandler> = [
           timestamp: "2025-02-18T12:19:56.263258Z",
           try_number: 1,
         },
+        { event: "::group::Pre Execute" },
+        {
+          event: "DAG bundles loaded: dags-folder, example_dags",
+          level: "info",
+          timestamp: "2025-02-18T12:19:56.400000Z",
+        },
+        {
+          event: "Filling up the DagBag from /files/dags/log_grouping.py",
+          level: "info",
+          timestamp: "2025-02-18T12:19:56.400000Z",
+        },
+        { event: "::endgroup::" },
         {
           dag_id: "log_grouping",
-          event: "Task finished",
+          event: "Done. Returned value was: None",
           level: "info",
           map_index: -1,
           run_id: "manual__2025-02-18T12:19",

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/Logs.test.tsx
@@ -181,7 +181,7 @@ describe("Task log grouping", () => {
 });
 
 describe("Task Identity preamble", () => {
-  it("renders Task Identity preamble after the Log message source details group", async () => {
+  it("renders Task Identity preamble after the 'Pre Execute' group header as first group element", async () => {
     render(
       <AppWrapper initialEntries={["/dags/log_grouping/runs/manual__2025-02-18T12:19/tasks/ti_context"]} />,
     );
@@ -192,22 +192,27 @@ describe("Task Identity preamble", () => {
 
     expect(sourceGroup).toBeInTheDocument();
 
-    // Task Identity preamble should be visible
-    expect(screen.getByText("Task Identity")).toBeInTheDocument();
+    // Expand the Pre Execute group to reveal the preamble
+    const groupHeader = screen.getByTestId("summary-Pre Execute");
+
+    fireEvent.click(groupHeader);
+
+    // Task Identity preamble should be visible after expanding the group
+    await waitFor(() => expect(screen.getByText("Task Identity")).toBeInTheDocument());
     expect(screen.getByText("ti_id")).toBeInTheDocument();
     // Value is a text node adjacent to =; match via partial text
     expect(screen.getByText(/01951900-16f6-7c1c-ae66-91bdfe9e0cfd/u)).toBeInTheDocument();
+    expect(screen.getByText("Done. Returned value was: None")).toBeInTheDocument();
 
-    // Preamble should come after the source details group in DOM order.
+    // Preamble should come after the "Pre Execute" group header in DOM order.
     const preamble = screen.getByText("Task Identity");
-    const groupHeader = sourceGroup.closest('[data-testid^="group-header-"]');
 
     expect(preamble).toBeInTheDocument();
     expect(groupHeader).toBeInTheDocument();
 
     // DOCUMENT_POSITION_FOLLOWING (4) is set when preamble comes after groupHeader
     // eslint-disable-next-line no-bitwise
-    expect(groupHeader!.compareDocumentPosition(preamble) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(groupHeader.compareDocumentPosition(preamble) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("does not render TI context fields on individual log lines", async () => {

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.test.ts
@@ -44,7 +44,7 @@ describe("getDownloadText", () => {
     translate,
   };
 
-  it("places Task Identity preamble after the source details endgroup, before the first log line", () => {
+  it("places Task Identity preamble after the 'Pre Execute' group header, before the first log line", () => {
     const fetchedData = {
       content: [
         { event: "::group::Log message source details" },
@@ -52,6 +52,7 @@ describe("getDownloadText", () => {
         { event: "/logs/b.log" },
         { event: "some source detail" },
         { event: "::endgroup::" },
+        tiLine("::group::Pre Execute", "2026-01-01T00:00:00Z"),
         tiLine("First log line", "2026-01-01T00:00:00Z"),
         tiLine("Second log line", "2026-01-01T00:00:01Z"),
       ],
@@ -60,10 +61,10 @@ describe("getDownloadText", () => {
 
     const lines = getDownloadText({ ...baseOptions, fetchedData });
     const preambleIdx = lines.findIndex((line) => line.includes("Task Identity"));
-    const endGroupIdx = lines.findIndex((line) => line.includes("::endgroup::"));
+    const preExecuteGroupIdx = lines.findIndex((line) => line.includes("::group::Pre Execute"));
     const firstLogIdx = lines.findIndex((line) => line.includes("First log line"));
 
-    expect(preambleIdx).toBeGreaterThan(endGroupIdx);
+    expect(preambleIdx).toBeGreaterThan(preExecuteGroupIdx);
     expect(preambleIdx).toBeLessThan(firstLogIdx);
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/utils.ts
@@ -67,14 +67,14 @@ export const getDownloadText = ({
   );
 
   if (tiContext !== undefined) {
-    const firstEndGroup = lines.findIndex((line) => {
+    const preExecuteGroup = lines.findIndex((line) => {
       const text = typeof line === "string" ? line : line.event;
 
-      return text.includes("::endgroup::");
+      return text.includes("::group::Pre Execute");
     });
 
     rendered.splice(
-      firstEndGroup === -1 ? 0 : firstEndGroup + 1,
+      preExecuteGroup === -1 ? 0 : preExecuteGroup + 1,
       0,
       renderTIContextPreamble(tiContext, "text", "Task Identity") as string,
     );

--- a/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useLogs.tsx
@@ -175,31 +175,36 @@ const parseLogs = ({
   })();
 
   // Extract TI identity fields from the first structured log line and insert a single preamble
-  // entry after the "Log message source details" group (or at position 0 if absent), so they
+  // entry after the "Pre Execute" group header (or at position 0 if absent), so they
   // appear once rather than repeated on every line.
   const tiContext = extractTIContext(data);
 
   if (tiContext !== undefined) {
     let insertAt = 0;
-    const sourceDetailsIndex = flatEntries.findIndex(
+    let insertGroup: { id: number; level: number; parentId?: number; type: "header" | "line" } | undefined =
+      undefined;
+    const preExecuteIndex = flatEntries.findIndex(
       (entry) =>
         entry.group?.type === "header" &&
         typeof entry.element === "string" &&
-        entry.element.startsWith("Log message source details"),
+        entry.element.startsWith("Pre Execute"),
     );
 
-    const sourceGroup = sourceDetailsIndex === -1 ? undefined : flatEntries[sourceDetailsIndex];
+    const preExecuteGroup = preExecuteIndex === -1 ? undefined : flatEntries[preExecuteIndex];
 
-    if (sourceGroup?.group !== undefined) {
-      const sourceGroupId = sourceGroup.group.id;
-      const lastMemberIndex = flatEntries.reduce(
-        (last, entry, idx) => (entry.group?.id === sourceGroupId ? idx : last),
-        sourceDetailsIndex,
-      );
-
-      insertAt = lastMemberIndex + 1;
+    if (preExecuteGroup?.group !== undefined) {
+      insertAt = preExecuteIndex + 1;
+      insertGroup = {
+        id: preExecuteGroup.group.id,
+        level: preExecuteGroup.group.level,
+        parentId: preExecuteGroup.group.id,
+        type: "line",
+      };
     }
-    flatEntries.splice(insertAt, 0, { element: renderTIContextPreamble(tiContext, "jsx", "Task Identity") });
+    flatEntries.splice(insertAt, 0, {
+      element: renderTIContextPreamble(tiContext, "jsx", "Task Identity"),
+      group: insertGroup,
+    });
   }
 
   return {


### PR DESCRIPTION
In #66036 @ashb optimized the struct log to replace the task identity attributes with a single log line.

Still one log line between the "Log message source details" and "Pre Execute" block.

This PR makes another round of log UI cleaning and moves the log line into the "Pre Execute" log group. Is this okay? For me looks much cleaner and the task identity is actually only needed for troubleshooting in my view. Not for a user checking logs.

Before this PR/main:
<img width="619" height="431" alt="image" src="https://github.com/user-attachments/assets/4efc56da-1ad9-4606-a5b5-31dcf3902275" />

Default view after this change:
<img width="649" height="407" alt="image" src="https://github.com/user-attachments/assets/c15058a7-5444-485c-a56b-f4743f19414a" />

If you expand the "Pre Execute" block the Task Identity is displayed:
<img width="709" height="544" alt="image" src="https://github.com/user-attachments/assets/ae80f49b-44da-4d26-95f7-bff7e8e6de65" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

Claude Sonnet 4.5 (but only for fixing JSX tests)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
