### PR TITLE
Fix duplicated logs and memory issue with S3 log handler

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -62,6 +62,8 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
             has_uploaded = self.write(log, remote_loc)
             if has_uploaded and self.delete_local_copy:
                 shutil.rmtree(os.path.dirname(local_loc))
+            elif has_uploaded:
+                local_loc.write_text("")
 
     @cached_property
     def hook(self):
@@ -119,7 +121,9 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
         try:
             if append and self.s3_log_exists(remote_log_location):
                 old_log = self.s3_read(remote_log_location)
-                log = f"{old_log}\n{log}" if old_log else log
+                if old_log:
+                    sep = "" if old_log.endswith("\n") else "\n"
+                    log = f"{old_log}{sep}{log}"
         except Exception:
             self.log.exception("Could not verify previous log to append")
             return False

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -184,6 +184,24 @@ class TestS3RemoteLogIO:
 
         assert body == b"previous \ntext"
 
+    def test_upload_repeated_appends_no_duplication(self):
+        """Simulate reschedule-mode sensor: each cycle appends to the local log, then uploads.
+
+        Without truncation after upload, the S3 object accumulates duplicate
+        lines and grows O(N^2).  The correct behavior is that each line appears
+        in S3 exactly once.
+        """
+        local_log = self.subject.base_log_folder / "1.log"
+        local_log.parent.mkdir(parents=True, exist_ok=True)
+
+        for cycle in range(1, 4):
+            with open(local_log, "a") as f:
+                f.write(f"cycle {cycle}\n")
+            self.subject.upload(local_log, self.ti)
+
+        body = boto3.resource("s3").Object("bucket", self.remote_log_key).get()["Body"].read()
+        assert body == b"cycle 1\ncycle 2\ncycle 3\n"
+
     def test_write_raises(self, caplog):
         url = "s3://nonexistentbucket/foo"
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->


In our Kubernetes based celery executor, we ran into a runaway memory issue with a sensor that used
`mode="reschedule"` and kept scheduling to the same worker repeatedly. In this environment we have
a dedicated worker set devoted to sensors and the task was getting rescheduled to the same worker
every time the poke was executed. As such, the local log file existed and was getting appended to and
then the S3 log file was also getting appended to each time.

Over time, this caused a large memory spike as the supervisor process loaded the logs from S3, attempted
to append a copy of the logs again, upload the result, and then repeat. The memory usage eventually crashed
the worker due to OOM.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
