### PR TITLE
init

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/exceptions.py
+++ b/providers/databricks/src/airflow/providers/databricks/exceptions.py
@@ -30,3 +30,19 @@ class DatabricksSqlExecutionError(AirflowException):
 
 class DatabricksSqlExecutionTimeout(DatabricksSqlExecutionError):
     """Raised when a sql execution times out."""
+
+
+class DatabricksWorkflowRepairError(AirflowException):
+    """Raised when Databricks Workflow repair coordination fails."""
+
+
+class DatabricksWorkflowRepairMetadataError(DatabricksWorkflowRepairError):
+    """Raised when workflow repair metadata is missing or invalid."""
+
+
+class DatabricksWorkflowRepairBudgetExhausted(DatabricksWorkflowRepairError):
+    """Raised when a Databricks Workflow run fails after exhausting repair attempts."""
+
+
+class DatabricksWorkflowRepairTriggerError(DatabricksWorkflowRepairError):
+    """Raised when a Databricks Workflow repair trigger emits an invalid event."""

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -27,6 +27,10 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, BaseOperatorLink, XCom, conf
+from airflow.providers.databricks.exceptions import (
+    DatabricksWorkflowRepairBudgetExhausted,
+    DatabricksWorkflowRepairTriggerError,
+)
 from airflow.providers.databricks.hooks.databricks import (
     DatabricksHook,
     RunLifeCycleState,
@@ -43,9 +47,11 @@ from airflow.providers.databricks.plugins.databricks_workflow import (
 )
 from airflow.providers.databricks.triggers.databricks import (
     DatabricksExecutionTrigger,
+    DatabricksWorkflowRepairWaitTrigger,
 )
 from airflow.providers.databricks.utils.databricks import (
     extract_failed_task_errors,
+    find_new_workflow_task_attempt,
     normalise_json_content,
     validate_trigger_event,
 )
@@ -1429,19 +1435,64 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
             self.databricks_task_key,
             run_state.life_cycle_state,
         )
-        if self.deferrable and not run_state.is_terminal:
-            self.defer(
-                trigger=DatabricksExecutionTrigger(
-                    run_id=current_task_run_id,
-                    databricks_conn_id=self.databricks_conn_id,
-                    polling_period_seconds=self.polling_period_seconds,
-                    retry_limit=self.databricks_retry_limit,
-                    retry_delay=self.databricks_retry_delay,
-                    retry_args=self.databricks_retry_args,
-                    caller=self.caller,
-                ),
-                method_name=DEFER_METHOD_NAME,
-            )
+        if self.deferrable:
+            if not run_state.is_terminal:
+                self.defer(
+                    trigger=DatabricksExecutionTrigger(
+                        run_id=current_task_run_id,
+                        databricks_conn_id=self.databricks_conn_id,
+                        polling_period_seconds=self.polling_period_seconds,
+                        retry_limit=self.databricks_retry_limit,
+                        retry_delay=self.databricks_retry_delay,
+                        retry_args=self.databricks_retry_args,
+                        caller=self.caller,
+                    ),
+                    method_name=DEFER_METHOD_NAME,
+                )
+            elif not run_state.is_successful:
+                tg = self._workflow_task_group_with_repair()
+                if tg is not None:
+                    self._defer_to_workflow_repair_wait(
+                        original_sub_run_id=current_task_run_id,
+                        original_start_time=run.get("start_time"),
+                        tg=tg,
+                    )
+        else:
+            tg = self._workflow_task_group_with_repair()
+            if tg is not None:
+                while True:
+                    while not run_state.is_terminal:
+                        time.sleep(self.polling_period_seconds)
+                        run = self._hook.get_run(current_task_run_id)
+                        run_state = RunState(**run["state"])
+                        self.log.info(
+                            "Current state of the databricks task %s is %s",
+                            self.databricks_task_key,
+                            run_state.life_cycle_state,
+                        )
+                    if run_state.is_successful:
+                        break
+                    new_sub_run_id = self._sync_wait_for_new_sub_run_attempt(
+                        original_sub_run_id=current_task_run_id,
+                        original_start_time=run.get("start_time"),
+                        tg=tg,
+                    )
+                    if new_sub_run_id is None:
+                        break
+                    self.log.info(
+                        "Workflow coordinator produced a new attempt for task_key %s (sub-run %s).",
+                        self.databricks_task_key,
+                        new_sub_run_id,
+                    )
+                    current_task_run_id = new_sub_run_id
+                    run = self._hook.get_run(current_task_run_id)
+                    run_state = RunState(**run["state"])
+                    self.log.info(
+                        "Current state of the databricks task %s is %s",
+                        self.databricks_task_key,
+                        run_state.life_cycle_state,
+                    )
+
         while not run_state.is_terminal:
             time.sleep(self.polling_period_seconds)
             run = self._hook.get_run(current_task_run_id)
@@ -1461,13 +1512,7 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
     def execute(self, context: Context) -> None:
         """Execute the operator. Launch the job and monitor it if wait_for_termination is set to True."""
         if self._databricks_workflow_task_group:
-            # If we are in a DatabricksWorkflowTaskGroup, we should have an upstream task launched.
-            if not self.workflow_run_metadata:
-                launch_task_id = next(task for task in self.upstream_task_ids if task.endswith(".launch"))
-                self.workflow_run_metadata = context["ti"].xcom_pull(task_ids=launch_task_id)
-            workflow_run_metadata = WorkflowRunMetadata(**self.workflow_run_metadata)
-            self.databricks_run_id = workflow_run_metadata.run_id
-            self.databricks_conn_id = workflow_run_metadata.conn_id
+            workflow_run_metadata = self._resolve_workflow_run_metadata(context)
 
             # Store operator links in XCom for Airflow 3 compatibility
             if AIRFLOW_V_3_0_PLUS:
@@ -1482,10 +1527,166 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
         if self.wait_for_termination:
             self.monitor_databricks_job()
 
+    def _resolve_workflow_run_metadata(self, context: Context | dict | None) -> WorkflowRunMetadata:
+        """
+        Populate ``databricks_run_id`` / ``databricks_conn_id`` from ``workflow_run_metadata``.
+
+        Resolves both the standard ``execute`` path and the deferrable-resume path: when a task
+        resumes via ``execute_complete``, the operator is freshly re-instantiated, so any
+        attributes set during ``execute`` (including ``databricks_run_id``) are lost. The
+        templated ``workflow_run_metadata`` field is rendered from the upstream ``.launch``
+        task's XCom on every task-instance run, so it is the canonical source for the parent
+        workflow run id across both entry points.
+        """
+        if not self.workflow_run_metadata and context is not None:
+            launch_task_id = next((task for task in self.upstream_task_ids if task.endswith(".launch")), None)
+            ti = context.get("ti") if isinstance(context, dict) else context["ti"]
+            if launch_task_id is not None and ti is not None:
+                self.workflow_run_metadata = ti.xcom_pull(task_ids=launch_task_id)
+        if not self.workflow_run_metadata:
+            raise ValueError("workflow_run_metadata is required to resolve the parent workflow run")
+        workflow_run_metadata = WorkflowRunMetadata(**self.workflow_run_metadata)
+        self.databricks_run_id = workflow_run_metadata.run_id
+        self.databricks_conn_id = workflow_run_metadata.conn_id
+        return workflow_run_metadata
+
     def execute_complete(self, context: dict | None, event: dict) -> None:
         run_state = RunState.from_json(event["run_state"])
         errors = event.get("errors", [])
+
+        if not run_state.is_successful:
+            tg = self._workflow_task_group_with_repair()
+            if tg is not None:
+                self._resolve_workflow_run_metadata(context)
+                self._defer_to_workflow_repair_wait(
+                    original_sub_run_id=event["run_id"],
+                    original_start_time=event.get("run_start_time"),
+                    tg=tg,
+                )
+
         self._handle_terminal_run_state(run_state, errors)
