### PR TITLE
Fix cron preset schedules (@daily, @hourly, ...) failing validation in Task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/timetables/_cron.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/_cron.py
@@ -27,11 +27,26 @@ if TYPE_CHECKING:
     from pendulum.tz.timezone import FixedTimezone, Timezone
 
 
+# Keep in sync with airflow.utils.dates.cron_presets.
+cron_presets: dict[str, str] = {
+    "@hourly": "0 * * * *",
+    "@daily": "0 0 * * *",
+    "@weekly": "0 0 * * 0",
+    "@monthly": "0 0 1 * *",
+    "@quarterly": "0 0 1 */3 *",
+    "@yearly": "0 0 1 1 *",
+}
+
+
+def _expand_cron_preset(value: str) -> str:
+    return cron_presets.get(value, value)
+
+
 @attrs.define
 class CronMixin:
     """Mixin to provide interface to work with croniter."""
 
-    expression: str
+    expression: str = attrs.field(converter=_expand_cron_preset)
     timezone: str | Timezone | FixedTimezone
 
     def validate(self) -> None:

--- a/task-sdk/tests/task_sdk/definitions/timetables/__init__.py
+++ b/task-sdk/tests/task_sdk/definitions/timetables/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/task-sdk/tests/task_sdk/definitions/timetables/test_cron.py
+++ b/task-sdk/tests/task_sdk/definitions/timetables/test_cron.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.sdk.definitions.timetables._cron import CronMixin, cron_presets
+from airflow.sdk.exceptions import AirflowTimetableInvalid
+
+
+@pytest.mark.parametrize("preset", list(cron_presets))
+def test_validate_accepts_cron_preset(preset):
+    CronMixin(expression=preset, timezone="UTC").validate()
+
+
+@pytest.mark.parametrize(("preset", "expanded"), list(cron_presets.items()))
+def test_preset_expanded_at_construction(preset, expanded):
+    assert CronMixin(expression=preset, timezone="UTC").expression == expanded
+
+
+def test_validate_rejects_invalid_expression():
+    with pytest.raises(AirflowTimetableInvalid):
+        CronMixin(expression="not a cron", timezone="UTC").validate()


### PR DESCRIPTION
closes: #66101

Cron preset schedules (`@hourly`, `@daily`, `@weekly`, `@monthly`, `@quarterly`, `@yearly`) regressed between 3.1.8 and 3.2.x — `DAG(..., schedule="@daily")` raises `AirflowTimetableInvalid` at parse time, during `DAG.__init__` → `self.timetable.validate()`.

The Task SDK's `CronMixin` (`task-sdk/src/airflow/sdk/definitions/timetables/_cron.py`) hands the preset string straight to `croniter` without expanding it. The legacy `airflow-core` `CronMixin` still maps presets via `self._expression = cron_presets.get(cron, cron)` before validating, but that class is now only reached through `coerce_to_core_timetable` — user code at parse time hits the task-sdk version, which is where the bug bites.

Expand presets on the task-sdk `CronMixin` via an `attrs` field converter so the stored `expression` matches the legacy invariant (preset already expanded). All four cron timetable subclasses (`CronDataIntervalTimetable`, `CronTriggerTimetable`, `CronPartitionTimetable`, `MultipleCronTriggerTimetable`) inherit `expression` from this mixin and pick up the fix with no per-subclass change.

`cron_presets` is duplicated locally in task-sdk with a `# Keep in sync with airflow.utils.dates.cron_presets` comment, to keep task-sdk self-contained without a new cross-package import.

Regression tests in `task-sdk/tests/task_sdk/definitions/timetables/test_cron.py` cover preset acceptance, expansion at construction (guards against a validate-only "simplification" reverting the fix), and rejection of genuinely invalid cron expressions.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
