### PR TITLE
Revert "[v3-2-test] Load hook metadata from YAML without importing Hook class (#63826) (#64723)"

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -27,11 +27,10 @@ from airflow.api_fastapi.core_api.datamodels.connections import (
     ConnectionHookMetaData,
     StandardHookFields,
 )
-from airflow.providers_manager import HookInfo, ProvidersManager
 from airflow.serialization.definitions.param import SerializedParam
 
 if TYPE_CHECKING:
-    from airflow.providers_manager import ConnectionFormWidgetInfo
+    from airflow.providers_manager import ConnectionFormWidgetInfo, HookInfo
 
 log = logging.getLogger(__name__)
 
@@ -126,6 +125,8 @@ class HookMetaService:
     ]:
         """Get hooks with all details w/o FAB needing to be installed."""
         from unittest import mock
+
+        from airflow.providers_manager import ProvidersManager
 
         def mock_lazy_gettext(txt: str) -> str:
             """Mock for flask_babel.lazy_gettext."""
@@ -281,16 +282,19 @@ class HookMetaService:
     @staticmethod
     @cache
     def hook_meta_data() -> list[ConnectionHookMetaData]:
-        pm = ProvidersManager()
-        widgets = HookMetaService._convert_extra_fields(pm._connection_form_widgets_from_metadata)
-        return [
-            ConnectionHookMetaData(
-                connection_type=meta.connection_type,
-                hook_class_name=meta.hook_class_name,
-                default_conn_name=None,
-                hook_name=meta.hook_name,
-                standard_fields=HookMetaService._make_standard_fields(meta.field_behaviour),
-                extra_fields=widgets.get(meta.connection_type),
+        hooks, connection_form_widgets, field_behaviours = HookMetaService._get_hooks_with_mocked_fab()
+        result: list[ConnectionHookMetaData] = []
+        widgets = HookMetaService._convert_extra_fields(connection_form_widgets)
+        for hook_key, hook_info in hooks.items():
+            if not hook_info:
+                continue
+            hook_meta = ConnectionHookMetaData(
+                connection_type=hook_key,
+                hook_class_name=hook_info.hook_class_name,
+                default_conn_name=None,  # TODO: later
+                hook_name=hook_info.hook_name,
+                standard_fields=HookMetaService._make_standard_fields(field_behaviours.get(hook_key)),
+                extra_fields=widgets.get(hook_key),
             )
-            for meta in pm.iter_connection_type_hook_ui_metadata()
-        ]
+            result.append(hook_meta)
+        return result

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -378,10 +378,6 @@
                         "description": "Hook class name that implements the connection type",
                         "type": "string"
                     },
-                    "hook-name": {
-                        "description": "Display name for the connection type in the UI (e.g. 'File (path)', 'Slack')",
-                        "type": "string"
-                    },
                     "ui-field-behaviour": {
                         "description": "Customizations for standard connection form fields",
                         "type": "object",

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -298,10 +298,6 @@
                     "hook-class-name": {
                         "description": "Hook class name that implements the connection type",
                         "type": "string"
-                    },
-                    "hook-name": {
-                        "description": "Display name for the connection type in the UI",
-                        "type": "string"
                     }
                 },
                 "required": [

--- a/airflow-core/src/airflow/providers_manager.py
+++ b/airflow-core/src/airflow/providers_manager.py
@@ -26,7 +26,7 @@ import json
 import logging
 import traceback
 import warnings
-from collections.abc import Callable, Iterator, MutableMapping
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 from functools import wraps
 from importlib.resources import files as resource_files
@@ -243,15 +243,6 @@ class HookInfo(NamedTuple):
     dialects: list[str] = []
 
 
-class ConnectionTypeHookUIMetadata(NamedTuple):
-    """Hook metadata for one connection type (connection UI); ``field_behaviour`` is standard fields."""
-
-    connection_type: str
-    hook_name: str
-    hook_class_name: str | None
-    field_behaviour: dict | None
-
-
 class ConnectionFormWidgetInfo(NamedTuple):
     """Connection Form Widget information."""
 
@@ -422,8 +413,6 @@ class ProvidersManager(LoggingMixin):
         self._dialect_provider_dict: dict[str, DialectInfo] = {}
         # Keeps dict of hooks keyed by connection type. They are lazy evaluated at access time
         self._hooks_lazy_dict: LazyDictWithCache[str, HookInfo | Callable] = LazyDictWithCache()
-        # Keeps hook display names read from provider.yaml (hook-name field)
-        self._hook_name_dict: dict[str, str] = {}
         # Keeps methods that should be used to add custom widgets tuple of keyed by name of the extra field
         self._connection_form_widgets: dict[str, ConnectionFormWidgetInfo] = {}
         # Customizations for javascript fields are kept here
@@ -990,9 +979,6 @@ class ProvidersManager(LoggingMixin):
                 if not connection_type or not hook_class_name:
                     continue
 
-                if hook_name := conn_config.get("hook-name"):
-                    self._hook_name_dict[connection_type] = hook_name
-
                 if conn_fields := conn_config.get("conn-fields"):
                     self._add_widgets(package_name, hook_class_name, connection_type, conn_fields)
 
@@ -1362,45 +1348,6 @@ class ProvidersManager(LoggingMixin):
         self.initialize_providers_hooks()
         # When we return hooks here it will only be used to retrieve hook information
         return self._hooks_lazy_dict
-
-    def iter_connection_type_hook_ui_metadata(self) -> Iterator[ConnectionTypeHookUIMetadata]:
-        """
-        Yield hook metadata per connection type for the connection UI.
-
-        Does not import hook classes.
-        """
-        self.initialize_providers_hooks()
-        all_types = frozenset(self._hooks_lazy_dict) | frozenset(self._hook_provider_dict)
-        for conn_type in sorted(all_types):
-            raw_entry = self._hooks_lazy_dict._raw_dict.get(conn_type)
-            provider_entry = self._hook_provider_dict.get(conn_type)
-            if isinstance(raw_entry, HookInfo):
-                hook_name = raw_entry.hook_name
-                hook_class_name = raw_entry.hook_class_name
-            elif provider_entry:
-                hook_name = self._hook_name_dict.get(conn_type, conn_type)
-                hook_class_name = provider_entry.hook_class_name
-            else:
-                hook_name = self._hook_name_dict.get(conn_type, conn_type)
-                hook_class_name = None
-            yield ConnectionTypeHookUIMetadata(
-                connection_type=conn_type,
-                hook_name=hook_name,
-                hook_class_name=hook_class_name,
-                field_behaviour=self._field_behaviours.get(conn_type),
-            )
-
-    @property
-    def _connection_form_widgets_from_metadata(self) -> dict[str, ConnectionFormWidgetInfo]:
-        """Return connection form widgets from metadata without importing every hook."""
-        self.initialize_providers_hooks()
-        return self._connection_form_widgets
-
-    @property
-    def _field_behaviours_from_metadata(self) -> dict[str, dict]:
-        """Return field behaviour dicts from metadata without importing every hook."""
-        self.initialize_providers_hooks()
-        return self._field_behaviours
 
     @property
     def dialects(self) -> MutableMapping[str, DialectInfo]:

--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -428,14 +428,6 @@ class TestProvidersMetadataLoading:
         assert "relabeling" in behaviour
         assert "placeholders" in behaviour
 
-    def test_iter_connection_type_hook_ui_metadata_matches_field_behaviours(self):
-        """iter_connection_type_hook_ui_metadata should expose the same standard-field behaviour dict."""
-        pm = ProvidersManager()
-        pm.initialize_providers_hooks()
-        by_type = {m.connection_type: m for m in pm.iter_connection_type_hook_ui_metadata()}
-        assert "http" in by_type
-        assert by_type["http"].field_behaviour == pm._field_behaviours["http"]
-
     def test_ui_metadata_loading_without_hook_import(self):
         """Test that UI metadata loads from provider info without importing hook classes."""
         with patch("airflow.providers_manager.import_string") as mock_import:

--- a/providers/airbyte/provider.yaml
+++ b/providers/airbyte/provider.yaml
@@ -97,7 +97,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.airbyte.hooks.airbyte.AirbyteHook
-    hook-name: "Airbyte"
     connection-type: airbyte
     ui-field-behaviour:
       hidden-fields:

--- a/providers/airbyte/src/airflow/providers/airbyte/get_provider_info.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.airbyte.hooks.airbyte.AirbyteHook",
-                "hook-name": "Airbyte",
                 "connection-type": "airbyte",
                 "ui-field-behaviour": {
                     "hidden-fields": ["extra", "port"],

--- a/providers/alibaba/provider.yaml
+++ b/providers/alibaba/provider.yaml
@@ -123,13 +123,10 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.oss.OSSHook
-    hook-name: "OSS"
     connection-type: oss
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.analyticdb_spark.AnalyticDBSparkHook
-    hook-name: "AnalyticDB Spark"
     connection-type: adb_spark
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.base_alibaba.AlibabaBaseHook
-    hook-name: "Alibaba Cloud"
     connection-type: alibaba_cloud
     conn-fields:
       access_key_id:
@@ -147,7 +144,6 @@ connection-types:
             - 'null'
           format: password
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.maxcompute.MaxComputeHook
-    hook-name: "MaxCompute"
     connection-type: maxcompute
     ui-field-behaviour:
       hidden-fields:

--- a/providers/alibaba/src/airflow/providers/alibaba/get_provider_info.py
+++ b/providers/alibaba/src/airflow/providers/alibaba/get_provider_info.py
@@ -91,17 +91,14 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.alibaba.cloud.hooks.oss.OSSHook",
-                "hook-name": "OSS",
                 "connection-type": "oss",
             },
             {
                 "hook-class-name": "airflow.providers.alibaba.cloud.hooks.analyticdb_spark.AnalyticDBSparkHook",
-                "hook-name": "AnalyticDB Spark",
                 "connection-type": "adb_spark",
             },
             {
                 "hook-class-name": "airflow.providers.alibaba.cloud.hooks.base_alibaba.AlibabaBaseHook",
-                "hook-name": "Alibaba Cloud",
                 "connection-type": "alibaba_cloud",
                 "conn-fields": {
                     "access_key_id": {
@@ -116,7 +113,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.alibaba.cloud.hooks.maxcompute.MaxComputeHook",
-                "hook-name": "MaxCompute",
                 "connection-type": "maxcompute",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "login", "password", "port", "extra"],

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -931,7 +931,6 @@ extra-links:
 
 connection-types:
   - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook
-    hook-name: "Amazon Web Services"
     connection-type: aws
     ui-field-behaviour:
       hidden-fields:
@@ -956,7 +955,6 @@ connection-types:
             "endpoint_url": "http://localhost:4566"
           }
   - hook-class-name: airflow.providers.amazon.aws.hooks.chime.ChimeWebhookHook
-    hook-name: "Amazon Chime Webhook"
     connection-type: chime
     ui-field-behaviour:
       hidden-fields:
@@ -971,7 +969,6 @@ connection-types:
         host: hooks.chime.aws/incomingwebhook/
         password: T00000000?token=XXXXXXXXXXXXXXXXXXXXXXXX
   - hook-class-name: airflow.providers.amazon.aws.hooks.emr.EmrHook
-    hook-name: "Amazon Elastic MapReduce"
     connection-type: emr
     ui-field-behaviour:
       hidden-fields:
@@ -1002,14 +999,12 @@ connection-types:
             "StepConcurrencyLevel": 2
           }
   - hook-class-name: airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook
-    hook-name: "Amazon Redshift"
     connection-type: redshift
     ui-field-behaviour:
       relabeling:
         login: User
         schema: Database
   - hook-class-name: airflow.providers.amazon.aws.hooks.athena_sql.AthenaSQLHook
-    hook-name: "Amazon Athena"
     connection-type: athena
     ui-field-behaviour:
       hidden-fields:

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1084,7 +1084,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook",
-                "hook-name": "Amazon Web Services",
                 "connection-type": "aws",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "port"],