+
+    def _workflow_task_group_with_repair(self) -> DatabricksWorkflowTaskGroup | None:
+        if not AIRFLOW_V_3_0_PLUS:
+            return None
+        tg = self._databricks_workflow_task_group
+        if tg is None or getattr(tg, "max_full_run_repairs", 0) <= 0:
+            return None
+        return tg
+
+    def _sync_wait_for_new_sub_run_attempt(
+        self,
+        original_sub_run_id: int,
+        original_start_time: int | None,
+        tg: DatabricksWorkflowTaskGroup,
+    ) -> int | None:
+        """
+        Sync equivalent of :class:`DatabricksWorkflowRepairWaitTrigger`.
+
+        Polls the parent run for a new attempt of ``self.databricks_task_key`` after a
+        sub-run reaches terminal failure, then lets the caller switch to that attempt and
+        continue polling. Returns the new sub-run id, or ``None`` if the parent run
+        terminates without producing a new attempt within the grace window.
+        """
+        self.log.info(
+            "Sub-run %s for task_key %s reached terminal failure; waiting for a repair "
+            "attempt issued by the workflow coordinator.",
+            original_sub_run_id,
+            self.databricks_task_key,
+        )
+        polling_period_seconds = tg.repair_polling_period_seconds
+        terminal_grace_polls = 3
+        terminal_observations = 0
+        while True:
+            run_info = self._hook.get_run(self.databricks_run_id)  # type: ignore[arg-type]
+            parent_run_state = RunState(**run_info["state"])
+            tasks = run_info.get("tasks", [])
+            new_attempt = find_new_workflow_task_attempt(
+                tasks=tasks,
+                task_key=self.databricks_task_key,
+                original_sub_run_id=original_sub_run_id,
+                original_start_time=original_start_time,
+            )
+            if new_attempt is not None:
+                return new_attempt["run_id"]
+            if parent_run_state.is_terminal:
+                terminal_observations += 1
+                if terminal_observations >= terminal_grace_polls:
+                    self.log.info(
+                        "Parent run %s reached terminal state %s without a new attempt for "
+                        "task_key %s after %s grace polls.",
+                        self.databricks_run_id,
+                        parent_run_state.result_state,
+                        self.databricks_task_key,
+                        terminal_grace_polls,
+                    )
+                    return None
+            else:
+                terminal_observations = 0
+            time.sleep(polling_period_seconds)
+
+    def _defer_to_workflow_repair_wait(
+        self,
+        original_sub_run_id: int,
+        original_start_time: int | None,
+        tg: DatabricksWorkflowTaskGroup,
+    ) -> None:
+        self.log.info(
+            "Sub-run %s for task_key %s reached terminal failure; deferring to wait for a repair "
+            "attempt issued by the workflow coordinator.",
+            original_sub_run_id,
+            self.databricks_task_key,
+        )
+        self.defer(
+            trigger=DatabricksWorkflowRepairWaitTrigger(
+                run_id=self.databricks_run_id,  # type: ignore[arg-type]
+                databricks_conn_id=self.databricks_conn_id,
+                databricks_task_key=self.databricks_task_key,
+                original_sub_run_id=original_sub_run_id,
+                original_start_time=original_start_time,
+                polling_period_seconds=tg.repair_polling_period_seconds,
+                retry_limit=self.databricks_retry_limit,
+                retry_delay=self.databricks_retry_delay,
+                retry_args=self.databricks_retry_args,
+                caller=self.caller,
+            ),
+            method_name="execute_complete_after_repair_wait",
+        )
+
+    def execute_complete_after_repair_wait(self, context: dict | None, event: dict) -> None:
+        status = event.get("status")
+        if status == "new_attempt":
+            new_sub_run_id = event["new_sub_run_id"]
+            self.log.info(
+                "Workflow coordinator produced a new attempt for task_key %s (sub-run %s); "
+                "deferring on a fresh DatabricksExecutionTrigger to monitor it.",
+                self.databricks_task_key,
+                new_sub_run_id,
+            )
+            self.defer(
+                trigger=DatabricksExecutionTrigger(
+                    run_id=new_sub_run_id,
+                    databricks_conn_id=self.databricks_conn_id,
+                    polling_period_seconds=self.polling_period_seconds,
+                    retry_limit=self.databricks_retry_limit,
+                    retry_delay=self.databricks_retry_delay,
+                    retry_args=self.databricks_retry_args,
+                    caller=self.caller,
+                ),
+                method_name=DEFER_METHOD_NAME,
+            )
+        elif status == "parent_failed":
+            parent_state = RunState.from_json(event["parent_run_state"])
+            raise DatabricksWorkflowRepairBudgetExhausted(
+                f"Databricks workflow run {event.get('parent_run_id')} reached terminal failure "
+                f"({parent_state.result_state}) without producing a new attempt for task_key "
+                f"{self.databricks_task_key!r}; repair budget is exhausted or the coordinator "
+                f"did not issue a repair."
+            )
+        else:
+            raise DatabricksWorkflowRepairTriggerError(
+                f"DatabricksWorkflowRepairWaitTrigger emitted unexpected status {status!r}: {event}"
+            )
 
 
 class DatabricksNotebookOperator(DatabricksTaskBaseOperator):

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -19,19 +19,27 @@ from __future__ import annotations
 
 import json
 import time
+import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from mergedeep import merge
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, TaskGroup
+from airflow.providers.common.compat.sdk import AirflowException, BaseOperator, TaskGroup, conf
+from airflow.providers.databricks.exceptions import (
+    DatabricksWorkflowRepairBudgetExhausted,
+    DatabricksWorkflowRepairMetadataError,
+    DatabricksWorkflowRepairTriggerError,
+)
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunLifeCycleState
 from airflow.providers.databricks.plugins.databricks_workflow import (
     WorkflowJobRepairAllFailedLink,
     WorkflowJobRunLink,
     store_databricks_job_run_link,
 )
+from airflow.providers.databricks.triggers.databricks import DatabricksWorkflowRepairCoordinatorTrigger
+from airflow.providers.databricks.utils.databricks import build_repair_run_json, extract_failed_task_errors
 from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS
 
 if TYPE_CHECKING:
@@ -300,6 +308,224 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
             )
 
 
+class _DatabricksFullRunRepairCoordinatorOperator(BaseOperator):
+    """
+    Watch a Databricks Workflow run and trigger ``rerun_all_failed_tasks`` repairs.
+
+    Runs as a sibling of the downstream Databricks task monitors inside a
+    :class:`DatabricksWorkflowTaskGroup`. The ``launch`` task remains responsible for creating the
+    job and returning metadata immediately so downstream tasks can fan out; this operator owns the
+    long-lived defer cycle that watches the whole run and issues one repair call per failure batch,
+    so the original job cluster is reused.
+
+    Downstream task monitors observe repairs independently by deferring on
+    :class:`~airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairWaitTrigger`
+    when their sub-run hits a terminal failure; that trigger polls the Databricks API for the next
+    attempt of the same ``task_key`` rather than reading any inter-task XCom. The coordinator's
+    final return value carries ``{run_id, repair_attempts, latest_repair_id}`` for any user code
+    that wants a post-run summary.
+
+    :param task_id: The task id of the operator (typically ``"full_run_repair_coordinator"``).
+    :param databricks_conn_id: Connection id used by the coordinator trigger and repair calls.
+    :param launch_task_id: The full task id of the workflow ``launch`` task whose return value
+        carries ``{conn_id, job_id, run_id}``.
+    :param max_full_run_repairs: Total repair attempts allowed across the run.
+    :param repair_polling_period_seconds: Poll interval forwarded to the coordinator trigger.
+    :param databricks_retry_limit: Hook retry limit for transient API failures.
+    :param databricks_retry_delay: Hook retry delay (seconds).
+    :param databricks_retry_args: Optional ``tenacity.Retrying`` kwargs forwarded to the hook.
+    :param deferrable: If ``True``, watch the run by deferring on
+        :class:`DatabricksWorkflowRepairCoordinatorTrigger`. If ``False``, watch it via a
+        synchronous poll loop that runs the same state machine inline.
+    """
+
+    caller = "_DatabricksFullRunRepairCoordinatorOperator"
+
+    def __init__(
+        self,
+        task_id: str,
+        databricks_conn_id: str,
+        launch_task_id: str,
+        max_full_run_repairs: int,
+        repair_polling_period_seconds: int = 30,
+        databricks_retry_limit: int = 3,
+        databricks_retry_delay: int = 10,
+        databricks_retry_args: dict[Any, Any] | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        **kwargs,
+    ):
+        if max_full_run_repairs < 1:
+            raise ValueError(
+                f"max_full_run_repairs must be >= 1 for the workflow coordinator task, got {max_full_run_repairs}"
+            )
+        super().__init__(task_id=task_id, **kwargs)
+        self.databricks_conn_id = databricks_conn_id
+        self.launch_task_id = launch_task_id
+        self.max_full_run_repairs = max_full_run_repairs
+        self.repair_polling_period_seconds = repair_polling_period_seconds
+        self.databricks_retry_limit = databricks_retry_limit
+        self.databricks_retry_delay = databricks_retry_delay
+        self.databricks_retry_args = databricks_retry_args
+        self.deferrable = deferrable
+
+    @cached_property
+    def _hook(self) -> DatabricksHook:
+        return DatabricksHook(
+            self.databricks_conn_id,
+            retry_limit=self.databricks_retry_limit,
+            retry_delay=self.databricks_retry_delay,
+            retry_args=self.databricks_retry_args,
+            caller=self.caller,
+        )
+
+    def _make_trigger(
+        self,
+        run_id: int,
+        repair_attempts: int,
+        latest_repair_id: int | None,
+    ) -> DatabricksWorkflowRepairCoordinatorTrigger:
+        return DatabricksWorkflowRepairCoordinatorTrigger(
+            run_id=run_id,
+            databricks_conn_id=self.databricks_conn_id,
+            max_full_run_repairs=self.max_full_run_repairs,
+            repair_attempts=repair_attempts,
+            latest_repair_id=latest_repair_id,
+            polling_period_seconds=self.repair_polling_period_seconds,
+            retry_limit=self.databricks_retry_limit,
+            retry_delay=self.databricks_retry_delay,
+            retry_args=self.databricks_retry_args,
+            caller=self.caller,
+        )
+
+    def execute(self, context: Context) -> Any:
+        launch_value = context["ti"].xcom_pull(task_ids=self.launch_task_id)
+        if not launch_value:
+            raise DatabricksWorkflowRepairMetadataError(
+                f"Launch task {self.launch_task_id!r} did not publish workflow run metadata; "
+                "cannot coordinate repairs."
+            )
+        metadata = WorkflowRunMetadata(**launch_value)
+
+        if self.deferrable:
+            self.defer(
+                trigger=self._make_trigger(
+                    run_id=metadata.run_id,
+                    repair_attempts=0,
+                    latest_repair_id=None,
+                ),
+                method_name="execute_complete",
+            )
+        return self._run_sync(metadata.run_id)
+
+    def _run_sync(self, run_id: int) -> dict[str, Any]:
+        """Sync equivalent of :class:`DatabricksWorkflowRepairCoordinatorTrigger`'s state machine."""
+        repair_attempts = 0
+        latest_repair_id: int | None = None
+        while True:
+            run_state = self._hook.get_run_state(run_id)
+            while not run_state.is_terminal:
+                self.log.info(
+                    "Databricks run %s in state %s. Sleeping for %s seconds.",
+                    run_id,
+                    run_state,
+                    self.repair_polling_period_seconds,
+                )
+                time.sleep(self.repair_polling_period_seconds)
+                run_state = self._hook.get_run_state(run_id)
+
+            if run_state.is_successful:
+                self.log.info(
+                    "Databricks workflow run %s completed (repair_attempts=%s).",
+                    run_id,
+                    repair_attempts,
+                )
+                return {
+                    "run_id": run_id,
+                    "repair_attempts": repair_attempts,
+                    "latest_repair_id": latest_repair_id,
+                }
+
+            run_info = self._hook.get_run(run_id)
+            errors = extract_failed_task_errors(self._hook, run_info, run_state)
+
+            if repair_attempts >= self.max_full_run_repairs:
+                raise DatabricksWorkflowRepairBudgetExhausted(
+                    f"Databricks workflow run {run_id} failed after {repair_attempts} repair "
+                    f"attempt(s); repair budget exhausted (max_full_run_repairs={self.max_full_run_repairs}). "
+                    f"Errors: {errors}"
+                )
+
+            self.log.info(
+                "Databricks run %s reached terminal failure state %s. Repairing all failed "
+                "tasks (attempt %s of %s, latest_repair_id=%s).",
+                run_id,
+                run_state.result_state,
+                repair_attempts + 1,
+                self.max_full_run_repairs,
+                latest_repair_id,
+            )
+            repair_json = build_repair_run_json(
+                run_id=run_id,
+                latest_repair_id=latest_repair_id,
+                overriding_parameters=run_info.get("overriding_parameters"),
+            )
+            latest_repair_id = self._hook.repair_run(repair_json)
+            repair_attempts += 1
+            self.log.info(
+                "Databricks repair_run accepted for run %s; new repair_id=%s.",
+                run_id,
+                latest_repair_id,
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
+        status = event.get("status")
+        run_id = event["run_id"]
+        repair_attempts = event["repair_attempts"]
+        latest_repair_id = event.get("latest_repair_id")
+
+        if status == "completed":
+            self.log.info(
+                "Databricks workflow run %s completed (repair_attempts=%s).",
+                run_id,
+                repair_attempts,
+            )
+            return {
+                "run_id": run_id,
+                "repair_attempts": repair_attempts,
+                "latest_repair_id": latest_repair_id,
+            }
+
+        if status == "repaired":
+            self.log.info(
+                "Databricks workflow run %s repaired (repair_attempts=%s, latest_repair_id=%s); "
+                "re-deferring to monitor the repaired run.",
+                run_id,
+                repair_attempts,
+                latest_repair_id,
+            )
+            self.defer(
+                trigger=self._make_trigger(
+                    run_id=run_id,
+                    repair_attempts=repair_attempts,
+                    latest_repair_id=latest_repair_id,
+                ),
+                method_name="execute_complete",
+            )
+            return None
+
+        if status == "failed":
+            errors = event.get("errors", [])
+            raise DatabricksWorkflowRepairBudgetExhausted(
+                f"Databricks workflow run {run_id} failed after {repair_attempts} repair "
+                f"attempt(s); repair budget exhausted (max_full_run_repairs={self.max_full_run_repairs}). "
+                f"Errors: {errors}"
+            )
+
+        raise DatabricksWorkflowRepairTriggerError(
+            f"DatabricksWorkflowRepairCoordinatorTrigger emitted unexpected status {status!r}: {event}"
+        )
+
+
 class DatabricksWorkflowTaskGroup(TaskGroup):
     """
     A task group that takes a list of tasks and creates a databricks workflow.
@@ -338,6 +564,12 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         all python tasks in the workflow.
     :param spark_submit_params: A list of spark submit parameters to pass to the workflow. These parameters
         will be passed to all spark submit tasks.
+    :param max_full_run_repairs: Maximum number of automatic ``rerun_all_failed_tasks`` repair attempts to
+        issue against the Databricks run when downstream tasks fail. Each repair reuses the
+        original job cluster. Set to ``0`` to disable auto-repair (current behavior). Only takes
+        effect on Airflow 3+; ignored on Airflow 2.x. Defaults to ``0``.
+    :param repair_polling_period_seconds: How often the repair coordinator polls the
+        Databricks run state. Only used when ``max_full_run_repairs > 0``.
     """
 
     is_databricks = True
@@ -355,8 +587,12 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         notebook_params: dict | None = None,
         python_params: list | None = None,
         spark_submit_params: list | None = None,
+        max_full_run_repairs: int = 0,
+        repair_polling_period_seconds: int = 30,
         **kwargs,
     ):
