### PR TITLE
Remove trigger event payload from INFO log in run_trigger()

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1664,9 +1664,15 @@ class TriggerRunner:
                     event_stream = trigger.run()
 
                 async for event in event_stream:
-                    await self.log.ainfo(
-                        "Trigger fired event", name=self.triggers[trigger_id]["name"]
-                    )
+                    # Avoid logging the full payload at INFO — it may contain sensitive data and
+                    # inflate log storage on every execution. DEBUG is used instead so developers
+                    # can still inspect the payload when needed without.
+                    await self.log.ainfo("Trigger fired event", name=self.triggers[trigger_id]["name"])
+                    if self.log.is_enabled_for(logging.DEBUG):
+                        await self.log.adebug(
+                            "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
+                        )
+
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None
                     if shared_key is not None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1666,12 +1666,11 @@ class TriggerRunner:
                 async for event in event_stream:
                     # Avoid logging the full payload at INFO — it may contain sensitive data and
                     # inflate log storage on every execution. DEBUG is used instead so developers
-                    # can still inspect the payload when needed without.
+                    # can still inspect the payload when needed without cluttering production logs.
                     await self.log.ainfo("Trigger fired event", name=self.triggers[trigger_id]["name"])
-                    if self.log.is_enabled_for(logging.DEBUG):
-                        await self.log.adebug(
-                            "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
-                        )
+                    await self.log.adebug(
+                        "Trigger fired event payload", name=self.triggers[trigger_id]["name"], result=event
+                    )
 
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1665,7 +1665,7 @@ class TriggerRunner:
 
                 async for event in event_stream:
                     await self.log.ainfo(
-                        "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
+                        "Trigger fired event", name=self.triggers[trigger_id]["name"]
                     )
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1667,7 +1667,7 @@ class TriggerRunner:
 
                 async for event in event_stream:
                     await self.log.ainfo(
-                        "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
+                        "Trigger fired event", name=self.triggers[trigger_id]["name"]
                     )
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1666,9 +1666,15 @@ class TriggerRunner:
                     event_stream = trigger.run()
 
                 async for event in event_stream:
-                    await self.log.ainfo(
-                        "Trigger fired event", name=self.triggers[trigger_id]["name"]
-                    )
+                    # Avoid logging the full payload at INFO — it may contain sensitive data and
+                    # inflate log storage on every execution. DEBUG is used instead so developers
+                    # can still inspect the payload when needed without.
+                    await self.log.ainfo("Trigger fired event", name=self.triggers[trigger_id]["name"])
+                    if self.log.is_enabled_for(logging.DEBUG):
+                        await self.log.adebug(
+                            "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
+                        )
+
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None
                     if shared_key is not None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1668,12 +1668,11 @@ class TriggerRunner:
                 async for event in event_stream:
                     # Avoid logging the full payload at INFO — it may contain sensitive data and
                     # inflate log storage on every execution. DEBUG is used instead so developers
-                    # can still inspect the payload when needed without.
+                    # can still inspect the payload when needed without cluttering production logs.
                     await self.log.ainfo("Trigger fired event", name=self.triggers[trigger_id]["name"])
-                    if self.log.is_enabled_for(logging.DEBUG):
-                        await self.log.adebug(
-                            "Trigger fired event", name=self.triggers[trigger_id]["name"], result=event
-                        )
+                    await self.log.adebug(
+                        "Trigger fired event payload", name=self.triggers[trigger_id]["name"], result=event
+                    )
 
                     self.triggers[trigger_id]["events"] += 1
                     seq: int | None = None

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3285,3 +3285,81 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
     trigger_id, _event, seq = events[0]
     assert trigger_id == 1
     assert seq is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
