### PR TITLE
Fix CloudRunExecuteJobOperator deferrable mode silently passing on cancel

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_run.py
@@ -21,6 +21,8 @@ from collections.abc import AsyncIterator, Sequence
 from enum import Enum
 from typing import Any, Literal
 
+from google.cloud.run_v2 import Execution
+
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_run import CloudRunAsyncHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
@@ -127,13 +129,50 @@ class CloudRunJobFinishedTrigger(BaseTrigger):
                             "job_name": self.job_name,
                         }
                     )
-                else:
+                    return
+
+                # The LRO can complete without populating ``operation.error`` even when the
+                # underlying Cloud Run Execution did not succeed — for example when the job is
+                # cancelled from the Google Cloud UI or API, every remaining task ends up in
+                # ``cancelled_count`` rather than ``failed_count``. Mirror the sync path's
+                # ``_fail_if_execution_failed`` check on the Execution payload so deferrable mode
+                # surfaces the same failure semantics.
+                execution = Execution.deserialize(operation.response.value)
+                if execution.succeeded_count + execution.failed_count != execution.task_count:
                     yield TriggerEvent(
                         {
-                            "status": RunJobStatus.SUCCESS.value,
+                            "status": RunJobStatus.FAIL.value,
+                            "operation_error_code": None,
+                            "operation_error_message": (
+                                f"Cloud Run Job did not finish all tasks: task_count="
+                                f"{execution.task_count}, succeeded_count="
+                                f"{execution.succeeded_count}, failed_count="
+                                f"{execution.failed_count}, cancelled_count="
+                                f"{execution.cancelled_count}."
+                            ),
                             "job_name": self.job_name,
                         }
                     )
+                    return
+                if execution.failed_count > 0:
+                    yield TriggerEvent(
+                        {
+                            "status": RunJobStatus.FAIL.value,
+                            "operation_error_code": None,
+                            "operation_error_message": (
+                                f"Some Cloud Run Job tasks failed: failed_count="
+                                f"{execution.failed_count} of task_count={execution.task_count}."
+                            ),
+                            "job_name": self.job_name,
+                        }
+                    )
+                    return
+                yield TriggerEvent(
+                    {
+                        "status": RunJobStatus.SUCCESS.value,
+                        "job_name": self.job_name,
+                    }
+                )
                 return
             elif operation.error.message:
                 raise AirflowException(f"Cloud Run Job error: {operation.error.message}")

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
@@ -253,6 +253,32 @@ class TestCloudRunExecuteJobOperator:
         )
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)
+    def test_execute_deferrable_execute_complete_method_fail_on_cancellation(self, hook_mock):
+        """
+        Pin the contract that a FAIL event emitted by the trigger when a Cloud Run Job is
+        cancelled (no ``operation.error`` but ``cancelled_count > 0``) propagates as an
+        AirflowException — see #57791.
+        """
+        operator = CloudRunExecuteJobOperator(
+            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
+        )
+
+        event = {
+            "status": RunJobStatus.FAIL.value,
+            "operation_error_code": None,
+            "operation_error_message": (
+                "Cloud Run Job did not finish all tasks: task_count=3, succeeded_count=1, "
+                "failed_count=0, cancelled_count=2."
+            ),
+            "job_name": JOB_NAME,
+        }
+
+        with pytest.raises(AirflowException) as e:
+            operator.execute_complete(mock.MagicMock(), event)
+
+        assert "cancelled_count=2" in str(e.value)
+
+    @mock.patch(CLOUD_RUN_HOOK_PATH)
     def test_execute_deferrable_execute_complete_method_success(self, hook_mock):
         hook_mock.return_value.get_job.return_value = JOB
 

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_run.py
@@ -20,11 +20,25 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from google.cloud.run_v2 import Execution
 from google.protobuf.any_pb2 import Any
 from google.rpc.status_pb2 import Status
 
 from airflow.providers.google.cloud.triggers.cloud_run import CloudRunJobFinishedTrigger, RunJobStatus
 from airflow.triggers.base import TriggerEvent
+
+
+def _packed_execution_response(task_count, succeeded_count, failed_count, cancelled_count=0):
+    """Build a ``google.protobuf.Any`` packed with an ``Execution`` proto for trigger tests."""
+    execution = Execution()
+    execution.task_count = task_count
+    execution.succeeded_count = succeeded_count
+    execution.failed_count = failed_count
+    execution.cancelled_count = cancelled_count
+    response = Any()
+    response.Pack(Execution.pb(execution))
+    return response
+
 
 OPERATION_NAME = "operation"
 JOB_NAME = "jobName"
