### PR TITLE
Add CohereHook behavior tests

### DIFF
--- a/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
+++ b/providers/cohere/tests/unit/cohere/hooks/test_cohere.py
@@ -16,7 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from airflow.models import Connection
 from airflow.providers.cohere.hooks.cohere import (
@@ -44,3 +47,61 @@ class TestCohereHook:
             hook = CohereHook(timeout=timeout)
             _ = hook.get_conn()
             client.assert_called_once_with(api_key=api_key, timeout=timeout, base_url=base_url)
+
+    def test_create_embeddings_passes_request_options_to_embed(self):
+        embeddings = [[0.1, 0.2], [0.3, 0.4]]
+        response = SimpleNamespace(embeddings=SimpleNamespace(float_=embeddings))
+        client = MagicMock(spec=["embed"])
+        client.embed.return_value = response
+        request_options = {"max_retries": 2, "timeout_in_seconds": 30}
+
+        hook = CohereHook(request_options=request_options)
+        with patch.object(CohereHook, "get_conn", autospec=True, return_value=client) as get_conn:
+            result = hook.create_embeddings(texts=["hello", "world"], model="embed-english-v3.0")
+
+        assert result == embeddings
+        get_conn.assert_called_once_with(hook)
+        client.embed.assert_called_once_with(
+            texts=["hello", "world"],
+            model="embed-english-v3.0",
+            input_type="search_document",
+            embedding_types=["float"],
+            request_options=request_options,
+        )
+
+    def test_create_embeddings_raises_when_float_embeddings_are_missing(self):
+        response = SimpleNamespace(embeddings=SimpleNamespace(float_=None))
+        client = MagicMock(spec=["embed"])
+        client.embed.return_value = response
+
+        hook = CohereHook()
+        with (
+            patch.object(CohereHook, "get_conn", autospec=True, return_value=client),
+            pytest.raises(ValueError, match="Embeddings response is missing float_ field"),
+        ):
+            hook.create_embeddings(texts=["hello"])
+
+    def test_connection_returns_success_tuple(self):
+        client = MagicMock(spec=["chat"])
+        messages = [{"role": "user", "content": "hello"}]
+
+        hook = CohereHook()
+        with patch.object(CohereHook, "get_conn", autospec=True, return_value=client) as get_conn:
+            result = hook.test_connection(model="command-a-03-2025", messages=messages)
+
+        assert result == (True, "Connection successfully established.")
+        get_conn.assert_called_once_with(hook)
+        client.chat.assert_called_once_with(model="command-a-03-2025", messages=messages)
+
+    def test_connection_returns_failure_tuple_with_error_message(self):
+        client = MagicMock(spec=["chat"])
+        client.chat.side_effect = RuntimeError("invalid API key")
+        messages = [{"role": "user", "content": "hello"}]
+
+        hook = CohereHook()
+        with patch.object(CohereHook, "get_conn", autospec=True, return_value=client) as get_conn:
+            result = hook.test_connection(model="command-a-03-2025", messages=messages)
+
+        assert result == (False, "Unexpected error: invalid API key")
+        get_conn.assert_called_once_with(hook)
+        client.chat.assert_called_once_with(model="command-a-03-2025", messages=messages)


### PR DESCRIPTION
Add focused unit tests for `CohereHook` behavior.

This covers:
- `create_embeddings` passing request options and expected embed call arguments
- `create_embeddings` raising when float embeddings are missing
- `test_connection` success and failure tuple behavior

Tests:
- `prek run ruff-format --files providers/cohere/tests/unit/cohere/hooks/test_cohere.py`
- `prek run ruff --files providers/cohere/tests/unit/cohere/hooks/test_cohere.py`
- `breeze run pytest providers/cohere/tests/unit/cohere/hooks/test_cohere.py -xvs`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