@@ -1098,7 +1097,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.amazon.aws.hooks.chime.ChimeWebhookHook",
-                "hook-name": "Amazon Chime Webhook",
                 "connection-type": "chime",
                 "ui-field-behaviour": {
                     "hidden-fields": ["login", "port", "extra"],
@@ -1112,7 +1110,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.amazon.aws.hooks.emr.EmrHook",
-                "hook-name": "Amazon Elastic MapReduce",
                 "connection-type": "emr",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "port", "login", "password"],
@@ -1124,13 +1121,11 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook",
-                "hook-name": "Amazon Redshift",
                 "connection-type": "redshift",
                 "ui-field-behaviour": {"relabeling": {"login": "User", "schema": "Database"}},
             },
             {
                 "hook-class-name": "airflow.providers.amazon.aws.hooks.athena_sql.AthenaSQLHook",
-                "hook-name": "Amazon Athena",
                 "connection-type": "athena",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "port"],

--- a/providers/apache/cassandra/provider.yaml
+++ b/providers/apache/cassandra/provider.yaml
@@ -85,5 +85,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook
-    hook-name: "Cassandra"
     connection-type: cassandra

--- a/providers/apache/cassandra/src/airflow/providers/apache/cassandra/get_provider_info.py
+++ b/providers/apache/cassandra/src/airflow/providers/apache/cassandra/get_provider_info.py
@@ -53,7 +53,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook",
-                "hook-name": "Cassandra",
                 "connection-type": "cassandra",
             }
         ],

--- a/providers/apache/drill/provider.yaml
+++ b/providers/apache/drill/provider.yaml
@@ -81,5 +81,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.drill.hooks.drill.DrillHook
-    hook-name: "Drill"
     connection-type: drill

--- a/providers/apache/drill/src/airflow/providers/apache/drill/get_provider_info.py
+++ b/providers/apache/drill/src/airflow/providers/apache/drill/get_provider_info.py
@@ -44,7 +44,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.drill.hooks.drill.DrillHook",
-                "hook-name": "Drill",
                 "connection-type": "drill",
             }
         ],

--- a/providers/apache/druid/provider.yaml
+++ b/providers/apache/druid/provider.yaml
@@ -95,7 +95,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.druid.hooks.druid.DruidDbApiHook
-    hook-name: "Druid"
     connection-type: druid
 
 transfers:

--- a/providers/apache/druid/src/airflow/providers/apache/druid/get_provider_info.py
+++ b/providers/apache/druid/src/airflow/providers/apache/druid/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.druid.hooks.druid.DruidDbApiHook",
-                "hook-name": "Druid",
                 "connection-type": "druid",
             }
         ],

--- a/providers/apache/hdfs/provider.yaml
+++ b/providers/apache/hdfs/provider.yaml
@@ -97,5 +97,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook
-    hook-name: "Apache WebHDFS"
     connection-type: webhdfs

--- a/providers/apache/hdfs/src/airflow/providers/apache/hdfs/get_provider_info.py
+++ b/providers/apache/hdfs/src/airflow/providers/apache/hdfs/get_provider_info.py
@@ -52,7 +52,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook",
-                "hook-name": "Apache WebHDFS",
                 "connection-type": "webhdfs",
             }
         ],

--- a/providers/apache/hive/provider.yaml
+++ b/providers/apache/hive/provider.yaml
@@ -143,7 +143,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveCliHook
-    hook-name: "Hive Client Wrapper"
     connection-type: hive_cli
     ui-field-behaviour:
       hidden-fields:
@@ -179,10 +178,8 @@ connection-types:
             - 'null'
           default: false
   - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
-    hook-name: "Hive Server 2 Thrift"
     connection-type: hiveserver2
   - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook
-    hook-name: "Hive Metastore Thrift"
     connection-type: hive_metastore
 
 plugins:

--- a/providers/apache/hive/src/airflow/providers/apache/hive/get_provider_info.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/get_provider_info.py
@@ -95,7 +95,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.hive.hooks.hive.HiveCliHook",
-                "hook-name": "Hive Client Wrapper",
                 "connection-type": "hive_cli",
                 "ui-field-behaviour": {"hidden-fields": ["extra"], "relabeling": {}},
                 "conn-fields": {
@@ -119,12 +118,10 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.apache.hive.hooks.hive.HiveServer2Hook",
-                "hook-name": "Hive Server 2 Thrift",
                 "connection-type": "hiveserver2",
             },
             {
                 "hook-class-name": "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook",
-                "hook-name": "Hive Metastore Thrift",
                 "connection-type": "hive_metastore",
             },
         ],

--- a/providers/apache/iceberg/provider.yaml
+++ b/providers/apache/iceberg/provider.yaml
@@ -55,7 +55,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.iceberg.hooks.iceberg.IcebergHook
-    hook-name: "Iceberg"
     connection-type: iceberg
     ui-field-behaviour:
       hidden-fields:

--- a/providers/apache/iceberg/src/airflow/providers/apache/iceberg/get_provider_info.py
+++ b/providers/apache/iceberg/src/airflow/providers/apache/iceberg/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.iceberg.hooks.iceberg.IcebergHook",
-                "hook-name": "Iceberg",
                 "connection-type": "iceberg",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port"],

--- a/providers/apache/impala/provider.yaml
+++ b/providers/apache/impala/provider.yaml
@@ -69,5 +69,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.impala.hooks.impala.ImpalaHook
-    hook-name: "Impala"
     connection-type: impala

--- a/providers/apache/impala/src/airflow/providers/apache/impala/get_provider_info.py
+++ b/providers/apache/impala/src/airflow/providers/apache/impala/get_provider_info.py
@@ -44,7 +44,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.impala.hooks.impala.ImpalaHook",
-                "hook-name": "Impala",
                 "connection-type": "impala",
             }
         ],

--- a/providers/apache/kafka/provider.yaml
+++ b/providers/apache/kafka/provider.yaml
@@ -95,7 +95,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.kafka.hooks.base.KafkaBaseHook
-    hook-name: "Apache Kafka"
     connection-type: kafka
     ui-field-behaviour:
       hidden-fields:

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/get_provider_info.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/get_provider_info.py
@@ -73,7 +73,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.kafka.hooks.base.KafkaBaseHook",
-                "hook-name": "Apache Kafka",
                 "connection-type": "kafka",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "login", "password", "port", "host"],

--- a/providers/apache/kylin/provider.yaml
+++ b/providers/apache/kylin/provider.yaml
@@ -79,5 +79,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.kylin.hooks.kylin.KylinHook
-    hook-name: "Apache Kylin"
     connection-type: kylin

--- a/providers/apache/kylin/src/airflow/providers/apache/kylin/get_provider_info.py
+++ b/providers/apache/kylin/src/airflow/providers/apache/kylin/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.kylin.hooks.kylin.KylinHook",
-                "hook-name": "Apache Kylin",
                 "connection-type": "kylin",
             }
         ],

--- a/providers/apache/livy/provider.yaml
+++ b/providers/apache/livy/provider.yaml
@@ -106,5 +106,4 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.livy.hooks.livy.LivyHook
-    hook-name: "Apache Livy"
     connection-type: livy

--- a/providers/apache/livy/src/airflow/providers/apache/livy/get_provider_info.py
+++ b/providers/apache/livy/src/airflow/providers/apache/livy/get_provider_info.py
@@ -62,7 +62,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.livy.hooks.livy.LivyHook",
-                "hook-name": "Apache Livy",
                 "connection-type": "livy",
             }
         ],

--- a/providers/apache/pig/provider.yaml
+++ b/providers/apache/pig/provider.yaml
@@ -78,4 +78,3 @@ hooks:
 connection-types:
   - connection-type: pig_cli
     hook-class-name: airflow.providers.apache.pig.hooks.pig.PigCliHook
-    hook-name: "Pig Client Wrapper"