@@ -87,6 +101,7 @@ class TestCloudBatchJobFinishedTrigger:
             operation.name = "name"
             operation.error = Any()
             operation.error.ParseFromString(b"")
+            operation.response = _packed_execution_response(task_count=3, succeeded_count=3, failed_count=0)
             return operation
 
         mock_hook.return_value.get_operation = _mock_operation
@@ -101,6 +116,59 @@ class TestCloudBatchJobFinishedTrigger:
             )
             == actual
         )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_run.CloudRunAsyncHook")
+    async def test_trigger_yields_fail_when_job_cancelled(
+        self, mock_hook, trigger: CloudRunJobFinishedTrigger
+    ):
+        """
+        When the Cloud Run Job is cancelled via the Google Cloud UI/API the LRO completes with
+        no ``operation.error`` set but the Execution reports a non-zero ``cancelled_count``. The
+        trigger must surface this as a failure to mirror the sync path's semantics — see #57791.
+        """
+
+        async def _mock_operation(operation_name, location, use_regional_endpoint):
+            operation = mock.MagicMock()
+            operation.done = True
+            operation.error = Any()
+            operation.error.ParseFromString(b"")
+            operation.response = _packed_execution_response(
+                task_count=3, succeeded_count=1, failed_count=0, cancelled_count=2
+            )
+            return operation
+
+        mock_hook.return_value.get_operation = _mock_operation
+        generator = trigger.run()
+        actual = await generator.asend(None)  # type:ignore[attr-defined]
+        assert actual.payload["status"] == RunJobStatus.FAIL.value
+        assert actual.payload["job_name"] == JOB_NAME
+        assert "cancelled_count=2" in actual.payload["operation_error_message"]
+        assert "did not finish all tasks" in actual.payload["operation_error_message"]
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_run.CloudRunAsyncHook")
+    async def test_trigger_yields_fail_when_some_tasks_failed(
+        self, mock_hook, trigger: CloudRunJobFinishedTrigger
+    ):
+        """
+        Regression-guard symmetry with the sync path: when ``failed_count > 0`` and the counts
+        sum to ``task_count`` the deferrable trigger must still report failure.
+        """
+
+        async def _mock_operation(operation_name, location, use_regional_endpoint):
+            operation = mock.MagicMock()
+            operation.done = True
+            operation.error = Any()
+            operation.error.ParseFromString(b"")
+            operation.response = _packed_execution_response(task_count=3, succeeded_count=1, failed_count=2)
+            return operation
+
+        mock_hook.return_value.get_operation = _mock_operation
+        generator = trigger.run()
+        actual = await generator.asend(None)  # type:ignore[attr-defined]
+        assert actual.payload["status"] == RunJobStatus.FAIL.value
+        assert "Some Cloud Run Job tasks failed" in actual.payload["operation_error_message"]
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.triggers.cloud_run.CloudRunAsyncHook")


### PR DESCRIPTION
In deferrable mode, `CloudRunExecuteJobOperator` was reporting task success
even when the underlying Cloud Run Job was cancelled mid-run. The sync path
guards against this in `_fail_if_execution_failed` by checking that
`succeeded_count + failed_count == task_count` on the returned `Execution`,
but `CloudRunJobFinishedTrigger` only inspected `operation.done` and
`operation.error`. A user-initiated cancel from the Google Cloud UI/API
completes the LRO without populating `operation.error`, so the trigger
yielded `SUCCESS` and `execute_complete` happily fetched the Job and
returned.

Fix: when the LRO is done with no `operation.error`, deserialize the
`Execution` from `operation.response` and apply the same count check the
sync path uses, yielding `FAIL` with a descriptive message when the
counts indicate cancellation or partial completion. The operator already
raises `AirflowException` on `FAIL` events, so no operator change is
needed.

closes: #57791

## Tests

- New `test_trigger_yields_fail_when_job_cancelled` — LRO done, no
  `operation.error`, `Execution` has `task_count=3, succeeded_count=1,
  cancelled_count=2`; assert `FAIL` event with a message mentioning
  cancellation and the cancelled count.
- New `test_trigger_yields_fail_when_some_tasks_failed` — symmetry guard
  against the sync path's `failed_count > 0` branch.
- Updated existing success test to provide a real packed `Execution`
  proto in `operation.response` so the new deserialization path is
  exercised.
- New `test_execute_deferrable_execute_complete_method_fail_on_cancellation`
  pins the operator-level contract that a cancellation-shaped `FAIL`
  event propagates as `AirflowException`.

All 6 trigger tests and 31 operator tests pass locally:
`uv run --project providers/google pytest providers/google/tests/unit/google/cloud/triggers/test_cloud_run.py providers/google/tests/unit/google/cloud/operators/test_cloud_run.py -xvs`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)