### PR TITLE
Isolate openlineage extractor test from hook lineage collector pollution

### DIFF
--- a/providers/openlineage/tests/unit/openlineage/extractors/test_base.py
+++ b/providers/openlineage/tests/unit/openlineage/extractors/test_base.py
@@ -436,10 +436,25 @@ def test_default_extractor_uses_different_operatorlineage_class():
 
 
 def test_default_extractor_uses_wrong_operatorlineage_class():
-    operator = OperatorWrongOperatorLineageClass(task_id="task_id")
-    # If extractor returns lineage class that can't be changed into OperatorLineage, just return
-    # empty OperatorLineage
-    assert ExtractorManager().extract_metadata(mock.MagicMock(), operator, None, None) == OperatorLineage()
+    # The hook lineage collector is a process-wide singleton; other tests in the same
+    # pytest session (e.g. providers/common/ai/.../durable/test_storage.py via
+    # ObjectStoragePath operations) populate it, and ExtractorManager.extract_metadata
+    # falls through to it when the extractor returns an unusable lineage class, leaking
+    # those datasets into this assertion. Pin a fresh collector for isolation. Durable
+    # fix (clearing the collector in teardown for tests that exercise ObjectStoragePath)
+    # is tracked at https://github.com/apache/airflow/issues/67044.
+    from airflow.providers.common.compat.sdk import HookLineageCollector
+
+    with mock.patch(
+        "airflow.providers.common.compat.lineage.hook.get_hook_lineage_collector",
+        return_value=HookLineageCollector(),
+    ):
+        operator = OperatorWrongOperatorLineageClass(task_id="task_id")
+        # If extractor returns lineage class that can't be changed into OperatorLineage,
+        # just return empty OperatorLineage
+        assert (
+            ExtractorManager().extract_metadata(mock.MagicMock(), operator, None, None) == OperatorLineage()
+        )
 
 
 def test_operator_lineage_merge_concatenates_inputs_and_outputs():


### PR DESCRIPTION
## Summary

`providers/openlineage/tests/unit/openlineage/extractors/test_base.py::test_default_extractor_uses_wrong_operatorlineage_class` deterministically fails on the `Compat 3.0.6:P3.10` and `Compat 3.1.8:P3.10` provider-distributions jobs (e.g. [this run](https://github.com/apache/airflow/actions/runs/25960137370/job/76314571245)) because the **process-wide singleton** hook lineage collector gets populated by `ObjectStoragePath` operations from `providers/common/ai/.../durable/test_storage.py` running earlier in the same pytest session.

`ExtractorManager.extract_metadata` (`providers/openlineage/src/airflow/providers/openlineage/extractors/manager.py:130-135`) falls through to `get_hook_lineage()` whenever the extractor's lineage is unusable, so the polluted singleton's datasets get merged into the assertion and `== OperatorLineage()` fails.

This is invisible on `main` because the local SDK returns a `NoOpCollector` when no hook lineage reader plugin is installed, and the scheduled CI only runs Compat 2.10.5/3.0.0 (where `common.ai` isn't installed). The regression dates from #64199 (durable execution for `AgentOperator`).

## Fix

Patch `get_hook_lineage_collector` with a fresh `HookLineageCollector()` for the duration of the test. Minimal, scoped to the one assertion, no changes to the polluting tests.

Full root cause and the durable fix (resetting the collector in teardown for tests that exercise `ObjectStoragePath`) tracked at #67044.

## Test plan

- [x] Local: `uv run --project providers/openlineage pytest providers/openlineage/tests/unit/openlineage/extractors/test_base.py` — all 36 tests pass.
- [x] All `prek` hooks pass on the changed file.
- [ ] CI: Compat 3.0.6/3.1.8 jobs become green.

related: #67044, #66825 (rebase blocked on this fix)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)