--- a/providers/apache/pig/src/airflow/providers/apache/pig/get_provider_info.py
+++ b/providers/apache/pig/src/airflow/providers/apache/pig/get_provider_info.py
@@ -48,7 +48,6 @@ def get_provider_info():
             {
                 "connection-type": "pig_cli",
                 "hook-class-name": "airflow.providers.apache.pig.hooks.pig.PigCliHook",
-                "hook-name": "Pig Client Wrapper",
             }
         ],
     }

--- a/providers/apache/pinot/provider.yaml
+++ b/providers/apache/pinot/provider.yaml
@@ -82,8 +82,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.pinot.hooks.pinot.PinotDbApiHook
-    hook-name: "Pinot Broker"
     connection-type: pinot
   - hook-class-name: airflow.providers.apache.pinot.hooks.pinot.PinotAdminHook
-    hook-name: "Pinot Admin"
     connection-type: pinot_admin

--- a/providers/apache/pinot/src/airflow/providers/apache/pinot/get_provider_info.py
+++ b/providers/apache/pinot/src/airflow/providers/apache/pinot/get_provider_info.py
@@ -44,12 +44,10 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.pinot.hooks.pinot.PinotDbApiHook",
-                "hook-name": "Pinot Broker",
                 "connection-type": "pinot",
             },
             {
                 "hook-class-name": "airflow.providers.apache.pinot.hooks.pinot.PinotAdminHook",
-                "hook-name": "Pinot Admin",
                 "connection-type": "pinot_admin",
             },
         ],

--- a/providers/apache/spark/provider.yaml
+++ b/providers/apache/spark/provider.yaml
@@ -114,7 +114,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apache.spark.hooks.spark_connect.SparkConnectHook
-    hook-name: "Spark Connect"
     connection-type: spark_connect
     ui-field-behaviour:
       hidden-fields:
@@ -131,10 +130,8 @@ connection-types:
             - 'null'
           default: false
   - hook-class-name: airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
-    hook-name: "Spark JDBC"
     connection-type: spark_jdbc
   - hook-class-name: airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
-    hook-name: "Spark SQL"
     connection-type: spark_sql
     ui-field-behaviour:
       hidden-fields:
@@ -152,7 +149,6 @@ connection-types:
             - string
             - 'null'
   - hook-class-name: airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook
-    hook-name: "Spark"
     connection-type: spark
     ui-field-behaviour:
       hidden-fields:

--- a/providers/apache/spark/src/airflow/providers/apache/spark/get_provider_info.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/get_provider_info.py
@@ -63,7 +63,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.spark.hooks.spark_connect.SparkConnectHook",
-                "hook-name": "Spark Connect",
                 "connection-type": "spark_connect",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],
@@ -75,12 +74,10 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook",
-                "hook-name": "Spark JDBC",
                 "connection-type": "spark_jdbc",
             },
             {
                 "hook-class-name": "airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook",
-                "hook-name": "Spark SQL",
                 "connection-type": "spark_sql",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "login", "password", "extra"],
@@ -96,7 +93,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook",
-                "hook-name": "Spark",
                 "connection-type": "spark",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "login", "password", "extra"],

--- a/providers/apache/tinkerpop/provider.yaml
+++ b/providers/apache/tinkerpop/provider.yaml
@@ -51,5 +51,4 @@ hooks:
       - airflow.providers.apache.tinkerpop.hooks.gremlin
 connection-types:
   - hook-class-name: airflow.providers.apache.tinkerpop.hooks.gremlin.GremlinHook
-    hook-name: "Gremlin"
     connection-type: gremlin

--- a/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/get_provider_info.py
+++ b/providers/apache/tinkerpop/src/airflow/providers/apache/tinkerpop/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apache.tinkerpop.hooks.gremlin.GremlinHook",
-                "hook-name": "Gremlin",
                 "connection-type": "gremlin",
             }
         ],

--- a/providers/apprise/provider.yaml
+++ b/providers/apprise/provider.yaml
@@ -67,7 +67,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.apprise.hooks.apprise.AppriseHook
-    hook-name: "Apprise"
     connection-type: apprise
     conn-fields:
       config:

--- a/providers/apprise/src/airflow/providers/apprise/get_provider_info.py
+++ b/providers/apprise/src/airflow/providers/apprise/get_provider_info.py
@@ -39,7 +39,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.apprise.hooks.apprise.AppriseHook",
-                "hook-name": "Apprise",
                 "connection-type": "apprise",
                 "conn-fields": {
                     "config": {

--- a/providers/arangodb/provider.yaml
+++ b/providers/arangodb/provider.yaml
@@ -78,7 +78,6 @@ sensors:
 
 connection-types:
   - hook-class-name: airflow.providers.arangodb.hooks.arangodb.ArangoDBHook
-    hook-name: "ArangoDB"
     connection-type: arangodb
     ui-field-behaviour:
       hidden-fields:

--- a/providers/arangodb/src/airflow/providers/arangodb/get_provider_info.py
+++ b/providers/arangodb/src/airflow/providers/arangodb/get_provider_info.py
@@ -52,7 +52,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.arangodb.hooks.arangodb.ArangoDBHook",
-                "hook-name": "ArangoDB",
                 "connection-type": "arangodb",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "extra"],

--- a/providers/asana/provider.yaml
+++ b/providers/asana/provider.yaml
@@ -78,7 +78,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.asana.hooks.asana.AsanaHook
-    hook-name: "Asana"
     connection-type: asana
     ui-field-behaviour:
       hidden-fields:

--- a/providers/asana/src/airflow/providers/asana/get_provider_info.py
+++ b/providers/asana/src/airflow/providers/asana/get_provider_info.py
@@ -42,7 +42,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.asana.hooks.asana.AsanaHook",
-                "hook-name": "Asana",
                 "connection-type": "asana",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "host", "login", "schema"],

--- a/providers/atlassian/jira/provider.yaml
+++ b/providers/atlassian/jira/provider.yaml
@@ -78,7 +78,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.atlassian.jira.hooks.jira.JiraHook
-    hook-name: "JIRA"
     connection-type: jira
 
 notifications:

--- a/providers/atlassian/jira/src/airflow/providers/atlassian/jira/get_provider_info.py
+++ b/providers/atlassian/jira/src/airflow/providers/atlassian/jira/get_provider_info.py
@@ -55,7 +55,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.atlassian.jira.hooks.jira.JiraHook",
-                "hook-name": "JIRA",
                 "connection-type": "jira",
             }
         ],

--- a/providers/cloudant/provider.yaml
+++ b/providers/cloudant/provider.yaml
@@ -74,7 +74,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.cloudant.hooks.cloudant.CloudantHook
-    hook-name: "Cloudant"
     connection-type: cloudant
     ui-field-behaviour:
       hidden-fields:

--- a/providers/cloudant/src/airflow/providers/cloudant/get_provider_info.py
+++ b/providers/cloudant/src/airflow/providers/cloudant/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.cloudant.hooks.cloudant.CloudantHook",
-                "hook-name": "Cloudant",
                 "connection-type": "cloudant",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],

--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -168,7 +168,6 @@ secrets-backends:
 
 connection-types:
   - hook-class-name: airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook
-    hook-name: "Kubernetes Cluster Connection"
     connection-type: kubernetes
     conn-fields:
       in_cluster:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -81,7 +81,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook",
-                "hook-name": "Kubernetes Cluster Connection",
                 "connection-type": "kubernetes",
                 "conn-fields": {
                     "in_cluster": {

--- a/providers/cohere/provider.yaml
+++ b/providers/cohere/provider.yaml
@@ -72,7 +72,6 @@ operators:
 
 connection-types:
   - hook-class-name: airflow.providers.cohere.hooks.cohere.CohereHook
-    hook-name: "Cohere"
     connection-type: cohere
     ui-field-behaviour:
       hidden-fields: ["schema", "login", "port", "extra"]

--- a/providers/cohere/src/airflow/providers/cohere/get_provider_info.py
+++ b/providers/cohere/src/airflow/providers/cohere/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.cohere.hooks.cohere.CohereHook",
-                "hook-name": "Cohere",
                 "connection-type": "cohere",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "login", "port", "extra"],

--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -61,7 +61,6 @@ plugins:
 
 connection-types:
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook
-    hook-name: "Pydantic AI"
     connection-type: pydanticai
     ui-field-behaviour:
       hidden-fields:
@@ -81,7 +80,6 @@ connection-types:
             - string
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook
-    hook-name: "Pydantic AI (Azure OpenAI)"
     connection-type: pydanticai-azure
     ui-field-behaviour:
       hidden-fields:
@@ -109,7 +107,6 @@ connection-types:
             - string
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIBedrockHook
-    hook-name: "Pydantic AI (AWS Bedrock)"
     connection-type: pydanticai-bedrock
     ui-field-behaviour:
       hidden-fields:
@@ -192,7 +189,6 @@ connection-types:
             - number
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIVertexHook
-    hook-name: "Pydantic AI (Google Vertex AI)"
     connection-type: pydanticai-vertex
     ui-field-behaviour:
       hidden-fields:
@@ -254,7 +250,6 @@ connection-types:
             - string
             - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.mcp.MCPHook
-    hook-name: "MCP Server"
     connection-type: mcp
     ui-field-behaviour:
       hidden-fields:

--- a/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
@@ -66,7 +66,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook",
-                "hook-name": "Pydantic AI",
                 "connection-type": "pydanticai",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],
@@ -83,7 +82,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook",
-                "hook-name": "Pydantic AI (Azure OpenAI)",
                 "connection-type": "pydanticai-azure",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],
@@ -105,7 +103,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIBedrockHook",
-                "hook-name": "Pydantic AI (AWS Bedrock)",
                 "connection-type": "pydanticai-bedrock",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login", "host", "password"],
@@ -167,7 +164,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIVertexHook",
-                "hook-name": "Pydantic AI (Google Vertex AI)",
                 "connection-type": "pydanticai-vertex",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login", "host", "password"],
@@ -214,7 +210,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.common.ai.hooks.mcp.MCPHook",
-                "hook-name": "MCP Server",
                 "connection-type": "mcp",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],

