### PR TITLE
Extract selector-based I/O loop helpers into a shared module

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/selector_loop.py
+++ b/task-sdk/src/airflow/sdk/execution_time/selector_loop.py
@@ -1,0 +1,159 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Selector-based I/O loop utilities shared across subprocess monitors.
+
+These building blocks let a process multiplex socket I/O without threads
+and are used by :class:`~airflow.sdk.execution_time.supervisor.WatchedSubprocess`
+and any other selector-driven bridge.
+
+The common contract for every callback registered with the selector:
+
+* The selector stores a ``(handler, on_close)`` tuple as ``key.data``.
+* ``handler(fileobj) -> bool`` reads available data and returns
+  ``True`` to keep listening, ``False`` on EOF / error.
+* ``on_close(fileobj)`` is called when the handler returns ``False``;
+  it must unregister the fileobj from the selector.
+* :func:`service_selector` drives one iteration of this protocol.
+"""
+
+from __future__ import annotations
+
+import selectors
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from socket import socket
+
+    # (handler, on_close) — stored as ``selector.register(..., data=cb)``
+    SelectorCallback = tuple[Callable[[socket], bool], Callable[[socket], None]]
+
+
+# Sockets, even the `.makefile()` function don't correctly do line buffering on reading. If a chunk is read
+# and it doesn't contain a new line character, `.readline()` will just return the chunk as is.
+#
+# This returns a callback suitable for attaching to a `selector` that reads in to a buffer, and yields lines
+# to a (sync) generator
+def make_buffered_socket_reader(
+    gen: Generator[None, bytes | bytearray, None],
+    on_close: Callable[[socket], None],
+    buffer_size: int = 4096,
+) -> SelectorCallback:
+    """
+    Create a selector callback that line-buffers socket data into a generator.
+
+    Bytes are accumulated until a newline is found; each
+    complete line is sent to *gen* via ``gen.send(line)``.  On EOF the
+    remainder of the buffer (if any) is flushed.
+
+    Returns a ``(handler, on_close)`` tuple suitable for
+    ``selector.register(..., data=...)``.
+    """
+    buffer = bytearray()  # This will hold our accumulated binary data
+    read_buffer = bytearray(buffer_size)  # Temporary buffer for each read
+
+    # We need to start up the generator to get it to the point it's at waiting on the yield
+    next(gen)
+
+    def cb(sock: socket):
+        nonlocal buffer, read_buffer
+        # Read up to `buffer_size` bytes of data from the socket
+        n_received = sock.recv_into(read_buffer)
+
+        if not n_received:
+            # If no data is returned, the connection is closed. Return whatever is left in the buffer
+            if len(buffer):
+                with suppress(StopIteration):
+                    gen.send(buffer)
+            return False
+
+        buffer.extend(read_buffer[:n_received])
+
+        # We could have read multiple lines in one go, yield them all
+        while (newline_pos := buffer.find(b"\n")) != -1:
+            line = buffer[: newline_pos + 1]
+            try:
+                gen.send(line)
+            except StopIteration:
+                return False
+            buffer = buffer[newline_pos + 1 :]  # Update the buffer with remaining data
+
+        return True
+
+    return cb, on_close
+
+
+def make_raw_forwarder(
+    dest: socket,
+    on_close: Callable[[socket], None],
+) -> SelectorCallback:
+    """
+    Create a selector callback that forwards raw bytes to *dest*.
+
+    Used for transparent protocol bridges where bytes must be shuttled
+    between two sockets without interpretation (e.g. length-prefixed
+    msgpack frames between a supervisor and a Java subprocess).
+    """
+
+    def cb(sock: socket) -> bool:
+        data = sock.recv(65536)
+        if not data:
+            return False
+        try:
+            dest.sendall(data)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return False
+        return True
+
+    return cb, on_close
+
+
+def service_selector(selector: selectors.BaseSelector, timeout: float = 1.0) -> None:
+    """
+    Process one round of selector events.
+
+    For each ready socket whose handler returns ``False`` (EOF / error),
+    the socket's *on_close* callback is invoked and the socket is closed.
+    """
+    # Ensure minimum timeout to prevent CPU spike with tight loop when timeout is 0 or negative
+    timeout = max(0.01, timeout)
+    events = selector.select(timeout=timeout)
+    for key, _ in events:
+        # Retrieve the handler responsible for processing this file object (e.g., stdout, stderr)
+        socket_handler, on_close = key.data
+
+        # Example of handler behavior:
+        # If the subprocess writes "Hello, World!" to stdout:
+        # - `socket_handler` reads and processes the message.
+        # - If EOF is reached, the handler returns False to signal no more reads are expected.
+        # - BrokenPipeError should be caught and treated as if the handler returned false, similar
+        # to EOF case
+        try:
+            need_more = socket_handler(key.fileobj)
+        except (BrokenPipeError, ConnectionResetError):
+            need_more = False
+
+        # If the handler signals that the file object is no longer needed (EOF, closed, etc.)
+        # unregister it from the selector to stop monitoring; `wait()` blocks until all selectors
+        # are removed.
+        if not need_more:
+            sock: socket = key.fileobj  # type: ignore[assignment]
+            on_close(sock)
+            sock.close()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -144,6 +144,7 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_get_variable_keys,
     handle_mask_secret,
 )
+from airflow.sdk.execution_time.selector_loop import make_buffered_socket_reader, service_selector
 
 try:
     from socket import send_fds
@@ -162,6 +163,7 @@ if TYPE_CHECKING:
     from airflow.executors.workloads import BundleInfo
     from airflow.sdk.bases.secrets_backend import BaseSecretsBackend
     from airflow.sdk.definitions.connection import Connection
+    from airflow.sdk.execution_time.selector_loop import SelectorCallback
     from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 
 __all__ = ["ActivitySubprocess", "WatchedSubprocess", "supervise", "supervise_task"]
@@ -715,7 +717,7 @@ class WatchedSubprocess:
             target_loggers += (log,)
         return target_loggers
 
-    def _create_log_forwarder(self, loggers, name, log_level=logging.INFO) -> Callable[[socket], bool]:
+    def _create_log_forwarder(self, loggers, name, log_level=logging.INFO) -> SelectorCallback:
         """Create a socket handler that forwards logs to a logger."""
         loggers = tuple(
             reconfigure_logger(
@@ -909,41 +911,15 @@ class WatchedSubprocess:
         """
         Service subprocess events by processing socket activity and checking for process exit.
 
