### PR TITLE
[v3-2-test] UI: Update French (fr) translations to 100% coverage

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
@@ -3,6 +3,7 @@
     "description": "Description",
     "key": "Clé",
     "name": "Nom",
+    "team": "Équipe",
     "value": "Valeur"
   },
   "config": {
@@ -83,6 +84,23 @@
   "formActions": {
     "save": "Sauvegarder"
   },
+  "jobs": {
+    "columns": {
+      "executorClass": "Classe d'exécuteur",
+      "hostname": "Nom d'hôte",
+      "id": "ID",
+      "jobType": "Type de travail",
+      "latestHeartbeat": "Dernier battement",
+      "unixname": "Nom Unix"
+    },
+    "filters": {
+      "allStates": "Tous les états",
+      "allTypes": "Tous les types",
+      "dagProcessorJob": "DagProcessorJob",
+      "schedulerJob": "SchedulerJob",
+      "triggererJob": "TriggererJob"
+    }
+  },
   "plugins": {
     "columns": {
       "source": "Source"
@@ -106,7 +124,8 @@
       "includeDeferred": "Inclure les Tâches Différées",
       "nameMaxLength": "Le nom peut contenir un maximum de 250 caractères",
       "nameRequired": "Le nom est requis",
-      "slots": "Slots"
+      "slots": "Slots",
+      "slotsHelperText": "Utilisez -1 pour des slots illimités."
     },
     "noPoolsFound": "Aucun pool trouvé",
     "pool_many": "Pools",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
@@ -1,4 +1,8 @@
 {
+  "additional_data": "Données supplémentaires",
+  "asset_many": "Assets",
+  "asset_one": "Asset",
+  "asset_other": "Assets",
   "consumingDags": "Dags consomatteurs",
   "consumingTasks": "Tâches consommatrices",
   "createEvent": {
@@ -28,5 +32,7 @@
   "name": "Nom",
   "producingTasks": "Tasks productrices",
   "scheduledDags": "Dags planifiés",
-  "searchPlaceholder": "Rechercher des Assets"
+  "scheduling": "Planification",
+  "searchPlaceholder": "Rechercher des Assets",
+  "taskDependencies": "Dépendances de tâches"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
@@ -12,11 +12,35 @@
     "title": "Journal d'Audit"
   },
   "xcom": {
+    "add": {
+      "error": "Échec de l'ajout du XCom",
+      "errorTitle": "Erreur",
+      "success": "XCom ajouté avec succès",
+      "successTitle": "XCom ajouté",
+      "title": "Ajouter un XCom"
+    },
     "columns": {
       "dag": "Dag",
       "key": "Clé",
       "value": "Valeur"
     },
-    "title": "XCom"
+    "delete": {
+      "error": "Échec de la suppression du XCom",
+      "errorTitle": "Erreur",
+      "success": "XCom supprimé avec succès",
+      "successTitle": "XCom supprimé",
+      "title": "Supprimer le XCom",
+      "warning": "Êtes-vous sûr de vouloir supprimer ce XCom ? Cette action est irréversible."
+    },
+    "edit": {
+      "error": "Échec de la mise à jour du XCom",
+      "errorTitle": "Erreur",
+      "success": "XCom mis à jour avec succès",
+      "successTitle": "XCom mis à jour",
+      "title": "Modifier le XCom"
+    },
+    "key": "Clé",
+    "title": "XCom",
+    "value": "Valeur"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -25,11 +25,13 @@
   "backfill_other": "Rattrapages",
   "browse": {
     "auditLog": "Journal d'audit",
+    "jobs": "Travaux",
     "requiredActions": "Actions requises",
     "xcoms": "XComs"
   },
   "collapseAllExtra": "Réduire tous les extra json",
   "collapseDetailsPanel": "Replier le panneau des détails",
+  "consumingAsset": "Asset consommateur",
   "createdAssetEvent_many": "Événements d'Asset créés",
   "createdAssetEvent_one": "Événement d'Asset créé",
   "createdAssetEvent_other": "Événements d'Asset créés",
@@ -65,6 +67,8 @@
     "dataIntervalEnd": "Fin de l'intervalle de données",
     "dataIntervalStart": "Début de l'intervalle de données",
     "lastSchedulingDecision": "Dernière décision de planification",
+    "mappedPartitionKey": "Clé de partition mappée",
+    "partitionKey": "Clé de partition",
     "queuedAt": "Mis en file à",
     "runAfter": "Exécuté après",
     "runType": "Type d'exécution",
@@ -79,6 +83,11 @@
   "dagWarnings": "Avertissements/erreurs du Dag",
   "defaultToGraphView": "Vue par défaut : graphe",
   "defaultToGridView": "Vue par défaut : grille",
+  "delete": "Supprimer",
+  "diff": "Différences",
+  "diffCompareWith": "Comparer avec",
+  "diffExit": "Quitter les différences",
+  "diffSelectVersionToCompare": "Sélectionnez une version à comparer",
   "direction": "Direction",
   "docs": {
     "documentation": "Documentation",
@@ -91,6 +100,7 @@
     "tooltip": "Appuyez sur {{hotkey}} pour télécharger les journaux"
   },
   "duration": "Durée",
+  "edit": "Modifier",
   "endDate": "Date de fin",
   "error": {
     "back": "Retour",
@@ -99,6 +109,12 @@
     "invalidUrl": "Page introuvable. Veuillez vérifier l'URL et réessayer.",
     "notFound": "Page introuvable",
     "title": "Erreur"
+  },
+  "errors": {
+    "forbidden": {
+      "description": "Vous n'avez pas l'autorisation d'effectuer cette action.",
+      "title": "Accès refusé"
+    }
   },
   "expand": {
     "collapse": "Réduire",
@@ -115,22 +131,31 @@
   },
   "filter": "Filtre",
   "filters": {
+    "durationFrom": "Durée à partir de",
+    "durationTo": "Durée jusqu'à",
+    "endTime": "Heure de fin",
     "logicalDateFrom": "Date logique de début",
     "logicalDateTo": "Date logique de fin",
     "runAfterFrom": "Exécuté après - de",
-    "runAfterTo": "Exécuté après - à"
+    "runAfterTo": "Exécuté après - à",
+    "searchAsset": "Rechercher un Asset",
+    "selectDateRange": "Sélectionner une plage de dates",
+    "startTime": "Heure de début"
   },
+  "generateToken": "Générer un jeton",
   "logicalDate": "Date logique",
   "logout": "Déconnexion",
   "logoutConfirmation": "Vous êtes sur le point de vous déconnecter de l'application.",
   "mapIndex": "Map Index",
   "modal": {
+    "add": "Ajouter",
     "cancel": "Annuler",
     "confirm": "Confirmer",
     "delete": {
       "button": "Supprimer",
       "confirmation": "Êtes-vous sûr de vouloir supprimer {{resourceName}} ? Cette action est irréversible."
-    }
+    },
+    "save": "Enregistrer"
   },
   "nav": {
     "admin": "Admin",
@@ -151,19 +176,19 @@
     "placeholder": "Ajouter une note...",
     "taskInstance": "Note de Task Instance"
   },
-  "pools": {
-    "deferred": "Différé",
-    "open": "Libre",
-    "pools_many": "Pools",
-    "pools_one": "Pool",
-    "pools_other": "Pools",
-    "queued": "En file",
-    "running": "En cours",
-    "scheduled": "Planifié"
+  "partitionedDagRun_many": "Exécutions de Dag partitionnées",
+  "partitionedDagRun_one": "Exécution de Dag partitionnée",
+  "partitionedDagRun_other": "Exécutions de Dag partitionnées",
+  "partitionedDagRunDetail": {
+    "receivedAssetEvents": "Événements d'Asset reçus"
   },
+  "pendingDagRun_many": "{{count}} exécutions de Dag en attente",
+  "pendingDagRun_one": "{{count}} exécution de Dag en attente",
+  "pendingDagRun_other": "{{count}} exécutions de Dag en attente",
   "reset": "Réinitialiser",
   "runId": "ID d'exécution",
   "runTypes": {
+    "asset_materialization": "Matérialisation d'Asset",
     "asset_triggered": "Déclenché par Asset",
     "backfill": "Rattrapage",
     "manual": "Manuel",
@@ -176,6 +201,12 @@
     },
     "tooltip": "Appuyez sur {{hotkey}} pour faire défiler vers le {{direction}}"
   },
+  "search": {
+    "advanced": {
+      "description": "Correspond n'importe où dans la valeur (recherche par sous-chaîne). Plus lent sur les grands déploiements car cela ne peut pas utiliser l'index B-tree par défaut. Consultez la section de la documentation sur les index de métadonnées personnalisés pour plus de détails.",
+      "title": "Correspondance n'importe où"
+    }
+  },
   "security": {
     "actions": "Actions",
     "permissions": "Permissions",
@@ -185,6 +216,7 @@
   },
   "selectLanguage": "Choisir la langue",
   "showDetailsPanel": "Afficher le panneau des détails",
+  "signedInAs": "Connecté en tant que",
   "source": {
     "hide": "Masquer la source",
     "hotkey": "s",
@@ -200,6 +232,7 @@
     "failed": "Échoué",
     "no_status": "Aucun statut",
     "none": "Aucun statut",
+    "open": "Ouvert",
     "planned": "Planifié",
     "queued": "En file",
     "removed": "Supprimé",
@@ -253,6 +286,7 @@
     "priorityWeight": "Poids de la priorité",
     "queue": "File",
     "queuedWhen": "Mis en file à",
+    "renderedMapIndex": "Map Index rendu",
     "scheduledWhen": "Planifié à",
     "triggerer": {
       "assigned": "Déclencheur assigné",
@@ -322,10 +356,26 @@
       }
     }
   },
+  "tokenGeneration": {
+    "apiToken": "Jeton d'API",
+    "cliToken": "Jeton CLI",
+    "errorDescription": "Une erreur est survenue lors de la génération du jeton. Veuillez réessayer.",
+    "errorTitle": "Échec de la génération du jeton",
+    "generate": "Générer",
+    "selectType": "Sélectionnez le type de jeton à générer.",
+    "title": "Générer un jeton",
+    "tokenExpiresIn": "Ce jeton expire dans {{duration}}.",
+    "tokenGenerated": "Votre jeton a été généré.",
+    "tokenShownOnce": "Ce jeton ne sera affiché qu'une seule fois. Copiez-le maintenant."
+  },
   "total": "Total {{state}}",
   "triggered": "Déclenché",
   "tryNumber": "Numéro de l'essai",
   "user": "Utilisateur",
+  "validation": {
+    "mustBeAtLeast": "Doit être au moins {{min}}.",
+    "mustBeValidNumber": "Doit être un nombre valide."
+  },
   "wrap": {
     "hotkey": "w",
     "tooltip": "Appuyez sur {{hotkey}} pour activer/désactiver le retour à la ligne",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -11,6 +11,8 @@
     "maxRuns": "Nombre maximum d'exécutions actives",
     "missingAndErroredRuns": "Exécutions manquantes et en erreur",
     "missingRuns": "Exécutions manquantes",
+    "overrideExistingParams": "Remplacer les paramètres sur les exécutions existantes",
+    "permissionDenied": "Échec de l'exécution à blanc : l'utilisateur n'a pas l'autorisation de créer des rattrapages.",
     "reprocessBehavior": "Comportement de réexécution",
     "run": "Lancer le rattrapage",
     "selectDescription": "Exécuter ce Dag pour une plage de dates",
@@ -45,13 +47,18 @@
     "invalidJson": "Format JSON invalide : {{errorMessage}}"
   },
   "dagWarnings": {
-    "error_many": "{{count}} erreurs",
     "error_one": "1 erreur",
-    "error_other": "{{count}} erreurs",
     "errorAndWarning": "1 erreur et {{warningText}}",
     "warning_many": "{{count}} avertissements",
     "warning_one": "1 avertissement",
     "warning_other": "{{count}} avertissements"
+  },
+  "dateRangeFilter": {
+    "validation": {
+      "invalidDateFormat": "Format de date invalide.",
+      "invalidTimeFormat": "Format d'heure invalide.",
+      "startBeforeEnd": "La date/heure de début doit être antérieure à la date/heure de fin"
+    }
   },
   "durationChart": {
     "duration": "Durée (secondes)",
@@ -92,7 +99,8 @@
     "taskCount_many": "{{count}} tâches",
     "taskCount_one": "{{count}} tâche",
     "taskCount_other": "{{count}} tâches",
-    "taskGroup": "Groupe de tâches"
+    "taskGroup": "Groupe de tâches",
+    "zoomToTask": "Zoomer sur la tâche sélectionnée"
   },
   "limitedList": "+{{count}} supplémentaires",
   "limitedList.allItems": "Tous les {{count}} éléments :",
@@ -114,22 +122,40 @@
   "sortedDescending": "tri décroissant",
   "sortedUnsorted": "non trié",
   "taskTries": "Essais de tâche",
+  "taskTryPlaceholder": "Essai de tâche",
+  "team": {
+    "selector": {
+      "helperText": "Optionnel. Restreindre l'utilisation à une équipe spécifique.",
+      "label": "Équipe",
+      "placeHolder": "Sélectionner une équipe"
+    }
+  },
   "toggleCardView": "Afficher en mode cartes",
   "toggleTableView": "Afficher en mode tableau",
   "triggerDag": {
     "button": "Déclencher",
+    "dataInterval": "Intervalle de données",
+    "dataIntervalAuto": "Déduit de la date logique et du calendrier",
+    "dataIntervalManual": "Spécifier manuellement",
+    "intervalEnd": "Fin",
+    "intervalStart": "Début",
     "loading": "Chargement des informations du Dag...",
     "loadingFailed": "Échec du chargement des informations du Dag. Veuillez réessayer.",
+    "manualRunDenied": "Les exécutions manuelles ne sont pas autorisées pour ce Dag",
     "runIdHelp": "Optionnel – sera généré s'il n'est pas fourni",
     "selectDescription": "Déclencher une exécution unique de ce Dag",
     "selectLabel": "Exécution unique",
     "title": "Déclencher un Dag",
     "toaster": {
+      "error": {
+        "title": "Échec du déclenchement du Dag"
+      },
       "success": {
         "description": "L'exécution du Dag a été déclenchée avec succès.",
         "title": "Dag déclenché"
       }
     },
+    "triggerAgainWithConfig": "Déclencher à nouveau avec cette configuration",
     "unpause": "Réactiver {{dagDisplayName}} lors du déclenchement"
   },
   "trimText": {
@@ -145,6 +171,7 @@
     "versionId": "ID de version"
   },
   "versionSelect": {
+    "allVersions": "Toutes les versions",
     "dagVersion": "Version du Dag",
     "versionCode": "v{{versionCode}}"
   }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
@@ -45,12 +45,16 @@
     "buttons": {
       "resetToLatest": "Réinitialiser à la dernière version",
       "toggleGroup": "Afficher/Masquer le groupe"
-    }
+    },
+    "runTypeLegend": "Légende des types de Run"
   },
   "header": {
     "buttons": {
       "advanced": "Avancé",
       "dagDocs": "Documentation du Dag"
+    },
+    "status": {
+      "deactivated": "Désactivé"
     }
   },
   "logs": {
@@ -72,6 +76,12 @@
   "navigation": {
     "navigation": "Navigation : {{arrow}}",
     "toggleGroup": "Basculer le groupe : Espace"
+  },
+  "notFound": {
+    "back": "Retour",
+    "backToDags": "Retour aux Dags",
+    "message": "Le Dag « {{dagId}} » n'existe pas.",
+    "title": "Dag introuvable"
   },
   "overview": {
     "buttons": {
@@ -118,6 +128,35 @@
     },
     "graphDirection": {
       "label": "Orientation du graphe"
+    },
+    "showVersionIndicator": {
+      "label": "Afficher l'indicateur de version",
+      "options": {
+        "hideAll": "Tout masquer",
+        "showAll": "Tout afficher",
+        "showBundleVersion": "Afficher la version du bundle",
+        "showDagVersion": "Afficher la version du Dag"
+      }
+    },
+    "taskStreamFilter": {
+      "activeFilter": "Filtre actif",
+      "clearFilter": "Effacer le filtre",
+      "clickTask": "Cliquez sur une tâche pour la sélectionner comme racine du filtre",
+      "depth": "Profondeur",
+      "direction": "Direction",
+      "label": "Filtre",
+      "mode": "Mode",
+      "modeTooltip": "Le mode Statique conserve la vue actuelle lors de la navigation vers d'autres tâches, tandis que le mode Parcourir met automatiquement à jour le filtre actif vers la tâche cliquée pour faciliter la traversée du Dag.",
+      "modes": {
+        "static": "Statique",
+        "traverse": "Parcourir"
+      },
+      "options": {
+        "both": "En amont et en aval",
+        "downstream": "En aval",
+        "upstream": "En amont"
+      },
+      "selectedTask": "Tâche sélectionnée"
     }
   },
   "paramsFailed": "Échec du chargement des paramètres",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
@@ -20,8 +20,7 @@
       "all": "Tous",
       "paused": "En pause"
     },