--- a/providers/databricks/provider.yaml
+++ b/providers/databricks/provider.yaml
@@ -167,7 +167,6 @@ sensors:
 
 connection-types:
   - hook-class-name: airflow.providers.databricks.hooks.databricks.DatabricksHook
-    hook-name: "Databricks"
     connection-type: databricks
 
 plugins:

--- a/providers/databricks/src/airflow/providers/databricks/get_provider_info.py
+++ b/providers/databricks/src/airflow/providers/databricks/get_provider_info.py
@@ -117,7 +117,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.databricks.hooks.databricks.DatabricksHook",
-                "hook-name": "Databricks",
                 "connection-type": "databricks",
             }
         ],

--- a/providers/datadog/provider.yaml
+++ b/providers/datadog/provider.yaml
@@ -78,7 +78,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.datadog.hooks.datadog.DatadogHook
-    hook-name: "Datadog"
     connection-type: datadog
     conn-fields:
       api_host:

--- a/providers/datadog/src/airflow/providers/datadog/get_provider_info.py
+++ b/providers/datadog/src/airflow/providers/datadog/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.datadog.hooks.datadog.DatadogHook",
-                "hook-name": "Datadog",
                 "connection-type": "datadog",
                 "conn-fields": {
                     "api_host": {"label": "API endpoint", "schema": {"type": ["string", "null"]}},

--- a/providers/dbt/cloud/provider.yaml
+++ b/providers/dbt/cloud/provider.yaml
@@ -112,7 +112,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook
-    hook-name: "dbt Cloud"
     connection-type: dbt_cloud
     ui-field-behaviour:
       hidden-fields:

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/get_provider_info.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook",
-                "hook-name": "dbt Cloud",
                 "connection-type": "dbt_cloud",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port"],

--- a/providers/dingding/provider.yaml
+++ b/providers/dingding/provider.yaml
@@ -78,5 +78,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.dingding.hooks.dingding.DingdingHook
-    hook-name: "DingTalk Custom Robot (Dingding)"
     connection-type: dingding

--- a/providers/dingding/src/airflow/providers/dingding/get_provider_info.py
+++ b/providers/dingding/src/airflow/providers/dingding/get_provider_info.py
@@ -47,7 +47,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.dingding.hooks.dingding.DingdingHook",
-                "hook-name": "DingTalk Custom Robot (Dingding)",
                 "connection-type": "dingding",
             }
         ],

--- a/providers/discord/provider.yaml
+++ b/providers/discord/provider.yaml
@@ -80,7 +80,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook
-    hook-name: "Discord"
     connection-type: discord
     conn-fields:
       webhook_endpoint:

--- a/providers/discord/src/airflow/providers/discord/get_provider_info.py
+++ b/providers/discord/src/airflow/providers/discord/get_provider_info.py
@@ -49,7 +49,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook",
-                "hook-name": "Discord",
                 "connection-type": "discord",
                 "conn-fields": {
                     "webhook_endpoint": {"label": "Webhook Endpoint", "schema": {"type": ["string", "null"]}}

--- a/providers/docker/provider.yaml
+++ b/providers/docker/provider.yaml
@@ -116,7 +116,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.docker.hooks.docker.DockerHook
-    hook-name: "Docker"
     connection-type: docker
     conn-fields:
       reauth:

--- a/providers/docker/src/airflow/providers/docker/get_provider_info.py
+++ b/providers/docker/src/airflow/providers/docker/get_provider_info.py
@@ -53,7 +53,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.docker.hooks.docker.DockerHook",
-                "hook-name": "Docker",
                 "connection-type": "docker",
                 "conn-fields": {
                     "reauth": {

--- a/providers/elasticsearch/provider.yaml
+++ b/providers/elasticsearch/provider.yaml
@@ -102,7 +102,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchSQLHook
-    hook-name: "Elasticsearch"
     connection-type: elasticsearch
 
 logging:

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/get_provider_info.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchSQLHook",
-                "hook-name": "Elasticsearch",
                 "connection-type": "elasticsearch",
             }
         ],

--- a/providers/exasol/provider.yaml
+++ b/providers/exasol/provider.yaml
@@ -99,5 +99,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.exasol.hooks.exasol.ExasolHook
-    hook-name: "Exasol"
     connection-type: exasol

--- a/providers/exasol/src/airflow/providers/exasol/get_provider_info.py
+++ b/providers/exasol/src/airflow/providers/exasol/get_provider_info.py
@@ -44,7 +44,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.exasol.hooks.exasol.ExasolHook",
-                "hook-name": "Exasol",
                 "connection-type": "exasol",
             }
         ],

--- a/providers/facebook/provider.yaml
+++ b/providers/facebook/provider.yaml
@@ -75,5 +75,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook
-    hook-name: "Facebook Ads"
     connection-type: facebook_social

--- a/providers/facebook/src/airflow/providers/facebook/get_provider_info.py
+++ b/providers/facebook/src/airflow/providers/facebook/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook",
-                "hook-name": "Facebook Ads",
                 "connection-type": "facebook_social",
             }
         ],

--- a/providers/ftp/provider.yaml
+++ b/providers/ftp/provider.yaml
@@ -87,5 +87,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.ftp.hooks.ftp.FTPHook
-    hook-name: "FTP"
     connection-type: ftp

--- a/providers/ftp/src/airflow/providers/ftp/get_provider_info.py
+++ b/providers/ftp/src/airflow/providers/ftp/get_provider_info.py
@@ -53,10 +53,6 @@ def get_provider_info():
             }
         ],
         "connection-types": [
-            {
-                "hook-class-name": "airflow.providers.ftp.hooks.ftp.FTPHook",
-                "hook-name": "FTP",
-                "connection-type": "ftp",
-            }
+            {"hook-class-name": "airflow.providers.ftp.hooks.ftp.FTPHook", "connection-type": "ftp"}
         ],
     }

--- a/providers/git/provider.yaml
+++ b/providers/git/provider.yaml
@@ -64,7 +64,6 @@ bundles:
 
 connection-types:
   - hook-class-name: airflow.providers.git.hooks.git.GitHook
-    hook-name: "GIT"
     connection-type: git
     ui-field-behaviour:
       hidden-fields:

--- a/providers/git/src/airflow/providers/git/get_provider_info.py
+++ b/providers/git/src/airflow/providers/git/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.git.hooks.git.GitHook",
-                "hook-name": "GIT",
                 "connection-type": "git",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],

--- a/providers/github/provider.yaml
+++ b/providers/github/provider.yaml
@@ -83,7 +83,6 @@ sensors:
 
 connection-types:
   - hook-class-name: airflow.providers.github.hooks.github.GithubHook
-    hook-name: "GitHub"
     connection-type: github
     ui-field-behaviour:
       hidden-fields:

--- a/providers/github/src/airflow/providers/github/get_provider_info.py
+++ b/providers/github/src/airflow/providers/github/get_provider_info.py
@@ -46,7 +46,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.github.hooks.github.GithubHook",
-                "hook-name": "GitHub",
                 "connection-type": "github",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login", "extra"],

--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1133,7 +1133,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.google.common.hooks.base_google.GoogleBaseHook
-    hook-name: "Google Cloud"
     connection-type: google_cloud_platform
     ui-field-behaviour:
       hidden-fields: ["host", "schema", "login", "password", "port", "extra"]
@@ -1201,16 +1200,12 @@ connection-types:
           type: ["boolean", "null"]
           default: false
   - hook-class-name: airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook
-    hook-name: "Google Dataprep"
     connection-type: dataprep
   - hook-class-name: airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook
-    hook-name: "Google Cloud SQL"
     connection-type: gcpcloudsql
   - hook-class-name: airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook
-    hook-name: "Google Cloud SQL Database"
     connection-type: gcpcloudsqldb
   - hook-class-name: airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
-    hook-name: "Google Bigquery"
     connection-type: gcpbigquery
     ui-field-behaviour:
       hidden-fields: ["host", "schema", "login", "password", "port", "extra"]
@@ -1299,17 +1294,14 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook
-    hook-name: "Google Cloud SSH"
     connection-type: gcpssh
     ui-field-behaviour:
       hidden-fields: ["host", "schema", "login", "password", "port", "extra"]
       relabeling: {}
       placeholders: {}
   - hook-class-name: airflow.providers.google.leveldb.hooks.leveldb.LevelDBHook
-    hook-name: "LevelDB"
     connection-type: leveldb
   - hook-class-name: airflow.providers.google.ads.hooks.ads.GoogleAdsHook
-    hook-name: "Google Ads"
     connection-type: google_ads
     ui-field-behaviour:
       hidden-fields: ["host", "login", "schema", "port"]
@@ -1336,7 +1328,6 @@ connection-types:
           type: ["string", "null"]
           format: password
   - hook-class-name: airflow.providers.google.cloud.hooks.looker.LookerHook
-    hook-name: "Google Looker"
     connection-type: gcp_looker
 
 extra-links:

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1380,7 +1380,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.google.common.hooks.base_google.GoogleBaseHook",
-                "hook-name": "Google Cloud",
                 "connection-type": "google_cloud_platform",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "login", "password", "port", "extra"],
@@ -1439,22 +1438,18 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook",
-                "hook-name": "Google Dataprep",
                 "connection-type": "dataprep",
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook",
-                "hook-name": "Google Cloud SQL",
                 "connection-type": "gcpcloudsql",
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook",
-                "hook-name": "Google Cloud SQL Database",
                 "connection-type": "gcpcloudsqldb",
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.bigquery.BigQueryHook",
-                "hook-name": "Google Bigquery",
                 "connection-type": "gcpbigquery",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "login", "password", "port", "extra"],
@@ -1524,7 +1519,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook",
-                "hook-name": "Google Cloud SSH",
                 "connection-type": "gcpssh",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "login", "password", "port", "extra"],
@@ -1534,12 +1528,10 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.google.leveldb.hooks.leveldb.LevelDBHook",
-                "hook-name": "LevelDB",
                 "connection-type": "leveldb",
             },
             {
                 "hook-class-name": "airflow.providers.google.ads.hooks.ads.GoogleAdsHook",
-                "hook-name": "Google Ads",
                 "connection-type": "google_ads",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "login", "schema", "port"],
