### PR TITLE
providers/mongo: ping mongod before yielding from mongodb_container fixture

### DIFF
--- a/providers/mongo/tests/conftest.py
+++ b/providers/mongo/tests/conftest.py
@@ -20,6 +20,7 @@ import contextlib
 import time
 
 import pytest
+from pymongo import MongoClient
 from testcontainers.mongodb import MongoDbContainer
 
 pytest_plugins = "tests_common.pytest_plugin"
@@ -27,6 +28,30 @@ pytest_plugins = "tests_common.pytest_plugin"
 # Pinned to a specific major to keep the image tag stable and avoid drifting
 # under us when Docker Hub re-resolves :latest on every run.
 MONGO_IMAGE = "mongo:8.0"
+
+
+def _wait_for_mongo_ready(url: str, timeout: int = 60) -> None:
+    """Poll mongod via ``ping`` until it answers or the timeout expires.
+
+    ``MongoDbContainer.start()`` only waits for the ``waiting for connections``
+    log line, which mongod can emit a few milliseconds before the TCP listener
+    is actually accepting on the published port. Under
+    ``--resolution lowest-direct`` (testcontainers 4.12.0, pymongo 4.13.2) we
+    occasionally observed every ``TestMongoHook`` test failing with
+    ``Connection refused`` on the very first ``MongoHook.get_conn()`` call.
+    Actively pinging mongod after the log gate closes the gap.
+    """
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with MongoClient(url, serverSelectionTimeoutMS=2000) as client:
+                client.admin.command("ping")
+            return
+        except Exception as exc:
+            last_exc = exc
+            time.sleep(1)
+    raise TimeoutError(f"mongod at {url} did not answer ping within {timeout}s") from last_exc
 
 
 @pytest.fixture(scope="session")
@@ -48,7 +73,9 @@ def mongodb_container():
                 continue
             raise
         try:
-            yield container.get_connection_url()
+            url = container.get_connection_url()
+            _wait_for_mongo_ready(url)
+            yield url
         finally:
             container.stop()
         return


### PR DESCRIPTION
The `Low dep tests: providers` mongo job is occasionally flaky on ARM CI —
every `TestMongoHook` test errors at `setup_method` with:

```
pymongo.errors.ServerSelectionTimeoutError: 172.17.0.1:32769:
[Errno 111] Connection refused
```

while the same SHA passes on the other parallel runs (e.g. mongo-3.11
failed in run [25978857524](https://github.com/apache/airflow/actions/runs/25978857524/job/76374215829#step:8:1)
while every other mongo slot on that SHA was green).

**Root cause:** under `uv --resolution lowest-direct`, `testcontainers` is
pinned at the floor (`4.12.0`). `MongoDbContainer.start()` only waits for
the `"waiting for connections"` log line, and mongod can emit that line a
few milliseconds before the TCP listener is actually accepting on the
published port. The fixture yielded `get_connection_url()` immediately
after `start()` returned, so the first hook setup hit a closed port.

No testcontainers version on PyPI closes that gap — `testcontainers 4.13.2`
only made the log regex case-insensitive for legacy mongo 3.6 images
(see [testcontainers-python#783](https://github.com/testcontainers/testcontainers-python/pull/783)),
which doesn't help mongo:8.0. The reliable fix is in our own conftest.

**Fix:** after `container.start()` succeeds, actively ping mongod with
`pymongo.MongoClient.admin.command("ping")` retried for up to 60 s, then
yield. All dependent fixtures now see a mongod that genuinely accepts
connections.

Observed failing CI job: https://github.com/apache/airflow/actions/runs/25978857524/job/76374215829

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)