+        if max_full_run_repairs < 0:
+            raise ValueError(f"max_full_run_repairs must be >= 0, got {max_full_run_repairs}")
         self.databricks_conn_id = databricks_conn_id
         self.access_control_list = access_control_list
         self.existing_clusters = existing_clusters or []
@@ -368,6 +604,8 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         self.notebook_params = notebook_params or {}
         self.python_params = python_params or []
         self.spark_submit_params = spark_submit_params or []
+        self.max_full_run_repairs = max_full_run_repairs
+        self.repair_polling_period_seconds = repair_polling_period_seconds
         super().__init__(**kwargs)
 
     def __exit__(
@@ -403,11 +641,41 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
                         f"Task {task.task_id} does not support conversion to databricks workflow task."
                     )
 
+                if AIRFLOW_V_3_0_PLUS and self.max_full_run_repairs > 0:
+                    task_retries = getattr(task, "retries", 0)
+                    if isinstance(task_retries, int) and task_retries > 0:
+                        warnings.warn(
+                            f"Task {task.task_id!r} in DatabricksWorkflowTaskGroup "
+                            f"{self.group_id!r} has retries={task_retries} while "
+                            f"max_full_run_repairs={self.max_full_run_repairs}. Databricks-side repair supersedes "
+                            "task-level retries for sub-run failures: a failed sub-run defers the "
+                            "monitor on the repair-wait trigger and resumes in the same Airflow "
+                            "attempt. Retries on the monitor will not trigger additional repairs "
+                            "and only add cost on non-repair-related transient failures. Consider "
+                            "setting retries=0 on workflow tasks when max_full_run_repairs > 0.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                 task.workflow_run_metadata = create_databricks_workflow_task.output
                 create_databricks_workflow_task.relevant_upstreams.append(task.task_id)
                 create_databricks_workflow_task.add_task(task.task_id, task)
 
             for root_task in roots:
                 root_task.set_upstream(create_databricks_workflow_task)
+
+            if AIRFLOW_V_3_0_PLUS and self.max_full_run_repairs > 0:
+                repair_coordinator_task = _DatabricksFullRunRepairCoordinatorOperator(
+                    dag=self.dag,
+                    task_group=self,
+                    task_id="full_run_repair_coordinator",
+                    databricks_conn_id=self.databricks_conn_id,
+                    launch_task_id=create_databricks_workflow_task.task_id,
+                    max_full_run_repairs=self.max_full_run_repairs,
+                    repair_polling_period_seconds=self.repair_polling_period_seconds,
+                    # Retrying the coordinator would re-enter execute() with repair_attempts=0
+                    # and start the budget over.
+                    retries=0,
+                )
+                repair_coordinator_task.set_upstream(create_databricks_workflow_task)
         finally:
             super().__exit__(_type, _value, _tb)

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -313,24 +313,22 @@ class _DatabricksFullRunRepairCoordinatorOperator(BaseOperator):
     Watch a Databricks Workflow run and trigger ``rerun_all_failed_tasks`` repairs.
 
     Runs as a sibling of the downstream Databricks task monitors inside a
-    :class:`DatabricksWorkflowTaskGroup`. The ``launch`` task remains responsible for creating the
-    job and returning metadata immediately so downstream tasks can fan out; this operator owns the
-    long-lived defer cycle that watches the whole run and issues one repair call per failure batch,
-    so the original job cluster is reused.
+    :class:`DatabricksWorkflowTaskGroup`. The ``launch`` task creates or resets the job, starts the
+    run, and publishes ``{conn_id, job_id, run_id}`` so monitors can fan out. This operator then
+    owns the parent-run repair budget, waits for terminal run states, and issues one repair call per
+    failed batch.
 
-    Downstream task monitors observe repairs independently by deferring on
-    :class:`~airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairWaitTrigger`
-    when their sub-run hits a terminal failure; that trigger polls the Databricks API for the next
-    attempt of the same ``task_key`` rather than reading any inter-task XCom. The coordinator's
-    final return value carries ``{run_id, repair_attempts, latest_repair_id}`` for any user code
-    that wants a post-run summary.
+    Downstream task monitors observe repairs independently from the Databricks API when their
+    sub-run fails; they do not share repair state through XCom. The coordinator's final return
+    value carries ``{run_id, repair_attempts, latest_repair_id}`` for any user code that wants a
+    post-run summary.
 
-    :param task_id: The task id of the operator (typically ``"full_run_repair_coordinator"``).
+    :param task_id: The task id of the operator (typically ``"repair_coordinator"``).
     :param databricks_conn_id: Connection id used by the coordinator trigger and repair calls.
     :param launch_task_id: The full task id of the workflow ``launch`` task whose return value
         carries ``{conn_id, job_id, run_id}``.
     :param max_full_run_repairs: Total repair attempts allowed across the run.
-    :param repair_polling_period_seconds: Poll interval forwarded to the coordinator trigger.
+    :param repair_polling_period_seconds: Poll interval used by the trigger or sync poll loop.
     :param databricks_retry_limit: Hook retry limit for transient API failures.
     :param databricks_retry_delay: Hook retry delay (seconds).
     :param databricks_retry_args: Optional ``tenacity.Retrying`` kwargs forwarded to the hook.
@@ -667,7 +665,7 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
                 repair_coordinator_task = _DatabricksFullRunRepairCoordinatorOperator(
                     dag=self.dag,
                     task_group=self,
-                    task_id="full_run_repair_coordinator",
+                    task_id="repair_coordinator",
                     databricks_conn_id=self.databricks_conn_id,
                     launch_task_id=create_databricks_workflow_task.task_id,
                     max_full_run_repairs=self.max_full_run_repairs,

--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -21,8 +21,12 @@ import asyncio
 import time
 from typing import Any
 
-from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.providers.databricks.utils.databricks import extract_failed_task_errors_async
+from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunState
+from airflow.providers.databricks.utils.databricks import (
+    build_repair_run_json,
+    extract_failed_task_errors_async,
+    find_new_workflow_task_attempt,
+)
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 
@@ -113,11 +117,362 @@ class DatabricksExecutionTrigger(BaseTrigger):
                         "run_id": self.run_id,
                         "run_page_url": self.run_page_url,
                         "run_state": run_state.to_json(),
+                        "run_start_time": run_info.get("start_time"),
                         "repair_run": self.repair_run,
                         "errors": failed_tasks,
                     }
                 )
                 return
