### PR TITLE
Fix connection extra JSON initialization

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -68,19 +68,26 @@ export const FlexibleForm = ({
   setError,
   subHeader,
 }: FlexibleFormProps) => {
-  const { paramsDict: params, setDisabled, setInitialParamDict, setParamsDict } = useParamStore(namespace);
+  const {
+    initializeParamsDict,
+    initialParamDict,
+    paramsDict: params,
+    setDisabled,
+    setInitialParamDict,
+    setParamsDict,
+  } = useParamStore(namespace);
   const processedSections = new Map();
   const [sectionError, setSectionError] = useState<Map<string, boolean>>(new Map());
 
   useEffect(() => {
     // Initialize paramsDict and initialParamDict when modal opens
-    if (Object.keys(initialParamsDict.paramsDict).length > 0 && Object.keys(params).length === 0) {
+    if (Object.keys(initialParamsDict.paramsDict).length > 0 && Object.keys(initialParamDict).length === 0) {
       const paramsCopy = structuredClone(initialParamsDict.paramsDict);
 
-      setParamsDict(paramsCopy);
+      initializeParamsDict(paramsCopy);
       setInitialParamDict(initialParamsDict.paramsDict);
     }
-  }, [initialParamsDict, params, setParamsDict, setInitialParamDict]);
+  }, [initialParamsDict, initialParamDict, initializeParamsDict, setInitialParamDict]);
 
   useEffect(
     () => () => {

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
@@ -1,0 +1,69 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ParamsSpec } from "src/queries/useDagParams";
+
+import { paramsDictWithConfValues } from "./useParamStore";
+
+const schema = (type: Array<string> | string, title: string) => ({
+  const: undefined,
+  description_md: undefined,
+  enum: undefined,
+  examples: undefined,
+  format: undefined,
+  items: undefined,
+  maximum: undefined,
+  maxLength: undefined,
+  minimum: undefined,
+  minLength: undefined,
+  section: undefined,
+  title,
+  type,
+  values_display: undefined,
+});
+
+describe("paramsDictWithConfValues", () => {
+  it("hydrates provider extra fields from existing raw JSON values", () => {
+    const snowflakeExtraFields: ParamsSpec = {
+      account: {
+        description: null,
+        schema: schema(["string", "null"], "Account"),
+        value: undefined,
+      },
+      insecure_mode: {
+        description: "Turns off OCSP certificate checks",
+        schema: schema(["boolean", "null"], "Insecure Mode"),
+        value: false,
+      },
+    };
+
+    const paramsDict = paramsDictWithConfValues(snowflakeExtraFields, '{"account":"1234"}');
+
+    expect(paramsDict.account?.value).toBe("1234");
+    expect(paramsDict.insecure_mode?.value).toBe(false);
+    expect(Object.keys(paramsDict)).toEqual(["account", "insecure_mode"]);
+  });
+
+  it("keeps raw JSON keys that are not declared by the provider schema", () => {
+    const paramsDict = paramsDictWithConfValues({}, '{"account":"1234"}');
+
+    expect(paramsDict.account?.value).toBe("1234");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -44,6 +44,7 @@ export const paramPlaceholder: ParamSpec = {
 type FormStore = {
   conf: string;
   disabled: boolean;
+  initializeParamsDict: (newParamsDict: ParamsSpec) => void;
   initialParamDict: ParamsSpec;
   paramsDict: ParamsSpec;
   setConf: (confString: string) => void;
@@ -52,10 +53,46 @@ type FormStore = {
   setParamsDict: (newParamsDict: ParamsSpec) => void;
 };
 
+export const paramsDictWithConfValues = (newParamsDict: ParamsSpec, confString: string): ParamsSpec => {
+  const parsedConf = JSON.parse(confString) as Record<string, unknown>;
+  const paramsWithValues: Array<[string, ParamSpec]> = [];
+  const inParamsDict = new Set<string>(Object.keys(newParamsDict));
+
+  for (const [key, param] of Object.entries(newParamsDict)) {
+    paramsWithValues.push([
+      key,
+      {
+        description: param.description ?? null,
+        schema: param.schema,
+        value: Object.hasOwn(parsedConf, key) ? parsedConf[key] : param.value,
+      },
+    ]);
+  }
+
+  for (const [key, value] of Object.entries(parsedConf)) {
+    if (!inParamsDict.has(key)) {
+      paramsWithValues.push([
+        key,
+        {
+          description: null,
+          schema: paramPlaceholder.schema,
+          value,
+        },
+      ]);
+    }
+  }
+
+  return Object.fromEntries(paramsWithValues);
+};
+
 const createParamStore = () =>
   create<FormStore>((set) => ({
     conf: "{}",
     disabled: false,
+    initializeParamsDict: (newParamsDict: ParamsSpec) =>
+      set((state) => ({
+        paramsDict: paramsDictWithConfValues(newParamsDict, state.conf),
+      })),
     initialParamDict: {},
     paramsDict: {},
 


### PR DESCRIPTION
closes: #57984

Preserve existing raw connection extra JSON when the provider-specific extra-field form initializes. This hydrates provider fields from the existing JSON instead of writing untouched field defaults back into `extra`, so Snowflake extras such as `{"account":"1234"}` are not replaced during form initialization.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