@@ -1561,7 +1553,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.google.cloud.hooks.looker.LookerHook",
-                "hook-name": "Google Looker",
                 "connection-type": "gcp_looker",
             },
         ],

--- a/providers/grpc/provider.yaml
+++ b/providers/grpc/provider.yaml
@@ -77,7 +77,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.grpc.hooks.grpc.GrpcHook
-    hook-name: "GRPC Connection"
     connection-type: grpc
     ui-field-behaviour:
       hidden-fields:

--- a/providers/grpc/src/airflow/providers/grpc/get_provider_info.py
+++ b/providers/grpc/src/airflow/providers/grpc/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.grpc.hooks.grpc.GrpcHook",
-                "hook-name": "GRPC Connection",
                 "connection-type": "grpc",
                 "ui-field-behaviour": {
                     "hidden-fields": ["login", "password", "schema", "extra"],

--- a/providers/hashicorp/provider.yaml
+++ b/providers/hashicorp/provider.yaml
@@ -86,7 +86,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.hashicorp.hooks.vault.VaultHook
-    hook-name: "Hashicorp Vault"
     connection-type: vault
     ui-field-behaviour:
       hidden-fields: ["extra"]

--- a/providers/hashicorp/src/airflow/providers/hashicorp/get_provider_info.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/get_provider_info.py
@@ -43,7 +43,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.hashicorp.hooks.vault.VaultHook",
-                "hook-name": "Hashicorp Vault",
                 "connection-type": "vault",
                 "ui-field-behaviour": {"hidden-fields": ["extra"]},
                 "conn-fields": {

--- a/providers/http/provider.yaml
+++ b/providers/http/provider.yaml
@@ -115,7 +115,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.http.hooks.http.HttpHook
-    hook-name: "HTTP"
     connection-type: http
     ui-field-behaviour:
       hidden-fields: []

--- a/providers/http/src/airflow/providers/http/get_provider_info.py
+++ b/providers/http/src/airflow/providers/http/get_provider_info.py
@@ -63,7 +63,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.http.hooks.http.HttpHook",
-                "hook-name": "HTTP",
                 "connection-type": "http",
                 "ui-field-behaviour": {"hidden-fields": [], "relabeling": {}, "placeholders": {}},
                 "conn-fields": {},

--- a/providers/imap/provider.yaml
+++ b/providers/imap/provider.yaml
@@ -85,7 +85,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.imap.hooks.imap.ImapHook
-    hook-name: "IMAP"
     connection-type: imap
 
 config:

--- a/providers/imap/src/airflow/providers/imap/get_provider_info.py
+++ b/providers/imap/src/airflow/providers/imap/get_provider_info.py
@@ -47,11 +47,7 @@ def get_provider_info():
             }
         ],
         "connection-types": [
-            {
-                "hook-class-name": "airflow.providers.imap.hooks.imap.ImapHook",
-                "hook-name": "IMAP",
-                "connection-type": "imap",
-            }
+            {"hook-class-name": "airflow.providers.imap.hooks.imap.ImapHook", "connection-type": "imap"}
         ],
         "config": {
             "imap": {

--- a/providers/influxdb/provider.yaml
+++ b/providers/influxdb/provider.yaml
@@ -80,7 +80,6 @@ operators:
 
 connection-types:
   - hook-class-name: airflow.providers.influxdb.hooks.influxdb.InfluxDBHook
-    hook-name: "Influxdb"
     connection-type: influxdb
     ui-field-behaviour:
       hidden-fields:

--- a/providers/influxdb/src/airflow/providers/influxdb/get_provider_info.py
+++ b/providers/influxdb/src/airflow/providers/influxdb/get_provider_info.py
@@ -46,7 +46,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.influxdb.hooks.influxdb.InfluxDBHook",
-                "hook-name": "Influxdb",
                 "connection-type": "influxdb",
                 "ui-field-behaviour": {
                     "hidden-fields": ["login", "password"],

--- a/providers/informatica/provider.yaml
+++ b/providers/informatica/provider.yaml
@@ -44,7 +44,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.informatica.hooks.edc.InformaticaEDCHook
-    hook-name: "Informatica EDC"
     connection-type: informatica_edc
 
 plugins:

--- a/providers/informatica/src/airflow/providers/informatica/get_provider_info.py
+++ b/providers/informatica/src/airflow/providers/informatica/get_provider_info.py
@@ -40,7 +40,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.informatica.hooks.edc.InformaticaEDCHook",
-                "hook-name": "Informatica EDC",
                 "connection-type": "informatica_edc",
             }
         ],

--- a/providers/jdbc/provider.yaml
+++ b/providers/jdbc/provider.yaml
@@ -87,7 +87,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.jdbc.hooks.jdbc.JdbcHook
-    hook-name: "JDBC Connection"
     connection-type: jdbc
     ui-field-behaviour:
       hidden-fields:

--- a/providers/jdbc/src/airflow/providers/jdbc/get_provider_info.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/get_provider_info.py
@@ -44,7 +44,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.jdbc.hooks.jdbc.JdbcHook",
-                "hook-name": "JDBC Connection",
                 "connection-type": "jdbc",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "schema"],

--- a/providers/jenkins/provider.yaml
+++ b/providers/jenkins/provider.yaml
@@ -93,7 +93,6 @@ sensors:
 
 connection-types:
   - hook-class-name: airflow.providers.jenkins.hooks.jenkins.JenkinsHook
-    hook-name: "Jenkins"
     connection-type: jenkins
     ui-field-behaviour:
       hidden-fields:

--- a/providers/jenkins/src/airflow/providers/jenkins/get_provider_info.py
+++ b/providers/jenkins/src/airflow/providers/jenkins/get_provider_info.py
@@ -49,7 +49,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.jenkins.hooks.jenkins.JenkinsHook",
-                "hook-name": "Jenkins",
                 "connection-type": "jenkins",
                 "ui-field-behaviour": {
                     "hidden-fields": ["extra"],

--- a/providers/microsoft/azure/provider.yaml
+++ b/providers/microsoft/azure/provider.yaml
@@ -351,7 +351,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook
-    hook-name: "Azure"
     connection-type: azure
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host"]
@@ -382,7 +381,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.compute.AzureComputeHook
-    hook-name: "Azure Compute"
     connection-type: azure_compute
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host"]
@@ -413,7 +411,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook
-    hook-name: "Azure Data Explorer"
     connection-type: azure_data_explorer
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "extra"]
@@ -455,7 +452,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.batch.AzureBatchHook
-    hook-name: "Azure Batch Service"
     connection-type: azure_batch
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -477,7 +473,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.cosmos.AzureCosmosDBHook
-    hook-name: "Azure CosmosDB"
     connection-type: azure_cosmos
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -517,7 +512,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeHook
-    hook-name: "Azure Data Lake"
     connection-type: azure_data_lake
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -547,7 +541,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.fileshare.AzureFileShareHook
-    hook-name: "Azure FileShare"
     connection-type: azure_fileshare
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -578,7 +571,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.container_volume.AzureContainerVolumeHook
-    hook-name: "Azure Container Volume"
     connection-type: azure_container_volume
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -614,10 +606,8 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.container_instance.AzureContainerInstanceHook
-    hook-name: "Azure Container Instance"
     connection-type: azure_container_instance
   - hook-class-name: airflow.providers.microsoft.azure.hooks.wasb.WasbHook
-    hook-name: "Azure Blob Storage"
     connection-type: wasb
     ui-field-behaviour:
       hidden-fields: ["schema", "port"]
@@ -665,7 +655,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook
-    hook-name: "Azure Data Factory"
     connection-type: azure_data_factory
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]
@@ -699,7 +688,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.container_registry.AzureContainerRegistryHook
-    hook-name: "Azure Container Registry"
     connection-type: azure_container_registry
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "extra"]
@@ -731,7 +719,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.asb.BaseAzureServiceBusHook
-    hook-name: "Azure Service Bus"
     connection-type: azure_service_bus
     ui-field-behaviour:
       hidden-fields: ["port", "host", "extra", "login", "password"]
@@ -763,7 +750,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.synapse.BaseAzureSynapseHook
-    hook-name: "Azure Synapse"
     connection-type: azure_synapse
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "extra"]
@@ -790,7 +776,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeStorageV2Hook
-    hook-name: "Azure Data Lake Storage V2"
     connection-type: adls
     ui-field-behaviour:
       hidden-fields: ["schema", "port"]
@@ -824,7 +809,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.msgraph.KiotaRequestAdapterHook
-    hook-name: "Microsoft Graph API"
     connection-type: msgraph
     ui-field-behaviour:
       hidden-fields: ["extra"]
@@ -891,7 +875,6 @@ connection-types:
         schema:
           type: ["string", "null"]
   - hook-class-name: airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook
-    hook-name: "Power BI"
     connection-type: powerbi
     ui-field-behaviour:
       hidden-fields: ["schema", "port", "host", "extra"]

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/get_provider_info.py
@@ -344,7 +344,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook",
-                "hook-name": "Azure",
                 "connection-type": "azure",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host"],
@@ -375,7 +374,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.compute.AzureComputeHook",
-                "hook-name": "Azure Compute",
                 "connection-type": "azure_compute",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host"],
@@ -406,7 +404,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook",
-                "hook-name": "Azure Data Explorer",
                 "connection-type": "azure_data_explorer",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],
@@ -443,7 +440,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.batch.AzureBatchHook",
-                "hook-name": "Azure Batch Service",
                 "connection-type": "azure_batch",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -464,7 +460,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.cosmos.AzureCosmosDBHook",
-                "hook-name": "Azure CosmosDB",
                 "connection-type": "azure_cosmos",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -507,7 +502,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeHook",
-                "hook-name": "Azure Data Lake",
                 "connection-type": "azure_data_lake",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -537,7 +531,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.fileshare.AzureFileShareHook",
