### PR TITLE
Clarify scope of require_confirmation_dag_change in Airflow 2.x UI

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2130,10 +2130,12 @@ webserver:
       default: "1.0"
     require_confirmation_dag_change:
       description: |
-        Require confirmation when changing a DAG in the web UI. This is to prevent accidental changes
-        to a DAG that may be running on sensitive environments like production.
-        When set to ``True``, confirmation dialog will be shown when a user tries to Pause/Unpause,
-        Trigger a DAG
+        Require confirmation when changing a DAG in the web UI. This helps prevent accidental changes
+        in sensitive environments such as production.
+        When set to ``True``, a confirmation dialog is shown when a user tries to Pause/Unpause
+        or Trigger a DAG **from the DAG detail page** (Grid view).
+        In Airflow 2.x, this does **not** apply to Pause/Unpause or Trigger actions
+        on the DAG list page (``/home``).
       version_added: 2.9.0
       type: boolean
       example: ~


### PR DESCRIPTION
## Summary
Clarifies in `config.yml` that `require_confirmation_dag_change` shows confirmation
dialogs on the DAG detail page (Grid) in Airflow 2.x, not on the DAG list (`/home`).

## Context
Addresses confusion reported in https://github.com/apache/airflow/discussions/45852

## Test plan
- [x] Doc-only change (`airflow/config_templates/config.yml`)
- [x] CI docs build (on PR)

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)