### PR TITLE
Remove the leftover temporary report file in BidManager download

### DIFF
--- a/providers/google/src/airflow/providers/google/marketing_platform/operators/bid_manager.py
+++ b/providers/google/src/airflow/providers/google/marketing_platform/operators/bid_manager.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
 import urllib.request
@@ -338,19 +339,46 @@ class GoogleBidManagerDownloadReportOperator(BaseOperator):
         no_redirect_opener = urllib.request.build_opener(_NoRedirect)
         self.log.info("Starting downloading report %s", self.report_id)
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            with no_redirect_opener.open(file_url) as response:  # nosec
-                shutil.copyfileobj(response, temp_file, length=self.chunk_size)
+            try:
+                with no_redirect_opener.open(file_url) as response:  # nosec
+                    shutil.copyfileobj(response, temp_file, length=self.chunk_size)
 
-            temp_file.flush()
-            # Upload the local file to bucket
-            bucket_name = self._set_bucket_name(self.bucket_name)
-            gcs_hook.upload(
-                bucket_name=bucket_name,
-                object_name=report_name,
-                gzip=self.gzip,
-                filename=temp_file.name,
-                mime_type="text/csv",
-            )
+                temp_file.flush()
+                # Close the handle before any operation that opens or unlinks the
+                # file by name: on Windows a NamedTemporaryFile keeps the handle
+                # open, and unlink (or a re-open from another component) raises
+                # PermissionError while it is held. close() is idempotent and the
+                # surrounding ``with`` still runs __exit__ harmlessly.
+                temp_file.close()
+                # Upload the local file to bucket
+                bucket_name = self._set_bucket_name(self.bucket_name)
+                gcs_hook.upload(
+                    bucket_name=bucket_name,
+                    object_name=report_name,
+                    gzip=self.gzip,
+                    filename=temp_file.name,
+                    mime_type="text/csv",
+                )
+            finally:
+                # On the failure path the handle may still be open; close it
+                # idempotently so the unlink below also succeeds on Windows.
+                temp_file.close()
+                # Always remove the unencrypted report left in the temp directory,
+                # on both the success and the failure path. Don't silently swallow
+                # unexpected OSErrors: a missing file is benign and ignored, but
+                # anything else (e.g. PermissionError from another handle still
+                # holding the file) is surfaced via a log warning so that real
+                # cleanup failures are observable.
+                try:
+                    os.unlink(temp_file.name)
+                except FileNotFoundError:
+                    pass
+                except OSError as cleanup_err:
+                    self.log.warning(
+                        "Failed to remove temporary report file %s: %s",
+                        temp_file.name,
+                        cleanup_err,
+                    )
         self.log.info(
             "Report %s was saved in bucket %s as %s.",
             self.report_id,

--- a/providers/google/tests/unit/google/marketing_platform/operators/test_bid_manager.py
+++ b/providers/google/tests/unit/google/marketing_platform/operators/test_bid_manager.py
@@ -145,6 +145,226 @@ class TestGoogleBidManagerDownloadReportOperator:
             key="report_name", value=REPORT_NAME + ".gz"
         )
 
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.os")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.shutil")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.urllib.request")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.tempfile")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GCSHook")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GoogleBidManagerHook")
+    def test_execute_cleans_up_temp_file(
+        self,
+        mock_hook,
+        mock_gcs_hook,
+        mock_temp,
+        mock_request,
+        mock_shutil,
+        mock_os,
+    ):
+        mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
+        mock_hook.return_value.get_report.return_value = {
+            "metadata": {
+                "status": {"state": "DONE"},
+                "googleCloudStoragePath": "https://storage.googleapis.com/bucket/report.csv",
+            }
+        }
+        mock_context = {"task_instance": mock.Mock()}
+
+        op = GoogleBidManagerDownloadReportOperator(
+            query_id=QUERY_ID,
+            report_id=REPORT_ID,
+            bucket_name=BUCKET_NAME,
+            report_name=REPORT_NAME,
+            task_id="test_task",
+        )
+        op.execute(context=mock_context)
+
+        # The unencrypted report must not be left behind in the temp directory.
+        mock_os.unlink.assert_called_once_with(FILENAME)
+
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.os")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.shutil")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.urllib.request")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.tempfile")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GCSHook")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GoogleBidManagerHook")
+    def test_execute_cleans_up_temp_file_on_upload_failure(
+        self,
+        mock_hook,
+        mock_gcs_hook,
+        mock_temp,
+        mock_request,
+        mock_shutil,
+        mock_os,
+    ):
+        mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
+        mock_hook.return_value.get_report.return_value = {
+            "metadata": {
+                "status": {"state": "DONE"},
+                "googleCloudStoragePath": "https://storage.googleapis.com/bucket/report.csv",
+            }
+        }
+        mock_gcs_hook.return_value.upload.side_effect = RuntimeError("upload failed")
+        mock_context = {"task_instance": mock.Mock()}
+
+        op = GoogleBidManagerDownloadReportOperator(
+            query_id=QUERY_ID,
+            report_id=REPORT_ID,
+            bucket_name=BUCKET_NAME,
+            report_name=REPORT_NAME,
+            task_id="test_task",
+        )
+        # The exception from the upload must still propagate ...
+        with pytest.raises(RuntimeError, match="upload failed"):
+            op.execute(context=mock_context)
+
+        # ... and the temp file must still be cleaned up on the failure path.
+        mock_os.unlink.assert_called_once_with(FILENAME)
+
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.os")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.shutil")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.urllib.request")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.tempfile")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GCSHook")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GoogleBidManagerHook")
+    def test_execute_closes_temp_file_before_unlink(
+        self,
+        mock_hook,
+        mock_gcs_hook,
+        mock_temp,
+        mock_request,
+        mock_shutil,
+        mock_os,
+    ):
+        """The temp file handle must be closed BEFORE ``os.unlink`` is called.
+
+        Windows raises ``PermissionError`` on ``os.unlink`` while another handle
+        on the same path is still open, and that error is an ``OSError`` subclass
+        which the surrounding ``contextlib.suppress(OSError)`` would silently
+        swallow — leaving the unencrypted report on disk. Enforce close→unlink
+        order so the cleanup is real on every platform.
+        """
+        # Share a single parent mock so we can compare call order across the
+        # tempfile-handle close and the module-level os.unlink calls.
+        parent = mock.MagicMock()
+        temp_handle = parent.temp_handle
+        temp_handle.name = FILENAME
+        mock_temp.NamedTemporaryFile.return_value.__enter__.return_value = temp_handle
+        mock_os.unlink = parent.unlink
+
+        mock_hook.return_value.get_report.return_value = {
+            "metadata": {
+                "status": {"state": "DONE"},
+                "googleCloudStoragePath": "https://storage.googleapis.com/bucket/report.csv",
+            }
+        }
+        mock_context = {"task_instance": mock.Mock()}
+
+        op = GoogleBidManagerDownloadReportOperator(
+            query_id=QUERY_ID,
+            report_id=REPORT_ID,
+            bucket_name=BUCKET_NAME,
+            report_name=REPORT_NAME,
+            task_id="test_task",
+        )
+        op.execute(context=mock_context)
+
+        # Inspect the recorded call order on the shared parent. The first
+        # close() must come before the unlink() — otherwise Windows would
+        # PermissionError on the unlink.
+        ordered = [c[0] for c in parent.mock_calls if c[0] in ("temp_handle.close", "unlink")]
+        assert "temp_handle.close" in ordered, "temp_file.close() must be called"
+        assert "unlink" in ordered, "os.unlink must be called"
+        assert ordered.index("temp_handle.close") < ordered.index("unlink"), (
+            f"close() must precede unlink(); observed order: {ordered}"
+        )
+
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.os")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.shutil")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.urllib.request")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.tempfile")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GCSHook")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GoogleBidManagerHook")
+    def test_execute_logs_warning_on_unexpected_unlink_failure(
+        self,
+        mock_hook,
+        mock_gcs_hook,
+        mock_temp,
+        mock_request,
+        mock_shutil,
+        mock_os,
+        caplog,
+    ):
+        """Unexpected OSError on cleanup must surface as a log.warning, not be silently swallowed."""
+        mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
+        # Simulate the case shahar1 flagged: PermissionError fires on Windows
+        # because something still holds a handle on the temp file.
+        mock_os.unlink.side_effect = PermissionError(13, "Permission denied", FILENAME)
+        mock_hook.return_value.get_report.return_value = {
+            "metadata": {
+                "status": {"state": "DONE"},
+                "googleCloudStoragePath": "https://storage.googleapis.com/bucket/report.csv",
+            }
+        }
+        mock_context = {"task_instance": mock.Mock()}
+
+        op = GoogleBidManagerDownloadReportOperator(
+            query_id=QUERY_ID,
+            report_id=REPORT_ID,
+            bucket_name=BUCKET_NAME,
+            report_name=REPORT_NAME,
+            task_id="test_task",
+        )
+        with caplog.at_level("WARNING"):
+            op.execute(context=mock_context)
+
+        # The execute must not raise (cleanup failure is non-fatal) ...
+        # ... but the warning must mention the file path so the failure is observable.
+        assert any(
+            FILENAME in record.message and "Failed to remove temporary report file" in record.message
+            for record in caplog.records
+        ), f"Expected a warning about cleanup failure; got: {[r.message for r in caplog.records]}"
+
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.os")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.shutil")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.urllib.request")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.tempfile")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GCSHook")
+    @mock.patch("airflow.providers.google.marketing_platform.operators.bid_manager.GoogleBidManagerHook")
+    def test_execute_swallows_filenotfound_on_unlink(
+        self,
+        mock_hook,
+        mock_gcs_hook,
+        mock_temp,
+        mock_request,
+        mock_shutil,
+        mock_os,
+        caplog,
+    ):
+        """A FileNotFoundError on unlink (file already gone) is benign and must not warn."""
+        mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
+        mock_os.unlink.side_effect = FileNotFoundError(2, "No such file", FILENAME)
+        mock_hook.return_value.get_report.return_value = {
+            "metadata": {
+                "status": {"state": "DONE"},
+                "googleCloudStoragePath": "https://storage.googleapis.com/bucket/report.csv",
+            }
+        }
+        mock_context = {"task_instance": mock.Mock()}
+
+        op = GoogleBidManagerDownloadReportOperator(
+            query_id=QUERY_ID,
+            report_id=REPORT_ID,
+            bucket_name=BUCKET_NAME,
+            report_name=REPORT_NAME,
+            task_id="test_task",
+        )
+        with caplog.at_level("WARNING"):
+            op.execute(context=mock_context)
+
+        assert not any(
+            "Failed to remove temporary report file" in record.message for record in caplog.records
+        ), "FileNotFoundError on cleanup must be silent (file already gone is benign)"
+
     @pytest.mark.parametrize(
         "test_bucket_name",
         [BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='taskflow_op') }}"],


### PR DESCRIPTION
`GoogleBidManagerDownloadReportOperator.execute` downloads the report into a
`tempfile.NamedTemporaryFile(delete=False)` and never removes it. The
unencrypted report is left in the worker's temp directory after the task
finishes — and also on any failure (download error, `_set_bucket_name`, the GCS
upload) before the function returns.

This wraps the download/upload in `try/finally` and `os.unlink`s the temp file
on both the success and the failure path. There is no behaviour change other
than the temporary file no longer being left behind.

Covered by two new `test_bid_manager.py` tests — `test_execute_cleans_up_temp_file`
and `test_execute_cleans_up_temp_file_on_upload_failure` — which assert the temp
file is gone after a successful run and after an upload failure.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Anthropic Claude (Claude Code) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
