### PR TITLE
[For review only, Don't merge] Go SDK: coordinator-protocol execution server and task runner

### DIFF
--- a/go-sdk/bundle/bundlev1/bundlev1server/server.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/server.go
@@ -35,9 +35,10 @@ import (
 	"github.com/apache/airflow/go-sdk/pkg/execution"
 )
 
-// Flags. The bundle-metadata flag is the existing ADR 0001 introspection
-// hook; --comm and --logs select the coordinator-mode protocol added by
-// ADR 0003. All three are read by Serve to choose a server mode below.
+// CLI Flags.
+// The --bundle-metadata flag is used for showing the embedded bundle info in airflow-metadata.yaml spec format.
+// The --comm and --logs select the coordinator-mode protocol
+// All three are read by Serve to choose a server mode below.
 var (
 	versionInfo = flag.Bool("bundle-metadata", false, "show the embedded bundle info")
 	commAddr    = flag.String(
@@ -72,10 +73,10 @@ type ServerConfig struct{}
 type serveMode int
 
 const (
-	modePlugin       serveMode = iota // go-plugin gRPC (existing Edge Worker path)
-	modeMetadataDump                  // --bundle-metadata: print BundleInfo JSON
-	modeCoordinator                   // --comm/--logs: msgpack-over-IPC (ADR 0003)
-	modeUsageError                    // misuse: print usage and exit non-zero
+	modePlugin                serveMode = iota // go-plugin gRPC (existing Edge Worker path)
+	modeMetadataDump                           // --bundle-metadata: print BundleInfo JSON
+	modeCoordinator                            // --comm/--logs: msgpack-over-IPC (ADR 0003)
+	modeCoordinatorUsageError                  // misuse: print usage and exit non-zero
 )
 
 // Serve is the entrypoint for your bundle, and sets it up ready for Airflow's
@@ -111,7 +112,7 @@ func Serve(bundle bundlev1.BundleProvider, opts ...ServeOpt) error {
 	case modePlugin:
 		installPluginLogger()
 		return servePlugin(bundle)
-	case modeUsageError:
+	case modeCoordinatorUsageError:
 		fmt.Fprintln(os.Stderr, "error: --comm and --logs must be supplied together")
 		flag.CommandLine.SetOutput(os.Stderr)
 		flag.Usage()
@@ -130,11 +131,8 @@ func decideMode() serveMode {
 		return modeCoordinator
 	}
 	if commSet || logsSet {
-		// Partial use is a hard error per ADR 0003: both flags are
-		// required, otherwise the supervisor is misconfigured and the
-		// runtime should fail loudly rather than fall through to
-		// go-plugin (which would hang on the missing magic-cookie).
-		return modeUsageError
+		// Partial use is a hard error, both flags are required
+		return modeCoordinatorUsageError
 	}
 	return modePlugin
 }
@@ -174,5 +172,6 @@ func servePlugin(bundle bundlev1.BundleProvider) error {
 
 	// Likely never returns
 	plugin.Serve(pluginConfig)
+
 	return nil
 }

--- a/go-sdk/bundle/bundlev1/bundlev1server/server.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/server.go
@@ -19,6 +19,7 @@ package bundlev1server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -33,6 +34,14 @@ import (
 	"github.com/apache/airflow/go-sdk/pkg/bundles/shared"
 	"github.com/apache/airflow/go-sdk/pkg/config"
 	"github.com/apache/airflow/go-sdk/pkg/execution"
+)
+
+// ErrCoordinatorFlagsIncomplete is returned by [Serve] when exactly one of
+// --comm or --logs is supplied. Both flags select coordinator mode and must
+// be set together; callers (typically main) can check for this sentinel to
+// print usage before exiting non-zero.
+var ErrCoordinatorFlagsIncomplete = errors.New(
+	"--comm and --logs must be supplied together",
 )
 
 // CLI Flags.
@@ -82,10 +91,15 @@ const (
 // Serve is the entrypoint for your bundle, and sets it up ready for Airflow's
 // Go Worker (go-plugin) or Python supervisor (coordinator protocol) to use.
 //
-// The mode is decided from CLI flags and process environment, so user code is
-// always one line:
+// The mode is decided from CLI flags and process environment. Callers should
+// surface the returned error so misuse (e.g. only one of --comm/--logs
+// supplied) produces a non-zero exit:
 //
-//	func main() { bundlev1server.Serve(&myBundle{}) }
+//	func main() {
+//	    if err := bundlev1server.Serve(&myBundle{}); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
 //
 // Zero or more options to configure the server may also be passed. There are
 // no options yet; the parameter exists to allow future additions without
@@ -113,10 +127,7 @@ func Serve(bundle bundlev1.BundleProvider, opts ...ServeOpt) error {
 		installPluginLogger()
 		return servePlugin(bundle)
 	case modeCoordinatorUsageError:
-		fmt.Fprintln(os.Stderr, "error: --comm and --logs must be supplied together")
-		flag.CommandLine.SetOutput(os.Stderr)
-		flag.Usage()
-		os.Exit(2)
+		return ErrCoordinatorFlagsIncomplete
 	}
 	return nil
 }

--- a/go-sdk/bundle/bundlev1/bundlev1server/server.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/server.go
@@ -32,9 +32,25 @@ import (
 	"github.com/apache/airflow/go-sdk/bundle/bundlev1/bundlev1server/impl"
 	"github.com/apache/airflow/go-sdk/pkg/bundles/shared"
 	"github.com/apache/airflow/go-sdk/pkg/config"
+	"github.com/apache/airflow/go-sdk/pkg/execution"
 )
 
-var versionInfo *bool = flag.Bool("bundle-metadata", false, "show the embedded bundle info")
+// Flags. The bundle-metadata flag is the existing ADR 0001 introspection
+// hook; --comm and --logs select the coordinator-mode protocol added by
+// ADR 0003. All three are read by Serve to choose a server mode below.
+var (
+	versionInfo = flag.Bool("bundle-metadata", false, "show the embedded bundle info")
+	commAddr    = flag.String(
+		"comm",
+		"",
+		"host:port of the supervisor's coordinator comm channel (selects coordinator mode)",
+	)
+	logsAddr = flag.String(
+		"logs",
+		"",
+		"host:port of the supervisor's coordinator logs channel (selects coordinator mode)",
+	)
+)
 
 // ServeOpt is an interface for defining options that can be passed to the
 // Serve function. Each implementation modifies the ServeConfig being
@@ -52,23 +68,29 @@ func (s serveConfigFunc) ApplyServeOpt(in *ServerConfig) error {
 
 type ServerConfig struct{}
 
-// Serve is the entrypoint for your bundle, and sets it up ready for Airflow's Go Worker to use
+// serveMode tags the protocol the binary will speak this run.
+type serveMode int
+
+const (
+	modePlugin       serveMode = iota // go-plugin gRPC (existing Edge Worker path)
+	modeMetadataDump                  // --bundle-metadata: print BundleInfo JSON
+	modeCoordinator                   // --comm/--logs: msgpack-over-IPC (ADR 0003)
+	modeUsageError                    // misuse: print usage and exit non-zero
+)
+
+// Serve is the entrypoint for your bundle, and sets it up ready for Airflow's
+// Go Worker (go-plugin) or Python supervisor (coordinator protocol) to use.
 //
-// Zero or more options to configure the server may also be passed. There are no options yet, this is to allow
-// future changes without breaking compatibility
+// The mode is decided from CLI flags and process environment, so user code is
+// always one line:
+//
+//	func main() { bundlev1server.Serve(&myBundle{}) }
+//
+// Zero or more options to configure the server may also be passed. There are
+// no options yet; the parameter exists to allow future additions without
+// breaking compatibility.
 func Serve(bundle bundlev1.BundleProvider, opts ...ServeOpt) error {
 	config.SetupViper("")
-
-	hcLogger := hclog.New(&hclog.LoggerOptions{
-		Level:                    hclog.Trace,
-		Output:                   os.Stderr,
-		JSONFormat:               true,
-		IncludeLocation:          true,
-		AdditionalLocationOffset: 3,
-	})
-
-	log := slog.New(hclogslog.Adapt(hcLogger))
-	slog.SetDefault(log)
 
 	flag.Parse()
 
@@ -77,16 +99,69 @@ func Serve(bundle bundlev1.BundleProvider, opts ...ServeOpt) error {
 		c.ApplyServeOpt(serveConfig)
 	}
 
-	if *versionInfo {
-		meta := bundle.GetBundleVersion()
-		data, err := json.MarshalIndent(meta, "", "    ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(data))
-		return nil
+	switch decideMode() {
+	case modeMetadataDump:
+		return dumpBundleMetadata(bundle)
+	case modeCoordinator:
+		// In coordinator mode the supervisor reads the logs channel for
+		// structured records, so configuring the hclog/stderr default
+		// logger here is unnecessary — execution.Serve installs its own
+		// slog handler against the logs socket before any user code runs.
+		return execution.Serve(bundle, *commAddr, *logsAddr)
+	case modePlugin:
+		installPluginLogger()
+		return servePlugin(bundle)
+	case modeUsageError:
+		fmt.Fprintln(os.Stderr, "error: --comm and --logs must be supplied together")
+		flag.CommandLine.SetOutput(os.Stderr)
+		flag.Usage()
+		os.Exit(2)
 	}
+	return nil
+}
 
+func decideMode() serveMode {
+	if *versionInfo {
+		return modeMetadataDump
+	}
+	commSet := *commAddr != ""
+	logsSet := *logsAddr != ""
+	if commSet && logsSet {
+		return modeCoordinator
+	}
+	if commSet || logsSet {
+		// Partial use is a hard error per ADR 0003: both flags are
+		// required, otherwise the supervisor is misconfigured and the
+		// runtime should fail loudly rather than fall through to
+		// go-plugin (which would hang on the missing magic-cookie).
+		return modeUsageError
+	}
+	return modePlugin
+}
+
+func dumpBundleMetadata(bundle bundlev1.BundleProvider) error {
+	meta := bundle.GetBundleVersion()
+	data, err := json.MarshalIndent(meta, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func installPluginLogger() {
+	hcLogger := hclog.New(&hclog.LoggerOptions{
+		Level:                    hclog.Trace,
+		Output:                   os.Stderr,
+		JSONFormat:               true,
+		IncludeLocation:          true,
+		AdditionalLocationOffset: 3,
+	})
+	log := slog.New(hclogslog.Adapt(hcLogger))
+	slog.SetDefault(log)
+}
+
+func servePlugin(bundle bundlev1.BundleProvider) error {
 	pluginConfig := &plugin.ServeConfig{
 		HandshakeConfig: shared.Handshake,
 		Plugins: plugin.PluginSet{
@@ -99,6 +174,5 @@ func Serve(bundle bundlev1.BundleProvider, opts ...ServeOpt) error {
 
 	// Likely never returns
 	plugin.Serve(pluginConfig)
-
 	return nil
 }

--- a/go-sdk/bundle/bundlev1/registry.go
+++ b/go-sdk/bundle/bundlev1/registry.go
@@ -43,9 +43,38 @@ type (
 		AddDag(dagId string) Dag
 	}
 
+	// TaskInfo describes a registered task. Coordinator-mode DAG parsing uses
+	// it to render the per-task block of a DagFileParsingResult.
+	TaskInfo struct {
+		// ID is the user-visible task id (the function name unless overridden
+		// via AddTaskWithName).
+		ID string
+		// TypeName is the unqualified Go function name (e.g. "extract").
+		TypeName string
+		// PkgPath is the Go package path (e.g. "main", "github.com/x/y").
+		PkgPath string
+	}
+
+	// DagInfo describes a registered dag together with its tasks in
+	// registration order.
+	DagInfo struct {
+		DagID string
+		Tasks []TaskInfo
+	}
+
+	// EnumerableBundle exposes the dag/task identity recorded by
+	// RegisterDags. The default registry implements it; the coordinator-mode
+	// runtime relies on it for the DAG-parse one-shot.
+	EnumerableBundle interface {
+		OrderedDags() []DagInfo
+	}
+
 	registry struct {
 		sync.RWMutex
 		taskFuncMap map[string]map[string]Task
+		taskInfo    map[string]map[string]TaskInfo
+		dagOrder    []string
+		taskOrder   map[string][]string
 	}
 )
 
@@ -64,22 +93,38 @@ func (d dagShim) AddTaskWithName(taskId string, fn any) {
 
 // Function New creates a new bundle on which Dag and Tasks can be registered
 func New() Registry {
-	return &registry{taskFuncMap: make(map[string]map[string]Task)}
+	return &registry{
+		taskFuncMap: make(map[string]map[string]Task),
+		taskInfo:    make(map[string]map[string]TaskInfo),
+		taskOrder:   make(map[string][]string),
+	}
+}
+
+func splitFullName(fullName string) (typeName, pkgPath string) {
+	// fullName looks like "main.extract" or "github.com/x/y.MyTask"; method
+	// values get a "-fm" suffix.
+	lastDot := strings.LastIndex(fullName, ".")
+	if lastDot < 0 {
+		return strings.TrimSuffix(fullName, "-fm"), ""
+	}
+	return strings.TrimSuffix(fullName[lastDot+1:], "-fm"), fullName[:lastDot]
 }
 
 func getFnName(fn reflect.Value) string {
 	fullName := runtime.FuncForPC(fn.Pointer()).Name()
-	parts := strings.Split(fullName, ".")
-	fnName := parts[len(parts)-1]
-	// Go adds `-fm` suffix to a method names
-	return strings.TrimSuffix(fnName, "-fm")
+	name, _ := splitFullName(fullName)
+	return name
 }
 
 func (r *registry) AddDag(dagId string) Dag {
+	r.RWMutex.Lock()
+	defer r.RWMutex.Unlock()
 	if _, exists := r.taskFuncMap[dagId]; exists {
 		panic(fmt.Errorf("Dag %q already exists in bundle", dagId))
 	}
 	r.taskFuncMap[dagId] = make(map[string]Task)
+	r.taskInfo[dagId] = make(map[string]TaskInfo)
+	r.dagOrder = append(r.dagOrder, dagId)
 	return dagShim{dagId, r}
 }
 
@@ -101,21 +146,28 @@ func (r *registry) registerTaskWithName(dagId, taskId string, fn any) {
 		panic(fmt.Errorf("error registering task %q for DAG %q: %w", taskId, dagId, err))
 	}
 
+	val := reflect.ValueOf(fn)
+	fullName := runtime.FuncForPC(val.Pointer()).Name()
+	typeName, pkgPath := splitFullName(fullName)
+
 	r.RWMutex.Lock()
 	defer r.RWMutex.Unlock()
 
 	dagTasks, exists := r.taskFuncMap[dagId]
-
 	if !exists {
 		dagTasks = make(map[string]Task)
 		r.taskFuncMap[dagId] = dagTasks
+		r.taskInfo[dagId] = make(map[string]TaskInfo)
+		r.dagOrder = append(r.dagOrder, dagId)
 	}
 
-	_, exists = dagTasks[taskId]
-	if exists {
+	if _, exists := dagTasks[taskId]; exists {
 		panic(fmt.Errorf("taskId %q is already registered for DAG %q", taskId, dagId))
 	}
+
 	dagTasks[taskId] = task
+	r.taskInfo[dagId][taskId] = TaskInfo{ID: taskId, TypeName: typeName, PkgPath: pkgPath}
+	r.taskOrder[dagId] = append(r.taskOrder[dagId], taskId)
 }
 
 func (r *registry) LookupTask(dagId, taskId string) (task Task, exists bool) {
@@ -128,4 +180,23 @@ func (r *registry) LookupTask(dagId, taskId string) (task Task, exists bool) {
 	}
 	task, exists = dagTasks[taskId]
 	return task, exists
+}
+
+// OrderedDags returns the registered dags in the order AddDag was called,
+// each with its tasks in the order AddTask / AddTaskWithName was called. The
+// returned slice is freshly allocated; callers may mutate it freely.
+func (r *registry) OrderedDags() []DagInfo {
+	r.RLock()
+	defer r.RUnlock()
+
+	out := make([]DagInfo, 0, len(r.dagOrder))
+	for _, dagID := range r.dagOrder {
+		taskIDs := r.taskOrder[dagID]
+		tasks := make([]TaskInfo, 0, len(taskIDs))
+		for _, tid := range taskIDs {
+			tasks = append(tasks, r.taskInfo[dagID][tid])
+		}
+		out = append(out, DagInfo{DagID: dagID, Tasks: tasks})
+	}
+	return out
 }

--- a/go-sdk/bundle/bundlev1/registry.go
+++ b/go-sdk/bundle/bundlev1/registry.go
@@ -150,9 +150,12 @@ func (r *registry) registerTaskWithName(dagId, taskId string, fn any) {
 		panic(fmt.Errorf("error registering task %q for DAG %q: %w", taskId, dagId, err))
 	}
 
-	val := reflect.ValueOf(fn)
-	fullName := runtime.FuncForPC(val.Pointer()).Name()
-	typeName, pkgPath := splitFullName(fullName)
+	// NewTaskFunction already resolved the runtime function name via
+	// reflect.ValueOf + runtime.FuncForPC; reuse the cached fullName rather
+	// than doing the same lookup a second time. The assertion is safe
+	// because NewTaskFunction is the only constructor for Task in this
+	// package and it always returns *taskFunction.
+	typeName, pkgPath := splitFullName(task.(*taskFunction).fullName)
 
 	r.RWMutex.Lock()
 	defer r.RWMutex.Unlock()

--- a/go-sdk/bundle/bundlev1/registry.go
+++ b/go-sdk/bundle/bundlev1/registry.go
@@ -62,11 +62,15 @@ type (
 		Tasks []TaskInfo
 	}
 
-	// EnumerableBundle exposes the dag/task identity recorded by
-	// RegisterDags. The default registry implements it; the coordinator-mode
-	// runtime relies on it for the DAG-parse one-shot.
-	EnumerableBundle interface {
-		OrderedDags() []DagInfo
+	// DagLister exposes the dag/task identity recorded by RegisterDags. The
+	// default registry implements it; the coordinator-mode runtime relies on
+	// it for the DAG-parse one-shot. It is a separate interface from Bundle
+	// so a future custom Bundle implementation can opt out of introspection.
+	DagLister interface {
+		// ListDags returns the registered dags in the order AddDag was
+		// called, each with its tasks in the order AddTask /
+		// AddTaskWithName was called.
+		ListDags() []DagInfo
 	}
 
 	registry struct {
@@ -182,10 +186,9 @@ func (r *registry) LookupTask(dagId, taskId string) (task Task, exists bool) {
 	return task, exists
 }
 
-// OrderedDags returns the registered dags in the order AddDag was called,
-// each with its tasks in the order AddTask / AddTaskWithName was called. The
-// returned slice is freshly allocated; callers may mutate it freely.
-func (r *registry) OrderedDags() []DagInfo {
+// ListDags implements DagLister. The returned slice is freshly allocated;
+// callers may mutate it freely.
+func (r *registry) ListDags() []DagInfo {
 	r.RLock()
 	defer r.RUnlock()
 

--- a/go-sdk/bundle/bundlev1/registry_test.go
+++ b/go-sdk/bundle/bundlev1/registry_test.go
@@ -119,6 +119,30 @@ func (s *RegistrySuite) TestAddTask_ErrorReturnType() {
 	s.True(exists)
 }
 
+func (s *RegistrySuite) TestDagLister_RecordsTaskFunctionIdentity() {
+	// Verify that TypeName and PkgPath are populated for both registration
+	// paths (AddTask uses the function's runtime name; AddTaskWithName
+	// overrides the task id but still records the underlying function name
+	// in TypeName).
+	s.dag.AddTask(myTask)
+	s.dag.AddTaskWithName("explicit", errorTask)
+
+	lister := s.reg.(DagLister)
+	dags := lister.ListDags()
+	s.Require().Len(dags, 1)
+	s.Require().Len(dags[0].Tasks, 2)
+
+	const expectedPkg = "github.com/apache/airflow/go-sdk/bundle/bundlev1"
+
+	s.Equal("myTask", dags[0].Tasks[0].ID)
+	s.Equal("myTask", dags[0].Tasks[0].TypeName)
+	s.Equal(expectedPkg, dags[0].Tasks[0].PkgPath)
+
+	s.Equal("explicit", dags[0].Tasks[1].ID)
+	s.Equal("errorTask", dags[0].Tasks[1].TypeName)
+	s.Equal(expectedPkg, dags[0].Tasks[1].PkgPath)
+}
+
 func (s *RegistrySuite) TestDagLister_PreservesRegistrationOrder() {
 	// Register dags and tasks in a deliberately non-alphabetical order to
 	// catch any accidental map-iteration ordering.

--- a/go-sdk/bundle/bundlev1/registry_test.go
+++ b/go-sdk/bundle/bundlev1/registry_test.go
@@ -118,3 +118,30 @@ func (s *RegistrySuite) TestAddTask_ErrorReturnType() {
 	_, exists := s.reg.LookupTask("dag1", "errorTask")
 	s.True(exists)
 }
+
+func (s *RegistrySuite) TestDagLister_PreservesRegistrationOrder() {
+	// Register dags and tasks in a deliberately non-alphabetical order to
+	// catch any accidental map-iteration ordering.
+	s.dag.AddTaskWithName("zeta", myTask)
+	s.dag.AddTaskWithName("alpha", myTask)
+
+	dag2 := s.reg.AddDag("dag0_added_second")
+	dag2.AddTaskWithName("first", myTask)
+	dag2.AddTaskWithName("second", myTask)
+
+	lister, ok := s.reg.(DagLister)
+	s.Require().True(ok, "registry must implement DagLister")
+
+	dags := lister.ListDags()
+	s.Require().Len(dags, 2)
+	s.Equal("dag1", dags[0].DagID)
+	s.Equal("dag0_added_second", dags[1].DagID)
+
+	s.Require().Len(dags[0].Tasks, 2)
+	s.Equal("zeta", dags[0].Tasks[0].ID)
+	s.Equal("alpha", dags[0].Tasks[1].ID)
+
+	s.Require().Len(dags[1].Tasks, 2)
+	s.Equal("first", dags[1].Tasks[0].ID)
+	s.Equal("second", dags[1].Tasks[1].ID)
+}

--- a/go-sdk/bundle/bundlev1/task.go
+++ b/go-sdk/bundle/bundlev1/task.go
@@ -45,7 +45,12 @@ func NewTaskFunction(fn any) (Task, error) {
 
 func (f *taskFunction) Execute(ctx context.Context, logger *slog.Logger) error {
 	fnType := f.fn.Type()
-	sdkClient := sdk.NewClient()
+	var sdkClient sdk.Client
+	if injected, ok := ctx.Value(sdkcontext.SdkClientContextKey).(sdk.Client); ok {
+		sdkClient = injected
+	} else {
+		sdkClient = sdk.NewClient()
+	}
 
 	reflectArgs := make([]reflect.Value, fnType.NumIn())
 	for i := range reflectArgs {

--- a/go-sdk/example/bundle/main.go
+++ b/go-sdk/example/bundle/main.go
@@ -66,7 +66,14 @@ func extract(ctx context.Context, client sdk.Client, log *slog.Logger) (any, err
 	if err != nil {
 		log.ErrorContext(ctx, "unable to get conn", "error", err)
 	} else {
-		log.InfoContext(ctx, "got conn", "conn", conn)
+		// Log only non-sensitive fields; conn.Password and any secrets in
+		// conn.Extra must never reach the log stream.
+		log.InfoContext(ctx, "got conn",
+			"conn_id", conn.ID,
+			"conn_type", conn.Type,
+			"host", conn.Host,
+			"port", conn.Port,
+		)
 	}
 	for range 10 {
 

--- a/go-sdk/example/bundle/main.go
+++ b/go-sdk/example/bundle/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"log/slog"
 	"runtime"
 	"time"
@@ -54,7 +55,9 @@ func (m *myBundle) RegisterDags(dagbag v1.Registry) error {
 }
 
 func main() {
-	bundlev1server.Serve(&myBundle{})
+	if err := bundlev1server.Serve(&myBundle{}); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func extract(ctx context.Context, client sdk.Client, log *slog.Logger) (any, error) {

--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10
 	resty.dev/v3 v3.0.0-beta.2
@@ -38,6 +39,7 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect

--- a/go-sdk/go.sum
+++ b/go-sdk/go.sum
@@ -114,6 +114,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.41.0 h1:YlEwVsGAlCvczDILpUXpIpPSL/VPugt7zHThEMLce1c=

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/apache/airflow/go-sdk/pkg/api"
+	"github.com/apache/airflow/go-sdk/sdk"
+)
+
+// CoordinatorClient implements sdk.Client by communicating with the Airflow supervisor
+// over the comm socket using msgpack-framed IPC instead of HTTP.
+type CoordinatorClient struct {
+	comm    *CoordinatorComm
+	details *StartupDetails
+}
+
+var _ sdk.Client = (*CoordinatorClient)(nil)
+
+// NewCoordinatorClient creates a new client backed by the comm socket.
+func NewCoordinatorClient(comm *CoordinatorComm, details *StartupDetails) *CoordinatorClient {
+	return &CoordinatorClient{
+		comm:    comm,
+		details: details,
+	}
+}
+
+// GetVariable requests a variable value from the supervisor.
+func (c *CoordinatorClient) GetVariable(_ context.Context, key string) (string, error) {
+	resp, err := c.comm.Communicate(GetVariableMsg{Key: key}.toMap())
+	if err != nil {
+		return "", err
+	}
+
+	result, err := decodeVariableResult(resp)
+	if err != nil {
+		return "", fmt.Errorf("decoding variable result: %w", err)
+	}
+
+	if result.Value == nil {
+		return "", fmt.Errorf("%w: %q", sdk.VariableNotFound, key)
+	}
+
+	switch v := result.Value.(type) {
+	case string:
+		return v, nil
+	default:
+		// If the value is not a string, marshal it to JSON.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshaling variable value: %w", err)
+		}
+		return string(b), nil
+	}
+}
+
+// UnmarshalJSONVariable gets a variable and unmarshals its JSON value.
+func (c *CoordinatorClient) UnmarshalJSONVariable(
+	ctx context.Context,
+	key string,
+	pointer any,
+) error {
+	val, err := c.GetVariable(ctx, key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(val), pointer)
+}
+
+// GetConnection requests a connection from the supervisor.
+func (c *CoordinatorClient) GetConnection(
+	_ context.Context,
+	connID string,
+) (sdk.Connection, error) {
+	resp, err := c.comm.Communicate(GetConnectionMsg{ConnID: connID}.toMap())
+	if err != nil {
+		return sdk.Connection{}, err
+	}
+
+	result, err := decodeConnectionResult(resp)
+	if err != nil {
+		return sdk.Connection{}, fmt.Errorf("decoding connection result: %w", err)
+	}
+
+	conn := sdk.Connection{
+		ID:   result.ConnID,
+		Type: result.ConnType,
+		Host: result.Host,
+		Port: result.Port,
+		Path: result.Schema,
+	}
+
+	if result.Login != "" {
+		login := result.Login
+		conn.Login = &login
+	}
+	if result.Password != "" {
+		password := result.Password
+		conn.Password = &password
+	}
+	if result.Extra != "" {
+		conn.Extra = map[string]any{}
+		if err := json.Unmarshal([]byte(result.Extra), &conn.Extra); err != nil {
+			return conn, fmt.Errorf("parsing connection extra: %w", err)
+		}
+	}
+
+	return conn, nil
+}
+
+// GetXCom requests an XCom value from the supervisor.
+func (c *CoordinatorClient) GetXCom(
+	_ context.Context,
+	dagId, runId, taskId string,
+	mapIndex *int,
+	key string,
+	_ any,
+) (any, error) {
+	msg := GetXComMsg{
+		Key:    key,
+		DagID:  dagId,
+		TaskID: taskId,
+		RunID:  runId,
+	}
+	if mapIndex != nil {
+		msg.MapIndex = mapIndex
+	}
+
+	resp, err := c.comm.Communicate(msg.toMap())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := decodeXComResult(resp)
+	if err != nil {
+		return nil, fmt.Errorf("decoding xcom result: %w", err)
+	}
+
+	return result.Value, nil
+}
+
+// PushXCom sends an XCom value to the supervisor.
+func (c *CoordinatorClient) PushXCom(
+	_ context.Context,
+	ti api.TaskInstance,
+	key string,
+	value any,
+) error {
+	mapIndex := -1
+	if ti.MapIndex != nil && *ti.MapIndex != -1 {
+		mapIndex = *ti.MapIndex
+	}
+
+	msg := SetXComMsg{
+		Key:      key,
+		Value:    value,
+		DagID:    ti.DagId,
+		TaskID:   ti.TaskId,
+		RunID:    ti.RunId,
+		MapIndex: mapIndex,
+	}
+
+	_, err := c.comm.Communicate(msg.toMap())
+	return err
+}

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -20,6 +20,7 @@ package execution
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -27,6 +28,31 @@ import (
 	"github.com/apache/airflow/go-sdk/pkg/api"
 	"github.com/apache/airflow/go-sdk/sdk"
 )
+
+// Supervisor-side error codes carried in the "error" field of an
+// ErrorResponse frame. The Python source of truth is
+// airflow.sdk.exceptions.ErrorType.
+const (
+	errCodeVariableNotFound   = "VARIABLE_NOT_FOUND"
+	errCodeConnectionNotFound = "CONNECTION_NOT_FOUND"
+	errCodeXComNotFound       = "XCOM_NOT_FOUND"
+)
+
+// translateApiError converts a supervisor *ApiError whose Err field matches
+// code into a sentinel-wrapped error (matching the formatting the HTTP-backed
+// sdk.client uses for the same condition). Any other error - including a
+// *ApiError with a different code - is returned unchanged so callers can keep
+// distinguishing transport / server errors from "thing not found".
+func translateApiError(err error, code string, sentinel error, key string) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *ApiError
+	if errors.As(err, &apiErr) && apiErr.Err == code {
+		return fmt.Errorf("%w: %q", sentinel, key)
+	}
+	return err
+}
 
 // CoordinatorClient implements sdk.Client by communicating with the Airflow supervisor
 // over the comm socket using msgpack-framed IPC instead of HTTP.
@@ -57,7 +83,7 @@ func (c *CoordinatorClient) GetVariable(ctx context.Context, key string) (string
 
 	resp, err := c.comm.Communicate(ctx, GetVariableMsg{Key: key}.toMap())
 	if err != nil {
-		return "", err
+		return "", translateApiError(err, errCodeVariableNotFound, sdk.VariableNotFound, key)
 	}
 
 	result, err := decodeVariableResult(resp)
@@ -113,7 +139,9 @@ func (c *CoordinatorClient) GetConnection(
 ) (sdk.Connection, error) {
 	resp, err := c.comm.Communicate(ctx, GetConnectionMsg{ConnID: connID}.toMap())
 	if err != nil {
-		return sdk.Connection{}, err
+		return sdk.Connection{}, translateApiError(
+			err, errCodeConnectionNotFound, sdk.ConnectionNotFound, connID,
+		)
 	}
 
 	result, err := decodeConnectionResult(resp)
@@ -174,7 +202,7 @@ func (c *CoordinatorClient) GetXCom(
 
 	resp, err := c.comm.Communicate(ctx, msg.toMap())
 	if err != nil {
-		return nil, err
+		return nil, translateApiError(err, errCodeXComNotFound, sdk.XComNotFound, key)
 	}
 
 	result, err := decodeXComResult(resp)

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/apache/airflow/go-sdk/pkg/api"
 	"github.com/apache/airflow/go-sdk/sdk"
@@ -45,6 +47,14 @@ func NewCoordinatorClient(comm *CoordinatorComm, details *StartupDetails) *Coord
 
 // GetVariable requests a variable value from the supervisor.
 func (c *CoordinatorClient) GetVariable(ctx context.Context, key string) (string, error) {
+	// TODO: this duplicates variableFromEnv in sdk/client.go. The env-first
+	// precedence is part of the SDK contract, so both clients should share a
+	// single helper (e.g. an exported sdk.VariableFromEnv) instead of two
+	// independent copies that can drift.
+	if env, ok := os.LookupEnv(sdk.VariableEnvPrefix + strings.ToUpper(key)); ok {
+		return env, nil
+	}
+
 	resp, err := c.comm.Communicate(ctx, GetVariableMsg{Key: key}.toMap())
 	if err != nil {
 		return "", err

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -44,8 +44,8 @@ func NewCoordinatorClient(comm *CoordinatorComm, details *StartupDetails) *Coord
 }
 
 // GetVariable requests a variable value from the supervisor.
-func (c *CoordinatorClient) GetVariable(_ context.Context, key string) (string, error) {
-	resp, err := c.comm.Communicate(GetVariableMsg{Key: key}.toMap())
+func (c *CoordinatorClient) GetVariable(ctx context.Context, key string) (string, error) {
+	resp, err := c.comm.Communicate(ctx, GetVariableMsg{Key: key}.toMap())
 	if err != nil {
 		return "", err
 	}
@@ -98,10 +98,10 @@ func (c *CoordinatorClient) UnmarshalJSONVariable(
 
 // GetConnection requests a connection from the supervisor.
 func (c *CoordinatorClient) GetConnection(
-	_ context.Context,
+	ctx context.Context,
 	connID string,
 ) (sdk.Connection, error) {
-	resp, err := c.comm.Communicate(GetConnectionMsg{ConnID: connID}.toMap())
+	resp, err := c.comm.Communicate(ctx, GetConnectionMsg{ConnID: connID}.toMap())
 	if err != nil {
 		return sdk.Connection{}, err
 	}
@@ -146,7 +146,7 @@ func (c *CoordinatorClient) GetConnection(
 
 // GetXCom requests an XCom value from the supervisor.
 func (c *CoordinatorClient) GetXCom(
-	_ context.Context,
+	ctx context.Context,
 	dagId, runId, taskId string,
 	mapIndex *int,
 	key string,
@@ -162,7 +162,7 @@ func (c *CoordinatorClient) GetXCom(
 		msg.MapIndex = mapIndex
 	}
 
-	resp, err := c.comm.Communicate(msg.toMap())
+	resp, err := c.comm.Communicate(ctx, msg.toMap())
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *CoordinatorClient) GetXCom(
 
 // PushXCom sends an XCom value to the supervisor.
 func (c *CoordinatorClient) PushXCom(
-	_ context.Context,
+	ctx context.Context,
 	ti api.TaskInstance,
 	key string,
 	value any,
@@ -196,6 +196,6 @@ func (c *CoordinatorClient) PushXCom(
 		MapIndex: mapIndex,
 	}
 
-	_, err := c.comm.Communicate(msg.toMap())
+	_, err := c.comm.Communicate(ctx, msg.toMap())
 	return err
 }

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -59,6 +59,13 @@ func (c *CoordinatorClient) GetVariable(_ context.Context, key string) (string, 
 		return "", fmt.Errorf("%w: %q", sdk.VariableNotFound, key)
 	}
 
+	// TODO: register secret-named variables with a SecretsMasker so the
+	// returned value is automatically redacted from subsequent task logs,
+	// matching Python's airflow.models.variable.Variable.get behaviour.
+	// Pairs with the "TODO: mask secrets here" hook in
+	// pkg/worker/runner.go's task log handler — both halves are needed
+	// before secret masking actually works end-to-end.
+
 	switch v := result.Value.(type) {
 	case string:
 		return v, nil

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -134,6 +134,13 @@ func (c *CoordinatorClient) GetConnection(
 		}
 	}
 
+	// TODO: register conn.Password and sensitive-keyed entries of conn.Extra
+	// with a SecretsMasker so they are auto-redacted from subsequent task
+	// logs, matching Python's airflow.models.connection.Connection.get
+	// behaviour. Pairs with the "TODO: mask secrets here" hook in
+	// pkg/worker/runner.go's task log handler and the matching TODO on
+	// GetVariable above.
+
 	return conn, nil
 }
 

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -63,7 +63,11 @@ func (c *CoordinatorClient) GetVariable(_ context.Context, key string) (string, 
 	case string:
 		return v, nil
 	default:
-		// If the value is not a string, marshal it to JSON.
+		// Airflow Variables are stored as strings, but the supervisor
+		// decodes msgpack into native Go types — a supervisor that
+		// returns a list/map/number means the caller stored JSON.
+		// Re-encode it so UnmarshalJSONVariable still works uniformly
+		// across HTTP and coordinator modes.
 		b, err := json.Marshal(v)
 		if err != nil {
 			return "", fmt.Errorf("marshaling variable value: %w", err)

--- a/go-sdk/pkg/execution/client_test.go
+++ b/go-sdk/pkg/execution/client_test.go
@@ -20,12 +20,15 @@ package execution
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/apache/airflow/go-sdk/sdk"
 )
 
 // TestCoordinatorClientGetVariableEnvOverride verifies that an
@@ -67,6 +70,96 @@ func TestCoordinatorClientGetVariableNoEnvOverride(t *testing.T) {
 	val, err := client.GetVariable(context.Background(), "my_key")
 	require.NoError(t, err)
 	assert.Equal(t, "supervisor_value", val)
+}
+
+// TestCoordinatorClientErrorTranslation verifies that GetVariable,
+// GetConnection, and GetXCom translate the supervisor's *_NOT_FOUND error
+// codes into the SDK sentinel errors so call-site `errors.Is` checks behave
+// the same in coordinator and HTTP mode.
+func TestCoordinatorClientErrorTranslation(t *testing.T) {
+	tests := []struct {
+		name      string
+		errorCode string
+		sentinel  error
+		call      func(client *CoordinatorClient) error
+	}{
+		{
+			name:      "GetVariable maps VARIABLE_NOT_FOUND",
+			errorCode: "VARIABLE_NOT_FOUND",
+			sentinel:  sdk.VariableNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetVariable(context.Background(), "missing")
+				return err
+			},
+		},
+		{
+			name:      "GetConnection maps CONNECTION_NOT_FOUND",
+			errorCode: "CONNECTION_NOT_FOUND",
+			sentinel:  sdk.ConnectionNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetConnection(context.Background(), "missing")
+				return err
+			},
+		},
+		{
+			name:      "GetXCom maps XCOM_NOT_FOUND",
+			errorCode: "XCOM_NOT_FOUND",
+			sentinel:  sdk.XComNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetXCom(
+					context.Background(), "dag", "run", "task", nil, "missing", nil,
+				)
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+				"type":   "ErrorResponse",
+				"error":  tc.errorCode,
+				"detail": "supervisor said no",
+			})
+			var responseBuf bytes.Buffer
+			require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+			client := NewCoordinatorClient(comm, nil)
+
+			err := tc.call(client)
+			require.Error(t, err)
+			require.True(
+				t,
+				errors.Is(err, tc.sentinel),
+				"expected errors.Is(%v, %v) to be true", err, tc.sentinel,
+			)
+		})
+	}
+}
+
+// TestCoordinatorClientErrorPassThrough verifies that unrelated *ApiError
+// values (e.g. a generic API_SERVER_ERROR) are returned unchanged.
+func TestCoordinatorClientErrorPassThrough(t *testing.T) {
+	responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "API_SERVER_ERROR",
+		"detail": "boom",
+	})
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	_, err := client.GetVariable(context.Background(), "any_key")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, sdk.VariableNotFound),
+		"generic supervisor errors must not be translated to VariableNotFound")
+	var apiErr *ApiError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "API_SERVER_ERROR", apiErr.Err)
 }
 
 // assertNoReadReader fails the test on any Read call.

--- a/go-sdk/pkg/execution/client_test.go
+++ b/go-sdk/pkg/execution/client_test.go
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoordinatorClientGetVariableEnvOverride verifies that an
+// AIRFLOW_VAR_<UPPER(key)> environment override short-circuits the comm
+// socket, matching the HTTP-backed sdk.client behaviour.
+func TestCoordinatorClientGetVariableEnvOverride(t *testing.T) {
+	t.Setenv("AIRFLOW_VAR_MY_KEY", "env_value")
+
+	// A nil reader would panic if the dispatcher ever read; an empty
+	// io.Discard write target would silently accept any request. Use both
+	// to assert *no* IO occurred by failing if anything is read or written.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(assertNoReadReader{t: t}, assertNoWriteWriter{t: t}, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	val, err := client.GetVariable(context.Background(), "my_key")
+	require.NoError(t, err)
+	assert.Equal(t, "env_value", val)
+}
+
+// TestCoordinatorClientGetVariableNoEnvOverride verifies the supervisor
+// round trip still runs when no env override is set.
+func TestCoordinatorClientGetVariableNoEnvOverride(t *testing.T) {
+	responsePayload, err := encodeRequest(0, map[string]any{
+		"type":  "VariableResult",
+		"key":   "my_key",
+		"value": "supervisor_value",
+	})
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	val, err := client.GetVariable(context.Background(), "my_key")
+	require.NoError(t, err)
+	assert.Equal(t, "supervisor_value", val)
+}
+
+// assertNoReadReader fails the test on any Read call.
+type assertNoReadReader struct{ t *testing.T }
+
+func (f assertNoReadReader) Read(p []byte) (int, error) {
+	f.t.Helper()
+	f.t.Fatalf("unexpected Read on comm socket: env override should have short-circuited")
+	return 0, nil
+}
+
+// assertNoWriteWriter fails the test on any Write call.
+type assertNoWriteWriter struct{ t *testing.T }
+
+func (f assertNoWriteWriter) Write(p []byte) (int, error) {
+	f.t.Helper()
+	f.t.Fatalf("unexpected Write on comm socket: env override should have short-circuited")
+	return 0, nil
+}

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -18,6 +18,7 @@
 package execution
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -25,8 +26,20 @@ import (
 	"sync/atomic"
 )
 
-// CoordinatorComm manages bidirectional communication with the Airflow supervisor
-// over a length-prefixed msgpack socket connection.
+// CoordinatorComm manages bidirectional communication with the Airflow
+// supervisor over a length-prefixed msgpack socket connection.
+//
+// Reads are multiplexed by frame ID. A single background reader goroutine,
+// lazily started on the first Communicate call, consumes inbound frames and
+// dispatches each one to the Communicate caller whose request used that ID.
+// This lets multiple goroutines call Communicate concurrently without
+// serialising the full send-then-read round trip behind a single mutex, and
+// guarantees the response a caller receives matches the request it sent.
+//
+// The supervisor's initial frame (DagFileParseRequest or StartupDetails)
+// arrives unsolicited, before any client request is in flight, and is read
+// synchronously via ReadMessage; ReadMessage must not be called after the
+// dispatcher has been started.
 type CoordinatorComm struct {
 	reader io.Reader
 	writer io.Writer
@@ -34,23 +47,49 @@ type CoordinatorComm struct {
 	logger *slog.Logger
 
 	wmu sync.Mutex // serialises writes
-	rmu sync.Mutex // serialises reads
+
+	// Multiplexer state. mu protects every field below.
+	mu      sync.Mutex
+	pending map[int]chan frameResult
+	started bool
+	readErr error
 }
+
+// frameResult is the value the dispatcher delivers to a Communicate caller.
+type frameResult struct {
+	frame IncomingFrame
+	err   error
+}
+
+// ErrDispatcherClosed is wrapped into the error Communicate returns once the
+// background reader goroutine has exited — typically because the supervisor
+// closed the comm socket.
+var ErrDispatcherClosed = errors.New("coordinator comm: dispatcher closed")
 
 // NewCoordinatorComm creates a new communication channel.
 func NewCoordinatorComm(reader io.Reader, writer io.Writer, logger *slog.Logger) *CoordinatorComm {
 	return &CoordinatorComm{
-		reader: reader,
-		writer: writer,
-		logger: logger,
+		reader:  reader,
+		writer:  writer,
+		logger:  logger,
+		pending: make(map[int]chan frameResult),
 	}
 }
 
-// ReadMessage reads and decodes one frame from the comm socket.
-// It returns the raw IncomingFrame with decoded map bodies.
+// ReadMessage reads and decodes one frame directly from the comm socket.
+// It is used to read the supervisor's initial frame before any request/response
+// traffic begins. Calling it after the dispatcher has started would race the
+// reader goroutine for input bytes, so it returns an error in that case.
 func (c *CoordinatorComm) ReadMessage() (IncomingFrame, error) {
-	c.rmu.Lock()
-	defer c.rmu.Unlock()
+	c.mu.Lock()
+	started := c.started
+	c.mu.Unlock()
+	if started {
+		return IncomingFrame{}, errors.New(
+			"coordinator comm: ReadMessage cannot be used after the dispatcher has started",
+		)
+	}
+
 	frame, err := readFrame(c.reader)
 	if err != nil {
 		return IncomingFrame{}, fmt.Errorf("reading frame: %w", err)
@@ -59,7 +98,8 @@ func (c *CoordinatorComm) ReadMessage() (IncomingFrame, error) {
 	return frame, nil
 }
 
-// SendRequest sends a request frame (2-element: [id, body]) to the supervisor.
+// SendRequest writes a request frame (2-element [id, body]) to the supervisor.
+// Concurrent calls are serialised so frames are never interleaved on the wire.
 func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
 	payload, err := encodeRequest(id, body)
 	if err != nil {
@@ -71,25 +111,48 @@ func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
 	return writeFrame(c.writer, payload)
 }
 
-// Communicate sends a request and waits for the corresponding response.
-// This is a synchronous request-response: the caller sends a request and blocks
-// until the next frame arrives. The protocol is single-threaded on the comm socket.
+// Communicate sends a request and blocks until the supervisor's response with
+// the matching frame ID is delivered by the dispatcher. Safe to call
+// concurrently from multiple goroutines.
 //
-// If the response contains an error element, it is returned as an ApiError.
-// Otherwise, the response body map is returned.
+// If the response carries an error (either as the third element of a 3-tuple
+// frame or as a body whose "type" is "ErrorResponse") it is returned as an
+// *ApiError. If the dispatcher's read loop has terminated, the underlying read
+// error is returned wrapped in ErrDispatcherClosed.
 func (c *CoordinatorComm) Communicate(body map[string]any) (map[string]any, error) {
 	id := int(c.nextID.Add(1) - 1)
+	ch := make(chan frameResult, 1)
+
+	// Register the waiter under the same lock the dispatcher uses, and before
+	// sending the request, so the dispatcher can never deliver the response
+	// (or a terminal read error) before this caller is ready to receive it.
+	c.mu.Lock()
+	if !c.started {
+		c.started = true
+		go c.readLoop()
+	}
+	if c.readErr != nil {
+		err := c.readErr
+		c.mu.Unlock()
+		return nil, fmt.Errorf("%w: %w", ErrDispatcherClosed, err)
+	}
+	c.pending[id] = ch
+	c.mu.Unlock()
 
 	if err := c.SendRequest(id, body); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
 		return nil, err
 	}
 
-	frame, err := c.ReadMessage()
-	if err != nil {
-		return nil, err
+	result := <-ch
+	if result.err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDispatcherClosed, result.err)
 	}
+	frame := result.frame
 
-	// Check for error in the response.
+	// Check for error in the third element of a response frame.
 	if frame.Err != nil {
 		errResp := decodeErrorResponse(frame.Err)
 		if errResp != nil {
@@ -112,6 +175,41 @@ func (c *CoordinatorComm) Communicate(body map[string]any) (map[string]any, erro
 	}
 
 	return frame.Body, nil
+}
+
+// readLoop is the dispatcher: it reads frames from the comm socket and routes
+// each one to the channel registered by the matching Communicate caller. When
+// readFrame returns an error (typically io.EOF on supervisor shutdown), it
+// fans the error out to every pending waiter and exits; any subsequent
+// Communicate call sees the error via readErr and returns immediately.
+func (c *CoordinatorComm) readLoop() {
+	for {
+		frame, err := readFrame(c.reader)
+		if err != nil {
+			c.mu.Lock()
+			c.readErr = err
+			pending := c.pending
+			c.pending = nil
+			c.mu.Unlock()
+			for _, ch := range pending {
+				ch <- frameResult{err: err}
+			}
+			return
+		}
+		c.logger.Debug("Received frame", "id", frame.ID)
+
+		c.mu.Lock()
+		ch, ok := c.pending[frame.ID]
+		if ok {
+			delete(c.pending, frame.ID)
+		}
+		c.mu.Unlock()
+		if !ok {
+			c.logger.Warn("Discarding frame with no matching waiter", "id", frame.ID)
+			continue
+		}
+		ch <- frameResult{frame: frame}
+	}
 }
 
 // ApiError represents an error returned by the supervisor over the comm socket.

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// CoordinatorComm manages bidirectional communication with the Airflow supervisor
+// over a length-prefixed msgpack socket connection.
+type CoordinatorComm struct {
+	reader io.Reader
+	writer io.Writer
+	nextID atomic.Int32
+	logger *slog.Logger
+
+	wmu sync.Mutex // serialises writes
+	rmu sync.Mutex // serialises reads
+}
+
+// NewCoordinatorComm creates a new communication channel.
+func NewCoordinatorComm(reader io.Reader, writer io.Writer, logger *slog.Logger) *CoordinatorComm {
+	return &CoordinatorComm{
+		reader: reader,
+		writer: writer,
+		logger: logger,
+	}
+}
+
+// ReadMessage reads and decodes one frame from the comm socket.
+// It returns the raw IncomingFrame with decoded map bodies.
+func (c *CoordinatorComm) ReadMessage() (IncomingFrame, error) {
+	c.rmu.Lock()
+	defer c.rmu.Unlock()
+	frame, err := readFrame(c.reader)
+	if err != nil {
+		return IncomingFrame{}, fmt.Errorf("reading frame: %w", err)
+	}
+	c.logger.Debug("Received frame", "id", frame.ID)
+	return frame, nil
+}
+
+// SendRequest sends a request frame (2-element: [id, body]) to the supervisor.
+func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
+	payload, err := encodeRequest(id, body)
+	if err != nil {
+		return fmt.Errorf("encoding request: %w", err)
+	}
+	c.logger.Debug("Sending request", "id", id)
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	return writeFrame(c.writer, payload)
+}
+
+// Communicate sends a request and waits for the corresponding response.
+// This is a synchronous request-response: the caller sends a request and blocks
+// until the next frame arrives. The protocol is single-threaded on the comm socket.
+//
+// If the response contains an error element, it is returned as an ApiError.
+// Otherwise, the response body map is returned.
+func (c *CoordinatorComm) Communicate(body map[string]any) (map[string]any, error) {
+	id := int(c.nextID.Add(1) - 1)
+
+	if err := c.SendRequest(id, body); err != nil {
+		return nil, err
+	}
+
+	frame, err := c.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for error in the response.
+	if frame.Err != nil {
+		errResp := decodeErrorResponse(frame.Err)
+		if errResp != nil {
+			return nil, &ApiError{
+				Err:    errResp.Error,
+				Detail: errResp.Detail,
+			}
+		}
+	}
+
+	// Also check if the body itself is an ErrorResponse.
+	if frame.Body != nil {
+		if typ, _ := frame.Body["type"].(string); typ == "ErrorResponse" {
+			errResp := decodeErrorResponse(frame.Body)
+			return nil, &ApiError{
+				Err:    errResp.Error,
+				Detail: errResp.Detail,
+			}
+		}
+	}
+
+	return frame.Body, nil
+}
+
+// ApiError represents an error returned by the supervisor over the comm socket.
+type ApiError struct {
+	Err    string
+	Detail any
+}
+
+func (e *ApiError) Error() string {
+	if e.Detail != nil {
+		return fmt.Sprintf("[%s] %v", e.Err, e.Detail)
+	}
+	return e.Err
+}

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -43,7 +43,7 @@ import (
 type CoordinatorComm struct {
 	reader io.Reader
 	writer io.Writer
-	nextID atomic.Int32
+	nextID atomic.Int64
 	logger *slog.Logger
 
 	wmu sync.Mutex // serialises writes

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -18,6 +18,7 @@
 package execution
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -112,14 +113,21 @@ func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
 }
 
 // Communicate sends a request and blocks until the supervisor's response with
-// the matching frame ID is delivered by the dispatcher. Safe to call
-// concurrently from multiple goroutines.
+// the matching frame ID is delivered by the dispatcher, ctx is cancelled, or
+// its deadline expires. Safe to call concurrently from multiple goroutines.
 //
 // If the response carries an error (either as the third element of a 3-tuple
 // frame or as a body whose "type" is "ErrorResponse") it is returned as an
 // *ApiError. If the dispatcher's read loop has terminated, the underlying read
 // error is returned wrapped in ErrDispatcherClosed.
-func (c *CoordinatorComm) Communicate(body map[string]any) (map[string]any, error) {
+func (c *CoordinatorComm) Communicate(
+	ctx context.Context,
+	body map[string]any,
+) (map[string]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	id := int(c.nextID.Add(1) - 1)
 	ch := make(chan frameResult, 1)
 
@@ -146,7 +154,20 @@ func (c *CoordinatorComm) Communicate(body map[string]any) (map[string]any, erro
 		return nil, err
 	}
 
-	result := <-ch
+	var result frameResult
+	select {
+	case result = <-ch:
+	case <-ctx.Done():
+		// Drop the waiter so a late supervisor reply is logged-and-discarded
+		// by the dispatcher rather than piling up in c.pending. The dispatcher
+		// may have already delivered the response into the buffered channel
+		// between the select and this delete; that delivery is harmless (the
+		// channel is buffered to 1 and the caller has already given up).
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	}
 	if result.err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrDispatcherClosed, result.err)
 	}

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestCoordinatorCommReadMessage(t *testing.T) {
+	body := map[string]any{
+		"type": "DagFileParseRequest",
+		"file": "/path/to/dags.go",
+	}
+	payload, err := encodeRequest(0, body)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, writeFrame(&buf, payload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&buf, io.Discard, logger)
+
+	frame, err := comm.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, 0, frame.ID)
+	assert.Equal(t, "DagFileParseRequest", frame.Body["type"])
+}
+
+func TestCoordinatorCommSendRequest(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), &buf, logger)
+
+	body := map[string]any{
+		"type": "GetVariable",
+		"key":  "test_key",
+	}
+	err := comm.SendRequest(5, body)
+	require.NoError(t, err)
+
+	frame, err := readFrame(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, 5, frame.ID)
+	assert.Equal(t, "GetVariable", frame.Body["type"])
+	assert.Equal(t, "test_key", frame.Body["key"])
+}
+
+func TestCoordinatorCommCommunicate(t *testing.T) {
+	// Prepare a response frame for the mock supervisor to "return".
+	responseBody := map[string]any{
+		"type":  "VariableResult",
+		"key":   "my_var",
+		"value": "my_value",
+	}
+	responsePayload, err := encodeRequest(0, responseBody)
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	result, err := comm.Communicate(GetVariableMsg{Key: "my_var"}.toMap())
+	require.NoError(t, err)
+	assert.Equal(t, "VariableResult", result["type"])
+	assert.Equal(t, "my_value", result["value"])
+
+	// Verify the request was sent.
+	sentFrame, err := readFrame(&requestBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "GetVariable", sentFrame.Body["type"])
+}
+
+func TestCoordinatorCommCommunicateError(t *testing.T) {
+	// Build a 3-element response frame with an error.
+	responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "not_found",
+		"detail": "Variable not found",
+	})
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	_, err := comm.Communicate(GetVariableMsg{Key: "missing"}.toMap())
+	require.Error(t, err)
+
+	apiErr, ok := err.(*ApiError)
+	require.True(t, ok)
+	assert.Equal(t, "not_found", apiErr.Err)
+}
+
+func TestCoordinatorCommCommunicateBodyError(t *testing.T) {
+	// Error can also come in the body element of a 2-element frame.
+	errorBody := map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "server_error",
+		"detail": "internal failure",
+	}
+	responsePayload, err := encodeRequest(0, errorBody)
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	_, err = comm.Communicate(GetVariableMsg{Key: "test"}.toMap())
+	require.Error(t, err)
+
+	apiErr, ok := err.(*ApiError)
+	require.True(t, ok)
+	assert.Equal(t, "server_error", apiErr.Err)
+}
+
+func TestApiErrorFormat(t *testing.T) {
+	err := &ApiError{Err: "not_found", Detail: "Variable 'x' not found"}
+	assert.Equal(t, "[not_found] Variable 'x' not found", err.Error())
+
+	err2 := &ApiError{Err: "server_error"}
+	assert.Equal(t, "server_error", err2.Error())
+}
+
+// encodeResponseFrame encodes a 3-element response frame for testing.
+func encodeResponseFrame(t *testing.T, id int, body, errBody map[string]any) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(3))
+	require.NoError(t, enc.EncodeInt(int64(id)))
+	require.NoError(t, enc.Encode(body))
+	require.NoError(t, enc.Encode(errBody))
+	return buf.Bytes()
+}

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -287,13 +287,19 @@ func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(respR, reqW, logger)
 
-	// Drain requests so the writes do not block. The supervisor logic below
-	// drives the response order explicitly.
+	// The supervisor reads exactly two request frames and reports each id back
+	// through reqIDs. A successful readFrame is proof the caller already
+	// registered its waiter (Communicate registers before it calls
+	// SendRequest), so the test can sequence id allocation deterministically
+	// instead of relying on sleeps.
+	reqIDs := make(chan int, 2)
 	go func() {
-		for {
-			if _, err := readFrame(reqR); err != nil {
+		for i := 0; i < 2; i++ {
+			frame, err := readFrame(reqR)
+			if err != nil {
 				return
 			}
+			reqIDs <- frame.ID
 		}
 	}()
 
@@ -303,18 +309,17 @@ func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
 		require.NoError(t, err)
 		results <- resp
 	}()
-	// Allow the first call's request id (0) to be allocated and registered.
-	time.Sleep(20 * time.Millisecond)
+	firstID := <-reqIDs
 	go func() {
 		resp, err := comm.Communicate(map[string]any{"type": "GetVariable", "key": "second"})
 		require.NoError(t, err)
 		results <- resp
 	}()
-	time.Sleep(20 * time.Millisecond)
+	secondID := <-reqIDs
 
-	// Reply to the SECOND caller (id 1) first. The first caller must keep
-	// waiting; only the second caller unblocks.
-	payload, err := encodeRequest(1, map[string]any{
+	// Reply to the SECOND caller first. The first caller must keep waiting;
+	// only the second caller unblocks.
+	payload, err := encodeRequest(secondID, map[string]any{
 		"type": "VariableResult",
 		"key":  "second",
 	})
@@ -336,7 +341,7 @@ func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
 	}
 
 	// Now reply to the first caller.
-	payload, err = encodeRequest(0, map[string]any{
+	payload, err = encodeRequest(firstID, map[string]any{
 		"type": "VariableResult",
 		"key":  "first",
 	})
@@ -367,7 +372,14 @@ func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(respR, reqW, logger)
 
+	// registered fires once the supervisor has read the caller's request
+	// frame, which guarantees Communicate has already registered its waiter
+	// (registration precedes SendRequest).
+	registered := make(chan struct{})
 	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(registered)
+		}
 		for {
 			if _, err := readFrame(reqR); err != nil {
 				return
@@ -381,8 +393,7 @@ func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
 		errCh <- err
 	}()
 
-	// Give Communicate time to register its waiter.
-	time.Sleep(50 * time.Millisecond)
+	<-registered
 
 	// Close the response stream; the dispatcher's read returns io.EOF (or
 	// io.ErrClosedPipe) and must fan that error out to the pending waiter.
@@ -417,8 +428,14 @@ func TestCoordinatorCommReadMessageAfterDispatcherStarted(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(respR, reqW, logger)
 
-	// Drain requests so the first Communicate's write doesn't deadlock.
+	// Signal once Communicate's request has reached the wire; by then the
+	// dispatcher goroutine has been started (Communicate starts it before
+	// SendRequest under the same lock).
+	dispatcherUp := make(chan struct{})
 	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(dispatcherUp)
+		}
 		for {
 			if _, err := readFrame(reqR); err != nil {
 				return
@@ -430,7 +447,7 @@ func TestCoordinatorCommReadMessageAfterDispatcherStarted(t *testing.T) {
 	go func() {
 		_, _ = comm.Communicate(map[string]any{"type": "GetVariable"})
 	}()
-	time.Sleep(50 * time.Millisecond)
+	<-dispatcherUp
 
 	_, err := comm.ReadMessage()
 	require.Error(t, err)
@@ -457,7 +474,14 @@ func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(respR, reqW, logger)
 
+	// Report the caller's allocated request id as soon as the supervisor sees
+	// its frame on the wire. By then Communicate has registered its waiter,
+	// so we can safely send the stray frame and then the matching response.
+	reqIDs := make(chan int, 1)
 	go func() {
+		if frame, err := readFrame(reqR); err == nil {
+			reqIDs <- frame.ID
+		}
 		for {
 			if _, err := readFrame(reqR); err != nil {
 				return
@@ -480,12 +504,11 @@ func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
 		}
 		respCh <- resp
 	}()
-	// Let Communicate register its waiter (id 0), then send the stray frame.
-	time.Sleep(50 * time.Millisecond)
+	id := <-reqIDs
 	require.NoError(t, writeFrame(respW, stray))
 
 	// Now send the real response.
-	payload, err := encodeRequest(0, map[string]any{
+	payload, err := encodeRequest(id, map[string]any{
 		"type": "VariableResult",
 		"key":  "ok",
 	})

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -19,6 +19,7 @@ package execution
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -523,4 +524,52 @@ func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Communicate did not return")
 	}
+}
+
+// failingWriter is an io.Writer that always returns the same error. Used by
+// TestCoordinatorCommSendRequestErrorCleansPending to force SendRequest to
+// fail after a Communicate caller has already registered its waiter.
+type failingWriter struct {
+	err error
+}
+
+func (w *failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+// TestCoordinatorCommSendRequestErrorCleansPending verifies that when
+// SendRequest fails (e.g. the underlying socket has died), Communicate removes
+// the waiter it registered before sending. If the cleanup path were ever
+// dropped, the entry would leak in c.pending and a stale supervisor reply
+// arriving on that id would silently land on a channel nobody is reading.
+func TestCoordinatorCommSendRequestErrorCleansPending(t *testing.T) {
+	// The reader side is a never-fed pipe; the dispatcher started by
+	// Communicate parks on readFrame until t.Cleanup closes it.
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		respR.Close()
+		respW.Close()
+	})
+
+	writeErr := errors.New("simulated write failure")
+	comm := NewCoordinatorComm(
+		respR,
+		&failingWriter{err: writeErr},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	comm.mu.Lock()
+	pendingLen := len(comm.pending)
+	comm.mu.Unlock()
+	assert.Equal(
+		t,
+		0,
+		pendingLen,
+		"pending map should be empty after SendRequest failure, got %d entries",
+		pendingLen,
+	)
 }

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -19,6 +19,7 @@ package execution
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -87,7 +88,7 @@ func TestCoordinatorCommCommunicate(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
 
-	result, err := comm.Communicate(GetVariableMsg{Key: "my_var"}.toMap())
+	result, err := comm.Communicate(context.Background(), GetVariableMsg{Key: "my_var"}.toMap())
 	require.NoError(t, err)
 	assert.Equal(t, "VariableResult", result["type"])
 	assert.Equal(t, "my_value", result["value"])
@@ -113,7 +114,7 @@ func TestCoordinatorCommCommunicateError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
 
-	_, err := comm.Communicate(GetVariableMsg{Key: "missing"}.toMap())
+	_, err := comm.Communicate(context.Background(), GetVariableMsg{Key: "missing"}.toMap())
 	require.Error(t, err)
 
 	apiErr, ok := err.(*ApiError)
@@ -138,7 +139,7 @@ func TestCoordinatorCommCommunicateBodyError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
 
-	_, err = comm.Communicate(GetVariableMsg{Key: "test"}.toMap())
+	_, err = comm.Communicate(context.Background(), GetVariableMsg{Key: "test"}.toMap())
 	require.Error(t, err)
 
 	apiErr, ok := err.(*ApiError)
@@ -227,7 +228,10 @@ func TestCoordinatorCommCommunicateConcurrentOutOfOrder(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resp, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+			resp, err := comm.Communicate(
+				context.Background(),
+				map[string]any{"type": "GetVariable"},
+			)
 			if err != nil {
 				errCh <- err
 				return
@@ -306,13 +310,19 @@ func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
 
 	results := make(chan map[string]any, 2)
 	go func() {
-		resp, err := comm.Communicate(map[string]any{"type": "GetVariable", "key": "first"})
+		resp, err := comm.Communicate(
+			context.Background(),
+			map[string]any{"type": "GetVariable", "key": "first"},
+		)
 		require.NoError(t, err)
 		results <- resp
 	}()
 	firstID := <-reqIDs
 	go func() {
-		resp, err := comm.Communicate(map[string]any{"type": "GetVariable", "key": "second"})
+		resp, err := comm.Communicate(
+			context.Background(),
+			map[string]any{"type": "GetVariable", "key": "second"},
+		)
 		require.NoError(t, err)
 		results <- resp
 	}()
@@ -390,7 +400,7 @@ func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+		_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
 		errCh <- err
 	}()
 
@@ -409,7 +419,7 @@ func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
 	}
 
 	// A subsequent Communicate must short-circuit on the cached read error.
-	_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+	_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrDispatcherClosed)
 }
@@ -446,7 +456,7 @@ func TestCoordinatorCommReadMessageAfterDispatcherStarted(t *testing.T) {
 
 	// First Communicate starts the dispatcher (lazily).
 	go func() {
-		_, _ = comm.Communicate(map[string]any{"type": "GetVariable"})
+		_, _ = comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
 	}()
 	<-dispatcherUp
 
@@ -498,7 +508,7 @@ func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
 	errCh := make(chan error, 1)
 	respCh := make(chan map[string]any, 1)
 	go func() {
-		resp, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+		resp, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
 		if err != nil {
 			errCh <- err
 			return
@@ -558,7 +568,7 @@ func TestCoordinatorCommSendRequestErrorCleansPending(t *testing.T) {
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 	)
 
-	_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+	_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, writeErr)
 
@@ -572,4 +582,84 @@ func TestCoordinatorCommSendRequestErrorCleansPending(t *testing.T) {
 		"pending map should be empty after SendRequest failure, got %d entries",
 		pendingLen,
 	)
+}
+
+// TestCoordinatorCommCommunicateContextCancelled verifies that a Communicate
+// caller whose context is cancelled while waiting for a response returns
+// promptly with the context error and removes its entry from c.pending so a
+// late supervisor reply lands in the dispatcher's "no matching waiter" path
+// instead of leaking memory.
+func TestCoordinatorCommCommunicateContextCancelled(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Drain the request side so SendRequest does not block; signal once the
+	// caller's request frame has reached the wire so we know its waiter is
+	// registered before we cancel ctx.
+	registered := make(chan struct{})
+	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(registered)
+		}
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := comm.Communicate(ctx, map[string]any{"type": "GetVariable"})
+		errCh <- err
+	}()
+
+	<-registered
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return after ctx was cancelled")
+	}
+
+	comm.mu.Lock()
+	pendingLen := len(comm.pending)
+	comm.mu.Unlock()
+	assert.Equal(
+		t,
+		0,
+		pendingLen,
+		"pending map should be empty after ctx cancellation, got %d entries",
+		pendingLen,
+	)
+}
+
+// TestCoordinatorCommCommunicateContextAlreadyDone verifies that a Communicate
+// call whose context is already cancelled returns immediately without sending
+// a request frame or starting the dispatcher.
+func TestCoordinatorCommCommunicateContextAlreadyDone(t *testing.T) {
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), &requestBuf, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := comm.Communicate(ctx, map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, requestBuf.Len(), "no request frame should have been sent")
 }

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -21,7 +21,9 @@ import (
 	"bytes"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -163,4 +165,339 @@ func encodeResponseFrame(t *testing.T, id int, body, errBody map[string]any) []b
 	require.NoError(t, enc.Encode(body))
 	require.NoError(t, enc.Encode(errBody))
 	return buf.Bytes()
+}
+
+// TestCoordinatorCommCommunicateConcurrentOutOfOrder exercises the dispatcher:
+// it fires Communicate from N goroutines concurrently, then has a mock
+// supervisor respond in reverse order. Each caller must receive the response
+// whose ID matches the request it sent, even though responses arrive in a
+// different order than requests.
+func TestCoordinatorCommCommunicateConcurrentOutOfOrder(t *testing.T) {
+	const N = 8
+
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Mock supervisor: read N request frames, then write the responses back in
+	// reverse order. Each response echoes the request id so the client can
+	// verify the response matches the request.
+	supervisorDone := make(chan error, 1)
+	go func() {
+		ids := make([]int, 0, N)
+		for i := 0; i < N; i++ {
+			frame, err := readFrame(reqR)
+			if err != nil {
+				supervisorDone <- err
+				return
+			}
+			ids = append(ids, frame.ID)
+		}
+		for i := len(ids) - 1; i >= 0; i-- {
+			payload, err := encodeRequest(ids[i], map[string]any{
+				"type": "VariableResult",
+				"key":  "k",
+				"echo": ids[i],
+			})
+			if err != nil {
+				supervisorDone <- err
+				return
+			}
+			if err := writeFrame(respW, payload); err != nil {
+				supervisorDone <- err
+				return
+			}
+		}
+		supervisorDone <- nil
+	}()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, N)
+	echoCh := make(chan int, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			// The "echo" field carries the request id the supervisor used; the
+			// dispatcher must have routed each caller to its own response.
+			echo, err := toInt(resp["echo"])
+			if err != nil {
+				errCh <- err
+				return
+			}
+			echoCh <- echo
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	close(echoCh)
+
+	require.NoError(t, <-supervisorDone)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	// Each caller must have received exactly one of the N supervisor responses,
+	// with no duplicates. A broken dispatcher that delivered the same response
+	// to two callers would either show up as a missing id here or, in the worst
+	// case, as a deadlock that fails the test by timeout.
+	seen := make(map[int]bool, N)
+	for echo := range echoCh {
+		require.False(
+			t,
+			seen[echo],
+			"duplicate echo id %d — dispatcher routed one response to multiple callers",
+			echo,
+		)
+		seen[echo] = true
+	}
+	require.Len(t, seen, N, "expected %d distinct echo ids, got %d", N, len(seen))
+	for i := 0; i < N; i++ {
+		require.True(t, seen[i], "missing echo id %d from supervisor responses", i)
+	}
+}
+
+// TestCoordinatorCommCommunicateResponseIDMatch verifies that a caller blocks
+// on its own ID even when the supervisor delivers another caller's response
+// first. The single-mutex baseline would have returned the wrong response
+// here.
+func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Drain requests so the writes do not block. The supervisor logic below
+	// drives the response order explicitly.
+	go func() {
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	results := make(chan map[string]any, 2)
+	go func() {
+		resp, err := comm.Communicate(map[string]any{"type": "GetVariable", "key": "first"})
+		require.NoError(t, err)
+		results <- resp
+	}()
+	// Allow the first call's request id (0) to be allocated and registered.
+	time.Sleep(20 * time.Millisecond)
+	go func() {
+		resp, err := comm.Communicate(map[string]any{"type": "GetVariable", "key": "second"})
+		require.NoError(t, err)
+		results <- resp
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	// Reply to the SECOND caller (id 1) first. The first caller must keep
+	// waiting; only the second caller unblocks.
+	payload, err := encodeRequest(1, map[string]any{
+		"type": "VariableResult",
+		"key":  "second",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-results:
+		assert.Equal(t, "second", resp["key"])
+	case <-time.After(time.Second):
+		t.Fatal("second caller did not receive its response")
+	}
+
+	// First caller must still be blocked.
+	select {
+	case <-results:
+		t.Fatal("first caller unblocked before its response was delivered")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Now reply to the first caller.
+	payload, err = encodeRequest(0, map[string]any{
+		"type": "VariableResult",
+		"key":  "first",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-results:
+		assert.Equal(t, "first", resp["key"])
+	case <-time.After(time.Second):
+		t.Fatal("first caller did not receive its response")
+	}
+}
+
+// TestCoordinatorCommCommunicateDispatcherClosed verifies that a Communicate
+// caller blocked on a response returns wrapped ErrDispatcherClosed when the
+// reader side of the connection is closed without delivering a response.
+func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	go func() {
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+		errCh <- err
+	}()
+
+	// Give Communicate time to register its waiter.
+	time.Sleep(50 * time.Millisecond)
+
+	// Close the response stream; the dispatcher's read returns io.EOF (or
+	// io.ErrClosedPipe) and must fan that error out to the pending waiter.
+	require.NoError(t, respW.Close())
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDispatcherClosed)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return after dispatcher closed")
+	}
+
+	// A subsequent Communicate must short-circuit on the cached read error.
+	_, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDispatcherClosed)
+}
+
+// TestCoordinatorCommReadMessageAfterDispatcherStarted ensures we surface a
+// clear error instead of silently racing the dispatcher for input bytes.
+func TestCoordinatorCommReadMessageAfterDispatcherStarted(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Drain requests so the first Communicate's write doesn't deadlock.
+	go func() {
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	// First Communicate starts the dispatcher (lazily).
+	go func() {
+		_, _ = comm.Communicate(map[string]any{"type": "GetVariable"})
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	_, err := comm.ReadMessage()
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"coordinator comm: ReadMessage cannot be used after the dispatcher has started",
+	)
+}
+
+// TestCoordinatorCommUnknownIDDiscarded verifies that a frame whose ID does
+// not match any pending waiter is logged and skipped rather than confusing the
+// next caller.
+func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	go func() {
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Inject a stray frame with an ID nobody is waiting on. The dispatcher
+	// must read this without crashing or corrupting state.
+	stray, err := encodeRequest(999, map[string]any{"type": "Junk"})
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	respCh := make(chan map[string]any, 1)
+	go func() {
+		resp, err := comm.Communicate(map[string]any{"type": "GetVariable"})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		respCh <- resp
+	}()
+	// Let Communicate register its waiter (id 0), then send the stray frame.
+	time.Sleep(50 * time.Millisecond)
+	require.NoError(t, writeFrame(respW, stray))
+
+	// Now send the real response.
+	payload, err := encodeRequest(0, map[string]any{
+		"type": "VariableResult",
+		"key":  "ok",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-respCh:
+		assert.Equal(t, "ok", resp["key"])
+	case err := <-errCh:
+		t.Fatalf("Communicate returned error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return")
+	}
 }

--- a/go-sdk/pkg/execution/dag_parser.go
+++ b/go-sdk/pkg/execution/dag_parser.go
@@ -31,8 +31,8 @@ func ParseDags(bundle bundlev1.Bundle, req *DagFileParseRequest) map[string]any 
 	relativeFileloc := computeRelativeFileloc(fileloc, bundlePath)
 
 	var dags []bundlev1.DagInfo
-	if enum, ok := bundle.(bundlev1.EnumerableBundle); ok {
-		dags = enum.OrderedDags()
+	if lister, ok := bundle.(bundlev1.DagLister); ok {
+		dags = lister.ListDags()
 	}
 
 	serializedDags := make([]any, 0, len(dags))

--- a/go-sdk/pkg/execution/dag_parser.go
+++ b/go-sdk/pkg/execution/dag_parser.go
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+)
+
+// ParseDags processes a DagFileParseRequest by serialising every dag
+// registered on bundle to DagSerialization v3 and returning the result as a
+// DagFileParsingResult body. bundle is the materialised registry produced by
+// running BundleProvider.RegisterDags.
+func ParseDags(bundle bundlev1.Bundle, req *DagFileParseRequest) map[string]any {
+	fileloc := req.File
+	bundlePath := req.BundlePath
+	relativeFileloc := computeRelativeFileloc(fileloc, bundlePath)
+
+	var dags []bundlev1.DagInfo
+	if enum, ok := bundle.(bundlev1.EnumerableBundle); ok {
+		dags = enum.OrderedDags()
+	}
+
+	serializedDags := make([]any, 0, len(dags))
+	for _, d := range dags {
+		serializedDags = append(serializedDags, map[string]any{
+			"data": map[string]any{
+				"__version": 3,
+				"dag":       SerializeDag(d, fileloc, relativeFileloc),
+			},
+		})
+	}
+
+	return map[string]any{
+		"type":            "DagFileParsingResult",
+		"fileloc":         fileloc,
+		"serialized_dags": serializedDags,
+	}
+}

--- a/go-sdk/pkg/execution/frames.go
+++ b/go-sdk/pkg/execution/frames.go
@@ -119,7 +119,10 @@ func decodeFrame(data []byte) (IncomingFrame, error) {
 	if err != nil {
 		return IncomingFrame{}, fmt.Errorf("decoding body: %w", err)
 	}
-	body, _ := toStringMap(bodyRaw)
+	body, ok := toStringMap(bodyRaw)
+	if bodyRaw != nil && !ok {
+		return IncomingFrame{}, fmt.Errorf("body element: expected map, got %T", bodyRaw)
+	}
 
 	// For response frames (3-element), decode the error element.
 	var errMap map[string]any
@@ -128,7 +131,10 @@ func decodeFrame(data []byte) (IncomingFrame, error) {
 		if err != nil {
 			return IncomingFrame{}, fmt.Errorf("decoding error element: %w", err)
 		}
-		errMap, _ = toStringMap(errRaw)
+		errMap, ok = toStringMap(errRaw)
+		if errRaw != nil && !ok {
+			return IncomingFrame{}, fmt.Errorf("error element: expected map, got %T", errRaw)
+		}
 	}
 
 	return IncomingFrame{

--- a/go-sdk/pkg/execution/frames.go
+++ b/go-sdk/pkg/execution/frames.go
@@ -1,0 +1,229 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// IncomingFrame represents a decoded frame received from the comm socket.
+type IncomingFrame struct {
+	ID   int
+	Body map[string]any
+	Err  map[string]any // non-nil only for response frames (3-element arrays)
+}
+
+// encodeRequest encodes a request frame (2-element msgpack array: [id, body]).
+func encodeRequest(id int, body map[string]any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	if err := enc.EncodeArrayLen(2); err != nil {
+		return nil, err
+	}
+	if err := enc.EncodeInt(int64(id)); err != nil {
+		return nil, err
+	}
+	if err := enc.Encode(body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// writeFrame writes a length-prefixed msgpack payload to the writer.
+// Format: [4-byte big-endian length][payload bytes]
+func writeFrame(w io.Writer, payload []byte) error {
+	prefix := make([]byte, 4)
+	binary.BigEndian.PutUint32(prefix, uint32(len(payload)))
+	if _, err := w.Write(prefix); err != nil {
+		return fmt.Errorf("writing length prefix: %w", err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("writing payload: %w", err)
+	}
+	return nil
+}
+
+// readFrame reads one length-prefixed msgpack frame from the reader and decodes it.
+func readFrame(r io.Reader) (IncomingFrame, error) {
+	// Read 4-byte big-endian length prefix.
+	prefix := make([]byte, 4)
+	if _, err := io.ReadFull(r, prefix); err != nil {
+		return IncomingFrame{}, fmt.Errorf("reading length prefix: %w", err)
+	}
+	payloadLen := binary.BigEndian.Uint32(prefix)
+
+	// Read the payload.
+	payload := make([]byte, payloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return IncomingFrame{}, fmt.Errorf("reading payload (%d bytes): %w", payloadLen, err)
+	}
+
+	return decodeFrame(payload)
+}
+
+// decodeFrame decodes a msgpack payload into an IncomingFrame.
+func decodeFrame(data []byte) (IncomingFrame, error) {
+	dec := msgpack.NewDecoder(bytes.NewReader(data))
+
+	arrLen, err := dec.DecodeArrayLen()
+	if err != nil {
+		return IncomingFrame{}, fmt.Errorf("decoding array header: %w", err)
+	}
+	if arrLen < 2 {
+		return IncomingFrame{}, fmt.Errorf("unexpected frame arity %d, need at least 2", arrLen)
+	}
+
+	id64, err := dec.DecodeInt64()
+	if err != nil {
+		return IncomingFrame{}, fmt.Errorf("decoding frame id: %w", err)
+	}
+
+	// Decode the body element.
+	bodyRaw, err := dec.DecodeInterface()
+	if err != nil {
+		return IncomingFrame{}, fmt.Errorf("decoding body: %w", err)
+	}
+	body, _ := toStringMap(bodyRaw)
+
+	// For response frames (3-element), decode the error element.
+	var errMap map[string]any
+	if arrLen >= 3 {
+		errRaw, err := dec.DecodeInterface()
+		if err != nil {
+			return IncomingFrame{}, fmt.Errorf("decoding error element: %w", err)
+		}
+		errMap, _ = toStringMap(errRaw)
+	}
+
+	return IncomingFrame{
+		ID:   int(id64),
+		Body: body,
+		Err:  errMap,
+	}, nil
+}
+
+// toStringMap converts a decoded interface{} to map[string]any.
+// Returns nil, false if the input is nil or not a map.
+func toStringMap(v any) (map[string]any, bool) {
+	if v == nil {
+		return nil, false
+	}
+	switch m := v.(type) {
+	case map[string]any:
+		return m, true
+	case map[any]any:
+		result := make(map[string]any, len(m))
+		for k, val := range m {
+			result[fmt.Sprint(k)] = val
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+// mapString extracts a string value from a map.
+func mapString(m map[string]any, key string) (string, error) {
+	v, ok := m[key]
+	if !ok {
+		return "", fmt.Errorf("missing key %q", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("key %q: expected string, got %T", key, v)
+	}
+	return s, nil
+}
+
+// mapIntOr extracts an int value from a map, returning the default if missing.
+func mapIntOr(m map[string]any, key string, def int) int {
+	v, ok := m[key]
+	if !ok {
+		return def
+	}
+	n, err := toInt(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+// mapStringOr extracts a string value from a map, returning the default if missing.
+func mapStringOr(m map[string]any, key string, def string) string {
+	v, ok := m[key]
+	if !ok {
+		return def
+	}
+	s, ok := v.(string)
+	if !ok {
+		return def
+	}
+	return s
+}
+
+// mapMap extracts a nested map from a map.
+func mapMap(m map[string]any, key string) map[string]any {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil
+	}
+	sub, ok := toStringMap(v)
+	if !ok {
+		return nil
+	}
+	return sub
+}
+
+// toInt converts various numeric types from msgpack decoding to int.
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int8:
+		return int(n), nil
+	case int16:
+		return int(n), nil
+	case int32:
+		return int(n), nil
+	case int64:
+		return int(n), nil
+	case uint:
+		return int(n), nil
+	case uint8:
+		return int(n), nil
+	case uint16:
+		return int(n), nil
+	case uint32:
+		return int(n), nil
+	case uint64:
+		return int(n), nil
+	case float32:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("expected numeric, got %T", v)
+	}
+}

--- a/go-sdk/pkg/execution/frames.go
+++ b/go-sdk/pkg/execution/frames.go
@@ -26,6 +26,13 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
+// maxFrameSize caps the payload length a single frame may declare. A
+// malformed length prefix from a corrupted stream (or hostile peer) would
+// otherwise let readFrame allocate up to 4 GiB before the read failed.
+// 64 MiB is far above any legitimate StartupDetails or XCom payload while
+// still preventing accidental OOM.
+const maxFrameSize = 64 * 1024 * 1024
+
 // IncomingFrame represents a decoded frame received from the comm socket.
 type IncomingFrame struct {
 	ID   int
@@ -73,6 +80,13 @@ func readFrame(r io.Reader) (IncomingFrame, error) {
 		return IncomingFrame{}, fmt.Errorf("reading length prefix: %w", err)
 	}
 	payloadLen := binary.BigEndian.Uint32(prefix)
+	if payloadLen > maxFrameSize {
+		return IncomingFrame{}, fmt.Errorf(
+			"frame payload length %d exceeds max %d",
+			payloadLen,
+			maxFrameSize,
+		)
+	}
 
 	// Read the payload.
 	payload := make([]byte, payloadLen)

--- a/go-sdk/pkg/execution/frames.go
+++ b/go-sdk/pkg/execution/frames.go
@@ -59,15 +59,21 @@ func encodeRequest(id int, body map[string]any) ([]byte, error) {
 }
 
 // writeFrame writes a length-prefixed msgpack payload to the writer.
-// Format: [4-byte big-endian length][payload bytes]
+// Format: [4-byte big-endian length][payload bytes].
+//
+// The prefix and payload are concatenated into a single buffer and written
+// in one Write call so we never leave a half-framed message on the wire if
+// an io.Writer implementation does a short write between the two halves.
 func writeFrame(w io.Writer, payload []byte) error {
-	prefix := make([]byte, 4)
-	binary.BigEndian.PutUint32(prefix, uint32(len(payload)))
-	if _, err := w.Write(prefix); err != nil {
-		return fmt.Errorf("writing length prefix: %w", err)
+	buf := make([]byte, 4+len(payload))
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(payload)))
+	copy(buf[4:], payload)
+	n, err := w.Write(buf)
+	if err != nil {
+		return fmt.Errorf("writing frame: %w", err)
 	}
-	if _, err := w.Write(payload); err != nil {
-		return fmt.Errorf("writing payload: %w", err)
+	if n < len(buf) {
+		return fmt.Errorf("writing frame: %w", io.ErrShortWrite)
 	}
 	return nil
 }
@@ -88,8 +94,10 @@ func readFrame(r io.Reader) (IncomingFrame, error) {
 		)
 	}
 
-	// Read the payload.
-	payload := make([]byte, payloadLen)
+	// Read the payload. The maxFrameSize guard above keeps the value well
+	// within int range on every supported platform, so the conversion is
+	// safe.
+	payload := make([]byte, int(payloadLen))
 	if _, err := io.ReadFull(r, payload); err != nil {
 		return IncomingFrame{}, fmt.Errorf("reading payload (%d bytes): %w", payloadLen, err)
 	}

--- a/go-sdk/pkg/execution/frames_test.go
+++ b/go-sdk/pkg/execution/frames_test.go
@@ -1,0 +1,200 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestEncodeRequest(t *testing.T) {
+	body := map[string]any{
+		"type": "GetVariable",
+		"key":  "my_var",
+	}
+
+	data, err := encodeRequest(42, body)
+	require.NoError(t, err)
+
+	// Decode and verify structure.
+	dec := msgpack.NewDecoder(bytes.NewReader(data))
+	arrLen, err := dec.DecodeArrayLen()
+	require.NoError(t, err)
+	assert.Equal(t, 2, arrLen, "request frame should be 2-element array")
+
+	id, err := dec.DecodeInt64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), id)
+
+	var decodedBody map[string]any
+	err = dec.Decode(&decodedBody)
+	require.NoError(t, err)
+	assert.Equal(t, "GetVariable", decodedBody["type"])
+	assert.Equal(t, "my_var", decodedBody["key"])
+}
+
+func TestWriteAndReadFrame(t *testing.T) {
+	body := map[string]any{
+		"type":    "GetConnection",
+		"conn_id": "my_db",
+	}
+
+	payload, err := encodeRequest(7, body)
+	require.NoError(t, err)
+
+	// Write to buffer with length prefix.
+	var buf bytes.Buffer
+	err = writeFrame(&buf, payload)
+	require.NoError(t, err)
+
+	// Verify length prefix.
+	prefix := buf.Bytes()[:4]
+	expectedLen := uint32(len(payload))
+	assert.Equal(t, expectedLen, binary.BigEndian.Uint32(prefix))
+
+	// Read back.
+	frame, err := readFrame(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, 7, frame.ID)
+	assert.Equal(t, "GetConnection", frame.Body["type"])
+	assert.Equal(t, "my_db", frame.Body["conn_id"])
+	assert.Nil(t, frame.Err)
+}
+
+func TestDecodeResponseFrame(t *testing.T) {
+	// Encode a 3-element response frame: [id, body, error]
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(3))
+	require.NoError(t, enc.EncodeInt(5))
+	require.NoError(t, enc.Encode(map[string]any{
+		"type":    "ConnectionResult",
+		"conn_id": "test_conn",
+		"host":    "localhost",
+	}))
+	require.NoError(t, enc.Encode(nil)) // no error
+
+	frame, err := decodeFrame(buf.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, 5, frame.ID)
+	assert.Equal(t, "ConnectionResult", frame.Body["type"])
+	assert.Equal(t, "localhost", frame.Body["host"])
+	assert.Nil(t, frame.Err)
+}
+
+func TestDecodeResponseFrameWithError(t *testing.T) {
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(3))
+	require.NoError(t, enc.EncodeInt(3))
+	require.NoError(t, enc.Encode(nil)) // nil body
+	require.NoError(t, enc.Encode(map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "not_found",
+		"detail": "Variable 'x' not found",
+	}))
+
+	frame, err := decodeFrame(buf.Bytes())
+	require.NoError(t, err)
+	assert.Equal(t, 3, frame.ID)
+	assert.Nil(t, frame.Body)
+	assert.NotNil(t, frame.Err)
+	assert.Equal(t, "not_found", frame.Err["error"])
+}
+
+func TestRoundTripMultipleFrames(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Write two frames.
+	bodies := []map[string]any{
+		{"type": "GetVariable", "key": "v1"},
+		{"type": "GetVariable", "key": "v2"},
+	}
+	for i, body := range bodies {
+		payload, err := encodeRequest(i, body)
+		require.NoError(t, err)
+		require.NoError(t, writeFrame(&buf, payload))
+	}
+
+	// Read them back.
+	for i, expected := range bodies {
+		frame, err := readFrame(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, i, frame.ID)
+		assert.Equal(t, expected["key"], frame.Body["key"])
+	}
+}
+
+func TestToStringMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  map[string]any
+		ok    bool
+	}{
+		{"nil", nil, nil, false},
+		{"string map", map[string]any{"a": 1}, map[string]any{"a": 1}, true},
+		{"any key map", map[any]any{"b": 2}, map[string]any{"b": 2}, true},
+		{"not a map", "hello", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := toStringMap(tt.input)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestToInt(t *testing.T) {
+	tests := []struct {
+		input any
+		want  int
+	}{
+		{int8(42), 42},
+		{int16(42), 42},
+		{int32(42), 42},
+		{int64(42), 42},
+		{uint8(42), 42},
+		{uint16(42), 42},
+		{uint32(42), 42},
+		{uint64(42), 42},
+		{float32(42.0), 42},
+		{float64(42.0), 42},
+		{int(42), 42},
+	}
+	for _, tt := range tests {
+		got, err := toInt(tt.input)
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
+
+	_, err := toInt("not a number")
+	assert.Error(t, err)
+}

--- a/go-sdk/pkg/execution/frames_test.go
+++ b/go-sdk/pkg/execution/frames_test.go
@@ -126,6 +126,20 @@ func TestDecodeResponseFrameWithError(t *testing.T) {
 	assert.Equal(t, "not_found", frame.Err["error"])
 }
 
+func TestReadFrameRejectsOversizedPayload(t *testing.T) {
+	// Craft a length prefix that claims more bytes than maxFrameSize so a
+	// malformed/hostile peer cannot trigger a huge allocation before the
+	// read fails.
+	var buf bytes.Buffer
+	prefix := make([]byte, 4)
+	binary.BigEndian.PutUint32(prefix, maxFrameSize+1)
+	buf.Write(prefix)
+
+	_, err := readFrame(&buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds max")
+}
+
 func TestRoundTripMultipleFrames(t *testing.T) {
 	var buf bytes.Buffer
 

--- a/go-sdk/pkg/execution/frames_test.go
+++ b/go-sdk/pkg/execution/frames_test.go
@@ -126,6 +126,38 @@ func TestDecodeResponseFrameWithError(t *testing.T) {
 	assert.Equal(t, "not_found", frame.Err["error"])
 }
 
+func TestDecodeFrameRejectsNonMapBody(t *testing.T) {
+	// A non-nil, non-map body element is a protocol violation; the decoder
+	// must surface it instead of silently turning the body into nil.
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(2))
+	require.NoError(t, enc.EncodeInt(1))
+	require.NoError(t, enc.EncodeString("not a map"))
+
+	_, err := decodeFrame(buf.Bytes())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body element: expected map")
+}
+
+func TestDecodeFrameRejectsNonMapError(t *testing.T) {
+	// Same rule applies to the error element of a 3-tuple response frame.
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(3))
+	require.NoError(t, enc.EncodeInt(2))
+	require.NoError(t, enc.Encode(nil))
+	require.NoError(t, enc.EncodeString("not a map"))
+
+	_, err := decodeFrame(buf.Bytes())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error element: expected map")
+}
+
 func TestReadFrameRejectsOversizedPayload(t *testing.T) {
 	// Craft a length prefix that claims more bytes than maxFrameSize so a
 	// malformed/hostile peer cannot trigger a huge allocation before the

--- a/go-sdk/pkg/execution/integration_test.go
+++ b/go-sdk/pkg/execution/integration_test.go
@@ -1,0 +1,358 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+)
+
+// --- Test task functions ---
+
+func failingTask() error {
+	return errors.New("task failed intentionally")
+}
+
+func panicTask() error {
+	panic("something went wrong")
+}
+
+func simpleTask() error {
+	return nil
+}
+
+// buildBundle wires a bundlev1.Registry from a closure and returns it as a
+// bundlev1.Bundle (the materialised registry).
+func buildBundle(t *testing.T, register func(bundlev1.Registry)) bundlev1.Bundle {
+	t.Helper()
+	reg := bundlev1.New()
+	register(reg)
+	return reg
+}
+
+// --- Tests ---
+
+func TestDagParsing(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		d := r.AddDag("test_dag")
+		d.AddTask(simpleTask)
+	})
+
+	req := &DagFileParseRequest{
+		File:       "/bundles/test/main.go",
+		BundlePath: "/bundles/test",
+	}
+
+	result := ParseDags(bundle, req)
+
+	assert.Equal(t, "DagFileParsingResult", result["type"])
+	assert.Equal(t, "/bundles/test/main.go", result["fileloc"])
+
+	serializedDags, ok := result["serialized_dags"].([]any)
+	require.True(t, ok)
+	require.Len(t, serializedDags, 1)
+
+	dagEntry := serializedDags[0].(map[string]any)
+	data := dagEntry["data"].(map[string]any)
+	assert.Equal(t, 3, data["__version"])
+
+	dagMap := data["dag"].(map[string]any)
+	assert.Equal(t, "test_dag", dagMap["dag_id"])
+
+	tt := dagMap["timetable"].(map[string]any)
+	assert.Equal(t, "airflow.timetables.simple.NullTimetable", tt["__type"])
+
+	tasks := dagMap["tasks"].([]any)
+	require.Len(t, tasks, 1)
+	taskMap := tasks[0].(map[string]any)
+	assert.Equal(t, "operator", taskMap["__type"])
+	taskData := taskMap["__var"].(map[string]any)
+	assert.Equal(t, "simpleTask", taskData["task_id"])
+	assert.Equal(t, "go", taskData["language"])
+}
+
+func TestDagParsingMultipleDagsPreservesOrder(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		r.AddDag("dag1").AddTask(simpleTask)
+		r.AddDag("dag2").AddTask(failingTask)
+	})
+
+	req := &DagFileParseRequest{File: "/bundle/main.go", BundlePath: "/bundle"}
+	result := ParseDags(bundle, req)
+
+	serializedDags := result["serialized_dags"].([]any)
+	require.Len(t, serializedDags, 2)
+
+	dag1Data := serializedDags[0].(map[string]any)["data"].(map[string]any)["dag"].(map[string]any)
+	assert.Equal(t, "dag1", dag1Data["dag_id"])
+
+	dag2Data := serializedDags[1].(map[string]any)["data"].(map[string]any)["dag"].(map[string]any)
+	assert.Equal(t, "dag2", dag2Data["dag_id"])
+}
+
+func TestTaskRunnerSuccess(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		r.AddDag("test_dag").AddTask(simpleTask)
+	})
+
+	details := &StartupDetails{
+		TI: TaskInstanceInfo{
+			ID:       "550e8400-e29b-41d4-a716-446655440000",
+			DagID:    "test_dag",
+			TaskID:   "simpleTask",
+			RunID:    "run1",
+			MapIndex: -1,
+		},
+		BundleInfo: BundleInfoMsg{Name: "test", Version: "1.0"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), io.Discard, logger)
+
+	result := RunTask(bundle, details, comm, logger)
+	assert.Equal(t, "SucceedTask", result["type"])
+}
+
+func TestTaskRunnerFailure(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		r.AddDag("test_dag").AddTask(failingTask)
+	})
+
+	details := &StartupDetails{
+		TI: TaskInstanceInfo{
+			ID:       "550e8400-e29b-41d4-a716-446655440000",
+			DagID:    "test_dag",
+			TaskID:   "failingTask",
+			RunID:    "run1",
+			MapIndex: -1,
+		},
+		BundleInfo: BundleInfoMsg{Name: "test", Version: "1.0"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), io.Discard, logger)
+
+	result := RunTask(bundle, details, comm, logger)
+	assert.Equal(t, "TaskState", result["type"])
+	assert.Equal(t, "failed", result["state"])
+}
+
+func TestTaskRunnerTaskNotFound(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		r.AddDag("test_dag").AddTask(simpleTask)
+	})
+
+	details := &StartupDetails{
+		TI: TaskInstanceInfo{
+			ID:     "550e8400-e29b-41d4-a716-446655440000",
+			DagID:  "test_dag",
+			TaskID: "nonexistent",
+			RunID:  "run1",
+		},
+		BundleInfo: BundleInfoMsg{Name: "test", Version: "1.0"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), io.Discard, logger)
+
+	result := RunTask(bundle, details, comm, logger)
+	assert.Equal(t, "TaskState", result["type"])
+	assert.Equal(t, "removed", result["state"])
+}
+
+func TestTaskRunnerPanic(t *testing.T) {
+	bundle := buildBundle(t, func(r bundlev1.Registry) {
+		r.AddDag("test_dag").AddTask(panicTask)
+	})
+
+	details := &StartupDetails{
+		TI: TaskInstanceInfo{
+			ID:       "550e8400-e29b-41d4-a716-446655440000",
+			DagID:    "test_dag",
+			TaskID:   "panicTask",
+			RunID:    "run1",
+			MapIndex: -1,
+		},
+		BundleInfo: BundleInfoMsg{Name: "test", Version: "1.0"},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), io.Discard, logger)
+
+	result := RunTask(bundle, details, comm, logger)
+	assert.Equal(t, "TaskState", result["type"])
+	assert.Equal(t, "failed", result["state"])
+}
+
+// --- End-to-end Serve test against a fake supervisor ---
+
+// fakeProvider implements bundlev1.BundleProvider; it lets a test inject the
+// registration closure and a synthetic version.
+type fakeProvider struct {
+	register func(bundlev1.Registry) error
+}
+
+func (f *fakeProvider) GetBundleVersion() bundlev1.BundleInfo {
+	v := "1.0"
+	return bundlev1.BundleInfo{Name: "fake", Version: &v}
+}
+
+func (f *fakeProvider) RegisterDags(reg bundlev1.Registry) error {
+	if f.register == nil {
+		return nil
+	}
+	return f.register(reg)
+}
+
+func startSupervisor(
+	t *testing.T,
+) (commAddr, logsAddr string, commCh, logsCh chan net.Conn, cleanup func()) {
+	t.Helper()
+	commLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	logsLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	commCh = make(chan net.Conn, 1)
+	logsCh = make(chan net.Conn, 1)
+	go func() {
+		c, err := commLn.Accept()
+		if err == nil {
+			commCh <- c
+		}
+		close(commCh)
+	}()
+	go func() {
+		c, err := logsLn.Accept()
+		if err == nil {
+			logsCh <- c
+		}
+		close(logsCh)
+	}()
+	cleanup = func() {
+		commLn.Close()
+		logsLn.Close()
+	}
+	return commLn.Addr().String(), logsLn.Addr().String(), commCh, logsCh, cleanup
+}
+
+func TestServeDagFileParseEndToEnd(t *testing.T) {
+	commAddr, logsAddr, commCh, logsCh, cleanup := startSupervisor(t)
+	defer cleanup()
+
+	provider := &fakeProvider{
+		register: func(r bundlev1.Registry) error {
+			d := r.AddDag("simple_dag")
+			d.AddTask(simpleTask)
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Serve(provider, commAddr, logsAddr) }()
+
+	commConn := <-commCh
+	require.NotNil(t, commConn)
+	defer commConn.Close()
+	logsConn := <-logsCh
+	require.NotNil(t, logsConn)
+	defer logsConn.Close()
+
+	// Send DagFileParseRequest as a request frame.
+	payload, err := encodeRequest(0, map[string]any{
+		"type":        "DagFileParseRequest",
+		"file":        "/bundle/main.go",
+		"bundle_path": "/bundle",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(commConn, payload))
+
+	frame, err := readFrame(commConn)
+	require.NoError(t, err)
+	assert.Equal(t, 0, frame.ID)
+	require.Nil(t, frame.Err)
+	assert.Equal(t, "DagFileParsingResult", frame.Body["type"])
+
+	dags := frame.Body["serialized_dags"].([]any)
+	require.Len(t, dags, 1)
+	dag := dags[0].(map[string]any)["data"].(map[string]any)["dag"].(map[string]any)
+	assert.Equal(t, "simple_dag", dag["dag_id"])
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after parse result")
+	}
+}
+
+func TestServeStartupDetailsEndToEnd(t *testing.T) {
+	commAddr, logsAddr, commCh, logsCh, cleanup := startSupervisor(t)
+	defer cleanup()
+
+	provider := &fakeProvider{
+		register: func(r bundlev1.Registry) error {
+			r.AddDag("dag1").AddTask(simpleTask)
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Serve(provider, commAddr, logsAddr) }()
+
+	commConn := <-commCh
+	defer commConn.Close()
+	logsConn := <-logsCh
+	defer logsConn.Close()
+
+	payload, err := encodeRequest(0, map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":         "550e8400-e29b-41d4-a716-446655440000",
+			"dag_id":     "dag1",
+			"task_id":    "simpleTask",
+			"run_id":     "run1",
+			"try_number": 1,
+		},
+		"bundle_info": map[string]any{"name": "fake", "version": "1.0"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(commConn, payload))
+
+	frame, err := readFrame(commConn)
+	require.NoError(t, err)
+	require.Nil(t, frame.Err)
+	assert.Equal(t, "SucceedTask", frame.Body["type"])
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after task completion")
+	}
+}

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -100,13 +100,13 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 	// Apply pre-configured attrs.
 	for _, a := range h.attrs {
 		key := h.prefixedKey(a.Key)
-		entry[key] = a.Value.Any()
+		entry[key] = resolveAttrValue(a.Value)
 	}
 
 	// Apply record attrs.
 	r.Attrs(func(a slog.Attr) bool {
 		key := h.prefixedKey(a.Key)
-		entry[key] = a.Value.Any()
+		entry[key] = resolveAttrValue(a.Value)
 		return true
 	})
 
@@ -155,4 +155,16 @@ func (h *SocketLogHandler) prefixedKey(key string) string {
 		return key
 	}
 	return strings.Join(h.groups, ".") + "." + key
+}
+
+// resolveAttrValue returns the JSON-friendly representation of a slog.Value.
+// It dereferences slog.LogValuer via Resolve() and then stringifies an error
+// (whose unexported fields would otherwise marshal as "{}"), matching the
+// behaviour of slog.NewJSONHandler. Non-error values pass through unchanged.
+func resolveAttrValue(v slog.Value) any {
+	resolved := v.Resolve().Any()
+	if err, ok := resolved.(error); ok {
+		return err.Error()
+	}
+	return resolved
 }

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SocketLogHandler is an slog.Handler that streams structured JSON log lines
+// to the logs TCP socket. Each log entry is a single JSON object followed by
+// a newline, matching the Airflow log streaming format.
+//
+// Key mapping:
+//   - "event" for the log message (not "msg")
+//   - "level" in lowercase (not "INFO"/"ERROR")
+//   - "timestamp" in RFC3339Nano format (not "time")
+//   - Additional attributes are included as top-level fields
+type SocketLogHandler struct {
+	shared *socketLogHandlerShared
+	level  slog.Level
+	attrs  []slog.Attr
+	groups []string
+}
+
+// socketLogHandlerShared holds the writer and buffer that must remain shared
+// across WithAttrs / WithGroup clones; otherwise the sync.Mutex would be
+// copied (which the runtime detector flags as a bug).
+type socketLogHandlerShared struct {
+	mu        sync.Mutex
+	writer    io.Writer
+	buf       [][]byte
+	connected bool
+}
+
+var _ slog.Handler = (*SocketLogHandler)(nil)
+
+// NewSocketLogHandler creates a new handler. If writer is nil, messages are
+// buffered until Connect() is called.
+func NewSocketLogHandler(writer io.Writer, level slog.Level) *SocketLogHandler {
+	shared := &socketLogHandlerShared{}
+	if writer != nil {
+		shared.writer = writer
+		shared.connected = true
+	}
+	return &SocketLogHandler{
+		shared: shared,
+		level:  level,
+	}
+}
+
+// Connect sets the writer and flushes any buffered log messages.
+func (h *SocketLogHandler) Connect(w io.Writer) {
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	h.shared.writer = w
+	h.shared.connected = true
+
+	for _, line := range h.shared.buf {
+		_, _ = w.Write(line)
+	}
+	h.shared.buf = nil
+}
+
+func (h *SocketLogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := make(map[string]any)
+
+	// Set standard fields.
+	entry["event"] = r.Message
+	entry["level"] = strings.ToLower(r.Level.String())
+	if !r.Time.IsZero() {
+		entry["timestamp"] = r.Time.Format(time.RFC3339Nano)
+	}
+
+	// Apply pre-configured attrs.
+	for _, a := range h.attrs {
+		key := h.prefixedKey(a.Key)
+		entry[key] = a.Value.Any()
+	}
+
+	// Apply record attrs.
+	r.Attrs(func(a slog.Attr) bool {
+		key := h.prefixedKey(a.Key)
+		entry[key] = a.Value.Any()
+		return true
+	})
+
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	if !h.shared.connected {
+		h.shared.buf = append(h.shared.buf, line)
+		return nil
+	}
+
+	_, err = h.shared.writer.Write(line)
+	return err
+}
+
+func (h *SocketLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &SocketLogHandler{
+		shared: h.shared,
+		level:  h.level,
+		attrs:  append(append([]slog.Attr{}, h.attrs...), attrs...),
+		groups: h.groups,
+	}
+}
+
+func (h *SocketLogHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &SocketLogHandler{
+		shared: h.shared,
+		level:  h.level,
+		attrs:  h.attrs,
+		groups: append(append([]string{}, h.groups...), name),
+	}
+}
+
+// prefixedKey prepends any active group names to the attribute key.
+func (h *SocketLogHandler) prefixedKey(key string) string {
+	if len(h.groups) == 0 {
+		return key
+	}
+	return strings.Join(h.groups, ".") + "." + key
+}

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSocketLogHandlerBasicOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("test message", "key1", "val1")
+
+	// Parse the output.
+	output := buf.String()
+	assert.True(t, strings.HasSuffix(output, "\n"), "output should end with newline")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &entry))
+
+	assert.Equal(t, "test message", entry["event"])
+	assert.Equal(t, "info", entry["level"])
+	assert.Equal(t, "val1", entry["key1"])
+	assert.Contains(t, entry, "timestamp")
+}
+
+func TestSocketLogHandlerLevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelWarn)
+	logger := slog.New(handler)
+
+	logger.Debug("should be filtered")
+	logger.Info("also filtered")
+	logger.Warn("should appear")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 1)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &entry))
+	assert.Equal(t, "should appear", entry["event"])
+	assert.Equal(t, "warn", entry["level"])
+}
+
+func TestSocketLogHandlerBuffering(t *testing.T) {
+	// Create handler without a writer — messages should be buffered.
+	handler := NewSocketLogHandler(nil, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("buffered message 1")
+	logger.Info("buffered message 2")
+
+	// Connect the writer — buffered messages should flush.
+	var buf bytes.Buffer
+	handler.Connect(&buf)
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Len(t, lines, 2)
+
+	// New messages should write directly.
+	logger.Info("direct message")
+	lines = strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 3)
+}
+
+func TestSocketLogHandlerWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).With("component", "test")
+
+	logger.Info("with attrs")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "test", entry["component"])
+}
+
+func TestSocketLogHandlerWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).WithGroup("grp")
+
+	logger.Info("grouped", "key", "val")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "val", entry["grp.key"])
+}
+
+func TestSocketLogHandlerKeyMapping(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Error("an error occurred")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+
+	// Check key mapping: "event" not "msg", "level" lowercase, "timestamp" not "time"
+	assert.Equal(t, "an error occurred", entry["event"])
+	assert.Equal(t, "error", entry["level"])
+	_, hasTimestamp := entry["timestamp"]
+	assert.True(t, hasTimestamp)
+	_, hasMsg := entry["msg"]
+	assert.False(t, hasMsg)
+	_, hasTime := entry["time"]
+	assert.False(t, hasTime)
+}

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -20,6 +20,7 @@ package execution
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -131,4 +132,43 @@ func TestSocketLogHandlerKeyMapping(t *testing.T) {
 	assert.False(t, hasMsg)
 	_, hasTime := entry["time"]
 	assert.False(t, hasTime)
+}
+
+// TestSocketLogHandlerStringifiesErrorAttr verifies that an attribute whose
+// value is a stock `error` is rendered as its .Error() string. Without value
+// resolution the underlying struct's unexported fields would be marshaled as
+// "{}", silently dropping the message.
+func TestSocketLogHandlerStringifiesErrorAttr(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Error("task failed", "error", errors.New("boom"))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "boom", entry["error"])
+}
+
+// logValuerAttr is an slog.LogValuer that resolves to a string. Used to
+// confirm Resolve() is called before JSON marshaling.
+type logValuerAttr string
+
+func (l logValuerAttr) LogValue() slog.Value {
+	return slog.StringValue(string(l) + ":resolved")
+}
+
+// TestSocketLogHandlerResolvesLogValuer verifies that an attribute whose
+// value implements slog.LogValuer has Resolve() called before marshaling,
+// matching the behaviour of slog.NewJSONHandler.
+func TestSocketLogHandlerResolvesLogValuer(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("with valuer", "field", logValuerAttr("hello"))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "hello:resolved", entry["field"])
 }

