### PR TITLE
Use FastAPI exception handler for execution API database errors

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -30,6 +30,7 @@ from cadwyn import (
 )
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from airflow.api_fastapi.auth.tokens import (
@@ -267,6 +268,19 @@ def create_task_execution_api_app() -> FastAPI:
     def handle_exceptions(request: Request, exc: Exception):
         logger.exception("Handle died with an error", exc_info=(type(exc), exc, exc.__traceback__))
         content = {"message": "Internal server error"}
+        if correlation_id := request.headers.get("correlation-id"):
+            content["correlation-id"] = correlation_id
+        return JSONResponse(status_code=500, content=content)
+
+    @app.exception_handler(SQLAlchemyError)
+    def handle_database_exceptions(request: Request, exc: SQLAlchemyError):
+        logger.exception(
+            "Database error handling request",
+            path=request.url.path,
+            method=request.method,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        content: dict[str, str] = {"detail": "Database error occurred"}
         if correlation_id := request.headers.get("correlation-id"):
             content["correlation-id"] = correlation_id
         return JSONResponse(status_code=500, content=content)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -30,7 +30,6 @@ from cadwyn import (
 )
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
-from sqlalchemy.exc import SQLAlchemyError
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from airflow.api_fastapi.auth.tokens import (
@@ -272,18 +271,10 @@ def create_task_execution_api_app() -> FastAPI:
             content["correlation-id"] = correlation_id
         return JSONResponse(status_code=500, content=content)
 
-    @app.exception_handler(SQLAlchemyError)
-    def handle_database_exceptions(request: Request, exc: SQLAlchemyError):
-        logger.exception(
-            "Database error handling request",
-            path=request.url.path,
-            method=request.method,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
-        content: dict[str, str] = {"detail": "Database error occurred"}
-        if correlation_id := request.headers.get("correlation-id"):
-            content["correlation-id"] = correlation_id
-        return JSONResponse(status_code=500, content=content)
+    from airflow.api_fastapi.execution_api.exceptions import EXECUTION_API_ERROR_HANDLERS
+
+    for handler in EXECUTION_API_ERROR_HANDLERS:
+        app.add_exception_handler(handler.exception_cls, handler.exception_handler)
 
     return app
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/exceptions.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import structlog
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import SQLAlchemyError
+
+from airflow.api_fastapi.common.exceptions import BaseErrorHandler
+
+logger = structlog.get_logger(logger_name=__name__)
+
+
+class _DatabaseErrorHandler(BaseErrorHandler[SQLAlchemyError]):
+    """Handle SQLAlchemyError exceptions raised within the execution API."""
+
+    def __init__(self):
+        super().__init__(SQLAlchemyError)
+
+    def exception_handler(self, request: Request, exc: SQLAlchemyError):
+        logger.exception(
+            "Database error handling request",
+            path=request.url.path,
+            method=request.method,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        content: dict[str, str] = {"detail": "Database error occurred"}
+        if correlation_id := request.headers.get("correlation-id"):
+            content["correlation-id"] = correlation_id
+        return JSONResponse(status_code=500, content=content)
+
+
+EXECUTION_API_ERROR_HANDLERS: list[BaseErrorHandler] = [_DatabaseErrorHandler()]

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -35,7 +35,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from pydantic import JsonValue
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
-from sqlalchemy.exc import NoResultFound, SQLAlchemyError
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
@@ -242,74 +242,66 @@ def ti_run(
         retry_reason=None,
     )
 
-    try:
-        result = session.execute(query)
-        log.info("Task instance state updated", rows_affected=getattr(result, "rowcount", 0))
+    result = session.execute(query)
+    log.info("Task instance state updated", rows_affected=getattr(result, "rowcount", 0))
 
-        dr = (
-            session.scalars(
-                select(DR)
-                .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
-                .options(joinedload(DR.consumed_asset_events))
-            )
-            .unique()
-            .one_or_none()
+    dr = (
+        session.scalars(
+            select(DR)
+            .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
+            .options(joinedload(DR.consumed_asset_events))
         )
+        .unique()
+        .one_or_none()
+    )
 
-        if not dr:
-            log.error("DagRun not found", dag_id=ti.dag_id, run_id=ti.run_id)
-            raise ValueError(f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.")
+    if not dr:
+        log.error("DagRun not found", dag_id=ti.dag_id, run_id=ti.run_id)
+        raise ValueError(f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.")
 
-        # Send the keys to the SDK so that the client requests to clear those XComs from the server.
-        # The reason we cannot do this here in the server is because we need to issue a purge on custom XCom backends
-        # too. With the current assumption, the workers ONLY have access to the custom XCom backends directly and they
-        # can issue the purge.
+    # Send the keys to the SDK so that the client requests to clear those XComs from the server.
+    # The reason we cannot do this here in the server is because we need to issue a purge on custom XCom backends
+    # too. With the current assumption, the workers ONLY have access to the custom XCom backends directly and they
+    # can issue the purge.
 
-        # However, do not clear it for deferral
-        xcom_keys = []
-        if not ti.next_method:
-            map_index = None if ti.map_index < 0 else ti.map_index
-            xcom_query = select(XComModel.key).where(
-                XComModel.dag_id == ti.dag_id,
-                XComModel.task_id == ti.task_id,
-                XComModel.run_id == ti.run_id,
-            )
-            if map_index is not None:
-                xcom_query = xcom_query.where(XComModel.map_index == map_index)
-
-            xcom_keys = list(session.scalars(xcom_query))
-        task_reschedule_count = (
-            session.scalar(
-                select(func.count(TaskReschedule.id)).where(TaskReschedule.ti_id == task_instance_id)
-            )
-            or 0
+    # However, do not clear it for deferral
+    xcom_keys = []
+    if not ti.next_method:
+        map_index = None if ti.map_index < 0 else ti.map_index
+        xcom_query = select(XComModel.key).where(
+            XComModel.dag_id == ti.dag_id,
+            XComModel.task_id == ti.task_id,
+            XComModel.run_id == ti.run_id,
         )
+        if map_index is not None:
+            xcom_query = xcom_query.where(XComModel.map_index == map_index)
 
-        from airflow.api_fastapi.execution_api.security import get_team_name_for_ti
+        xcom_keys = list(session.scalars(xcom_query))
+    task_reschedule_count = (
+        session.scalar(select(func.count(TaskReschedule.id)).where(TaskReschedule.ti_id == task_instance_id))
+        or 0
+    )
 
-        dr.team_name = get_team_name_for_ti(task_instance_id, session)
+    from airflow.api_fastapi.execution_api.security import get_team_name_for_ti
 
-        context = TIRunContext(
-            dag_run=dr,
-            task_reschedule_count=task_reschedule_count,
-            max_tries=ti.max_tries,
-            # TODO: Add variables and connections that are needed (and has perms) for the task
-            variables=[],
-            connections=[],
-            xcom_keys_to_clear=xcom_keys,
-            should_retry=_is_eligible_to_retry(previous_state, ti.try_number, ti.max_tries),
-        )
+    dr.team_name = get_team_name_for_ti(task_instance_id, session)
 
-        # Only set if they are non-null
-        if ti.next_method:
-            context.next_method = ti.next_method
-            context.next_kwargs = ti.next_kwargs
-            context.start_date = ti.start_date
-    except SQLAlchemyError:
-        log.exception("Error marking Task Instance state as running")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
-        )
+    context = TIRunContext(
+        dag_run=dr,
+        task_reschedule_count=task_reschedule_count,
+        max_tries=ti.max_tries,
+        # TODO: Add variables and connections that are needed (and has perms) for the task
+        variables=[],
+        connections=[],
+        xcom_keys_to_clear=xcom_keys,
+        should_retry=_is_eligible_to_retry(previous_state, ti.try_number, ti.max_tries),
+    )
+
+    # Only set if they are non-null
+    if ti.next_method:
+        context.next_method = ti.next_method
+        context.next_kwargs = ti.next_kwargs
+        context.start_date = ti.start_date
 
     # JWTReissueMiddleware also writes Refreshed-API-Token but skips workload tokens, so we set it here for the workload→execution swap.
     if token.claims.scope == "workload":
@@ -435,33 +427,25 @@ def ti_update_state(
         if ti is not None:
             _handle_fail_fast_for_dag(ti=ti, dag_id=dag_id, session=session, dag_bag=dag_bag)
 
-    # TODO: Replace this with FastAPI's Custom Exception handling:
-    # https://fastapi.tiangolo.com/tutorial/handling-errors/#install-custom-exception-handlers
-    try:
-        result = session.execute(query)
-        log.info(
-            "Task instance state updated",
-            new_state=updated_state,
-            rows_affected=getattr(result, "rowcount", 0),
+    result = session.execute(query)
+    log.info(
+        "Task instance state updated",
+        new_state=updated_state,
+        rows_affected=getattr(result, "rowcount", 0),
+    )
+    session.add(
+        Log(
+            event=updated_state.value,
+            task_id=task_id,
+            dag_id=dag_id,
+            run_id=run_id,
+            map_index=map_index,
+            try_number=try_number,
+            logical_date=logical_date,
+            owner=owners,
+            extra=json.dumps({"host_name": hostname}) if hostname else None,
         )
-        session.add(
-            Log(
-                event=updated_state.value,
-                task_id=task_id,
-                dag_id=dag_id,
-                run_id=run_id,
-                map_index=map_index,
-                try_number=try_number,
-                logical_date=logical_date,
-                owner=owners,
-                extra=json.dumps({"host_name": hostname}) if hostname else None,
-            )
-        )
-    except SQLAlchemyError as e:
-        log.error("Error updating Task Instance state", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
-        )
+    )
 
     if updated_state == TaskInstanceState.SUCCESS:
         if conf.getboolean("state_store", "clear_on_success"):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -16,7 +16,10 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import TaskInstance
 from airflow.api_fastapi.execution_api.versions import bundle
@@ -111,3 +114,30 @@ class TestCorrelationIdMiddleware:
 
         # Verify they didn't interfere with each other
         assert correlation_id_1 != correlation_id_2
+
+
+class TestDatabaseErrorHandler:
+    def test_sqlalchemy_error_returns_500(self, client):
+        """SQLAlchemyError on a real route is caught by the handler and returns 500."""
+        with mock.patch(
+            "airflow.api_fastapi.execution_api.routes.health.health",
+            side_effect=SQLAlchemyError("db failure"),
+        ):
+            response = client.get("/execution/health")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Database error occurred"}
+
+    def test_sqlalchemy_error_includes_correlation_id(self, client):
+        """correlation-id header is echoed in the error response body on SQLAlchemyError."""
+        correlation_id = "db-error-correlation-id"
+        with mock.patch(
+            "airflow.api_fastapi.execution_api.routes.health.health",
+            side_effect=SQLAlchemyError("db failure"),
+        ):
+            response = client.get("/execution/health", headers={"correlation-id": correlation_id})
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["detail"] == "Database error occurred"
+        assert body["correlation-id"] == correlation_id


### PR DESCRIPTION
The execution API had two routes (`ti_run`, `ti_update_state`) wrapping their `session.execute` calls in `try/except SQLAlchemyError` and converting to `HTTPException(500, "Database error occurred")`. The TODO in `routes/task_instances.py` flagged this for replacement with FastAPI's [custom exception handlers](https://fastapi.tiangolo.com/tutorial/handling-errors/#install-custom-exception-handlers).

This adds `@app.exception_handler(SQLAlchemyError)` alongside the existing catch-all in `execution_api/app.py`. The new handler logs the request path/method and returns `{"detail": "Database error occurred"}` with status 500 — the same shape the routes produced before. The per-route `try/except` blocks are removed and bodies dedented (which accounts for most of the line churn).

### Scope note

The TODO was only on `ti_update_state` (around the call to `session.execute(query)` that writes the new state + audit `Log`). However, `ti_run` had the **same** `try/except SQLAlchemyError` boilerplate without a TODO, doing literally the same translation. Once the global handler exists, both local catches become redundant, so this PR removes both for consistency rather than leaving the codebase in a half-migrated state.

If reviewers prefer a strict TODO-only scope, I'm happy to revert the `ti_run` change and open a separate cleanup PR for it.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

<!-- pr-triage-fold: triaged=2026-06-22T06:31:40.647663+00:00 head=683dc9a action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @ColtenOuO** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Tests** — failing: provider distributions tests / Compat 2.11.1:P3.10:, provider distributions tests / Compat 3.0.6:P3.10:, provider distributions tests / Compat 3.1.8:P3.10:, provider distributions tests / Compat 3.2.1:P3.10:.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->