-                "hook-name": "Azure FileShare",
                 "connection-type": "azure_fileshare",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -573,7 +566,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.container_volume.AzureContainerVolumeHook",
-                "hook-name": "Azure Container Volume",
                 "connection-type": "azure_container_volume",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -611,12 +603,10 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.container_instance.AzureContainerInstanceHook",
-                "hook-name": "Azure Container Instance",
                 "connection-type": "azure_container_instance",
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.wasb.WasbHook",
-                "hook-name": "Azure Blob Storage",
                 "connection-type": "wasb",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port"],
@@ -665,7 +655,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook",
-                "hook-name": "Azure Data Factory",
                 "connection-type": "azure_data_factory",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],
@@ -692,7 +681,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.container_registry.AzureContainerRegistryHook",
-                "hook-name": "Azure Container Registry",
                 "connection-type": "azure_container_registry",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],
@@ -730,7 +718,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.asb.BaseAzureServiceBusHook",
-                "hook-name": "Azure Service Bus",
                 "connection-type": "azure_service_bus",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "host", "extra", "login", "password"],
@@ -762,7 +749,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.synapse.BaseAzureSynapseHook",
-                "hook-name": "Azure Synapse",
                 "connection-type": "azure_synapse",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],
@@ -788,7 +774,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeStorageV2Hook",
-                "hook-name": "Azure Data Lake Storage V2",
                 "connection-type": "adls",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port"],
@@ -827,7 +812,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.msgraph.KiotaRequestAdapterHook",
-                "hook-name": "Microsoft Graph API",
                 "connection-type": "msgraph",
                 "ui-field-behaviour": {
                     "hidden-fields": ["extra"],
@@ -867,7 +851,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook",
-                "hook-name": "Power BI",
                 "connection-type": "powerbi",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "host", "extra"],

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -278,7 +278,7 @@ class AzureDataLakeStorageV2Hook(BaseHook):
     conn_name_attr = "adls_conn_id"
     default_conn_name = "adls_default"
     conn_type = "adls"
-    hook_name = "Azure Data Lake Storage V2"
+    hook_name = "Azure Date Lake Storage V2"
 
     @classmethod
     @add_managed_identity_connection_widgets

--- a/providers/microsoft/mssql/provider.yaml
+++ b/providers/microsoft/mssql/provider.yaml
@@ -89,5 +89,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook
-    hook-name: "Microsoft SQL Server"
     connection-type: mssql

--- a/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/get_provider_info.py
+++ b/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook",
-                "hook-name": "Microsoft SQL Server",
                 "connection-type": "mssql",
             }
         ],

--- a/providers/microsoft/psrp/provider.yaml
+++ b/providers/microsoft/psrp/provider.yaml
@@ -82,5 +82,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.microsoft.psrp.hooks.psrp.PsrpHook
-    hook-name: "PowerShell Remoting Protocol"
     connection-type: psrp

--- a/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/get_provider_info.py
+++ b/providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/get_provider_info.py
@@ -48,7 +48,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.microsoft.psrp.hooks.psrp.PsrpHook",
-                "hook-name": "PowerShell Remoting Protocol",
                 "connection-type": "psrp",
             }
         ],

--- a/providers/microsoft/winrm/provider.yaml
+++ b/providers/microsoft/winrm/provider.yaml
@@ -92,5 +92,4 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook
-    hook-name: "WinRM"
     connection-type: winrm

--- a/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
+++ b/providers/microsoft/winrm/src/airflow/providers/microsoft/winrm/get_provider_info.py
@@ -56,7 +56,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.microsoft.winrm.hooks.winrm.WinRMHook",
-                "hook-name": "WinRM",
                 "connection-type": "winrm",
             }
         ],

--- a/providers/mongo/provider.yaml
+++ b/providers/mongo/provider.yaml
@@ -86,7 +86,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.mongo.hooks.mongo.MongoHook
-    hook-name: "MongoDB"
     connection-type: mongo
     conn-fields:
       srv:

--- a/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
+++ b/providers/mongo/src/airflow/providers/mongo/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.mongo.hooks.mongo.MongoHook",
-                "hook-name": "MongoDB",
                 "connection-type": "mongo",
                 "conn-fields": {
                     "srv": {"label": "Srv", "schema": {"type": ["boolean", "null"]}},

--- a/providers/mysql/provider.yaml
+++ b/providers/mysql/provider.yaml
@@ -117,7 +117,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.mysql.hooks.mysql.MySqlHook
-    hook-name: "MySQL"
     connection-type: mysql
 
 asset-uris:

--- a/providers/mysql/src/airflow/providers/mysql/get_provider_info.py
+++ b/providers/mysql/src/airflow/providers/mysql/get_provider_info.py
@@ -59,11 +59,7 @@ def get_provider_info():
             },
         ],
         "connection-types": [
-            {
-                "hook-class-name": "airflow.providers.mysql.hooks.mysql.MySqlHook",
-                "hook-name": "MySQL",
-                "connection-type": "mysql",
-            }
+            {"hook-class-name": "airflow.providers.mysql.hooks.mysql.MySqlHook", "connection-type": "mysql"}
         ],
         "asset-uris": [
             {"schemes": ["mysql", "mariadb"], "handler": "airflow.providers.mysql.assets.mysql.sanitize_uri"}

--- a/providers/neo4j/provider.yaml
+++ b/providers/neo4j/provider.yaml
@@ -92,5 +92,4 @@ sensors:
 
 connection-types:
   - hook-class-name: airflow.providers.neo4j.hooks.neo4j.Neo4jHook
-    hook-name: "Neo4j"
     connection-type: neo4j

--- a/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/get_provider_info.py
@@ -46,10 +46,6 @@ def get_provider_info():
             {"integration-name": "Neo4j", "python-modules": ["airflow.providers.neo4j.sensors.neo4j"]}
         ],
         "connection-types": [
-            {
-                "hook-class-name": "airflow.providers.neo4j.hooks.neo4j.Neo4jHook",
-                "hook-name": "Neo4j",
-                "connection-type": "neo4j",
-            }
+            {"hook-class-name": "airflow.providers.neo4j.hooks.neo4j.Neo4jHook", "connection-type": "neo4j"}
         ],
     }

--- a/providers/odbc/provider.yaml
+++ b/providers/odbc/provider.yaml
@@ -85,5 +85,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.odbc.hooks.odbc.OdbcHook
-    hook-name: "ODBC"
     connection-type: odbc

--- a/providers/odbc/src/airflow/providers/odbc/get_provider_info.py
+++ b/providers/odbc/src/airflow/providers/odbc/get_provider_info.py
@@ -37,10 +37,6 @@ def get_provider_info():
         ],
         "hooks": [{"integration-name": "ODBC", "python-modules": ["airflow.providers.odbc.hooks.odbc"]}],
         "connection-types": [
-            {
-                "hook-class-name": "airflow.providers.odbc.hooks.odbc.OdbcHook",
-                "hook-name": "ODBC",
-                "connection-type": "odbc",
-            }
+            {"hook-class-name": "airflow.providers.odbc.hooks.odbc.OdbcHook", "connection-type": "odbc"}
         ],
     }

--- a/providers/openai/provider.yaml
+++ b/providers/openai/provider.yaml
@@ -89,7 +89,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.openai.hooks.openai.OpenAIHook
-    hook-name: "OpenAI"
     connection-type: openai
     ui-field-behaviour:
       hidden-fields:

--- a/providers/openai/src/airflow/providers/openai/get_provider_info.py
+++ b/providers/openai/src/airflow/providers/openai/get_provider_info.py
@@ -56,7 +56,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.openai.hooks.openai.OpenAIHook",
-                "hook-name": "OpenAI",
                 "connection-type": "openai",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "login"],

--- a/providers/openfaas/provider.yaml
+++ b/providers/openfaas/provider.yaml
@@ -69,7 +69,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.openfaas.hooks.openfaas.OpenFaasHook
-    hook-name: "OpenFaaS"
     connection-type: openfaas
     ui-field-behaviour:
       hidden-fields:

--- a/providers/openfaas/src/airflow/providers/openfaas/get_provider_info.py
+++ b/providers/openfaas/src/airflow/providers/openfaas/get_provider_info.py
@@ -40,7 +40,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.openfaas.hooks.openfaas.OpenFaasHook",
-                "hook-name": "OpenFaaS",
                 "connection-type": "openfaas",
                 "ui-field-behaviour": {"hidden-fields": ["schema", "port", "login", "password", "extra"]},
             }

--- a/providers/opensearch/provider.yaml
+++ b/providers/opensearch/provider.yaml
@@ -74,7 +74,6 @@ operators:
 
 connection-types:
   - hook-class-name: airflow.providers.opensearch.hooks.opensearch.OpenSearchHook
-    hook-name: "OpenSearch Hook"
     connection-type: opensearch
     ui-field-behaviour:
       hidden-fields:

--- a/providers/opensearch/src/airflow/providers/opensearch/get_provider_info.py
+++ b/providers/opensearch/src/airflow/providers/opensearch/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.opensearch.hooks.opensearch.OpenSearchHook",
-                "hook-name": "OpenSearch Hook",
                 "connection-type": "opensearch",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],

--- a/providers/opsgenie/provider.yaml
+++ b/providers/opsgenie/provider.yaml
@@ -81,7 +81,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.opsgenie.hooks.opsgenie.OpsgenieAlertHook
-    hook-name: "Opsgenie"
     connection-type: opsgenie
     ui-field-behaviour:
       hidden-fields:

--- a/providers/opsgenie/src/airflow/providers/opsgenie/get_provider_info.py
+++ b/providers/opsgenie/src/airflow/providers/opsgenie/get_provider_info.py
@@ -47,7 +47,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.opsgenie.hooks.opsgenie.OpsgenieAlertHook",
-                "hook-name": "Opsgenie",
                 "connection-type": "opsgenie",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "schema", "login", "extra"],

