### PR TITLE
Replace per-TI session.merge() with a single UPDATE keyed on TI.id when a dagrun_timeout fires

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2403,10 +2403,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 key=lambda ti: ti.start_date or timezone.make_aware(datetime.min),
                 default=None,
             )
-            for task_instance in unfinished_task_instances:
-                task_instance.state = TaskInstanceState.SKIPPED
-                session.merge(task_instance)
-            session.flush()
+            if unfinished_task_instances:
+                session.execute(
+                    update(TI)
+                    .where(TI.id.in_(ti.id for ti in unfinished_task_instances))
+                    .values(state=TaskInstanceState.SKIPPED)
+                    .execution_options(synchronize_session="fetch")
+                )
+                session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
 
             if dag_run.state in State.finished_dr_states and dag_run.run_type in (


### PR DESCRIPTION
When `dagrun_timeout` fires, the scheduler loaded every unfinished TaskInstance, set its state in Python, and called `session.merge()` per row. The TIs are already attached to the session, so the merge is redundant and the ORM unit-of-work flush emits one UPDATE per row — N statements for N tasks.

This PR replaces the loop with a single `update(TI).where(TI.id.in_(...))` and `synchronize_session="fetch"`, matching the bulk pattern already used at [scheduler_job_runner.py:798-803](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/jobs/scheduler_job_runner.py#L798-L803) and aligning with the AGENTS.md rule to batch scheduler DELETE/UPDATE (#66908).

Behaviour is unchanged.