### PR TITLE
Add support for mTLS and private CAs to the api client / server

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/gunicorn_app.py
+++ b/airflow-core/src/airflow/api_fastapi/gunicorn_app.py
@@ -44,6 +44,8 @@ from uvicorn.workers import UvicornWorker
 from airflow.configuration import conf
 
 if TYPE_CHECKING:
+    from ssl import VerifyMode
+
     from fastapi import FastAPI
     from gunicorn.app.base import Application
 
@@ -244,6 +246,7 @@ def create_gunicorn_app(
     ssl_cert: str | None = None,
     ssl_key: str | None = None,
     ssl_ca_file: str | None = None,
+    ssl_cert_reqs: VerifyMode | None = None,
     log_level: str = "info",
     proxy_headers: bool = False,
 ) -> AirflowGunicornApp:
@@ -256,6 +259,8 @@ def create_gunicorn_app(
     :param worker_timeout: Worker timeout in seconds
     :param ssl_cert: Path to SSL certificate file
     :param ssl_key: Path to SSL key file
+    :param ssl_ca_file: Path to the SSL CA certs file
+    :param ssl_cert_reqs: SSL client certificate requirements
     :param log_level: Log level (debug, info, warning, error, critical)
     :param proxy_headers: Whether to trust proxy headers
     """
@@ -278,6 +283,8 @@ def create_gunicorn_app(
         options["keyfile"] = ssl_key
         if ssl_ca_file:
             options["ca_certs"] = ssl_ca_file
+        if ssl_cert_reqs is not None:
+            options["cert_reqs"] = ssl_cert_reqs
 
     if proxy_headers:
         options["forwarded_allow_ips"] = "*"

--- a/airflow-core/src/airflow/api_fastapi/gunicorn_app.py
+++ b/airflow-core/src/airflow/api_fastapi/gunicorn_app.py
@@ -243,6 +243,7 @@ def create_gunicorn_app(
     worker_timeout: int,
     ssl_cert: str | None = None,
     ssl_key: str | None = None,
+    ssl_ca_file: str | None = None,
     log_level: str = "info",
     proxy_headers: bool = False,
 ) -> AirflowGunicornApp:
@@ -275,6 +276,8 @@ def create_gunicorn_app(
     if ssl_cert and ssl_key:
         options["certfile"] = ssl_cert
         options["keyfile"] = ssl_key
+        if ssl_ca_file:
+            options["ca_certs"] = ssl_ca_file
 
     if proxy_headers:
         options["forwarded_allow_ips"] = "*"

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -779,6 +779,7 @@ ARG_SSL_CERT_REQS = Arg(
     ("--ssl-cert-reqs",),
     default=conf.get("api", "ssl_cert_reqs", fallback="none"),
     help="(Optional) Set certificate verification options.",
+    choices=("none", "optional", "required"),
 )
 ARG_DEV = Arg(("-d", "--dev"), help="Start in development mode with hot-reload enabled", action="store_true")
 

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -775,6 +775,11 @@ ARG_SSL_CA_FILE = Arg(
     default=conf.get("api", "ssl_ca_file", fallback=None),
     help="(Optional) Path to the SSL CA file",
 )
+ARG_SSL_CERT_REQS = Arg(
+    ("--ssl-cert-reqs",),
+    default=conf.get("api", "ssl_cert_reqs", fallback="none"),
+    help="(Optional) Set certificate verification options.",
+)
 ARG_DEV = Arg(("-d", "--dev"), help="Start in development mode with hot-reload enabled", action="store_true")
 
 # scheduler
@@ -2179,6 +2184,7 @@ core_commands: list[CLICommand] = [
             ARG_SSL_CERT,
             ARG_SSL_KEY,
             ARG_SSL_CA_FILE,
+            ARG_SSL_CERT_REQS,
             ARG_DEV,
             ARG_API_SERVER_ALLOW_PROXY_FORWARDING,
         ),

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -770,6 +770,11 @@ ARG_SSL_KEY = Arg(
     default=conf.get("api", "ssl_key"),
     help="Path to the key to use with the SSL certificate",
 )
+ARG_SSL_CA_FILE = Arg(
+    ("--ssl-ca-file",),
+    default=conf.get("api", "ssl_ca_file", fallback=None),
+    help="(Optional) Path to the SSL CA file",
+)
 ARG_DEV = Arg(("-d", "--dev"), help="Start in development mode with hot-reload enabled", action="store_true")
 
 # scheduler
@@ -2173,6 +2178,7 @@ core_commands: list[CLICommand] = [
             ARG_LOG_FILE,
             ARG_SSL_CERT,
             ARG_SSL_KEY,
+            ARG_SSL_CA_FILE,
             ARG_DEV,
             ARG_API_SERVER_ALLOW_PROXY_FORWARDING,
         ),

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -64,7 +64,7 @@ def _run_api_server_with_gunicorn(
     """
     from airflow.api_fastapi.gunicorn_app import create_gunicorn_app
 
-    ssl_cert, ssl_key = _get_ssl_cert_and_key_filepaths(args)
+    ssl_cert, ssl_key, ssl_ca_file = _get_ssl_filepaths(args)
 
     log_level = conf.get("logging", "uvicorn_logging_level", fallback="info").lower()
 
@@ -75,6 +75,7 @@ def _run_api_server_with_gunicorn(
         worker_timeout=worker_timeout,
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
+        ssl_ca_file=ssl_ca_file,
         log_level=log_level,
         proxy_headers=proxy_headers,
     )
@@ -96,7 +97,7 @@ def _run_api_server_with_uvicorn(
     This is the default mode. Note that uvicorn's multiprocess mode does not
     share memory between workers (each worker loads everything independently).
     """
-    ssl_cert, ssl_key = _get_ssl_cert_and_key_filepaths(args)
+    ssl_cert, ssl_key, ssl_ca_file = _get_ssl_filepaths(args)
 
     # setproctitle causes issue on Mac OS: https://github.com/benoitc/gunicorn/issues/3021
     os_type = sys.platform
@@ -118,6 +119,7 @@ def _run_api_server_with_uvicorn(
         "timeout_worker_healthcheck": worker_timeout,
         "ssl_keyfile": ssl_key,
         "ssl_certfile": ssl_cert,
+        "ssl_ca_certs": ssl_ca_file,
         # HttpAccessLogMiddleware handles access logging; disable uvicorn's built-in access log.
         "access_log": False,
         "log_level": uvicorn_log_level,
@@ -254,21 +256,23 @@ def api_server(args: Namespace):
     )
 
 
-def _get_ssl_cert_and_key_filepaths(cli_arguments) -> tuple[str | None, str | None]:
+def _get_ssl_filepaths(cli_arguments) -> tuple[str | None, str | None, str | None]:
     error_template_1 = "Need both, have provided {} but not {}"
     error_template_2 = "SSL related file does not exist {}"
 
-    ssl_cert, ssl_key = cli_arguments.ssl_cert, cli_arguments.ssl_key
+    ssl_cert, ssl_key, ssl_ca_file = cli_arguments.ssl_cert, cli_arguments.ssl_key, cli_arguments.ssl_ca_file
     if ssl_cert and ssl_key:
         if not os.path.isfile(ssl_cert):
             raise AirflowConfigException(error_template_2.format(ssl_cert))
         if not os.path.isfile(ssl_key):
             raise AirflowConfigException(error_template_2.format(ssl_key))
+        if ssl_ca_file is not None and not os.path.isfile(ssl_ca_file):
+            raise AirflowConfigException(error_template_2.format(ssl_ca_file))
 
-        return (ssl_cert, ssl_key)
+        return (ssl_cert, ssl_key, ssl_ca_file)
     if ssl_cert:
         raise AirflowConfigException(error_template_1.format("SSL certificate", "SSL key"))
     if ssl_key:
         raise AirflowConfigException(error_template_1.format("SSL key", "SSL certificate"))
 
-    return (None, None)
+    return (None, None, None)

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import os
+import ssl
 import sys
 import textwrap
 from collections.abc import Callable
@@ -76,6 +77,7 @@ def _run_api_server_with_gunicorn(
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
         ssl_ca_file=ssl_ca_file,
+        ssl_cert_reqs=_ssl_cert_reqs(args),
         log_level=log_level,
         proxy_headers=proxy_headers,
     )
@@ -120,6 +122,7 @@ def _run_api_server_with_uvicorn(
         "ssl_keyfile": ssl_key,
         "ssl_certfile": ssl_cert,
         "ssl_ca_certs": ssl_ca_file,
+        "ssl_cert_reqs": _ssl_cert_reqs(args),
         # HttpAccessLogMiddleware handles access logging; disable uvicorn's built-in access log.
         "access_log": False,
         "log_level": uvicorn_log_level,
@@ -276,3 +279,13 @@ def _get_ssl_filepaths(cli_arguments) -> tuple[str | None, str | None, str | Non
         raise AirflowConfigException(error_template_1.format("SSL key", "SSL certificate"))
 
     return (None, None, None)
+
+def _ssl_cert_reqs(cli_arguments):
+    cert_reqs = cli_arguments.ssl_cert_reqs
+    if cert_reqs is None or cert_reqs == "none":
+        return ssl.CERT_NONE
+    if cert_reqs == "required":
+        return ssl.CERT_REQUIRED
+    if cert_reqs == "optional":
+        return ssl.CERT_OPTIONAL
+    raise ValueError("Invalid ssl cert reqs option: %s", cert_reqs)

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -288,4 +288,4 @@ def _ssl_cert_reqs(cli_arguments):
         return ssl.CERT_REQUIRED
     if cert_reqs == "optional":
         return ssl.CERT_OPTIONAL
-    raise ValueError("Invalid ssl cert reqs option: %s", cert_reqs)
+    raise ValueError(f"Invalid ssl_cert_reqs option: {cert_reqs}")

--- a/airflow-core/src/airflow/cli/commands/api_server_command.py
+++ b/airflow-core/src/airflow/cli/commands/api_server_command.py
@@ -280,6 +280,7 @@ def _get_ssl_filepaths(cli_arguments) -> tuple[str | None, str | None, str | Non
 
     return (None, None, None)
 
+
 def _ssl_cert_reqs(cli_arguments):
     cert_reqs = cli_arguments.ssl_cert_reqs
     if cert_reqs is None or cert_reqs == "none":

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1774,6 +1774,15 @@ api:
       type: string
       example: ~
       default: ~
+    ssl_cert_reqs:
+      description: |
+        Enable ssl certificate verification on the api server.
+        See https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode
+        Valid options are 'none', 'optional' or 'required'
+      version_added: ~
+      type: string
+      example: "required"
+      default: "none"
     maximum_page_limit:
       description: |
         Used to set the maximum page limit for API requests. If limit passed as param

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1767,6 +1767,13 @@ api:
       type: string
       example: ~
       default: ""
+    ssl_ca_file:
+      description: |
+        Path to the SSL CA file for the api server. Defaults to None.
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
     maximum_page_limit:
       description: |
         Used to set the maximum page limit for API requests. If limit passed as param

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1892,6 +1892,13 @@ api:
       type: string
       example: "/etc/airflow/certs/client.key"
       default: ~
+    client_use_public_certs:
+      description: |
+        Enable loading of public CA certificates from certifi into the client SSL context.
+      version_added: ~
+      type: boolean
+      example: ~
+      default: "True"
 workers:
   description: Configuration related to workers that run Airflow tasks.
   options:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1773,7 +1773,7 @@ api:
       version_added: ~
       type: string
       example: ~
-      default: ""
+      default: ~
     maximum_page_limit:
       description: |
         Used to set the maximum page limit for API requests. If limit passed as param

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import ssl
 import sys
 from unittest import mock
 
@@ -147,6 +148,8 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "ssl_key_path_placeholder",
                     "--ssl-ca-file",
                     "ssl_ca_file_placeholder",
+                    "--ssl-cert-reqs",
+                    "required",
                     "--apps",
                     "core",
                 ],
@@ -154,6 +157,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "ssl_keyfile": "ssl_key_path_placeholder",
                     "ssl_certfile": "ssl_cert_path_placeholder",
                     "ssl_ca_certs": "ssl_ca_file_placeholder",
+                    "ssl_cert_reqs": ssl.CERT_REQUIRED,
                 },
                 id="api-server with SSL cert and key",
             ),
@@ -167,6 +171,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "ssl_keyfile": None,
                     "ssl_certfile": None,
                     "ssl_ca_certs": None,
+                    "ssl_cert_reqs": ssl.CERT_NONE,
                     "log_config": "my_log_config.yaml",
                 },
                 id="api-server with log config",
@@ -255,6 +260,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             ssl_keyfile=None,
             ssl_certfile=None,
             ssl_ca_certs=None,
+            ssl_cert_reqs=ssl.CERT_NONE,
             access_log=False,
             log_level="info",
             proxy_headers=False,

--- a/airflow-core/tests/unit/cli/commands/test_api_server_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_api_server_command.py
@@ -145,12 +145,15 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                     "ssl_cert_path_placeholder",
                     "--ssl-key",
                     "ssl_key_path_placeholder",
+                    "--ssl-ca-file",
+                    "ssl_ca_file_placeholder",
                     "--apps",
                     "core",
                 ],
                 {
                     "ssl_keyfile": "ssl_key_path_placeholder",
                     "ssl_certfile": "ssl_cert_path_placeholder",
+                    "ssl_ca_certs": "ssl_ca_file_placeholder",
                 },
                 id="api-server with SSL cert and key",
             ),
@@ -163,20 +166,24 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
                 {
                     "ssl_keyfile": None,
                     "ssl_certfile": None,
+                    "ssl_ca_certs": None,
                     "log_config": "my_log_config.yaml",
                 },
                 id="api-server with log config",
             ),
         ],
     )
-    def test_args_to_uvicorn(self, ssl_cert_and_key, cli_args, expected_additional_kwargs):
-        cert_path, key_path = ssl_cert_and_key
+    def test_args_to_uvicorn(self, ssl_cert_key_and_ca, cli_args, expected_additional_kwargs):
+        cert_path, key_path, ca_path = ssl_cert_key_and_ca
         if "ssl_cert_path_placeholder" in cli_args:
             cli_args[cli_args.index("ssl_cert_path_placeholder")] = str(cert_path)
             expected_additional_kwargs["ssl_certfile"] = str(cert_path)
         if "ssl_key_path_placeholder" in cli_args:
             cli_args[cli_args.index("ssl_key_path_placeholder")] = str(key_path)
             expected_additional_kwargs["ssl_keyfile"] = str(key_path)
+        if "ssl_ca_file_placeholder" in cli_args:
+            cli_args[cli_args.index("ssl_ca_file_placeholder")] = str(ca_path)
+            expected_additional_kwargs["ssl_ca_certs"] = str(ca_path)
 
         with (
             mock.patch("uvicorn.run") as mock_run,
@@ -247,6 +254,7 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             timeout_worker_healthcheck=60,
             ssl_keyfile=None,
             ssl_certfile=None,
+            ssl_ca_certs=None,
             access_log=False,
             log_level="info",
             proxy_headers=False,
@@ -314,22 +322,24 @@ class TestCliApiServer(_CommonCLIUvicornTestClass):
             (["--ssl-key", "_.key"], "Need both.*key.*certificate"),
         ],
     )
-    def test_get_ssl_cert_and_key_filepaths_with_incorrect_usage(self, ssl_arguments, error_pattern):
+    def test_get_ssl_filepaths_with_incorrect_usage(self, ssl_arguments, error_pattern):
         args = self.parser.parse_args(["api-server"] + ssl_arguments)
         with pytest.raises(AirflowConfigException, match=error_pattern):
-            api_server_command._get_ssl_cert_and_key_filepaths(args)
+            api_server_command._get_ssl_filepaths(args)
 
-    def test_get_ssl_cert_and_key_filepaths_with_correct_usage(self, ssl_cert_and_key):
-        cert_path, key_path = ssl_cert_and_key
+    def test_get_ssl_filepaths_with_correct_usage(self, ssl_cert_key_and_ca):
+        cert_path, key_path, ca_path = ssl_cert_key_and_ca
 
         args = self.parser.parse_args(
-            ["api-server"] + ["--ssl-cert", str(cert_path), "--ssl-key", str(key_path)]
+            ["api-server"]
+            + ["--ssl-cert", str(cert_path), "--ssl-key", str(key_path), "--ssl-ca-file", str(ca_path)]
         )
-        assert api_server_command._get_ssl_cert_and_key_filepaths(args) == (str(cert_path), str(key_path))
+        assert api_server_command._get_ssl_filepaths(args) == (str(cert_path), str(key_path), str(ca_path))
 
     @pytest.fixture
-    def ssl_cert_and_key(self, tmp_path):
-        cert_path, key_path = tmp_path / "_.crt", tmp_path / "_.key"
+    def ssl_cert_key_and_ca(self, tmp_path):
+        cert_path, key_path, ca_path = tmp_path / "_.crt", tmp_path / "_.key", tmp_path / "ca.crt"
         cert_path.touch()
         key_path.touch()
-        return cert_path, key_path
+        ca_path.touch()
+        return cert_path, key_path, ca_path

--- a/airflow-core/tests/unit/cli/commands/test_gunicorn_monitor.py
+++ b/airflow-core/tests/unit/cli/commands/test_gunicorn_monitor.py
@@ -430,12 +430,14 @@ class TestCreateGunicornApp:
                 worker_timeout=120,
                 ssl_cert="/path/to/cert.pem",
                 ssl_key="/path/to/key.pem",
+                ssl_ca_file="/path/to/ca.crt",
             )
 
             options = mock_app_class.call_args[0][0]
 
             assert options["certfile"] == "/path/to/cert.pem"
             assert options["keyfile"] == "/path/to/key.pem"
+            assert options["ca_certs"] == "/path/to/ca.crt"
 
     def test_create_app_with_proxy_headers(self):
         """Test creating an app with proxy headers enabled."""

--- a/airflow-core/tests/unit/cli/commands/test_gunicorn_monitor.py
+++ b/airflow-core/tests/unit/cli/commands/test_gunicorn_monitor.py
@@ -431,6 +431,7 @@ class TestCreateGunicornApp:
                 ssl_cert="/path/to/cert.pem",
                 ssl_key="/path/to/key.pem",
                 ssl_ca_file="/path/to/ca.crt",
+                ssl_cert_reqs=1,
             )
 
             options = mock_app_class.call_args[0][0]
@@ -438,6 +439,7 @@ class TestCreateGunicornApp:
             assert options["certfile"] == "/path/to/cert.pem"
             assert options["keyfile"] == "/path/to/key.pem"
             assert options["ca_certs"] == "/path/to/ca.crt"
+            assert options["cert_reqs"] == 1
 
     def test_create_app_with_proxy_headers(self):
         """Test creating an app with proxy headers enabled."""

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1089,6 +1089,7 @@ API_RETRIES = conf.getint("workers", "execution_api_retries")
 API_RETRY_WAIT_MIN = conf.getfloat("workers", "execution_api_retry_wait_min")
 API_RETRY_WAIT_MAX = conf.getfloat("workers", "execution_api_retry_wait_max")
 API_SSL_CERT_PATH = conf.get("api", "ssl_cert")
+API_SSL_CA_FILE_PATH = conf.get("api", "ssl_ca_file", fallback=certifi.where())
 API_TIMEOUT = conf.getfloat("workers", "execution_api_timeout")
 API_CLIENT_SSL_CERT = conf.get("api", "client_ssl_cert", fallback=None)
 API_CLIENT_SSL_KEY = conf.get("api", "client_ssl_key", fallback=None)
@@ -1105,8 +1106,13 @@ def _should_retry_api_request(exception: BaseException) -> bool:
 class Client(httpx.Client):
     @lru_cache()
     @staticmethod
-    def _get_ssl_context_cached(ca_file: str, ca_path: str | None = None) -> ssl.SSLContext:
-        """Cache SSL context to prevent memory growth from repeated context creation."""
+    def _get_ssl_context_cached(ca_file: str | None = None, ca_path: str | None = None) -> ssl.SSLContext:
+        """
+        Cache SSL context to prevent memory growth from repeated context creation.
+
+        :param ca_file: Certificate Authority.
+        :param ca_path: Certificate File, optional.
+        """
         ctx = ssl.create_default_context(cafile=ca_file)
         if ca_path:
             ctx.load_verify_locations(ca_path)
@@ -1125,7 +1131,7 @@ class Client(httpx.Client):
         else:
             kwargs["base_url"] = base_url
             # Call via the class to avoid binding lru_cache wires to this instance.
-            kwargs["verify"] = type(self)._get_ssl_context_cached(certifi.where(), API_SSL_CERT_PATH)
+            kwargs["verify"] = type(self)._get_ssl_context_cached(API_SSL_CA_FILE_PATH, API_SSL_CERT_PATH)
 
             if API_CLIENT_SSL_CERT or API_CLIENT_SSL_KEY:
                 if not (API_CLIENT_SSL_CERT and API_CLIENT_SSL_KEY):

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1089,10 +1089,11 @@ API_RETRIES = conf.getint("workers", "execution_api_retries")
 API_RETRY_WAIT_MIN = conf.getfloat("workers", "execution_api_retry_wait_min")
 API_RETRY_WAIT_MAX = conf.getfloat("workers", "execution_api_retry_wait_max")
 API_SSL_CERT_PATH = conf.get("api", "ssl_cert")
-API_SSL_CA_FILE_PATH = conf.get("api", "ssl_ca_file", fallback=certifi.where())
+API_SSL_CA_FILE_PATH = conf.get("api", "ssl_ca_file", fallback=None)
 API_TIMEOUT = conf.getfloat("workers", "execution_api_timeout")
 API_CLIENT_SSL_CERT = conf.get("api", "client_ssl_cert", fallback=None)
 API_CLIENT_SSL_KEY = conf.get("api", "client_ssl_key", fallback=None)
+API_CLIENT_USE_PUBLIC_CERTS = conf.getboolean("api", "client_use_public_certs", fallback=True)
 
 
 def _should_retry_api_request(exception: BaseException) -> bool:
@@ -1110,10 +1111,15 @@ class Client(httpx.Client):
         """
         Cache SSL context to prevent memory growth from repeated context creation.
 
-        :param ca_file: Certificate Authority.
+        If `client_use_public_certs` is enabled certifi.where() will be loaded into the context.
+
+        :param ca_file: Certificate Authority, optional.
         :param ca_path: Certificate File, optional.
         """
         ctx = ssl.create_default_context(cafile=ca_file)
+        if API_CLIENT_USE_PUBLIC_CERTS:
+            log.info("Using Public CAs from certifi")
+            ctx.load_verify_locations(certifi.where())
         if ca_path:
             ctx.load_verify_locations(ca_path)
         return ctx

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -116,6 +116,15 @@ class TestClient:
 
         assert isinstance(err.value, FileNotFoundError)
 
+    @mock.patch("ssl.SSLContext")
+    @mock.patch("airflow.sdk.api.client.API_CLIENT_USE_PUBLIC_CERTS", True)
+    def test_use_public_certs(self, mock_use_public_certs, mock_ssl_context):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=200)
+
+        make_client(httpx.MockTransport(handle_request))
+        mock_ssl_context.load_verify_locations.assert_called_with(certifi.where())
+
     @mock.patch("airflow.sdk.api.client.API_TIMEOUT", 60.0)
     def test_timeout_configuration(self):
         def handle_request(request: httpx.Request) -> httpx.Response:

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -116,14 +116,14 @@ class TestClient:
 
         assert isinstance(err.value, FileNotFoundError)
 
-    @mock.patch("ssl.SSLContext")
+    @mock.patch("ssl.create_default_context")
     @mock.patch("airflow.sdk.api.client.API_CLIENT_USE_PUBLIC_CERTS", True)
-    def test_use_public_certs(self, mock_use_public_certs, mock_ssl_context):
+    def test_use_public_certs(self, mock_default_context):
         def handle_request(request: httpx.Request) -> httpx.Response:
             return httpx.Response(status_code=200)
 
         make_client(httpx.MockTransport(handle_request))
-        mock_ssl_context.load_verify_locations.assert_called_with(certifi.where())
+        mock_default_context.return_value.load_verify_locations.assert_called_with(certifi.where())
 
     @mock.patch("airflow.sdk.api.client.API_TIMEOUT", 60.0)
     def test_timeout_configuration(self):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -106,6 +106,16 @@ class TestClient:
 
         assert isinstance(err.value, FileNotFoundError)
 
+    @mock.patch("airflow.sdk.api.client.API_SSL_CA_FILE_PATH", "/capath/does/not/exist/")
+    def test_ssl_with_cafile(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=200)
+
+        with pytest.raises(FileNotFoundError) as err:
+            make_client(httpx.MockTransport(handle_request))
+
+        assert isinstance(err.value, FileNotFoundError)
+
     @mock.patch("airflow.sdk.api.client.API_TIMEOUT", 60.0)
     def test_timeout_configuration(self):
         def handle_request(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Add `ssl_ca_file` config option to specify root CA bundle
---

When using mTLS for the execution api, certificate verification fails if the CA for the certificate is not loaded into the ssl context. By specifying the CA using `--ssl-ca-file` (or `[api] ssl_ca_file` in the config), the required root certificate can be specified. This is a common use case for enterprise applications that use a private root CA.

Add an option for using the certifi public certificates as `[api] client_use_public_certs`, which is enabled by default. This is separate from any certificate added by the `ssl_ca_file` option.

Adding the `--ssl-cert-reqs` (`[api] ssl_cert_reqs`) option allows enabling server-side certificate verification using `required` / `ssl.CERT_REQUIRED`

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