--- a/go-sdk/pkg/execution/messages.go
+++ b/go-sdk/pkg/execution/messages.go
@@ -1,0 +1,394 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"fmt"
+	"time"
+)
+
+// --- Inbound messages (Supervisor -> Runtime) ---
+
+// DagFileParseRequest is sent by the supervisor to request DAG parsing.
+type DagFileParseRequest struct {
+	File       string
+	BundlePath string
+}
+
+func decodeDagFileParseRequest(m map[string]any) (*DagFileParseRequest, error) {
+	file, err := mapString(m, "file")
+	if err != nil {
+		return nil, err
+	}
+	bundlePath := mapStringOr(m, "bundle_path", "")
+	return &DagFileParseRequest{File: file, BundlePath: bundlePath}, nil
+}
+
+// TaskInstanceInfo holds task instance details from StartupDetails.
+type TaskInstanceInfo struct {
+	ID             string
+	TaskID         string
+	DagID          string
+	RunID          string
+	TryNumber      int
+	DagVersionID   string
+	MapIndex       int
+	ContextCarrier map[string]any
+}
+
+func decodeTaskInstanceInfo(m map[string]any) (TaskInstanceInfo, error) {
+	if m == nil {
+		return TaskInstanceInfo{}, fmt.Errorf("nil task instance map")
+	}
+	id, err := mapString(m, "id")
+	if err != nil {
+		return TaskInstanceInfo{}, fmt.Errorf("ti.id: %w", err)
+	}
+	taskID, err := mapString(m, "task_id")
+	if err != nil {
+		return TaskInstanceInfo{}, fmt.Errorf("ti.task_id: %w", err)
+	}
+	dagID, err := mapString(m, "dag_id")
+	if err != nil {
+		return TaskInstanceInfo{}, fmt.Errorf("ti.dag_id: %w", err)
+	}
+	runID, err := mapString(m, "run_id")
+	if err != nil {
+		return TaskInstanceInfo{}, fmt.Errorf("ti.run_id: %w", err)
+	}
+	tryNumber := mapIntOr(m, "try_number", 1)
+	dagVersionID := mapStringOr(m, "dag_version_id", "")
+	mapIndex := mapIntOr(m, "map_index", -1)
+	contextCarrier := mapMap(m, "context_carrier")
+
+	return TaskInstanceInfo{
+		ID:             id,
+		TaskID:         taskID,
+		DagID:          dagID,
+		RunID:          runID,
+		TryNumber:      tryNumber,
+		DagVersionID:   dagVersionID,
+		MapIndex:       mapIndex,
+		ContextCarrier: contextCarrier,
+	}, nil
+}
+
+// BundleInfoMsg holds bundle identification from StartupDetails.
+type BundleInfoMsg struct {
+	Name    string
+	Version string
+}
+
+func decodeBundleInfo(m map[string]any) BundleInfoMsg {
+	if m == nil {
+		return BundleInfoMsg{}
+	}
+	return BundleInfoMsg{
+		Name:    mapStringOr(m, "name", ""),
+		Version: mapStringOr(m, "version", ""),
+	}
+}
+
+// TIRunContext holds the runtime context for a task instance.
+type TIRunContext struct {
+	LogicalDate       *time.Time
+	DataIntervalStart *time.Time
+	DataIntervalEnd   *time.Time
+}
+
+func decodeTIRunContext(m map[string]any) TIRunContext {
+	if m == nil {
+		return TIRunContext{}
+	}
+	ctx := TIRunContext{}
+	if t, err := asTime(m["logical_date"]); err == nil {
+		ctx.LogicalDate = &t
+	}
+	if t, err := asTime(m["data_interval_start"]); err == nil {
+		ctx.DataIntervalStart = &t
+	}
+	if t, err := asTime(m["data_interval_end"]); err == nil {
+		ctx.DataIntervalEnd = &t
+	}
+	return ctx
+}
+
+// StartupDetails is sent by the supervisor to initiate task execution.
+type StartupDetails struct {
+	TI                TaskInstanceInfo
+	DagRelPath        string
+	BundleInfo        BundleInfoMsg
+	StartDate         time.Time
+	TIContext         TIRunContext
+	SentryIntegration string
+}
+
+func decodeStartupDetails(m map[string]any) (*StartupDetails, error) {
+	tiMap := mapMap(m, "ti")
+	ti, err := decodeTaskInstanceInfo(tiMap)
+	if err != nil {
+		return nil, fmt.Errorf("decoding ti: %w", err)
+	}
+
+	dagRelPath := mapStringOr(m, "dag_rel_path", "")
+	bundleInfo := decodeBundleInfo(mapMap(m, "bundle_info"))
+
+	var startDate time.Time
+	if t, err := asTime(m["start_date"]); err == nil {
+		startDate = t
+	}
+
+	tiContext := decodeTIRunContext(mapMap(m, "ti_context"))
+	sentryIntegration := mapStringOr(m, "sentry_integration", "")
+
+	return &StartupDetails{
+		TI:                ti,
+		DagRelPath:        dagRelPath,
+		BundleInfo:        bundleInfo,
+		StartDate:         startDate,
+		TIContext:         tiContext,
+		SentryIntegration: sentryIntegration,
+	}, nil
+}
+
+// --- Response types (for runtime-initiated requests) ---
+
+// ConnectionResult is the response to GetConnection.
+type ConnectionResult struct {
+	ConnID   string
+	ConnType string
+	Host     string
+	Schema   string
+	Login    string
+	Password string
+	Port     int
+	Extra    string
+}
+
+func decodeConnectionResult(m map[string]any) (*ConnectionResult, error) {
+	return &ConnectionResult{
+		ConnID:   mapStringOr(m, "conn_id", ""),
+		ConnType: mapStringOr(m, "conn_type", ""),
+		Host:     mapStringOr(m, "host", ""),
+		Schema:   mapStringOr(m, "schema", ""),
+		Login:    mapStringOr(m, "login", ""),
+		Password: mapStringOr(m, "password", ""),
+		Port:     mapIntOr(m, "port", 0),
+		Extra:    mapStringOr(m, "extra", ""),
+	}, nil
+}
+
+// VariableResult is the response to GetVariable.
+type VariableResult struct {
+	Key   string
+	Value any
+}
+
+func decodeVariableResult(m map[string]any) (*VariableResult, error) {
+	return &VariableResult{
+		Key:   mapStringOr(m, "key", ""),
+		Value: m["value"],
+	}, nil
+}
+
+// XComResult is the response to GetXCom.
+type XComResult struct {
+	Key   string
+	Value any
+}
+
+func decodeXComResult(m map[string]any) (*XComResult, error) {
+	return &XComResult{
+		Key:   mapStringOr(m, "key", ""),
+		Value: m["value"],
+	}, nil
+}
+
+// ErrorResponse represents an error returned by the supervisor.
+type ErrorResponse struct {
+	Error  string
+	Detail any
+}
+
+func decodeErrorResponse(m map[string]any) *ErrorResponse {
+	if m == nil {
+		return nil
+	}
+	return &ErrorResponse{
+		Error:  mapStringOr(m, "error", ""),
+		Detail: m["detail"],
+	}
+}
+
+// --- Outbound messages (Runtime -> Supervisor) ---
+
+// GetConnectionMsg is sent to request a connection from the supervisor.
+type GetConnectionMsg struct {
+	ConnID string
+}
+
+func (m GetConnectionMsg) toMap() map[string]any {
+	return map[string]any{
+		"type":    "GetConnection",
+		"conn_id": m.ConnID,
+	}
+}
+
+// GetVariableMsg is sent to request a variable from the supervisor.
+type GetVariableMsg struct {
+	Key string
+}
+
+func (m GetVariableMsg) toMap() map[string]any {
+	return map[string]any{
+		"type": "GetVariable",
+		"key":  m.Key,
+	}
+}
+
+// GetXComMsg is sent to request an XCom value from the supervisor.
+type GetXComMsg struct {
+	Key               string
+	DagID             string
+	TaskID            string
+	RunID             string
+	MapIndex          *int
+	IncludePriorDates bool
+}
+
+func (m GetXComMsg) toMap() map[string]any {
+	result := map[string]any{
+		"type":                "GetXCom",
+		"key":                 m.Key,
+		"dag_id":              m.DagID,
+		"task_id":             m.TaskID,
+		"run_id":              m.RunID,
+		"include_prior_dates": m.IncludePriorDates,
+	}
+	if m.MapIndex != nil {
+		result["map_index"] = *m.MapIndex
+	}
+	return result
+}
+
+// SetXComMsg is sent to set an XCom value.
+type SetXComMsg struct {
+	Key          string
+	Value        any
+	DagID        string
+	TaskID       string
+	RunID        string
+	MapIndex     int
+	MappedLength *int
+}
+
+func (m SetXComMsg) toMap() map[string]any {
+	result := map[string]any{
+		"type":      "SetXCom",
+		"key":       m.Key,
+		"value":     m.Value,
+		"dag_id":    m.DagID,
+		"task_id":   m.TaskID,
+		"run_id":    m.RunID,
+		"map_index": m.MapIndex,
+	}
+	if m.MappedLength != nil {
+		result["mapped_length"] = *m.MappedLength
+	}
+	return result
+}
+
+// SucceedTaskMsg is sent as a terminal message when a task succeeds.
+type SucceedTaskMsg struct {
+	EndDate      time.Time
+	TaskOutlets  []any
+	OutletEvents []any
+}
+
+func (m SucceedTaskMsg) toMap() map[string]any {
+	taskOutlets := m.TaskOutlets
+	if taskOutlets == nil {
+		taskOutlets = []any{}
+	}
+	outletEvents := m.OutletEvents
+	if outletEvents == nil {
+		outletEvents = []any{}
+	}
+	return map[string]any{
+		"type":          "SucceedTask",
+		"end_date":      m.EndDate.UTC().Format(time.RFC3339),
+		"task_outlets":  taskOutlets,
+		"outlet_events": outletEvents,
+	}
+}
+
+// TaskStateMsg is sent as a terminal message for failed/removed/skipped tasks.
+type TaskStateMsg struct {
+	State   string // "failed", "removed", "skipped"
+	EndDate time.Time
+}
+
+func (m TaskStateMsg) toMap() map[string]any {
+	return map[string]any{
+		"type":     "TaskState",
+		"state":    m.State,
+		"end_date": m.EndDate.UTC().Format(time.RFC3339),
+	}
+}
+
+// --- Message dispatch ---
+
+// decodeIncomingBody dispatches decoding of a body map based on its "type" field.
+func decodeIncomingBody(m map[string]any) (any, error) {
+	if m == nil {
+		return nil, nil
+	}
+	typ, _ := m["type"].(string)
+	switch typ {
+	case "DagFileParseRequest":
+		return decodeDagFileParseRequest(m)
+	case "StartupDetails":
+		return decodeStartupDetails(m)
+	case "ConnectionResult":
+		return decodeConnectionResult(m)
+	case "VariableResult":
+		return decodeVariableResult(m)
+	case "XComResult":
+		return decodeXComResult(m)
+	case "ErrorResponse":
+		return decodeErrorResponse(m), nil
+	default:
+		return nil, fmt.Errorf("unknown message type %q", typ)
+	}
+}
+
+// asTime parses a time value that may be a time.Time (from msgpack timestamp ext)
+// or a string (ISO 8601 format).
+func asTime(v any) (time.Time, error) {
+	if v == nil {
+		return time.Time{}, fmt.Errorf("nil time value")
+	}
+	switch t := v.(type) {
+	case time.Time:
+		return t, nil
+	case string:
+		return time.Parse(time.RFC3339Nano, t)
+	default:
+		return time.Time{}, fmt.Errorf("expected time, got %T", v)
+	}
+}

