### PR TITLE
Harden IMAP hook against symlink-followed attachment writes

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -314,7 +314,22 @@ class ImapHook(BaseHook):
     def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
         file_path = self._correct_path(name, local_output_directory)
 
-        with open(file_path, "wb") as file:
+        # Defense-in-depth: ``_is_symlink`` (called from ``_create_files``) only inspects
+        # ``name`` relative to the CWD, not the actual target the attachment is written
+        # to. Re-check the real joined target and refuse to write through a symlink there,
+        # matching the existing ``_is_symlink`` rejection style.
+        if os.path.islink(file_path):
+            self.log.error("Can not create file because it is a symlink!")
+            return
+
+        # ``O_NOFOLLOW`` closes the TOCTOU window between the check above and the open:
+        # if ``file_path`` is (or becomes) a symlink, the open fails instead of following
+        # the link. It is feature-gated with ``getattr`` because it does not exist on
+        # Windows. ``O_CREAT | O_TRUNC`` (deliberately without ``O_EXCL``) preserves the
+        # hook's existing overwrite-on-redownload behaviour.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(file_path, flags, 0o600)
+        with os.fdopen(fd, "wb") as file:
             file.write(payload)
 
 

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import imaplib
 import json
+import os
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -30,7 +31,11 @@ from airflow.providers.imap.hooks.imap import ImapHook
 from tests_common.test_utils.config import conf_vars
 
 imaplib_string = "airflow.providers.imap.hooks.imap.imaplib"
-open_string = "airflow.providers.imap.hooks.imap.open"
+# ``ImapHook._create_file`` writes attachments through ``os.open`` / ``os.fdopen``
+# (with ``O_NOFOLLOW``) rather than the builtin ``open`` so that a symlink at the
+# real target path cannot redirect the write. Tests patch those two symbols.
+os_open_string = "airflow.providers.imap.hooks.imap.os.open"
+os_fdopen_string = "airflow.providers.imap.hooks.imap.os.fdopen"
 
 
 def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name="test1.csv", use_ssl=True):
