### PR TITLE
Fix LangChain hook tests failing when langchain is not installed

### DIFF
--- a/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
@@ -28,14 +28,19 @@ from airflow.providers.common.ai.hooks.langchain import LangChainHook
 def _stub_langchain_modules():
     # langchain is an optional dep; stub sys.modules so @patch can resolve
     # langchain.* targets without it being installed.
+    # Submodule entries are derived from parent mock attributes so @patch
+    # (which resolves via getattr) and the hook's lazy imports (which read
+    # sys.modules["langchain.chat_models"]) see the same object.
+    lc = MagicMock()
+    lc_core = MagicMock()
     mocks = {
-        "langchain": MagicMock(),
-        "langchain.chat_models": MagicMock(),
-        "langchain.embeddings": MagicMock(),
-        "langchain_core": MagicMock(),
-        "langchain_core.embeddings": MagicMock(),
-        "langchain_core.language_models": MagicMock(),
-        "langchain_core.language_models.chat_models": MagicMock(),
+        "langchain": lc,
+        "langchain.chat_models": lc.chat_models,
+        "langchain.embeddings": lc.embeddings,
+        "langchain_core": lc_core,
+        "langchain_core.embeddings": lc_core.embeddings,
+        "langchain_core.language_models": lc_core.language_models,
+        "langchain_core.language_models.chat_models": lc_core.language_models.chat_models,
     }
     with patch.dict(sys.modules, mocks):
         yield

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
@@ -16,11 +16,29 @@
 # under the License.
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from airflow.providers.common.ai.hooks.langchain import LangChainHook
+
+
+@pytest.fixture(autouse=True)
+def _stub_langchain_modules():
+    # langchain is an optional dep; stub sys.modules so @patch can resolve
+    # langchain.* targets without it being installed.
+    mocks = {
+        "langchain": MagicMock(),
+        "langchain.chat_models": MagicMock(),
+        "langchain.embeddings": MagicMock(),
+        "langchain_core": MagicMock(),
+        "langchain_core.embeddings": MagicMock(),
+        "langchain_core.language_models": MagicMock(),
+        "langchain_core.language_models.chat_models": MagicMock(),
+    }
+    with patch.dict(sys.modules, mocks):
+        yield
 
 
 def _conn(password: str = "", host: str = "", extra: dict | None = None) -> MagicMock:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Fix to errors seen in: https://github.com/apache/airflow/actions/runs/26144521163/job/76898272728?pr=67041

Example: 

```bash
_________________________________________________________________ TestGetChatModel.test_dispatches_via_init_chat_model_with_api_key ____________________________________________________________________
[gw1] linux -- Python 3.10.20 /usr/local/bin/python3
/usr/python/lib/python3.10/unittest/mock.py:1376: in patched
    with self.decoration_helper(patched,
/usr/python/lib/python3.10/contextlib.py:135: in __enter__
    return next(self.gen)
/usr/python/lib/python3.10/unittest/mock.py:1358: in decoration_helper
    arg = exit_stack.enter_context(patching)
/usr/python/lib/python3.10/contextlib.py:492: in enter_context
    result = _cm_type.__enter__(cm)
/usr/python/lib/python3.10/unittest/mock.py:1431: in __enter__
    self.target = self.getter()
/usr/python/lib/python3.10/unittest/mock.py:1618: in <lambda>
    getter = lambda: _importer(target)
/usr/python/lib/python3.10/unittest/mock.py:1257: in _importer
    thing = __import__(import_path)
E   ModuleNotFoundError: No module named 'langchain'
```


The LangChain hook tests fail in CI with `ModuleNotFoundError: No module named 'langchain'`. Langchain is an optional dep not installed in std test envs like Non DB tests.

Add an autouse fixture that pre populates `sys.modules` with `MagicMock` stubs for the relevant `langchain` modules before each test. This lets `@patch` resolve its targets without `langchain` installed, while keeping all tests always-running rather than skipping them.

The `TestLangChainHookInit`, `TestGetUiFieldBehaviour`, and `TestResolveModelId` classes have no langchain dependency and they anyways mocked most of it and are unaffected


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