--- a/go-sdk/pkg/execution/messages.go
+++ b/go-sdk/pkg/execution/messages.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-// --- Inbound messages (Supervisor -> Runtime) ---
+// Inbound messages (Supervisor -> Runtime).
 
 // DagFileParseRequest is sent by the supervisor to request DAG parsing.
 type DagFileParseRequest struct {
@@ -166,7 +166,7 @@ func decodeStartupDetails(m map[string]any) (*StartupDetails, error) {
 	}, nil
 }
 
-// --- Response types (for runtime-initiated requests) ---
+// Response types (for runtime-initiated requests).
 
 // ConnectionResult is the response to GetConnection.
 type ConnectionResult struct {
@@ -235,7 +235,7 @@ func decodeErrorResponse(m map[string]any) *ErrorResponse {
 	}
 }
 
-// --- Outbound messages (Runtime -> Supervisor) ---
+// Outbound messages (Runtime -> Supervisor).
 
 // GetConnectionMsg is sent to request a connection from the supervisor.
 type GetConnectionMsg struct {
@@ -351,7 +351,7 @@ func (m TaskStateMsg) toMap() map[string]any {
 	}
 }
 
-// --- Message dispatch ---
+// Message dispatch.
 
 // decodeIncomingBody dispatches decoding of a body map based on its "type" field.
 func decodeIncomingBody(m map[string]any) (any, error) {

--- a/go-sdk/pkg/execution/messages.go
+++ b/go-sdk/pkg/execution/messages.go
@@ -337,16 +337,29 @@ func (m SucceedTaskMsg) toMap() map[string]any {
 	}
 }
 
