### PR TITLE
Fix multiple_outputs no-op on deferrable KubernetesPodOperator

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -28,7 +28,7 @@ import os
 import re
 import shlex
 import string
-from collections.abc import Callable, Container, Iterable, Sequence
+from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from contextlib import AbstractContextManager, suppress
 from enum import Enum
 from functools import cached_property
@@ -1074,17 +1074,12 @@ class KubernetesPodOperator(BaseOperator):
                         "Trigger emitted an %s event, failing the task: %s", event["status"], event["message"]
                     )
                     message = event.get("stack_trace", event["message"])
-                    # Push manually before the raise — matches the sync-path
-                    # failure-push in cleanup ("Ensure that existing XCom is
-                    # pushed even in case of failure").
-                    if self.do_xcom_push and xcom_sidecar_output:
-                        context["ti"].xcom_push(XCOM_RETURN_KEY, xcom_sidecar_output)
+                    if self.do_xcom_push:
+                        self._push_xcom_with_fan_out(context["ti"], xcom_sidecar_output)
                     raise AirflowException(message)
         finally:
             self._clean(event=event, context=context, result=xcom_sidecar_output)
 
-        # Return on success so the task runner's _push_xcom_if_needed handles
-        # return_value and multiple_outputs fan-out, matching execute_sync.
         if self.do_xcom_push:
             return xcom_sidecar_output
 
@@ -1115,6 +1110,31 @@ class KubernetesPodOperator(BaseOperator):
                 context=context,
                 result=result,
             )
+
+    def _push_xcom_with_fan_out(self, ti: Any, value: Any) -> None:
+        """Push ``return_value`` and, when ``multiple_outputs`` is set, also fan a dict out per key.
+
+        Mirrors the task runner's ``_push_xcom_if_needed`` so the failure-path manual pushes
+        in ``cleanup`` (sync) and ``trigger_reentry`` (async) honour ``multiple_outputs`` —
+        previously they pushed only ``return_value``, silently dropping per-key fan-out.
+        On success both paths return the value and let the runner perform the push instead.
+        """
+        if not value:
+            return
+        if self.multiple_outputs:
+            if not isinstance(value, Mapping):
+                raise TypeError(
+                    f"Returned output was type {type(value)} expected dictionary for multiple_outputs"
+                )
+            for key in value:
+                if not isinstance(key, str):
+                    raise TypeError(
+                        "Returned dictionary keys must be strings when using "
+                        f"multiple_outputs, found {key} ({type(key)}) instead"
+                    )
+            for k, v in value.items():
+                ti.xcom_push(k, v)
+        ti.xcom_push(XCOM_RETURN_KEY, value)
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(3),
@@ -1197,9 +1217,9 @@ class KubernetesPodOperator(BaseOperator):
             failed = pod_phase != PodPhase.SUCCEEDED
 
         if failed:
-            if self.do_xcom_push and xcom_result and context:
+            if self.do_xcom_push and context:
                 # Ensure that existing XCom is pushed even in case of failure
-                context["ti"].xcom_push(XCOM_RETURN_KEY, xcom_result)
+                self._push_xcom_with_fan_out(context["ti"], xcom_result)
 
             if self.log_events_on_failure:
                 self._read_pod_container_states(pod, reraise=False)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1112,14 +1112,15 @@ class KubernetesPodOperator(BaseOperator):
             )
 
     def _push_xcom_with_fan_out(self, ti: Any, value: Any) -> None:
-        """Push ``return_value`` and, when ``multiple_outputs`` is set, also fan a dict out per key.
+        """
+        Push ``return_value`` and, when ``multiple_outputs`` is set, also fan a dict out per key.
 
         Mirrors the task runner's ``_push_xcom_if_needed`` so the failure-path manual pushes
         in ``cleanup`` (sync) and ``trigger_reentry`` (async) honour ``multiple_outputs`` —
         previously they pushed only ``return_value``, silently dropping per-key fan-out.
         On success both paths return the value and let the runner perform the push instead.
         """
-        if not value:
+        if value is None:
             return
         if self.multiple_outputs:
             if not isinstance(value, Mapping):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1074,12 +1074,19 @@ class KubernetesPodOperator(BaseOperator):
                         "Trigger emitted an %s event, failing the task: %s", event["status"], event["message"]
                     )
                     message = event.get("stack_trace", event["message"])
+                    # Push manually before the raise — matches the sync-path
+                    # failure-push in cleanup ("Ensure that existing XCom is
+                    # pushed even in case of failure").
+                    if self.do_xcom_push and xcom_sidecar_output:
+                        context["ti"].xcom_push(XCOM_RETURN_KEY, xcom_sidecar_output)
                     raise AirflowException(message)
         finally:
             self._clean(event=event, context=context, result=xcom_sidecar_output)
 
-            if self.do_xcom_push and xcom_sidecar_output:
-                context["ti"].xcom_push(XCOM_RETURN_KEY, xcom_sidecar_output)
+        # Return on success so the task runner's _push_xcom_if_needed handles
+        # return_value and multiple_outputs fan-out, matching execute_sync.
+        if self.do_xcom_push:
+            return xcom_sidecar_output
 
     def _clean(self, event: dict[str, Any], result: dict | None, context: Context) -> None:
         if self.pod is None:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -3451,13 +3451,17 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
     # check if it gets the pod
     mocked_hook.return_value.get_pod.assert_called_once_with(TEST_NAME, TEST_NAMESPACE)
 
-    # assert that the xcom are extracted/not extracted
+    # On the success path, ``trigger_reentry`` returns the sidecar output and
+    # leaves the XCom push to the task runner's ``_push_xcom_if_needed`` —
+    # see #67224. The operator no longer pushes ``return_value`` manually here.
     if do_xcom_push:
         mock_extract_xcom.assert_called_once()
-        context["ti"].xcom_push.assert_called_with(XCOM_RETURN_KEY, mock_extract_xcom.return_value)
+        assert result is mock_extract_xcom.return_value
+        context["ti"].xcom_push.assert_not_called()
     else:
         mock_extract_xcom.assert_not_called()
         assert result is None
+        context["ti"].xcom_push.assert_not_called()
 
     # check if it waits for the pod to complete
     assert read_pod_mock.call_count == 3
@@ -3498,22 +3502,73 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     # check if it gets the pod
     mocked_hook.return_value.get_pod.assert_called_once_with(TEST_NAME, TEST_NAMESPACE)
 
-    # assert that it does not push the xcom
-    ti_mock.xcom_push.assert_not_called()
-
+    # On the failure path, the operator pushes ``return_value`` manually
+    # before raising so partial sidecar output is preserved even when the
+    # task runner won't see a return value (see #67224). This happens
+    # before the ``finally``-block ``_clean`` runs, so even a failing
+    # cleanup (simulated here via side_effect) doesn't suppress the push.
     if do_xcom_push:
-        # assert that the xcom are not extracted if do_xcom_push is False
         mock_extract_xcom.assert_called_once()
+        ti_mock.xcom_push.assert_called_once_with(XCOM_RETURN_KEY, mock_extract_xcom.return_value)
     else:
-        # but that it is extracted when do_xcom_push is true because the sidecare
-        # needs to be terminated
+        # ``extract_xcom`` is skipped entirely when ``do_xcom_push=False``,
+        # and there's nothing to push.
         mock_extract_xcom.assert_not_called()
+        ti_mock.xcom_push.assert_not_called()
 
     # check if it waits for the pod to complete
     assert read_pod_mock.call_count == 3
 
     # assert that the cleanup is called
     post_complete_action.assert_called_once()
+
+
+@patch(KUB_OP_PATH.format("extract_xcom"))
+@patch(KUB_OP_PATH.format("post_complete_action"))
+@patch(HOOK_CLASS)
+def test_async_trigger_reentry_returns_sidecar_output_for_multiple_outputs(
+    mocked_hook, post_complete_action, mock_extract_xcom
+):
+    """``trigger_reentry`` must return the sidecar output so the task runner
+    runs ``_push_xcom_if_needed``, which honors ``multiple_outputs`` by fanning
+    out the returned dict into per-key XComs. Before #67224 the operator pushed
+    ``return_value`` manually inside the ``finally`` block and returned
+    ``None``, which silently bypassed the runner's fan-out — making
+    ``multiple_outputs=True`` a no-op on deferrable KPO. The sync path's
+    ``execute_sync`` already returns ``result`` (line 760 in pod.py); this
+    test pins the deferrable path to the same contract.
+    """
+    metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
+    succeeded_state = mock.MagicMock(**metadata, **{"status.phase": "Succeeded"})
+    mocked_hook.return_value.get_pod.return_value = succeeded_state
+    # ``return_value`` (not ``side_effect``) so the pod-await poll loop can
+    # call this any number of times without exhausting a fixed list.
+    mocked_hook.return_value.core_v1_client.read_namespaced_pod.return_value = succeeded_state
+
+    sidecar_output = {"export_arn": "arn:aws:dynamodb:::export/x", "s3_uri": "s3://b/p"}
+    mock_extract_xcom.return_value = sidecar_output
+
+    k = KubernetesPodOperator(task_id="task", deferrable=True, do_xcom_push=True, multiple_outputs=True)
+    context = create_context(k)
+    context["ti"].xcom_push = MagicMock()
+
+    success_event = {
+        "status": "success",
+        "message": TEST_SUCCESS_MESSAGE,
+        "name": TEST_NAME,
+        "namespace": TEST_NAMESPACE,
+    }
+
+    result = k.trigger_reentry(context, success_event)
+
+    # The dict is returned — this is the fix. The task runner's
+    # ``_push_xcom_if_needed`` (in ``task-sdk/.../execution_time/task_runner.py``)
+    # then handles both ``return_value`` push and the ``multiple_outputs``
+    # per-key fan-out, exercised end-to-end in ``test-sdk/`` unit tests.
+    assert result is sidecar_output
+    # The operator itself no longer pushes ``return_value`` manually on the
+    # success path — that would double-push when the runner fires.
+    context["ti"].xcom_push.assert_not_called()
 
 
 def test_default_container_logs():

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import re
 from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING
@@ -1883,6 +1884,33 @@ class TestKubernetesPodOperator:
 
         context["ti"].xcom_push.assert_called_with(XCOM_RETURN_KEY, {"Test key": "Test value"})
 
+    @patch(f"{POD_MANAGER_CLASS}.extract_xcom")
+    @patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start")
+    @patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
+    def test_xcom_push_failed_pod_fans_out_for_multiple_outputs(
+        self, remote_pod, mock_await, mock_extract_xcom
+    ):
+        """On the sync failure path, ``multiple_outputs=True`` must fan the sidecar dict out
+        into per-key XComs in addition to the ``return_value`` push — matching the task runner
+        behaviour applied on the success path.
+        """
+        k = KubernetesPodOperator(
+            task_id="task", on_finish_action="delete_pod", do_xcom_push=True, multiple_outputs=True
+        )
+
+        remote_pod.return_value.status.phase = "Failed"
+        sidecar_output = {"export_arn": "arn:aws:dynamodb:::export/x", "s3_uri": "s3://b/p"}
+        mock_extract_xcom.return_value = json.dumps(sidecar_output)
+        context = create_context(k)
+        context["ti"].xcom_push = MagicMock()
+
+        with pytest.raises(AirflowException):
+            k.execute(context=context)
+
+        context["ti"].xcom_push.assert_any_call("export_arn", "arn:aws:dynamodb:::export/x")
+        context["ti"].xcom_push.assert_any_call("s3_uri", "s3://b/p")
+        context["ti"].xcom_push.assert_any_call(XCOM_RETURN_KEY, sidecar_output)
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("kwargs", "actual_exit_code", "expected_exc"),
@@ -3451,12 +3479,9 @@ def test_async_kpo_wait_termination_before_cleanup_on_success(
     # check if it gets the pod
     mocked_hook.return_value.get_pod.assert_called_once_with(TEST_NAME, TEST_NAMESPACE)
 
-    # On the success path, ``trigger_reentry`` returns the sidecar output and
-    # leaves the XCom push to the task runner's ``_push_xcom_if_needed`` —
-    # see #67224. The operator no longer pushes ``return_value`` manually here.
     if do_xcom_push:
         mock_extract_xcom.assert_called_once()
-        assert result is mock_extract_xcom.return_value
+        assert result == mock_extract_xcom.return_value
         context["ti"].xcom_push.assert_not_called()
     else:
         mock_extract_xcom.assert_not_called()
@@ -3502,17 +3527,12 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
     # check if it gets the pod
     mocked_hook.return_value.get_pod.assert_called_once_with(TEST_NAME, TEST_NAMESPACE)
 
-    # On the failure path, the operator pushes ``return_value`` manually
-    # before raising so partial sidecar output is preserved even when the
-    # task runner won't see a return value (see #67224). This happens
-    # before the ``finally``-block ``_clean`` runs, so even a failing
-    # cleanup (simulated here via side_effect) doesn't suppress the push.
+    # The failure-path push happens before the ``finally``-block ``_clean`` runs,
+    # so even a failing cleanup (simulated here via side_effect) doesn't suppress it.
     if do_xcom_push:
         mock_extract_xcom.assert_called_once()
         ti_mock.xcom_push.assert_called_once_with(XCOM_RETURN_KEY, mock_extract_xcom.return_value)
     else:
-        # ``extract_xcom`` is skipped entirely when ``do_xcom_push=False``,
-        # and there's nothing to push.
         mock_extract_xcom.assert_not_called()
         ti_mock.xcom_push.assert_not_called()
 
@@ -3529,20 +3549,13 @@ def test_async_kpo_wait_termination_before_cleanup_on_failure(
 def test_async_trigger_reentry_returns_sidecar_output_for_multiple_outputs(
     mocked_hook, post_complete_action, mock_extract_xcom
 ):
-    """``trigger_reentry`` must return the sidecar output so the task runner
-    runs ``_push_xcom_if_needed``, which honors ``multiple_outputs`` by fanning
-    out the returned dict into per-key XComs. Before #67224 the operator pushed
-    ``return_value`` manually inside the ``finally`` block and returned
-    ``None``, which silently bypassed the runner's fan-out — making
-    ``multiple_outputs=True`` a no-op on deferrable KPO. The sync path's
-    ``execute_sync`` already returns ``result`` (line 760 in pod.py); this
-    test pins the deferrable path to the same contract.
+    """On the success path with ``multiple_outputs=True``, ``trigger_reentry`` returns the
+    sidecar dict and does not push ``return_value`` itself — the task runner's
+    ``_push_xcom_if_needed`` handles both the ``return_value`` push and the per-key fan-out.
     """
     metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
     succeeded_state = mock.MagicMock(**metadata, **{"status.phase": "Succeeded"})
     mocked_hook.return_value.get_pod.return_value = succeeded_state