+
+
+class DatabricksWorkflowRepairCoordinatorTrigger(BaseTrigger):
+    """
+    Coordinate whole-run polling and ``rerun_all_failed_tasks`` repair for a Databricks Workflow run.
+
+    Owned by the ``coordinator`` sibling task that
+    :class:`~airflow.providers.databricks.operators.databricks_workflow.DatabricksWorkflowTaskGroup`
+    injects when ``max_full_run_repairs > 0`` on Airflow 3+. Keeps a single Databricks job run alive across
+    repair attempts so the same job cluster is reused. Each defer/resume cycle of the coordinator
+    task corresponds to one iteration:
+
+    1. Poll the run until it reaches a terminal state.
+    2. On terminal success, yield ``status="completed"``.
+    3. On terminal failure with repair budget remaining, call
+       :meth:`~airflow.providers.databricks.hooks.databricks.DatabricksHook.repair_run` with
+       ``rerun_all_failed_tasks=True`` and yield ``status="repaired"`` along with the new
+       ``latest_repair_id`` and bumped ``repair_attempts``; the coordinator task then re-defers on
+       a fresh trigger instance with the new state. Downstream task monitors observe the new sub-run
+       attempt by polling the Databricks API directly (via
+       :class:`DatabricksWorkflowRepairWaitTrigger`), not via any inter-task XCom.
+    4. On terminal failure with the budget exhausted, yield ``status="failed"``.
+
+    The Databricks ``run_id`` is stable across repair attempts; only ``latest_repair_id`` changes.
+
+    :param run_id: The Databricks run id to coordinate.
+    :param databricks_conn_id: Airflow connection id for the Databricks hook.
+    :param max_full_run_repairs: Total repair attempts allowed for this run.
+    :param repair_attempts: Repair attempts already performed (defaults to 0 on the first defer).
+    :param latest_repair_id: Repair id of the most recent repair attempt, or ``None`` on the first
+        defer. Forwarded to ``repair_run`` so Databricks knows which attempt is the latest.
+    :param polling_period_seconds: How often to poll the run state.
+    :param retry_limit: Hook retry limit for transient Databricks API failures.
+    :param retry_delay: Hook retry delay (seconds).
+    :param retry_args: Optional tenacity ``Retrying`` kwargs forwarded to the hook.
+    :param run_page_url: The Databricks UI URL for this run, surfaced in events for logging.
+    :param caller: Caller label forwarded to the hook for diagnostics.
+    """
+
+    def __init__(
+        self,
+        run_id: int,
+        databricks_conn_id: str,
+        max_full_run_repairs: int,
+        repair_attempts: int = 0,
+        latest_repair_id: int | None = None,
+        polling_period_seconds: int = 30,
+        retry_limit: int = 3,
+        retry_delay: int = 10,
+        retry_args: dict[Any, Any] | None = None,
+        run_page_url: str | None = None,
+        caller: str = "DatabricksWorkflowRepairCoordinatorTrigger",
+    ) -> None:
+        super().__init__()
+        self.run_id = run_id
+        self.databricks_conn_id = databricks_conn_id
+        self.max_full_run_repairs = max_full_run_repairs
+        self.repair_attempts = repair_attempts
+        self.latest_repair_id = latest_repair_id
+        self.polling_period_seconds = polling_period_seconds
+        self.retry_limit = retry_limit
+        self.retry_delay = retry_delay
+        self.retry_args = retry_args
+        self.run_page_url = run_page_url
+        self.caller = caller
+        self.hook = DatabricksHook(
+            databricks_conn_id,
+            retry_limit=self.retry_limit,
+            retry_delay=self.retry_delay,
+            retry_args=retry_args,
+            caller=caller,
+        )
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairCoordinatorTrigger",
+            {
+                "run_id": self.run_id,
+                "databricks_conn_id": self.databricks_conn_id,
+                "max_full_run_repairs": self.max_full_run_repairs,
+                "repair_attempts": self.repair_attempts,
+                "latest_repair_id": self.latest_repair_id,
+                "polling_period_seconds": self.polling_period_seconds,
+                "retry_limit": self.retry_limit,
+                "retry_delay": self.retry_delay,
+                "retry_args": self.retry_args,
+                "run_page_url": self.run_page_url,
+                "caller": self.caller,
+            },
+        )
+
+    async def on_kill(self) -> None:
+        """Cancel the Databricks run when the trigger is cancelled by a user action."""
+        if self.run_id:
+            from asgiref.sync import sync_to_async
+
+            self.log.info("Cancelling Databricks run %s.", self.run_id)
+            await sync_to_async(self.hook.cancel_run)(self.run_id)
+
+    async def run(self):
+        from asgiref.sync import sync_to_async
+
+        async with self.hook:
+            while True:
+                run_state = await self.hook.a_get_run_state(self.run_id)
+                if not run_state.is_terminal:
+                    self.log.info(
+                        "run-id %s in run state %s. sleeping for %s seconds",
+                        self.run_id,
+                        run_state,
+                        self.polling_period_seconds,
+                    )
+                    await asyncio.sleep(self.polling_period_seconds)
+                    continue
+
+                run_info = await self.hook.a_get_run(self.run_id)
+                errors = await extract_failed_task_errors_async(self.hook, run_info, run_state)
+
+                if run_state.is_successful:
+                    self.log.info("Databricks run %s completed successfully.", self.run_id)
+                    yield TriggerEvent(
+                        {
+                            "status": "completed",
+                            "run_id": self.run_id,
+                            "run_page_url": self.run_page_url,
+                            "run_state": run_state.to_json(),
+                            "repair_attempts": self.repair_attempts,
+                            "latest_repair_id": self.latest_repair_id,
+                            "errors": errors,
+                        }
+                    )
+                    return
+
+                if self.repair_attempts >= self.max_full_run_repairs:
+                    self.log.info(
+                        "Databricks run %s reached terminal failure state %s and repair budget "
+                        "is exhausted (max_full_run_repairs=%s).",
+                        self.run_id,
+                        run_state.result_state,
+                        self.max_full_run_repairs,
+                    )
+                    yield TriggerEvent(
+                        {
+                            "status": "failed",
+                            "run_id": self.run_id,
+                            "run_page_url": self.run_page_url,
+                            "run_state": run_state.to_json(),
+                            "repair_attempts": self.repair_attempts,
+                            "latest_repair_id": self.latest_repair_id,
+                            "errors": errors,
+                        }
+                    )
+                    return
+
+                self.log.info(
+                    "Databricks run %s reached terminal failure state %s. Repairing all failed "
+                    "tasks (attempt %s of %s, latest_repair_id=%s).",
+                    self.run_id,
+                    run_state.result_state,
+                    self.repair_attempts + 1,
+                    self.max_full_run_repairs,
+                    self.latest_repair_id,
+                )
+
+                repair_json = build_repair_run_json(
+                    run_id=self.run_id,
+                    latest_repair_id=self.latest_repair_id,
+                    overriding_parameters=run_info.get("overriding_parameters"),
+                )
+
+                new_repair_id = await sync_to_async(self.hook.repair_run)(repair_json)
+                self.log.info(
+                    "Databricks repair_run accepted for run %s; new repair_id=%s.",
+                    self.run_id,
+                    new_repair_id,
+                )
+
+                yield TriggerEvent(
+                    {
+                        "status": "repaired",
+                        "run_id": self.run_id,
+                        "run_page_url": self.run_page_url,
+                        "run_state": run_state.to_json(),
+                        "repair_attempts": self.repair_attempts + 1,
+                        "latest_repair_id": new_repair_id,
+                        "errors": errors,
+                    }
+                )
+                return
+
+
+class DatabricksWorkflowRepairWaitTrigger(BaseTrigger):
+    """
+    Wait for the next attempt of a single Databricks Workflow task after its sub-run failed.
+
+    Used by Databricks task monitors inside a
+    :class:`~airflow.providers.databricks.operators.databricks_workflow.DatabricksWorkflowTaskGroup`
+    when ``max_full_run_repairs > 0`` on Airflow 3+. A monitor whose sub-run reaches terminal failure defers
+    on this trigger; the trigger polls the parent run's task list and yields when a new attempt of
+    the same ``task_key`` appears (issued by the sibling ``coordinator`` task via
+    ``rerun_all_failed_tasks``), so the monitor can then defer on a fresh
+    :class:`DatabricksExecutionTrigger` watching the new sub-run id.
+
+    Each poll cycle:
+
+    1. If a Databricks task with our ``databricks_task_key`` exists whose ``run_id`` differs from
+       ``original_sub_run_id`` and whose ``start_time`` is newer, yield ``status="new_attempt"``
+       with the new sub-run id.
+    2. Otherwise, if the parent run is in a terminal failure state, count one "grace" observation.
+       After ``terminal_grace_polls`` consecutive terminal observations without a new attempt,
+       yield ``status="parent_failed"``. This avoids racing the coordinator: the parent run is
+       briefly terminal between sub-run failure and the coordinator issuing ``repair_run``.
+    3. Otherwise (parent still running, or terminal but inside the grace window), sleep and poll
+       again.
+
+    :param run_id: Parent workflow run id (stable across repairs).
+    :param databricks_conn_id: Airflow connection id for the Databricks hook.
+    :param databricks_task_key: The ``task_key`` of the Databricks task to watch for a new attempt.
+    :param original_sub_run_id: The sub-run id of the attempt that just failed; the trigger only
+        yields ``new_attempt`` for a sub-run id different from this one.
+    :param polling_period_seconds: How often to poll the parent run.
+    :param terminal_grace_polls: Number of consecutive terminal-with-no-new-attempt observations
+        required before yielding ``status="parent_failed"``. Bounds how long we wait for the
+        coordinator to issue a repair after observing terminal failure.
+    :param retry_limit: Hook retry limit for transient Databricks API failures.
+    :param retry_delay: Hook retry delay (seconds).
+    :param retry_args: Optional tenacity ``Retrying`` kwargs forwarded to the hook.
+    :param run_page_url: The Databricks UI URL for the parent run, surfaced in events for logging.
+    :param caller: Caller label forwarded to the hook for diagnostics.
+    """
+
+    def __init__(
+        self,
+        run_id: int,
+        databricks_conn_id: str,
+        databricks_task_key: str,
+        original_sub_run_id: int,
+        original_start_time: int | None = None,
+        polling_period_seconds: int = 30,
+        terminal_grace_polls: int = 3,
+        retry_limit: int = 3,
+        retry_delay: int = 10,
+        retry_args: dict[Any, Any] | None = None,
+        run_page_url: str | None = None,
+        caller: str = "DatabricksWorkflowRepairWaitTrigger",
+    ) -> None:
+        super().__init__()
+        if terminal_grace_polls < 1:
+            raise ValueError(f"terminal_grace_polls must be >= 1, got {terminal_grace_polls}")
+        self.run_id = run_id
+        self.databricks_conn_id = databricks_conn_id
+        self.databricks_task_key = databricks_task_key
+        self.original_sub_run_id = original_sub_run_id
+        self.original_start_time = original_start_time
+        self.polling_period_seconds = polling_period_seconds
+        self.terminal_grace_polls = terminal_grace_polls
+        self.retry_limit = retry_limit
+        self.retry_delay = retry_delay
+        self.retry_args = retry_args
+        self.run_page_url = run_page_url
+        self.caller = caller
+        self.hook = DatabricksHook(
+            databricks_conn_id,
+            retry_limit=self.retry_limit,
+            retry_delay=self.retry_delay,
+            retry_args=retry_args,
+            caller=caller,
+        )
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairWaitTrigger",
+            {
+                "run_id": self.run_id,
+                "databricks_conn_id": self.databricks_conn_id,
+                "databricks_task_key": self.databricks_task_key,
+                "original_sub_run_id": self.original_sub_run_id,
+                "original_start_time": self.original_start_time,
+                "polling_period_seconds": self.polling_period_seconds,
+                "terminal_grace_polls": self.terminal_grace_polls,
+                "retry_limit": self.retry_limit,
+                "retry_delay": self.retry_delay,
+                "retry_args": self.retry_args,
+                "run_page_url": self.run_page_url,
+                "caller": self.caller,
+            },
+        )
+
+    def _find_new_attempt(self, tasks: list[dict[str, Any]]) -> dict[str, Any] | None:
+        return find_new_workflow_task_attempt(
+            tasks=tasks,
+            task_key=self.databricks_task_key,
+            original_sub_run_id=self.original_sub_run_id,
+            original_start_time=self.original_start_time,
+        )
+
+    async def run(self):
+        terminal_observations = 0
+        async with self.hook:
+            while True:
+                run_info = await self.hook.a_get_run(self.run_id)
+                run_state = RunState(**run_info["state"])
+                tasks = run_info.get("tasks", [])
+
+                new_attempt = self._find_new_attempt(tasks)
+                if new_attempt is not None:
+                    self.log.info(
+                        "Databricks workflow run %s produced a new attempt for task_key %s "
+                        "(new sub-run id %s).",
+                        self.run_id,
+                        self.databricks_task_key,
+                        new_attempt["run_id"],
+                    )
+                    yield TriggerEvent(
+                        {
+                            "status": "new_attempt",
+                            "parent_run_id": self.run_id,
+                            "databricks_task_key": self.databricks_task_key,
+                            "new_sub_run_id": new_attempt["run_id"],
+                            "run_page_url": self.run_page_url,
+                        }
+                    )
+                    return
+
+                if run_state.is_terminal and not run_state.is_successful:
+                    terminal_observations += 1
+                    self.log.info(
+                        "Databricks workflow run %s is in terminal failure state %s with no new "
+                        "attempt for task_key %s (grace %s of %s).",
+                        self.run_id,
+                        run_state.result_state,
+                        self.databricks_task_key,
+                        terminal_observations,
+                        self.terminal_grace_polls,
+                    )
+                    if terminal_observations >= self.terminal_grace_polls:
+                        yield TriggerEvent(
+                            {
+                                "status": "parent_failed",
+                                "parent_run_id": self.run_id,
+                                "databricks_task_key": self.databricks_task_key,
+                                "parent_run_state": run_state.to_json(),
+                                "run_page_url": self.run_page_url,
+                            }
+                        )
+                        return
+                else:
+                    terminal_observations = 0
+
+                await asyncio.sleep(self.polling_period_seconds)
 
 
 class DatabricksSQLStatementExecutionTrigger(BaseTrigger):