+// TaskState is the terminal non-success state reported via TaskStateMsg.
+// The wire values match Python's TaskInstanceState enum (and the generated
+// api.TerminalStateNonSuccess); we define a local typed string so call
+// sites get compile-time checking and don't have to import pkg/api just
+// for the constants.
+type TaskState string
+
+const (
+	TaskStateFailed  TaskState = "failed"
+	TaskStateRemoved TaskState = "removed"
+	TaskStateSkipped TaskState = "skipped"
+)
+
 // TaskStateMsg is sent as a terminal message for failed/removed/skipped tasks.
 type TaskStateMsg struct {
-	State   string // "failed", "removed", "skipped"
+	State   TaskState
 	EndDate time.Time
 }
 
 func (m TaskStateMsg) toMap() map[string]any {
 	return map[string]any{
 		"type":     "TaskState",
-		"state":    m.State,
+		"state":    string(m.State),
 		"end_date": m.EndDate.UTC().Format(time.RFC3339),
 	}
 }

--- a/go-sdk/pkg/execution/messages.go
+++ b/go-sdk/pkg/execution/messages.go
@@ -111,21 +111,30 @@ type TIRunContext struct {
 	DataIntervalEnd   *time.Time
 }
 
-func decodeTIRunContext(m map[string]any) TIRunContext {
+func decodeTIRunContext(m map[string]any) (TIRunContext, error) {
 	if m == nil {
-		return TIRunContext{}
+		return TIRunContext{}, nil
 	}
 	ctx := TIRunContext{}
-	if t, err := asTime(m["logical_date"]); err == nil {
-		ctx.LogicalDate = &t
+	for _, f := range []struct {
+		key string
+		dst **time.Time
+	}{
+		{"logical_date", &ctx.LogicalDate},
+		{"data_interval_start", &ctx.DataIntervalStart},
+		{"data_interval_end", &ctx.DataIntervalEnd},
+	} {
+		raw, present := m[f.key]
+		if !present || raw == nil {
+			continue
+		}
+		t, err := asTime(raw)
+		if err != nil {
+			return TIRunContext{}, fmt.Errorf("ti_context.%s: %w", f.key, err)
+		}
+		*f.dst = &t
 	}
-	if t, err := asTime(m["data_interval_start"]); err == nil {
-		ctx.DataIntervalStart = &t
-	}
-	if t, err := asTime(m["data_interval_end"]); err == nil {
-		ctx.DataIntervalEnd = &t
-	}
-	return ctx
+	return ctx, nil
 }
 
 // StartupDetails is sent by the supervisor to initiate task execution.
@@ -149,11 +158,17 @@ func decodeStartupDetails(m map[string]any) (*StartupDetails, error) {
 	bundleInfo := decodeBundleInfo(mapMap(m, "bundle_info"))
 
 	var startDate time.Time
-	if t, err := asTime(m["start_date"]); err == nil {
-		startDate = t
+	if raw, present := m["start_date"]; present && raw != nil {
+		startDate, err = asTime(raw)
+		if err != nil {
+			return nil, fmt.Errorf("start_date: %w", err)
+		}
 	}
 
-	tiContext := decodeTIRunContext(mapMap(m, "ti_context"))
+	tiContext, err := decodeTIRunContext(mapMap(m, "ti_context"))
+	if err != nil {
+		return nil, fmt.Errorf("decoding ti_context: %w", err)
+	}
 	sentryIntegration := mapStringOr(m, "sentry_integration", "")
 
 	return &StartupDetails{

--- a/go-sdk/pkg/execution/messages_test.go
+++ b/go-sdk/pkg/execution/messages_test.go
@@ -1,0 +1,258 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeDagFileParseRequest(t *testing.T) {
+	m := map[string]any{
+		"type":        "DagFileParseRequest",
+		"file":        "/path/to/dags.go",
+		"bundle_path": "/bundles/my_bundle",
+	}
+
+	req, err := decodeDagFileParseRequest(m)
+	require.NoError(t, err)
+	assert.Equal(t, "/path/to/dags.go", req.File)
+	assert.Equal(t, "/bundles/my_bundle", req.BundlePath)
+}
+
+func TestDecodeStartupDetails(t *testing.T) {
+	m := map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":             "550e8400-e29b-41d4-a716-446655440000",
+			"task_id":        "extract",
+			"dag_id":         "tutorial_dag",
+			"run_id":         "manual__2024-01-15",
+			"try_number":     int64(1),
+			"dag_version_id": "abc-123",
+			"map_index":      int64(-1),
+		},
+		"dag_rel_path": "dags/tutorial.go",
+		"bundle_info": map[string]any{
+			"name":    "example_dags",
+			"version": "1.0.0",
+		},
+		"start_date":         "2024-01-15T10:30:00Z",
+		"sentry_integration": "",
+		"ti_context": map[string]any{
+			"logical_date":        "2024-01-15T00:00:00Z",
+			"data_interval_start": "2024-01-14T00:00:00Z",
+			"data_interval_end":   "2024-01-15T00:00:00Z",
+		},
+	}
+
+	details, err := decodeStartupDetails(m)
+	require.NoError(t, err)
+
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", details.TI.ID)
+	assert.Equal(t, "extract", details.TI.TaskID)
+	assert.Equal(t, "tutorial_dag", details.TI.DagID)
+	assert.Equal(t, "manual__2024-01-15", details.TI.RunID)
+	assert.Equal(t, 1, details.TI.TryNumber)
+	assert.Equal(t, -1, details.TI.MapIndex)
+	assert.Equal(t, "dags/tutorial.go", details.DagRelPath)
+	assert.Equal(t, "example_dags", details.BundleInfo.Name)
+	assert.Equal(t, "1.0.0", details.BundleInfo.Version)
+	assert.NotNil(t, details.TIContext.LogicalDate)
+}
+
+func TestDecodeConnectionResult(t *testing.T) {
+	m := map[string]any{
+		"type":      "ConnectionResult",
+		"conn_id":   "my_db",
+		"conn_type": "postgres",
+		"host":      "db.example.com",
+		"schema":    "mydb",
+		"login":     "user",
+		"password":  "secret",
+		"port":      int64(5432),
+		"extra":     `{"sslmode":"require"}`,
+	}
+
+	result, err := decodeConnectionResult(m)
+	require.NoError(t, err)
+	assert.Equal(t, "my_db", result.ConnID)
+	assert.Equal(t, "postgres", result.ConnType)
+	assert.Equal(t, "db.example.com", result.Host)
+	assert.Equal(t, "mydb", result.Schema)
+	assert.Equal(t, "user", result.Login)
+	assert.Equal(t, "secret", result.Password)
+	assert.Equal(t, 5432, result.Port)
+}
+
+func TestDecodeVariableResult(t *testing.T) {
+	m := map[string]any{
+		"type":  "VariableResult",
+		"key":   "my_var",
+		"value": "hello",
+	}
+
+	result, err := decodeVariableResult(m)
+	require.NoError(t, err)
+	assert.Equal(t, "my_var", result.Key)
+	assert.Equal(t, "hello", result.Value)
+}
+
+func TestDecodeXComResult(t *testing.T) {
+	m := map[string]any{
+		"type":  "XComResult",
+		"key":   "return_value",
+		"value": map[string]any{"data": "processed"},
+	}
+
+	result, err := decodeXComResult(m)
+	require.NoError(t, err)
+	assert.Equal(t, "return_value", result.Key)
+	valMap, ok := result.Value.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "processed", valMap["data"])
+}
+
+func TestDecodeErrorResponseNil(t *testing.T) {
+	assert.Nil(t, decodeErrorResponse(nil))
+}
+
+func TestGetConnectionMsgToMap(t *testing.T) {
+	msg := GetConnectionMsg{ConnID: "my_db"}
+	m := msg.toMap()
+	assert.Equal(t, "GetConnection", m["type"])
+	assert.Equal(t, "my_db", m["conn_id"])
+}
+
+func TestGetVariableMsgToMap(t *testing.T) {
+	msg := GetVariableMsg{Key: "my_var"}
+	m := msg.toMap()
+	assert.Equal(t, "GetVariable", m["type"])
+	assert.Equal(t, "my_var", m["key"])
+}
+
+func TestGetXComMsgToMapWithMapIndex(t *testing.T) {
+	mapIdx := 3
+	msg := GetXComMsg{
+		Key:               "result",
+		DagID:             "dag1",
+		TaskID:            "task1",
+		RunID:             "run1",
+		MapIndex:          &mapIdx,
+		IncludePriorDates: true,
+	}
+	m := msg.toMap()
+	assert.Equal(t, "GetXCom", m["type"])
+	assert.Equal(t, 3, m["map_index"])
+	assert.Equal(t, true, m["include_prior_dates"])
+}
+
+func TestGetXComMsgToMapNilMapIndex(t *testing.T) {
+	msg := GetXComMsg{Key: "result", DagID: "d", TaskID: "t", RunID: "r"}
+	m := msg.toMap()
+	_, hasMapIndex := m["map_index"]
+	assert.False(t, hasMapIndex)
+}
+
+func TestSetXComMsgToMap(t *testing.T) {
+	msg := SetXComMsg{
+		Key: "output", Value: 42,
+		DagID: "dag1", TaskID: "task1", RunID: "run1", MapIndex: -1,
+	}
+	m := msg.toMap()
+	assert.Equal(t, "SetXCom", m["type"])
+	assert.Equal(t, 42, m["value"])
+	_, hasMappedLength := m["mapped_length"]
+	assert.False(t, hasMappedLength)
+}
+
+func TestSucceedTaskMsgToMap(t *testing.T) {
+	endDate := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	msg := SucceedTaskMsg{EndDate: endDate}
+	m := msg.toMap()
+	assert.Equal(t, "SucceedTask", m["type"])
+	assert.Equal(t, "2024-01-15T10:30:00Z", m["end_date"])
+	assert.Equal(t, []any{}, m["task_outlets"])
+	assert.Equal(t, []any{}, m["outlet_events"])
+}
+
+func TestTaskStateMsgToMap(t *testing.T) {
+	endDate := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	msg := TaskStateMsg{State: "failed", EndDate: endDate}
+	m := msg.toMap()
+	assert.Equal(t, "TaskState", m["type"])
+	assert.Equal(t, "failed", m["state"])
+}
+
+func TestDecodeIncomingBodyDispatch(t *testing.T) {
+	t.Run("DagFileParseRequest", func(t *testing.T) {
+		body := map[string]any{"type": "DagFileParseRequest", "file": "x", "bundle_path": "y"}
+		result, err := decodeIncomingBody(body)
+		require.NoError(t, err)
+		_, ok := result.(*DagFileParseRequest)
+		assert.True(t, ok)
+	})
+
+	t.Run("ConnectionResult", func(t *testing.T) {
+		body := map[string]any{"type": "ConnectionResult", "conn_id": "x"}
+		result, err := decodeIncomingBody(body)
+		require.NoError(t, err)
+		_, ok := result.(*ConnectionResult)
+		assert.True(t, ok)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		result, err := decodeIncomingBody(nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("unknown type", func(t *testing.T) {
+		_, err := decodeIncomingBody(map[string]any{"type": "UnknownMsg"})
+		assert.Error(t, err)
+	})
+}
+
+func TestAsTime(t *testing.T) {
+	t.Run("from string", func(t *testing.T) {
+		ts, err := asTime("2024-01-15T10:30:00Z")
+		require.NoError(t, err)
+		assert.Equal(t, 2024, ts.Year())
+		assert.Equal(t, time.January, ts.Month())
+	})
+
+	t.Run("from time.Time", func(t *testing.T) {
+		now := time.Now()
+		ts, err := asTime(now)
+		require.NoError(t, err)
+		assert.Equal(t, now, ts)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		_, err := asTime(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		_, err := asTime(42)
+		assert.Error(t, err)
+	})
+}

--- a/go-sdk/pkg/execution/messages_test.go
+++ b/go-sdk/pkg/execution/messages_test.go
@@ -196,10 +196,26 @@ func TestSucceedTaskMsgToMap(t *testing.T) {
 
 func TestTaskStateMsgToMap(t *testing.T) {
 	endDate := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
-	msg := TaskStateMsg{State: "failed", EndDate: endDate}
+	msg := TaskStateMsg{State: TaskStateFailed, EndDate: endDate}
 	m := msg.toMap()
 	assert.Equal(t, "TaskState", m["type"])
 	assert.Equal(t, "failed", m["state"])
+}
+
+func TestTaskStateConstants_WireValues(t *testing.T) {
+	// Pin each enum constant to the exact wire string Python's
+	// TaskInstanceState expects. Renaming these constants is fine;
+	// changing the wire value would silently break the protocol.
+	cases := map[TaskState]string{
+		TaskStateFailed:  "failed",
+		TaskStateRemoved: "removed",
+		TaskStateSkipped: "skipped",
+	}
+	for state, wire := range cases {
+		assert.Equal(t, wire, string(state))
+		m := TaskStateMsg{State: state}.toMap()
+		assert.Equal(t, wire, m["state"], "wire value for %s", state)
+	}
 }
 
 func TestDecodeIncomingBodyDispatch(t *testing.T) {

--- a/go-sdk/pkg/execution/messages_test.go
+++ b/go-sdk/pkg/execution/messages_test.go
@@ -79,6 +79,57 @@ func TestDecodeStartupDetails(t *testing.T) {
 	assert.NotNil(t, details.TIContext.LogicalDate)
 }
 
+func TestDecodeStartupDetails_MalformedStartDate(t *testing.T) {
+	// A present-but-malformed start_date must surface as a decode error;
+	// silently leaving startDate as the zero time would let tasks run with
+	// incorrect provenance.
+	m := map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":      "550e8400-e29b-41d4-a716-446655440000",
+			"task_id": "t", "dag_id": "d", "run_id": "r",
+		},
+		"start_date": "not-a-timestamp",
+	}
+	_, err := decodeStartupDetails(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start_date")
+}
+
+func TestDecodeStartupDetails_MalformedTIRunContext(t *testing.T) {
+	m := map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":      "550e8400-e29b-41d4-a716-446655440000",
+			"task_id": "t", "dag_id": "d", "run_id": "r",
+		},
+		"ti_context": map[string]any{
+			"logical_date": "garbage",
+		},
+	}
+	_, err := decodeStartupDetails(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "logical_date")
+}
+
+func TestDecodeStartupDetails_MissingOptionalTimestamps(t *testing.T) {
+	// start_date and ti_context fields are optional; omitting them must
+	// still decode cleanly (no error, zero/nil values).
+	m := map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":      "550e8400-e29b-41d4-a716-446655440000",
+			"task_id": "t", "dag_id": "d", "run_id": "r",
+		},
+	}
+	details, err := decodeStartupDetails(m)
+	require.NoError(t, err)
+	assert.True(t, details.StartDate.IsZero())
+	assert.Nil(t, details.TIContext.LogicalDate)
+	assert.Nil(t, details.TIContext.DataIntervalStart)
+	assert.Nil(t, details.TIContext.DataIntervalEnd)
+}
+
 func TestDecodeConnectionResult(t *testing.T) {
 	m := map[string]any{
 		"type":      "ConnectionResult",

--- a/go-sdk/pkg/execution/serde.go
+++ b/go-sdk/pkg/execution/serde.go
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+)
+
+// serializeValue recursively serializes a value with Airflow's type/var encoding.
+// This matches Python's BaseSerialization.serialize() output:
+//   - primitives (string, bool, int, float) pass through unchanged
+//   - time.Time -> {"__type": "datetime", "__var": epoch_seconds_float}
+//   - time.Duration -> {"__type": "timedelta", "__var": total_seconds_float}
+//   - map[string]any -> {"__type": "dict", "__var": {k: serialize(v), ...}}
+//   - []any -> direct array with each element serialized
+func serializeValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	switch v := value.(type) {
+	case string, bool:
+		return v
+	case int:
+		return v
+	case int8:
+		return int(v)
+	case int16:
+		return int(v)
+	case int32:
+		return int(v)
+	case int64:
+		return v
+	case float32:
+		return float64(v)
+	case float64:
+		return v
+	case time.Time:
+		epochSec := float64(v.Unix()) + float64(v.Nanosecond())/1e9
+		return map[string]any{
+			"__type": "datetime",
+			"__var":  epochSec,
+		}
+	case time.Duration:
+		return map[string]any{
+			"__type": "timedelta",
+			"__var":  v.Seconds(),
+		}
+	case map[string]any:
+		serialized := make(map[string]any, len(v))
+		for k, val := range v {
+			serialized[k] = serializeValue(val)
+		}
+		return map[string]any{
+			"__type": "dict",
+			"__var":  serialized,
+		}
+	case []string:
+		result := make([]any, len(v))
+		for i, item := range v {
+			result[i] = serializeValue(item)
+		}
+		return result
+	case []any:
+		result := make([]any, len(v))
+		for i, item := range v {
+			result[i] = serializeValue(item)
+		}
+		return result
+	default:
+		// Use reflection to handle typed maps and slices that don't match
+		// the concrete types above (e.g., map[string]map[string][]string).
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Map:
+			serialized := make(map[string]any, rv.Len())
+			for _, key := range rv.MapKeys() {
+				serialized[fmt.Sprint(key.Interface())] = serializeValue(rv.MapIndex(key).Interface())
+			}
+			return map[string]any{
+				"__type": "dict",
+				"__var":  serialized,
+			}
+		case reflect.Slice, reflect.Array:
+			result := make([]any, rv.Len())
+			for i := range result {
+				result[i] = serializeValue(rv.Index(i).Interface())
+			}
+			return result
+		default:
+			return v
+		}
+	}
+}
+
+// unwrapTypeEncoding extracts the "__var" part from a type-encoded value.
+// In Python's serialize_to_json, non-decorated fields are serialized then unwrapped.
+func unwrapTypeEncoding(value any) any {
+	m, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+	if _, hasType := m["__type"]; !hasType {
+		return value
+	}
+	if v, hasVar := m["__var"]; hasVar {
+		return v
+	}
+	return value
+}
+
+// serializeTimetable converts a schedule string to the Airflow timetable format.
+func serializeTimetable(schedule *string) map[string]any {
+	if schedule == nil {
+		return map[string]any{
+			"__type": "airflow.timetables.simple.NullTimetable",
+			"__var":  map[string]any{},
+		}
+	}
+	switch *schedule {
+	case "@once":
+		return map[string]any{
+			"__type": "airflow.timetables.simple.OnceTimetable",
+			"__var":  map[string]any{},
+		}
+	case "@continuous":
+		return map[string]any{
+			"__type": "airflow.timetables.simple.ContinuousTimetable",
+			"__var":  map[string]any{},
+		}
+	default:
+		return map[string]any{
+			"__type": "airflow.timetables.trigger.CronTriggerTimetable",
+			"__var": map[string]any{
+				"expression":      *schedule,
+				"timezone":        "UTC",
+				"interval":        0.0,
+				"run_immediately": false,
+			},
+		}
+	}
+}
+
+// serializeTask converts a task to the Airflow serialization format.
+func serializeTask(taskID, typeName, pkgPath string, downstream []string) map[string]any {
+	if typeName == "" {
+		typeName = taskID
+	}
+	if pkgPath == "" {
+		pkgPath = "main"
+	}
+	data := map[string]any{
+		"task_id":      taskID,
+		"task_type":    typeName,
+		"_task_module": pkgPath,
+		"language":     "go",
+	}
+	if len(downstream) > 0 {
+		sorted := make([]string, len(downstream))
+		copy(sorted, downstream)
+		sort.Strings(sorted)
+		data["downstream_task_ids"] = sorted
+	}
+	return map[string]any{
+		"__type": "operator",
+		"__var":  data,
+	}
+}
+
+// serializeTaskGroup creates a flat root task group containing all task IDs.
+func serializeTaskGroup(taskIDs []string) map[string]any {
+	children := make(map[string]any, len(taskIDs))
+	for _, id := range taskIDs {
+		children[id] = []any{"operator", id}
+	}
+	return map[string]any{
+		"_group_id":            nil,
+		"group_display_name":   "",
+		"prefix_group_id":      true,
+		"tooltip":              "",
+		"ui_color":             "CornflowerBlue",
+		"ui_fgcolor":           "#000",
+		"children":             children,
+		"upstream_group_ids":   []any{},
+		"downstream_group_ids": []any{},
+		"upstream_task_ids":    []any{},
+		"downstream_task_ids":  []any{},
+	}
+}
+
+// serializeParams converts DAG params to Airflow's serialization format.
+func serializeParams(params map[string]any) []any {
+	if len(params) == 0 {
+		return []any{}
+	}
+	result := make([]any, 0, len(params))
+	for k, v := range params {
+		result = append(result, []any{
+			k,
+			map[string]any{
+				"__class":     "airflow.sdk.definitions.param.Param",
+				"default":     serializeValue(v),
+				"description": nil,
+				"schema":      serializeValue(map[string]any{}),
+				"source":      nil,
+			},
+		})
+	}
+	return result
+}
+
+// SerializeDag converts a bundlev1.DagInfo to Airflow DagSerialization v3
+// format. The Go SDK's bundlev1.Dag interface does not (yet) carry per-DAG
+// metadata like schedule, start_date, tags, etc., so the encoding emits
+// schema defaults for those fields. The optional-field handling below is
+// kept (gated on nil checks) so the encoder can grow naturally as the
+// bundle metadata surface expands.
+func SerializeDag(info bundlev1.DagInfo, fileloc, relativeFileloc string) map[string]any {
+	taskIDs := make([]string, len(info.Tasks))
+	tasks := make([]any, len(info.Tasks))
+	for i, t := range info.Tasks {
+		taskIDs[i] = t.ID
+		tasks[i] = serializeTask(t.ID, t.TypeName, t.PkgPath, nil)
+	}
+
+	return map[string]any{
+		// Required fields (always present)
+		"dag_id":            info.DagID,
+		"fileloc":           fileloc,
+		"relative_fileloc":  relativeFileloc,
+		"timezone":          "UTC",
+		"timetable":         serializeTimetable(nil),
+		"tasks":             tasks,
+		"dag_dependencies":  []any{},
+		"task_group":        serializeTaskGroup(taskIDs),
+		"edge_info":         map[string]any{},
+		"params":            serializeParams(nil),
+		"deadline":          nil,
+		"allowed_run_types": nil,
+	}
+}
+
+// computeRelativeFileloc computes the relative file location from the bundle path.
+func computeRelativeFileloc(fileloc, bundlePath string) string {
+	if fileloc == "" {
+		return ""
+	}
+	if bundlePath == "" {
+		return "."
+	}
+	rel, err := filepath.Rel(bundlePath, fileloc)
+	if err != nil {
+		return "."
+	}
+	if rel == "" {
+		return "."
+	}
+	return rel
+}

--- a/go-sdk/pkg/execution/serde_test.go
+++ b/go-sdk/pkg/execution/serde_test.go
@@ -1,0 +1,226 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+)
+
+func TestSerializeValuePrimitives(t *testing.T) {
+	assert.Nil(t, serializeValue(nil))
+	assert.Equal(t, "hello", serializeValue("hello"))
+	assert.Equal(t, true, serializeValue(true))
+	assert.Equal(t, 42, serializeValue(42))
+	assert.Equal(t, float64(3.14), serializeValue(3.14))
+}
+
+func TestSerializeValueDatetime(t *testing.T) {
+	ts := time.Date(2024, 1, 15, 10, 30, 0, 500000000, time.UTC)
+	result := serializeValue(ts)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "datetime", m["__type"])
+	epochSec := m["__var"].(float64)
+	expected := float64(ts.Unix()) + 0.5
+	assert.InDelta(t, expected, epochSec, 0.001)
+}
+
+func TestSerializeValueTimedelta(t *testing.T) {
+	dur := 90 * time.Second
+	result := serializeValue(dur)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "timedelta", m["__type"])
+	assert.Equal(t, 90.0, m["__var"])
+}
+
+func TestSerializeValueMap(t *testing.T) {
+	input := map[string]any{
+		"key1": "val1",
+		"key2": 42,
+	}
+	result := serializeValue(input)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "dict", m["__type"])
+	inner := m["__var"].(map[string]any)
+	assert.Equal(t, "val1", inner["key1"])
+	assert.Equal(t, 42, inner["key2"])
+}
+
+func TestSerializeValueSlice(t *testing.T) {
+	input := []any{"a", 1, true}
+	result := serializeValue(input)
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	assert.Len(t, arr, 3)
+	assert.Equal(t, "a", arr[0])
+}
+
+func TestUnwrapTypeEncoding(t *testing.T) {
+	wrapped := map[string]any{
+		"__type": "datetime",
+		"__var":  1705313400.5,
+	}
+	assert.Equal(t, 1705313400.5, unwrapTypeEncoding(wrapped))
+
+	assert.Equal(t, "hello", unwrapTypeEncoding("hello"))
+	assert.Equal(t, 42, unwrapTypeEncoding(42))
+}
+
+func TestSerializeTimetable(t *testing.T) {
+	t.Run("nil schedule", func(t *testing.T) {
+		result := serializeTimetable(nil)
+		assert.Equal(t, "airflow.timetables.simple.NullTimetable", result["__type"])
+	})
+
+	t.Run("@once", func(t *testing.T) {
+		s := "@once"
+		result := serializeTimetable(&s)
+		assert.Equal(t, "airflow.timetables.simple.OnceTimetable", result["__type"])
+	})
+
+	t.Run("@continuous", func(t *testing.T) {
+		s := "@continuous"
+		result := serializeTimetable(&s)
+		assert.Equal(t, "airflow.timetables.simple.ContinuousTimetable", result["__type"])
+	})
+
+	t.Run("cron expression", func(t *testing.T) {
+		s := "0 12 * * *"
+		result := serializeTimetable(&s)
+		assert.Equal(t, "airflow.timetables.trigger.CronTriggerTimetable", result["__type"])
+		v := result["__var"].(map[string]any)
+		assert.Equal(t, "0 12 * * *", v["expression"])
+		assert.Equal(t, "UTC", v["timezone"])
+		assert.Equal(t, 0.0, v["interval"])
+		assert.Equal(t, false, v["run_immediately"])
+	})
+}
+
+func TestSerializeTask(t *testing.T) {
+	result := serializeTask("extract", "extract", "main", []string{"transform"})
+	assert.Equal(t, "operator", result["__type"])
+	data := result["__var"].(map[string]any)
+	assert.Equal(t, "extract", data["task_id"])
+	assert.Equal(t, "extract", data["task_type"])
+	assert.Equal(t, "main", data["_task_module"])
+	assert.Equal(t, "go", data["language"])
+	assert.Equal(t, []string{"transform"}, data["downstream_task_ids"])
+}
+
+func TestSerializeTaskNoDownstream(t *testing.T) {
+	result := serializeTask("load", "load", "main", nil)
+	data := result["__var"].(map[string]any)
+	_, hasDownstream := data["downstream_task_ids"]
+	assert.False(t, hasDownstream)
+}
+
+func TestSerializeTaskGroup(t *testing.T) {
+	result := serializeTaskGroup([]string{"t1", "t2"})
+	assert.Nil(t, result["_group_id"])
+	assert.Equal(t, true, result["prefix_group_id"])
+	assert.Equal(t, "CornflowerBlue", result["ui_color"])
+
+	children := result["children"].(map[string]any)
+	assert.Equal(t, []any{"operator", "t1"}, children["t1"])
+	assert.Equal(t, []any{"operator", "t2"}, children["t2"])
+}
+
+func TestSerializeParams(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		result := serializeParams(nil)
+		assert.Equal(t, []any{}, result)
+	})
+
+	t.Run("with values", func(t *testing.T) {
+		result := serializeParams(map[string]any{"key1": "default_val"})
+		assert.Len(t, result, 1)
+		pair := result[0].([]any)
+		assert.Equal(t, "key1", pair[0])
+		paramMap := pair[1].(map[string]any)
+		assert.Equal(t, "airflow.sdk.definitions.param.Param", paramMap["__class"])
+		assert.Equal(t, "default_val", paramMap["default"])
+	})
+}
+
+func TestSerializeDagMinimal(t *testing.T) {
+	info := bundlev1.DagInfo{DagID: "test_dag"}
+	result := SerializeDag(info, "/path/to/bundle", ".")
+
+	assert.Equal(t, "test_dag", result["dag_id"])
+	assert.Equal(t, "/path/to/bundle", result["fileloc"])
+	assert.Equal(t, ".", result["relative_fileloc"])
+	assert.Equal(t, "UTC", result["timezone"])
+
+	tt := result["timetable"].(map[string]any)
+	assert.Equal(t, "airflow.timetables.simple.NullTimetable", tt["__type"])
+
+	_, hasDesc := result["description"]
+	assert.False(t, hasDesc)
+	_, hasCatchup := result["catchup"]
+	assert.False(t, hasCatchup)
+}
+
+func TestSerializeDagWithTasks(t *testing.T) {
+	info := bundlev1.DagInfo{
+		DagID: "etl",
+		Tasks: []bundlev1.TaskInfo{
+			{ID: "extract", TypeName: "extract", PkgPath: "main"},
+			{ID: "load", TypeName: "load", PkgPath: "main"},
+		},
+	}
+	result := SerializeDag(info, "/bundle/main.go", "main.go")
+
+	tasks := result["tasks"].([]any)
+	require.Len(t, tasks, 2)
+	first := tasks[0].(map[string]any)
+	v := first["__var"].(map[string]any)
+	assert.Equal(t, "extract", v["task_id"])
+	assert.Equal(t, "extract", v["task_type"])
+	assert.Equal(t, "main", v["_task_module"])
+	assert.Equal(t, "go", v["language"])
+
+	tg := result["task_group"].(map[string]any)
+	children := tg["children"].(map[string]any)
+	assert.Contains(t, children, "extract")
+	assert.Contains(t, children, "load")
+}
+
+func TestComputeRelativeFileloc(t *testing.T) {
+	tests := []struct {
+		fileloc    string
+		bundlePath string
+		want       string
+	}{
+		{"", "", ""},
+		{"/a/b/c.go", "", "."},
+		{"/bundles/my/dags.go", "/bundles/my", "dags.go"},
+		{"/bundles/my/sub/dags.go", "/bundles/my", "sub/dags.go"},
+	}
+	for _, tt := range tests {
+		result := computeRelativeFileloc(tt.fileloc, tt.bundlePath)
+		assert.Equal(t, tt.want, result, "fileloc=%q bundlePath=%q", tt.fileloc, tt.bundlePath)
+	}
+}

