### PR TITLE
Reject invalid TaskInstance state update payloads

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -109,12 +109,6 @@ class TISuccessStatePayload(StrictBaseModel):
     rendered_map_index: str | None = None
 
 
-class TITargetStatePayload(StrictBaseModel):
-    """Schema for updating TaskInstance to a target state, excluding terminal and running states."""
-
-    state: IntermediateTIState
-
-
 class TIDeferredStatePayload(StrictBaseModel):
     """Schema for updating TaskInstance to a deferred state."""
 
@@ -247,15 +241,13 @@ def ti_state_discriminator(v: dict[str, str] | StrictBaseModel) -> str:
         return "awaiting_input"
     if state == TIState.UP_FOR_RETRY:
         return "up_for_retry"
-    return "_other_"
+    return "__unsupported__"
 
 
 # It is called "_terminal_" to avoid future conflicts if we added an actual state named "terminal"
-# and "_other_" is a catch-all for all other states that are not covered by the other schemas.
 TIStateUpdate = Annotated[
     Annotated[TITerminalStatePayload, Tag("_terminal_")]
     | Annotated[TISuccessStatePayload, Tag("success")]
-    | Annotated[TITargetStatePayload, Tag("_other_")]
     | Annotated[TIDeferredStatePayload, Tag("deferred")]
     | Annotated[TIRescheduleStatePayload, Tag("up_for_reschedule")]
     | Annotated[TIAwaitingInputStatePayload, Tag("awaiting_input")]

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1501,24 +1501,34 @@ class TestTIUpdateState:
             "message": "Task Instance not found",
         }
 
-    def test_ti_update_state_running_errors(self, client, session, create_task_instance, time_machine):
+    @pytest.mark.parametrize(
+        "payload_state",
+        [State.RUNNING, State.SCHEDULED, State.QUEUED, State.RESTARTING],
+    )
+    def test_ti_update_state_rejects_unsupported_payload_state(
+        self, client, session, create_task_instance, payload_state
+    ):
         """
-        Test that a 422 error is returned when the Task Instance state is RUNNING in the payload.
+        Test that a 422 error is returned when the Task Instance state is unsupported in the payload.
 
-        Task should be set to Running state via the /execution/task-instances/{task_instance_id}/run endpoint.
+        Task states owned by the scheduler or executor should not be accepted as worker-reported
+        state transitions.
         """
         ti = create_task_instance(
-            task_id="test_ti_update_state_running_errors",
-            state=State.QUEUED,
+            task_id="test_ti_update_state_rejects_unsupported_payload_state",
+            state=State.RUNNING,
             session=session,
             start_date=DEFAULT_START_DATE,
         )
 
         session.commit()
 
-        response = client.patch(f"/execution/task-instances/{ti.id}/state", json={"state": "running"})
+        response = client.patch(f"/execution/task-instances/{ti.id}/state", json={"state": payload_state})
 
         assert response.status_code == 422
+        session.expire_all()
+        assert session.get(TaskInstance, ti.id).state == State.RUNNING
+        assert session.scalars(select(Log).where(Log.dag_id == ti.dag_id)).all() == []
 
     def test_ti_update_state_database_error(self, client, session, create_task_instance):
         """

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -204,20 +204,6 @@ class InactiveAssetsResponse(BaseModel):
     inactive_assets: Annotated[list[AssetProfile] | None, Field(title="Inactive Assets")] = None
 
 
-class IntermediateTIState(str, Enum):
-    """
-    States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
-    """
-
-    SCHEDULED = "scheduled"
-    QUEUED = "queued"
-    RESTARTING = "restarting"
-    UP_FOR_RETRY = "up_for_retry"
-    UP_FOR_RESCHEDULE = "up_for_reschedule"
-    DEFERRED = "deferred"
-    AWAITING_INPUT = "awaiting_input"
-
-
 class PrevSuccessfulDagRunResponse(BaseModel):
     """
     Schema for response with previous successful DagRun information for Task Template Context.
@@ -358,17 +344,6 @@ class TISuccessStatePayload(BaseModel):
     task_outlets: Annotated[list[AssetProfile] | None, Field(title="Task Outlets")] = None
     outlet_events: Annotated[list[dict[str, Any]] | None, Field(title="Outlet Events")] = None
     rendered_map_index: Annotated[str | None, Field(title="Rendered Map Index")] = None
-
-
-class TITargetStatePayload(BaseModel):
-    """
-    Schema for updating TaskInstance to a target state, excluding terminal and running states.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    state: IntermediateTIState
 
 
 class TaskBreadcrumbsResponse(BaseModel):


### PR DESCRIPTION
## Why
I found The Execution API `/execution/task-instances/{task_instance_id}/state` endpoint previously exposed a catch-all TaskInstance state payload schema that allowed scheduler/executor- owned states such as `scheduled`, `queued`, and `restarting`.

  Those states are not valid worker-reported execution outcomes for this endpoint. Since the route implementation does not handle them, sending one could fall through to an error path and potentially mark a running task as failed instead of rejecting the invalid payload.

we should block them in schema stage and return 422, we may not want them to change to `FAIL`

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-18T13:57:11Z head=8570154 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @henry3260** · by `@potiuk` · 2026-06-18 13:57 UTC
>
> Paused pending your next update — this PR has been inactive for ~30 days, so it's been moved to draft to keep the review queue clear:
> - Rebase on the latest `main`, address any new failures, and mark it **Ready for review** when you pick it back up — no rush.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->