### PR TITLE
Fix SecretsMasker merge round-trip for Kubernetes env vars

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -432,12 +432,20 @@ class SecretsMasker(logging.Filter):
             # Determine if we should treat this as sensitive
             is_sensitive = force_sensitive or (name is not None and self.should_hide_value_for_key(name))
 
+            v1_env_var_name = None
+            if isinstance(new_item, dict) and _is_v1_env_var(old_item):
+                # redact(V1EnvVar) returns a dict, so merge against the old object's serialized shape.
+                old_item = old_item.to_dict()
+                v1_env_var_name = old_item.get("name")
+
             if isinstance(new_item, dict) and isinstance(old_item, dict):
                 merged = {}
                 for key in new_item.keys():
                     if key in old_item:
                         # For dicts, pass the key as name unless we're in sensitive mode
                         child_name = None if is_sensitive else key
+                        if key == "value" and v1_env_var_name:
+                            child_name = v1_env_var_name
                         merged[key] = self._merge(
                             new_item[key],
                             old_item[key],

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -1427,6 +1427,41 @@ class TestSecretsMaskerMerge:
         assert result == new_enum
         assert isinstance(result, MyEnum)
 
+    def test_merge_round_trip_kubernetes_env_var(self):
+        class MockV1EnvVar:
+            def __init__(self, name, value, value_from=None):
+                self.name = name
+                self.value = value
+                self.value_from = value_from
+
+            def to_dict(self):
+                return {"name": self.name, "value": self.value, "value_from": self.value_from}
+
+        original_env_var = MockV1EnvVar("password", "original_password", "original_source")
+        normal_env_var = MockV1EnvVar("app_name", "original_app")
+
+        with patch(
+            "airflow_shared.secrets_masker.secrets_masker._is_v1_env_var",
+            side_effect=lambda item: isinstance(item, MockV1EnvVar),
+        ):
+            redacted_env_var = self.masker.redact(original_env_var)
+            redacted_env_var["value_from"] = "***"
+
+            merged = self.masker.merge(redacted_env_var, original_env_var)
+
+            updated_env_var = {**redacted_env_var, "value": "updated_password"}
+            merged_updated = self.masker.merge(updated_env_var, original_env_var)
+
+            normal_merged = self.masker.merge({"name": "app_name", "value": "***"}, normal_env_var)
+
+        assert merged == {
+            "name": "password",
+            "value": "original_password",
+            "value_from": "***",
+        }
+        assert merged_updated["value"] == "updated_password"
+        assert normal_merged["value"] == "***"
+
     def test_merge_round_trip(self):
         # Original data with sensitive information
         original_config = {


### PR DESCRIPTION
## Why
This change normalizes the original `V1EnvVar` to its `dict `representation during merge and applies the env var name only when merging the `value` field.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