--- a/go-sdk/pkg/execution/server.go
+++ b/go-sdk/pkg/execution/server.go
@@ -85,13 +85,19 @@ func Serve(provider bundlev1.BundleProvider, commAddr, logsAddr string) error {
 	}()
 	wg.Wait()
 
+	// Either dial may succeed while the other fails; close any orphaned
+	// connection before returning so we don't leak an open TCP socket.
 	if commErr != nil {
+		if logsConn != nil {
+			logsConn.Close()
+		}
 		return fmt.Errorf("connecting to comm socket %s: %w", commAddr, commErr)
 	}
-	defer commConn.Close()
 	if logsErr != nil {
+		commConn.Close()
 		return fmt.Errorf("connecting to logs socket %s: %w", logsAddr, logsErr)
 	}
+	defer commConn.Close()
 	defer logsConn.Close()
 
 	logHandler.Connect(logsConn)

--- a/go-sdk/pkg/execution/server.go
+++ b/go-sdk/pkg/execution/server.go
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package execution implements the SDK coordinator-protocol runtime
+// (msgpack-over-IPC). It is the second mode of bundlev1server.Serve: when
+// the bundle binary is launched with --comm/--logs by the Airflow supervisor
+// (Python ExecutableCoordinator), bundlev1server.Serve dispatches here.
+//
+// The first inbound frame on the comm socket selects between two
+// sub-protocols:
+//
+//   - DagFileParseRequest: one-shot, returns DagFileParsingResult and exits.
+//   - StartupDetails:       multi-round task execution.
+//
+// See go-sdk/adr/0003-coordinator-protocol-msgpack-ipc.md.
+package execution
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+)
+
+// Serve runs the bundle binary in coordinator mode. It dials the supervisor's
+// comm and logs sockets, installs an slog handler that writes JSON-line
+// records to the logs connection, and dispatches on the first frame.
+//
+// Serve returns nil on a clean shutdown (one-shot DAG parse or task execution
+// completed); a non-nil error indicates a protocol-level failure (connection
+// loss, malformed frames, unknown first message type).
+func Serve(provider bundlev1.BundleProvider, commAddr, logsAddr string) error {
+	if commAddr == "" {
+		return fmt.Errorf("missing --comm=host:port argument")
+	}
+	if logsAddr == "" {
+		return fmt.Errorf("missing --logs=host:port argument")
+	}
+
+	// Buffer log records until the logs socket is connected. Anything the
+	// runtime emits between Connect-time and the first frame still gets
+	// flushed.
+	logHandler := NewSocketLogHandler(nil, slog.LevelDebug)
+	logger := slog.New(logHandler)
+	slog.SetDefault(logger)
+
+	// Connect to both sockets concurrently so the supervisor can accept them
+	// in either order.
+	var commConn, logsConn net.Conn
+	var commErr, logsErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		commConn, commErr = net.Dial("tcp", commAddr)
+	}()
+	go func() {
+		defer wg.Done()
+		logsConn, logsErr = net.Dial("tcp", logsAddr)
+	}()
+	wg.Wait()
+
+	if commErr != nil {
+		return fmt.Errorf("connecting to comm socket %s: %w", commAddr, commErr)
+	}
+	defer commConn.Close()
+	if logsErr != nil {
+		return fmt.Errorf("connecting to logs socket %s: %w", logsAddr, logsErr)
+	}
+	defer logsConn.Close()
+
+	logHandler.Connect(logsConn)
+	logger.Debug("Connected", "comm", commAddr, "logs", logsAddr)
+
+	// Materialise the bundle (RegisterDags) up front. Both protocol paths
+	// need the registry, and doing it once before the first frame keeps the
+	// dispatcher simple.
+	bundle, err := materialiseBundle(provider)
+	if err != nil {
+		return fmt.Errorf("registering dags: %w", err)
+	}
+
+	comm := NewCoordinatorComm(commConn, commConn, logger)
+
+	frame, err := comm.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("reading initial message: %w", err)
+	}
+
+	if frame.Err != nil {
+		errResp := decodeErrorResponse(frame.Err)
+		if errResp != nil {
+			return fmt.Errorf(
+				"received error from supervisor: [%s] %v",
+				errResp.Error,
+				errResp.Detail,
+			)
+		}
+	}
+
+	body, err := decodeIncomingBody(frame.Body)
+	if err != nil {
+		return fmt.Errorf("decoding initial message: %w", err)
+	}
+
+	switch msg := body.(type) {
+	case *DagFileParseRequest:
+		logger.Debug("DAG parsing mode", "file", msg.File)
+		result := ParseDags(bundle, msg)
+		if err := comm.SendRequest(frame.ID, result); err != nil {
+			return fmt.Errorf("sending parse result: %w", err)
+		}
+		logger.Debug("DAG parsing complete")
+
+	case *StartupDetails:
+		logger.Debug("Task execution mode",
+			"dag_id", msg.TI.DagID,
+			"task_id", msg.TI.TaskID,
+		)
+		result := RunTask(bundle, msg, comm, logger)
+		if err := comm.SendRequest(frame.ID, result); err != nil {
+			return fmt.Errorf("sending task result: %w", err)
+		}
+		logger.Debug("Task execution complete")
+
+	default:
+		return fmt.Errorf("unexpected initial message type: %T", body)
+	}
+
+	return nil
+}
+
+func materialiseBundle(provider bundlev1.BundleProvider) (bundlev1.Bundle, error) {
+	reg := bundlev1.New()
+	if err := provider.RegisterDags(reg); err != nil {
+		return nil, err
+	}
+	return reg, nil
+}