-    "runIdPatternFilter": "Rechercher des exécutions de Dag",
-    "triggeringUserNameFilter": "Rechercher par utilisateur déclencheur"
+    "runIdPatternFilter": "Rechercher des exécutions de Dag"
   },
   "ownerLink": "Lien du propriétaire pour {{owner}}",
   "runAndTaskActions": {
@@ -34,6 +33,10 @@
       "buttonTooltip": "Appuyez sur Maj+c pour réinitialiser",
       "error": "Échec de la réinitialisation de {{type}}",
       "title": "Réinitialiser {{type}}"
+    },
+    "confirmationDialog": {
+      "description": "La tâche est actuellement dans l'état {{state}}, démarrée par l'utilisateur {{user}} à {{time}}. \nL'utilisateur ne peut pas réinitialiser cette tâche tant qu'elle n'a pas fini de s'exécuter ou tant que l'option « Empêcher la réexécution si la tâche est en cours » n'est pas décochée dans la boîte de dialogue de réinitialisation.",
+      "title": "Impossible de réinitialiser l'instance de tâche"
     },
     "delete": {
       "button": "Supprimer {{type}}",
@@ -62,6 +65,7 @@
       "future": "Futur",
       "onlyFailed": "Réinitialiser uniquement les tâches échouées",
       "past": "Passé",
+      "preventRunningTasks": "Empêcher la réexécution si la tâche est en cours",
       "queueNew": "Ajouter de nouvelles tâches en file d'attente",
       "runOnLatestVersion": "Exécuter avec la dernière version du bundle",
       "upstream": "En amont"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dashboard.json
@@ -31,7 +31,8 @@
   "poolSlots": "Emplacements de pool",
   "sortBy": {
     "newestFirst": "Plus récents d'abord",
-    "oldestFirst": "Plus anciens d'abord"
+    "oldestFirst": "Plus anciens d'abord",
+    "placeholder": "Trier par"
   },
   "source": "Source",
   "stats": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/hitl.json
@@ -1,5 +1,7 @@
 {
   "filters": {
+    "body": "Corps",
+    "createdAt": "Créé le",
     "response": {
       "all": "Tous",
       "pending": "En attente",
@@ -14,11 +16,13 @@
   "requiredActionCount_other": "Actions requises ({{count}})",
   "requiredActionState": "État de l'action requise",
   "response": {
+    "created": "Réponse créée le ",
     "error": "Échec de la réponse",
     "optionsDescription": "Choisissez vos options pour cette instance de tâche",
     "optionsLabel": "Options",
     "received": "Réponse reçue à ",
     "respond": "Répondre",
+    "responded_by_user_name": "Répondu par (nom d'utilisateur)",
     "success": "Réponse pour {{taskId}} réussie",
     "title": "Instance de tâche humaine - {{taskId}}"
   },


### PR DESCRIPTION
Brings the French (`fr`) UI locale on `v3-2-test` to 100% coverage. Started fresh on `apache/v3-2-test` (not cherry-picked from #67240) because the set of required keys differs from `main` — some translation keys correspond to features not backported to 3.2.

Procedure followed the established workflow:

1. `breeze ui check-translation-completeness --language fr --add-missing --remove-unused` — scaffolded 134 missing keys with `TODO: translate:` stubs and removed 11 keys no longer required on this branch.
2. Translations filled with the same vocabulary as the `main` PR, kept aligned with the FR glossary in `.github/skills/airflow-translations/locales/fr.md` (formal "vous", `Dag` / `Asset` / `XCom` / `Map Index` kept in English, `_many` === `_other`).
3. Re-ran the script to verify 100% coverage, 0 missing, 0 unused, 0 TODOs.

Only `airflow-core/src/airflow/ui/public/i18n/locales/fr/*.json` files touched.

<!-- drag the /tmp/fr-v3-2-test-translation.png screenshot here -->
<img width="1970" height="1026" alt="fr-v3-2-test-translation" src="https://github.com/user-attachments/assets/3c22f52e-4f8d-4b4a-90a8-37de6327f423" />

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)