### PR TITLE
Refresh uv.lock and Edge OpenAPI spec after #67093 env upgrade

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
@@ -1257,8 +1257,8 @@ components:
       - queue
       - priority_weight
       title: TaskInstanceDTO
-      description: Schema for TaskInstance with minimal required fields needed for
-        Executors and Task SDK.
+      description: TaskInstanceDTO with executor-specific ``external_executor_id``
+        field and ``key`` property.
     TaskInstanceState:
       type: string
       enum:

--- a/uv.lock
+++ b/uv.lock
@@ -1414,6 +1414,35 @@ zendesk = [
 ]
 
 [package.dev-dependencies]
+ci-image = [
+    { name = "apache-airflow", extra = ["all"] },
+    { name = "apache-airflow-breeze" },
+    { name = "apache-airflow-ctl" },
+    { name = "apache-airflow-ctl-tests" },
+    { name = "apache-airflow-dev" },
+    { name = "apache-airflow-devel-common", extra = ["docs", "docs-gen", "no-doc"] },
+    { name = "apache-airflow-docker-tests" },
+    { name = "apache-airflow-helm-chart" },
+    { name = "apache-airflow-kubernetes-tests" },
+    { name = "apache-airflow-scripts" },
+    { name = "apache-airflow-shared-configuration" },
+    { name = "apache-airflow-shared-dagnode" },
+    { name = "apache-airflow-shared-listeners" },
+    { name = "apache-airflow-shared-logging" },
+    { name = "apache-airflow-shared-module-loading" },
+    { name = "apache-airflow-shared-observability" },
+    { name = "apache-airflow-shared-plugins-manager" },
+    { name = "apache-airflow-shared-providers-discovery" },
+    { name = "apache-airflow-shared-secrets-backend" },
+    { name = "apache-airflow-shared-secrets-masker" },
+    { name = "apache-airflow-shared-serialization" },
+    { name = "apache-airflow-shared-state" },
+    { name = "apache-airflow-shared-template-rendering" },
+    { name = "apache-airflow-shared-timezones" },
+    { name = "apache-airflow-task-sdk", extra = ["all"] },
+    { name = "apache-airflow-task-sdk-integration-tests" },
+    { name = "plyvel" },
+]
 dev = [
     { name = "apache-airflow", extra = ["all"] },
     { name = "apache-airflow-breeze" },
@@ -1687,6 +1716,37 @@ requires-dist = [
 provides-extras = ["all-core", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd", "all-task-sdk", "airbyte", "akeyless", "alibaba", "amazon", "apache-cassandra", "apache-drill", "apache-druid", "apache-flink", "apache-hdfs", "apache-hive", "apache-iceberg", "apache-impala", "apache-kafka", "apache-kylin", "apache-livy", "apache-pig", "apache-pinot", "apache-spark", "apache-tinkerpop", "apprise", "arangodb", "asana", "atlassian-jira", "celery", "cloudant", "cncf-kubernetes", "cohere", "common-ai", "common-compat", "common-io", "common-messaging", "common-sql", "databricks", "datadog", "dbt-cloud", "dingding", "discord", "docker", "edge3", "elasticsearch", "exasol", "fab", "facebook", "ftp", "git", "github", "google", "grpc", "hashicorp", "http", "imap", "influxdb", "informatica", "jdbc", "jenkins", "keycloak", "microsoft-azure", "microsoft-mssql", "microsoft-psrp", "microsoft-winrm", "mongo", "mysql", "neo4j", "odbc", "openai", "openfaas", "openlineage", "opensearch", "opsgenie", "oracle", "pagerduty", "papermill", "pgvector", "pinecone", "postgres", "presto", "qdrant", "redis", "salesforce", "samba", "segment", "sendgrid", "sftp", "singularity", "slack", "smtp", "snowflake", "sqlite", "ssh", "standard", "tableau", "telegram", "teradata", "trino", "vertica", "vespa", "weaviate", "yandex", "ydb", "zendesk", "all", "aiobotocore", "apache-atlas", "apache-webhdfs", "amazon-aws-auth", "cloudpickle", "github-enterprise", "google-auth", "ldap", "pandas", "polars", "rabbitmq", "sentry", "s3fs", "uv"]
 
 [package.metadata.requires-dev]
+ci-image = [
+    { name = "apache-airflow", extras = ["all"], editable = "." },
+    { name = "apache-airflow-breeze", editable = "dev/breeze" },
+    { name = "apache-airflow-ctl", editable = "airflow-ctl" },
+    { name = "apache-airflow-ctl-tests", editable = "airflow-ctl-tests" },
+    { name = "apache-airflow-dev", editable = "dev" },
+    { name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" },
+    { name = "apache-airflow-devel-common", extras = ["docs-gen"], editable = "devel-common" },
+    { name = "apache-airflow-devel-common", extras = ["no-doc"], editable = "devel-common" },
+    { name = "apache-airflow-docker-tests", editable = "docker-tests" },
+    { name = "apache-airflow-helm-chart", editable = "chart" },
+    { name = "apache-airflow-kubernetes-tests", editable = "kubernetes-tests" },
+    { name = "apache-airflow-scripts", editable = "scripts" },
+    { name = "apache-airflow-shared-configuration", editable = "shared/configuration" },
+    { name = "apache-airflow-shared-dagnode", editable = "shared/dagnode" },
+    { name = "apache-airflow-shared-listeners", editable = "shared/listeners" },
+    { name = "apache-airflow-shared-logging", editable = "shared/logging" },
+    { name = "apache-airflow-shared-module-loading", editable = "shared/module_loading" },
+    { name = "apache-airflow-shared-observability", editable = "shared/observability" },
+    { name = "apache-airflow-shared-plugins-manager", editable = "shared/plugins_manager" },
+    { name = "apache-airflow-shared-providers-discovery", editable = "shared/providers_discovery" },
+    { name = "apache-airflow-shared-secrets-backend", editable = "shared/secrets_backend" },
+    { name = "apache-airflow-shared-secrets-masker", editable = "shared/secrets_masker" },
+    { name = "apache-airflow-shared-serialization", editable = "shared/serialization" },
+    { name = "apache-airflow-shared-state", editable = "shared/state" },
+    { name = "apache-airflow-shared-template-rendering", editable = "shared/template_rendering" },
+    { name = "apache-airflow-shared-timezones", editable = "shared/timezones" },
+    { name = "apache-airflow-task-sdk", extras = ["all"], editable = "task-sdk" },
+    { name = "apache-airflow-task-sdk-integration-tests", editable = "task-sdk-integration-tests" },
+    { name = "plyvel", specifier = ">=1.5.1" },
+]
 dev = [
     { name = "apache-airflow", extras = ["all"], editable = "." },
     { name = "apache-airflow-breeze", editable = "dev/breeze" },
@@ -20333,8 +20393,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Three independent drifts that surfaced as `files were modified by hook` on every open PR running full `CI image checks / Static checks`:

- **Edge worker OpenAPI yaml** (`providers/edge3/.../v2-edge-generated.yaml`): the `TaskInstanceDTO` description string is stale relative to the source docstring at `airflow-core/src/airflow/executors/workloads/task.py:62-64`. The drift was introduced by #67174 ("Introduce BaseTaskInstanceDTO and duplicate it across core and task-sdk"), which split the class but didn't regenerate the edge3 yaml. Pure description-string change — no schema, property, or required-field changes; no API contract break.

- **uv.lock `ci-image` dev-dependency group**: catches up to the `[dependency-groups.ci-image]` block added by #67130 (which didn't refresh the lockfile). `pyproject.toml:1380` already defines the group; this PR just materializes it in `uv.lock`.

- **uv.lock `secretstorage` markers**: normalized by `uv 0.11.14` (bumped by #67093 "[main] Upgrade important CI environment"). The new compound markers are a disjoint disjunction-of-conjunctions rewrite — semantically equivalent for all common platforms (linux, darwin-arm64, darwin-x86_64); the added emscripten/win32 clauses are explicit normalization, not a behavior change.

Unblocks #66574, #67184, #67180 and any other open PR running full Static checks.

Regenerated locally inside Breeze via:
- `PATH=".venv/bin:$PATH" prek run generate-openapi-spec-edge --all-files`
- `uv lock --refresh`

Diff is +64/−4 across 2 files. No code change.
