### PR TITLE
Fix FAB session cookie TypeError with Werkzeug 3.0+

### DIFF
--- a/providers/fab/src/airflow/providers/fab/www/session.py
+++ b/providers/fab/src/airflow/providers/fab/www/session.py
@@ -65,3 +65,18 @@ class AirflowDatabaseSessionInterface(SessionExemptMixin, SqlAlchemySessionInter
 
 class AirflowSecureCookieSessionInterface(SessionExemptMixin, SecureCookieSessionInterface):
     """Session interface that exempts some routes and stores session data in a signed cookie."""
+
+    def save_session(self, app, session, response):
+        """Save session, ensuring cookie values are str for Werkzeug 3.0+."""
+        # Werkzeug 3.0 removed automatic bytes-to-str coercion in set_cookie().
+        # The itsdangerous signing serializer may return bytes in some
+        # configurations; coerce to str so the cookie value is always valid.
+        original_set_cookie = response.set_cookie
+
+        def _str_set_cookie(key, value="", **kwargs):
+            if isinstance(value, bytes):
+                value = value.decode("utf-8")
+            return original_set_cookie(key, value, **kwargs)
+
+        response.set_cookie = _str_set_cookie
+        return super().save_session(app, session, response)

--- a/providers/fab/tests/unit/fab/www/test_session.py
+++ b/providers/fab/tests/unit/fab/www/test_session.py
@@ -81,14 +81,19 @@ class TestAirflowSecureCookieSessionInterface:
 
         response.set_cookie = track_set_cookie
 
-        # Patch super().save_session to simulate Flask calling set_cookie with bytes
-        with patch.object(
-            type(interface).__mro__[1],
-            "save_session",
-            side_effect=lambda self, app, session, response: response.set_cookie(
-                "session", b"signed-bytes-value"
+        # Patch the grandparent (SecureCookieSessionInterface) save_session to
+        # simulate Flask calling set_cookie with bytes.  patch.object replaces
+        # the method on the class with a MagicMock; when called via super() the
+        # mock's side_effect receives positional args WITHOUT self.
+        with (
+            patch("flask.request") as mock_request,
+            patch.object(
+                type(interface).__mro__[2],
+                "save_session",
+                side_effect=lambda *args, **kwargs: response.set_cookie("session", b"signed-bytes-value"),
             ),
         ):
+            mock_request.path = "/any"
             interface.save_session(app, session, response)
 
         assert len(captured_values) == 1
@@ -108,13 +113,15 @@ class TestAirflowSecureCookieSessionInterface:
 
         response.set_cookie = track_set_cookie
 
-        with patch.object(
-            type(interface).__mro__[1],
-            "save_session",
-            side_effect=lambda self, app, session, response: response.set_cookie(
-                "session", "already-a-string"
+        with (
+            patch("flask.request") as mock_request,
+            patch.object(
+                type(interface).__mro__[2],
+                "save_session",
+                side_effect=lambda *args, **kwargs: response.set_cookie("session", "already-a-string"),
             ),
         ):
+            mock_request.path = "/any"
             interface.save_session(app, session, response)
 
         assert len(captured_values) == 1

--- a/providers/fab/tests/unit/fab/www/test_session.py
+++ b/providers/fab/tests/unit/fab/www/test_session.py
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from flask_babel import LazyString
+
+from airflow.providers.fab.www.session import (
+    AirflowSecureCookieSessionInterface,
+    _LazySafeSerializer,
+)
+
+
+class TestLazySafeSerializer:
+    def setup_method(self):
+        self.serializer = _LazySafeSerializer()
+
+    def test_dumps_returns_bytes(self):
+        result = self.serializer.dumps({"key": "value"})
+        assert isinstance(result, bytes)
+
+    def test_roundtrip(self):
+        data = {"user_id": 42, "role": "Admin", "active": True}
+        encoded = self.serializer.dumps(data)
+        decoded = self.serializer.loads(encoded)
+        assert decoded == data
+
+    def test_lazy_string_converted(self):
+        lazy = LazyString(lambda: "translated")
+        encoded = self.serializer.dumps({"label": lazy})
+        decoded = self.serializer.loads(encoded)
+        assert decoded["label"] == "translated"
+
+    def test_empty_session(self):
+        encoded = self.serializer.dumps({})
+        decoded = self.serializer.loads(encoded)
+        assert decoded == {}
+
+    def test_nested_data(self):
+        data = {"prefs": {"theme": "dark", "items": [1, 2, 3]}}
+        encoded = self.serializer.dumps(data)
+        decoded = self.serializer.loads(encoded)
+        assert decoded == data
+
+    def test_encode_decode_aliases(self):
+        data = {"alias": True}
+        assert self.serializer.encode(data) == self.serializer.dumps(data)
+
+        encoded = self.serializer.dumps(data)
+        assert self.serializer.decode(encoded) == self.serializer.loads(encoded)
+
+
+class TestAirflowSecureCookieSessionInterface:
+    """Test that save_session coerces bytes cookie values to str for Werkzeug 3.0+."""
+
+    def test_save_session_decodes_bytes_cookie_value(self):
+        interface = AirflowSecureCookieSessionInterface()
+        app = MagicMock()
+        session = MagicMock()
+        response = MagicMock()
+
+        captured_values = []
+
+        def track_set_cookie(key, value="", **kwargs):
+            captured_values.append(value)
+
+        response.set_cookie = track_set_cookie
+
+        # Patch super().save_session to simulate Flask calling set_cookie with bytes
+        with patch.object(
+            type(interface).__mro__[1],
+            "save_session",
+            side_effect=lambda self, app, session, response: response.set_cookie(
+                "session", b"signed-bytes-value"
+            ),
+        ):
+            interface.save_session(app, session, response)
+
+        assert len(captured_values) == 1
+        assert isinstance(captured_values[0], str)
+        assert captured_values[0] == "signed-bytes-value"
+
+    def test_save_session_passes_str_value_unchanged(self):
+        interface = AirflowSecureCookieSessionInterface()
+        app = MagicMock()
+        session = MagicMock()
+        response = MagicMock()
+
+        captured_values = []
+
+        def track_set_cookie(key, value="", **kwargs):
+            captured_values.append(value)
+
+        response.set_cookie = track_set_cookie
+
+        with patch.object(
+            type(interface).__mro__[1],
+            "save_session",
+            side_effect=lambda self, app, session, response: response.set_cookie(
+                "session", "already-a-string"
+            ),
+        ):
+            interface.save_session(app, session, response)
+
+        assert len(captured_values) == 1
+        assert isinstance(captured_values[0], str)
+        assert captured_values[0] == "already-a-string"

--- a/providers/fab/tests/unit/fab/www/test_session.py
+++ b/providers/fab/tests/unit/fab/www/test_session.py
@@ -85,8 +85,12 @@ class TestAirflowSecureCookieSessionInterface:
         # simulate Flask calling set_cookie with bytes.  patch.object replaces
         # the method on the class with a MagicMock; when called via super() the
         # mock's side_effect receives positional args WITHOUT self.
+        #
+        # session.py imports `request` via `from flask import request`, so we
+        # must patch the name in that module's namespace rather than flask.request
+        # (which is a different reference once the import has been evaluated).
         with (
-            patch("flask.request") as mock_request,
+            patch("airflow.providers.fab.www.session.request") as mock_request,
             patch.object(
                 type(interface).__mro__[2],
                 "save_session",
@@ -114,7 +118,7 @@ class TestAirflowSecureCookieSessionInterface:
         response.set_cookie = track_set_cookie
 
         with (
-            patch("flask.request") as mock_request,
+            patch("airflow.providers.fab.www.session.request") as mock_request,
             patch.object(
                 type(interface).__mro__[2],
                 "save_session",


### PR DESCRIPTION
## Root Cause

Werkzeug 3.0 [removed automatic bytes-to-str coercion](https://github.com/pallets/werkzeug/commit/5ff0a573f4b78d9724f1f063fb058fd6bc76b24d) in `dump_cookie()`. When `session_backend=securecookie`, the itsdangerous signing serializer may return `bytes`, which Werkzeug 3.0+ rejects with `TypeError: cannot use a string pattern on a bytes-like object`.

## Fix

Override `save_session()` in `AirflowSecureCookieSessionInterface` to wrap `response.set_cookie()` with bytes-to-str coercion. If the signed session value is `bytes`, it is decoded to `str` before being passed to Werkzeug.

The database session serializer (`_LazySafeSerializer`) is **not** modified — msgpack encoding produces proper binary `bytes` for `LargeBinary` columns and works correctly.

## Tests

Added `providers/fab/tests/unit/fab/www/test_session.py` covering:
- `_LazySafeSerializer` roundtrip, LazyString handling, bytes output, encode/decode aliases
- `AirflowSecureCookieSessionInterface.save_session` bytes-to-str coercion
- String values pass through unchanged

closes: #64921

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)