### PR TITLE
Handle commas in provider Project-URL metadata

### DIFF
--- a/shared/providers_discovery/src/airflow_shared/providers_discovery/providers_discovery.py
+++ b/shared/providers_discovery/src/airflow_shared/providers_discovery/providers_discovery.py
@@ -337,9 +337,9 @@ def discover_all_providers_from_packages(
         if project_urls:
             for entry in project_urls:
                 if "," in entry:
-                    name, url = entry.split(",")
+                    name, url = entry.split(",", 1)
                     if name.strip().lower() == "documentation":
-                        documentation_url = url
+                        documentation_url = url.strip()
                         break
 
         provider_info["documentation-url"] = documentation_url

--- a/shared/providers_discovery/tests/providers_discovery/test_providers_discovery.py
+++ b/shared/providers_discovery/tests/providers_discovery/test_providers_discovery.py
@@ -17,9 +17,16 @@
 # under the License.
 from __future__ import annotations
 
+from email.message import Message
+from unittest.mock import Mock
+
 import pytest
 
-from airflow_shared.providers_discovery import LazyDictWithCache
+from airflow_shared.providers_discovery import (
+    LazyDictWithCache,
+    discover_all_providers_from_packages,
+    providers_discovery as providers_discovery_module,
+)
 
 
 @pytest.mark.parametrize(
@@ -110,3 +117,30 @@ def test_lazy_cache_dict_clear():
     assert len(lazy_cache_dict) == 0
     assert not lazy_cache_dict._raw_dict
     assert not lazy_cache_dict._resolved
+
+
+def test_discover_all_providers_preserves_commas_in_project_url(monkeypatch):
+    provider_info = {
+        "package-name": "apache-airflow-providers-test",
+        "name": "Test",
+        "description": "Test provider",
+        "versions": ["1.0.0"],
+    }
+    metadata = Message()
+    metadata["Name"] = "apache-airflow-providers-test"
+    metadata["Project-URL"] = " Documentation , https://example.invalid/docs?query=a,b "
+    dist = Mock(metadata=metadata, version="1.0.0")
+    entry_point = Mock()
+    entry_point.load.return_value = lambda: provider_info
+    monkeypatch.setattr(
+        providers_discovery_module,
+        "entry_points_with_dist",
+        lambda group: [(entry_point, dist)],
+    )
+
+    providers = {}
+    discover_all_providers_from_packages(providers, Mock())
+
+    assert providers["apache-airflow-providers-test"].data["documentation-url"] == (
+        "https://example.invalid/docs?query=a,b"
+    )


### PR DESCRIPTION
Make provider discovery parse package metadata `Project-URL` entries by splitting only on the first comma and trimming surrounding URL whitespace.

How this is fixed:
- Use `split(",", 1)` when reading provider metadata `Project-URL` entries.
- Strip surrounding whitespace from the discovered documentation URL.
- Add a focused regression test for a documentation URL that contains a comma in the URL portion.

Benefit:
- Valid provider package metadata with commas in documentation URLs no longer breaks provider discovery.
- Third-party and future provider packages get a more robust metadata parser without changing provider schemas or adding broader behavior.

closes: #67061

Tests:
- `breeze run pytest shared/providers_discovery/tests/providers_discovery/test_providers_discovery.py -xvs`
- `prek --config /tmp/airflow-precommit-python312.yaml --from-ref upstream/main`
- `git diff --check`

Note: the temporary prek config only changed `default_language_version.python` from `python3` to `python3.12` so the local hook environment used Python 3.12 instead of the Anaconda Python 3.9 on PATH.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex GPT-5

Generated-by: OpenAI Codex GPT-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)