### PR TITLE
Cache Celery apps when publishing workloads

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -32,7 +32,7 @@ import sys
 import traceback
 from collections.abc import Collection, Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
-from functools import cache, lru_cache
+from functools import cache
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
@@ -160,11 +160,15 @@ def create_celery_app(team_conf: ExecutorConf | AirflowConfigParser) -> Celery:
     return celery_app
 
 
-@lru_cache(maxsize=8)
+@cache
 def _get_celery_app_for_workload(team_name: str | None) -> Celery:
-    """Return a subprocess-local Celery app cached by team name for task publishing."""
-    if TYPE_CHECKING:
-        _conf: ExecutorConf | AirflowConfigParser
+    """
+    Return a Celery app cached by team name for task publishing.
+
+    Publishing workloads may run either inline in the scheduler process or in a publisher
+    subprocess. Cache the app in whichever process executes the publish path so result
+    backend resolution is amortized while retaining per-team broker isolation.
+    """
     if AIRFLOW_V_3_2_PLUS:
         from airflow.executors.base_executor import ExecutorConf
 

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -32,7 +32,7 @@ import sys
 import traceback
 from collections.abc import Collection, Mapping, MutableMapping, Sequence
 from concurrent.futures import ProcessPoolExecutor
-from functools import cache
+from functools import cache, lru_cache
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
@@ -158,6 +158,21 @@ def create_celery_app(team_conf: ExecutorConf | AirflowConfigParser) -> Celery:
         celery_app.task(name="execute_command")(execute_command)
 
     return celery_app
+
+
+@lru_cache(maxsize=8)
+def _get_celery_app_for_workload(team_name: str | None) -> Celery:
+    """Return a subprocess-local Celery app cached by team name for task publishing."""
+    if TYPE_CHECKING:
+        _conf: ExecutorConf | AirflowConfigParser
+    if AIRFLOW_V_3_2_PLUS:
+        from airflow.executors.base_executor import ExecutorConf
+
+        _conf = ExecutorConf(team_name)
+    else:
+        # Airflow <3.2 ExecutorConf doesn't exist (at least not with the required attributes), fall back to global conf.
+        _conf = conf
+    return create_celery_app(_conf)
 
 
 # Keep module-level app for backward compatibility.
