### PR TITLE
[v3-2-test] UI: Stop polling getLatestRunInfo on paused Dags with no active runs (#67249)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -88,7 +88,7 @@ export const Dag = () => {
 
   // Ensures continuous refresh to detect new runs when there's no
   // pending state and new runs are initiated from other page
-  useRefreshOnNewDagRuns(dagId, hasPendingRuns);
+  useRefreshOnNewDagRuns(dagId, hasPendingRuns, dag?.is_paused);
 
   const {
     data: latestRun,

--- a/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useRefreshOnNewDagRuns.ts
@@ -28,7 +28,11 @@ import {
 import { gridQueryKeys } from "./gridViewQueryKeys";
 import { useConfig } from "./useConfig";
 
-export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | undefined) => {
+export const useRefreshOnNewDagRuns = (
+  dagId: string,
+  hasPendingRuns: boolean | undefined,
+  isPaused?: boolean,
+) => {
   const queryClient = useQueryClient();
   const hasSyncedLatestRunRef = useRef(false);
   const previousLatestRunSignatureRef = useRef("");
@@ -38,7 +42,7 @@ export const useRefreshOnNewDagRuns = (dagId: string, hasPendingRuns: boolean | 
 
   const { data: latestDagRun } = useDagServiceGetLatestRunInfo({ dagId }, undefined, {
     enabled: Boolean(dagId),
-    refetchInterval: Boolean(dagId) && !hasPendingRuns ? pollIntervalMs : false,
+    refetchInterval: Boolean(dagId) && !hasPendingRuns && !isPaused ? pollIntervalMs : false,
   });
 
   useEffect(() => {


### PR DESCRIPTION

useRefreshOnNewDagRuns was polling every 5 s indefinitely whenever hasPendingRuns was false, including on Dags that are paused and have no active runs. Pass isPaused from the Dag details into the hook and skip the refetchInterval when the Dag is paused and idle.

Note: backport applies only the paused-Dag polling fix from #67249. The deadline-related changes are skipped because the deadline-alerts feature is not present in v3-2-test.

(cherry picked from commit 3047ad7fa3cbb8d442840111bed7febfab0a767e)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
