### PR TITLE
Add ExecutableCoordinator for native self-contained Dag bundles

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -765,7 +765,6 @@ hiveserver
 hmsclient
 hoc
 homebrew
-honour
 hookimpl
 hookspec
 HostAliases
@@ -1471,7 +1470,6 @@ sendgrid
 sentimentMax
 ser
 serde
-serialisation
 serialise
 serializable
 SerializedDAG
@@ -1783,7 +1781,6 @@ unpause
 unpaused
 unpausing
 unpredicted
-Unrecognised
 unsanitized
 unscoped
 untestable

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -502,6 +502,7 @@ doesn
 doesnt
 dom
 Dont
+dotfiles
 DownloadReportV
 downscaling
 downstreams
@@ -554,6 +555,7 @@ enableAutoScale
 enablement
 encodable
 encryptor
+endian
 enqueue
 enqueued
 Entra
@@ -763,6 +765,7 @@ hiveserver
 hmsclient
 hoc
 homebrew
+honour
 hookimpl
 hookspec
 HostAliases
@@ -1067,6 +1070,7 @@ msfabric
 msg
 msgraph
 mssql
+mtime
 mTLS
 multi-cloud
 multimodal
@@ -1467,6 +1471,7 @@ sendgrid
 sentimentMax
 ser
 serde
+serialisation
 serialise
 serializable
 SerializedDAG
@@ -1778,6 +1783,7 @@ unpause
 unpaused
 unpausing
 unpredicted
+Unrecognised
 unsanitized
 unscoped
 untestable

