### PR TITLE
Avoid logging Execution API bearer tokens

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/security.py
@@ -124,7 +124,7 @@ class JWTBearer(HTTPBearer):
         try:
             claims = await validator.avalidated_claims(creds.credentials, dict(self.required_claims))
         except Exception as err:
-            log.warning("Failed to validate JWT", exc_info=True, token=creds.credentials)
+            log.warning("Failed to validate JWT", exc_info=True)
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Invalid auth token: {err}")
 
         claims.setdefault("scope", "execution")

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_security.py
@@ -20,10 +20,11 @@ from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
-from fastapi import APIRouter, FastAPI, Request, Security
+from fastapi import APIRouter, Depends, FastAPI, Request, Security
 from fastapi.testclient import TestClient
 
 from airflow.api_fastapi.execution_api.datamodels.token import TIClaims, TIToken, TokenScope
+from airflow.api_fastapi.execution_api.deps import _container
 from airflow.api_fastapi.execution_api.security import (
     ExecutionAPIRoute,
     _jwt_bearer,
@@ -86,6 +87,42 @@ class TestExecutionAPIRoute:
                     Security(require_auth, scopes=["token:bogus"]),
                 ],
             )
+
+
+class TestJWTBearer:
+    def test_jwt_validation_failure_does_not_log_raw_token(self):
+        raw_token = "raw-secret-token-material"
+
+        class RejectingValidator:
+            async def avalidated_claims(self, token, required_claims):
+                assert token == raw_token
+                raise ValueError("bad token")
+
+        class Services:
+            async def aget(self, _):
+                return RejectingValidator()
+
+        async def get_services():
+            yield Services()
+
+        app = FastAPI()
+        app.dependency_overrides[_container] = get_services
+
+        @app.get("/needs-token")
+        async def needs_token(token=Depends(_jwt_bearer)):
+            return {"ok": True}
+
+        with patch("airflow.api_fastapi.execution_api.security.log.warning") as warning:
+            resp = TestClient(app).get("/needs-token", headers={"Authorization": f"Bearer {raw_token}"})
+
+        assert resp.status_code == 403
+        assert "Invalid auth token" in resp.json()["detail"]
+        warning.assert_called_once()
+        warning_args, warning_kwargs = warning.call_args
+        assert raw_token not in repr(warning_args)
+        assert raw_token not in repr(warning_kwargs)
+        assert "token" not in warning_kwargs
+        assert warning_kwargs["exc_info"] is True
 
 
 class TestTokenTypeScopeEnforcement:


### PR DESCRIPTION
I noticed that Execution API JWT validation failures currently pass the raw bearer token into structured logs via `token=creds.credentials`.

This may have been added intentionally to help debug token validation failures. From what I can tell, Airflow's structlog rendering includes that field in both text and JSON logs, so I wanted to ask maintainers to check whether retaining the raw credential value in rendered logs is acceptable.

This PR removes the raw token field from that warning log while preserving `exc_info=True` and the existing HTTP 403 behavior.

If this field is intentional and maintainers consider it acceptable, please feel free to reject this change.

closes: #67142

Validation:

- `breeze run pytest airflow-core/tests/unit/api_fastapi/execution_api/test_security.py::TestJWTBearer::test_jwt_validation_failure_does_not_log_raw_token -xvs`
- `breeze run pytest airflow-core/tests/unit/api_fastapi/execution_api/test_security.py -xvs`
- `prek run ruff --files airflow-core/src/airflow/api_fastapi/execution_api/security.py airflow-core/tests/unit/api_fastapi/execution_api/test_security.py`
- `git diff --check`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
