### PR TITLE
Sync ``RuntimeTaskInstanceProtocol`` with ``RuntimeTaskInstance``

### DIFF
--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -30,6 +30,7 @@ __all__ = ["TaskInstance", "TaskInstanceKey"]
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    import jinja2
     from pydantic import AwareDatetime, JsonValue
 
     from airflow.models.taskinstance import TaskInstance as SchedulerTaskInstance
@@ -135,10 +136,18 @@ class RuntimeTaskInstanceProtocol(Protocol):
     start_date: AwareDatetime
     end_date: AwareDatetime | None = None
     state: TaskInstanceState | None = None
+    is_mapped: bool | None = None
+    rendered_map_index: str | None = None
+
+    @property
+    def log_url(self) -> str: ...
+
+    @property
+    def mark_success_url(self) -> str: ...
 
     def xcom_pull(
         self,
-        task_ids: str | list[str] | None = None,
+        task_ids: str | Iterable[str] | None = None,
         dag_id: str | None = None,
         key: str = BaseXCom.XCOM_RETURN_KEY,
         include_prior_dates: bool = False,
@@ -152,7 +161,13 @@ class RuntimeTaskInstanceProtocol(Protocol):
 
     def get_template_context(self) -> Context: ...
 
-    def get_first_reschedule_date(self, first_try_number) -> AwareDatetime | None: ...
+    def render_templates(
+        self,
+        context: Context | None = None,
+        jinja_env: jinja2.Environment | None = None,
+    ) -> BaseOperator: ...
+
+    def get_first_reschedule_date(self, context: Context) -> AwareDatetime | None: ...
 
     def get_previous_dagrun(self, state: str | None = None) -> DagRunProtocol | None: ...
 


### PR DESCRIPTION

`RuntimeTaskInstanceProtocol` (`task-sdk/src/airflow/sdk/types.py`) had drifted from `RuntimeTaskInstance` (`task-sdk/src/airflow/sdk/execution_time/task_runner.py`). This PR realigns the public protocol with what the runtime implementation actually exposes.

## What changed

- **Fix `get_first_reschedule_date` signature.** The protocol declared `(self, first_try_number)` but both the implementation and the only caller ([`sdk/bases/sensor.py:188`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/bases/sensor.py#L188)) take a `Context`. Anyone type-checking against the protocol would have been told the wrong shape.
- **Broaden `xcom_pull.task_ids`** to `str | Iterable[str] | None` to match the implementation (was `str | list[str] | None`).
- **Add missing public surface** present on `RuntimeTaskInstance` but absent from the protocol:
  - `log_url` and `mark_success_url` properties (referenced externally, e.g. [openlineage](https://github.com/apache/airflow/blob/main/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py#L1056) via `getattr(ti, "log_url", None)`).
  - `render_templates(context, jinja_env)` method.
  - `is_mapped` and `rendered_map_index` fields.
