### PR TITLE
Fix hardcoded OS path in K8s provider

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -18,9 +18,9 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from kubernetes import client
 from kubernetes.client.api_client import ApiClient
@@ -61,7 +61,7 @@ def generate_pod_yaml(args):
         dag = get_bagged_dag(bundle_names=args.bundle_name, dag_id=args.dag_id)
     else:
         dag = get_bagged_dag(subdir=args.subdir, dag_id=args.dag_id)
-    yaml_output_path = args.output_path
+    yaml_output_path = Path(args.output_path) / "airflow_yaml_output"
 
     dm = DagModel(dag_id=dag.dag_id)
 
@@ -112,11 +112,11 @@ def generate_pod_yaml(args):
         api_client = ApiClient()
         date_string = pod_generator.datetime_to_label_safe_datestring(logical_date)
         yaml_file_name = f"{args.dag_id}_{ti.task_id}_{date_string}.yml"
-        os.makedirs(os.path.dirname(yaml_output_path + "/airflow_yaml_output/"), exist_ok=True)
-        with open(yaml_output_path + "/airflow_yaml_output/" + yaml_file_name, "w") as output:
+        yaml_output_path.mkdir(parents=True, exist_ok=True)
+        with open(yaml_output_path / yaml_file_name, "w") as output:
             sanitized_pod = api_client.sanitize_for_serialization(pod)
             output.write(yaml.dump(sanitized_pod))
-    print(f"YAML output can be found at {yaml_output_path}/airflow_yaml_output/")
+    print(f"YAML output can be found at {yaml_output_path}")
 
 
 @cli_utils.action_cli(check_db=False)


### PR DESCRIPTION
Similar like #67039 fixing some hardcoded OS sep in K8s provider. Not really problematic but to be safe.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
