### PR TITLE
Isolate Kubernetes executor client config from the global default

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -35,7 +35,7 @@ from urllib3.exceptions import HTTPError
 
 from airflow.models import Connection
 from airflow.providers.cncf.kubernetes.exceptions import KubernetesApiError, KubernetesApiPermissionError
-from airflow.providers.cncf.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
+from airflow.providers.cncf.kubernetes.kube_client import _enable_tcp_keepalive
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     API_TIMEOUT,
     API_TIMEOUT_OFFSET_SERVER_SIDE,
@@ -318,8 +318,9 @@ class KubernetesHook(BaseHook, PodOperatorHookProtocol):
             self.disable_tcp_keepalive, _get_bool(self._get_field("disable_tcp_keepalive"))
         )
 
-        if disable_verify_ssl is True:
-            _disable_verify_ssl()
+        # ``disable_verify_ssl`` is applied locally to the returned client's own
+        # Configuration by ``_TimeoutK8sApiClient`` below, so there is no need to
+        # mutate the process-wide ``Configuration._default`` singleton here.
         if disable_tcp_keepalive is not True:
             _enable_tcp_keepalive()
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/kube_client.py
@@ -33,16 +33,6 @@ try:
 
     has_kubernetes = True
 
-    def _get_default_configuration() -> Configuration:
-        if hasattr(Configuration, "get_default_copy"):
-            return Configuration.get_default_copy()
-        return Configuration()
-
-    def _disable_verify_ssl() -> None:
-        configuration = _get_default_configuration()
-        configuration.verify_ssl = False
-        Configuration.set_default(configuration)
-
 except ImportError as e:
     # We need an exception class to be able to use it in ``except`` elsewhere
     # in the code base
@@ -121,13 +111,15 @@ def get_kube_client(
     if conf.getboolean("kubernetes_executor", "enable_tcp_keepalive"):
         _enable_tcp_keepalive()
 
-    configuration = _get_default_configuration()
+    # Build a fresh, isolated Configuration for this client instead of reading
+    # (or mutating) the process-wide ``Configuration._default`` singleton.
+    # This keeps TLS settings such as ``verify_ssl=False`` scoped to the
+    # Kubernetes executor's own client and prevents leaking them to any other
+    # component in the process that later reads the default Configuration.
+    configuration = Configuration()
     api_client_retry_configuration = conf.getjson(
         "kubernetes_executor", "api_client_retry_configuration", fallback={}
     )
-
-    if not conf.getboolean("kubernetes_executor", "verify_ssl"):
-        _disable_verify_ssl()
 
     if isinstance(api_client_retry_configuration, dict):
         configuration.retries = urllib3.util.Retry(**api_client_retry_configuration)

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/hooks/test_kubernetes.py
@@ -315,7 +315,7 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        ("disable_verify_ssl", "conn_id", "disable_called"),
+        ("disable_verify_ssl", "conn_id", "expected_verify_ssl_disabled"),
         (
             (True, None, True),
             (None, None, False),
@@ -329,22 +329,24 @@ class TestKubernetesHook:
         ),
     )
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
-    @patch(f"{HOOK_MODULE}._disable_verify_ssl")
     def test_disable_verify_ssl(
         self,
-        mock_disable,
         disable_verify_ssl,
         conn_id,
-        disable_called,
+        expected_verify_ssl_disabled,
     ):
         """
-        Verifies whether disable verify ssl is called depending on combination of hook param and
-        connection extra. Hook param should beat extra.
+        Verifies whether TLS verification is disabled on the returned client depending on the
+        combination of hook param and connection extra. Hook param should beat extra.
+
+        The decision is now observed directly on the returned client's own ``Configuration``
+        (``_TimeoutK8sApiClient`` applies ``verify_ssl=False`` locally) rather than on a call to
+        the removed global mutator, so this also confirms the setting never leaks past this client.
         """
         kubernetes_hook = KubernetesHook(conn_id=conn_id, disable_verify_ssl=disable_verify_ssl)
         api_conn = kubernetes_hook.get_conn()
