### PR TITLE
fix: escape LDAP filter chars in FAB _search_ldap and _ldap_get_nested_groups (#66417)

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -2405,10 +2405,12 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             raise ValueError("AUTH_LDAP_SEARCH must be set")
 
         # build the filter string for the LDAP search
+        # escape username to prevent LDAP injection attacks
+        escaped_username = ldap.filter.escape_filter_chars(username)
         if self.auth_ldap_search_filter:
-            filter_str = f"(&{self.auth_ldap_search_filter}({self.auth_ldap_uid_field}={username}))"
+            filter_str = f"(&{self.auth_ldap_search_filter}({self.auth_ldap_uid_field}={escaped_username}))"
         else:
-            filter_str = f"({self.auth_ldap_uid_field}={username})"
+            filter_str = f"({self.auth_ldap_uid_field}={escaped_username})"
 
         # build what fields to request in the LDAP search
         request_fields = [
@@ -2478,7 +2480,11 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         """
         log.debug("Nested groups for LDAP enabled.")
         # filter for microsoft active directory only
-        nested_groups_filter_str = f"(&(objectCategory=Group)(member:1.2.840.113556.1.4.1941:={user_dn}))"
+        # escape user_dn to prevent LDAP injection attacks
+        escaped_user_dn = ldap.filter.escape_filter_chars(user_dn)
+        nested_groups_filter_str = (
+            "(&(objectCategory=Group)(member:1.2.840.113556.1.4.1941:=" + escaped_user_dn + "))"
+        )
         nested_groups_request_fields = ["cn"]
 
         nested_groups_search_result = con.search_s(


### PR DESCRIPTION
Backport of [#66417](https://github.com/apache/airflow/pull/66417) to `v3-2-test` for inclusion in the 3.2.2 release.

## Scope

Surgical backport — brings **only** the LDAP-escape hunks from #66417:

- `_search_ldap`: escape `username` with `ldap.filter.escape_filter_chars` before f-string interpolation into the LDAP filter.
- `_ldap_get_nested_groups`: escape `user_dn` likewise.

#66417 also bundled unrelated changes (JWT decode rewrite removing `import jwt`, `uuid.uuid1` → `uuid.uuid4` in `registration_hash`, `_hash_password` change in `add_register_user`) that are **not** included here. Those remain on `main` and should be considered for backport on their own merits if needed.

---

Generated-by: Claude Opus 4.7 (1M context) following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