-    # ``return_value`` (not ``side_effect``) so the pod-await poll loop can
-    # call this any number of times without exhausting a fixed list.
     mocked_hook.return_value.core_v1_client.read_namespaced_pod.return_value = succeeded_state
 
     sidecar_output = {"export_arn": "arn:aws:dynamodb:::export/x", "s3_uri": "s3://b/p"}
@@ -3561,14 +3574,38 @@ def test_async_trigger_reentry_returns_sidecar_output_for_multiple_outputs(
 
     result = k.trigger_reentry(context, success_event)
 
-    # The dict is returned — this is the fix. The task runner's
-    # ``_push_xcom_if_needed`` (in ``task-sdk/.../execution_time/task_runner.py``)
-    # then handles both ``return_value`` push and the ``multiple_outputs``
-    # per-key fan-out, exercised end-to-end in ``test-sdk/`` unit tests.
-    assert result is sidecar_output
-    # The operator itself no longer pushes ``return_value`` manually on the
-    # success path — that would double-push when the runner fires.
+    assert result == sidecar_output
     context["ti"].xcom_push.assert_not_called()
+
+
+@patch(KUB_OP_PATH.format("extract_xcom"))
+@patch(KUB_OP_PATH.format("post_complete_action"))
+@patch(HOOK_CLASS)
+def test_async_trigger_reentry_failure_fans_out_for_multiple_outputs(
+    mocked_hook, post_complete_action, mock_extract_xcom
+):
+    """On the async failure path with ``multiple_outputs=True``, ``trigger_reentry`` must fan
+    the partial sidecar dict out into per-key XComs before raising — matching the sync failure
+    path so behaviour is consistent regardless of execution mode.
+    """
+    metadata = {"metadata.name": TEST_NAME, "metadata.namespace": TEST_NAMESPACE}
+    failed_state = mock.MagicMock(**metadata, **{"status.phase": "Failed"})
+    mocked_hook.return_value.get_pod.return_value = failed_state
+    mocked_hook.return_value.core_v1_client.read_namespaced_pod.return_value = failed_state
+
+    sidecar_output = {"export_arn": "arn:aws:dynamodb:::export/x", "s3_uri": "s3://b/p"}
+    mock_extract_xcom.return_value = sidecar_output
+
+    k = KubernetesPodOperator(task_id="task", deferrable=True, do_xcom_push=True, multiple_outputs=True)
+    ti_mock = MagicMock()
+    failure_event = {"status": "failed", "message": "error", "name": TEST_NAME, "namespace": TEST_NAMESPACE}
+
+    with pytest.raises(AirflowException):
+        k.trigger_reentry({"ti": ti_mock}, failure_event)
+
+    ti_mock.xcom_push.assert_any_call("export_arn", "arn:aws:dynamodb:::export/x")
+    ti_mock.xcom_push.assert_any_call("s3_uri", "s3://b/p")
+    ti_mock.xcom_push.assert_any_call(XCOM_RETURN_KEY, sidecar_output)
 
 
 def test_default_container_logs():


### PR DESCRIPTION
## Summary

`KubernetesPodOperator(do_xcom_push=True, multiple_outputs=True, deferrable=True)` silently failed to fan out the sidecar's `return.json` dict into per-key XComs — only `return_value` was published. Downstream tasks subscripting a key got `None` at runtime with no error.

Root cause: `trigger_reentry` pushed `return_value` manually inside a `finally` block and never returned the value to the task runner, so the runner's `_push_xcom_if_needed` (the code that honors `multiple_outputs` and fans the dict out) was bypassed.

The sync path's `execute_sync` already returns `result` (`pod.py:760`). This aligns the deferrable path with the same contract.

## Behaviour change

- **Success path** (new): `trigger_reentry` returns `xcom_sidecar_output`. The task runner pushes `return_value` and, when `multiple_outputs=True`, also fans the dict out into per-key XComs.
- **Failure path** (preserved): the manual `xcom_push(XCOM_RETURN_KEY, ...)` moves into the `event["status"] != "success"` branch, above the `raise`. Partial sidecar output is still surfaced in XCom, and the push now happens even when `_clean` subsequently raises (strict improvement — previously the in-`finally` push was unreachable in that case).

`multiple_outputs` fan-out is deliberately **not** applied on the failure path: downstream tasks that would consume per-key XComs are in `UPSTREAM_FAILED` anyway. The single-key `return_value` push on failure mirrors the sync path's failure-time push at `pod.py:1198` ("Ensure that existing XCom is pushed even in case of failure").

## History

The deferred-path manual push was introduced by #58488 and refined by #58998. #58488 was titled "Deferred KubernetesPodOperator pushes XCom on successful execution" — the intent was success-path only. #58998 then removed a `return` from the `finally` block (returning from `finally` silently swallows exceptions) and replaced it with `xcom_push`, preserving the symptom on both paths. The success-path fan-out was lost in that translation; this PR restores it.

## Closes

Fixes #67224

## Tests

Updated `test_async_kpo_wait_termination_before_cleanup_on_success` and `test_async_kpo_wait_termination_before_cleanup_on_failure` to reflect the new contract.

Added `test_async_trigger_reentry_returns_sidecar_output_for_multiple_outputs` to lock in the success-path return value with `multiple_outputs=True`.

The end-to-end `_push_xcom_if_needed` fan-out behavior is already covered by task-SDK unit tests.
