### PR TITLE
Clarify OpenTelemetry Metrics & Traces Configuration

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1092,6 +1092,10 @@ logging:
       type: string
       example: ~
       default: "warn"
+# OpenTelemetry configuration is split into two different sections:
+# - metrics: for monitoring data
+# - traces: for task execution flow
+# Both sections use 'otel*_' settings, but they configure different features and are NOT interchangable
 metrics:
   description: |
     `StatsD <https://github.com/statsd/statsd>`__ integration settings.


### PR DESCRIPTION
* related: #43366
-->
This PR clarifies OpenTelemetry metrics and OpenTelemetry traces configurations are independent of each other.

It add explanatory comments to reduce confusion of the use of otel_* in the OpenTelemetry metrics vs OpenTelemetry traces configuration.

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=d37c1fe action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @everetch** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->