@@ -389,24 +404,12 @@ def send_workload_to_executor(
     Send workload to executor (serialized and executed as a Celery task).
 
     This function is called in ProcessPoolExecutor subprocesses. To avoid pickling issues with
-    team-specific Celery apps, we pass the team_name and reconstruct the Celery app here.
+    team-specific Celery apps, we pass the team_name and create the app in the subprocess. The app
+    is cached per subprocess and team so Celery backend resolution is amortized across publishes.
     """
     key, args, queue, team_name = workload_tuple
 
-    # Reconstruct the Celery app from configuration, which may or may not be team-specific.
-    # ExecutorConf wraps config access to automatically use team-specific config where present.
-    if TYPE_CHECKING:
-        _conf: ExecutorConf | AirflowConfigParser
-    # Check if Airflow version is greater than or equal to 3.2 to import ExecutorConf.
-    if AIRFLOW_V_3_2_PLUS:
-        from airflow.executors.base_executor import ExecutorConf
-
-        _conf = ExecutorConf(team_name)
-    else:
-        # Airflow <3.2 ExecutorConf doesn't exist (at least not with the required attributes), fall back to global conf.
-        _conf = conf
-    # Create the Celery app with the correct configuration.
-    celery_app = create_celery_app(_conf)
+    celery_app = _get_celery_app_for_workload(team_name)
 
     celery_task_id = None
     if AIRFLOW_V_3_0_PLUS:

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -407,9 +407,13 @@ def send_workload_to_executor(
     """
     Send workload to executor (serialized and executed as a Celery task).
 
-    This function is called in ProcessPoolExecutor subprocesses. To avoid pickling issues with
-    team-specific Celery apps, we pass the team_name and create the app in the subprocess. The app
-    is cached per subprocess and team so Celery backend resolution is amortized across publishes.
+    This function runs either inline in the long-lived scheduler process (single-workload or
+    sync_parallelism=1 path) or in short-lived ProcessPoolExecutor subprocesses (multi-workload
+    path). To avoid pickling issues with team-specific Celery apps, we pass the team_name and
+    create the app at call time. The cached app lives for the duration of the caller process, so
+    the main benefit is the scheduler-inline path where the cache persists across publish cycles.
+    In the ProcessPoolExecutor path, each subprocess is recreated per publish batch and the cache
+    only lasts for that single batch.
     """
     key, args, queue, team_name = workload_tuple
 

--- a/providers/celery/tests/integration/celery/test_celery_executor.py
+++ b/providers/celery/tests/integration/celery/test_celery_executor.py
@@ -116,12 +116,18 @@ def _prepare_app(broker_url=None, execute=None):
         session = backend.ResultSession()
         session.close()
 
+    # Clear the per-team workload app cache so the patched create_celery_app
+    # is actually called. Without this, _get_celery_app_for_workload returns
+    # a stale app from a previous test and the patched factory is bypassed.
+    celery_executor_utils._get_celery_app_for_workload.cache_clear()
+
     with patch_app, patch_execute, patch_factory:
         try:
             yield test_app
         finally:
             # Clear event loop to tear down each celery instance
             set_event_loop(None)
+            celery_executor_utils._get_celery_app_for_workload.cache_clear()
 
 
 def setup_dagrun_with_success_and_fail_workloads(dag_maker):

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -558,8 +558,37 @@ def test_send_workload_uses_external_executor_id_as_celery_task_id():
     assert result.task_id == pre_assigned_id
 
 
+@pytest.mark.parametrize("team_name", [None, "team-a"])
+def test_get_celery_app_for_workload_reuses_cache_for_same_team(team_name):
+    first_app = mock.Mock()
+    second_app = mock.Mock()
+
+    with mock.patch(
+        "airflow.providers.celery.executors.celery_executor_utils.create_celery_app",
+        side_effect=[first_app, second_app],
+    ) as mock_create_celery_app:
+        assert celery_executor_utils._get_celery_app_for_workload(team_name) is first_app
+        assert celery_executor_utils._get_celery_app_for_workload(team_name) is first_app
+
+    mock_create_celery_app.assert_called_once()
+
+
+def test_get_celery_app_for_workload_keeps_cache_team_scoped():
+    team_a_app = mock.Mock()
+    team_b_app = mock.Mock()
+
+    with mock.patch(
+        "airflow.providers.celery.executors.celery_executor_utils.create_celery_app",
+        side_effect=[team_a_app, team_b_app],
+    ) as mock_create_celery_app:
+        assert celery_executor_utils._get_celery_app_for_workload("team-a") is team_a_app
+        assert celery_executor_utils._get_celery_app_for_workload("team-b") is team_b_app
+
+    assert mock_create_celery_app.call_count == 2
+
+
 def test_send_workload_reuses_celery_app_for_same_team():
-    """Publishing multiple workloads for the same team reuses the subprocess-local Celery app."""
+    """Publishing multiple workloads for the same team reuses the cached Celery app."""
     celery_executor_utils._get_celery_app_for_workload.cache_clear()
     key = TaskInstanceKey(
         dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1
@@ -590,7 +619,7 @@ def test_send_workload_reuses_celery_app_for_same_team():
 
 
 def test_send_workload_keeps_celery_app_cache_team_scoped():
-    """Different teams get distinct cached Celery app instances in the publisher subprocess."""
+    """Different teams get distinct cached Celery app instances in the publisher process."""
     celery_executor_utils._get_celery_app_for_workload.cache_clear()
     key = TaskInstanceKey(
         dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -77,6 +77,13 @@ else:
 pytestmark = pytest.mark.db_test
 
 
+@pytest.fixture(autouse=True)
+def clear_cached_workload_celery_apps():
+    celery_executor_utils._get_celery_app_for_workload.cache_clear()
+    yield
+    celery_executor_utils._get_celery_app_for_workload.cache_clear()
+
+
 FAKE_EXCEPTION_MSG = "Fake Exception"
 
 
@@ -549,6 +556,71 @@ def test_send_workload_uses_external_executor_id_as_celery_task_id():
         args=("{}",), queue="default", task_id=pre_assigned_id
     )
     assert result.task_id == pre_assigned_id
+
+
+def test_send_workload_reuses_celery_app_for_same_team():
+    """Publishing multiple workloads for the same team reuses the subprocess-local Celery app."""
+    celery_executor_utils._get_celery_app_for_workload.cache_clear()
+    key = TaskInstanceKey(
+        dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1
+    )
+    mock_result = mock.Mock(task_id="mock-task-id")
+    mock_celery_task = mock.Mock()
+    mock_celery_task.apply_async.return_value = mock_result
+    mock_app = mock.Mock()
+    task_name = "execute_workload" if AIRFLOW_V_3_0_PLUS else "execute_command"
+    mock_app.tasks = {task_name: mock_celery_task}
+
+    if AIRFLOW_V_3_0_PLUS:
+        workload = mock.Mock()
+        workload.ti.external_executor_id = None
+        workload.model_dump_json.return_value = "{}"
+    else:
+        workload = ["airflow", "tasks", "run", "test_dag", "test_task", "test_run"]
+
+    with mock.patch(
+        "airflow.providers.celery.executors.celery_executor_utils.create_celery_app",
+        return_value=mock_app,
+    ) as mock_create_celery_app:
+        celery_executor_utils.send_workload_to_executor((key, workload, "default", "team-a"))
+        celery_executor_utils.send_workload_to_executor((key, workload, "default", "team-a"))
+
+    mock_create_celery_app.assert_called_once()
+    assert mock_celery_task.apply_async.call_count == 2
+
+
+def test_send_workload_keeps_celery_app_cache_team_scoped():
+    """Different teams get distinct cached Celery app instances in the publisher subprocess."""
+    celery_executor_utils._get_celery_app_for_workload.cache_clear()
+    key = TaskInstanceKey(
+        dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1
+    )
+    mock_result = mock.Mock(task_id="mock-task-id")
+    team_a_task = mock.Mock()
+    team_a_task.apply_async.return_value = mock_result
+    team_b_task = mock.Mock()
+    team_b_task.apply_async.return_value = mock_result
+    task_name = "execute_workload" if AIRFLOW_V_3_0_PLUS else "execute_command"
+    team_a_app = mock.Mock(tasks={task_name: team_a_task})
+    team_b_app = mock.Mock(tasks={task_name: team_b_task})
+
+    if AIRFLOW_V_3_0_PLUS:
+        workload = mock.Mock()
+        workload.ti.external_executor_id = None
+        workload.model_dump_json.return_value = "{}"
+    else:
+        workload = ["airflow", "tasks", "run", "test_dag", "test_task", "test_run"]
+
+    with mock.patch(
+        "airflow.providers.celery.executors.celery_executor_utils.create_celery_app",
+        side_effect=[team_a_app, team_b_app],
+    ) as mock_create_celery_app:
+        celery_executor_utils.send_workload_to_executor((key, workload, "default", "team-a"))
+        celery_executor_utils.send_workload_to_executor((key, workload, "default", "team-b"))
+
+    assert mock_create_celery_app.call_count == 2
+    team_a_task.apply_async.assert_called_once()
+    team_b_task.apply_async.assert_called_once()
 
 
 @conf_vars({("celery", "result_backend"): "rediss://test_user:test_password@localhost:6379/0"})

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -589,7 +589,6 @@ def test_get_celery_app_for_workload_keeps_cache_team_scoped():
 
 def test_send_workload_reuses_celery_app_for_same_team():
     """Publishing multiple workloads for the same team reuses the cached Celery app."""
-    celery_executor_utils._get_celery_app_for_workload.cache_clear()
     key = TaskInstanceKey(
         dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1
     )
@@ -620,7 +619,6 @@ def test_send_workload_reuses_celery_app_for_same_team():
 
 def test_send_workload_keeps_celery_app_cache_team_scoped():
     """Different teams get distinct cached Celery app instances in the publisher process."""
-    celery_executor_utils._get_celery_app_for_workload.cache_clear()
     key = TaskInstanceKey(
         dag_id="test_dag", task_id="test_task", run_id="test_run", map_index=-1, try_number=1
     )


### PR DESCRIPTION
## What

- cache the Celery app used by `send_workload_to_executor` inside each publisher subprocess
- key the cache by `team_name` so multi-team configurations still get isolated app instances
- add regression coverage proving repeated publishes for the same team reuse the app while different teams remain separated

## Why

`send_workload_to_executor` currently creates a fresh `Celery()` app for every publish. Each fresh app loses Celery's lazy backend cache, so `apply_async()` repeatedly performs backend resolution and entry point scanning. On large deployments this can push task publishing past `[celery] operation_timeout`.

Caching the app per subprocess preserves the post-AIP-67 behavior of constructing apps inside publisher subprocesses while restoring per-process amortization.

fixes #67123

## Tests

- `uv run --project providers/celery pytest providers/celery/tests/unit/celery/executors/test_celery_executor.py -q`
- `uv run ruff check providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py providers/celery/tests/unit/celery/executors/test_celery_executor.py`
- `uv run ruff format --check providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py providers/celery/tests/unit/celery/executors/test_celery_executor.py`

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=1414d9e action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anmolxlight** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Your review threads from `@kaxil` look addressed — please confirm this PR is **ready for maintainer review confirmation**:
> - 4 thread(s) show your engagement (post-review commits and/or replies).
>
> **The ball is in your court** — you've been assigned to this PR. Reply `yes / ready` (and mark the threads resolved) and a maintainer will pick it up from the queue.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->