### PR TITLE
Fix Breeze dry-run commands executing in quiet mode

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -151,7 +151,11 @@ def run_command(
             kwargs["stderr"] = subprocess.STDOUT
     command_to_print = " ".join(shlex.quote(c) for c in cmd) if isinstance(cmd, list) else cmd
     env_to_print = get_environments_to_print(env)
-    if not get_verbose(verbose_override) and not get_dry_run(dry_run_override) or quiet:
+    verbose = get_verbose(verbose_override)
+    dry_run = get_dry_run(dry_run_override)
+    if dry_run and quiet:
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+    if not dry_run and (not verbose or quiet):
         if quiet and not kwargs.get("capture_output"):
             kwargs["stdout"] = subprocess.DEVNULL
             kwargs["stderr"] = subprocess.DEVNULL
@@ -166,7 +170,7 @@ def run_command(
         get_console(output=output).print(
             f"\n[info]{env_to_print}{escape(command_to_print)}[/]\n", soft_wrap=True
         )
-        if get_dry_run(dry_run_override):
+        if dry_run:
             return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
         try:
             if output_outside_the_group and os.environ.get("GITHUB_ACTIONS") == "true":

--- a/dev/breeze/tests/test_run_utils.py
+++ b/dev/breeze/tests/test_run_utils.py
@@ -23,6 +23,7 @@ from airflow_breeze.utils.run_utils import (
     change_directory_permission,
     change_file_permission,
     check_if_buildx_plugin_installed,
+    run_command,
 )
 
 
@@ -44,6 +45,16 @@ def test_change_directory_permission(tmp_path):
     assert not (mode & stat.S_IWOTH)
     assert mode & stat.S_IXGRP
     assert mode & stat.S_IXOTH
+
+
+@mock.patch("airflow_breeze.utils.run_utils.subprocess.run")
+def test_run_command_dry_run_quiet_does_not_execute(mock_subprocess_run):
+    result = run_command(["echo", "hello"], dry_run_override=True, quiet=True)
+
+    mock_subprocess_run.assert_not_called()
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
 
 
 @mock.patch("airflow_breeze.utils.run_utils.run_command")


### PR DESCRIPTION
## Why
`run_command(..., quiet=True, dry_run_override=True)` could still execute the command because the quiet-mode branch bypassed the dry-run handling.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
