### PR TITLE
OTel integration: add 90s execution_timeout to heavy DAG-run tests

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -382,6 +382,7 @@ class TestOtelIntegration:
             )
         return ti
 
+    @pytest.mark.execution_timeout(90)
     @pytest.mark.parametrize(
         ("legacy_names_on_bool", "legacy_names_exported"),
         [
@@ -417,6 +418,7 @@ class TestOtelIntegration:
             if legacy_names_exported:
                 assert set(legacy_metric_names).issubset(metrics_dict.keys())
 
+    @pytest.mark.execution_timeout(90)
     def test_export_metrics_during_process_shutdown(self, capfd):
         out, dag = self.dag_execution_for_testing_metrics(capfd)
 


### PR DESCRIPTION
The default per-test timeout in core-integration CI is 60s (set by
breeze via `--setup-timeout` / `--execution-timeout` / `--teardown-timeout`,
default in `dev/breeze/src/airflow_breeze/commands/testing_commands.py:547`).

The heavy fixture `dag_execution_for_testing_metrics` starts a real
scheduler + apiserver, triggers a DAG, waits up to 90s for the run to
finish, plus a 10s sleep for span_status processing. Happy-path timings
we see in CI cluster around ~38s but the upper tail brushes against 60s.

`test_dag_execution_succeeds` already has `@pytest.mark.execution_timeout(90)`.
Its two siblings sharing the same fixture (`test_export_legacy_metric_names`
and `test_export_metrics_during_process_shutdown`) were missing the marker,
so they failed the moment one parametrize variant ticked past 60s — saw
that in https://github.com/apache/airflow/actions/runs/26086088389/job/76701766269
(60.01s, missed by 0.01s).

Aligns those two tests with the existing 90s budget. No behavior change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.7 (1M context)

Generated-by: Claude Opus 4.7 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)