-        assert mock_disable.called is disable_called
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
+        assert api_conn.configuration.verify_ssl is (not expected_verify_ssl_disabled)
 
     @pytest.mark.parametrize(
         "config_source",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/test_client.py
@@ -24,7 +24,6 @@ from kubernetes.client import Configuration
 from urllib3.connection import HTTPConnection, HTTPSConnection
 
 from airflow.providers.cncf.kubernetes.kube_client import (
-    _disable_verify_ssl,
     _enable_tcp_keepalive,
     get_kube_client,
 )
@@ -79,18 +78,36 @@ class TestClient:
         assert HTTPConnection.default_socket_options == expected_http_connection_options
         assert HTTPSConnection.default_socket_options == expected_https_connection_options
 
-    def test_disable_verify_ssl(self):
-        configuration = Configuration()
-        assert configuration.verify_ssl
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.config")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.conf")
+    def test_get_kube_client_does_not_pollute_global_default(self, conf, config):
+        """Disabling ``verify_ssl`` for the executor's client must not leak to the global default.
 
-        _disable_verify_ssl()
+        ``get_kube_client`` previously called ``Configuration.set_default(...)`` which mutated the
+        process-wide ``Configuration._default`` singleton, disabling TLS verification for every
+        other component in the process that later read the default Configuration. The client now
+        builds an isolated ``Configuration()``, so the global default must stay untouched.
+        """
 
-        # Support wide range of kube client libraries
-        if hasattr(Configuration, "get_default_copy"):
-            configuration = Configuration.get_default_copy()
-        else:
-            configuration = Configuration()
-        assert not configuration.verify_ssl
+        def _default_verify_ssl() -> bool:
+            if hasattr(Configuration, "get_default_copy"):
+                return Configuration.get_default_copy().verify_ssl
+            return Configuration().verify_ssl
+
+        # Sanity check: the global default verifies TLS before we do anything.
+        assert _default_verify_ssl() is True
+
+        conf.getboolean.return_value = False
+        conf.getjson.return_value = {"total": 3, "backoff_factor": 0.5}
+
+        client = get_kube_client(in_cluster=False)
+
+        # The executor's own client still has TLS verification disabled ...
+        conf.getboolean.assert_called_with("kubernetes_executor", "verify_ssl")
+        assert client.api_client.configuration.verify_ssl is False
+
+        # ... but the process-wide default Configuration must remain unpolluted.
+        assert _default_verify_ssl() is True
 
     @mock.patch("kubernetes.config.incluster_config.InClusterConfigLoader")
     @conf_vars(


### PR DESCRIPTION
`get_kube_client()` derived its `kubernetes.client.Configuration` from the
global default and, when `[kubernetes_executor] verify_ssl=False` was set,
called `Configuration.set_default()` — mutating the process-wide
`Configuration._default` singleton. Other code in the same worker process that
later reads the default Configuration would then silently inherit
`verify_ssl=False`.

This builds a fresh, isolated `Configuration()` for the executor client and
applies `verify_ssl` / `ssl_ca_cert` only to that local object — the same
isolation #63478 applied to `KubernetesHook`. Executor behaviour is unchanged
(TLS verification is still disabled for the executor's own client when
configured); only the global-state side effect is dropped.

Covered by an updated `test_client.py`: `test_disable_verify_ssl` is replaced
by `test_get_kube_client_does_not_pollute_global_default`, which asserts the
executor client still has `verify_ssl=False` while the process-wide default
Configuration stays untouched.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Anthropic Claude (Claude Code) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-02T17:38:30Z head=df9c6b3 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Lougarou** · by `@potiuk` · 2026-07-02 17:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - These required **static checks** are failing and need a code fix (a rerun won't help): `CI image checks / Static checks`, `MyPy providers checks`. Run them locally with `pre-commit`/`prek` and push the fixes.
> - The following required checks are failing: `MySQL tests: core / DB-core:MySQL:8.0:3.10:Always`, `Non-DB tests: providers / Non-DB-prov::3.10:amazon...google`, `Postgres tests: core / DB-core:Postgres:14:3.10:Always`, `Sqlite tests: core / DB-core:Sqlite:3.10:Always`, `provider distributions tests / Compat 2.11.1:P3.10:`, `provider distributions tests / Compat 3.0.6:P3.10:`. Please investigate and push a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->