### PR TITLE
Fix variables import with structured falsy values

### DIFF
--- a/airflow-core/newsfragments/67060.bugfix.rst
+++ b/airflow-core/newsfragments/67060.bugfix.rst
@@ -1,0 +1,1 @@
+Fix variable import handling for structured falsy values.

--- a/airflow-core/newsfragments/67060.bugfix.rst
+++ b/airflow-core/newsfragments/67060.bugfix.rst
@@ -1,1 +1,0 @@
-Fix variable import handling for structured falsy values.

--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -155,7 +155,7 @@ def variables_import(args, *, session: Session = NEW_SESSION):
         try:
             value = v
             description = None
-            if isinstance(v, dict) and v.get("value"):  # verify that var configuration has value
+            if isinstance(v, dict) and "value" in v:  # verify that var configuration has value
                 value, description = v["value"], v.get("description")
             Variable.set(k, value, description, serialize_json=not isinstance(value, str))
         except Exception as e:

--- a/airflow-core/tests/unit/cli/commands/test_variable_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_variable_command.py
@@ -474,6 +474,37 @@ class TestCliVariables:
             )
             assert session.scalar(select(Variable.description).where(Variable.key == "var3")) is None
 
+    @pytest.mark.parametrize(
+        ("value", "deserialize_json"),
+        [
+            ("", False),
+            (0, True),
+            (False, True),
+            (None, True),
+        ],
+        ids=["empty_string", "zero", "false", "null"],
+    )
+    def test_variables_import_with_structured_falsy_values(
+        self, create_variable_file, value, deserialize_json
+    ):
+        """Test variables_import preserves structured falsy values and descriptions."""
+        file = create_variable_file(
+            {"falsy_key": {"value": value, "description": "Falsy value description"}},
+            format="json",
+        )
+
+        with create_session() as session:
+            variable_command.variables_import(
+                self.parser.parse_args(["variables", "import", os.fspath(file)]), session=session
+            )
+
+        assert Variable.get("falsy_key", deserialize_json=deserialize_json) == value
+        with create_session() as session:
+            assert (
+                session.scalar(select(Variable.description).where(Variable.key == "falsy_key"))
+                == "Falsy value description"
+            )
+
     def test_variables_import_env(self, create_variable_file, env_variable_data):
         """Test variables_import with ENV format"""
         env_file = create_variable_file(env_variable_data, format="env")

--- a/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
@@ -47,6 +47,10 @@ def import_(args, api_client=NEW_API_CLIENT) -> list[str]:
             rich.print(f"[red]Invalid variable file: {args.file}")
             sys.exit(1)
 
+    if not isinstance(var_json, dict):
+        rich.print(f"[red]Invalid variable file: {args.file}")
+        sys.exit(1)
+
     action_on_existence = BulkActionOnExistence(args.action_on_existing_key)
     vars_to_update = []
     for k, v in var_json.items():

--- a/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/variable_command.py
@@ -21,6 +21,7 @@ import os
 import sys
 
 import rich
+from rich.console import Console
 
 from airflowctl.api.client import NEW_API_CLIENT, ClientKind, provide_api_client
 from airflowctl.api.datamodels.generated import (
@@ -31,6 +32,10 @@ from airflowctl.api.datamodels.generated import (
 )
 
 
+def _print_file_error(message: str, file_path: str) -> None:
+    Console().print(f"[red]{message}: {file_path}", soft_wrap=True)
+
+
 @provide_api_client(kind=ClientKind.CLI)
 def import_(args, api_client=NEW_API_CLIENT) -> list[str]:
     """Import variables from a given file."""
@@ -38,17 +43,17 @@ def import_(args, api_client=NEW_API_CLIENT) -> list[str]:
     errors_message = "[red]Import failed! errors: {errors}[/red]"
 
     if not os.path.exists(args.file):
-        rich.print(f"[red]Missing variable file: {args.file}")
+        _print_file_error("Missing variable file", args.file)
         sys.exit(1)
     with open(args.file) as var_file:
         try:
             var_json = json.load(var_file)
         except json.JSONDecodeError:
-            rich.print(f"[red]Invalid variable file: {args.file}")
+            _print_file_error("Invalid variable file", args.file)
             sys.exit(1)
 
     if not isinstance(var_json, dict):
-        rich.print(f"[red]Invalid variable file: {args.file}")
+        _print_file_error("Invalid variable file", args.file)
         sys.exit(1)
 
     action_on_existence = BulkActionOnExistence(args.action_on_existing_key)

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -89,17 +90,20 @@ class TestCliVariableCommands:
             "",
             0,
             False,
+            None,
         ],
-        ids=["empty_string", "zero", "false"],
+        ids=["empty_string", "zero", "false", "null"],
     )
-    def test_import_falsy_values(self, api_client_maker, tmp_path, monkeypatch, falsy_value):
+    def test_import_falsy_values(self, tmp_path, monkeypatch, falsy_value):
         """Test that falsy values (empty string, 0, False) are correctly imported."""
-        api_client = api_client_maker(
-            path="/api/v2/variables",
-            response_json=self.bulk_response_success.model_dump(),
-            expected_http_status_code=200,
-            kind=ClientKind.CLI,
-        )
+        captured_variables = None
+
+        def bulk(variables):
+            nonlocal captured_variables
+            captured_variables = variables
+            return self.bulk_response_success
+
+        api_client = SimpleNamespace(variables=SimpleNamespace(bulk=bulk))
 
         monkeypatch.chdir(tmp_path)
         expected_json_path = tmp_path / self.export_file_name
@@ -113,6 +117,24 @@ class TestCliVariableCommands:
             api_client=api_client,
         )
         assert response == [self.key]
+        entity = captured_variables.actions[0].entities[0]
+        assert entity.value.root == falsy_value
+        assert entity.description == "test falsy value"
+
+    def test_import_rejects_non_object_json(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        expected_json_path = tmp_path / self.export_file_name
+        expected_json_path.write_text(json.dumps([self.key]))
+
+        with pytest.raises(SystemExit) as exit_info:
+            variable_command.import_(
+                self.parser.parse_args(["variables", "import", expected_json_path.as_posix()]),
+            )
+
+        assert exit_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Invalid variable file:" in output
+        assert expected_json_path.as_posix() in output
 
     def test_import_error(self, api_client_maker, tmp_path, monkeypatch):
         api_client = api_client_maker(


### PR DESCRIPTION
Fix variable import handling for structured falsy values.

This keeps core CLI and `airflowctl` import semantics aligned when a variable entry is shaped like `{"value": ..., "description": ...}` and the value is falsy, such as an empty string, `0`, `false`, or `null`.

It also makes `airflowctl variables import` reject non-object JSON input with the existing invalid-file error instead of failing later while iterating.

Tests:
- `breeze run pytest airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py -xvs`
- `breeze run pytest airflow-core/tests/unit/cli/commands/test_variable_command.py::TestCliVariables::test_variables_import_with_structured_falsy_values -xvs`
- `prek run ruff --files airflow-core/src/airflow/cli/commands/variable_command.py airflow-core/tests/unit/cli/commands/test_variable_command.py airflow-ctl/src/airflowctl/ctl/commands/variable_command.py airflow-ctl/tests/airflow_ctl/ctl/commands/test_variable_command.py`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