+    """Ensure the full event payload is not logged at INFO level."""
+    runner = TriggerRunner()
+    runner.triggers = {
+        1: {
+            "task": MagicMock(spec=asyncio.Task),
+            "is_watcher": False,
+            "name": "test_dag/run_id/test_task/0/1",
+            "events": 0,
+        }
+    }
+
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
+
+    payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
+
+    async def fake_run():
+        yield TriggerEvent(payload)
+
+    mock_trigger.run = fake_run
+
+    await runner.run_trigger(1, mock_trigger)
+
+    assert any(log["event"] == "Trigger fired event" for log in cap_structlog), (
+        "Expected a 'Trigger fired event' log entry"
+    )
+    info_logs = [log for log in cap_structlog if log.get("log_level") == "info"]
+
+    for _key, value in payload.items():
+        assert not any(str(value) in str(log) for log in info_logs), (
+            "payload value must not appear in INFO-level logs"
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_event_payload_available_at_debug(cap_structlog):
+    runner = TriggerRunner()
+    runner.triggers = {
+        1: {
+            "task": MagicMock(spec=asyncio.Task),
+            "is_watcher": False,
+            "name": "test_dag/run_id/test_task/0/1",
+            "events": 0,
+        }
+    }
+
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
+
+    payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
+
+    async def fake_run():
+        yield TriggerEvent(payload)
+
+    mock_trigger.run = fake_run
+
+    mock_log = AsyncMock()
+    mock_log.isEnabledFor = MagicMock(return_value=True)
+    runner.log = mock_log
+
+    await runner.run_trigger(1, mock_trigger)
+
+    # ainfo must not be called with result
+    for call in mock_log.ainfo.call_args_list:
+        assert "result" not in call.kwargs, "Payload must not appear in ainfo call"
+
+    # adebug must be called with full payload as 'result'
+    print(mock_log.adebug.call_args.kwargs.get("result"))
+    mock_log.adebug.assert_awaited_once()
+    assert mock_log.adebug.call_args.kwargs.get("result") == TriggerEvent(payload), (
+        "Full event payload must be passed to adebug as 'result'"
+    )

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3329,6 +3329,9 @@ async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
 
 @pytest.mark.asyncio
 async def test_trigger_event_payload_available_at_debug(cap_structlog):
+    """Ensure the full event payload is available at DEBUG level for diagnostics."""
+
+    cap_structlog.set_level("debug")
     runner = TriggerRunner()
     runner.triggers = {
         1: {
@@ -3339,33 +3342,22 @@ async def test_trigger_event_payload_available_at_debug(cap_structlog):
         }
     }
 
-    mock_trigger = MagicMock(spec=BaseTrigger)
-    mock_trigger.task_instance = MagicMock()
-    mock_trigger.task_instance.map_index = -1
-
     payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
 
     async def fake_run():
         yield TriggerEvent(payload)
 
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
     mock_trigger.run = fake_run
-
-    mock_log = AsyncMock()
-    mock_log.isEnabledFor = MagicMock(return_value=True)
-    runner.log = mock_log
-
     mock_trigger.cleanup = AsyncMock()
 
     task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
     await task
 
-    # ainfo must not be called with result
-    for call in mock_log.ainfo.call_args_list:
-        assert "result" not in call.kwargs, "Payload must not appear in ainfo call"
-
-    # adebug must be called with full payload as 'result'
-    print(mock_log.adebug.call_args.kwargs.get("result"))
-    mock_log.adebug.assert_awaited_once()
-    assert mock_log.adebug.call_args.kwargs.get("result") == TriggerEvent(payload), (
-        "Full event payload must be passed to adebug as 'result'"
-    )
+    debug_logs = [log for log in cap_structlog if log.get("log_level") == "debug"]
+    assert any(
+        log.get("event") == "Trigger fired event payload" and log.get("result") == TriggerEvent(payload)
+        for log in debug_logs
+    ), "Full event payload must be logged at DEBUG level"

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3311,7 +3311,10 @@ async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
 
     mock_trigger.run = fake_run
 
-    await runner.run_trigger(1, mock_trigger)
+    mock_trigger.cleanup = AsyncMock()
+
+    task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
+    await task
 
     assert any(log["event"] == "Trigger fired event" for log in cap_structlog), (
         "Expected a 'Trigger fired event' log entry"
@@ -3351,7 +3354,10 @@ async def test_trigger_event_payload_available_at_debug(cap_structlog):
     mock_log.isEnabledFor = MagicMock(return_value=True)
     runner.log = mock_log
 
-    await runner.run_trigger(1, mock_trigger)
+    mock_trigger.cleanup = AsyncMock()
+
+    task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
+    await task
 
     # ainfo must not be called with result
     for call in mock_log.ainfo.call_args_list:

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3298,6 +3298,9 @@ async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
 
 @pytest.mark.asyncio
 async def test_trigger_event_payload_available_at_debug(cap_structlog):
+    """Ensure the full event payload is available at DEBUG level for diagnostics."""
+
+    cap_structlog.set_level("debug")
     runner = TriggerRunner()
     runner.triggers = {
         1: {
@@ -3308,33 +3311,22 @@ async def test_trigger_event_payload_available_at_debug(cap_structlog):
         }
     }
 
-    mock_trigger = MagicMock(spec=BaseTrigger)
-    mock_trigger.task_instance = MagicMock()
-    mock_trigger.task_instance.map_index = -1
-
     payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
 
     async def fake_run():
         yield TriggerEvent(payload)
 
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
     mock_trigger.run = fake_run
-
-    mock_log = AsyncMock()
-    mock_log.isEnabledFor = MagicMock(return_value=True)
-    runner.log = mock_log
-
     mock_trigger.cleanup = AsyncMock()
 
     task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
     await task
 
-    # ainfo must not be called with result
-    for call in mock_log.ainfo.call_args_list:
-        assert "result" not in call.kwargs, "Payload must not appear in ainfo call"
-
-    # adebug must be called with full payload as 'result'
-    print(mock_log.adebug.call_args.kwargs.get("result"))
-    mock_log.adebug.assert_awaited_once()
-    assert mock_log.adebug.call_args.kwargs.get("result") == TriggerEvent(payload), (
-        "Full event payload must be passed to adebug as 'result'"
-    )
+    debug_logs = [log for log in cap_structlog if log.get("log_level") == "debug"]
+    assert any(
+        log.get("event") == "Trigger fired event payload" and log.get("result") == TriggerEvent(payload)
+        for log in debug_logs
+    ), "Full event payload must be logged at DEBUG level"

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3254,3 +3254,81 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
     trigger_id, _event, seq = events[0]
     assert trigger_id == 1
     assert seq is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
+    """Ensure the full event payload is not logged at INFO level."""
+    runner = TriggerRunner()
+    runner.triggers = {
+        1: {
+            "task": MagicMock(spec=asyncio.Task),
+            "is_watcher": False,
+            "name": "test_dag/run_id/test_task/0/1",
+            "events": 0,
+        }
+    }
+
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
+
+    payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
+
+    async def fake_run():
+        yield TriggerEvent(payload)
+
+    mock_trigger.run = fake_run
+
+    await runner.run_trigger(1, mock_trigger)
+
+    assert any(log["event"] == "Trigger fired event" for log in cap_structlog), (
+        "Expected a 'Trigger fired event' log entry"
+    )
+    info_logs = [log for log in cap_structlog if log.get("log_level") == "info"]
+
+    for _key, value in payload.items():
+        assert not any(str(value) in str(log) for log in info_logs), (
+            "payload value must not appear in INFO-level logs"
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_event_payload_available_at_debug(cap_structlog):
+    runner = TriggerRunner()
+    runner.triggers = {
+        1: {
+            "task": MagicMock(spec=asyncio.Task),
+            "is_watcher": False,
+            "name": "test_dag/run_id/test_task/0/1",
+            "events": 0,
+        }
+    }
+
+    mock_trigger = MagicMock(spec=BaseTrigger)
+    mock_trigger.task_instance = MagicMock()
+    mock_trigger.task_instance.map_index = -1
+
+    payload = {"api_response": {"token": "s3cr3t-api-k3y", "user_id": 42}}
+
+    async def fake_run():
+        yield TriggerEvent(payload)
+
+    mock_trigger.run = fake_run
+
+    mock_log = AsyncMock()
+    mock_log.isEnabledFor = MagicMock(return_value=True)
+    runner.log = mock_log
+
+    await runner.run_trigger(1, mock_trigger)
+
+    # ainfo must not be called with result
+    for call in mock_log.ainfo.call_args_list:
+        assert "result" not in call.kwargs, "Payload must not appear in ainfo call"
+
+    # adebug must be called with full payload as 'result'
+    print(mock_log.adebug.call_args.kwargs.get("result"))
+    mock_log.adebug.assert_awaited_once()
+    assert mock_log.adebug.call_args.kwargs.get("result") == TriggerEvent(payload), (
+        "Full event payload must be passed to adebug as 'result'"
+    )

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3280,7 +3280,10 @@ async def test_trigger_event_payload_not_logged_at_info(cap_structlog):
 
     mock_trigger.run = fake_run
 
-    await runner.run_trigger(1, mock_trigger)
+    mock_trigger.cleanup = AsyncMock()
+
+    task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
+    await task
 
     assert any(log["event"] == "Trigger fired event" for log in cap_structlog), (
         "Expected a 'Trigger fired event' log entry"
@@ -3320,7 +3323,10 @@ async def test_trigger_event_payload_available_at_debug(cap_structlog):
     mock_log.isEnabledFor = MagicMock(return_value=True)
     runner.log = mock_log
 
-    await runner.run_trigger(1, mock_trigger)
+    mock_trigger.cleanup = AsyncMock()
+
+    task = asyncio.create_task(runner.run_trigger(1, mock_trigger))
+    await task
 
     # ainfo must not be called with result
     for call in mock_log.ainfo.call_args_list:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

# fix: remove trigger event payload from INFO log in `run_trigger()`
 
## What and Why
 
In TriggerRunner.run_trigger(), the full TriggerEvent payload is currently
logged at INFO level on every trigger execution via result=event.
For data-heavy triggers such as MSGraphTrigger,
this payload contains the entire serialised API response — which can be significant in size — written to log files on every execution, causing: 

 
- Excessive log file growth and storage consumption
- Sensitive API response data written to plain-text log files

## Fix
 
Removed `result=event` from the INFO log line in `run_trigger()`.
 
---
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X ] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
