### PR TITLE
Preserve raw Extras JSON in connection form

### DIFF
--- a/airflow-core/newsfragments/67054.bugfix.rst
+++ b/airflow-core/newsfragments/67054.bugfix.rst
@@ -1,0 +1,1 @@
+Fix connection edit form silently overwriting raw Extras JSON with widget defaults.

--- a/airflow-core/newsfragments/67054.bugfix.rst
+++ b/airflow-core/newsfragments/67054.bugfix.rst
@@ -1,1 +1,0 @@
-Fix connection edit form silently overwriting raw Extras JSON with widget defaults.

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldAdvancedArray.tsx
@@ -36,7 +36,7 @@ export const FieldAdvancedArray = ({ name, namespace = "default", onUpdate }: Fl
         // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
         paramsDict[name].value = null;
       }
-      setParamsDict(paramsDict);
+      setParamsDict(paramsDict, name);
     } else {
       try {
         const parsedValue = JSON.parse(value) as unknown;
@@ -66,7 +66,7 @@ export const FieldAdvancedArray = ({ name, namespace = "default", onUpdate }: Fl
           paramsDict[name].value = parsedValue;
         }
 
-        setParamsDict(paramsDict);
+        setParamsDict(paramsDict, name);
         onUpdate(String(parsedValue));
       } catch (_error) {
         onUpdate(undefined, expectedType === "number" ? String(_error).replace("JSON", "Array") : _error);

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
@@ -29,7 +29,7 @@ export const FieldBool = ({ name, namespace = "default" }: FlexibleFormElementPr
       paramsDict[name].value = value;
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
   };
 
   return (

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -39,7 +39,7 @@ export const FieldDateTime = ({
       paramsDict[name].value = value === "" ? null : value;
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(value);
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDropdown.tsx
@@ -78,7 +78,7 @@ export const FieldDropdown = ({ name, namespace = "default", onUpdate }: Flexibl
       }
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(selected?.value ?? "");
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiSelect.tsx
@@ -64,7 +64,7 @@ export const FieldMultiSelect = ({ name, namespace = "default", onUpdate }: Flex
     if (paramsDict[name]) {
       paramsDict[name].value = newValueArray;
     }
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(String(newValueArray));
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiType.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiType.test.tsx
@@ -109,6 +109,7 @@ describe("FieldMultiType", () => {
       render(<FieldMultiType name="test_param" onUpdate={vi.fn()} />, { wrapper: Wrapper });
       fireEvent.change(screen.getByRole("textbox"), { target: { value: '{"key": "val"}' } });
       expect(mockParamsDict.test_param.value).toEqual({ key: "val" });
+      expect(mockSetParamsDict).toHaveBeenCalledWith(mockParamsDict, "test_param");
     });
 
     it("stores a plain string when JSON parse fails", () => {
@@ -181,6 +182,7 @@ describe("FieldMultiType", () => {
       render(<FieldMultiType name="test_param" onUpdate={vi.fn()} />, { wrapper: Wrapper });
       fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
       expect(mockParamsDict.test_param.value).toBeNull();
+      expect(mockSetParamsDict).toHaveBeenCalledWith(mockParamsDict, "test_param");
     });
 
     it("calls onUpdate with the raw input string", () => {
@@ -208,6 +210,7 @@ describe("FieldMultiType", () => {
       fireEvent.change(screen.getByRole("textbox"), { target: { value: "nightly" } });
       expect(onUpdate).toHaveBeenCalledWith("", expect.stringContaining("integer"));
       expect(mockParamsDict.test_param.value).toBe(0);
+      expect(mockSetParamsDict).not.toHaveBeenCalled();
     });
 
     it("accepts a valid integer for type=['integer','object']", () => {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiType.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultiType.tsx
@@ -66,7 +66,7 @@ export const FieldMultiType = ({ name, namespace = "default", onUpdate }: Flexib
       // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
       paramsDict[name].value = null;
       setInputText(null);
-      setParamsDict(paramsDict);
+      setParamsDict(paramsDict, name);
       onUpdate(value);
 
       return;
@@ -95,7 +95,7 @@ export const FieldMultiType = ({ name, namespace = "default", onUpdate }: Flexib
     if (matched) {
       paramsDict[name].value = resolved;
       setInputText(null);
-      setParamsDict(paramsDict);
+      setParamsDict(paramsDict, name);
       onUpdate(value);
     } else {
       // Don't overwrite the last valid stored value; keep the typed text visible and signal the error.

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldMultilineText.tsx
@@ -31,7 +31,7 @@ export const FieldMultilineText = ({ name, namespace = "default", onUpdate }: Fl
       paramsDict[name].value = value === "" ? null : value;
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(value);
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldNumber.tsx
@@ -38,7 +38,7 @@ export const FieldNumber = ({ name, namespace = "default", onUpdate }: FlexibleF
       }
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(value);
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldObject.tsx
@@ -34,7 +34,7 @@ export const FieldObject = ({ name, namespace = "default", onUpdate }: FlexibleF
         paramsDict[name].value = parsedValue;
       }
 
-      setParamsDict(paramsDict);
+      setParamsDict(paramsDict, name);
       onUpdate(value);
     } catch (_error) {
       onUpdate("", _error);

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldString.tsx
@@ -33,7 +33,7 @@ export const FieldString = ({ name, namespace = "default", onUpdate }: FlexibleF
       paramsDict[name].value = value === "" ? null : value;
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(value);
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldStringArray.tsx
@@ -35,7 +35,7 @@ export const FieldStringArray = ({ name, namespace = "default", onUpdate }: Flex
       paramsDict[name].value = newValueArray;
     }
 
-    setParamsDict(paramsDict);
+    setParamsDict(paramsDict, name);
     onUpdate(newValue);
   };
 
@@ -48,7 +48,7 @@ export const FieldStringArray = ({ name, namespace = "default", onUpdate }: Flex
         paramsDict[name].value = null;
       }
 
-      setParamsDict(paramsDict);
+      setParamsDict(paramsDict, name);
     }
   };
 

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -68,19 +68,26 @@ export const FlexibleForm = ({
   setError,
   subHeader,
 }: FlexibleFormProps) => {
-  const { paramsDict: params, setDisabled, setInitialParamDict, setParamsDict } = useParamStore(namespace);
+  const {
+    initializeParamsDict,
+    initialParamDict,
+    paramsDict: params,
+    setDisabled,
+    setInitialParamDict,
+    setParamsDict,
+  } = useParamStore(namespace);
   const processedSections = new Map();
   const [sectionError, setSectionError] = useState<Map<string, boolean>>(new Map());
 
   useEffect(() => {
     // Initialize paramsDict and initialParamDict when modal opens
-    if (Object.keys(initialParamsDict.paramsDict).length > 0 && Object.keys(params).length === 0) {
+    if (Object.keys(initialParamsDict.paramsDict).length > 0 && Object.keys(initialParamDict).length === 0) {
       const paramsCopy = structuredClone(initialParamsDict.paramsDict);
 
-      setParamsDict(paramsCopy);
+      initializeParamsDict(paramsCopy);
       setInitialParamDict(initialParamsDict.paramsDict);
     }
-  }, [initialParamsDict, params, setParamsDict, setInitialParamDict]);
+  }, [initialParamsDict, initialParamDict, initializeParamsDict, setInitialParamDict]);
 
   useEffect(
     () => () => {

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
@@ -20,7 +20,7 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { ParamSchema, ParamsSpec } from "src/queries/useDagParams";
-import { buildParamsDictWithConfValues, useParamStore } from "src/queries/useParamStore";
+import { hydrateParams, useParamStore } from "src/queries/useParamStore";
 
 const buildSchema = (type: ParamSchema["type"], title: string): ParamSchema => ({
   const: undefined,
@@ -60,11 +60,9 @@ const renderParamStore = () => {
   return renderHook(() => useParamStore(`use-param-store-${namespaceId}`));
 };
 
-const parseConf = (conf: string): Record<string, unknown> => JSON.parse(conf) as Record<string, unknown>;
-
-describe("buildParamsDictWithConfValues", () => {
+describe("hydrateParams", () => {
   it("hydrates provider extra fields from existing raw JSON values", () => {
-    const paramsDict = buildParamsDictWithConfValues(snowflakeExtraFields, '{"account":"1234"}');
+    const paramsDict = hydrateParams(snowflakeExtraFields, '{"account":"1234"}');
 
     expect(paramsDict.account?.value).toBe("1234");
     expect(paramsDict.insecure_mode?.value).toBe(false);
@@ -72,7 +70,7 @@ describe("buildParamsDictWithConfValues", () => {
   });
 
   it("keeps raw JSON keys that are not declared by the provider schema", () => {
-    const paramsDict = buildParamsDictWithConfValues(snowflakeExtraFields, '{"warehouse":"raw"}');
+    const paramsDict = hydrateParams(snowflakeExtraFields, '{"warehouse":"raw"}');
 
     expect(paramsDict.warehouse?.value).toBe("raw");
   });
@@ -85,7 +83,7 @@ describe("useParamStore", () => {
     act(() => result.current.setConf('{"account":"1234","warehouse":"raw"}'));
     act(() => result.current.initializeParamsDict(snowflakeExtraFields));
 
-    expect(parseConf(result.current.conf)).toStrictEqual({
+    expect(JSON.parse(result.current.conf)).toStrictEqual({
       account: "1234",
       warehouse: "raw",
     });
@@ -98,7 +96,7 @@ describe("useParamStore", () => {
     act(() => result.current.setConf('{"account":"1234"}'));
     act(() => result.current.initializeParamsDict(snowflakeExtraFields));
 
-    expect(parseConf(result.current.conf)).toStrictEqual({ account: "1234" });
+    expect(JSON.parse(result.current.conf)).toStrictEqual({ account: "1234" });
   });
 
   it("serializes an unchanged boolean default after the user touches that field", () => {
@@ -117,7 +115,7 @@ describe("useParamStore", () => {
     insecureModeParam.value = false;
     act(() => result.current.setParamsDict(paramsDict, "insecure_mode"));
 
-    expect(parseConf(result.current.conf)).toStrictEqual({
+    expect(JSON.parse(result.current.conf)).toStrictEqual({
       account: "1234",
       insecure_mode: false,
     });
@@ -139,7 +137,7 @@ describe("useParamStore", () => {
     accountParam.value = "5678";
     act(() => result.current.setParamsDict(paramsDict, "account"));
 
-    expect(parseConf(result.current.conf)).toStrictEqual({
+    expect(JSON.parse(result.current.conf)).toStrictEqual({
       account: "5678",
       warehouse: "raw",
     });
@@ -161,9 +159,47 @@ describe("useParamStore", () => {
     accountParam.value = "1234";
     act(() => result.current.setParamsDict(paramsDict, "account"));
 
-    expect(parseConf(result.current.conf)).toStrictEqual({
+    expect(JSON.parse(result.current.conf)).toStrictEqual({
       account: "1234",
       warehouse: "raw",
     });
+  });
+
+  it("rehydrates provider fields without touching them after manual raw JSON edits", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+    act(() => result.current.setInitialParamDict(snowflakeExtraFields));
+    act(() => result.current.setConf('{"warehouse":"raw"}'));
+
+    expect(Object.keys(result.current.paramsDict)).toStrictEqual(["account", "insecure_mode", "warehouse"]);
+    expect(result.current.paramsDict.account?.value).toBeUndefined();
+    expect(result.current.paramsDict.insecure_mode?.value).toBe(false);
+    expect(result.current.paramsDict.warehouse?.value).toBe("raw");
+    expect(JSON.parse(result.current.conf)).toStrictEqual({ warehouse: "raw" });
+    expect(result.current.touchedKeys.size).toBe(0);
+  });
+
+  it("clears touched keys and conf on params reset", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    const paramsDict = structuredClone(result.current.paramsDict);
+    const accountParam = paramsDict.account;
+
+    if (accountParam === undefined) {
+      throw new Error("Expected account param");
+    }
+
+    accountParam.value = "5678";
+    act(() => result.current.setParamsDict(paramsDict, "account"));
+    act(() => result.current.setParamsDict({}));
+
+    expect(JSON.parse(result.current.conf)).toStrictEqual({});
+    expect(result.current.paramsDict).toStrictEqual({});
+    expect(result.current.touchedKeys.size).toBe(0);
   });
 });

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
@@ -1,0 +1,169 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ParamSchema, ParamsSpec } from "src/queries/useDagParams";
+import { buildParamsDictWithConfValues, useParamStore } from "src/queries/useParamStore";
+
+const buildSchema = (type: ParamSchema["type"], title: string): ParamSchema => ({
+  const: undefined,
+  description_md: undefined,
+  enum: undefined,
+  examples: undefined,
+  format: undefined,
+  items: undefined,
+  maximum: undefined,
+  maxLength: undefined,
+  minimum: undefined,
+  minLength: undefined,
+  section: undefined,
+  title,
+  type,
+  values_display: undefined,
+});
+
+const snowflakeExtraFields: ParamsSpec = {
+  account: {
+    description: null,
+    schema: buildSchema(["string", "null"], "Account"),
+    value: undefined,
+  },
+  insecure_mode: {
+    description: "Turns off OCSP certificate checks",
+    schema: buildSchema(["boolean", "null"], "Insecure Mode"),
+    value: false,
+  },
+};
+
+let namespaceId = 0;
+
+const renderParamStore = () => {
+  namespaceId += 1;
+
+  return renderHook(() => useParamStore(`use-param-store-${namespaceId}`));
+};
+
+const parseConf = (conf: string): Record<string, unknown> => JSON.parse(conf) as Record<string, unknown>;
+
+describe("buildParamsDictWithConfValues", () => {
+  it("hydrates provider extra fields from existing raw JSON values", () => {
+    const paramsDict = buildParamsDictWithConfValues(snowflakeExtraFields, '{"account":"1234"}');
+
+    expect(paramsDict.account?.value).toBe("1234");
+    expect(paramsDict.insecure_mode?.value).toBe(false);
+    expect(Object.keys(paramsDict)).toStrictEqual(["account", "insecure_mode"]);
+  });
+
+  it("keeps raw JSON keys that are not declared by the provider schema", () => {
+    const paramsDict = buildParamsDictWithConfValues(snowflakeExtraFields, '{"warehouse":"raw"}');
+
+    expect(paramsDict.warehouse?.value).toBe("raw");
+  });
+});
+
+describe("useParamStore", () => {
+  it("keeps raw-only JSON keys after form initialization", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234","warehouse":"raw"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    expect(parseConf(result.current.conf)).toStrictEqual({
+      account: "1234",
+      warehouse: "raw",
+    });
+    expect(result.current.paramsDict.warehouse?.value).toBe("raw");
+  });
+
+  it("does not inject an untouched boolean default into conf", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    expect(parseConf(result.current.conf)).toStrictEqual({ account: "1234" });
+  });
+
+  it("serializes an unchanged boolean default after the user touches that field", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    const paramsDict = structuredClone(result.current.paramsDict);
+    const insecureModeParam = paramsDict.insecure_mode;
+
+    if (insecureModeParam === undefined) {
+      throw new Error("Expected insecure_mode param");
+    }
+
+    insecureModeParam.value = false;
+    act(() => result.current.setParamsDict(paramsDict, "insecure_mode"));
+
+    expect(parseConf(result.current.conf)).toStrictEqual({
+      account: "1234",
+      insecure_mode: false,
+    });
+  });
+
+  it("lets a user-set widget value override a raw JSON key with the same name", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"account":"1234","warehouse":"raw"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    const paramsDict = structuredClone(result.current.paramsDict);
+    const accountParam = paramsDict.account;
+
+    if (accountParam === undefined) {
+      throw new Error("Expected account param");
+    }
+
+    accountParam.value = "5678";
+    act(() => result.current.setParamsDict(paramsDict, "account"));
+
+    expect(parseConf(result.current.conf)).toStrictEqual({
+      account: "5678",
+      warehouse: "raw",
+    });
+  });
+
+  it("keeps raw-only JSON keys when a user edits another widget", () => {
+    const { result } = renderParamStore();
+
+    act(() => result.current.setConf('{"warehouse":"raw"}'));
+    act(() => result.current.initializeParamsDict(snowflakeExtraFields));
+
+    const paramsDict = structuredClone(result.current.paramsDict);
+    const accountParam = paramsDict.account;
+
+    if (accountParam === undefined) {
+      throw new Error("Expected account param");
+    }
+
+    accountParam.value = "1234";
+    act(() => result.current.setParamsDict(paramsDict, "account"));
+
+    expect(parseConf(result.current.conf)).toStrictEqual({
+      account: "1234",
+      warehouse: "raw",
+    });
+  });
+});

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -44,18 +44,77 @@ export const paramPlaceholder: ParamSpec = {
 type FormStore = {
   conf: string;
   disabled: boolean;
+  initializeParamsDict: (newParamsDict: ParamsSpec) => void;
   initialParamDict: ParamsSpec;
   paramsDict: ParamsSpec;
   setConf: (confString: string) => void;
   setDisabled: (disabled: boolean) => void;
   setInitialParamDict: (newParamsDict: ParamsSpec) => void;
-  setParamsDict: (newParamsDict: ParamsSpec) => void;
+  setParamsDict: (newParamsDict: ParamsSpec, touchedKey?: string) => void;
+  touchedKeys: ReadonlySet<string>;
+};
+
+const getParsedConf = (confString: string): Record<string, unknown> =>
+  JSON.parse(confString) as Record<string, unknown>;
+
+export const buildParamsDictWithConfValues = (newParamsDict: ParamsSpec, confString: string): ParamsSpec => {
+  const parsedConf = getParsedConf(confString);
+  const paramsWithValues: Array<[string, ParamSpec]> = [];
+  const inParamsDict = new Set<string>(Object.keys(newParamsDict));
+
+  for (const [key, param] of Object.entries(newParamsDict)) {
+    paramsWithValues.push([
+      key,
+      {
+        description: param.description ?? null,
+        schema: param.schema,
+        value: Object.hasOwn(parsedConf, key) ? parsedConf[key] : param.value,
+      },
+    ]);
+  }
+
+  for (const [key, value] of Object.entries(parsedConf)) {
+    if (!inParamsDict.has(key)) {
+      paramsWithValues.push([
+        key,
+        {
+          description: null,
+          schema: paramPlaceholder.schema,
+          value,
+        },
+      ]);
+    }
+  }
+
+  return Object.fromEntries(paramsWithValues);
+};
+
+export const buildConfFromTouchedParams = (
+  paramsDict: ParamsSpec,
+  confString: string,
+  touchedKeys: ReadonlySet<string>,
+) => {
+  const nextConf = { ...getParsedConf(confString) };
+
+  for (const key of touchedKeys) {
+    const param = paramsDict[key];
+
+    if (param !== undefined) {
+      nextConf[key] = param.value;
+    }
+  }
+
+  return JSON.stringify(nextConf, undefined, 2);
 };
 
 const createParamStore = () =>
   create<FormStore>((set) => ({
     conf: "{}",
     disabled: false,
+    initializeParamsDict: (newParamsDict: ParamsSpec) =>
+      set((state) => ({
+        paramsDict: buildParamsDictWithConfValues(newParamsDict, state.conf),
+      })),
     initialParamDict: {},
     paramsDict: {},
 
@@ -112,20 +171,31 @@ const createParamStore = () =>
 
     setInitialParamDict: (newParamsDict: ParamsSpec) => set(() => ({ initialParamDict: newParamsDict })),
 
-    setParamsDict: (newParamsDict: ParamsSpec) =>
+    setParamsDict: (newParamsDict: ParamsSpec, touchedKey?: string) =>
       set((state) => {
-        const newConf = JSON.stringify(
-          Object.fromEntries(Object.entries(newParamsDict).map(([key, { value }]) => [key, value])),
-          undefined,
-          2,
-        );
+        if (Object.keys(newParamsDict).length === 0) {
+          return { conf: "{}", paramsDict: {}, touchedKeys: new Set<string>() };
+        }
 
-        if (state.conf === newConf && JSON.stringify(state.paramsDict) === JSON.stringify(newParamsDict)) {
+        const touchedKeys = new Set(state.touchedKeys);
+
+        if (touchedKey !== undefined) {
+          touchedKeys.add(touchedKey);
+        }
+
+        const newConf = buildConfFromTouchedParams(newParamsDict, state.conf, touchedKeys);
+
+        if (
+          state.conf === newConf &&
+          JSON.stringify(state.paramsDict) === JSON.stringify(newParamsDict) &&
+          touchedKeys.size === state.touchedKeys.size
+        ) {
           return {};
         }
 
-        return { conf: newConf, paramsDict: newParamsDict };
+        return { conf: newConf, paramsDict: newParamsDict, touchedKeys };
       }),
+    touchedKeys: new Set<string>(),
   }));
 
 const stores = new Map<string, ReturnType<typeof createParamStore>>();

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -54,47 +54,37 @@ type FormStore = {
   touchedKeys: ReadonlySet<string>;
 };
 
-const getParsedConf = (confString: string): Record<string, unknown> =>
-  JSON.parse(confString) as Record<string, unknown>;
-
-export const buildParamsDictWithConfValues = (newParamsDict: ParamsSpec, confString: string): ParamsSpec => {
-  const parsedConf = getParsedConf(confString);
-  const paramsWithValues: Array<[string, ParamSpec]> = [];
-  const inParamsDict = new Set<string>(Object.keys(newParamsDict));
+export const hydrateParams = (newParamsDict: ParamsSpec, confString: string): ParamsSpec => {
+  const parsedConf = JSON.parse(confString) as Record<string, unknown>;
+  const paramsWithValues: ParamsSpec = {};
 
   for (const [key, param] of Object.entries(newParamsDict)) {
-    paramsWithValues.push([
-      key,
-      {
-        description: param.description ?? null,
-        schema: param.schema,
-        value: Object.hasOwn(parsedConf, key) ? parsedConf[key] : param.value,
-      },
-    ]);
+    paramsWithValues[key] = {
+      description: param.description,
+      schema: param.schema,
+      value: Object.hasOwn(parsedConf, key) ? parsedConf[key] : param.value,
+    };
   }
 
   for (const [key, value] of Object.entries(parsedConf)) {
-    if (!inParamsDict.has(key)) {
-      paramsWithValues.push([
-        key,
-        {
-          description: null,
-          schema: paramPlaceholder.schema,
-          value,
-        },
-      ]);
+    if (!Object.hasOwn(newParamsDict, key)) {
+      paramsWithValues[key] = {
+        description: null,
+        schema: paramPlaceholder.schema,
+        value,
+      };
     }
   }
 
-  return Object.fromEntries(paramsWithValues);
+  return paramsWithValues;
 };
 
-export const buildConfFromTouchedParams = (
+export const serializeConf = (
   paramsDict: ParamsSpec,
   confString: string,
   touchedKeys: ReadonlySet<string>,
 ) => {
-  const nextConf = { ...getParsedConf(confString) };
+  const nextConf = JSON.parse(confString) as Record<string, unknown>;
 
   for (const key of touchedKeys) {
     const param = paramsDict[key];
@@ -113,7 +103,7 @@ const createParamStore = () =>
     disabled: false,
     initializeParamsDict: (newParamsDict: ParamsSpec) =>
       set((state) => ({
-        paramsDict: buildParamsDictWithConfValues(newParamsDict, state.conf),
+        paramsDict: hydrateParams(newParamsDict, state.conf),
       })),
     initialParamDict: {},
     paramsDict: {},
@@ -124,47 +114,12 @@ const createParamStore = () =>
           return {};
         }
 
-        const parsedConf = JSON.parse(confString) as Record<string, unknown>;
         const baseDict =
           Object.keys(state.initialParamDict).length > 0 ? state.initialParamDict : state.paramsDict;
+        const paramsDict =
+          Object.keys(baseDict).length > 0 ? hydrateParams(baseDict, confString) : state.paramsDict;
 
-        // Preserve a stable ordering of parameters (and thus sections in the trigger form)
-        // by following the order from the initial param dict when available.
-        const updatedParamsDictEntries: Array<[string, ParamSpec]> = [];
-        const inBase = new Set<string>(Object.keys(baseDict));
-
-        for (const [key, baseParam] of Object.entries(baseDict)) {
-          if (Object.hasOwn(parsedConf, key)) {
-            updatedParamsDictEntries.push([
-              key,
-              {
-                description: baseParam.description ?? null,
-                schema: baseParam.schema,
-                value: parsedConf[key],
-              },
-            ]);
-          }
-        }
-
-        // Append any extra keys that exist in the JSON but not in the base dict.
-        for (const [key, value] of Object.entries(parsedConf)) {
-          if (!inBase.has(key)) {
-            const existingParam = state.paramsDict[key] ?? state.initialParamDict[key];
-
-            updatedParamsDictEntries.push([
-              key,
-              {
-                description: existingParam?.description ?? null,
-                schema: existingParam?.schema ?? paramPlaceholder.schema,
-                value,
-              },
-            ]);
-          }
-        }
-
-        const updatedParamsDict: ParamsSpec = Object.fromEntries(updatedParamsDictEntries);
-
-        return { conf: confString, paramsDict: updatedParamsDict };
+        return { conf: confString, paramsDict, touchedKeys: new Set<string>() };
       }),
 
     setDisabled: (disabled: boolean) => set(() => ({ disabled })),
@@ -183,7 +138,7 @@ const createParamStore = () =>
           touchedKeys.add(touchedKey);
         }
 
-        const newConf = buildConfFromTouchedParams(newParamsDict, state.conf, touchedKeys);
+        const newConf = serializeConf(newParamsDict, state.conf, touchedKeys);
 
         if (
           state.conf === newConf &&


### PR DESCRIPTION
Fixes the connection form so provider-declared extra fields hydrate from existing raw Extras JSON instead of writing widget defaults back into `extra` during initial render.

The bug was caused by the shared `FlexibleForm` initialization path. When the connection form opened, it populated the parameter store by calling `setParamsDict`. That method serializes every parameter value into the JSON payload, including fields the user has not edited. For Snowflake, this meant a user could enter raw Extras JSON like `{"account":"1234"}`, but the first render of the provider widgets could replace that payload with schema defaults such as `{"insecure_mode": false}` before save.

This is fixed in the UI store rather than in the Snowflake provider because the bad payload is generated client-side. The Snowflake hook only declares the extra field widgets; it does not overwrite `extra` on the API side.

This change:

- adds an initialization path that reads existing raw JSON values into provider widget fields without mutating `conf`
- keeps raw JSON keys that are not declared in the provider schema
- tracks which widget keys the user actually edits and serializes only those touched keys back into `conf`
- allows edited widgets to intentionally override matching raw JSON keys
- avoids injecting default boolean values, such as `insecure_mode: false`, when the user never interacted with the checkbox
- adds regression coverage for schema-declared values, raw-only values, user edits, and untouched boolean defaults

Production impact:

- Users can safely create or edit provider connections by entering valid raw Extras JSON without losing keys during save.
- Existing connections with raw extras continue to display their values in matching provider widgets, while unrelated raw keys are preserved.
- Unchecked boolean widget defaults are no longer persisted just because the form rendered, reducing accidental configuration drift.
- The change is limited to the shared React form store and field update path; it does not change the FastAPI connection endpoints or provider hook behavior.

closes: #57984

Tests:

- `pnpm test useParamStore TriggerDAGForm`
- `pnpm tsc --noEmit`
- `pnpm lint`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
