### PR TITLE
[v3-2-test] UI: Preserve proxied URL on login redirect (#66690)

### DIFF
--- a/airflow-core/src/airflow/ui/src/main.tsx
+++ b/airflow-core/src/airflow/ui/src/main.tsx
@@ -34,7 +34,7 @@ import { ChakraCustomProvider } from "src/context/ChakraCustomProvider";
 import { ColorModeProvider } from "src/context/colorMode";
 import { TimezoneProvider } from "src/context/timezone";
 import { router } from "src/router";
-import { getRedirectPath } from "src/utils/links.ts";
+import { getNextHref, getRedirectPath } from "src/utils/links.ts";
 
 import i18n from "./i18n/config";
 import { client } from "./queryClient";
@@ -75,7 +75,7 @@ axios.interceptors.response.use(
     ) {
       const params = new URLSearchParams();
 
-      params.set("next", globalThis.location.href);
+      params.set("next", getNextHref(globalThis.location));
       const loginPath = getRedirectPath("api/v2/auth/login");
 
       globalThis.location.replace(`${loginPath}?${params.toString()}`);

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,7 +22,12 @@ import { describe, it, expect } from "vitest";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
-import { buildTaskInstanceUrl, getTaskInstanceAdditionalPath, getTaskInstanceLink } from "./links";
+import {
+  buildTaskInstanceUrl,
+  getNextHref,
+  getTaskInstanceAdditionalPath,
+  getTaskInstanceLink,
+} from "./links";
 
 describe("getTaskInstanceLink", () => {
   const testCases = [
@@ -282,5 +289,48 @@ describe("buildTaskInstanceUrl", () => {
         taskId: "new_task",
       }),
     ).toBe("/dags/new_dag/runs/new_run/tasks/new_task/mapped");
+  });
+});
+
+describe("getNextHref", () => {
+  // Regression tests for https://github.com/apache/airflow/issues/46533 — the
+  // "next" parameter sent to the login redirect must be a same-origin relative
+  // URL so that proxied deployments (e.g. Gitpod) don't bounce the browser
+  // back to the API server's reported origin (e.g. http://localhost:29091).
+  it.each([
+    {
+      description: "preserves pathname only",
+      expected: "/dags/my_dag",
+      input: { hash: "", pathname: "/dags/my_dag", search: "" },
+    },
+    {
+      description: "preserves pathname and search",
+      expected: "/dags/my_dag?tab=graph",
+      input: { hash: "", pathname: "/dags/my_dag", search: "?tab=graph" },
+    },
+    {
+      description: "preserves pathname, search, and hash",
+      expected: "/dags/my_dag?tab=graph#section",
+      input: { hash: "#section", pathname: "/dags/my_dag", search: "?tab=graph" },
+    },
+    {
+      description: "preserves proxied base path, search, and hash",
+      expected: "/team-a/dags/my_dag?tab=graph#section",
+      input: { hash: "#section", pathname: "/team-a/dags/my_dag", search: "?tab=graph" },
+    },
+    {
+      description: "handles root path",
+      expected: "/",
+      input: { hash: "", pathname: "/", search: "" },
+    },
+  ])("$description", ({ expected, input }) => {
+    expect(getNextHref(input)).toBe(expected);
+  });
+
+  it("does not include the origin (no http(s) prefix)", () => {
+    const result = getNextHref({ hash: "", pathname: "/dags/my_dag", search: "" });
+
+    expect(result.startsWith("http://")).toBe(false);
+    expect(result.startsWith("https://")).toBe(false);
   });
 });

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -47,6 +47,13 @@ export const getRedirectPath = (targetPath: string): string => {
   return new URL(targetPath, baseUrl).pathname;
 };
 
+// Build a same-origin "next" target (path + query + hash) from a Location.
+// Using a relative URL ensures redirects work correctly when the UI is
+// reached through a proxy or a different origin than the API server reports
+// (e.g. Gitpod port-based domains, see #46533).
+export const getNextHref = (location: Pick<Location, "hash" | "pathname" | "search">): string =>
+  `${location.pathname}${location.search}${location.hash}`;
+
 export const getTaskInstanceAdditionalPath = (pathname: string): string => {
   const subRoutes = taskInstanceRoutes.filter((route) => route.path !== undefined).map((route) => route.path);
   // Look for patterns like /tasks/{taskId}/mapped/{mapIndex}/{sub-route}


### PR DESCRIPTION
Backport of #66690 

### Backport notes

Conflict in \`airflow-core/src/airflow/ui/src/utils/links.test.ts\` resolved as follows:

- Upstream PR's test file imports/exercises both \`getNextHref\` (added by this PR) and \`getSafeExternalUrl\` (added by an earlier PR not on v3-2-test). Dropped the \`describe(\"getSafeExternalUrl\", ...)\` suite and its import — kept only the \`getNextHref\` test suite that this PR actually introduces.
- Added \`/* eslint-disable max-lines */\` to the test file because v3-2-test still has the older 250-line cap (PR #66124 raises it to 500 on main but isn't backported here). The directive matches the existing precedent in \`airflow-core/src/airflow/ui/rules/typescript.js:1\`.

\`main.tsx\` and \`links.ts\` auto-merged cleanly with only the \`getNextHref\` changes.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)