--- a/providers/oracle/provider.yaml
+++ b/providers/oracle/provider.yaml
@@ -105,5 +105,4 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.oracle.hooks.oracle.OracleHook
-    hook-name: "Oracle"
     connection-type: oracle

--- a/providers/oracle/src/airflow/providers/oracle/get_provider_info.py
+++ b/providers/oracle/src/airflow/providers/oracle/get_provider_info.py
@@ -57,7 +57,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.oracle.hooks.oracle.OracleHook",
-                "hook-name": "Oracle",
                 "connection-type": "oracle",
             }
         ],

--- a/providers/pagerduty/provider.yaml
+++ b/providers/pagerduty/provider.yaml
@@ -75,7 +75,6 @@ integrations:
 
 connection-types:
   - hook-class-name: airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook
-    hook-name: "Pagerduty"
     connection-type: pagerduty
     conn-fields:
       routing_key:
@@ -95,7 +94,6 @@ connection-types:
       relabeling:
         password: Pagerduty API token
   - hook-class-name: airflow.providers.pagerduty.hooks.pagerduty_events.PagerdutyEventsHook
-    hook-name: "Pagerduty Events"
     connection-type: pagerduty_events
     ui-field-behaviour:
       hidden-fields:

--- a/providers/pagerduty/src/airflow/providers/pagerduty/get_provider_info.py
+++ b/providers/pagerduty/src/airflow/providers/pagerduty/get_provider_info.py
@@ -37,7 +37,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook",
-                "hook-name": "Pagerduty",
                 "connection-type": "pagerduty",
                 "conn-fields": {
                     "routing_key": {
@@ -52,7 +51,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.pagerduty.hooks.pagerduty_events.PagerdutyEventsHook",
-                "hook-name": "Pagerduty Events",
                 "connection-type": "pagerduty_events",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "login", "schema", "host", "extra"],

--- a/providers/papermill/provider.yaml
+++ b/providers/papermill/provider.yaml
@@ -88,5 +88,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.papermill.hooks.kernel.KernelHook
-    hook-name: "Jupyter Kernel"
     connection-type: jupyter_kernel

--- a/providers/papermill/src/airflow/providers/papermill/get_provider_info.py
+++ b/providers/papermill/src/airflow/providers/papermill/get_provider_info.py
@@ -47,7 +47,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.papermill.hooks.kernel.KernelHook",
-                "hook-name": "Jupyter Kernel",
                 "connection-type": "jupyter_kernel",
             }
         ],

--- a/providers/pinecone/provider.yaml
+++ b/providers/pinecone/provider.yaml
@@ -68,7 +68,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.pinecone.hooks.pinecone.PineconeHook
-    hook-name: "Pinecone"
     connection-type: pinecone
     ui-field-behaviour:
       hidden-fields:

--- a/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
+++ b/providers/pinecone/src/airflow/providers/pinecone/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.pinecone.hooks.pinecone.PineconeHook",
-                "hook-name": "Pinecone",
                 "connection-type": "pinecone",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "schema"],

--- a/providers/postgres/provider.yaml
+++ b/providers/postgres/provider.yaml
@@ -108,7 +108,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.postgres.hooks.postgres.PostgresHook
-    hook-name: "Postgres"
     connection-type: postgres
     ui-field-behaviour:
       relabeling:

--- a/providers/postgres/src/airflow/providers/postgres/get_provider_info.py
+++ b/providers/postgres/src/airflow/providers/postgres/get_provider_info.py
@@ -50,7 +50,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.postgres.hooks.postgres.PostgresHook",
-                "hook-name": "Postgres",
                 "connection-type": "postgres",
                 "ui-field-behaviour": {"relabeling": {"schema": "Database"}},
             }

--- a/providers/presto/provider.yaml
+++ b/providers/presto/provider.yaml
@@ -102,5 +102,4 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.presto.hooks.presto.PrestoHook
-    hook-name: "Presto"
     connection-type: presto

--- a/providers/presto/src/airflow/providers/presto/get_provider_info.py
+++ b/providers/presto/src/airflow/providers/presto/get_provider_info.py
@@ -49,7 +49,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.presto.hooks.presto.PrestoHook",
-                "hook-name": "Presto",
                 "connection-type": "presto",
             }
         ],

--- a/providers/qdrant/provider.yaml
+++ b/providers/qdrant/provider.yaml
@@ -65,7 +65,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.qdrant.hooks.qdrant.QdrantHook
-    hook-name: "Qdrant"
     connection-type: qdrant
     conn-fields:
       url:

--- a/providers/qdrant/src/airflow/providers/qdrant/get_provider_info.py
+++ b/providers/qdrant/src/airflow/providers/qdrant/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.qdrant.hooks.qdrant.QdrantHook",
-                "hook-name": "Qdrant",
                 "connection-type": "qdrant",
                 "conn-fields": {
                     "url": {

--- a/providers/redis/provider.yaml
+++ b/providers/redis/provider.yaml
@@ -97,7 +97,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.redis.hooks.redis.RedisHook
-    hook-name: "Redis"
     connection-type: redis
     ui-field-behaviour:
       hidden-fields:

--- a/providers/redis/src/airflow/providers/redis/get_provider_info.py
+++ b/providers/redis/src/airflow/providers/redis/get_provider_info.py
@@ -60,7 +60,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.redis.hooks.redis.RedisHook",
-                "hook-name": "Redis",
                 "connection-type": "redis",
                 "ui-field-behaviour": {"hidden-fields": ["schema", "extra"], "relabeling": {}},
                 "conn-fields": {

--- a/providers/salesforce/provider.yaml
+++ b/providers/salesforce/provider.yaml
@@ -95,7 +95,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.salesforce.hooks.salesforce.SalesforceHook
-    hook-name: "Salesforce"
     connection-type: salesforce
     conn-fields:
       security_token:

--- a/providers/salesforce/src/airflow/providers/salesforce/get_provider_info.py
+++ b/providers/salesforce/src/airflow/providers/salesforce/get_provider_info.py
@@ -56,7 +56,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.salesforce.hooks.salesforce.SalesforceHook",
-                "hook-name": "Salesforce",
                 "connection-type": "salesforce",
                 "conn-fields": {
                     "security_token": {

--- a/providers/samba/provider.yaml
+++ b/providers/samba/provider.yaml
@@ -82,7 +82,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.samba.hooks.samba.SambaHook
-    hook-name: "Samba"
     connection-type: samba
     conn-fields:
       share_type:

--- a/providers/samba/src/airflow/providers/samba/get_provider_info.py
+++ b/providers/samba/src/airflow/providers/samba/get_provider_info.py
@@ -46,7 +46,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.samba.hooks.samba.SambaHook",
-                "hook-name": "Samba",
                 "connection-type": "samba",
                 "conn-fields": {
                     "share_type": {

--- a/providers/segment/provider.yaml
+++ b/providers/segment/provider.yaml
@@ -74,5 +74,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.segment.hooks.segment.SegmentHook
-    hook-name: "Segment"
     connection-type: segment

--- a/providers/segment/src/airflow/providers/segment/get_provider_info.py
+++ b/providers/segment/src/airflow/providers/segment/get_provider_info.py
@@ -46,7 +46,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.segment.hooks.segment.SegmentHook",
-                "hook-name": "Segment",
                 "connection-type": "segment",
             }
         ],

--- a/providers/sftp/provider.yaml
+++ b/providers/sftp/provider.yaml
@@ -116,7 +116,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.sftp.hooks.sftp.SFTPHook
-    hook-name: "SFTP"
     connection-type: sftp
     ui-field-behaviour:
       hidden-fields:

--- a/providers/sftp/src/airflow/providers/sftp/get_provider_info.py
+++ b/providers/sftp/src/airflow/providers/sftp/get_provider_info.py
@@ -59,7 +59,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.sftp.hooks.sftp.SFTPHook",
-                "hook-name": "SFTP",
                 "connection-type": "sftp",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],

--- a/providers/slack/provider.yaml
+++ b/providers/slack/provider.yaml
@@ -136,7 +136,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.slack.hooks.slack.SlackHook
-    hook-name: "Slack API"
     connection-type: slack
     ui-field-behaviour:
       hidden-fields:
@@ -175,7 +174,6 @@ connection-types:
             - 'null'
         description: Optional. Proxy to make the Slack API call.
   - hook-class-name: airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook
-    hook-name: "Slack Incoming Webhook"
     connection-type: slackwebhook
     ui-field-behaviour:
       hidden-fields:

--- a/providers/slack/src/airflow/providers/slack/get_provider_info.py
+++ b/providers/slack/src/airflow/providers/slack/get_provider_info.py
@@ -82,7 +82,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.slack.hooks.slack.SlackHook",
-                "hook-name": "Slack API",
                 "connection-type": "slack",
                 "ui-field-behaviour": {
                     "hidden-fields": ["login", "port", "host", "schema", "extra"],
@@ -114,7 +113,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook",
-                "hook-name": "Slack Incoming Webhook",
                 "connection-type": "slackwebhook",
                 "ui-field-behaviour": {
                     "hidden-fields": ["login", "port", "extra"],

--- a/providers/smtp/provider.yaml
+++ b/providers/smtp/provider.yaml
@@ -82,7 +82,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.smtp.hooks.smtp.SmtpHook
-    hook-name: "SMTP"
     connection-type: smtp
     conn-fields:
       from_email:

--- a/providers/smtp/src/airflow/providers/smtp/get_provider_info.py
+++ b/providers/smtp/src/airflow/providers/smtp/get_provider_info.py
@@ -49,7 +49,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.smtp.hooks.smtp.SmtpHook",
-                "hook-name": "SMTP",
                 "connection-type": "smtp",
                 "conn-fields": {
                     "from_email": {"label": "From email", "schema": {"type": ["string", "null"]}},

--- a/providers/snowflake/provider.yaml
+++ b/providers/snowflake/provider.yaml
@@ -148,7 +148,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.snowflake.hooks.snowflake.SnowflakeHook
-    hook-name: "Snowflake"
     connection-type: snowflake
     ui-field-behaviour:
       hidden-fields: ["port", "host"]

--- a/providers/snowflake/src/airflow/providers/snowflake/get_provider_info.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/get_provider_info.py
@@ -85,7 +85,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.snowflake.hooks.snowflake.SnowflakeHook",
-                "hook-name": "Snowflake",
                 "connection-type": "snowflake",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port", "host"],

--- a/providers/sqlite/provider.yaml
+++ b/providers/sqlite/provider.yaml
@@ -84,5 +84,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.sqlite.hooks.sqlite.SqliteHook
-    hook-name: "Sqlite"
     connection-type: sqlite

--- a/providers/sqlite/src/airflow/providers/sqlite/get_provider_info.py
+++ b/providers/sqlite/src/airflow/providers/sqlite/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.sqlite.hooks.sqlite.SqliteHook",
-                "hook-name": "Sqlite",
                 "connection-type": "sqlite",
             }
         ],

--- a/providers/ssh/provider.yaml
+++ b/providers/ssh/provider.yaml
@@ -107,7 +107,6 @@ triggers:
 
 connection-types:
   - hook-class-name: airflow.providers.ssh.hooks.ssh.SSHHook
-    hook-name: "SSH"
     connection-type: ssh
     ui-field-behaviour:
       hidden-fields:

--- a/providers/ssh/src/airflow/providers/ssh/get_provider_info.py
+++ b/providers/ssh/src/airflow/providers/ssh/get_provider_info.py
@@ -56,7 +56,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.ssh.hooks.ssh.SSHHook",
-                "hook-name": "SSH",
                 "connection-type": "ssh",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],

--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -137,7 +137,6 @@ config:
 
 connection-types:
   - hook-class-name: airflow.providers.standard.hooks.filesystem.FSHook
-    hook-name: "File (path)"
     connection-type: fs
     ui-field-behaviour:
       hidden-fields:
@@ -155,7 +154,6 @@ connection-types:
             - string
             - 'null'
   - hook-class-name: airflow.providers.standard.hooks.package_index.PackageIndexHook
-    hook-name: "Package Index (Python)"
     connection-type: package_index
     ui-field-behaviour:
       hidden-fields:

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -120,7 +120,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.standard.hooks.filesystem.FSHook",
-                "hook-name": "File (path)",
                 "connection-type": "fs",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "port", "login", "password", "extra"]
@@ -129,7 +128,6 @@ def get_provider_info():
             },
             {
                 "hook-class-name": "airflow.providers.standard.hooks.package_index.PackageIndexHook",
-                "hook-name": "Package Index (Python)",
                 "connection-type": "package_index",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],

--- a/providers/tableau/provider.yaml
+++ b/providers/tableau/provider.yaml
@@ -94,5 +94,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.tableau.hooks.tableau.TableauHook
-    hook-name: "Tableau"
     connection-type: tableau

--- a/providers/tableau/src/airflow/providers/tableau/get_provider_info.py
+++ b/providers/tableau/src/airflow/providers/tableau/get_provider_info.py
@@ -47,7 +47,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.tableau.hooks.tableau.TableauHook",
-                "hook-name": "Tableau",
                 "connection-type": "tableau",
             }
         ],