-        This method:
-        - Waits for activity on the registered file objects (via `self.selector.select`).
-        - Processes any events triggered on these file objects.
-        - Checks if the subprocess has exited during the wait.
+        Delegates the selector event loop to :func:`service_selector` (shared
+        with other selector-based bridges), then checks the subprocess status.
 
         :param max_wait_time: Maximum time to block while waiting for events, in seconds.
         :param raise_on_timeout: If True, raise an exception if the subprocess does not exit within the timeout.
         :param expect_signal: Signal not to log if the task exits with this code.
         :returns: The process exit code, or None if it's still alive
         """
-        # Ensure minimum timeout to prevent CPU spike with tight loop when timeout is 0 or negative
-        timeout = max(0.01, max_wait_time)
-        events = self.selector.select(timeout=timeout)
-        for key, _ in events:
-            # Retrieve the handler responsible for processing this file object (e.g., stdout, stderr)
-            socket_handler, on_close = key.data
-
-            # Example of handler behavior:
-            # If the subprocess writes "Hello, World!" to stdout:
-            # - `socket_handler` reads and processes the message.
-            # - If EOF is reached, the handler returns False to signal no more reads are expected.
-            # - BrokenPipeError should be caught and treated as if the handler returned false, similar
-            # to EOF case
-            try:
-                need_more = socket_handler(key.fileobj)
-            except (BrokenPipeError, ConnectionResetError):
-                need_more = False
-
-            # If the handler signals that the file object is no longer needed (EOF, closed, etc.)
-            # unregister it from the selector to stop monitoring; `wait()` blocks until all selectors
-            # are removed.
-            if not need_more:
-                sock: socket = key.fileobj  # type: ignore[assignment]
-                on_close(sock)
-                sock.close()
+        service_selector(self.selector, timeout=max_wait_time)
 
         # Check if the subprocess has exited
         return self._check_subprocess_exit(raise_on_timeout=raise_on_timeout, expect_signal=expect_signal)
@@ -2004,50 +1980,6 @@ def run_task_in_process(ti: TaskInstance, task) -> TaskRunResult:
     """Run a task in-process for testing."""
     # Run the task
     return InProcessTestSupervisor.start(what=ti, task=task)
-
-
-# Sockets, even the `.makefile()` function don't correctly do line buffering on reading. If a chunk is read
-# and it doesn't contain a new line character, `.readline()` will just return the chunk as is.
-#
-# This returns a callback suitable for attaching to a `selector` that reads in to a buffer, and yields lines
-# to a (sync) generator
-def make_buffered_socket_reader(
-    gen: Generator[None, bytes | bytearray, None],
-    on_close: Callable[[socket], None],
-    buffer_size: int = 4096,
-):
-    buffer = bytearray()  # This will hold our accumulated binary data
-    read_buffer = bytearray(buffer_size)  # Temporary buffer for each read
-
-    # We need to start up the generator to get it to the point it's at waiting on the yield
-    next(gen)
-
-    def cb(sock: socket):
-        nonlocal buffer, read_buffer
-        # Read up to `buffer_size` bytes of data from the socket
-        n_received = sock.recv_into(read_buffer)
-
-        if not n_received:
-            # If no data is returned, the connection is closed. Return whatever is left in the buffer
-            if len(buffer):
-                with suppress(StopIteration):
-                    gen.send(buffer)
-            return False
-
-        buffer.extend(read_buffer[:n_received])
-
-        # We could have read multiple lines in one go, yield them all
-        while (newline_pos := buffer.find(b"\n")) != -1:
-            line = buffer[: newline_pos + 1]
-            try:
-                gen.send(line)
-            except StopIteration:
-                return False
-            buffer = buffer[newline_pos + 1 :]  # Update the buffer with remaining data
-
-        return True
-
-    return cb, on_close
 
 
 def length_prefixed_frame_reader(

--- a/task-sdk/tests/task_sdk/execution_time/test_selector_loop.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_selector_loop.py
@@ -1,0 +1,479 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import selectors
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.sdk.execution_time.selector_loop import (
+    make_buffered_socket_reader,
+    make_raw_forwarder,
+    service_selector,
+)
+
+
+def _make_generator():
+    """Return a generator that collects sent lines into a list."""
+    received: list[bytes | bytearray] = []
+
+    def gen():
+        while True:
+            line = yield
+            received.append(bytes(line))
+
+    g = gen()
+    return g, received
+
+
+def _make_socket_pair():
+    """Create a connected TCP socket pair on localhost."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    addr = server.getsockname()
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(addr)
+    conn, _ = server.accept()
+    server.close()
+    return client, conn
+
+
+class TestMakeBufferedSocketReader:
+    def test_single_complete_line(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, returned_on_close = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+        # recv_into writes data and returns count
+        data = b"hello world\n"
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, data)
+
+        result = handler(sock)
+
+        assert result is True
+        assert received == [b"hello world\n"]
+        assert returned_on_close is on_close
+
+    def test_multiple_lines_in_single_recv(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+        data = b"line1\nline2\nline3\n"
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, data)
+
+        result = handler(sock)
+
+        assert result is True
+        assert received == [b"line1\n", b"line2\n", b"line3\n"]
+
+    def test_partial_line_accumulated_across_calls(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+
+        # First call: partial line (no newline)
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"hell")
+        result = handler(sock)
+        assert result is True
+        assert received == []
+
+        # Second call: rest of the line
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"o\n")
+        result = handler(sock)
+        assert result is True
+        assert received == [b"hello\n"]
+
+    def test_eof_flushes_remaining_buffer(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+
+        # Send partial data (no newline)
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"leftover")
+        handler(sock)
+        assert received == []
+
+        # EOF (recv_into returns 0) — clear side_effect so return_value takes effect
+        sock.recv_into.side_effect = None
+        sock.recv_into.return_value = 0
+        result = handler(sock)
+
+        assert result is False
+        assert received == [b"leftover"]
+
+    def test_eof_with_empty_buffer(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+        sock.recv_into.return_value = 0
+
+        result = handler(sock)
+
+        assert result is False
+        assert received == []
+
+    def test_generator_stop_iteration_returns_false(self):
+        """If the generator is exhausted, handler returns False."""
+
+        def limited_gen():
+            yield  # startup
+            yield  # receive one line, then stop
+
+        gen = limited_gen()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+        # First line succeeds
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"line1\n")
+        result = handler(sock)
+        assert result is True
+
+        # Second line triggers StopIteration in the generator
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"line2\n")
+        result = handler(sock)
+        assert result is False
+
+    def test_mixed_complete_and_partial_lines(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close)
+
+        sock = MagicMock(spec=socket.socket)
+        # Data contains one complete line and a partial line
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"complete\npart")
+        handler(sock)
+        assert received == [b"complete\n"]
+
+        # Finish the partial line
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, b"ial\n")
+        handler(sock)
+        assert received == [b"complete\n", b"partial\n"]
+
+    def test_custom_buffer_size(self):
+        gen, received = _make_generator()
+        on_close = MagicMock()
+        handler, _ = make_buffered_socket_reader(gen, on_close, buffer_size=8)
+
+        sock = MagicMock(spec=socket.socket)
+        # Data larger than buffer_size — recv_into only reads buffer_size bytes
+        full_data = b"abcdefghijklmnop\n"
+        # Simulate chunked reads
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, full_data[: len(buf)])
+        handler(sock)
+        # Only first 8 bytes read, no newline yet
+        assert received == []
+
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, full_data[8:16])
+        handler(sock)
+        assert received == []
+
+        sock.recv_into.side_effect = lambda buf: _fill_buffer(buf, full_data[16:])
+        handler(sock)
+        assert received == [b"abcdefghijklmnop\n"]
+
+
+def _fill_buffer(buf: bytearray, data: bytes) -> int:
+    """Helper to simulate socket.recv_into by filling the buffer."""
+    n = min(len(data), len(buf))
+    buf[:n] = data[:n]
+    return n
+
+
+class TestMakeRawForwarder:
+    def test_forwards_data_to_dest(self):
+        on_close = MagicMock()
+        dest = MagicMock(spec=socket.socket)
+        handler, returned_on_close = make_raw_forwarder(dest, on_close)
+
+        src = MagicMock(spec=socket.socket)
+        src.recv.return_value = b"hello"
+
+        result = handler(src)
+
+        assert result is True
+        dest.sendall.assert_called_once_with(b"hello")
+        assert returned_on_close is on_close
+
+    def test_eof_returns_false(self):
+        on_close = MagicMock()
+        dest = MagicMock(spec=socket.socket)
+        handler, _ = make_raw_forwarder(dest, on_close)
+
+        src = MagicMock(spec=socket.socket)
+        src.recv.return_value = b""
+
+        result = handler(src)
+
+        assert result is False
+        dest.sendall.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "exception",
+        [BrokenPipeError, ConnectionResetError, OSError],
+        ids=["broken_pipe", "connection_reset", "os_error"],
+    )
+    def test_sendall_exception_returns_false(self, exception):
+        on_close = MagicMock()
+        dest = MagicMock(spec=socket.socket)
+        dest.sendall.side_effect = exception
+        handler, _ = make_raw_forwarder(dest, on_close)
+
+        src = MagicMock(spec=socket.socket)
+        src.recv.return_value = b"data"
+
+        result = handler(src)
+
+        assert result is False
+
+    def test_multiple_forwards(self):
+        on_close = MagicMock()
+        dest = MagicMock(spec=socket.socket)
+        handler, _ = make_raw_forwarder(dest, on_close)
+
+        src = MagicMock(spec=socket.socket)
+
+        for chunk in [b"chunk1", b"chunk2", b"chunk3"]:
+            src.recv.return_value = chunk
+            assert handler(src) is True
+
+        assert dest.sendall.call_count == 3
+
+
+class TestServiceSelector:
+    def test_calls_handler_for_ready_sockets(self):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+        handler = MagicMock(return_value=True)
+        on_close = MagicMock()
+        sock = MagicMock(spec=socket.socket)
+
+        key = MagicMock()
+        key.data = (handler, on_close)
+        key.fileobj = sock
+
+        sel.select.return_value = [(key, selectors.EVENT_READ)]
+
+        service_selector(sel, timeout=1.0)
+
+        handler.assert_called_once_with(sock)
+        on_close.assert_not_called()
+        sock.close.assert_not_called()
+
+    def test_on_close_and_sock_close_when_handler_returns_false(self):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+        handler = MagicMock(return_value=False)
+        on_close = MagicMock()
+        sock = MagicMock(spec=socket.socket)
+
+        key = MagicMock()
+        key.data = (handler, on_close)
+        key.fileobj = sock
+
+        sel.select.return_value = [(key, selectors.EVENT_READ)]
+
+        service_selector(sel, timeout=1.0)
+
+        handler.assert_called_once_with(sock)
+        on_close.assert_called_once_with(sock)
+        sock.close.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exception",
+        [BrokenPipeError, ConnectionResetError],
+        ids=["broken_pipe", "connection_reset"],
+    )
+    def test_pipe_errors_treated_as_eof(self, exception):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+        handler = MagicMock(side_effect=exception)
+        on_close = MagicMock()
+        sock = MagicMock(spec=socket.socket)
+
+        key = MagicMock()
+        key.data = (handler, on_close)
+        key.fileobj = sock
+
+        sel.select.return_value = [(key, selectors.EVENT_READ)]
+
+        service_selector(sel, timeout=1.0)
+
+        on_close.assert_called_once_with(sock)
+        sock.close.assert_called_once()
+
+    def test_empty_selector_no_events(self):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+        sel.select.return_value = []
+
+        # Should not raise
+        service_selector(sel, timeout=1.0)
+
+    @pytest.mark.parametrize(
+        ("input_timeout", "expected_min"),
+        [
+            (0.0, 0.01),
+            (-1.0, 0.01),
+            (-100.0, 0.01),
+            (0.5, 0.5),
+            (2.0, 2.0),
+        ],
+        ids=["zero", "negative", "very_negative", "positive_half", "positive_two"],
+    )
+    def test_timeout_clamped_to_minimum(self, input_timeout, expected_min):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+        sel.select.return_value = []
+
+        service_selector(sel, timeout=input_timeout)
+
+        sel.select.assert_called_once()
+        actual_timeout = sel.select.call_args[1].get("timeout") or sel.select.call_args[0][0]
+        assert actual_timeout == pytest.approx(expected_min)
+
+    def test_multiple_ready_sockets(self):
+        sel = MagicMock(spec=selectors.DefaultSelector)
+
+        handler1 = MagicMock(return_value=True)
+        on_close1 = MagicMock()
+        sock1 = MagicMock(spec=socket.socket)
+        key1 = MagicMock()
+        key1.data = (handler1, on_close1)
+        key1.fileobj = sock1
+
+        handler2 = MagicMock(return_value=False)
+        on_close2 = MagicMock()
+        sock2 = MagicMock(spec=socket.socket)
+        key2 = MagicMock()
+        key2.data = (handler2, on_close2)
+        key2.fileobj = sock2
+
+        sel.select.return_value = [(key1, selectors.EVENT_READ), (key2, selectors.EVENT_READ)]
+
+        service_selector(sel, timeout=1.0)
+
+        # First socket: handler returns True, stays open
+        handler1.assert_called_once_with(sock1)
+        on_close1.assert_not_called()
+        sock1.close.assert_not_called()
+
+        # Second socket: handler returns False, closed
+        handler2.assert_called_once_with(sock2)
+        on_close2.assert_called_once_with(sock2)
+        sock2.close.assert_called_once()
+
+
+class TestSelectorLoopIntegration:
+    def test_buffered_reader_with_real_sockets(self):
+        """End-to-end: send lines through real sockets and verify buffered reading."""
+        gen, received = _make_generator()
+        sender, reader = _make_socket_pair()
+        try:
+            sel = selectors.DefaultSelector()
+
+            def on_close(sock):
+                sel.unregister(sock)
+
+            sel.register(reader, selectors.EVENT_READ, make_buffered_socket_reader(gen, on_close))
+
+            sender.sendall(b"first line\nsecond line\n")
+
+            service_selector(sel, timeout=1.0)
+
+            assert b"first line\n" in received
+            assert b"second line\n" in received
+
+            # Close sender, then drain
+            sender.close()
+            sender = None
+
+            service_selector(sel, timeout=0.5)
+
+            sel.close()
+        finally:
+            if sender:
+                sender.close()
+            reader.close()
+
+    def test_raw_forwarder_with_real_sockets(self):
+        """End-to-end: forward raw bytes between real socket pairs."""
+        src_send, src_recv = _make_socket_pair()
+        # Use socketpair for the destination so reads/writes are symmetric
+        dst_write, dst_read = socket.socketpair()
+        try:
+            sel = selectors.DefaultSelector()
+
+            def on_close(sock):
+                sel.unregister(sock)
+
+            sel.register(src_recv, selectors.EVENT_READ, make_raw_forwarder(dst_write, on_close))
+
+            src_send.sendall(b"raw data payload")
+
+            service_selector(sel, timeout=1.0)
+
+            dst_read.setblocking(False)
+            forwarded = dst_read.recv(4096)
+
+            assert forwarded == b"raw data payload"
+
+            sel.close()
+        finally:
+            for s in (src_send, src_recv, dst_write, dst_read):
+                s.close()
+
+    def test_eof_triggers_on_close_with_real_sockets(self):
+        """When the sender closes, the selector callback chain fires on_close."""
+        gen, received = _make_generator()
+        sender, reader = _make_socket_pair()
+        closed_sockets: list[socket.socket] = []
+        try:
+            sel = selectors.DefaultSelector()
+
+            def on_close(sock):
+                sel.unregister(sock)
+                closed_sockets.append(sock)
+
+            sel.register(reader, selectors.EVENT_READ, make_buffered_socket_reader(gen, on_close))
+
+            # Send data then close
+            sender.sendall(b"final\n")
+            service_selector(sel, timeout=1.0)
+            assert received == [b"final\n"]
+
+            sender.close()
+            sender = None
+            service_selector(sel, timeout=0.5)
+
+            # on_close should have been called, and socket closed by service_selector
+            assert len(closed_sockets) == 1
+
+            sel.close()
+        finally:
+            if sender:
+                sender.close()
+            reader.close()


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/65958

### Why

Extract the `selector_loop` modularization from https://github.com/apache/airflow/pull/65958 PR for further reusability and enhance the type annotation.
This improvement should not be blocked by the AIP-108 vote. 

### What

Pull the buffered socket reader and the selector dispatch loop out of ``WatchedSubprocess`` into ``airflow.sdk.execution_time.selector_loop``, together with a new ``make_raw_forwarder`` helper. ``WatchedSubprocess`` now delegates its event loop to ``service_selector`` and imports ``make_buffered_socket_reader`` from the shared module, so the same primitives can back other selector-driven bridges without copy/paste.

The behavior should be unchanged after this refactor.


---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