--- a/task-sdk/docs/airflow-metadata.schema.json
+++ b/task-sdk/docs/airflow-metadata.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://airflow.apache.org/schemas/sdk-executable/airflow-metadata-1.0.schema.json",
+  "title": "Airflow Executable SDK Bundle Metadata",
+  "description": "Build-time manifest declaring DAG and task identifiers exposed by an Airflow native-executable SDK bundle. See the Executable Bundle Spec documentation in the Airflow Task SDK.",
+  "type": "object",
+  "required": ["airflow_bundle_metadata_version", "sdk", "source", "dags"],
+  "additionalProperties": true,
+  "properties": {
+    "airflow_bundle_metadata_version": {
+      "type": "string",
+      "description": "Bundle-spec version this manifest conforms to (currently '1.0').",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "sdk": {
+      "type": "object",
+      "description": "Identifies the SDK that produced the bundle.",
+      "required": ["language", "version", "supervisor_schema_version"],
+      "additionalProperties": true,
+      "properties": {
+        "language": {
+          "type": "string",
+          "description": "Lower-case source-language identifier (e.g. 'go', 'rust', 'cpp', 'zig').",
+          "pattern": "^[a-z][a-z0-9_+.\\-]*$"
+        },
+        "version": {
+          "type": "string",
+          "description": "SDK version used at build time.",
+          "minLength": 1
+        },
+        "supervisor_schema_version": {
+          "type": "string",
+          "description": "Dated supervisor wire-schema version the bundle was compiled against (e.g. '2026-06-16'). The coordinator passes this value to the supervisor so it can downgrade outbound messages / upgrade inbound messages to a shape the bundle understands.",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        }
+      }
+    },
+    "source": {
+      "type": "string",
+      "description": "Original filename of the primary DAG source file (e.g. 'example.go'). The file's bytes are embedded in the bundle's source region; this field is a display name used by the Airflow UI.",
+      "minLength": 1
+    },
+    "dags": {
+      "type": "object",
+      "description": "Mapping of dag_id to DAG entry. Every dag_id the bundle exposes must appear here.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/dagEntry"
+      }
+    }
+  },
+  "$defs": {
+    "dagEntry": {
+      "type": "object",
+      "description": "Static description of a single DAG declared in the bundle.",
+      "required": ["tasks"],
+      "additionalProperties": true,
+      "properties": {
+        "tasks": {
+          "type": "array",
+          "description": "Static list of task_ids declared in the DAG.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/task-sdk/docs/bundle-spec.rst
+++ b/task-sdk/docs/bundle-spec.rst
@@ -1,0 +1,252 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Bundle Spec Format
+==================
+
+This document specifies the on-disk format of a build artifact produced by an
+Airflow native-executable SDK (Go, Rust, C++, Zig, ...) and consumed by
+:class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator`
+at deployment time.
+
+The goal is a single, language-agnostic *bundle* shape so that scheduler,
+worker, and UI behave identically regardless of which compiled SDK produced
+the DAG.
+
+Format version: ``1.0``.
+
+Container
+---------
+
+A bundle is **the compiled executable itself, with a fixed-format footer
+appended after the binary's normal end-of-file**. The executable remains
+directly runnable; the footer is data that follows the last byte the OS
+loader cares about and is invisible to ``exec()``. There is no enclosing
+archive.
+
+A bundle file therefore has three regions, in order from offset 0:
+
+1. The native executable (ELF / Mach-O / PE), including any code-signing
+   structures the platform appends.
+2. The primary DAG source file, embedded verbatim (UTF-8). MAY have length 0.
+3. The build-time manifest (``airflow-metadata.yaml`` content, UTF-8).
+
+The file ends with a fixed 32-byte trailer that locates regions (2) and (3)
+and identifies the file as a bundle. See :ref:`bundle-trailer-layout`.
+
+Filenames follow OS conventions for executables: no extension on Linux/macOS,
+``.exe`` on Windows. The scanner identifies bundles by the trailer's magic,
+not by the filename.
+
+.. _bundle-trailer-layout:
+
+Trailer Layout
+--------------
+
+The last 32 bytes of a conforming bundle are the trailer. All multi-byte
+integers are little-endian.
+
+::
+
+    bytes  0..3   source_len    uint32   length of the source region in bytes
+    bytes  4..7   metadata_len  uint32   length of the metadata region in bytes
+    bytes  8..11  footer_ver    uint32   currently 1
+    bytes 12..23  reserved      12 bytes, MUST be zero
+    bytes 24..31  magic         8 bytes ASCII "AFBNDL01"
+
+The magic is the byte sequence ``0x41 0x46 0x42 0x4E 0x44 0x4C 0x30 0x31``
+(``"AFBNDL01"``). The trailing ``01`` is the footer-format version repeated
+in ASCII so a human can identify a bundle at a glance
+(``tail -c 8 ./mybundle | xxd``); the binary ``footer_ver`` field is the
+authoritative source of truth for parsing.
+
+Reader algorithm:
+
+1. Open the file. Seek to ``EOF - 32``. Read 32 bytes.
+2. Compare bytes ``24..31`` against ``"AFBNDL01"``. If different, the file
+   is not a bundle; the scanner MUST ignore it.
+3. Parse ``footer_ver``. If unknown, fail with a versioning error.
+4. Compute ``metadata_start = filesize - 32 - metadata_len`` and
+   ``source_start = metadata_start - source_len``.
+5. Read ``metadata_len`` bytes from ``metadata_start`` for the manifest.
+6. Read ``source_len`` bytes from ``source_start`` for the source view.
+   If ``source_len == 0``, no source is embedded; the UI displays
+   "(source not available)".
+7. Validate ``source_start >= 0`` and that the implied binary region
+   (``[0, source_start)``) is non-empty.
+
+Source comes *before* metadata so a future ``footer_ver`` MAY introduce
+additional trailing blobs (e.g. signed checksums, compressed deps) by
+extending the trailer rather than inserting between existing blobs.
+
+.. _bundle-metadata-schema:
+
+``airflow-metadata.yaml`` schema
+--------------------------------
+
+The metadata region carries the same YAML manifest documented previously,
+produced at build time from a static scan of the DAG source. A
+machine-readable JSON Schema is published at
+:download:`airflow-metadata.schema.json` for use by build tooling, validators,
+and editors.
+
+.. code-block:: yaml
+
+    format_version: "1.0"
+    sdk:
+      language: go
+      version: "0.1.0"
+    source: example.go
+    dags:
+      example_dag:
+        tasks:
+          - extract
+          - transform
+          - load
+      another_dag:
+        tasks:
+          - run
+
+Top-level keys:
+
+``format_version`` (string, required)
+    The bundle-spec version this manifest conforms to. Currently ``"1.0"``.
+
+``sdk`` (mapping, required)
+    Identifies the SDK that produced the bundle.
+
+    - ``language`` (string, required): lower-case source-language identifier
+      (e.g. ``go``, ``rust``, ``cpp``, ``zig``).
+    - ``version`` (string, required): SDK version used at build time.
+
+``source`` (string, required)
+    Original filename of the primary DAG source file (e.g. ``example.go``).
+    The file's bytes live in the source region of the bundle, not at this
+    path; this field is a display name the Airflow UI uses to label the
+    source-view panel and pick a syntax-highlighting mode from the
+    extension.
+
+``dags`` (mapping, required)
+    Mapping of ``dag_id`` to a *DAG entry*. Every ``dag_id`` the bundle
+    exposes MUST appear here. The scanner uses these keys to match a DAG
+    parsing or task-execution request to the bundle that owns it.
+
+DAG entry fields:
+
+``tasks`` (list of strings, required)
+    Static list of ``task_id``\ s declared in the DAG. Empty lists are
+    permitted but discouraged.
+
+Unrecognised top-level or DAG-entry keys MUST be ignored by the consumer so
+that future SDK versions can extend the manifest without breaking older
+runtimes.
+
+Examples
+--------
+
+Go bundle::
+
+    example
+    ├── ELF/Mach-O/PE executable
+    ├── source region:   contents of example.go
+    ├── metadata region: airflow-metadata.yaml (source: example.go)
+    └── trailer (32 B):  AFBNDL01 magic + lengths
+
+Rust bundle::
+
+    pipeline
+    ├── ELF/Mach-O/PE executable
+    ├── source region:   contents of main.rs
+    ├── metadata region: airflow-metadata.yaml (source: main.rs)
+    └── trailer (32 B):  AFBNDL01 magic + lengths
+
+The bundle is one file. ``./example`` runs the binary; the appended data
+is invisible to ``exec()``.
+
+Build Pipeline Ordering
+-----------------------
+
+The footer is appended after the executable is otherwise complete. Producers
+that perform additional post-build steps MUST observe the following order:
+
+- **Strip** debug symbols *before* appending the footer. Strip
+  implementations operate on the binary's defined end and either leave
+  trailing data intact or truncate it; do not rely on either behaviour.
+- **Code-sign** *after* appending the footer on platforms whose signature
+  covers the entire file (Authenticode, certain notarisation flows). The
+  signature then attests to the footer's contents along with the binary.
+- **Compressors** such as UPX are NOT supported. They rewrite the file
+  end-to-end and destroy the trailer.
+
+Determinism: the trailer is byte-identical for byte-identical inputs, so a
+deterministic build plus a canonical (sorted-key) manifest serialisation
+yields a byte-identical bundle file.
+
+Deployment Layout
+-----------------
+
+Bundle files are placed **as-is** in any of the directories configured as the
+``executables_root`` kwarg on the
+:class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator` entry
+under ``[sdk] coordinators``. The scanner enumerates regular files in each
+directory, reads the last 32 bytes of each, and treats files whose magic
+matches ``"AFBNDL01"`` as bundles. Files without the magic are silently
+ignored, so non-bundle files (READMEs, dotfiles) MAY share the directory
+without interfering with the scan.
+
+::
+
+    /opt/airflow/executable-bundles/
+    ├── example
+    ├── pipeline
+    └── analytics
+
+At task-execution time the runtime execs the bundle file directly with the
+coordinator arguments (``--comm=<addr>`` / ``--logs=<addr>``). No extraction,
+no transient cache directory, no chmod-after-extract step is required: the
+file is already a runnable executable with the appropriate permission bits
+preserved by the build pipeline.
+
+The compiled executable MUST honour the SDK coordinator protocol —
+``--comm=<host:port>`` / ``--logs=<host:port>`` socket-based IPC.
+
+See :class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator`
+for the consumer-side coordinator.
+
+Inspection
+----------
+
+Because the bundle is a single executable rather than an archive,
+inspecting the embedded source and manifest requires a small CLI rather
+than an off-the-shelf ``unzip``. The Go SDK's ``airflow-go-pack`` tool
+provides an ``inspect`` subcommand that dumps both regions; equivalent
+helpers are expected from each language's packer.
+
+Compatibility and Versioning
+----------------------------
+
+- The current bundle-spec format version is ``1.0``; the current trailer
+  format version is ``1`` (``footer_ver = 1``).
+- Backward-incompatible bundle-spec changes increment the major component
+  of ``format_version`` and are gated behind an explicit opt-in on the
+  consumer side.
+- New optional manifest fields MAY be added in minor versions and MUST be
+  ignored by older consumers.
+- New trailer-format versions append fields after ``footer_ver`` (consuming
+  the reserved region) or extend the trailer with additional trailing
+  blobs ahead of the magic. Older readers MUST reject unknown
+  ``footer_ver`` rather than guessing.

--- a/task-sdk/docs/executable-bundle-spec.rst
+++ b/task-sdk/docs/executable-bundle-spec.rst
@@ -15,8 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
-Bundle Spec Format
-==================
+Executable Bundle Spec
+======================
 
 This document specifies the on-disk format of a build artifact produced by an
 Airflow native-executable SDK (Go, Rust, C++, Zig, ...) and consumed by
@@ -27,7 +27,7 @@ The goal is a single, language-agnostic *bundle* shape so that scheduler,
 worker, and UI behave identically regardless of which compiled SDK produced
 the DAG.
 
-Format version: ``1.0``.
+Bundle-spec version: ``1.0``.
 
 Container
 ---------
@@ -45,8 +45,9 @@ A bundle file therefore has three regions, in order from offset 0:
 2. The primary DAG source file, embedded verbatim (UTF-8). MAY have length 0.
 3. The build-time manifest (``airflow-metadata.yaml`` content, UTF-8).
 
-The file ends with a fixed 32-byte trailer that locates regions (2) and (3)
-and identifies the file as a bundle. See :ref:`bundle-trailer-layout`.
+The file ends with a fixed 64-byte trailer that locates regions (2) and (3),
+carries an integrity hash of the binary region, and identifies the file as a
+bundle. See :ref:`bundle-trailer-layout`.
 
 Filenames follow OS conventions for executables: no extension on Linux/macOS,
 ``.exe`` on Windows. The scanner identifies bundles by the trailer's magic,
@@ -57,16 +58,17 @@ not by the filename.
 Trailer Layout
 --------------
 
-The last 32 bytes of a conforming bundle are the trailer. All multi-byte
+The last 64 bytes of a conforming bundle are the trailer. All multi-byte
 integers are little-endian.
 
 ::
 
-    bytes  0..3   source_len    uint32   length of the source region in bytes
-    bytes  4..7   metadata_len  uint32   length of the metadata region in bytes
-    bytes  8..11  footer_ver    uint32   currently 1
-    bytes 12..23  reserved      12 bytes, MUST be zero
-    bytes 24..31  magic         8 bytes ASCII "AFBNDL01"
+    bytes  0..3    source_len     uint32     length of the source region in bytes
+    bytes  4..7    metadata_len   uint32     length of the metadata region in bytes
+    bytes  8..11   footer_ver     uint32     currently 1
+    bytes 12..43   binary_sha256  32 bytes   SHA-256 of the binary region
+    bytes 44..55   reserved       12 bytes   MUST be zero
+    bytes 56..63   magic          8 bytes    ASCII "AFBNDL01"
 
 The magic is the byte sequence ``0x41 0x46 0x42 0x4E 0x44 0x4C 0x30 0x31``
 (``"AFBNDL01"``). The trailing ``01`` is the footer-format version repeated
@@ -74,20 +76,33 @@ in ASCII so a human can identify a bundle at a glance
 (``tail -c 8 ./mybundle | xxd``); the binary ``footer_ver`` field is the
 authoritative source of truth for parsing.
 
+``binary_sha256`` is the SHA-256 digest computed over the **binary region
+only** — bytes ``[0, source_start)``. The hash field sits inside the trailer
+and therefore cannot cover the bytes it occupies; it provides *integrity*
+(the binary region has not been truncated, corrupted, or naively edited
+between packing and exec) rather than *authenticity*
+(see :ref:`bundle-code-signing` for how authenticity layers on top).
+
 Reader algorithm:
 
-1. Open the file. Seek to ``EOF - 32``. Read 32 bytes.
-2. Compare bytes ``24..31`` against ``"AFBNDL01"``. If different, the file
+1. Open the file. Seek to ``EOF - 64``. Read 64 bytes.
+2. Compare bytes ``56..63`` against ``"AFBNDL01"``. If different, the file
    is not a bundle; the scanner MUST ignore it.
 3. Parse ``footer_ver``. If unknown, fail with a versioning error.
-4. Compute ``metadata_start = filesize - 32 - metadata_len`` and
+4. Compute ``metadata_start = filesize - 64 - metadata_len`` and
    ``source_start = metadata_start - source_len``.
-5. Read ``metadata_len`` bytes from ``metadata_start`` for the manifest.
-6. Read ``source_len`` bytes from ``source_start`` for the source view.
+5. Validate ``source_start >= 0`` and that the implied binary region
+   (``[0, source_start)``) is non-empty.
+6. Compute SHA-256 over the binary region ``[0, source_start)`` and compare
+   to ``binary_sha256``. Mismatch is a hard failure handled identically to
+   a magic-check failure: the scanner logs and skips the file. The result
+   MAY be cached by ``(path, inode, mtime, size)`` so the runtime does not
+   re-hash on every exec; a cache miss (file replaced, mtime bumped)
+   triggers re-verification.
+7. Read ``metadata_len`` bytes from ``metadata_start`` for the manifest.
+8. Read ``source_len`` bytes from ``source_start`` for the source view.
    If ``source_len == 0``, no source is embedded; the UI displays
    "(source not available)".
-7. Validate ``source_start >= 0`` and that the implied binary region
-   (``[0, source_start)``) is non-empty.
 
 Source comes *before* metadata so a future ``footer_ver`` MAY introduce
 additional trailing blobs (e.g. signed checksums, compressed deps) by
@@ -106,10 +121,11 @@ and editors.
 
 .. code-block:: yaml
 
-    format_version: "1.0"
+    airflow_bundle_metadata_version: "1.0"
     sdk:
       language: go
       version: "0.1.0"
+      supervisor_schema_version: "2026-06-16"
     source: example.go
     dags:
       example_dag:
@@ -123,7 +139,7 @@ and editors.
 
 Top-level keys:
 
-``format_version`` (string, required)
+``airflow_bundle_metadata_version`` (string, required)
     The bundle-spec version this manifest conforms to. Currently ``"1.0"``.
 
 ``sdk`` (mapping, required)
@@ -132,6 +148,13 @@ Top-level keys:
     - ``language`` (string, required): lower-case source-language identifier
       (e.g. ``go``, ``rust``, ``cpp``, ``zig``).
     - ``version`` (string, required): SDK version used at build time.
+    - ``supervisor_schema_version`` (string, required): dated AIP-72
+      supervisor wire-schema version the bundle was compiled against, in
+      ``YYYY-MM-DD`` format (e.g. ``"2026-06-16"``). The coordinator passes
+      this value to the supervisor so it can downgrade outbound messages /
+      upgrade inbound messages to a shape the bundle understands. The value
+      MUST resolve against the supervisor's schema bundle; an unknown
+      version is rejected at coordinator start.
 
 ``source`` (string, required)
     Original filename of the primary DAG source file (e.g. ``example.go``).
@@ -164,7 +187,7 @@ Go bundle::
     ├── ELF/Mach-O/PE executable
     ├── source region:   contents of example.go
     ├── metadata region: airflow-metadata.yaml (source: example.go)
-    └── trailer (32 B):  AFBNDL01 magic + lengths
+    └── trailer (64 B):  lengths + binary_sha256 + AFBNDL01 magic
 
 Rust bundle::
 
@@ -172,7 +195,7 @@ Rust bundle::
     ├── ELF/Mach-O/PE executable
     ├── source region:   contents of main.rs
     ├── metadata region: airflow-metadata.yaml (source: main.rs)
-    └── trailer (32 B):  AFBNDL01 magic + lengths
+    └── trailer (64 B):  lengths + binary_sha256 + AFBNDL01 magic
 
 The bundle is one file. ``./example`` runs the binary; the appended data
 is invisible to ``exec()``.
@@ -186,15 +209,34 @@ that perform additional post-build steps MUST observe the following order:
 - **Strip** debug symbols *before* appending the footer. Strip
   implementations operate on the binary's defined end and either leave
   trailing data intact or truncate it; do not rely on either behaviour.
-- **Code-sign** *after* appending the footer on platforms whose signature
-  covers the entire file (Authenticode, certain notarisation flows). The
-  signature then attests to the footer's contents along with the binary.
-- **Compressors** such as UPX are NOT supported. They rewrite the file
-  end-to-end and destroy the trailer.
+- **Compute binary_sha256** over the on-disk bytes *as they stand
+  immediately before the append*. At that moment the whole file is the
+  binary region; nothing has been written past its OS-defined end yet, so
+  the digest matches what the reader will recompute over
+  ``[0, source_start)`` after the append.
+- **Append** ``<source><metadata><trailer>`` in a single write so a
+  partially written file fails the magic or hash check rather than
+  appearing as a half-valid bundle.
+
+.. _bundle-code-signing:
+
+Code Signing
+~~~~~~~~~~~~
+
+The bundle format itself does not require OS-level code signing.
+``binary_sha256`` provides integrity against truncation, in-flight
+corruption, and naive tampering, and Airflow's threat model treats
+``executables_root`` as Deployment-Manager-controlled — *authenticity*
+(signed by a trusted identity) is a deployment-time concern rather than a
+bundle-format one.
+
+**Compressors** such as UPX are NOT supported. They rewrite the file
+end-to-end, destroying both the trailer and the hash invariant.
 
 Determinism: the trailer is byte-identical for byte-identical inputs, so a
 deterministic build plus a canonical (sorted-key) manifest serialisation
-yields a byte-identical bundle file.
+yields a byte-identical bundle file (and therefore a stable
+``binary_sha256``).
 
 Deployment Layout
 -----------------
@@ -203,10 +245,12 @@ Bundle files are placed **as-is** in any of the directories configured as the
 ``executables_root`` kwarg on the
 :class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator` entry
 under ``[sdk] coordinators``. The scanner enumerates regular files in each
-directory, reads the last 32 bytes of each, and treats files whose magic
-matches ``"AFBNDL01"`` as bundles. Files without the magic are silently
-ignored, so non-bundle files (READMEs, dotfiles) MAY share the directory
-without interfering with the scan.
+directory, reads the last 64 bytes of each, and treats files whose magic
+matches ``"AFBNDL01"`` as bundles. Matched files are then SHA-256-verified
+per the reader algorithm; a mismatch demotes the file back to "ignored, with
+an error log." Files without the magic are silently ignored, so non-bundle
+files (READMEs, dotfiles) MAY share the directory without interfering with
+the scan.
 
 ::
 
@@ -219,7 +263,9 @@ At task-execution time the runtime execs the bundle file directly with the
 coordinator arguments (``--comm=<addr>`` / ``--logs=<addr>``). No extraction,
 no transient cache directory, no chmod-after-extract step is required: the
 file is already a runnable executable with the appropriate permission bits
-preserved by the build pipeline.
+preserved by the build pipeline. The integrity check runs at scan/discovery
+time and is cached by ``(path, inode, mtime, size)``, so the exec hot path
+does not re-hash.
 
 The compiled executable MUST honour the SDK coordinator protocol —
 ``--comm=<host:port>`` / ``--logs=<host:port>`` socket-based IPC.
@@ -239,14 +285,15 @@ helpers are expected from each language's packer.
 Compatibility and Versioning
 ----------------------------
 
-- The current bundle-spec format version is ``1.0``; the current trailer
-  format version is ``1`` (``footer_ver = 1``).
+- The current bundle-spec format version is ``1.0``
+  (``airflow_bundle_metadata_version``); the current trailer format version is
+  ``1`` (``footer_ver = 1``).
 - Backward-incompatible bundle-spec changes increment the major component
-  of ``format_version`` and are gated behind an explicit opt-in on the
-  consumer side.
+  of ``airflow_bundle_metadata_version`` and are gated behind an explicit opt-in
+  on the consumer side.
 - New optional manifest fields MAY be added in minor versions and MUST be
   ignored by older consumers.
-- New trailer-format versions append fields after ``footer_ver`` (consuming
-  the reserved region) or extend the trailer with additional trailing
-  blobs ahead of the magic. Older readers MUST reject unknown
+- New trailer-format versions append fields after ``binary_sha256``
+  (consuming the reserved region) or extend the trailer with additional
+  trailing blobs ahead of the magic. Older readers MUST reject unknown
   ``footer_ver`` rather than guessing.

--- a/task-sdk/docs/executable-bundle-spec.rst
+++ b/task-sdk/docs/executable-bundle-spec.rst
@@ -246,19 +246,22 @@ Deployment Layout
 Bundle files are placed **as-is** in any of the directories configured as the
 ``executables_root`` kwarg on the
 :class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator` entry
-under ``[sdk] coordinators``. The scanner enumerates regular files in each
-directory, reads the last 64 bytes of each, and treats files whose magic
-matches ``"AFBNDL01"`` as bundles. Matched files are then SHA-256-verified
-per the reader algorithm; a mismatch demotes the file back to "ignored, with
-an error log." Files without the magic are silently ignored, so non-bundle
-files (READMEs, dotfiles) MAY share the directory without interfering with
-the scan.
+under ``[sdk] coordinators``. The scanner walks each directory **recursively**
+and considers only regular files whose **executable bit is set** for the
+invoking user; files without the executable bit are skipped without reading
+their trailer. For each candidate it reads the last 64 bytes and treats files
+whose magic matches ``"AFBNDL01"`` as bundles. Matched files are then
+SHA-256-verified per the reader algorithm; a mismatch demotes the file back
+to "ignored, with an error log." Files without the magic are silently
+ignored, so non-bundle files (READMEs, dotfiles) MAY share the directory
+without interfering with the scan.
 
 ::
 
     /opt/airflow/executable-bundles/
     ├── example
-    ├── pipeline
+    ├── team-a/
+    │   └── pipeline
     └── analytics
 
 At task-execution time the runtime execs the bundle file directly with the

--- a/task-sdk/docs/executable-bundle-spec.rst
+++ b/task-sdk/docs/executable-bundle-spec.rst
@@ -176,7 +176,7 @@ DAG entry fields:
     Static list of ``task_id``\ s declared in the DAG. Empty lists are
     permitted but discouraged.
 
-Unrecognised top-level or DAG-entry keys MUST be ignored by the consumer so
+Unrecognized top-level or DAG-entry keys MUST be ignored by the consumer so
 that future SDK versions can extend the manifest without breaking older
 runtimes.
 
@@ -236,7 +236,7 @@ bundle-format one.
 end-to-end, destroying both the trailer and the hash invariant.
 
 Determinism: the trailer is byte-identical for byte-identical inputs, so a
-deterministic build plus a canonical (sorted-key) manifest serialisation
+deterministic build plus a canonical (sorted-key) manifest serialization
 yields a byte-identical bundle file (and therefore a stable
 ``binary_sha256``).
 
@@ -272,7 +272,7 @@ preserved by the build pipeline. The integrity check runs at scan/discovery
 time and is cached by ``(path, inode, mtime, size)``, so the exec hot path
 does not re-hash.
 
-The compiled executable MUST honour the SDK coordinator protocol —
+The compiled executable MUST honor the SDK coordinator protocol —
 ``--comm=<host:port>`` / ``--logs=<host:port>`` socket-based IPC.
 
 See :class:`~airflow.sdk.coordinators.executable.ExecutableCoordinator`

--- a/task-sdk/docs/executable-bundle-spec.rst
+++ b/task-sdk/docs/executable-bundle-spec.rst
@@ -153,8 +153,10 @@ Top-level keys:
       ``YYYY-MM-DD`` format (e.g. ``"2026-06-16"``). The coordinator passes
       this value to the supervisor so it can downgrade outbound messages /
       upgrade inbound messages to a shape the bundle understands. The value
-      MUST resolve against the supervisor's schema bundle; an unknown
-      version is rejected at coordinator start.
+      MUST resolve against the supervisor's schema bundle; the coordinator
+      validates it lazily when matching a bundle to a task at
+      task-execution time, and an unknown version causes that bundle to be
+      skipped.
 
 ``source`` (string, required)
     Original filename of the primary DAG source file (e.g. ``example.go``).

--- a/task-sdk/docs/index.rst
+++ b/task-sdk/docs/index.rst
@@ -175,3 +175,4 @@ For the full public API reference, see the :doc:`api` page.
   deferred-vs-async-operators
   api
   concepts
+  bundle-spec

--- a/task-sdk/docs/index.rst
+++ b/task-sdk/docs/index.rst
@@ -175,4 +175,4 @@ For the full public API reference, see the :doc:`api` page.
   deferred-vs-async-operators
   api
   concepts
-  bundle-spec
+  executable-bundle-spec

--- a/task-sdk/src/airflow/sdk/coordinators/executable/__init__.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/__init__.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Native executable runtime coordinator for the Apache Airflow Task SDK."""
+
+from __future__ import annotations
+
+from airflow.sdk.coordinators.executable.coordinator import ExecutableCoordinator
+
+__all__ = ["ExecutableCoordinator", "__version__"]
+
+__version__ = "0.1.0"

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -19,23 +19,16 @@
 
 from __future__ import annotations
 
-import itertools
 import os
 import pathlib
-import selectors
-import signal
-import socket
 import struct
-import subprocess
-import time
-from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import attrs
 import structlog
 import yaml
 
-from airflow.sdk.execution_time.coordinator import BaseCoordinator
-from airflow.sdk.execution_time.supervisor import ActivitySubprocess, NeverRaised, ProcessTracker
+from airflow.sdk.coordinators.socket.coordinator import SocketCoordinator
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -43,11 +36,7 @@ if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger
     from typing_extensions import Self
 
-    from airflow.sdk.api.client import Client
-    from airflow.sdk.api.datamodels._generated import BundleInfo
     from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
-
-    Tracked = TypeVar("Tracked", socket.socket, subprocess.Popen)
 
 log: FilteringBoundLogger = structlog.get_logger(logger_name="coordinators.executable")
 
@@ -141,194 +130,6 @@ class _Bundle:
         )
 
 
-def _start_server() -> socket.socket:
-    server = socket.socket()
-    server.bind(("127.0.0.1", 0))
-    server.setblocking(True)
-    server.listen(1)  # Just need to listen to the child process.
-    return server
-
-
-def _accept_connections(
-    servers: dict[str, socket.socket],
-    drains: dict[str, socket.socket],
-    proc: subprocess.Popen,
-    *,
-    max_wait: float = 10.0,
-    drain_size: int = 4096,
-) -> tuple[dict[socket.socket, socket.socket], dict[socket.socket, bytes]]:
-    """Block until the executable process connects to servers."""
-    accepted: dict[socket.socket, socket.socket] = {}
-    drained: dict[socket.socket, bytes] = {s: b"" for s in drains.values()}
-    with selectors.DefaultSelector() as sel:
-        for key, soc in itertools.chain(servers.items(), drains.items()):
-            sel.register(soc, selectors.EVENT_READ, data=key)
-        deadline = time.monotonic() + max_wait
-        while len(accepted) < len(servers):
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                for s in accepted.values():
-                    s.close()
-                raise TimeoutError("process did not connect within timeout")
-            if proc.poll() is not None:
-                for s in accepted.values():
-                    s.close()
-                raise RuntimeError(f"process exited with {proc.returncode} before connecting")
-            for event, _ in sel.select(timeout=min(remaining, 1.0)):
-                soc = cast("socket.socket", event.fileobj)
-                if soc in drained:
-                    if incoming := soc.recv(drain_size):
-                        log.debug("Draining child process stream", key=event.data)
-                        drained[soc] += incoming
-                    else:
-                        log.warning("Child stream closed before ready!", key=event.data)
-                        sel.unregister(soc)
-                else:
-                    log.debug("Accepting child process connection", key=event.data)
-                    conn, _ = soc.accept()
-                    sel.unregister(soc)
-                    accepted[soc] = conn
-    return accepted, drained
-
-
-class PopenTracker(ProcessTracker):
-    """
-    Process tracker backed by :class:`subprocess.Popen`.
-
-    :meta private:
-    """
-
-    ProcessNotFound = NeverRaised
-    TimeoutExpired = subprocess.TimeoutExpired
-
-    def __init__(self, impl: subprocess.Popen) -> None:
-        self._impl = impl
-
-    @property
-    def pid(self) -> int:
-        return self._impl.pid
-
-    def send_signal(self, s: signal.Signals) -> None:
-        self._impl.send_signal(s)
-
-    def wait(self, timeout: float | None) -> int:
-        return self._impl.wait(timeout)
-
-
-@attrs.define(kw_only=True)
-class _ResourceTracker:
-    timeout: float
-    tracked: dict[int, socket.socket | subprocess.Popen] = attrs.field(init=False, factory=dict)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *exc_info):
-        for o in self.tracked.values():
-            match o:
-                case socket.socket():
-                    o.close()
-                case subprocess.Popen():
-                    o.terminate()
-                    try:
-                        o.wait(self.timeout)
-                    except subprocess.TimeoutExpired:
-                        o.kill()
-
-    def track(self, *objects: Tracked) -> tuple[Tracked, ...]:
-        self.tracked.update((id(o), o) for o in objects)
-        return objects
-
-    def untrack(self, *objects: Tracked) -> tuple[Tracked, ...]:
-        for o in objects:
-            self.tracked.pop(id(o), None)
-        return objects
-
-
-@attrs.define(kw_only=True)
-class _ExecutableActivitySubprocess(ActivitySubprocess):
-    """Native executable task runner process."""
-
-    _comm_server: socket.socket
-    _logs_server: socket.socket
-
-    @classmethod
-    def start(  # type: ignore[override]
-        cls,
-        *,
-        what: TaskInstanceDTO,
-        dag_rel_path: str | os.PathLike[str],
-        bundle_info,
-        logger: FilteringBoundLogger | None = None,
-        sentry_integration: str = "",
-        executable_path: str,
-        startup_timeout: float = 10.0,
-        **kwargs,
-    ) -> Self:
-        with _ResourceTracker(timeout=startup_timeout) as tracker:
-            comm_server, logs_server = tracker.track(_start_server(), _start_server())
-            stdout_r, stdout_w = tracker.track(*socket.socketpair())
-            stderr_r, stderr_w = tracker.track(*socket.socketpair())
-
-            comm_host, comm_port = comm_server.getsockname()
-            logs_host, logs_port = logs_server.getsockname()
-
-            proc = subprocess.Popen(
-                [
-                    executable_path,
-                    f"--comm={comm_host}:{comm_port}",
-                    f"--logs={logs_host}:{logs_port}",
-                ],
-                stdout=stdout_w.fileno(),
-                stderr=stderr_w.fileno(),
-            )
-            tracker.track(proc)
-            for soc in tracker.untrack(stdout_w, stderr_w):
-                soc.close()
-            log.info("Starting subprocess", pid=proc.pid, executable=executable_path)
-
-            socks, drained = _accept_connections(
-                {"comm": comm_server, "logs": logs_server},
-                {"stdout": stdout_r, "stderr": stderr_r},
-                proc,
-                max_wait=startup_timeout,
-            )
-            tracker.track(*socks.values())
-
-            self = cls(
-                id=what.id,
-                pid=proc.pid,
-                process=PopenTracker(proc),
-                process_log=logger or structlog.get_logger(logger_name="task").bind(),
-                start_time=time.monotonic(),
-                stdin=socks[comm_server],
-                comm_server=comm_server,
-                logs_server=logs_server,
-                **kwargs,
-            )
-            self._register_pipe_readers(
-                *tracker.untrack(stdout_r, stderr_r, socks[comm_server], socks[logs_server]),
-                data=drained,
-            )
-            self._on_child_started(
-                ti=what,
-                dag_rel_path=dag_rel_path,
-                bundle_info=bundle_info,
-                sentry_integration=sentry_integration,
-            )
-
-            # Untrack everything left. 'self' keeps track of these and close the
-            # servers when the subprocess exits in 'wait'.
-            tracker.untrack(comm_server, logs_server, proc)
-
-        return self
-
-    def wait(self) -> int:
-        code = super().wait()
-        self._close_unused_sockets(self._comm_server, self._logs_server)
-        return code
-
-
 def _convert_executables_root(
     value: None | os.PathLike[str] | pathlib.Path | list[os.PathLike[str] | pathlib.Path],
 ) -> list[pathlib.Path]:
@@ -340,7 +141,7 @@ def _convert_executables_root(
 
 
 @attrs.define(kw_only=True)
-class ExecutableCoordinator(BaseCoordinator):
+class ExecutableCoordinator(SocketCoordinator):
     """
     Coordinator that launches a native executable subprocess for task execution.
 
@@ -364,7 +165,6 @@ class ExecutableCoordinator(BaseCoordinator):
 
     sdk: str = "executable"
     executables_root: list[pathlib.Path] = attrs.field(converter=_convert_executables_root, factory=list)
-    task_startup_timeout: float = 10.0
 
     def _resolve_executable(self, *, what: TaskInstanceDTO) -> str:
         """
@@ -380,29 +180,5 @@ class ExecutableCoordinator(BaseCoordinator):
             )
         return str(_Bundle.find(self.executables_root, what.dag_id).path)
 
-    def execute_task(
-        self,
-        *,
-        what: TaskInstanceDTO,
-        dag_rel_path: str | os.PathLike[str],
-        bundle_info: BundleInfo,
-        client: Client,
-        logger: FilteringBoundLogger | None = None,
-        sentry_integration: str = "",
-        subprocess_logs_to_stdout: bool,
-        **kwargs,
-    ) -> BaseCoordinator.ExecutionResult:
-        executable_path = self._resolve_executable(what=what)
-        process = _ExecutableActivitySubprocess.start(
-            what=what,
-            dag_rel_path=dag_rel_path,
-            bundle_info=bundle_info,
-            client=client,
-            logger=logger,
-            subprocess_logs_to_stdout=subprocess_logs_to_stdout,
-            sentry_integration=sentry_integration,
-            executable_path=executable_path,
-            startup_timeout=self.task_startup_timeout,
-        )
-        exit_code = process.wait()
-        return self.ExecutionResult(exit_code, process.final_state)
+    def _build_execute_task_command(self, *, what: TaskInstanceDTO) -> tuple[list[str], str | None]:
+        return [self._resolve_executable(what=what)], None

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -1,0 +1,324 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Native executable coordinator that launches a binary subprocess for task execution."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import selectors
+import socket
+import struct
+import subprocess
+import time
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
+
+import attrs
+import psutil
+import structlog
+import yaml
+
+from airflow.sdk.execution_time.coordinator import BaseCoordinator
+from airflow.sdk.execution_time.supervisor import ActivitySubprocess
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from structlog.typing import FilteringBoundLogger
+    from typing_extensions import Self
+
+    from airflow.sdk.api.client import Client
+    from airflow.sdk.api.datamodels._generated import BundleInfo
+    from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
+
+log: FilteringBoundLogger = structlog.get_logger(logger_name="coordinators.executable")
+
+
+FOOTER_MAGIC = b"AFBNDL01"
+FOOTER_SIZE = 32
+FOOTER_VERSION = 1
+
+
+class _Footer(NamedTuple):
+    source_len: int
+    metadata_len: int
+    footer_ver: int
+
+
+def _read_footer(path: pathlib.Path) -> _Footer | None:
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None
+    if size < FOOTER_SIZE:
+        return None
+    try:
+        with open(path, "rb") as f:
+            f.seek(size - FOOTER_SIZE)
+            trailer = f.read(FOOTER_SIZE)
+    except OSError:
+        return None
+    if len(trailer) != FOOTER_SIZE or trailer[24:32] != FOOTER_MAGIC:
+        return None
+    source_len, metadata_len, footer_ver = struct.unpack_from("<III", trailer, 0)
+    if footer_ver != FOOTER_VERSION:
+        raise ValueError(
+            f"Unsupported bundle footer_ver={footer_ver} in {path}; "
+            f"this runtime supports footer_ver={FOOTER_VERSION}."
+        )
+    metadata_start = size - FOOTER_SIZE - metadata_len
+    source_start = metadata_start - source_len
+    if source_start < 0:
+        raise ValueError(f"Bundle trailer in {path} declares regions that extend past the start of file.")
+    # Per the spec, the binary region [0, source_start) MUST be non-empty.
+    if source_start == 0:
+        raise ValueError(f"Bundle trailer in {path} leaves no room for the executable region.")
+    return _Footer(source_len=source_len, metadata_len=metadata_len, footer_ver=footer_ver)
+
+
+def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
+    try:
+        footer = _read_footer(path)
+    except ValueError:
+        return None
+    if footer is None:
+        return None
+    metadata_start = path.stat().st_size - FOOTER_SIZE - footer.metadata_len
+    with open(path, "rb") as f:
+        f.seek(metadata_start)
+        metadata_bytes = f.read(footer.metadata_len)
+    try:
+        data = yaml.safe_load(metadata_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _dag_ids(metadata: dict[str, Any]) -> set[str]:
+    dags = metadata.get("dags")
+    if not isinstance(dags, dict):
+        return set()
+    return set(dags.keys())
+
+
+@attrs.define
+class _Bundle:
+    path: pathlib.Path
+
+    @classmethod
+    def find(cls, executables_root: Sequence[pathlib.Path], dag_id: str) -> Self:
+        for root in executables_root:
+            for p in root.iterdir():
+                if not p.is_file() or not os.access(p, os.X_OK):
+                    continue
+                if (metadata := _read_bundle_metadata(p)) is None:
+                    continue
+                if dag_id in _dag_ids(metadata):
+                    return cls(p.resolve())
+        resolved_paths = os.pathsep.join(str(r.resolve()) for r in executables_root)
+        raise FileNotFoundError(
+            f"cannot find executable bundle containing dag_id={dag_id!r} in {resolved_paths}"
+        )
+
+
+def _start_server() -> socket.socket:
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.setblocking(True)
+    server.listen(1)  # Just need to listen to the child process.
+    return server
+
+
+def _accept_connections(
+    servers: dict[str, socket.socket],
+    proc: subprocess.Popen,
+    *,
+    max_wait: float = 10.0,
+) -> dict[str, socket.socket]:
+    """Block until the executable process connects to servers."""
+    accepted: dict[str, socket.socket] = {}
+    with selectors.DefaultSelector() as sel:
+        for key, soc in servers.items():
+            sel.register(soc, selectors.EVENT_READ, data=key)
+        deadline = time.monotonic() + max_wait
+        while len(accepted) < len(servers):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("process did not connect within timeout")
+            if proc.poll() is not None:
+                raise RuntimeError(f"process exited with {proc.returncode} before connecting")
+            for event, _ in sel.select(timeout=min(remaining, 1.0)):
+                log.debug("Accepting child process connection", key=(key := event.data))
+                conn, _ = cast("socket.socket", event.fileobj).accept()
+                sel.unregister(servers[key])
+                accepted[key] = conn
+    return accepted
+
+
+@attrs.define(kw_only=True)
+class _ExecutableActivitySubprocess(ActivitySubprocess):
+    """Native executable task runner process."""
+
+    _comm_server: socket.socket
+    _logs_server: socket.socket
+    _child_process: subprocess.Popen
+
+    # Keep track of channels used to pipe subprocess stdout and stderr so we can
+    # close them on exit. The "read" side is handled by _register_pipe_readers
+    # callbacks so we don't need to worry about them.
+    _stdout_w: socket.socket
+    _stderr_w: socket.socket
+
+    @classmethod
+    def start(  # type: ignore[override]
+        cls,
+        *,
+        what: TaskInstanceDTO,
+        dag_rel_path: str | os.PathLike[str],
+        bundle_info,
+        logger: FilteringBoundLogger | None = None,
+        sentry_integration: str = "",
+        executable_path: str,
+        **kwargs,
+    ) -> Self:
+        comm_server = _start_server()
+        logs_server = _start_server()
+
+        stdout_r, stdout_w = socket.socketpair()
+        stderr_r, stderr_w = socket.socketpair()
+
+        comm_host, comm_port = comm_server.getsockname()
+        logs_host, logs_port = logs_server.getsockname()
+
+        proc = subprocess.Popen(
+            [
+                executable_path,
+                f"--comm={comm_host}:{comm_port}",
+                f"--logs={logs_host}:{logs_port}",
+            ],
+            stdout=stdout_w.makefile("wb", buffering=0).fileno(),
+            stderr=stderr_w.makefile("wb", buffering=0).fileno(),
+        )
+        log.info("Starting subprocess", pid=proc.pid, executable=executable_path)
+        socks = _accept_connections({"comm": comm_server, "logs": logs_server}, proc)
+
+        self = cls(
+            id=what.id,
+            pid=proc.pid,
+            process=psutil.Process(proc.pid),
+            process_log=logger or structlog.get_logger(logger_name="task").bind(),
+            start_time=time.monotonic(),
+            stdin=socks["comm"],
+            child_process=proc,
+            comm_server=comm_server,
+            logs_server=logs_server,
+            stdout_w=stdout_w,
+            stderr_w=stderr_w,
+            **kwargs,
+        )
+        self._register_pipe_readers(stdout_r, stderr_r, socks["comm"], socks["logs"], data={})
+        self._on_child_started(
+            ti=what,
+            dag_rel_path=dag_rel_path,
+            bundle_info=bundle_info,
+            sentry_integration=sentry_integration,
+        )
+        return self
+
+    def wait(self) -> int:
+        code = super().wait()
+        self._close_unused_sockets(self._comm_server, self._logs_server, self._stdout_w, self._stderr_w)
+        return code
+
+
+def _convert_executables_root(
+    value: None | os.PathLike[str] | pathlib.Path | list[os.PathLike[str] | pathlib.Path],
+) -> list[pathlib.Path]:
+    if value is None:
+        return []
+    if isinstance(value, (str, os.PathLike, pathlib.Path)):
+        return [pathlib.Path(value)]
+    return [pathlib.Path(v) for v in value]
+
+
+@attrs.define(kw_only=True)
+class ExecutableCoordinator(BaseCoordinator):
+    """
+    Coordinator that launches a native executable subprocess for task execution.
+
+    Configuration is taken from the ``[sdk] coordinators`` entry that constructs
+    this instance::
+
+        {
+            "name": "go",
+            "classpath": "airflow.sdk.coordinators.executable.ExecutableCoordinator",
+            "kwargs": {
+                "executables_root": ["~/airflow/executable-bundles"],
+            },
+        }
+
+    :param executables_root: A list of directories scanned for executable
+        bundles when a Python stub DAG delegates task execution to a native
+        runtime.
+    """
+
+    sdk: str = "executable"
+    file_extension: str = ""
+    executables_root: list[pathlib.Path] = attrs.field(converter=_convert_executables_root, factory=list)
+
+    def _resolve_executable(self, *, what: TaskInstanceDTO) -> str:
+        """
+        Resolve the executable path for *what*.
+
+        Looks up the bundle whose embedded manifest declares ``what.dag_id``
+        in the configured ``executables_root`` directories.
+        """
+        if not self.executables_root:
+            raise ValueError(
+                "The executables_root kwarg must be set on the ExecutableCoordinator "
+                "to resolve the executable for task execution."
+            )
+        return str(_Bundle.find(self.executables_root, what.dag_id).path)
+
+    def execute_task(
+        self,
+        *,
+        what: TaskInstanceDTO,
+        dag_rel_path: str | os.PathLike[str],
+        bundle_info: BundleInfo,
+        client: Client,
+        logger: FilteringBoundLogger | None = None,
+        sentry_integration: str = "",
+        subprocess_logs_to_stdout: bool,
+        **kwargs,
+    ) -> BaseCoordinator.ExecutionResult:
+        executable_path = self._resolve_executable(what=what)
+        process = _ExecutableActivitySubprocess.start(
+            what=what,
+            dag_rel_path=dag_rel_path,
+            bundle_info=bundle_info,
+            client=client,
+            logger=logger,
+            subprocess_logs_to_stdout=subprocess_logs_to_stdout,
+            sentry_integration=sentry_integration,
+            executable_path=executable_path,
+        )
+        exit_code = process.wait()
+        return self.ExecutionResult(exit_code, process.final_state)

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -19,22 +19,23 @@
 
 from __future__ import annotations
 
+import itertools
 import os
 import pathlib
 import selectors
+import signal
 import socket
 import struct
 import subprocess
 import time
-from typing import TYPE_CHECKING, Any, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast
 
 import attrs
-import psutil
 import structlog
 import yaml
 
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
-from airflow.sdk.execution_time.supervisor import ActivitySubprocess
+from airflow.sdk.execution_time.supervisor import ActivitySubprocess, NeverRaised, ProcessTracker
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -45,6 +46,8 @@ if TYPE_CHECKING:
     from airflow.sdk.api.client import Client
     from airflow.sdk.api.datamodels._generated import BundleInfo
     from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
+
+    Tracked = TypeVar("Tracked", socket.socket, subprocess.Popen)
 
 log: FilteringBoundLogger = structlog.get_logger(logger_name="coordinators.executable")
 
@@ -148,28 +151,98 @@ def _start_server() -> socket.socket:
 
 def _accept_connections(
     servers: dict[str, socket.socket],
+    drains: dict[str, socket.socket],
     proc: subprocess.Popen,
     *,
     max_wait: float = 10.0,
-) -> dict[str, socket.socket]:
+    drain_size: int = 4096,
+) -> tuple[dict[socket.socket, socket.socket], dict[socket.socket, bytes]]:
     """Block until the executable process connects to servers."""
-    accepted: dict[str, socket.socket] = {}
+    accepted: dict[socket.socket, socket.socket] = {}
+    drained: dict[socket.socket, bytes] = {s: b"" for s in drains.values()}
     with selectors.DefaultSelector() as sel:
-        for key, soc in servers.items():
+        for key, soc in itertools.chain(servers.items(), drains.items()):
             sel.register(soc, selectors.EVENT_READ, data=key)
         deadline = time.monotonic() + max_wait
         while len(accepted) < len(servers):
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                for s in accepted.values():
+                    s.close()
                 raise TimeoutError("process did not connect within timeout")
             if proc.poll() is not None:
+                for s in accepted.values():
+                    s.close()
                 raise RuntimeError(f"process exited with {proc.returncode} before connecting")
             for event, _ in sel.select(timeout=min(remaining, 1.0)):
-                log.debug("Accepting child process connection", key=(key := event.data))
-                conn, _ = cast("socket.socket", event.fileobj).accept()
-                sel.unregister(servers[key])
-                accepted[key] = conn
-    return accepted
+                soc = cast("socket.socket", event.fileobj)
+                if soc in drained:
+                    if incoming := soc.recv(drain_size):
+                        log.debug("Draining child process stream", key=event.data)
+                        drained[soc] += incoming
+                    else:
+                        log.warning("Child stream closed before ready!", key=event.data)
+                        sel.unregister(soc)
+                else:
+                    log.debug("Accepting child process connection", key=event.data)
+                    conn, _ = soc.accept()
+                    sel.unregister(soc)
+                    accepted[soc] = conn
+    return accepted, drained
+
+
+class PopenTracker(ProcessTracker):
+    """
+    Process tracker backed by :class:`subprocess.Popen`.
+
+    :meta private:
+    """
+
+    ProcessNotFound = NeverRaised
+    TimeoutExpired = subprocess.TimeoutExpired
+
+    def __init__(self, impl: subprocess.Popen) -> None:
+        self._impl = impl
+
+    @property
+    def pid(self) -> int:
+        return self._impl.pid
+
+    def send_signal(self, s: signal.Signals) -> None:
+        self._impl.send_signal(s)
+
+    def wait(self, timeout: float | None) -> int:
+        return self._impl.wait(timeout)
+
+
+@attrs.define(kw_only=True)
+class _ResourceTracker:
+    timeout: float
+    tracked: dict[int, socket.socket | subprocess.Popen] = attrs.field(init=False, factory=dict)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        for o in self.tracked.values():
+            match o:
+                case socket.socket():
+                    o.close()
+                case subprocess.Popen():
+                    o.terminate()
+                    try:
+                        o.wait(self.timeout)
+                    except subprocess.TimeoutExpired:
+                        o.kill()
+
+    def track(self, *objects: Tracked) -> tuple[Tracked, ...]:
+        self.tracked.update((id(o), o) for o in objects)
+        return objects
+
+    def untrack(self, *objects: Tracked) -> tuple[Tracked, ...]:
+        for o in objects:
+            self.tracked.pop(id(o), None)
+        return objects
 
 
 @attrs.define(kw_only=True)
@@ -178,13 +251,6 @@ class _ExecutableActivitySubprocess(ActivitySubprocess):
 
     _comm_server: socket.socket
     _logs_server: socket.socket
-    _child_process: subprocess.Popen
-
-    # Keep track of channels used to pipe subprocess stdout and stderr so we can
-    # close them on exit. The "read" side is handled by _register_pipe_readers
-    # callbacks so we don't need to worry about them.
-    _stdout_w: socket.socket
-    _stderr_w: socket.socket
 
     @classmethod
     def start(  # type: ignore[override]
@@ -196,55 +262,70 @@ class _ExecutableActivitySubprocess(ActivitySubprocess):
         logger: FilteringBoundLogger | None = None,
         sentry_integration: str = "",
         executable_path: str,
+        startup_timeout: float = 10.0,
         **kwargs,
     ) -> Self:
-        comm_server = _start_server()
-        logs_server = _start_server()
+        with _ResourceTracker(timeout=startup_timeout) as tracker:
+            comm_server, logs_server = tracker.track(_start_server(), _start_server())
+            stdout_r, stdout_w = tracker.track(*socket.socketpair())
+            stderr_r, stderr_w = tracker.track(*socket.socketpair())
 
-        stdout_r, stdout_w = socket.socketpair()
-        stderr_r, stderr_w = socket.socketpair()
+            comm_host, comm_port = comm_server.getsockname()
+            logs_host, logs_port = logs_server.getsockname()
 
-        comm_host, comm_port = comm_server.getsockname()
-        logs_host, logs_port = logs_server.getsockname()
+            proc = subprocess.Popen(
+                [
+                    executable_path,
+                    f"--comm={comm_host}:{comm_port}",
+                    f"--logs={logs_host}:{logs_port}",
+                ],
+                stdout=stdout_w.fileno(),
+                stderr=stderr_w.fileno(),
+            )
+            tracker.track(proc)
+            for soc in tracker.untrack(stdout_w, stderr_w):
+                soc.close()
+            log.info("Starting subprocess", pid=proc.pid, executable=executable_path)
 
-        proc = subprocess.Popen(
-            [
-                executable_path,
-                f"--comm={comm_host}:{comm_port}",
-                f"--logs={logs_host}:{logs_port}",
-            ],
-            stdout=stdout_w.makefile("wb", buffering=0).fileno(),
-            stderr=stderr_w.makefile("wb", buffering=0).fileno(),
-        )
-        log.info("Starting subprocess", pid=proc.pid, executable=executable_path)
-        socks = _accept_connections({"comm": comm_server, "logs": logs_server}, proc)
+            socks, drained = _accept_connections(
+                {"comm": comm_server, "logs": logs_server},
+                {"stdout": stdout_r, "stderr": stderr_r},
+                proc,
+                max_wait=startup_timeout,
+            )
+            tracker.track(*socks.values())
 
-        self = cls(
-            id=what.id,
-            pid=proc.pid,
-            process=psutil.Process(proc.pid),
-            process_log=logger or structlog.get_logger(logger_name="task").bind(),
-            start_time=time.monotonic(),
-            stdin=socks["comm"],
-            child_process=proc,
-            comm_server=comm_server,
-            logs_server=logs_server,
-            stdout_w=stdout_w,
-            stderr_w=stderr_w,
-            **kwargs,
-        )
-        self._register_pipe_readers(stdout_r, stderr_r, socks["comm"], socks["logs"], data={})
-        self._on_child_started(
-            ti=what,
-            dag_rel_path=dag_rel_path,
-            bundle_info=bundle_info,
-            sentry_integration=sentry_integration,
-        )
+            self = cls(
+                id=what.id,
+                pid=proc.pid,
+                process=PopenTracker(proc),
+                process_log=logger or structlog.get_logger(logger_name="task").bind(),
+                start_time=time.monotonic(),
+                stdin=socks[comm_server],
+                comm_server=comm_server,
+                logs_server=logs_server,
+                **kwargs,
+            )
+            self._register_pipe_readers(
+                *tracker.untrack(stdout_r, stderr_r, socks[comm_server], socks[logs_server]),
+                data=drained,
+            )
+            self._on_child_started(
+                ti=what,
+                dag_rel_path=dag_rel_path,
+                bundle_info=bundle_info,
+                sentry_integration=sentry_integration,
+            )
+
+            # Untrack everything left. 'self' keeps track of these and close the
+            # servers when the subprocess exits in 'wait'.
+            tracker.untrack(comm_server, logs_server, proc)
+
         return self
 
     def wait(self) -> int:
         code = super().wait()
-        self._close_unused_sockets(self._comm_server, self._logs_server, self._stdout_w, self._stderr_w)
+        self._close_unused_sockets(self._comm_server, self._logs_server)
         return code
 
 
@@ -254,8 +335,8 @@ def _convert_executables_root(
     if value is None:
         return []
     if isinstance(value, (str, os.PathLike, pathlib.Path)):
-        return [pathlib.Path(value)]
-    return [pathlib.Path(v) for v in value]
+        return [pathlib.Path(value).expanduser()]
+    return [pathlib.Path(v).expanduser() for v in value]
 
 
 @attrs.define(kw_only=True)
@@ -277,11 +358,13 @@ class ExecutableCoordinator(BaseCoordinator):
     :param executables_root: A list of directories scanned for executable
         bundles when a Python stub DAG delegates task execution to a native
         runtime.
+    :param task_startup_timeout: Maximum time the coordinator waits for a task
+        process to start, in seconds. The default is 10 seconds.
     """
 
     sdk: str = "executable"
-    file_extension: str = ""
     executables_root: list[pathlib.Path] = attrs.field(converter=_convert_executables_root, factory=list)
+    task_startup_timeout: float = 10.0
 
     def _resolve_executable(self, *, what: TaskInstanceDTO) -> str:
         """
@@ -319,6 +402,7 @@ class ExecutableCoordinator(BaseCoordinator):
             subprocess_logs_to_stdout=subprocess_logs_to_stdout,
             sentry_integration=sentry_integration,
             executable_path=executable_path,
+            startup_timeout=self.task_startup_timeout,
         )
         exit_code = process.wait()
         return self.ExecutionResult(exit_code, process.final_state)

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -19,19 +19,22 @@
 
 from __future__ import annotations
 
+import functools
+import hashlib
 import os
 import pathlib
 import struct
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 
 import attrs
 import structlog
 import yaml
 
 from airflow.sdk.coordinators.socket.coordinator import SocketCoordinator
+from airflow.sdk.execution_time.schema import get_schema_version_migrator
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Iterator, Sequence
 
     from structlog.typing import FilteringBoundLogger
     from typing_extensions import Self
@@ -42,64 +45,168 @@ log: FilteringBoundLogger = structlog.get_logger(logger_name="coordinators.execu
 
 
 FOOTER_MAGIC = b"AFBNDL01"
-FOOTER_SIZE = 32
+FOOTER_SIZE = 64
 FOOTER_VERSION = 1
+_HASH_READ_CHUNK = 1 << 20
+# Upper bound on the verification cache.
+_VERIFY_CACHE_MAXSIZE = 256
 
 
-class _Footer(NamedTuple):
+@attrs.define
+class _Footer:
+    """
+    Parsed bundle trailer plus the byte offsets it implies.
+
+    All region offsets (``source_start``, ``metadata_start``) and the file
+    size at parse time are computed once in :meth:`read` so downstream
+    consumers do not re-derive them.
+    """
+
+    path: pathlib.Path
+    file_size: int
     source_len: int
     metadata_len: int
     footer_ver: int
+    binary_sha256: bytes
+    source_start: int
+    metadata_start: int
 
+    @classmethod
+    def read(cls, path: pathlib.Path) -> Self | None:
+        """
+        Parse the trailer of *path* and return the resulting footer.
 
-def _read_footer(path: pathlib.Path) -> _Footer | None:
-    try:
+        Returns ``None`` only when *path* is provably not a bundle (file is
+        smaller than the trailer, or the magic does not match).
+        """
         size = path.stat().st_size
-    except OSError:
-        return None
-    if size < FOOTER_SIZE:
-        return None
-    try:
+        if size < FOOTER_SIZE:
+            return None
+
         with open(path, "rb") as f:
             f.seek(size - FOOTER_SIZE)
             trailer = f.read(FOOTER_SIZE)
-    except OSError:
-        return None
-    if len(trailer) != FOOTER_SIZE or trailer[24:32] != FOOTER_MAGIC:
-        return None
-    source_len, metadata_len, footer_ver = struct.unpack_from("<III", trailer, 0)
-    if footer_ver != FOOTER_VERSION:
-        raise ValueError(
-            f"Unsupported bundle footer_ver={footer_ver} in {path}; "
-            f"this runtime supports footer_ver={FOOTER_VERSION}."
+
+        if len(trailer) != FOOTER_SIZE or trailer[56:64] != FOOTER_MAGIC:
+            return None
+
+        source_len, metadata_len, footer_ver = struct.unpack_from("<III", trailer, 0)
+        if footer_ver != FOOTER_VERSION:
+            raise ValueError(
+                f"Unsupported bundle footer_ver={footer_ver} in {path}; "
+                f"this runtime supports footer_ver={FOOTER_VERSION}."
+            )
+
+        binary_sha256 = bytes(trailer[12:44])
+        reserved = trailer[44:56]
+        if reserved != b"\x00" * 12:
+            raise ValueError(f"Bundle trailer in {path} has non-zero reserved bytes.")
+
+        metadata_start = size - FOOTER_SIZE - metadata_len
+        source_start = metadata_start - source_len
+        if source_start < 0:
+            raise ValueError(f"Bundle trailer in {path} declares regions that extend past the start of file.")
+        # Per the spec, the binary region [0, source_start) MUST be non-empty.
+        if source_start == 0:
+            raise ValueError(f"Bundle trailer in {path} leaves no room for the executable region.")
+
+        return cls(
+            path=path,
+            file_size=size,
+            source_len=source_len,
+            metadata_len=metadata_len,
+            footer_ver=footer_ver,
+            binary_sha256=binary_sha256,
+            source_start=source_start,
+            metadata_start=metadata_start,
         )
-    metadata_start = size - FOOTER_SIZE - metadata_len
-    source_start = metadata_start - source_len
-    if source_start < 0:
-        raise ValueError(f"Bundle trailer in {path} declares regions that extend past the start of file.")
-    # Per the spec, the binary region [0, source_start) MUST be non-empty.
-    if source_start == 0:
-        raise ValueError(f"Bundle trailer in {path} leaves no room for the executable region.")
-    return _Footer(source_len=source_len, metadata_len=metadata_len, footer_ver=footer_ver)
+
+
+def _hash_binary_region(path: pathlib.Path, source_start: int) -> bytes:
+    """Compute SHA-256 over bytes ``[0, source_start)`` of *path*."""
+    digest = hashlib.sha256()
+    remaining = source_start
+    with open(path, "rb") as f:
+        while remaining > 0:
+            chunk = f.read(min(_HASH_READ_CHUNK, remaining))
+            if not chunk:
+                raise ValueError(
+                    f"Bundle {path} truncated while hashing binary region "
+                    f"(expected {source_start} bytes, got {source_start - remaining})."
+                )
+            digest.update(chunk)
+            remaining -= len(chunk)
+    return digest.digest()
+
+
+# LRU-bounded cache of computed binary-region digests keyed by
+# (path, inode, mtime_ns, size). A cache hit means the file at *path* still
+# has the same identity as when we last hashed it, so re-hashing on every
+# exec is unnecessary. A miss (file replaced, mtime bumped, inode swapped
+# under us) yields a different key and forces re-verification;
+@functools.lru_cache(maxsize=_VERIFY_CACHE_MAXSIZE)
+def _cached_binary_region_digest(
+    path_str: str,
+    source_start: int,
+    st_ino: int,
+    st_mtime_ns: int,
+    st_size: int,
+) -> bytes:
+    # st_ino / st_mtime_ns / st_size participate in the cache key only; if any
+    # of them change, the LRU treats it as a different entry and re-hashes.
+    del st_ino, st_mtime_ns, st_size
+    return _hash_binary_region(pathlib.Path(path_str), source_start)
+
+
+def _verify_binary_sha256(footer: _Footer) -> bool:
+    """Verify *footer.binary_sha256* against the binary region of ``footer.path``."""
+    try:
+        st = footer.path.stat()
+    except OSError:
+        return False
+
+    try:
+        actual = _cached_binary_region_digest(
+            str(footer.path), footer.source_start, st.st_ino, st.st_mtime_ns, st.st_size
+        )
+    except (OSError, ValueError) as exc:
+        log.debug("Failed to hash bundle binary region", path=str(footer.path), error=str(exc))
+        return False
+
+    if actual != footer.binary_sha256:
+        log.debug(
+            "Bundle binary_sha256 mismatch; skipping",
+            path=str(footer.path),
+            expected=footer.binary_sha256.hex(),
+            actual=actual.hex(),
+        )
+        return False
+    return True
 
 
 def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
     try:
-        footer = _read_footer(path)
-    except ValueError:
+        if (footer := _Footer.read(path)) is None:
+            return None
+    except (OSError, ValueError) as exc:
+        log.debug("Invalid bundle trailer; skipping", path=str(path), error=str(exc))
         return None
-    if footer is None:
+
+    if not _verify_binary_sha256(footer):
         return None
-    metadata_start = path.stat().st_size - FOOTER_SIZE - footer.metadata_len
+
     with open(path, "rb") as f:
-        f.seek(metadata_start)
+        f.seek(footer.metadata_start)
         metadata_bytes = f.read(footer.metadata_len)
+
     try:
         data = yaml.safe_load(metadata_bytes.decode("utf-8"))
     except (UnicodeDecodeError, yaml.YAMLError):
         return None
+
     if not isinstance(data, dict):
         return None
+
     return data
 
 
@@ -107,23 +214,57 @@ def _dag_ids(metadata: dict[str, Any]) -> set[str]:
     dags = metadata.get("dags")
     if not isinstance(dags, dict):
         return set()
+
     return set(dags.keys())
+
+
+def _supervisor_schema_version(metadata: dict[str, Any]) -> str | None:
+    sdk = metadata.get("sdk")
+    if not isinstance(sdk, dict):
+        return None
+
+    value = sdk.get("supervisor_schema_version")
+    if not isinstance(value, str) or not value:
+        return None
+
+    return value
+
+
+def _find_executables(items: Iterable[pathlib.Path]) -> Iterator[pathlib.Path]:
+    """Yield executable regular files under *items*, descending into directories."""
+    for item in items:
+        if item.is_dir():
+            try:
+                children = item.iterdir()
+            except (FileNotFoundError, NotADirectoryError, PermissionError):
+                continue
+            yield from _find_executables(children)
+        elif item.is_file() and os.access(item, os.X_OK):
+            yield item
+
+
+def _validate_schema_version(instance, _, value) -> str:
+    return get_schema_version_migrator().resolve_version(str(value))
 
 
 @attrs.define
 class _Bundle:
     path: pathlib.Path
+    schema_version: str | None = attrs.field(validator=_validate_schema_version)
 
     @classmethod
     def find(cls, executables_root: Sequence[pathlib.Path], dag_id: str) -> Self:
-        for root in executables_root:
-            for p in root.iterdir():
-                if not p.is_file() or not os.access(p, os.X_OK):
-                    continue
-                if (metadata := _read_bundle_metadata(p)) is None:
-                    continue
-                if dag_id in _dag_ids(metadata):
-                    return cls(p.resolve())
+        log.debug("Finding executable bundles recursively", roots=executables_root)
+        for p in _find_executables(executables_root):
+            if (metadata := _read_bundle_metadata(p)) is None:
+                continue
+            if dag_id not in _dag_ids(metadata):
+                continue
+            try:
+                return cls(path=p.resolve(), schema_version=_supervisor_schema_version(metadata))
+            except (TypeError, ValueError) as exc:
+                log.debug("Bundle metadata rejected by validator; skipping", path=str(p), error=str(exc))
+                continue
         resolved_paths = os.pathsep.join(str(r.resolve()) for r in executables_root)
         raise FileNotFoundError(
             f"cannot find executable bundle containing dag_id={dag_id!r} in {resolved_paths}"
@@ -163,22 +304,11 @@ class ExecutableCoordinator(SocketCoordinator):
         process to start, in seconds. The default is 10 seconds.
     """
 
-    sdk: str = "executable"
-    executables_root: list[pathlib.Path] = attrs.field(converter=_convert_executables_root, factory=list)
-
-    def _resolve_executable(self, *, what: TaskInstanceDTO) -> str:
-        """
-        Resolve the executable path for *what*.
-
-        Looks up the bundle whose embedded manifest declares ``what.dag_id``
-        in the configured ``executables_root`` directories.
-        """
-        if not self.executables_root:
-            raise ValueError(
-                "The executables_root kwarg must be set on the ExecutableCoordinator "
-                "to resolve the executable for task execution."
-            )
-        return str(_Bundle.find(self.executables_root, what.dag_id).path)
+    executables_root: list[pathlib.Path] = attrs.field(
+        converter=_convert_executables_root,
+        validator=attrs.validators.min_len(1),
+    )
 
     def _build_execute_task_command(self, *, what: TaskInstanceDTO) -> tuple[list[str], str | None]:
-        return [self._resolve_executable(what=what)], None
+        bundle = _Bundle.find(self.executables_root, what.dag_id)
+        return [str(bundle.path)], bundle.schema_version

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -201,10 +201,16 @@ def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
 
     try:
         data = yaml.safe_load(metadata_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, yaml.YAMLError):
+    except (UnicodeDecodeError, yaml.YAMLError) as exc:
+        log.debug("Cannot decode bundle metadata; skipping", path=str(path), error=str(exc))
         return None
 
     if not isinstance(data, dict):
+        log.debug(
+            "Bundle metadata is not a mapping; skipping",
+            path=str(path),
+            type=type(data).__name__,
+        )
         return None
 
     return data
@@ -250,25 +256,41 @@ def _validate_schema_version(instance, _, value) -> str:
 @attrs.define
 class _Bundle:
     path: pathlib.Path
-    schema_version: str | None = attrs.field(validator=_validate_schema_version)
+    schema_version: str = attrs.field(validator=_validate_schema_version)
 
     @classmethod
     def find(cls, executables_root: Sequence[pathlib.Path], dag_id: str) -> Self:
         log.debug("Finding executable bundles recursively", roots=executables_root)
+        rejected: list[tuple[pathlib.Path, str]] = []
         for p in _find_executables(executables_root):
             if (metadata := _read_bundle_metadata(p)) is None:
                 continue
             if dag_id not in _dag_ids(metadata):
                 continue
+
             try:
-                return cls(path=p.resolve(), schema_version=_supervisor_schema_version(metadata))
+                if (schema_version := _supervisor_schema_version(metadata)) is None:
+                    reason = "missing or invalid sdk.supervisor_schema_version"
+                    log.debug("Bundle metadata rejected; skipping", path=str(p), error=reason)
+                    rejected.append((p.resolve(), reason))
+                    continue
+                return cls(path=p.resolve(), schema_version=schema_version)
             except (TypeError, ValueError) as exc:
-                log.debug("Bundle metadata rejected by validator; skipping", path=str(p), error=str(exc))
+                log.debug("Bundle metadata rejected; skipping", path=str(p), error=str(exc))
+                rejected.append((p.resolve(), str(exc)))
                 continue
+
         resolved_paths = os.pathsep.join(str(r.resolve()) for r in executables_root)
-        raise FileNotFoundError(
-            f"cannot find executable bundle containing dag_id={dag_id!r} in {resolved_paths}"
-        )
+        if rejected:
+            details = "; ".join(f"{path}: {reason}" for path, reason in rejected)
+            tp = (
+                "cannot find executable bundle with usable supervisor_schema_version "
+                "for dag_id={0!r} in {1}: matching bundles were rejected ({2})"
+            )
+        else:
+            tp = "cannot find executable bundle containing dag_id={0!r} in {1}"
+            details = ""
+        raise FileNotFoundError(tp.format(dag_id, resolved_paths, details))
 
 
 def _convert_executables_root(

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import hashlib
 import os
 import pathlib
+import stat
 import struct
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, BinaryIO
@@ -181,11 +182,6 @@ class _BinaryDigestCache:
 _digest_cache = _BinaryDigestCache(maxsize=_VERIFY_CACHE_MAXSIZE)
 
 
-def _clear_digest_cache() -> None:
-    """Drop all cached binary-region digests. Intended for tests."""
-    _digest_cache.clear()
-
-
 def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
     # One open per bundle: trailer-parse, hash (on cache miss), and
     # metadata-read all share the same fd, and the stat that keys the
@@ -277,15 +273,38 @@ def _supervisor_schema_version(metadata: dict[str, Any]) -> str | None:
 
 
 def _find_executables(items: Iterable[pathlib.Path]) -> Iterator[pathlib.Path]:
-    """Yield executable regular files under *items*, descending into directories."""
+    """
+    Yield executable regular files under *items*, descending into directories.
+
+    A symlink loop or a directory that hardlinks into one of its ancestors
+    would otherwise recurse until the interpreter stack is exhausted, so
+    directories are deduplicated by ``(st_dev, st_ino)`` for the duration
+    of a single scan.
+    """
+    seen_dirs: set[tuple[int, int]] = set()
+    yield from _walk_executables(items, seen_dirs)
+
+
+def _walk_executables(
+    items: Iterable[pathlib.Path], seen_dirs: set[tuple[int, int]]
+) -> Iterator[pathlib.Path]:
     for item in items:
-        if item.is_dir():
-            try:
-                children = item.iterdir()
-            except (FileNotFoundError, NotADirectoryError, PermissionError):
+        try:
+            st = item.stat()
+        except OSError:
+            continue
+        if stat.S_ISDIR(st.st_mode):
+            key = (st.st_dev, st.st_ino)
+            if key in seen_dirs:
+                log.debug("Skipping already-visited directory", path=str(item))
                 continue
-            yield from _find_executables(children)
-        elif item.is_file() and os.access(item, os.X_OK):
+            seen_dirs.add(key)
+            try:
+                children = list(item.iterdir())
+            except OSError:
+                continue
+            yield from _walk_executables(children, seen_dirs)
+        elif stat.S_ISREG(st.st_mode) and os.access(item, os.X_OK):
             yield item
 
 

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -19,12 +19,12 @@
 
 from __future__ import annotations
 
-import functools
 import hashlib
 import os
 import pathlib
 import struct
-from typing import TYPE_CHECKING, Any
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 import attrs
 import structlog
@@ -72,20 +72,22 @@ class _Footer:
     metadata_start: int
 
     @classmethod
-    def read(cls, path: pathlib.Path) -> Self | None:
+    def read(cls, f: BinaryIO, path: pathlib.Path, file_size: int) -> Self | None:
         """
-        Parse the trailer of *path* and return the resulting footer.
+        Parse the trailer from an already-open binary handle on *path*.
 
-        Returns ``None`` only when *path* is provably not a bundle (file is
-        smaller than the trailer, or the magic does not match).
+        *file_size* MUST come from a stat of the same fd so the trailer
+        offsets refer to the file currently held open (not whatever the
+        path resolves to at some later moment).
+
+        Returns ``None`` only when the file is provably not a bundle
+        (smaller than the trailer, or the magic does not match).
         """
-        size = path.stat().st_size
-        if size < FOOTER_SIZE:
+        if file_size < FOOTER_SIZE:
             return None
 
-        with open(path, "rb") as f:
-            f.seek(size - FOOTER_SIZE)
-            trailer = f.read(FOOTER_SIZE)
+        f.seek(file_size - FOOTER_SIZE)
+        trailer = f.read(FOOTER_SIZE)
 
         if len(trailer) != FOOTER_SIZE or trailer[56:64] != FOOTER_MAGIC:
             return None
@@ -102,7 +104,7 @@ class _Footer:
         if reserved != b"\x00" * 12:
             raise ValueError(f"Bundle trailer in {path} has non-zero reserved bytes.")
 
-        metadata_start = size - FOOTER_SIZE - metadata_len
+        metadata_start = file_size - FOOTER_SIZE - metadata_len
         source_start = metadata_start - source_len
         if source_start < 0:
             raise ValueError(f"Bundle trailer in {path} declares regions that extend past the start of file.")
@@ -112,7 +114,7 @@ class _Footer:
 
         return cls(
             path=path,
-            file_size=size,
+            file_size=file_size,
             source_len=source_len,
             metadata_len=metadata_len,
             footer_ver=footer_ver,
@@ -122,82 +124,98 @@ class _Footer:
         )
 
 
-def _hash_binary_region(path: pathlib.Path, source_start: int) -> bytes:
-    """Compute SHA-256 over bytes ``[0, source_start)`` of *path*."""
+def _hash_open_file(f: BinaryIO, length: int, path: pathlib.Path) -> bytes:
+    """Compute SHA-256 over the first *length* bytes of *f* (seeks to 0 first)."""
+    f.seek(0)
     digest = hashlib.sha256()
-    remaining = source_start
-    with open(path, "rb") as f:
-        while remaining > 0:
-            chunk = f.read(min(_HASH_READ_CHUNK, remaining))
-            if not chunk:
-                raise ValueError(
-                    f"Bundle {path} truncated while hashing binary region "
-                    f"(expected {source_start} bytes, got {source_start - remaining})."
-                )
-            digest.update(chunk)
-            remaining -= len(chunk)
+    remaining = length
+    while remaining > 0:
+        chunk = f.read(min(_HASH_READ_CHUNK, remaining))
+        if not chunk:
+            raise ValueError(
+                f"Bundle {path} truncated while hashing binary region "
+                f"(expected {length} bytes, got {length - remaining})."
+            )
+        digest.update(chunk)
+        remaining -= len(chunk)
     return digest.digest()
 
 
 # LRU-bounded cache of computed binary-region digests keyed by
-# (path, inode, mtime_ns, size). A cache hit means the file at *path* still
-# has the same identity as when we last hashed it, so re-hashing on every
-# exec is unnecessary. A miss (file replaced, mtime bumped, inode swapped
-# under us) yields a different key and forces re-verification;
-@functools.lru_cache(maxsize=_VERIFY_CACHE_MAXSIZE)
-def _cached_binary_region_digest(
-    path_str: str,
-    source_start: int,
-    st_ino: int,
-    st_mtime_ns: int,
-    st_size: int,
-) -> bytes:
-    # st_ino / st_mtime_ns / st_size participate in the cache key only; if any
-    # of them change, the LRU treats it as a different entry and re-hashes.
-    del st_ino, st_mtime_ns, st_size
-    return _hash_binary_region(pathlib.Path(path_str), source_start)
+# (path, source_start, inode, mtime_ns, size). A cache hit means the file
+# at *path* still has the same identity as when we last hashed it, so
+# re-hashing on every exec is unnecessary. A miss (file replaced, mtime
+# bumped, inode swapped under us) yields a different key and forces
+# re-verification.
+_digest_cache: OrderedDict[tuple[str, int, int, int, int], bytes] = OrderedDict()
 
 
-def _verify_binary_sha256(footer: _Footer) -> bool:
-    """Verify *footer.binary_sha256* against the binary region of ``footer.path``."""
-    try:
-        st = footer.path.stat()
-    except OSError:
-        return False
+def _clear_digest_cache() -> None:
+    """Drop all cached binary-region digests. Intended for tests."""
+    _digest_cache.clear()
 
-    try:
-        actual = _cached_binary_region_digest(
-            str(footer.path), footer.source_start, st.st_ino, st.st_mtime_ns, st.st_size
-        )
-    except (OSError, ValueError) as exc:
-        log.debug("Failed to hash bundle binary region", path=str(footer.path), error=str(exc))
-        return False
 
-    if actual != footer.binary_sha256:
-        log.debug(
-            "Bundle binary_sha256 mismatch; skipping",
-            path=str(footer.path),
-            expected=footer.binary_sha256.hex(),
-            actual=actual.hex(),
-        )
-        return False
-    return True
+def _store_digest(key: tuple[str, int, int, int, int], digest: bytes) -> None:
+    _digest_cache[key] = digest
+    _digest_cache.move_to_end(key)
+    while len(_digest_cache) > _VERIFY_CACHE_MAXSIZE:
+        _digest_cache.popitem(last=False)
 
 
 def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
+    # One open per bundle: trailer-parse, hash (on cache miss), and
+    # metadata-read all share the same fd, and the stat that keys the
+    # digest cache comes from that fd too. This both halves the syscall
+    # cost of the hot path and removes the trailer-vs-hash TOCTOU window
+    # where a path could be swapped between separate opens.
     try:
-        if (footer := _Footer.read(path)) is None:
+        f = open(path, "rb")
+    except OSError as exc:
+        log.debug("Cannot open bundle file; skipping", path=str(path), error=str(exc))
+        return None
+
+    with f:
+        try:
+            st = os.fstat(f.fileno())
+        except OSError as exc:
+            log.debug("Cannot stat bundle file; skipping", path=str(path), error=str(exc))
             return None
-    except (OSError, ValueError) as exc:
-        log.debug("Invalid bundle trailer; skipping", path=str(path), error=str(exc))
-        return None
 
-    if not _verify_binary_sha256(footer):
-        return None
+        try:
+            footer = _Footer.read(f, path, st.st_size)
+        except (OSError, ValueError) as exc:
+            log.debug("Invalid bundle trailer; skipping", path=str(path), error=str(exc))
+            return None
+        if footer is None:
+            return None
 
-    with open(path, "rb") as f:
-        f.seek(footer.metadata_start)
-        metadata_bytes = f.read(footer.metadata_len)
+        cache_key = (str(path), footer.source_start, st.st_ino, st.st_mtime_ns, st.st_size)
+        actual_digest = _digest_cache.get(cache_key)
+        if actual_digest is not None:
+            _digest_cache.move_to_end(cache_key)
+        else:
+            try:
+                actual_digest = _hash_open_file(f, footer.source_start, path)
+            except (OSError, ValueError) as exc:
+                log.debug("Failed to hash bundle binary region", path=str(path), error=str(exc))
+                return None
+            _store_digest(cache_key, actual_digest)
+
+        if actual_digest != footer.binary_sha256:
+            log.debug(
+                "Bundle binary_sha256 mismatch; skipping",
+                path=str(path),
+                expected=footer.binary_sha256.hex(),
+                actual=actual_digest.hex(),
+            )
+            return None
+
+        try:
+            f.seek(footer.metadata_start)
+            metadata_bytes = f.read(footer.metadata_len)
+        except OSError as exc:
+            log.debug("Cannot read bundle metadata; skipping", path=str(path), error=str(exc))
+            return None
 
     try:
         data = yaml.safe_load(metadata_bytes.decode("utf-8"))

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -31,7 +31,7 @@ import attrs
 import structlog
 import yaml
 
-from airflow.sdk.coordinators.socket.coordinator import SocketCoordinator
+from airflow.sdk.coordinators._subprocess import SubprocessCoordinator
 from airflow.sdk.execution_time.schema import get_schema_version_migrator
 
 if TYPE_CHECKING:
@@ -363,7 +363,7 @@ def _convert_executables_root(
 
 
 @attrs.define(kw_only=True)
-class ExecutableCoordinator(SocketCoordinator):
+class ExecutableCoordinator(SubprocessCoordinator):
     """
     Coordinator that launches a native executable subprocess for task execution.
 

--- a/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/executable/coordinator.py
@@ -141,25 +141,49 @@ def _hash_open_file(f: BinaryIO, length: int, path: pathlib.Path) -> bytes:
     return digest.digest()
 
 
-# LRU-bounded cache of computed binary-region digests keyed by
-# (path, source_start, inode, mtime_ns, size). A cache hit means the file
-# at *path* still has the same identity as when we last hashed it, so
-# re-hashing on every exec is unnecessary. A miss (file replaced, mtime
+_DigestKey = tuple[str, int, int, int, int]
+
+
+class _BinaryDigestCache:
+    """
+    Bounded LRU cache of bundle binary-region digests.
+
+    Entries are keyed by ``(path, source_start, st_ino, st_mtime_ns,
+    st_size)``; a hit means the file at *path* still has the same
+    identity as when we last hashed it. The bound prevents a
+    long-running supervisor that sees many bundle redeploys from
+    retaining every historical ``(ino, mtime_ns)`` tuple forever.
+    """
+
+    def __init__(self, maxsize: int) -> None:
+        self._maxsize = maxsize
+        self._entries: OrderedDict[_DigestKey, bytes] = OrderedDict()
+
+    def get(self, key: _DigestKey) -> bytes | None:
+        digest = self._entries.get(key)
+        if digest is not None:
+            self._entries.move_to_end(key)
+        return digest
+
+    def put(self, key: _DigestKey, digest: bytes) -> None:
+        self._entries[key] = digest
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._maxsize:
+            self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+# Single process-wide instance. A cache miss (file replaced, mtime
 # bumped, inode swapped under us) yields a different key and forces
 # re-verification.
-_digest_cache: OrderedDict[tuple[str, int, int, int, int], bytes] = OrderedDict()
+_digest_cache = _BinaryDigestCache(maxsize=_VERIFY_CACHE_MAXSIZE)
 
 
 def _clear_digest_cache() -> None:
     """Drop all cached binary-region digests. Intended for tests."""
     _digest_cache.clear()
-
-
-def _store_digest(key: tuple[str, int, int, int, int], digest: bytes) -> None:
-    _digest_cache[key] = digest
-    _digest_cache.move_to_end(key)
-    while len(_digest_cache) > _VERIFY_CACHE_MAXSIZE:
-        _digest_cache.popitem(last=False)
 
 
 def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
@@ -189,17 +213,15 @@ def _read_bundle_metadata(path: pathlib.Path) -> dict[str, Any] | None:
         if footer is None:
             return None
 
-        cache_key = (str(path), footer.source_start, st.st_ino, st.st_mtime_ns, st.st_size)
+        cache_key: _DigestKey = (str(path), footer.source_start, st.st_ino, st.st_mtime_ns, st.st_size)
         actual_digest = _digest_cache.get(cache_key)
-        if actual_digest is not None:
-            _digest_cache.move_to_end(cache_key)
-        else:
+        if actual_digest is None:
             try:
                 actual_digest = _hash_open_file(f, footer.source_start, path)
             except (OSError, ValueError) as exc:
                 log.debug("Failed to hash bundle binary region", path=str(path), error=str(exc))
                 return None
-            _store_digest(cache_key, actual_digest)
+            _digest_cache.put(cache_key, actual_digest)
 
         if actual_digest != footer.binary_sha256:
             log.debug(

--- a/task-sdk/tests/task_sdk/coordinators/executable/__init__.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -1,0 +1,538 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import contextlib
+import pathlib
+import socket
+import stat
+import struct
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from uuid6 import uuid7
+
+from airflow.sdk.coordinators.executable.coordinator import (
+    FOOTER_MAGIC,
+    FOOTER_SIZE,
+    ExecutableCoordinator,
+    _accept_connections,
+    _Bundle,
+    _ExecutableActivitySubprocess,
+    _start_server,
+)
+from airflow.sdk.execution_time.coordinator import BaseCoordinator
+from airflow.sdk.execution_time.supervisor import ActivitySubprocess
+from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
+if not AIRFLOW_V_3_3_PLUS:
+    pytest.skip("Coordinator is only compatible with Airflow >= 3.3.0", allow_module_level=True)
+
+_DEFAULT_BINARY_PAYLOAD = b"\x7fELF" + b"binary-stub-payload"
+
+
+def _make_metadata(dag_ids, source_filename: str = "example.go") -> dict:
+    return {
+        "format_version": "1.0",
+        "sdk": {"language": "go", "version": "0.1.0"},
+        "source": source_filename,
+        "dags": {dag_id: {"tasks": ["task1"]} for dag_id in dag_ids},
+    }
+
+
+def _build_bundle(
+    path: Path,
+    *,
+    dag_ids=("tutorial_dag",),
+    source: str | bytes = "package main\n\nfunc main() {}\n",
+    source_filename: str = "example.go",
+    metadata: dict | bytes | None = None,
+    binary_bytes: bytes = _DEFAULT_BINARY_PAYLOAD,
+    footer_ver: int = 1,
+    magic: bytes = FOOTER_MAGIC,
+    reserved: bytes = b"\x00" * 12,
+) -> Path:
+    if isinstance(source, str):
+        source_bytes = source.encode("utf-8")
+    else:
+        source_bytes = source
+
+    if metadata is None:
+        metadata_dict = _make_metadata(dag_ids, source_filename=source_filename)
+        metadata_bytes = yaml.safe_dump(metadata_dict, sort_keys=True).encode("utf-8")
+    elif isinstance(metadata, (bytes, bytearray)):
+        metadata_bytes = bytes(metadata)
+    else:
+        metadata_bytes = yaml.safe_dump(metadata, sort_keys=True).encode("utf-8")
+
+    if len(reserved) != 12:
+        raise ValueError("reserved must be exactly 12 bytes")
+    trailer = struct.pack("<III", len(source_bytes), len(metadata_bytes), footer_ver) + reserved + magic
+    assert len(trailer) == FOOTER_SIZE
+
+    path.write_bytes(binary_bytes + source_bytes + metadata_bytes + trailer)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _make_executable(path: Path) -> Path:
+    path.write_bytes(b"#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _make_ti(dag_id: str = "tutorial_dag", queue: str = "executable") -> TaskInstanceDTO:
+    return TaskInstanceDTO(
+        id=uuid7(),
+        dag_version_id=uuid7(),
+        task_id="task_1",
+        dag_id=dag_id,
+        run_id="run_1",
+        try_number=1,
+        map_index=-1,
+        pool_slots=1,
+        queue=queue,
+        priority_weight=1,
+    )
+
+
+class TestStartServer:
+    def test_returns_listening_socket(self):
+        server = _start_server()
+        try:
+            host, port = server.getsockname()
+        finally:
+            server.close()
+        assert host == "127.0.0.1"
+        assert port > 0
+
+    def test_two_calls_return_different_ports(self):
+        s1 = _start_server()
+        s2 = _start_server()
+        try:
+            _, port1 = s1.getsockname()
+            _, port2 = s2.getsockname()
+        finally:
+            s1.close()
+            s2.close()
+        assert port1 != port2
+
+
+class TestAcceptConnections:
+    def _connect_after_delay(self, addr: tuple[str, int], delay: float = 0.0) -> None:
+        def _connect():
+            time.sleep(delay)
+            c = socket.socket()
+            with contextlib.suppress(OSError):  # Server may already be closed in teardown.
+                c.connect(addr)
+
+        threading.Thread(target=_connect, daemon=True).start()
+
+    def test_accepts_multiple_servers(self):
+        comm_server = _start_server()
+        logs_server = _start_server()
+        _, comm_port = comm_server.getsockname()
+        _, logs_port = logs_server.getsockname()
+
+        self._connect_after_delay(("127.0.0.1", comm_port))
+        self._connect_after_delay(("127.0.0.1", logs_port))
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+
+        try:
+            accepted = _accept_connections({"comm": comm_server, "logs": logs_server}, mock_proc)
+            assert set(accepted) == {"comm", "logs"}
+            for sock in accepted.values():
+                sock.close()
+        finally:
+            comm_server.close()
+            logs_server.close()
+
+    def test_raises_timeout_when_no_connection(self):
+        server = _start_server()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        try:
+            with pytest.raises(TimeoutError, match="did not connect within timeout"):
+                _accept_connections({"comm": server}, mock_proc, max_wait=0.05)
+        finally:
+            server.close()
+
+    def test_raises_runtime_error_if_process_exits_before_connecting(self):
+        server = _start_server()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        try:
+            with pytest.raises(RuntimeError, match="process exited with 1"):
+                _accept_connections({"comm": server}, mock_proc)
+        finally:
+            server.close()
+
+
+class TestBundleFind:
+    def test_finds_matching_dag_id(self, tmp_path):
+        binary = _build_bundle(tmp_path / "my_bundle", dag_ids=["tutorial_dag", "other_dag"])
+
+        bundle = _Bundle.find([tmp_path], "tutorial_dag")
+        assert bundle.path == binary.resolve()
+
+    def test_picks_matching_bundle_among_many(self, tmp_path):
+        _build_bundle(tmp_path / "alpha", dag_ids=["alpha_dag"])
+        beta = _build_bundle(tmp_path / "beta", dag_ids=["beta_dag"])
+        _build_bundle(tmp_path / "gamma", dag_ids=["gamma_dag"])
+
+        bundle = _Bundle.find([tmp_path], "beta_dag")
+        assert bundle.path == beta.resolve()
+
+    def test_searches_multiple_roots(self, tmp_path):
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        root_a.mkdir()
+        root_b.mkdir()
+        _build_bundle(root_a / "alpha", dag_ids=["alpha_dag"])
+        target = _build_bundle(root_b / "beta", dag_ids=["beta_dag"])
+
+        bundle = _Bundle.find([root_a, root_b], "beta_dag")
+        assert bundle.path == target.resolve()
+
+    def test_skips_non_bundle_files(self, tmp_path):
+        (tmp_path / "README.md").write_text("not a bundle")
+        _make_executable(tmp_path / "stray_executable")
+        binary = _build_bundle(tmp_path / "real_bundle", dag_ids=["tutorial_dag"])
+
+        bundle = _Bundle.find([tmp_path], "tutorial_dag")
+        assert bundle.path == binary.resolve()
+
+    def test_skips_non_executable_files(self, tmp_path):
+        non_exec = _build_bundle(tmp_path / "non_exec", dag_ids=["tutorial_dag"])
+        non_exec.chmod(non_exec.stat().st_mode & ~(stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH))
+
+        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            _Bundle.find([tmp_path], "tutorial_dag")
+
+    def test_raises_when_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            _Bundle.find([tmp_path], "nonexistent_dag")
+
+    def test_raises_when_directory_missing(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            _Bundle.find([tmp_path / "does_not_exist"], "tutorial_dag")
+
+
+class TestExecutableCoordinatorAttributes:
+    def test_default_kwargs(self):
+        coordinator = ExecutableCoordinator()
+        assert coordinator.sdk == "executable"
+        assert coordinator.file_extension == ""
+        assert coordinator.executables_root == []
+
+    def test_executables_root_accepts_single_path(self, tmp_path):
+        coordinator = ExecutableCoordinator(executables_root=str(tmp_path))
+        assert coordinator.executables_root == [tmp_path]
+
+    def test_executables_root_accepts_list(self, tmp_path):
+        other = tmp_path / "other"
+        coordinator = ExecutableCoordinator(executables_root=[str(tmp_path), other])
+        assert coordinator.executables_root == [tmp_path, other]
+
+    def test_executables_root_none_becomes_empty_list(self):
+        coordinator = ExecutableCoordinator(executables_root=None)
+        assert coordinator.executables_root == []
+
+
+class TestResolveExecutable:
+    def test_resolves_via_executables_root(self, tmp_path):
+        binary = _build_bundle(tmp_path / "my_bundle", dag_ids=["tutorial_dag"])
+        ti = _make_ti(dag_id="tutorial_dag")
+
+        coordinator = ExecutableCoordinator(executables_root=[tmp_path])
+        resolved = coordinator._resolve_executable(what=ti)
+        assert resolved == str(binary.resolve())
+
+    def test_raises_when_executables_root_missing(self):
+        ti = _make_ti(dag_id="tutorial_dag")
+        coordinator = ExecutableCoordinator()
+        with pytest.raises(ValueError, match="executables_root kwarg must be set"):
+            coordinator._resolve_executable(what=ti)
+
+    def test_raises_when_dag_id_not_found(self, tmp_path):
+        _build_bundle(tmp_path / "my_bundle", dag_ids=["other_dag"])
+        ti = _make_ti(dag_id="tutorial_dag")
+
+        coordinator = ExecutableCoordinator(executables_root=[tmp_path])
+        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            coordinator._resolve_executable(what=ti)
+
+
+@pytest.fixture
+def bundles_dir(tmp_path):
+    _build_bundle(tmp_path / "my_bundle", dag_ids=["tutorial_dag"])
+    return tmp_path
+
+
+@pytest.fixture
+def mock_client(make_ti_context):
+    client = MagicMock()
+    client.task_instances.start.return_value = make_ti_context()
+    return client
+
+
+class TestExecutableCoordinatorExecuteTask:
+    def _captured_popen_cmd(self, bundles_dir: pathlib.Path, mock_client) -> list[str]:
+        """Run execute_task with mocked subprocess and return the command list."""
+        ti = _make_ti(dag_id="tutorial_dag")
+        coordinator = ExecutableCoordinator(executables_root=[bundles_dir])
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 12345
+        comm_sock = MagicMock(spec=socket.socket)
+        logs_sock = MagicMock(spec=socket.socket)
+        popen_calls: list = []
+
+        def capture_popen(cmd, **kwargs):
+            popen_calls.append(cmd)
+            return mock_proc
+
+        with (
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator.subprocess.Popen",
+                side_effect=capture_popen,
+            ),
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": comm_sock, "logs": logs_sock},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started"),
+            patch.object(ActivitySubprocess, "wait", return_value=0),
+            patch("psutil.Process"),
+        ):
+            coordinator.execute_task(
+                what=ti,
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                subprocess_logs_to_stdout=False,
+            )
+
+        assert popen_calls, "subprocess.Popen was not called"
+        return popen_calls[0]
+
+    def test_executable_path_is_first_arg(self, bundles_dir, mock_client):
+        cmd = self._captured_popen_cmd(bundles_dir, mock_client)
+        expected = str((bundles_dir / "my_bundle").resolve())
+        assert cmd[0] == expected
+
+    def test_comm_and_logs_args_present(self, bundles_dir, mock_client):
+        cmd = self._captured_popen_cmd(bundles_dir, mock_client)
+        comm_args = [a for a in cmd if a.startswith("--comm=")]
+        logs_args = [a for a in cmd if a.startswith("--logs=")]
+        assert len(comm_args) == 1
+        assert len(logs_args) == 1
+
+    def test_comm_and_logs_contain_port(self, bundles_dir, mock_client):
+        cmd = self._captured_popen_cmd(bundles_dir, mock_client)
+        comm_arg = next(a for a in cmd if a.startswith("--comm="))
+        logs_arg = next(a for a in cmd if a.startswith("--logs="))
+        assert ":" in comm_arg.split("=", 1)[1]
+        assert ":" in logs_arg.split("=", 1)[1]
+
+    def test_returns_execution_result(self, bundles_dir, mock_client):
+        ti = _make_ti(dag_id="tutorial_dag")
+        coordinator = ExecutableCoordinator(executables_root=[bundles_dir])
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 99999
+        comm_sock = MagicMock(spec=socket.socket)
+        logs_sock = MagicMock(spec=socket.socket)
+
+        with (
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": comm_sock, "logs": logs_sock},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started"),
+            patch.object(ActivitySubprocess, "wait", return_value=0),
+            patch("psutil.Process"),
+        ):
+            result = coordinator.execute_task(
+                what=ti,
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                subprocess_logs_to_stdout=False,
+            )
+
+        assert isinstance(result, BaseCoordinator.ExecutionResult)
+        assert result.exit_code == 0
+
+
+class TestExecutableActivitySubprocessStart:
+    """
+    Unit tests for _ExecutableActivitySubprocess.start().
+
+    These tests mock subprocess.Popen and _accept_connections to verify that
+    start() wires up the right command and stores the right sockets,
+    without requiring a real native binary to launch.
+    """
+
+    def _start_with_mocks(
+        self,
+        executable_path: str,
+        mock_client,
+        *,
+        ti: TaskInstanceDTO | None = None,
+    ):
+        ti = ti or _make_ti()
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 12345
+        comm_sock = MagicMock(spec=socket.socket)
+        logs_sock = MagicMock(spec=socket.socket)
+
+        with (
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator.subprocess.Popen",
+                return_value=mock_proc,
+            ) as popen_mock,
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": comm_sock, "logs": logs_sock},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started"),
+            patch("psutil.Process"),
+        ):
+            proc = _ExecutableActivitySubprocess.start(
+                what=ti,
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                executable_path=executable_path,
+                subprocess_logs_to_stdout=False,
+            )
+        return proc, popen_mock
+
+    def test_stdout_write_socket_stored_for_cleanup(self, bundles_dir, mock_client):
+        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
+        assert proc._stdout_w is not None
+
+    def test_stderr_write_socket_stored_for_cleanup(self, bundles_dir, mock_client):
+        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
+        assert proc._stderr_w is not None
+
+    def test_stdout_and_stderr_write_sockets_are_distinct(self, bundles_dir, mock_client):
+        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
+        assert proc._stdout_w is not proc._stderr_w
+
+    def test_stdin_is_comm_socket(self, bundles_dir, mock_client):
+        """stdin (used by send_msg) must be the accepted comm socket."""
+        ti = _make_ti()
+        comm_sock = MagicMock(spec=socket.socket)
+        logs_sock = MagicMock(spec=socket.socket)
+
+        with (
+            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": comm_sock, "logs": logs_sock},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started"),
+            patch("psutil.Process"),
+        ):
+            popen_mock.return_value.pid = 12345
+            proc = _ExecutableActivitySubprocess.start(
+                what=ti,
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=MagicMock(),
+                executable_path=str(bundles_dir / "my_bundle"),
+                subprocess_logs_to_stdout=False,
+            )
+
+        assert proc.stdin is comm_sock
+
+    def test_pid_taken_from_popen(self, bundles_dir, mock_client):
+        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
+        assert proc.pid == 12345
+
+    def test_on_child_started_called(self, bundles_dir, mock_client):
+        ti = _make_ti()
+        with (
+            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": MagicMock(), "logs": MagicMock()},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started") as mock_on_started,
+            patch("psutil.Process"),
+        ):
+            popen_mock.return_value.pid = 12345
+            _ExecutableActivitySubprocess.start(
+                what=ti,
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                executable_path=str(bundles_dir / "my_bundle"),
+                subprocess_logs_to_stdout=False,
+            )
+
+        mock_on_started.assert_called_once()
+        kwargs = mock_on_started.call_args.kwargs
+        assert kwargs["ti"] is ti
+        assert kwargs["dag_rel_path"] == "my_bundle"
+
+    def test_register_pipe_readers_called_with_four_sockets(self, bundles_dir, mock_client):
+        """Both socketpair read-ends and both TCP sockets must be registered."""
+        with (
+            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
+            patch(
+                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                return_value={"comm": MagicMock(), "logs": MagicMock()},
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers") as mock_register,
+            patch.object(ActivitySubprocess, "_on_child_started"),
+            patch("psutil.Process"),
+        ):
+            popen_mock.return_value.pid = 12345
+            _ExecutableActivitySubprocess.start(
+                what=_make_ti(),
+                dag_rel_path="my_bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                executable_path=str(bundles_dir / "my_bundle"),
+                subprocess_logs_to_stdout=False,
+            )
+
+        mock_register.assert_called_once()
+        args = mock_register.call_args.args
+        # positional: stdout, stderr, comm, logs — all four must be sockets
+        assert len(args) == 4

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -17,12 +17,14 @@
 # under the License.
 from __future__ import annotations
 
+import hashlib
 import pathlib
 import socket
 import stat
 import struct
 import subprocess
 from pathlib import Path
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,6 +36,7 @@ from airflow.sdk.coordinators.executable.coordinator import (
     FOOTER_SIZE,
     ExecutableCoordinator,
     _Bundle,
+    _cached_binary_region_digest,
 )
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess
@@ -49,8 +52,12 @@ _DEFAULT_BINARY_PAYLOAD = b"\x7fELF" + b"binary-stub-payload"
 
 def _make_metadata(dag_ids, source_filename: str = "example.go") -> dict:
     return {
-        "format_version": "1.0",
-        "sdk": {"language": "go", "version": "0.1.0"},
+        "airflow_bundle_metadata_version": "1.0",
+        "sdk": {
+            "language": "go",
+            "version": "0.1.0",
+            "supervisor_schema_version": "2026-06-16",
+        },
         "source": source_filename,
         "dags": {dag_id: {"tasks": ["task1"]} for dag_id in dag_ids},
     }
@@ -67,6 +74,7 @@ def _build_bundle(
     footer_ver: int = 1,
     magic: bytes = FOOTER_MAGIC,
     reserved: bytes = b"\x00" * 12,
+    binary_sha256: bytes | None = None,
 ) -> Path:
     if isinstance(source, str):
         source_bytes = source.encode("utf-8")
@@ -83,7 +91,12 @@ def _build_bundle(
 
     if len(reserved) != 12:
         raise ValueError("reserved must be exactly 12 bytes")
-    trailer = struct.pack("<III", len(source_bytes), len(metadata_bytes), footer_ver) + reserved + magic
+    digest = binary_sha256 if binary_sha256 is not None else hashlib.sha256(binary_bytes).digest()
+    if len(digest) != 32:
+        raise ValueError("binary_sha256 must be exactly 32 bytes")
+    trailer = (
+        struct.pack("<III", len(source_bytes), len(metadata_bytes), footer_ver) + digest + reserved + magic
+    )
     assert len(trailer) == FOOTER_SIZE
 
     path.write_bytes(binary_bytes + source_bytes + metadata_bytes + trailer)
@@ -127,6 +140,14 @@ class TestBundleFind:
         bundle = _Bundle.find([tmp_path], "beta_dag")
         assert bundle.path == beta.resolve()
 
+    def test_searches_nested_subdirectories(self, tmp_path):
+        nested = tmp_path / "team-a" / "release-2026.05"
+        nested.mkdir(parents=True)
+        target = _build_bundle(nested / "pipeline", dag_ids=["nested_dag"])
+
+        bundle = _Bundle.find([tmp_path], "nested_dag")
+        assert bundle.path == target.resolve()
+
     def test_searches_multiple_roots(self, tmp_path):
         root_a = tmp_path / "a"
         root_b = tmp_path / "b"
@@ -161,13 +182,65 @@ class TestBundleFind:
         with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
             _Bundle.find([tmp_path / "does_not_exist"], "tutorial_dag")
 
+    def test_skips_bundle_with_corrupted_binary_region(self, tmp_path):
+        bundle_path = _build_bundle(tmp_path / "tampered", dag_ids=["tutorial_dag"])
+        # Flip a byte in the binary region; the embedded SHA-256 no longer matches.
+        data = bytearray(bundle_path.read_bytes())
+        data[0] ^= 0xFF
+        bundle_path.write_bytes(bytes(data))
+        bundle_path.chmod(bundle_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        _cached_binary_region_digest.cache_clear()
+
+        with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
+            with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+                _Bundle.find([tmp_path], "tutorial_dag")
+
+        mock_log.debug.assert_any_call(
+            "Bundle binary_sha256 mismatch; skipping",
+            path=str(bundle_path),
+            expected=mock.ANY,
+            actual=mock.ANY,
+        )
+
+    def test_captures_schema_version_from_metadata(self, tmp_path):
+        _build_bundle(tmp_path / "with_schema", dag_ids=["tutorial_dag"])
+
+        bundle = _Bundle.find([tmp_path], "tutorial_dag")
+        assert bundle.schema_version == "2026-06-16"
+
+    def test_skips_bundle_when_schema_version_missing(self, tmp_path):
+        metadata = _make_metadata(["tutorial_dag"])
+        del metadata["sdk"]["supervisor_schema_version"]
+        bundle_path = _build_bundle(tmp_path / "no_schema", dag_ids=["tutorial_dag"], metadata=metadata)
+
+        # Validator rejects the missing schema_version, so find() treats the bundle as unusable.
+        with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
+            with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+                _Bundle.find([tmp_path], "tutorial_dag")
+
+        mock_log.debug.assert_any_call(
+            "Bundle metadata rejected by validator; skipping",
+            path=str(bundle_path),
+            error=mock.ANY,
+        )
+
+    def test_skips_bundle_with_unknown_schema_version(self, tmp_path):
+        metadata = _make_metadata(["tutorial_dag"])
+        metadata["sdk"]["supervisor_schema_version"] = "1999-01-01"
+        bundle_path = _build_bundle(tmp_path / "bogus_schema", dag_ids=["tutorial_dag"], metadata=metadata)
+
+        with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
+            with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+                _Bundle.find([tmp_path], "tutorial_dag")
+
+        mock_log.debug.assert_any_call(
+            "Bundle metadata rejected by validator; skipping",
+            path=str(bundle_path),
+            error=mock.ANY,
+        )
+
 
 class TestExecutableCoordinatorAttributes:
-    def test_default_kwargs(self):
-        coordinator = ExecutableCoordinator()
-        assert coordinator.sdk == "executable"
-        assert coordinator.executables_root == []
-
     def test_executables_root_accepts_single_path(self, tmp_path):
         coordinator = ExecutableCoordinator(executables_root=str(tmp_path))
         assert coordinator.executables_root == [tmp_path]
@@ -177,25 +250,34 @@ class TestExecutableCoordinatorAttributes:
         coordinator = ExecutableCoordinator(executables_root=[str(tmp_path), other])
         assert coordinator.executables_root == [tmp_path, other]
 
-    def test_executables_root_none_becomes_empty_list(self):
-        coordinator = ExecutableCoordinator(executables_root=None)
-        assert coordinator.executables_root == []
+    def test_executables_root_required(self):
+        with pytest.raises(TypeError, match="executables_root"):
+            ExecutableCoordinator()
+
+    def test_executables_root_must_be_non_empty(self):
+        with pytest.raises(ValueError, match="executables_root"):
+            ExecutableCoordinator(executables_root=None)
 
 
-class TestResolveExecutable:
-    def test_resolves_via_executables_root(self, tmp_path):
+class TestBuildExecuteTaskCommand:
+    def test_returns_resolved_executable_and_schema_version(self, tmp_path):
         binary = _build_bundle(tmp_path / "my_bundle", dag_ids=["tutorial_dag"])
         ti = _make_ti(dag_id="tutorial_dag")
 
         coordinator = ExecutableCoordinator(executables_root=[tmp_path])
-        resolved = coordinator._resolve_executable(what=ti)
-        assert resolved == str(binary.resolve())
+        command, schema_version = coordinator._build_execute_task_command(what=ti)
+        assert command == [str(binary.resolve())]
+        assert schema_version == "2026-06-16"
 
-    def test_raises_when_executables_root_missing(self):
+    def test_raises_when_bundle_omits_schema_version(self, tmp_path):
+        metadata = _make_metadata(["tutorial_dag"])
+        del metadata["sdk"]["supervisor_schema_version"]
+        _build_bundle(tmp_path / "my_bundle", dag_ids=["tutorial_dag"], metadata=metadata)
         ti = _make_ti(dag_id="tutorial_dag")
-        coordinator = ExecutableCoordinator()
-        with pytest.raises(ValueError, match="executables_root kwarg must be set"):
-            coordinator._resolve_executable(what=ti)
+
+        coordinator = ExecutableCoordinator(executables_root=[tmp_path])
+        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            coordinator._build_execute_task_command(what=ti)
 
     def test_raises_when_dag_id_not_found(self, tmp_path):
         _build_bundle(tmp_path / "my_bundle", dag_ids=["other_dag"])
@@ -203,7 +285,7 @@ class TestResolveExecutable:
 
         coordinator = ExecutableCoordinator(executables_root=[tmp_path])
         with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
-            coordinator._resolve_executable(what=ti)
+            coordinator._build_execute_task_command(what=ti)
 
 
 @pytest.fixture

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -17,16 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import contextlib
 import pathlib
 import socket
 import stat
 import struct
 import subprocess
-import threading
-import time
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -36,10 +33,7 @@ from airflow.sdk.coordinators.executable.coordinator import (
     FOOTER_MAGIC,
     FOOTER_SIZE,
     ExecutableCoordinator,
-    _accept_connections,
     _Bundle,
-    _ExecutableActivitySubprocess,
-    _start_server,
 )
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess
@@ -116,81 +110,6 @@ def _make_ti(dag_id: str = "tutorial_dag", queue: str = "executable") -> TaskIns
         queue=queue,
         priority_weight=1,
     )
-
-
-class TestStartServer:
-    def test_returns_listening_socket(self):
-        server = _start_server()
-        try:
-            host, port = server.getsockname()
-        finally:
-            server.close()
-        assert host == "127.0.0.1"
-        assert port > 0
-
-    def test_two_calls_return_different_ports(self):
-        s1 = _start_server()
-        s2 = _start_server()
-        try:
-            _, port1 = s1.getsockname()
-            _, port2 = s2.getsockname()
-        finally:
-            s1.close()
-            s2.close()
-        assert port1 != port2
-
-
-class TestAcceptConnections:
-    def _connect_after_delay(self, addr: tuple[str, int], delay: float = 0.0) -> None:
-        def _connect():
-            time.sleep(delay)
-            c = socket.socket()
-            with contextlib.suppress(OSError):  # Server may already be closed in teardown.
-                c.connect(addr)
-
-        threading.Thread(target=_connect, daemon=True).start()
-
-    def test_accepts_multiple_servers(self):
-        comm_server = _start_server()
-        logs_server = _start_server()
-        _, comm_port = comm_server.getsockname()
-        _, logs_port = logs_server.getsockname()
-
-        self._connect_after_delay(("127.0.0.1", comm_port))
-        self._connect_after_delay(("127.0.0.1", logs_port))
-
-        mock_proc = MagicMock(spec=subprocess.Popen)
-        mock_proc.poll.return_value = None
-
-        try:
-            accepted, _ = _accept_connections({"comm": comm_server, "logs": logs_server}, {}, mock_proc)
-            assert set(accepted) == {comm_server, logs_server}
-            for sock in accepted.values():
-                sock.close()
-        finally:
-            comm_server.close()
-            logs_server.close()
-
-    def test_raises_timeout_when_no_connection(self):
-        server = _start_server()
-        mock_proc = MagicMock(spec=subprocess.Popen)
-        mock_proc.poll.return_value = None
-        try:
-            with pytest.raises(TimeoutError, match="did not connect within timeout"):
-                _accept_connections({"comm": server}, {}, mock_proc, max_wait=0.05)
-        finally:
-            server.close()
-
-    def test_raises_runtime_error_if_process_exits_before_connecting(self):
-        server = _start_server()
-        mock_proc = MagicMock(spec=subprocess.Popen)
-        mock_proc.poll.return_value = 1
-        mock_proc.returncode = 1
-        try:
-            with pytest.raises(RuntimeError, match="process exited with 1"):
-                _accept_connections({"comm": server}, {}, mock_proc)
-        finally:
-            server.close()
 
 
 class TestBundleFind:
@@ -318,11 +237,11 @@ class TestExecutableCoordinatorExecuteTask:
 
         with (
             patch(
-                "airflow.sdk.coordinators.executable.coordinator.subprocess.Popen",
+                "airflow.sdk.coordinators.socket.coordinator.subprocess.Popen",
                 side_effect=capture_popen,
             ),
             patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                "airflow.sdk.coordinators.socket.coordinator._accept_connections",
                 side_effect=lambda servers, drains, proc, **kw: (
                     {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
                     {soc: b"" for soc in drains.values()},
@@ -349,20 +268,6 @@ class TestExecutableCoordinatorExecuteTask:
         expected = str((bundles_dir / "my_bundle").resolve())
         assert cmd[0] == expected
 
-    def test_comm_and_logs_args_present(self, bundles_dir, mock_client):
-        cmd = self._captured_popen_cmd(bundles_dir, mock_client)
-        comm_args = [a for a in cmd if a.startswith("--comm=")]
-        logs_args = [a for a in cmd if a.startswith("--logs=")]
-        assert len(comm_args) == 1
-        assert len(logs_args) == 1
-
-    def test_comm_and_logs_contain_port(self, bundles_dir, mock_client):
-        cmd = self._captured_popen_cmd(bundles_dir, mock_client)
-        comm_arg = next(a for a in cmd if a.startswith("--comm="))
-        logs_arg = next(a for a in cmd if a.startswith("--logs="))
-        assert ":" in comm_arg.split("=", 1)[1]
-        assert ":" in logs_arg.split("=", 1)[1]
-
     def test_returns_execution_result(self, bundles_dir, mock_client):
         ti = _make_ti(dag_id="tutorial_dag")
         coordinator = ExecutableCoordinator(executables_root=[bundles_dir])
@@ -375,7 +280,7 @@ class TestExecutableCoordinatorExecuteTask:
         with (
             patch("subprocess.Popen", return_value=mock_proc),
             patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
+                "airflow.sdk.coordinators.socket.coordinator._accept_connections",
                 side_effect=lambda servers, drains, proc, **kw: (
                     {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
                     {soc: b"" for soc in drains.values()},
@@ -396,144 +301,3 @@ class TestExecutableCoordinatorExecuteTask:
 
         assert isinstance(result, BaseCoordinator.ExecutionResult)
         assert result.exit_code == 0
-
-
-class TestExecutableActivitySubprocessStart:
-    """
-    Unit tests for _ExecutableActivitySubprocess.start().
-
-    These tests mock subprocess.Popen and _accept_connections to verify that
-    start() wires up the right command and stores the right sockets,
-    without requiring a real native binary to launch.
-    """
-
-    def _start_with_mocks(
-        self,
-        executable_path: str,
-        mock_client,
-        *,
-        ti: TaskInstanceDTO | None = None,
-    ):
-        ti = ti or _make_ti()
-
-        mock_proc = MagicMock(spec=subprocess.Popen)
-        mock_proc.pid = 12345
-        comm_sock = MagicMock(spec=socket.socket)
-        logs_sock = MagicMock(spec=socket.socket)
-
-        with (
-            patch(
-                "airflow.sdk.coordinators.executable.coordinator.subprocess.Popen",
-                return_value=mock_proc,
-            ) as popen_mock,
-            patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                side_effect=lambda servers, drains, proc, **kw: (
-                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
-                    {soc: b"" for soc in drains.values()},
-                ),
-            ),
-            patch.object(ActivitySubprocess, "_register_pipe_readers"),
-            patch.object(ActivitySubprocess, "_on_child_started"),
-            patch("psutil.Process"),
-        ):
-            proc = _ExecutableActivitySubprocess.start(
-                what=ti,
-                dag_rel_path="my_bundle",
-                bundle_info=MagicMock(),
-                client=mock_client,
-                executable_path=executable_path,
-                subprocess_logs_to_stdout=False,
-            )
-        return proc, popen_mock
-
-    def test_stdin_is_comm_socket(self, bundles_dir, mock_client):
-        """stdin (used by send_msg) must be the accepted comm socket."""
-        ti = _make_ti()
-        comm_sock = MagicMock(spec=socket.socket)
-        logs_sock = MagicMock(spec=socket.socket)
-
-        with (
-            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
-            patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                side_effect=lambda servers, drains, proc, **kw: (
-                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
-                    {soc: b"" for soc in drains.values()},
-                ),
-            ),
-            patch.object(ActivitySubprocess, "_register_pipe_readers"),
-            patch.object(ActivitySubprocess, "_on_child_started"),
-            patch("psutil.Process"),
-        ):
-            popen_mock.return_value.pid = 12345
-            proc = _ExecutableActivitySubprocess.start(
-                what=ti,
-                dag_rel_path="my_bundle",
-                bundle_info=MagicMock(),
-                client=MagicMock(),
-                executable_path=str(bundles_dir / "my_bundle"),
-                subprocess_logs_to_stdout=False,
-            )
-
-        assert proc.stdin is comm_sock
-
-    def test_pid_taken_from_popen(self, bundles_dir, mock_client):
-        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
-        assert proc.pid == 12345
-
-    def test_on_child_started_called(self, bundles_dir, mock_client):
-        ti = _make_ti()
-        with (
-            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
-            patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                side_effect=lambda servers, drains, proc, **kw: (
-                    {soc: MagicMock(spec=socket.socket) for soc in servers.values()},
-                    {soc: b"" for soc in drains.values()},
-                ),
-            ),
-            patch.object(ActivitySubprocess, "_register_pipe_readers"),
-            patch.object(ActivitySubprocess, "_on_child_started") as mock_on_started,
-            patch("psutil.Process"),
-        ):
-            popen_mock.return_value.pid = 12345
-            _ExecutableActivitySubprocess.start(
-                what=ti,
-                dag_rel_path="my_bundle",
-                bundle_info=MagicMock(),
-                client=mock_client,
-                executable_path=str(bundles_dir / "my_bundle"),
-                subprocess_logs_to_stdout=False,
-            )
-
-        mock_on_started.assert_called_once()
-        kwargs = mock_on_started.call_args.kwargs
-        assert kwargs["ti"] is ti
-        assert kwargs["dag_rel_path"] == "my_bundle"
-
-    def test_register_pipe_readers_called_with_four_sockets(self, bundles_dir, mock_client):
-        """Both socketpair read-ends and both TCP sockets must be registered, with a data kwarg."""
-        with (
-            patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
-            patch(
-                "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                side_effect=lambda servers, drains, proc, **kw: (
-                    {soc: MagicMock(spec=socket.socket) for soc in servers.values()},
-                    {soc: b"" for soc in drains.values()},
-                ),
-            ),
-            patch.object(ActivitySubprocess, "_register_pipe_readers") as mock_register,
-            patch.object(ActivitySubprocess, "_on_child_started"),
-            patch("psutil.Process"),
-        ):
-            popen_mock.return_value.pid = 12345
-            _ExecutableActivitySubprocess.start(
-                what=_make_ti(),
-                dag_rel_path="my_bundle",
-                bundle_info=MagicMock(),
-                client=mock_client,
-                executable_path=str(bundles_dir / "my_bundle"),
-                subprocess_logs_to_stdout=False,
-            )
-        assert mock_register.mock_calls == [call(ANY, ANY, ANY, ANY, data=ANY)]

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -26,7 +26,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 import yaml
@@ -163,8 +163,8 @@ class TestAcceptConnections:
         mock_proc.poll.return_value = None
 
         try:
-            accepted = _accept_connections({"comm": comm_server, "logs": logs_server}, mock_proc)
-            assert set(accepted) == {"comm", "logs"}
+            accepted, _ = _accept_connections({"comm": comm_server, "logs": logs_server}, {}, mock_proc)
+            assert set(accepted) == {comm_server, logs_server}
             for sock in accepted.values():
                 sock.close()
         finally:
@@ -177,7 +177,7 @@ class TestAcceptConnections:
         mock_proc.poll.return_value = None
         try:
             with pytest.raises(TimeoutError, match="did not connect within timeout"):
-                _accept_connections({"comm": server}, mock_proc, max_wait=0.05)
+                _accept_connections({"comm": server}, {}, mock_proc, max_wait=0.05)
         finally:
             server.close()
 
@@ -188,7 +188,7 @@ class TestAcceptConnections:
         mock_proc.returncode = 1
         try:
             with pytest.raises(RuntimeError, match="process exited with 1"):
-                _accept_connections({"comm": server}, mock_proc)
+                _accept_connections({"comm": server}, {}, mock_proc)
         finally:
             server.close()
 
@@ -247,7 +247,6 @@ class TestExecutableCoordinatorAttributes:
     def test_default_kwargs(self):
         coordinator = ExecutableCoordinator()
         assert coordinator.sdk == "executable"
-        assert coordinator.file_extension == ""
         assert coordinator.executables_root == []
 
     def test_executables_root_accepts_single_path(self, tmp_path):
@@ -324,7 +323,10 @@ class TestExecutableCoordinatorExecuteTask:
             ),
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": comm_sock, "logs": logs_sock},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers"),
             patch.object(ActivitySubprocess, "_on_child_started"),
@@ -374,7 +376,10 @@ class TestExecutableCoordinatorExecuteTask:
             patch("subprocess.Popen", return_value=mock_proc),
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": comm_sock, "logs": logs_sock},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers"),
             patch.object(ActivitySubprocess, "_on_child_started"),
@@ -423,7 +428,10 @@ class TestExecutableActivitySubprocessStart:
             ) as popen_mock,
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": comm_sock, "logs": logs_sock},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers"),
             patch.object(ActivitySubprocess, "_on_child_started"),
@@ -439,18 +447,6 @@ class TestExecutableActivitySubprocessStart:
             )
         return proc, popen_mock
 
-    def test_stdout_write_socket_stored_for_cleanup(self, bundles_dir, mock_client):
-        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
-        assert proc._stdout_w is not None
-
-    def test_stderr_write_socket_stored_for_cleanup(self, bundles_dir, mock_client):
-        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
-        assert proc._stderr_w is not None
-
-    def test_stdout_and_stderr_write_sockets_are_distinct(self, bundles_dir, mock_client):
-        proc, _ = self._start_with_mocks(str(bundles_dir / "my_bundle"), mock_client)
-        assert proc._stdout_w is not proc._stderr_w
-
     def test_stdin_is_comm_socket(self, bundles_dir, mock_client):
         """stdin (used by send_msg) must be the accepted comm socket."""
         ti = _make_ti()
@@ -461,7 +457,10 @@ class TestExecutableActivitySubprocessStart:
             patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": comm_sock, "logs": logs_sock},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers"),
             patch.object(ActivitySubprocess, "_on_child_started"),
@@ -489,7 +488,10 @@ class TestExecutableActivitySubprocessStart:
             patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": MagicMock(), "logs": MagicMock()},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {soc: MagicMock(spec=socket.socket) for soc in servers.values()},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers"),
             patch.object(ActivitySubprocess, "_on_child_started") as mock_on_started,
@@ -511,12 +513,15 @@ class TestExecutableActivitySubprocessStart:
         assert kwargs["dag_rel_path"] == "my_bundle"
 
     def test_register_pipe_readers_called_with_four_sockets(self, bundles_dir, mock_client):
-        """Both socketpair read-ends and both TCP sockets must be registered."""
+        """Both socketpair read-ends and both TCP sockets must be registered, with a data kwarg."""
         with (
             patch("airflow.sdk.coordinators.executable.coordinator.subprocess.Popen") as popen_mock,
             patch(
                 "airflow.sdk.coordinators.executable.coordinator._accept_connections",
-                return_value={"comm": MagicMock(), "logs": MagicMock()},
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {soc: MagicMock(spec=socket.socket) for soc in servers.values()},
+                    {soc: b"" for soc in drains.values()},
+                ),
             ),
             patch.object(ActivitySubprocess, "_register_pipe_readers") as mock_register,
             patch.object(ActivitySubprocess, "_on_child_started"),
@@ -531,8 +536,4 @@ class TestExecutableActivitySubprocessStart:
                 executable_path=str(bundles_dir / "my_bundle"),
                 subprocess_logs_to_stdout=False,
             )
-
-        mock_register.assert_called_once()
-        args = mock_register.call_args.args
-        # positional: stdout, stderr, comm, logs — all four must be sockets
-        assert len(args) == 4
+        assert mock_register.mock_calls == [call(ANY, ANY, ANY, ANY, data=ANY)]

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -441,11 +441,11 @@ class TestExecutableCoordinatorExecuteTask:
 
         with (
             patch(
-                "airflow.sdk.coordinators.socket.coordinator.subprocess.Popen",
+                "airflow.sdk.coordinators._subprocess.subprocess.Popen",
                 side_effect=capture_popen,
             ),
             patch(
-                "airflow.sdk.coordinators.socket.coordinator._accept_connections",
+                "airflow.sdk.coordinators._subprocess._accept_connections",
                 side_effect=lambda servers, drains, proc, **kw: (
                     {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
                     {soc: b"" for soc in drains.values()},
@@ -484,7 +484,7 @@ class TestExecutableCoordinatorExecuteTask:
         with (
             patch("subprocess.Popen", return_value=mock_proc),
             patch(
-                "airflow.sdk.coordinators.socket.coordinator._accept_connections",
+                "airflow.sdk.coordinators._subprocess._accept_connections",
                 side_effect=lambda servers, drains, proc, **kw: (
                     {servers["comm"]: comm_sock, servers["logs"]: logs_sock},
                     {soc: b"" for soc in drains.values()},

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -37,7 +37,7 @@ from airflow.sdk.coordinators.executable.coordinator import (
     ExecutableCoordinator,
     _BinaryDigestCache,
     _Bundle,
-    _clear_digest_cache,
+    _digest_cache,
 )
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess
@@ -252,6 +252,19 @@ class TestBundleFind:
         with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
             _Bundle.find([tmp_path / "does_not_exist"], "tutorial_dag")
 
+    def test_symlink_cycle_does_not_infinite_recurse(self, tmp_path):
+        nested = tmp_path / "inner"
+        nested.mkdir()
+        target = _build_bundle(nested / "pipeline", dag_ids=["loop_dag"])
+        loop = nested / "loop"
+        try:
+            loop.symlink_to(tmp_path)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        bundle = _Bundle.find([tmp_path], "loop_dag")
+        assert bundle.path == target.resolve()
+
     def test_skips_bundle_with_corrupted_binary_region(self, tmp_path):
         bundle_path = _build_bundle(tmp_path / "tampered", dag_ids=["tutorial_dag"])
         # Flip a byte in the binary region; the embedded SHA-256 no longer matches.
@@ -259,7 +272,7 @@ class TestBundleFind:
         data[0] ^= 0xFF
         bundle_path.write_bytes(bytes(data))
         bundle_path.chmod(bundle_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-        _clear_digest_cache()
+        _digest_cache.clear()
 
         with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
             with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -36,7 +36,7 @@ from airflow.sdk.coordinators.executable.coordinator import (
     FOOTER_SIZE,
     ExecutableCoordinator,
     _Bundle,
-    _cached_binary_region_digest,
+    _clear_digest_cache,
 )
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess
@@ -189,7 +189,7 @@ class TestBundleFind:
         data[0] ^= 0xFF
         bundle_path.write_bytes(bytes(data))
         bundle_path.chmod(bundle_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-        _cached_binary_region_digest.cache_clear()
+        _clear_digest_cache()
 
         with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
             with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -213,13 +213,13 @@ class TestBundleFind:
         del metadata["sdk"]["supervisor_schema_version"]
         bundle_path = _build_bundle(tmp_path / "no_schema", dag_ids=["tutorial_dag"], metadata=metadata)
 
-        # Validator rejects the missing schema_version, so find() treats the bundle as unusable.
+        # Converter rejects the missing schema_version, so find() treats the bundle as unusable.
         with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
-            with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+            with pytest.raises(FileNotFoundError, match="matching bundles were rejected"):
                 _Bundle.find([tmp_path], "tutorial_dag")
 
         mock_log.debug.assert_any_call(
-            "Bundle metadata rejected by validator; skipping",
+            "Bundle metadata rejected; skipping",
             path=str(bundle_path),
             error=mock.ANY,
         )
@@ -230,13 +230,52 @@ class TestBundleFind:
         bundle_path = _build_bundle(tmp_path / "bogus_schema", dag_ids=["tutorial_dag"], metadata=metadata)
 
         with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
+            with pytest.raises(FileNotFoundError, match="matching bundles were rejected") as exc_info:
+                _Bundle.find([tmp_path], "tutorial_dag")
+
+        mock_log.debug.assert_any_call(
+            "Bundle metadata rejected; skipping",
+            path=str(bundle_path),
+            error=mock.ANY,
+        )
+        # The raised error surfaces the rejection so a found-but-unusable bundle
+        # is not reported as missing.
+        msg = str(exc_info.value)
+        assert str(bundle_path.resolve()) in msg
+        assert "1999-01-01" in msg
+
+    def test_logs_when_metadata_yaml_is_malformed(self, tmp_path):
+        bundle_path = _build_bundle(
+            tmp_path / "bad_yaml",
+            dag_ids=["tutorial_dag"],
+            metadata=b"key: : not: valid: yaml: [",
+        )
+
+        with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
             with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
                 _Bundle.find([tmp_path], "tutorial_dag")
 
         mock_log.debug.assert_any_call(
-            "Bundle metadata rejected by validator; skipping",
+            "Cannot decode bundle metadata; skipping",
             path=str(bundle_path),
             error=mock.ANY,
+        )
+
+    def test_logs_when_metadata_is_not_a_mapping(self, tmp_path):
+        bundle_path = _build_bundle(
+            tmp_path / "scalar_meta",
+            dag_ids=["tutorial_dag"],
+            metadata=b"just-a-scalar\n",
+        )
+
+        with patch("airflow.sdk.coordinators.executable.coordinator.log") as mock_log:
+            with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+                _Bundle.find([tmp_path], "tutorial_dag")
+
+        mock_log.debug.assert_any_call(
+            "Bundle metadata is not a mapping; skipping",
+            path=str(bundle_path),
+            type=mock.ANY,
         )
 
 
@@ -276,7 +315,7 @@ class TestBuildExecuteTaskCommand:
         ti = _make_ti(dag_id="tutorial_dag")
 
         coordinator = ExecutableCoordinator(executables_root=[tmp_path])
-        with pytest.raises(FileNotFoundError, match="cannot find executable bundle"):
+        with pytest.raises(FileNotFoundError, match="matching bundles were rejected"):
             coordinator._build_execute_task_command(what=ti)
 
     def test_raises_when_dag_id_not_found(self, tmp_path):

--- a/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/coordinators/executable/test_coordinator.py
@@ -35,6 +35,7 @@ from airflow.sdk.coordinators.executable.coordinator import (
     FOOTER_MAGIC,
     FOOTER_SIZE,
     ExecutableCoordinator,
+    _BinaryDigestCache,
     _Bundle,
     _clear_digest_cache,
 )
@@ -123,6 +124,75 @@ def _make_ti(dag_id: str = "tutorial_dag", queue: str = "executable") -> TaskIns
         queue=queue,
         priority_weight=1,
     )
+
+
+class TestBinaryDigestCache:
+    def test_get_returns_none_for_missing_key(self):
+        cache = _BinaryDigestCache(maxsize=4)
+        assert cache.get(("/p", 0, 0, 0, 0)) is None
+
+    def test_put_then_get_returns_stored_digest(self):
+        cache = _BinaryDigestCache(maxsize=4)
+        key = ("/p", 100, 1, 2, 3)
+        cache.put(key, b"\xaa" * 32)
+        assert cache.get(key) == b"\xaa" * 32
+
+    def test_put_updates_existing_key(self):
+        cache = _BinaryDigestCache(maxsize=4)
+        key = ("/p", 100, 1, 2, 3)
+        cache.put(key, b"\xaa" * 32)
+        cache.put(key, b"\xbb" * 32)
+        assert cache.get(key) == b"\xbb" * 32
+
+    def test_eviction_drops_oldest_when_over_maxsize(self):
+        cache = _BinaryDigestCache(maxsize=2)
+        keys = [(f"/p{i}", i, 0, 0, 0) for i in range(3)]
+        for i, k in enumerate(keys):
+            cache.put(k, bytes([i]) * 32)
+
+        # First inserted entry should have been evicted.
+        assert cache.get(keys[0]) is None
+        assert cache.get(keys[1]) == bytes([1]) * 32
+        assert cache.get(keys[2]) == bytes([2]) * 32
+
+    def test_get_promotes_entry_so_it_is_not_evicted_next(self):
+        cache = _BinaryDigestCache(maxsize=2)
+        key_a = ("/a", 0, 0, 0, 0)
+        key_b = ("/b", 0, 0, 0, 0)
+        key_c = ("/c", 0, 0, 0, 0)
+        cache.put(key_a, b"\x01" * 32)
+        cache.put(key_b, b"\x02" * 32)
+
+        # Touch A so B becomes the LRU victim.
+        assert cache.get(key_a) == b"\x01" * 32
+        cache.put(key_c, b"\x03" * 32)
+
+        assert cache.get(key_a) == b"\x01" * 32
+        assert cache.get(key_b) is None
+        assert cache.get(key_c) == b"\x03" * 32
+
+    def test_put_promotes_existing_entry(self):
+        cache = _BinaryDigestCache(maxsize=2)
+        key_a = ("/a", 0, 0, 0, 0)
+        key_b = ("/b", 0, 0, 0, 0)
+        key_c = ("/c", 0, 0, 0, 0)
+        cache.put(key_a, b"\x01" * 32)
+        cache.put(key_b, b"\x02" * 32)
+
+        # Re-putting A should refresh it so B is the next victim.
+        cache.put(key_a, b"\x01" * 32)
+        cache.put(key_c, b"\x03" * 32)
+
+        assert cache.get(key_a) == b"\x01" * 32
+        assert cache.get(key_b) is None
+        assert cache.get(key_c) == b"\x03" * 32
+
+    def test_clear_drops_all_entries(self):
+        cache = _BinaryDigestCache(maxsize=4)
+        key = ("/p", 0, 0, 0, 0)
+        cache.put(key, b"\xaa" * 32)
+        cache.clear()
+        assert cache.get(key) is None
 
 
 class TestBundleFind:


### PR DESCRIPTION
- closes: https://github.com/apache/airflow/issues/66936
- related: #67153, #67154
- **Depends on:** #67153, #67635

Only the following file changes are relative:
- `task-sdk/docs/*`
- `task-sdk/src/airflow/sdk/coordinators/executable/*`

The `SocketCoordinator` and `JavaCoordinator` change should be covered in #67635.

## Why

`BaseCoordinator` already supports non-Python SDKs (Java is the prior art), but there is no in-tree coordinator for **native compiled** SDKs (Go, Rust, C++, Zig, ...).

This adds `ExecutableCoordinator` plus **executable bundle spec** (`AFBNDL01`) so any compiled SDK produces artifacts the Task SDK can discover, verify, and execute identically.

## How

- A bundle is the compiled executable with `<source><metadata><trailer>` appended after its OS-defined end; the file stays directly runnable and is identified by trailer magic, not by filename.
- The 64-byte trailer carries region lengths, `footer_ver`, a SHA-256 of the binary region, and the magic `AFBNDL01`. The hash is LRU-cached by `(path, inode, mtime_ns, size)` so the exec hot path doesn't re-hash.
- `executables_root` is scanned recursively; bundles with bad trailers, hash mismatches, or unknown `supervisor_schema_version` are logged at debug and skipped instead of failing the whole scan.
- Socket child-process plumbing is factored out of `JavaCoordinator` into a shared `SocketCoordinator` base (#67635) that both coordinators inherit from.

## What

- Spec + JSON Schema: `task-sdk/docs/executable-bundle-spec.rst`, `task-sdk/docs/airflow-metadata.schema.json`.
- `airflow.sdk.coordinators.executable.ExecutableCoordinator`: required non-empty `executables_root`, recursive scan, trailer + SHA-256 verification, schema-version resolution, returns `supervisor_schema_version` so the supervisor can negotiate the wire schema.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