--- a/providers/telegram/provider.yaml
+++ b/providers/telegram/provider.yaml
@@ -78,7 +78,6 @@ operators:
 
 connection-types:
   - hook-class-name: airflow.providers.telegram.hooks.telegram.TelegramHook
-    hook-name: "Telegram"
     connection-type: telegram
     ui-field-behaviour:
       hidden-fields:

--- a/providers/telegram/src/airflow/providers/telegram/get_provider_info.py
+++ b/providers/telegram/src/airflow/providers/telegram/get_provider_info.py
@@ -44,7 +44,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.telegram.hooks.telegram.TelegramHook",
-                "hook-name": "Telegram",
                 "connection-type": "telegram",
                 "ui-field-behaviour": {"hidden-fields": ["schema", "extra", "login", "port"]},
             }

--- a/providers/teradata/provider.yaml
+++ b/providers/teradata/provider.yaml
@@ -125,7 +125,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.teradata.hooks.teradata.TeradataHook
-    hook-name: "Teradata"
     connection-type: teradata
     ui-field-behaviour:
       hidden-fields:

--- a/providers/teradata/src/airflow/providers/teradata/get_provider_info.py
+++ b/providers/teradata/src/airflow/providers/teradata/get_provider_info.py
@@ -98,7 +98,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.teradata.hooks.teradata.TeradataHook",
-                "hook-name": "Teradata",
                 "connection-type": "teradata",
                 "ui-field-behaviour": {
                     "hidden-fields": ["port"],

--- a/providers/trino/provider.yaml
+++ b/providers/trino/provider.yaml
@@ -115,7 +115,6 @@ transfers:
 
 connection-types:
   - hook-class-name: airflow.providers.trino.hooks.trino.TrinoHook
-    hook-name: "Trino"
     connection-type: trino
     ui-field-behaviour:
       placeholders:

--- a/providers/trino/src/airflow/providers/trino/get_provider_info.py
+++ b/providers/trino/src/airflow/providers/trino/get_provider_info.py
@@ -53,7 +53,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.trino.hooks.trino.TrinoHook",
-                "hook-name": "Trino",
                 "connection-type": "trino",
                 "ui-field-behaviour": {
                     "placeholders": {

--- a/providers/vertica/provider.yaml
+++ b/providers/vertica/provider.yaml
@@ -82,5 +82,4 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.vertica.hooks.vertica.VerticaHook
-    hook-name: "Vertica"
     connection-type: vertica

--- a/providers/vertica/src/airflow/providers/vertica/get_provider_info.py
+++ b/providers/vertica/src/airflow/providers/vertica/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.vertica.hooks.vertica.VerticaHook",
-                "hook-name": "Vertica",
                 "connection-type": "vertica",
             }
         ],

--- a/providers/weaviate/provider.yaml
+++ b/providers/weaviate/provider.yaml
@@ -73,7 +73,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.weaviate.hooks.weaviate.WeaviateHook
-    hook-name: "Weaviate"
     connection-type: weaviate
     ui-field-behaviour:
       hidden-fields:

--- a/providers/weaviate/src/airflow/providers/weaviate/get_provider_info.py
+++ b/providers/weaviate/src/airflow/providers/weaviate/get_provider_info.py
@@ -41,7 +41,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.weaviate.hooks.weaviate.WeaviateHook",
-                "hook-name": "Weaviate",
                 "connection-type": "weaviate",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema"],

--- a/providers/yandex/provider.yaml
+++ b/providers/yandex/provider.yaml
@@ -110,7 +110,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook
-    hook-name: "Yandex Cloud"
     connection-type: yandexcloud
     ui-field-behaviour:
       hidden-fields:

--- a/providers/yandex/src/airflow/providers/yandex/get_provider_info.py
+++ b/providers/yandex/src/airflow/providers/yandex/get_provider_info.py
@@ -69,7 +69,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook",
-                "hook-name": "Yandex Cloud",
                 "connection-type": "yandexcloud",
                 "ui-field-behaviour": {
                     "hidden-fields": ["host", "schema", "login", "password", "port", "extra"]

--- a/providers/yandex/src/airflow/providers/yandex/hooks/yandex.py
+++ b/providers/yandex/src/airflow/providers/yandex/hooks/yandex.py
@@ -26,7 +26,7 @@ from airflow.providers.yandex.utils.credentials import (
     get_credentials,
     get_service_account_id,
 )
-from airflow.providers.yandex.utils.defaults import conn_name_attr, conn_type, default_conn_name
+from airflow.providers.yandex.utils.defaults import conn_name_attr, conn_type, default_conn_name, hook_name
 from airflow.providers.yandex.utils.fields import get_field_from_extras
 from airflow.providers.yandex.utils.user_agent import provider_user_agent
 
@@ -44,7 +44,7 @@ class YandexCloudBaseHook(BaseHook):
     conn_name_attr = conn_name_attr
     default_conn_name = default_conn_name
     conn_type = conn_type
-    hook_name = "Yandex Cloud"
+    hook_name = hook_name
 
     @classmethod
     def get_connection_form_widgets(cls) -> dict[str, Any]:

--- a/providers/ydb/provider.yaml
+++ b/providers/ydb/provider.yaml
@@ -67,7 +67,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.ydb.hooks.ydb.YDBHook
-    hook-name: "YDB"
     connection-type: ydb
     ui-field-behaviour:
       hidden-fields:

--- a/providers/ydb/src/airflow/providers/ydb/get_provider_info.py
+++ b/providers/ydb/src/airflow/providers/ydb/get_provider_info.py
@@ -40,7 +40,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.ydb.hooks.ydb.YDBHook",
-                "hook-name": "YDB",
                 "connection-type": "ydb",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "extra"],

--- a/providers/zendesk/provider.yaml
+++ b/providers/zendesk/provider.yaml
@@ -72,7 +72,6 @@ hooks:
 
 connection-types:
   - hook-class-name: airflow.providers.zendesk.hooks.zendesk.ZendeskHook
-    hook-name: "Zendesk"
     connection-type: zendesk
     ui-field-behaviour:
       hidden-fields:

--- a/providers/zendesk/src/airflow/providers/zendesk/get_provider_info.py
+++ b/providers/zendesk/src/airflow/providers/zendesk/get_provider_info.py
@@ -40,7 +40,6 @@ def get_provider_info():
         "connection-types": [
             {
                 "hook-class-name": "airflow.providers.zendesk.hooks.zendesk.ZendeskHook",
-                "hook-name": "Zendesk",
                 "connection-type": "zendesk",
                 "ui-field-behaviour": {
                     "hidden-fields": ["schema", "port", "extra"],


### PR DESCRIPTION
Reverts #64723 (cherry-pick of #63826) from `v3-2-test` ahead of the 3.2.2 release.

## Why

#63826 was originally targeted for 3.3.0, not 3.2.x as mentioned [here](https://github.com/apache/airflow/pull/63826#issuecomment-4252676399) 