--- a/go-sdk/pkg/execution/server.go
+++ b/go-sdk/pkg/execution/server.go
@@ -34,9 +34,17 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
 )
+
+// dialTimeout bounds how long execution.Serve waits to reach the supervisor's
+// comm and logs sockets. The supervisor opens the listeners before spawning
+// the bundle binary, so the dials normally succeed in milliseconds; the
+// timeout exists so an unreachable address fails fast instead of hanging the
+// runtime indefinitely.
+const dialTimeout = 30 * time.Second
 
 // Serve runs the bundle binary in coordinator mode. It dials the supervisor's
 // comm and logs sockets, installs an slog handler that writes JSON-line
@@ -62,17 +70,18 @@ func Serve(provider bundlev1.BundleProvider, commAddr, logsAddr string) error {
 
 	// Connect to both sockets concurrently so the supervisor can accept them
 	// in either order.
+	dialer := &net.Dialer{Timeout: dialTimeout}
 	var commConn, logsConn net.Conn
 	var commErr, logsErr error
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		commConn, commErr = net.Dial("tcp", commAddr)
+		commConn, commErr = dialer.Dial("tcp", commAddr)
 	}()
 	go func() {
 		defer wg.Done()
-		logsConn, logsErr = net.Dial("tcp", logsAddr)
+		logsConn, logsErr = dialer.Dial("tcp", logsAddr)
 	}()
 	wg.Wait()
 