--- a/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Any
+
 from airflow.providers.common.compat.sdk import AirflowException, XComArg
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunState
 
@@ -103,6 +105,53 @@ async def extract_failed_task_errors_async(
                     error = run_state.state_message
                 failed_tasks.append({"task_key": task_key, "run_id": task_run_id, "error": error})
     return failed_tasks
+
+
+def find_new_workflow_task_attempt(
+    tasks: list[dict[str, Any]],
+    task_key: str,
+    original_sub_run_id: int,
+    original_start_time: int | None,
+) -> dict[str, Any] | None:
+    """
+    Return the newest task entry matching ``task_key`` that is not the original sub-run.
+
+    Used by the repair-wait trigger and its sync counterpart to detect a new attempt of
+    a Databricks Workflow task after the prior sub-run reached terminal failure.
+    """
+    candidates = [
+        task
+        for task in tasks
+        if task.get("task_key") == task_key
+        and task.get("run_id") != original_sub_run_id
+        and (original_start_time is None or task.get("start_time", 0) > original_start_time)
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda task: task.get("start_time", 0))
+
+
+def build_repair_run_json(
+    run_id: int,
+    latest_repair_id: int | None,
+    overriding_parameters: Any = None,
+) -> dict[str, Any]:
+    """
+    Build the ``DatabricksHook.repair_run`` payload for ``rerun_all_failed_tasks`` repair.
+
+    Used by the coordinator trigger and its sync counterpart to keep the repair payload
+    shape in lock-step.
+    """
+    repair_json: dict[str, Any] = {
+        "run_id": run_id,
+        "rerun_all_failed_tasks": True,
+        "rerun_dependent_tasks": True,
+    }
+    if latest_repair_id is not None:
+        repair_json["latest_repair_id"] = latest_repair_id
+    if overriding_parameters is not None:
+        repair_json["overriding_parameters"] = overriding_parameters
+    return repair_json
 
 
 def validate_trigger_event(event: dict):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks.py
@@ -48,8 +48,11 @@ from airflow.providers.databricks.operators.databricks import (
 from airflow.providers.databricks.triggers.databricks import (
     DatabricksExecutionTrigger,
     DatabricksSQLStatementExecutionTrigger,
+    DatabricksWorkflowRepairWaitTrigger,
 )
 from airflow.providers.databricks.utils import databricks as utils
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 DATE = "2017-04-20"
 TASK_ID = "databricks-operator"
@@ -2724,3 +2727,184 @@ class TestDatabricksTaskOperator:
         expected_task_key = "test_task_key"
 
         assert expected_task_key == operator.databricks_task_key
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Workflow repair flow is Airflow 3+ only")
+class TestExecuteCompleteWorkflowRepair:
+    PARENT_RUN_ID = 100
+    ORIGINAL_SUB_RUN_ID = 500
+    NEW_SUB_RUN_ID = 700
+
+    @staticmethod
+    def _terminal_failure_event(sub_run_id: int) -> dict[str, Any]:
+        return {
+            "run_id": sub_run_id,
+            "run_page_url": "https://example",
+            "run_state": RunState(
+                life_cycle_state="TERMINATED",
+                state_message="boom",
+                result_state="FAILED",
+            ).to_json(),
+            "errors": [{"task_key": "tk", "run_id": sub_run_id, "error": "boom"}],
+        }
+
+    def _operator_with_workflow_tg(self, max_full_run_repairs: int) -> DatabricksNotebookOperator:
+        # Pass workflow_run_metadata (templated field) rather than setting
+        # databricks_run_id directly. Airflow re-instantiates the operator at deferrable
+        # resume time, so execute_complete must rederive the parent run id from the
+        # rendered template, not from any attribute set during execute().
+        operator = DatabricksNotebookOperator(
+            task_id="task1",
+            notebook_path="path",
+            source="WORKSPACE",
+            databricks_conn_id="databricks_default",
+            workflow_run_metadata={
+                "conn_id": "databricks_default",
+                "job_id": 1,
+                "run_id": self.PARENT_RUN_ID,
+            },
+        )
+
+        # _databricks_workflow_task_group walks up `task_group` looking for is_databricks=True.
+        # Hand it a single-hop chain so it finds our mocked group directly.
+        tg = MagicMock()
+        tg.is_databricks = True
+        tg.max_full_run_repairs = max_full_run_repairs
+        tg.repair_polling_period_seconds = 15
+        tg.task_group = None
+        operator.task_group = tg
+        return operator
+
+    def test_execute_complete_failure_defers_on_wait_trigger_when_max_full_run_repairs_set(self):
+        operator = self._operator_with_workflow_tg(max_full_run_repairs=2)
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute_complete(
+                context=None,
+                event=self._terminal_failure_event(self.ORIGINAL_SUB_RUN_ID),
+            )
+
+        trigger = exc.value.trigger
+        assert isinstance(trigger, DatabricksWorkflowRepairWaitTrigger)
+        assert trigger.run_id == self.PARENT_RUN_ID
+        assert trigger.databricks_task_key == operator.databricks_task_key
+        assert trigger.original_sub_run_id == self.ORIGINAL_SUB_RUN_ID
+        assert trigger.polling_period_seconds == 15
+        assert exc.value.method_name == "execute_complete_after_repair_wait"
+
+    def test_execute_complete_failure_pulls_workflow_metadata_from_xcom(self):
+        # Mirrors the deferrable-resume path where execute() never ran (so
+        # workflow_run_metadata was not pre-populated): the resolver must fall back
+        # to xcom_pull from the upstream .launch task to recover the parent run id.
+        operator = DatabricksNotebookOperator(
+            task_id="task1",
+            notebook_path="path",
+            source="WORKSPACE",
+            databricks_conn_id="databricks_default",
+        )
+        tg = MagicMock()
+        tg.is_databricks = True
+        tg.max_full_run_repairs = 2
+        tg.repair_polling_period_seconds = 15
+        tg.task_group = None
+        operator.task_group = tg
+        operator.upstream_task_ids = {"workflow.launch"}
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = {
+            "conn_id": "databricks_default",
+            "job_id": 1,
+            "run_id": self.PARENT_RUN_ID,
+        }
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute_complete(
+                context={"ti": ti},
+                event=self._terminal_failure_event(self.ORIGINAL_SUB_RUN_ID),
+            )
+
+        ti.xcom_pull.assert_called_once_with(task_ids="workflow.launch")
+        trigger = exc.value.trigger
+        assert isinstance(trigger, DatabricksWorkflowRepairWaitTrigger)
+        assert trigger.run_id == self.PARENT_RUN_ID
+
+    def test_execute_complete_after_repair_wait_new_attempt_defers_on_execution_trigger(self):
+        operator = self._operator_with_workflow_tg(max_full_run_repairs=2)
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute_complete_after_repair_wait(
+                context=None,
+                event={
+                    "status": "new_attempt",
+                    "parent_run_id": self.PARENT_RUN_ID,
+                    "databricks_task_key": operator.databricks_task_key,
+                    "new_sub_run_id": self.NEW_SUB_RUN_ID,
+                    "run_page_url": "https://example",
+                },
+            )
+
+        trigger = exc.value.trigger
+        assert isinstance(trigger, DatabricksExecutionTrigger)
+        assert trigger.run_id == self.NEW_SUB_RUN_ID
+        assert exc.value.method_name == "execute_complete"
+
+    def test_execute_complete_after_repair_wait_parent_failed_raises(self):
+        operator = self._operator_with_workflow_tg(max_full_run_repairs=2)
+
+        with pytest.raises(AirflowException, match="repair budget is exhausted"):
+            operator.execute_complete_after_repair_wait(
+                context=None,
+                event={
+                    "status": "parent_failed",
+                    "parent_run_id": self.PARENT_RUN_ID,
+                    "databricks_task_key": operator.databricks_task_key,
+                    "parent_run_state": RunState(
+                        life_cycle_state="TERMINATED",
+                        state_message=None,
+                        result_state="FAILED",
+                    ).to_json(),
+                    "run_page_url": "https://example",
+                },
+            )
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.time.sleep")
+    def test_sync_wait_for_new_sub_run_attempt_returns_new_attempt(self, mock_sleep):
+        operator = self._operator_with_workflow_tg(max_full_run_repairs=2)
+        hook = MagicMock()
+        operator.__dict__["_hook"] = hook
+        operator.databricks_run_id = self.PARENT_RUN_ID
+        hook.get_run.side_effect = [
+            {
+                "state": {"life_cycle_state": "RUNNING", "result_state": None, "state_message": None},
+                "tasks": [
+                    {
+                        "run_id": self.ORIGINAL_SUB_RUN_ID,
+                        "task_key": operator.databricks_task_key,
+                        "start_time": 1000,
+                    },
+                ],
+            },
+            {
+                "state": {"life_cycle_state": "RUNNING", "result_state": None, "state_message": None},
+                "tasks": [
+                    {
+                        "run_id": self.ORIGINAL_SUB_RUN_ID,
+                        "task_key": operator.databricks_task_key,
+                        "start_time": 1000,
+                    },
+                    {
+                        "run_id": self.NEW_SUB_RUN_ID,
+                        "task_key": operator.databricks_task_key,
+                        "start_time": 2000,
+                    },
+                ],
+            },
+        ]
+
+        result = operator._sync_wait_for_new_sub_run_attempt(
+            original_sub_run_id=self.ORIGINAL_SUB_RUN_ID,
+            original_start_time=1000,
+            tg=operator.task_group,
+        )
+
+        assert result == self.NEW_SUB_RUN_ID
+        mock_sleep.assert_called_once_with(15)

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -347,7 +347,7 @@ class TestDatabricksFullRunRepairCoordinatorOperator:
         deferrable: bool = True,
     ) -> _DatabricksFullRunRepairCoordinatorOperator:
         return _DatabricksFullRunRepairCoordinatorOperator(
-            task_id="full_run_repair_coordinator",
+            task_id="repair_coordinator",
             databricks_conn_id="databricks_default",
             launch_task_id=self.LAUNCH_TASK_ID,
             max_full_run_repairs=max_full_run_repairs,
@@ -471,7 +471,7 @@ class TestDatabricksWorkflowTaskGroupCoordinatorInjection:
                 task._convert_to_databricks_workflow_task = MagicMock(return_value={})
                 tg.add(task)
 
-        coordinator = tg.children["wf.full_run_repair_coordinator"]
+        coordinator = tg.children["wf.repair_coordinator"]
         assert isinstance(coordinator, _DatabricksFullRunRepairCoordinatorOperator)
         assert coordinator.max_full_run_repairs == 2
         assert coordinator.repair_polling_period_seconds == 15

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -28,18 +28,20 @@ pytest.importorskip("flask_session")
 
 from airflow import DAG
 from airflow.models.baseoperator import BaseOperator
-from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.databricks.hooks.databricks import RunLifeCycleState
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
+from airflow.providers.databricks.hooks.databricks import RunLifeCycleState, RunState
 from airflow.providers.databricks.operators.databricks_workflow import (
     DatabricksWorkflowTaskGroup,
     WorkflowRunMetadata,
     _CreateDatabricksWorkflowOperator,
+    _DatabricksFullRunRepairCoordinatorOperator,
     _flatten_node,
 )
+from airflow.providers.databricks.triggers.databricks import DatabricksWorkflowRepairCoordinatorTrigger
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.utils import timezone
+from airflow.utils.timezone import datetime as tz_datetime
 
-DEFAULT_DATE = timezone.datetime(2021, 1, 1)
+DEFAULT_DATE = tz_datetime(2021, 1, 1)
 
 ACCESS_CONTROL_LIST = [
     {
@@ -333,3 +335,167 @@ def test_on_kill(mock_databricks_hook, context, mock_workflow_run_metadata):
     operator.on_kill()
 
     operator._hook.cancel_run.assert_called_once_with(RUN_ID)
+
+
+class TestDatabricksFullRunRepairCoordinatorOperator:
+    LAUNCH_TASK_ID = "wf.launch"
+    LAUNCH_RETURN = {"conn_id": "databricks_default", "job_id": 42, "run_id": 100}
+
+    def _make_operator(
+        self,
+        max_full_run_repairs: int = 2,
+        deferrable: bool = True,
+    ) -> _DatabricksFullRunRepairCoordinatorOperator:
+        return _DatabricksFullRunRepairCoordinatorOperator(
+            task_id="full_run_repair_coordinator",
+            databricks_conn_id="databricks_default",
+            launch_task_id=self.LAUNCH_TASK_ID,
+            max_full_run_repairs=max_full_run_repairs,
+            repair_polling_period_seconds=10,
+            deferrable=deferrable,
+        )
+
+    def test_execute_raises_when_launch_xcom_missing(self):
+        operator = self._make_operator()
+        ctx = {"ti": MagicMock()}
+        ctx["ti"].xcom_pull.return_value = None
+
+        with pytest.raises(AirflowException, match="did not publish workflow run metadata"):
+            operator.execute(ctx)
+
+    def test_execute_defers_on_coordinator_trigger(self):
+        operator = self._make_operator(max_full_run_repairs=3)
+        ctx = {"ti": MagicMock()}
+        ctx["ti"].xcom_pull.return_value = self.LAUNCH_RETURN
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(ctx)
+
+        ctx["ti"].xcom_push.assert_not_called()
+        assert exc.value.method_name == "execute_complete"
+        trigger = exc.value.trigger
+        assert isinstance(trigger, DatabricksWorkflowRepairCoordinatorTrigger)
+        assert trigger.run_id == self.LAUNCH_RETURN["run_id"]
+        assert trigger.max_full_run_repairs == 3
+        assert trigger.repair_attempts == 0
+        assert trigger.latest_repair_id is None
+        assert trigger.polling_period_seconds == 10
+
+    def test_execute_complete_repaired_redefers_without_xcom_push(self):
+        operator = self._make_operator(max_full_run_repairs=3)
+        ctx = {"ti": MagicMock()}
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute_complete(
+                ctx,
+                event={
+                    "status": "repaired",
+                    "run_id": 100,
+                    "repair_attempts": 1,
+                    "latest_repair_id": 555,
+                },
+            )
+
+        ctx["ti"].xcom_push.assert_not_called()
+        trigger = exc.value.trigger
+        assert isinstance(trigger, DatabricksWorkflowRepairCoordinatorTrigger)
+        assert trigger.run_id == 100
+        assert trigger.repair_attempts == 1
+        assert trigger.latest_repair_id == 555
+        assert trigger.max_full_run_repairs == 3
+
+    def test_execute_complete_failed_raises_with_errors_in_message(self):
+        operator = self._make_operator(max_full_run_repairs=2)
+        ctx = {"ti": MagicMock()}
+        errors = [{"task_key": "t1", "run_id": 11, "error": "boom"}]
+
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(
+                ctx,
+                event={
+                    "status": "failed",
+                    "run_id": 100,
+                    "repair_attempts": 2,
+                    "latest_repair_id": 999,
+                    "errors": errors,
+                },
+            )
+
+        message = str(exc.value)
+        assert "100" in message
+        assert "max_full_run_repairs=2" in message
+        assert "boom" in message
+        ctx["ti"].xcom_push.assert_not_called()
+
+    @patch("airflow.providers.databricks.operators.databricks_workflow.time.sleep")
+    def test_sync_run_repairs_failed_run_and_returns_success(self, mock_sleep):
+        operator = self._make_operator(max_full_run_repairs=2, deferrable=False)
+        hook = MagicMock()
+        operator.__dict__["_hook"] = hook
+        hook.get_run_state.side_effect = [
+            RunState("TERMINATED", "FAILED", ""),
+            RunState("TERMINATED", "SUCCESS", ""),
+        ]
+        hook.get_run.return_value = {
+            "state": {"life_cycle_state": "TERMINATED", "result_state": "FAILED", "state_message": ""},
+            "tasks": [],
+            "overriding_parameters": {"notebook_params": {"date": "2024-01-01"}},
+        }
+        hook.repair_run.return_value = 555
+
+        result = operator._run_sync(run_id=100)
+
+        hook.repair_run.assert_called_once_with(
+            {
+                "run_id": 100,
+                "rerun_all_failed_tasks": True,
+                "rerun_dependent_tasks": True,
+                "overriding_parameters": {"notebook_params": {"date": "2024-01-01"}},
+            }
+        )
+        assert result == {"run_id": 100, "repair_attempts": 1, "latest_repair_id": 555}
+        mock_sleep.assert_not_called()
+
+
+class TestDatabricksWorkflowTaskGroupCoordinatorInjection:
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Coordinator task is only injected on Airflow 3+")
+    def test_max_full_run_repairs_positive_injects_coordinator_with_launch_upstream(self):
+        with DAG(dag_id="dwf_with_coord", schedule=None, start_date=DEFAULT_DATE):
+            with DatabricksWorkflowTaskGroup(
+                group_id="wf",
+                databricks_conn_id="databricks_conn",
+                max_full_run_repairs=2,
+                repair_polling_period_seconds=15,
+            ) as tg:
+                task = MagicMock(task_id="task1")
+                task._convert_to_databricks_workflow_task = MagicMock(return_value={})
+                tg.add(task)
+
+        coordinator = tg.children["wf.full_run_repair_coordinator"]
+        assert isinstance(coordinator, _DatabricksFullRunRepairCoordinatorOperator)
+        assert coordinator.max_full_run_repairs == 2
+        assert coordinator.repair_polling_period_seconds == 15
+        assert coordinator.launch_task_id == "wf.launch"
+        assert "wf.launch" in coordinator.upstream_task_ids
+
+    def test_negative_max_full_run_repairs_rejected(self):
+        with pytest.raises(ValueError, match="max_full_run_repairs must be >= 0"):
+            DatabricksWorkflowTaskGroup(
+                group_id="wf_invalid",
+                databricks_conn_id="databricks_conn",
+                max_full_run_repairs=-1,
+            )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Repair behavior only applies on Airflow 3+")
+    def test_warns_when_user_task_has_retries_and_max_full_run_repairs_positive(self):
+        with DAG(dag_id="dwf_warn_retries", schedule=None, start_date=DEFAULT_DATE):
+            tg = DatabricksWorkflowTaskGroup(
+                group_id="wf",
+                databricks_conn_id="databricks_conn",
+                max_full_run_repairs=1,
+            )
+            tg.__enter__()
+            task = EmptyOperator(task_id="task1", retries=2)
+            task._convert_to_databricks_workflow_task = MagicMock(return_value={})
+            with pytest.warns(UserWarning, match=r"retries=2 while max_full_run_repairs=1"):
+                tg.__exit__(None, None, None)

--- a/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/triggers/test_databricks.py
@@ -27,6 +27,8 @@ from airflow.providers.databricks.hooks.databricks import RunState, SQLStatement
 from airflow.providers.databricks.triggers.databricks import (
     DatabricksExecutionTrigger,
     DatabricksSQLStatementExecutionTrigger,
+    DatabricksWorkflowRepairCoordinatorTrigger,
+    DatabricksWorkflowRepairWaitTrigger,
 )
 from airflow.triggers.base import TriggerEvent
 
@@ -181,6 +183,7 @@ class TestDatabricksExecutionTrigger:
                         life_cycle_state=LIFE_CYCLE_STATE_TERMINATED, state_message="", result_state="SUCCESS"
                     ).to_json(),
                     "run_page_url": RUN_PAGE_URL,
+                    "run_start_time": None,
                     "repair_run": False,
                     "errors": [],
                 }
@@ -212,6 +215,7 @@ class TestDatabricksExecutionTrigger:
                         life_cycle_state=LIFE_CYCLE_STATE_TERMINATED, state_message="", result_state="FAILED"
                     ).to_json(),
                     "run_page_url": RUN_PAGE_URL,
+                    "run_start_time": None,
                     "repair_run": False,
                     "errors": [
                         {"task_key": TASK_RUN_ID1_KEY, "run_id": TASK_RUN_ID1, "error": ERROR_MESSAGE},
@@ -252,6 +256,7 @@ class TestDatabricksExecutionTrigger:
                         life_cycle_state=LIFE_CYCLE_STATE_TERMINATED, state_message="", result_state="SUCCESS"
                     ).to_json(),
                     "run_page_url": RUN_PAGE_URL,
+                    "run_start_time": None,
                     "repair_run": False,
                     "errors": [],
                 }
