### PR TITLE
Fix broken download URLs and variable names in airflow-ctl docs

### DIFF
--- a/airflow-ctl/docs/installation/installing-from-sources.rst
+++ b/airflow-ctl/docs/installation/installing-from-sources.rst
@@ -52,7 +52,7 @@ a ``INSTALL`` file containing details on how you can build and install airflowct
 Release integrity
 '''''''''''''''''
 
-`PGP signatures KEYS <https://downloads.apache.org/airflowctl/KEYS>`__
+`PGP signatures KEYS <https://downloads.apache.org/airflow/KEYS>`__
 
 It is essential that you verify the integrity of the downloaded files using the PGP or SHA signatures.
 The PGP signatures can be verified using GPG or PGP. Please download the KEYS as well as the asc
@@ -144,14 +144,14 @@ and SHA sum files with the script below:
         #!/bin/bash
         airflowctl_version="{{ airflowctl_version }}"
         ctl_download_dir="$(mktemp -d)"
-        pip download --no-deps "apache-airflow-ctl==${airflowctl_version}" --dest "${airflow_download_dir}"
-        curl "https://downloads.apache.org/airflowctl/${airflowctl_version}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.asc" \
-            -L -o "${airflowctl_download_dir}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.asc"
-        curl "https://downloads.apache.org/airflow/${airflowctl_version}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.sha512" \
-            -L -o "${airflowctl_download_dir}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.sha512"
+        pip download --no-deps "apache-airflow-ctl==${airflowctl_version}" --dest "${ctl_download_dir}"
+        curl "https://downloads.apache.org/airflow/airflow-ctl/${airflowctl_version}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.asc" \
+            -L -o "${ctl_download_dir}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.asc"
+        curl "https://downloads.apache.org/airflow/airflow-ctl/${airflowctl_version}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.sha512" \
+            -L -o "${ctl_download_dir}/apache_airflow_ctl-${airflowctl_version}-py3-none-any.whl.sha512"
         echo
-        echo "Please verify files downloaded to ${airflowctl_download_dir}"
-        ls -la "${airflowctl_download_dir}"
+        echo "Please verify files downloaded to ${ctl_download_dir}"
+        ls -la "${ctl_download_dir}"
         echo
 
 Once you verify the files following the instructions from previous chapter you can remove the temporary


### PR DESCRIPTION
Fix broken download URLs and variable names in airflow-ctl installing-from-sources docs

The `installing-from-sources.rst` page for airflow-ctl has two categories of bugs:

**Broken URLs (HTTP 404)**

The KEYS link and one of the curl commands use `downloads.apache.org/airflowctl/...`
which doesn't exist. The correct base path is `downloads.apache.org/airflow/KEYS`
(shared across all Airflow distributions) and `downloads.apache.org/airflow/airflow-ctl/{version}/`
(matching the `base_url` already defined in `airflow-ctl/docs/conf.py` line 210).

The second curl command was slightly different — it used `downloads.apache.org/airflow/${version}/`
but omitted the `airflow-ctl/` subdirectory.

**Undefined shell variables**

The bash verification script defines `ctl_download_dir` but then references two
non-existent variables (`airflow_download_dir` and `airflowctl_download_dir`).
Unified all references to `ctl_download_dir`.

closes: #67025

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.