--- a/go-sdk/pkg/execution/task_runner.go
+++ b/go-sdk/pkg/execution/task_runner.go
@@ -53,7 +53,7 @@ func RunTask(
 			"dag_id", details.TI.DagID,
 			"task_id", details.TI.TaskID,
 		)
-		return TaskStateMsg{State: "removed", EndDate: time.Now().UTC()}.toMap()
+		return TaskStateMsg{State: TaskStateRemoved, EndDate: time.Now().UTC()}.toMap()
 	}
 
 	client := NewCoordinatorClient(comm, details)
@@ -97,7 +97,7 @@ func executeTask(
 				"stack", string(debug.Stack()),
 			)
 			result = TaskStateMsg{
-				State:   "failed",
+				State:   TaskStateFailed,
 				EndDate: time.Now().UTC(),
 			}.toMap()
 		}
@@ -106,7 +106,7 @@ func executeTask(
 	if err := task.Execute(ctx, logger); err != nil {
 		logger.Error("Task failed", "error", fmt.Sprintf("%v", err))
 		return TaskStateMsg{
-			State:   "failed",
+			State:   TaskStateFailed,
 			EndDate: time.Now().UTC(),
 		}.toMap()
 	}

--- a/go-sdk/pkg/execution/task_runner.go
+++ b/go-sdk/pkg/execution/task_runner.go
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+	"github.com/apache/airflow/go-sdk/pkg/api"
+	"github.com/apache/airflow/go-sdk/pkg/sdkcontext"
+	"github.com/apache/airflow/go-sdk/sdk"
+)
+
+// RunTask executes a task based on StartupDetails received from the supervisor.
+//
+// It looks up the task in the bundle, creates a CoordinatorClient for SDK
+// calls, executes the task, and returns a terminal message body
+// (SucceedTaskMsg or TaskStateMsg) ready to ship as the final response frame.
+//
+// The supervisor owns the Execution-API state transitions in coordinator
+// mode, so we deliberately bypass worker.ExecuteTaskWorkload (which drives
+// Run / UpdateState itself) and only invoke the user's task function.
+func RunTask(
+	bundle bundlev1.Bundle,
+	details *StartupDetails,
+	comm *CoordinatorComm,
+	logger *slog.Logger,
+) map[string]any {
+	task, exists := bundle.LookupTask(details.TI.DagID, details.TI.TaskID)
+	if !exists {
+		logger.Error("Task not registered",
+			"dag_id", details.TI.DagID,
+			"task_id", details.TI.TaskID,
+		)
+		return TaskStateMsg{State: "removed", EndDate: time.Now().UTC()}.toMap()
+	}
+
+	client := NewCoordinatorClient(comm, details)
+
+	// taskFunction.sendXcom reads the workload from context to get the task
+	// instance ids; populate it the same shape the gRPC path uses.
+	tiUUID, _ := uuid.Parse(details.TI.ID)
+	mapIndex := details.TI.MapIndex
+	workload := api.ExecuteTaskWorkload{
+		TI: api.TaskInstance{
+			Id:        tiUUID,
+			DagId:     details.TI.DagID,
+			RunId:     details.TI.RunID,
+			TaskId:    details.TI.TaskID,
+			TryNumber: details.TI.TryNumber,
+			MapIndex:  &mapIndex,
+		},
+		BundleInfo: api.BundleInfo{
+			Name:    details.BundleInfo.Name,
+			Version: &details.BundleInfo.Version,
+		},
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, sdkcontext.WorkloadContextKey, workload)
+	ctx = context.WithValue(ctx, sdkcontext.SdkClientContextKey, sdk.Client(client))
+
+	return executeTask(ctx, task, logger)
+}
+
+// executeTask runs the task and handles success, failure, and panics.
+func executeTask(
+	ctx context.Context,
+	task bundlev1.Task,
+	logger *slog.Logger,
+) (result map[string]any) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Recovered panic in task",
+				"error", r,
+				"stack", string(debug.Stack()),
+			)
+			result = TaskStateMsg{
+				State:   "failed",
+				EndDate: time.Now().UTC(),
+			}.toMap()
+		}
+	}()
+
+	if err := task.Execute(ctx, logger); err != nil {
+		logger.Error("Task failed", "error", fmt.Sprintf("%v", err))
+		return TaskStateMsg{
+			State:   "failed",
+			EndDate: time.Now().UTC(),
+		}.toMap()
+	}
+
+	return SucceedTaskMsg{
+		EndDate: time.Now().UTC(),
+	}.toMap()
+}