@@ -373,3 +378,274 @@ class TestDatabricksSQLStatementExecutionTrigger:
     async def test_on_kill_cancels_statement(self, mock_cancel_sql_statement):
         await self.trigger.on_kill()
         mock_cancel_sql_statement.assert_called_once_with(STATEMENT_ID)
+
+
+class TestDatabricksWorkflowRepairCoordinatorTrigger:
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id=DEFAULT_CONN_ID,
+                conn_type="databricks",
+                host=HOST,
+                login=LOGIN,
+                password=PASSWORD,
+                extra=None,
+            )
+        )
+
+    def _make_trigger(
+        self,
+        max_full_run_repairs: int = 2,
+        repair_attempts: int = 0,
+        latest_repair_id: int | None = None,
+    ) -> DatabricksWorkflowRepairCoordinatorTrigger:
+        return DatabricksWorkflowRepairCoordinatorTrigger(
+            run_id=RUN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            max_full_run_repairs=max_full_run_repairs,
+            repair_attempts=repair_attempts,
+            latest_repair_id=latest_repair_id,
+            polling_period_seconds=POLLING_INTERVAL_SECONDS,
+            run_page_url=RUN_PAGE_URL,
+        )
+
+    def test_serialize_round_trips_state(self):
+        trigger = self._make_trigger(max_full_run_repairs=3, repair_attempts=1, latest_repair_id=42)
+        path, kwargs = trigger.serialize()
+
+        assert (
+            path
+            == "airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairCoordinatorTrigger"
+        )
+        assert kwargs == {
+            "run_id": RUN_ID,
+            "databricks_conn_id": DEFAULT_CONN_ID,
+            "max_full_run_repairs": 3,
+            "repair_attempts": 1,
+            "latest_repair_id": 42,
+            "polling_period_seconds": POLLING_INTERVAL_SECONDS,
+            "retry_limit": RETRY_LIMIT,
+            "retry_delay": RETRY_DELAY,
+            "retry_args": None,
+            "run_page_url": RUN_PAGE_URL,
+            "caller": "DatabricksWorkflowRepairCoordinatorTrigger",
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_state")
+    async def test_emits_completed_when_run_succeeds(self, mock_get_run_state, mock_get_run):
+        mock_get_run_state.return_value = RunState(
+            life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+            state_message="",
+            result_state="SUCCESS",
+        )
+        mock_get_run.return_value = GET_RUN_RESPONSE_TERMINATED
+
+        trigger = self._make_trigger(max_full_run_repairs=2, repair_attempts=0, latest_repair_id=None)
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "completed"
+        assert events[0].payload["run_id"] == RUN_ID
+        assert events[0].payload["repair_attempts"] == 0
+        assert events[0].payload["latest_repair_id"] is None
+        assert events[0].payload["errors"] == []
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.repair_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_output")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_state")
+    async def test_first_failure_within_budget_calls_repair_and_emits_repaired(
+        self, mock_get_run_state, mock_get_run, mock_get_run_output, mock_repair_run
+    ):
+        mock_get_run_state.return_value = RunState(
+            life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+            state_message="",
+            result_state="FAILED",
+        )
+        mock_get_run.return_value = GET_RUN_RESPONSE_TERMINATED_WITH_FAILED
+        mock_get_run_output.return_value = GET_RUN_OUTPUT_RESPONSE
+        mock_repair_run.return_value = 101
+
+        trigger = self._make_trigger(max_full_run_repairs=2, repair_attempts=0, latest_repair_id=None)
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "repaired"
+        assert events[0].payload["run_id"] == RUN_ID
+        assert events[0].payload["repair_attempts"] == 1
+        assert events[0].payload["latest_repair_id"] == 101
+        assert events[0].payload["errors"] == [
+            {"task_key": TASK_RUN_ID1_KEY, "run_id": TASK_RUN_ID1, "error": ERROR_MESSAGE},
+            {"task_key": TASK_RUN_ID3_KEY, "run_id": TASK_RUN_ID3, "error": ERROR_MESSAGE},
+        ]
+
+        mock_repair_run.assert_called_once()
+        repair_json = mock_repair_run.call_args.args[0]
+        assert repair_json["run_id"] == RUN_ID
+        assert repair_json["rerun_all_failed_tasks"] is True
+        # First repair: latest_repair_id was None, so the field must be omitted from the payload
+        assert "latest_repair_id" not in repair_json
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.repair_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_output")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_state")
+    async def test_emits_failed_when_budget_exhausted(
+        self, mock_get_run_state, mock_get_run, mock_get_run_output, mock_repair_run
+    ):
+        mock_get_run_state.return_value = RunState(
+            life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+            state_message="",
+            result_state="FAILED",
+        )
+        mock_get_run.return_value = GET_RUN_RESPONSE_TERMINATED_WITH_FAILED
+        mock_get_run_output.return_value = GET_RUN_OUTPUT_RESPONSE
+
+        trigger = self._make_trigger(max_full_run_repairs=2, repair_attempts=2, latest_repair_id=202)
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert events[0].payload["status"] == "failed"
+        assert events[0].payload["repair_attempts"] == 2
+        assert events[0].payload["latest_repair_id"] == 202
+        assert events[0].payload["errors"] == [
+            {"task_key": TASK_RUN_ID1_KEY, "run_id": TASK_RUN_ID1, "error": ERROR_MESSAGE},
+            {"task_key": TASK_RUN_ID3_KEY, "run_id": TASK_RUN_ID3, "error": ERROR_MESSAGE},
+        ]
+        mock_repair_run.assert_not_called()
+
+
+class TestDatabricksWorkflowRepairWaitTrigger:
+    PARENT_RUN_ID = 100
+    TASK_KEY = "monitored_task"
+    ORIGINAL_SUB_RUN_ID = 500
+    NEW_SUB_RUN_ID = 700
+
+    @pytest.fixture(autouse=True)
+    def setup_connections(self, create_connection_without_db):
+        create_connection_without_db(
+            Connection(
+                conn_id=DEFAULT_CONN_ID,
+                conn_type="databricks",
+                host=HOST,
+                login=LOGIN,
+                password=PASSWORD,
+                extra=None,
+            )
+        )
+
+    def _make_trigger(
+        self,
+        terminal_grace_polls: int = 3,
+    ) -> DatabricksWorkflowRepairWaitTrigger:
+        return DatabricksWorkflowRepairWaitTrigger(
+            run_id=self.PARENT_RUN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            databricks_task_key=self.TASK_KEY,
+            original_sub_run_id=self.ORIGINAL_SUB_RUN_ID,
+            polling_period_seconds=POLLING_INTERVAL_SECONDS,
+            terminal_grace_polls=terminal_grace_polls,
+            run_page_url=RUN_PAGE_URL,
+        )
+
+    def _run_payload(
+        self,
+        result_state: str | None,
+        life_cycle_state: str = LIFE_CYCLE_STATE_TERMINATED,
+        tasks: list[dict] | None = None,
+    ) -> dict:
+        return {
+            "run_page_url": RUN_PAGE_URL,
+            "state": {
+                "life_cycle_state": life_cycle_state,
+                "state_message": None,
+                "result_state": result_state,
+            },
+            "tasks": tasks or [],
+        }
+
+    def test_serialize_round_trips_state(self):
+        trigger = self._make_trigger(terminal_grace_polls=5)
+        path, kwargs = trigger.serialize()
+
+        assert path == "airflow.providers.databricks.triggers.databricks.DatabricksWorkflowRepairWaitTrigger"
+        assert kwargs == {
+            "run_id": self.PARENT_RUN_ID,
+            "databricks_conn_id": DEFAULT_CONN_ID,
+            "databricks_task_key": self.TASK_KEY,
+            "original_sub_run_id": self.ORIGINAL_SUB_RUN_ID,
+            "original_start_time": None,
+            "polling_period_seconds": POLLING_INTERVAL_SECONDS,
+            "terminal_grace_polls": 5,
+            "retry_limit": RETRY_LIMIT,
+            "retry_delay": RETRY_DELAY,
+            "retry_args": None,
+            "run_page_url": RUN_PAGE_URL,
+            "caller": "DatabricksWorkflowRepairWaitTrigger",
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run")
+    async def test_emits_new_attempt_when_new_sub_run_appears(self, mock_get_run):
+        mock_get_run.return_value = self._run_payload(
+            result_state=None,
+            life_cycle_state="RUNNING",
+            tasks=[
+                {
+                    "run_id": self.ORIGINAL_SUB_RUN_ID,
+                    "task_key": self.TASK_KEY,
+                    "start_time": 1000,
+                },
+                {
+                    "run_id": self.NEW_SUB_RUN_ID,
+                    "task_key": self.TASK_KEY,
+                    "start_time": 2000,
+                },
+            ],
+        )
+
+        trigger = self._make_trigger()
+        events = [event async for event in trigger.run()]
+
+        assert len(events) == 1
+        assert events[0].payload == {
+            "status": "new_attempt",
+            "parent_run_id": self.PARENT_RUN_ID,
+            "databricks_task_key": self.TASK_KEY,
+            "new_sub_run_id": self.NEW_SUB_RUN_ID,
+            "run_page_url": RUN_PAGE_URL,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("asyncio.sleep")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run")
+    async def test_emits_parent_failed_after_grace_polls(self, mock_get_run, mock_sleep):
+        terminal_payload = self._run_payload(
+            result_state="FAILED",
+            life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+            tasks=[
+                {
+                    "run_id": self.ORIGINAL_SUB_RUN_ID,
+                    "task_key": self.TASK_KEY,
+                    "start_time": 1000,
+                },
+            ],
+        )
+        mock_get_run.return_value = terminal_payload
+
+        trigger = self._make_trigger(terminal_grace_polls=3)
+        events = [event async for event in trigger.run()]
+
+        assert mock_get_run.call_count == 3
+        assert mock_sleep.call_count == 2
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload["status"] == "parent_failed"
+        assert payload["parent_run_id"] == self.PARENT_RUN_ID
+        assert payload["databricks_task_key"] == self.TASK_KEY
+        assert RunState.from_json(payload["parent_run_state"]).result_state == "FAILED"

--- a/providers/databricks/tests/unit/databricks/utils/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/utils/test_databricks.py
@@ -25,8 +25,10 @@ import pytest
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.databricks.hooks.databricks import RunState
 from airflow.providers.databricks.utils.databricks import (
+    build_repair_run_json,
     extract_failed_task_errors,
     extract_failed_task_errors_async,
+    find_new_workflow_task_attempt,
     normalise_json_content,
     validate_trigger_event,
 )
@@ -94,6 +96,42 @@ class TestDatabricksOperatorSharedFunctions:
         event = {}
         with pytest.raises(AirflowException):
             validate_trigger_event(event)
+
+    def test_find_new_workflow_task_attempt_picks_newest_matching_attempt(self):
+        tasks = [
+            {"run_id": TASK_RUN_ID_1, "task_key": TASK_KEY_1, "start_time": 1000},
+            {"run_id": 201, "task_key": TASK_KEY_1, "start_time": 1500},
+            {"run_id": 202, "task_key": TASK_KEY_1, "start_time": 2500},
+            {"run_id": 203, "task_key": TASK_KEY_2, "start_time": 3000},
+        ]
+
+        result = find_new_workflow_task_attempt(
+            tasks=tasks,
+            task_key=TASK_KEY_1,
+            original_sub_run_id=TASK_RUN_ID_1,
+            original_start_time=1000,
+        )
+
+        assert result == {"run_id": 202, "task_key": TASK_KEY_1, "start_time": 2500}
+
+    def test_build_repair_run_json_includes_optional_fields_only_when_present(self):
+        assert build_repair_run_json(run_id=RUN_ID, latest_repair_id=None) == {
+            "run_id": RUN_ID,
+            "rerun_all_failed_tasks": True,
+            "rerun_dependent_tasks": True,
+        }
+
+        assert build_repair_run_json(
+            run_id=RUN_ID,
+            latest_repair_id=42,
+            overriding_parameters={"notebook_params": {"date": "2024-01-01"}},
+        ) == {
+            "run_id": RUN_ID,
+            "rerun_all_failed_tasks": True,
+            "rerun_dependent_tasks": True,
+            "latest_repair_id": 42,
+            "overriding_parameters": {"notebook_params": {"date": "2024-01-01"}},
+        }
 
 
 class TestExtractFailedTaskErrors:


### PR DESCRIPTION
# Databricks Workflow Repair In Airflow 3

## Goal

Re-enable automatic repair for `DatabricksWorkflowTaskGroup` on Airflow 3 without
Flask-AppBuilder, direct metadata database access, or task instance state mutation.

When `max_full_run_repairs > 0`, a failed Databricks Workflow run should be repuaired with one
Databricks `repair_run` call per failed batch:

```python
{
    "run_id": run_id,
    "rerun_all_failed_tasks": True,
    "rerun_dependent_tasks": True,
}
```

`latest_repair_id` is added on later repairs so Databricks repairs the existing run instead
of starting a new workflow run. `max_full_run_repairs` defaults to `0`, preserving current behavior.

Databricks API reference: https://docs.databricks.com/api/workspace/jobs/repairrun

## Design

`DatabricksWorkflowTaskGroup` injects a `full_run_repair_coordinator` task after `launch` on
Airflow 3 when `max_full_run_repairs > 0`.

`launch` still owns only the setup phase: create or reset the Databricks job, start the
workflow run, store the run link, and return `{conn_id, job_id, run_id}` through XCom.

`full_run_repair_coordinator` owns the long-lived repair loop. It pulls the launch metadata and
waits for the parent Databricks run to reach a terminal state. On success it completes. On failure
with budget remaining, it calls `repair_run`, bumps `{repair_attempts, latest_repair_id}`, and
keeps watching the same `run_id`. On failure after the budget is exhausted, the coordinator fails.

Like other Databricks operators, the coordinator honors `deferrable` (defaults to
`conf.getboolean("operators", "default_deferrable", fallback=False)`). When `True` it defers on
`DatabricksWorkflowRepairCoordinatorTrigger` between each repair cycle; when `False` it runs the
same state machine inline as a sync poll loop. Both paths share the `build_repair_run_json` helper
so the Databricks API payload stays in lock-step.

Downstream Databricks task monitors are not forced into any mode — they keep whatever
`deferrable` the user configured on the operator. When a Databricks sub-run fails:

- in deferrable mode, the monitor defers on `DatabricksWorkflowRepairWaitTrigger` until a new
  sub-run with the same `task_key` appears, then defers on `DatabricksExecutionTrigger` to monitor
  the repaired sub-run;
- in sync mode, the monitor sync-polls the parent run's task list for the same condition and
  drops back into its existing `while not run_state.is_terminal` loop on the new `run_id`.

The sync and async paths share `find_new_workflow_task_attempt` so the candidate-selection rule is
identical. The sync branch is gated on `max_full_run_repairs > 0`; when the task group has no
repair budget, the monitor's existing sync poll loop runs unchanged (shipped behavior preserved).

If the parent run remains terminal-failed without producing a new sub-run for the grace
window, the downstream task fails.

## Why A Coordinator Task?

The repair loop cannot live cleanly in `launch` because `launch` must complete before Airflow
will schedule the downstream monitor tasks. Those monitors need the `{conn_id, job_id, run_id}`
XCom from `launch`, and they also need to be running so they can notice failed sub-runs and
wait for repaired attempts.

If `launch` stayed deferred until the whole Databricks run completed or exhausted repairs,
the downstream monitors would remain blocked behind their upstream dependency. Pushing XCom
early would not change that dependency state.

The coordinator keeps the graph semantics simple:

- `launch` publishes the stable Databricks run metadata and succeeds.
- downstream monitors fan out and track individual sub-runs.
- one sibling task owns the parent-run repair budget and `latest_repair_id`.
- failed monitors discover repaired attempts from the Databricks API instead of racing to call
  `repair_run` themselves.

This also gives the implementation a single writer for Databricks repairs. Without that, several
failed task monitors could try to repair the same parent run concurrently.

## Alternatives Considered

The sibling coordinator is not the only possible shape, but Databricks repair has one hard
constraint that drives the design: a run must not be in progress before `repair_run` can be
called. That makes task-local repair impossible while the parent workflow is still running;
some run-scoped owner has to wait for terminal state, decide whether budget remains, and issue
the repair.

Other options were considered:

- keep the repair loop in `launch`: simpler ownership, but `launch` would remain running until
  the Databricks workflow completed, blocking the downstream monitor tasks that give Airflow
  task-level visibility;
- add a finalizer task after all monitors: this makes the coordinator look like a natural join,
  but it fights Airflow task-state semantics because failed upstream monitors would already have
  completed or failed before repair can re-run their Databricks tasks;

Given those tradeoffs, the sibling coordinator is the least invasive option: it keeps a single
writer for the parent-run repair budget while preserving the existing fan-out of Airflow monitor
tasks. The main cost is that the TaskGroup gains an internal lifecycle task, so downstream
dependencies on the group also wait for the coordinator to finish.

## Notes

- Downstream Airflow tasks stay in the same Airflow attempt while waiting for Databricks repair
  and monitoring the repaired sub-run.
- Repair progress is stored in coordinator trigger serialization state. Downstream tasks discover
  new attempts from the Databricks API, not from shared XCom.
- Airflow 3 repair extra links remain disabled. Only `WorkflowJobRunLink` is exposed on Airflow 3.
- Provider docs, `providers/databricks/docs/changelog.rst`, and the FastAPI manual repair endpoint
  are outside the staged changes.
