### PR TITLE
Fix "Trigger again with this config" ignoring param changes made in the UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -130,7 +130,7 @@ const TriggerDAGForm = ({
     isPartitioned,
   ]);
 
-  // Automatically reset form when conf is fetched (only if no prefillConfig)
+  // Automatically reset form when conf is fetched
   useEffect(() => {
     if (conf && open && (!prefillConfig || hasAppliedPrefill)) {
       reset((prevValues) => ({ ...prevValues, conf }));

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -70,10 +70,10 @@ const TriggerDAGForm = ({
   const { t: translate } = useTranslation(["common", "components"]);
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const [formError, setFormError] = useState(false);
+  const [hasAppliedPrefill, setHasAppliedPrefill] = useState(false);
   const initialParamsDict = useDagParams(dagId, open);
   const { conf, initialParamDict, setConf, setInitialParamDict } = useParamStore();
   const [unpause, setUnpause] = useState(true);
-  const [hasAppliedPrefill, setHasAppliedPrefill] = useState(false);
   const { mutate: togglePause } = useTogglePause({ dagId });
 
   const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
@@ -135,7 +135,7 @@ const TriggerDAGForm = ({
     if (conf && open && (!prefillConfig || hasAppliedPrefill)) {
       reset((prevValues) => ({ ...prevValues, conf }));
     }
-  }, [conf, hasAppliedPrefill, prefillConfig, open, reset]);
+  }, [conf, hasAppliedPrefill, open, prefillConfig, reset]);
 
   const resetDateError = () => setErrors((prev) => ({ ...prev, date: undefined }));
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -70,43 +70,35 @@ const TriggerDAGForm = ({
   const { t: translate } = useTranslation(["common", "components"]);
   const [errors, setErrors] = useState<{ conf?: string; date?: unknown }>({});
   const [formError, setFormError] = useState(false);
-  const [hasAppliedPrefill, setHasAppliedPrefill] = useState(false);
   const initialParamsDict = useDagParams(dagId, open);
   const { conf, initialParamDict, setConf, setInitialParamDict } = useParamStore();
   const [unpause, setUnpause] = useState(true);
   const { mutate: togglePause } = useTogglePause({ dagId });
 
+  const defaultValues = {
+    conf: "",
+    dagRunId: "",
+    dataIntervalEnd: "",
+    dataIntervalMode: "auto",
+    dataIntervalStart: "",
+    // Default logical date to now, show it in the selected timezone.
+    // For partitioned Dags, logical date is not applicable.
+    logicalDate: isPartitioned ? "" : dayjs().format(DEFAULT_DATETIME_FORMAT),
+    note: "",
+    partitionKey: undefined,
+  };
+
   const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
-    defaultValues: {
-      conf,
-      dagRunId: "",
-      dataIntervalEnd: "",
-      dataIntervalMode: "auto",
-      dataIntervalStart: "",
-      // Default logical date to now, show it in the selected timezone.
-      // For partitioned Dags, logical date is not applicable.
-      logicalDate: isPartitioned ? "" : dayjs().format(DEFAULT_DATETIME_FORMAT),
-      note: "",
-      partitionKey: undefined,
-    },
+    defaultValues,
+    resetOptions: { keepDirtyValues: true },
+    values: { ...defaultValues, conf },
   });
 
-  // Pre-fill form when prefillConfig is provided (priority over conf)
-  // Only restore 'conf' (parameters), not logicalDate, runId, or partitionKey to avoid 409 conflicts
+  // Pre-fill conf when triggering again; reset dirty state when modal closes
   useEffect(() => {
     if (prefillConfig && open) {
       const confString = prefillConfig.conf ? JSON.stringify(prefillConfig.conf, undefined, 2) : "";
 
-      reset({
-        conf: confString,
-        dagRunId: "",
-        dataIntervalEnd: "",
-        dataIntervalMode: "auto",
-        dataIntervalStart: "",
-        logicalDate: isPartitioned ? "" : dayjs().format(DEFAULT_DATETIME_FORMAT),
-        note: "",
-        partitionKey: undefined,
-      });
       // Also update the param store to keep it in sync.
       // Wait until we have the initial params so section ordering stays consistent.
       if (confString && Object.keys(initialParamsDict.paramsDict).length > 0) {
@@ -115,9 +107,8 @@ const TriggerDAGForm = ({
         }
         setConf(confString);
       }
-      setHasAppliedPrefill(true);
     } else if (!open) {
-      setHasAppliedPrefill(false);
+      reset();
     }
   }, [
     prefillConfig,
@@ -127,15 +118,7 @@ const TriggerDAGForm = ({
     initialParamsDict.paramsDict,
     initialParamDict,
     setInitialParamDict,
-    isPartitioned,
   ]);
-
-  // Automatically reset form when conf is fetched
-  useEffect(() => {
-    if (conf && open && (!prefillConfig || hasAppliedPrefill)) {
-      reset((prevValues) => ({ ...prevValues, conf }));
-    }
-  }, [conf, hasAppliedPrefill, open, prefillConfig, reset]);
 
   const resetDateError = () => setErrors((prev) => ({ ...prev, date: undefined }));
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -18,7 +18,7 @@
  */
 import { Button, Box, Spacer, HStack, Field, Stack, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FiPlay } from "react-icons/fi";
@@ -75,18 +75,21 @@ const TriggerDAGForm = ({
   const [unpause, setUnpause] = useState(true);
   const { mutate: togglePause } = useTogglePause({ dagId });
 
-  const defaultValues = {
-    conf: "",
-    dagRunId: "",
-    dataIntervalEnd: "",
-    dataIntervalMode: "auto",
-    dataIntervalStart: "",
-    // Default logical date to now, show it in the selected timezone.
-    // For partitioned Dags, logical date is not applicable.
-    logicalDate: isPartitioned ? "" : dayjs().format(DEFAULT_DATETIME_FORMAT),
-    note: "",
-    partitionKey: undefined,
-  };
+  const defaultValues = useMemo(
+    () => ({
+      conf: "",
+      dagRunId: "",
+      dataIntervalEnd: "",
+      dataIntervalMode: "auto",
+      dataIntervalStart: "",
+      // Default logical date to now, show it in the selected timezone.
+      // For partitioned Dags, logical date is not applicable.
+      logicalDate: isPartitioned ? "" : dayjs().format(DEFAULT_DATETIME_FORMAT),
+      note: "",
+      partitionKey: undefined,
+    }),
+    [isPartitioned],
+  );
 
   const { control, handleSubmit, reset, watch } = useForm<DagRunTriggerParams>({
     defaultValues,


### PR DESCRIPTION
Closes #67243

When using "Trigger again with this config", any changes made to params in the trigger form were ignored and the original conf from the previous run was submitted instead.

The useEffect that syncs the param store's conf back into the form field had a `!prefillConfig` guard, which blocked it from running when "Trigger again" was used. So editing a param via the UI updated the store but the form field stayed on the original value.
Removed the guard so the form always stays in sync with the store, and removed prefillConfig from the dependency array since it is no longer used inside that effect.
> I used Claude (claude.ai) as an AI assistant for parts of this implementation..

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=adef5ab action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @shashbha14** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->