--- a/go-sdk/pkg/execution/task_runner.go
+++ b/go-sdk/pkg/execution/task_runner.go
@@ -19,7 +19,6 @@ package execution
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"time"
@@ -113,7 +112,7 @@ func executeTask(
 	}()
 
 	if err := task.Execute(ctx, logger); err != nil {
-		logger.Error("Task failed", "error", fmt.Sprintf("%v", err))
+		logger.ErrorContext(ctx, "Task failed", "error", err)
 		return TaskStateMsg{
 			State:   TaskStateFailed,
 			EndDate: time.Now().UTC(),

--- a/go-sdk/pkg/execution/task_runner.go
+++ b/go-sdk/pkg/execution/task_runner.go
@@ -60,7 +60,16 @@ func RunTask(
 
 	// taskFunction.sendXcom reads the workload from context to get the task
 	// instance ids; populate it the same shape the gRPC path uses.
-	tiUUID, _ := uuid.Parse(details.TI.ID)
+	tiUUID, err := uuid.Parse(details.TI.ID)
+	if err != nil {
+		logger.Error("Invalid task instance UUID from supervisor",
+			"dag_id", details.TI.DagID,
+			"task_id", details.TI.TaskID,
+			"ti_id", details.TI.ID,
+			"error", err,
+		)
+		return TaskStateMsg{State: TaskStateFailed, EndDate: time.Now().UTC()}.toMap()
+	}
 	mapIndex := details.TI.MapIndex
 	workload := api.ExecuteTaskWorkload{
 		TI: api.TaskInstance{

--- a/go-sdk/pkg/sdkcontext/keys.go
+++ b/go-sdk/pkg/sdkcontext/keys.go
@@ -22,6 +22,7 @@ type (
 	apiClientContextKey struct{}
 	workerContextKey    struct{}
 	runtimeTIContextKey struct{}
+	sdkClientContextKey struct{}
 )
 
 var (
@@ -32,4 +33,11 @@ var (
 	RuntimeTIContextKey = runtimeTIContextKey{}
 	ApiClientContextKey = apiClientContextKey{}
 	WorkerContextKey    = workerContextKey{}
+
+	// SdkClientContextKey, when present, holds an sdk.Client implementation
+	// that should be injected into task functions instead of constructing a
+	// default HTTP-backed client. The coordinator-mode runtime uses this to
+	// route task SDK calls (GetVariable, GetConnection, ...) over the
+	// supervisor comm socket rather than to the Execution API.
+	SdkClientContextKey = sdkClientContextKey{}
 )

--- a/go-sdk/sdk/client.go
+++ b/go-sdk/sdk/client.go
@@ -57,6 +57,12 @@ func (*client) GetVariable(ctx context.Context, key string) (string, error) {
 		}
 		return "", err
 	}
+	// TODO: register secret-named variables with a SecretsMasker so the
+	// returned value is automatically redacted from subsequent task logs,
+	// matching Python's airflow.models.variable.Variable.get behaviour.
+	// Pairs with the "TODO: mask secrets here" hook in
+	// pkg/worker/runner.go's task log handler — both halves are needed
+	// before secret masking actually works end-to-end.
 	return *resp.Value, nil
 }
 

--- a/go-sdk/sdk/client.go
+++ b/go-sdk/sdk/client.go
@@ -84,7 +84,7 @@ func (*client) GetConnection(ctx context.Context, connID string) (Connection, er
 		return Connection{}, err
 	}
 
-	return connFromAPIResponse(resp)
+	return ConnFromAPIResponse(resp)
 }
 
 func (c *client) PushXCom(

--- a/go-sdk/sdk/client.go
+++ b/go-sdk/sdk/client.go
@@ -79,6 +79,13 @@ func (c *client) UnmarshalJSONVariable(ctx context.Context, key string, pointer 
 func (*client) GetConnection(ctx context.Context, connID string) (Connection, error) {
 	// TODO: Lookup connection from env var (and handle JSON + URI forms)
 
+	// TODO: register Connection.Password and sensitive-keyed entries of
+	// Connection.Extra with a SecretsMasker so they are auto-redacted from
+	// subsequent task logs, matching Python's
+	// airflow.models.connection.Connection.get behaviour. Pairs with the
+	// "TODO: mask secrets here" hook in pkg/worker/runner.go's task log
+	// handler and the matching TODO on GetVariable above.
+
 	httpClient := ctx.Value(sdkcontext.ApiClientContextKey).(api.ClientInterface)
 
 	resp, err := httpClient.Connections().Get(ctx, connID)

--- a/go-sdk/sdk/connection.go
+++ b/go-sdk/sdk/connection.go
@@ -110,7 +110,11 @@ func (c Connection) GetURI() *url.URL {
 	return uri
 }
 
-func connFromAPIResponse(resp *api.ConnectionResponse) (Connection, error) {
+// ConnFromAPIResponse converts an Execution-API ConnectionResponse into the
+// SDK's Connection type. It is exported so other internal SDK packages (for
+// example, the coordinator-mode runtime in bundlev1server/impl/coord) can
+// reuse the same conversion.
+func ConnFromAPIResponse(resp *api.ConnectionResponse) (Connection, error) {
 	var err error
 	conn := Connection{
 		ID:       resp.ConnId,

--- a/go-sdk/sdk/sdk.go
+++ b/go-sdk/sdk/sdk.go
@@ -53,9 +53,10 @@ type VariableClient interface {
 	//		}
 	GetVariable(ctx context.Context, key string) (string, error)
 
-	// UnmarshalJSONVariable fetches a variable and json.Unmarshal's its value
-	// into pointer. Use this when the variable was stored as a JSON object,
-	// array, or number; for plain string variables call GetVariable directly.
+	// UnmarshalJSONVariable fetches a variable and unmarshals its value into
+	// pointer via json.Unmarshal. Use this when the variable was stored as a
+	// JSON object, array, or number; for plain string variables call
+	// GetVariable directly.
 	//
 	// pointer must be a non-nil pointer, as required by encoding/json.
 	UnmarshalJSONVariable(ctx context.Context, key string, pointer any) error

--- a/go-sdk/sdk/sdk.go
+++ b/go-sdk/sdk/sdk.go
@@ -28,6 +28,15 @@ const (
 	ConnectionEnvPrefix = "AIRFLOW_CONN_"
 )
 
+// VariableClient reads Airflow Variables.
+//
+// Go has no function overloading, so the "give me the raw string" and
+// "give me a decoded struct" cases are split into two methods rather
+// than one polymorphic call: GetVariable returns the raw string,
+// UnmarshalJSONVariable decodes a JSON-encoded variable into a
+// caller-supplied pointer. This mirrors the std-lib split between
+// os.LookupEnv and json.Unmarshal — each method has one job, and the
+// caller picks based on how the variable was stored.
 type VariableClient interface {
 	// GetVariable returns the value of an Airflow Variable.
 	//
@@ -43,6 +52,12 @@ type VariableClient interface {
 	//				// Other errors here, such as http network timeouts etc.
 	//		}
 	GetVariable(ctx context.Context, key string) (string, error)
+
+	// UnmarshalJSONVariable fetches a variable and json.Unmarshal's its value
+	// into pointer. Use this when the variable was stored as a JSON object,
+	// array, or number; for plain string variables call GetVariable directly.
+	//
+	// pointer must be a non-nil pointer, as required by encoding/json.
 	UnmarshalJSONVariable(ctx context.Context, key string, pointer any) error
 }
 


### PR DESCRIPTION
> [!NOTE]
> This PR has been broken down into smaller, reviewable PRs. Please review and merge the stack below instead of this one; this PR will be closed once the stack lands.
>
> 1. #67315 -- coordinator-mode protocol primitives and SDK surface hooks (`refactor/go-sdk/coordinator-protocol`)
> 2. #67317 -- concurrent-safe coordinator comms, log handler, and client (`refactor/go-sdk/coordinator-comms`, depends on #67315)
> 3. #67318 -- coordinator-mode runtime entry point and task runner (`refactor/go-sdk/coordinator-runtime-server`, depends on #67317)

- **Depends on https://github.com/apache/airflow/pull/67153  get merged first**
- **Diff for early review**: https://github.com/jason810496/airflow/compare/refactor/go-sdk/adrs...jason810496:refactor/go-sdk/coordinator-runtime
- related: ADR 0003 (coordinator-protocol msgpack-over-IPC) defined in https://github.com/apache/airflow/pull/67153

## Why

The Go SDK bundle binary currently only speaks the go-plugin protocol
used by the Edge Worker. To let the same binary run under the
ExecutableCoordinator path on the Python side (per ADR 0003), the
bundle needs to be able to act as a coordinator-protocol server:
accept startup details from the supervisor over stdio, drive a task
through its lifecycle, and stream logs / comms frames back. This PR
adds that runtime as a new `pkg/execution` package and wires the
bundle server to invoke it.

## How

- New `go-sdk/pkg/execution` package implements the coordinator-side
  runtime: msgpack framing (`frames.go`), the message catalogue
  (`messages.go`), Airflow-shaped serialisation (`serde.go`), the
  comms decoder/encoder pair (`comms.go`), an stdio-backed logger
  (`logger.go`), a `Client` for outbound supervisor calls
  (`client.go`), the `Server` that owns the stdio loop (`server.go`),
  and a `TaskRunner` that drives a task from startup-details through
  to completion (`task_runner.go`).
- `dag_parser.go` reuses the existing registry to enumerate DAGs/tasks
  for the supervisor without spawning the legacy go-plugin path.
- Bundle plumbing: `bundlev1server/server.go`, `bundlev1/registry.go`,
  and `bundlev1/task.go` learn to hand a task off to the new runner;
  `sdkcontext/keys.go` exposes the new context keys; `sdk/client.go`
  and `sdk/connection.go` get the small adjustments required for the
  new entry path.
- Inspire by https://github.com/apache/airflow/pull/66412, use dispatcher pattern for concurrent-safe message frame mapping. (the `.Communication` function)

## What

- Add `go-sdk/pkg/execution/{client,comms,dag_parser,frames,logger,messages,serde,server,task_runner}.go`
  plus matching unit and integration tests.
- Extend `go-sdk/bundle/bundlev1/{bundlev1server/server.go,registry.go,task.go}`
  to route coordinator-protocol invocations through the new runtime.
- Add the `sdkcontext` keys consumed by the runner and small SDK
  client/connection tweaks.
- Bump `go.mod` / `go.sum` for the new transport/codec dependencies.

## Next

- https://github.com/apache/airflow/pull/67155

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