@@ -305,32 +310,35 @@ class TestImapHook:
 
         mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_found(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_found(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments("test1.csv", "test_directory")
 
-        mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
-        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+        assert mock_os_open.call_args[0][0] == "test_directory/test1.csv"
+        mock_fdopen.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_not_found(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_not_found(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
             with pytest.raises(AirflowException):
                 imap_hook.download_mail_attachments("test1.txt", "test_directory")
 
-        mock_open_method.assert_not_called()
-        mock_open_method.return_value.write.assert_not_called()
+        mock_os_open.assert_not_called()
+        mock_fdopen.return_value.write.assert_not_called()
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_regex_found(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_with_regex_found(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -338,12 +346,13 @@ class TestImapHook:
                 name=r"test(\d+).csv", local_output_directory="test_directory", check_regex=True
             )
 
-        mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
-        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+        assert mock_os_open.call_args[0][0] == "test_directory/test1.csv"
+        mock_fdopen.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_regex_not_found(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_with_regex_not_found(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -354,12 +363,13 @@ class TestImapHook:
                     check_regex=True,
                 )
 
-        mock_open_method.assert_not_called()
-        mock_open_method.return_value.write.assert_not_called()
+        mock_os_open.assert_not_called()
+        mock_fdopen.return_value.write.assert_not_called()
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_latest_only(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_with_latest_only(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
 
         with ImapHook() as imap_hook:
@@ -367,36 +377,91 @@ class TestImapHook:
                 name="test1.csv", local_output_directory="test_directory", latest_only=True
             )
 
-        mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
-        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+        assert mock_os_open.call_args[0][0] == "test_directory/test1.csv"
+        mock_fdopen.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
 
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_escaping_chars(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_with_escaping_chars(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="../test1.csv")
 
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments(name="../test1.csv", local_output_directory="test_directory")
 
-        mock_open_method.assert_not_called()
-        mock_open_method.return_value.write.assert_not_called()
+        mock_os_open.assert_not_called()
+        mock_fdopen.return_value.write.assert_not_called()
 
     @patch("airflow.providers.imap.hooks.imap.os.path.islink", return_value=True)
-    @patch(open_string, new_callable=mock_open)
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_symlink(self, mock_imaplib, mock_open_method, mock_is_symlink):
+    def test_download_mail_attachments_with_symlink(
+        self, mock_imaplib, mock_os_open, mock_fdopen, mock_is_symlink
+    ):
         _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="symlink")
 
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments(name="symlink", local_output_directory="test_directory")
 
-        assert mock_is_symlink.call_count == 1
-        mock_open_method.assert_not_called()
-        mock_open_method.return_value.write.assert_not_called()
+        # ``os.path.islink`` is consulted twice: once by ``_is_symlink`` on the bare
+        # ``name`` and once by ``_create_file`` on the real joined target path.
+        assert mock_is_symlink.call_count >= 1
+        mock_os_open.assert_not_called()
+        mock_fdopen.return_value.write.assert_not_called()
 
-    @patch(open_string, new_callable=mock_open)
+    @patch("airflow.providers.imap.hooks.imap.os.path.islink")
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
     @patch(imaplib_string)
-    def test_download_mail_attachments_with_mail_filter(self, mock_imaplib, mock_open_method):
+    def test_download_mail_attachments_with_symlink_at_real_target(
+        self, mock_imaplib, mock_os_open, mock_fdopen, mock_islink
+    ):
+        """A symlink at the *real* joined output path must block the write.
+
+        ``_is_symlink`` (called from ``_create_files``) only inspects ``name``
+        relative to the CWD. This test pins the hardened ``_create_file`` check:
+        only the real joined target ``test_directory/test1.csv`` is a symlink, so
+        the write must be refused there even though the bare ``name`` is not.
+        """
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test1.csv")
+
+        # Bare ``name`` ("test1.csv") is not a symlink; the real joined target
+        # ("test_directory/test1.csv") is.
+        mock_islink.side_effect = lambda path: path == "test_directory/test1.csv"
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(name="test1.csv", local_output_directory="test_directory")
+
+        # The hardened ``_create_file`` symlink check must reject the real target
+        # before any file descriptor is opened, so no write goes through the link.
+        mock_islink.assert_any_call("test_directory/test1.csv")
+        mock_os_open.assert_not_called()
+        mock_fdopen.return_value.write.assert_not_called()
+
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_uses_o_nofollow(self, mock_imaplib, mock_os_open, mock_fdopen):
+        """``_create_file`` must open with ``O_NOFOLLOW`` (where available) to defeat the TOCTOU race."""
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="test1.csv")
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(name="test1.csv", local_output_directory="test_directory")
+
+        mock_os_open.assert_called_once()
+        flags = mock_os_open.call_args[0][1]
+        # Behaviour-preserving create/truncate flags are retained (no O_EXCL).
+        assert flags & os.O_CREAT
+        assert flags & os.O_TRUNC
+        # O_NOFOLLOW is platform-gated; assert it is set wherever the platform has it.
+        if hasattr(os, "O_NOFOLLOW"):
+            assert flags & os.O_NOFOLLOW
+
+    @patch(os_fdopen_string, new_callable=mock_open)
+    @patch(os_open_string)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_with_mail_filter(self, mock_imaplib, mock_os_open, mock_fdopen):
         _create_fake_imap(mock_imaplib, with_mail=True)
         mail_filter = '(SINCE "01-Jan-2019")'
 
@@ -406,7 +471,7 @@ class TestImapHook:
             )
 
         mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
-        assert mock_open_method.call_count == 1
+        assert mock_os_open.call_count == 1
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_max_mails(self, mock_imaplib):


### PR DESCRIPTION
`ImapHook._create_file` wrote downloaded attachments with a plain
`open(file_path, "wb")`, which follows a symlink at the destination. The
existing `_is_symlink` guard in `_create_files` only inspects the bare
attachment `name` relative to the current working directory — not the real
joined output path (`file_path`) that is actually written to.

This hardens `_create_file`:

- it re-checks `os.path.islink` on the real joined target and refuses to write
  through a symlink there, matching the existing `_is_symlink` rejection style;
- it opens via `os.open` with `O_NOFOLLOW` (feature-gated with
  `getattr(os, "O_NOFOLLOW", 0)`, so it is a no-op on Windows, which lacks the
  flag) to also close the check-to-open TOCTOU window.

The open flags are `O_WRONLY | O_CREAT | O_TRUNC` — deliberately **without**
`O_EXCL` — so the hook's existing overwrite-on-redownload behaviour is
preserved; the file mode is `0o600`. Legitimate downloads (including
redownload/overwrite) behave exactly as before; only writes that would pass
through a symlink are now refused.

`test_imap.py` is updated: the `download_mail_attachments` tests now patch
`os.open` / `os.fdopen` instead of the builtin `open`, the symlink test's
`islink` call-count expectation is relaxed (it is now legitimately consulted in
two places), and two tests are added — one pinning that a symlink at the real
joined target blocks the write, one pinning the `O_NOFOLLOW` / no-`O_EXCL` flags.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Anthropic Claude (Claude Code) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=81afaec action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Lougarou** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~30 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->