### PR TITLE
Add `dag_bundle_policy` cluster policy hook for DAG bundle initialization

### DIFF
--- a/airflow-core/docs/administration-and-deployment/cluster-policies.rst
+++ b/airflow-core/docs/administration-and-deployment/cluster-policies.rst
@@ -194,8 +194,9 @@ Note that since priority weight is determined dynamically using weight rules, yo
 Dag bundle policy
 ~~~~~~~~~~~~~~~~~
 
-Here's an example that makes a ``shared`` directory inside the DAG bundle importable by adding it to
-:data:`sys.path` once the bundle has been initialized:
+Here's an example that adds well-known subdirectories (``shared/``, ``libs/``,
+``plugins/``) inside the DAG bundle to :data:`sys.path` once the bundle has been
+initialized, so DAG files can import helpers from any of those locations:
 
 .. literalinclude:: /../tests/unit/cluster_policies/__init__.py
         :language: python

--- a/airflow-core/docs/administration-and-deployment/cluster-policies.rst
+++ b/airflow-core/docs/administration-and-deployment/cluster-policies.rst
@@ -27,7 +27,7 @@ Common use-cases include:
 * Setting default arguments on Dags / tasks
 * Performing custom routing logic
 
-There are three main types of cluster policy:
+There are four main types of cluster policy:
 
 * ``dag_policy``: Takes a :class:`~airflow.models.dag.DAG` parameter called ``dag``. Runs at load time of the
   Dag from DagBag :class:`~airflow.models.dagbag.DagBag`.
@@ -41,6 +41,11 @@ There are three main types of cluster policy:
   relates to a particular DagRun. It is executed in a "worker", not in the Dag file processor, just before the
   task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that
   task.
+* ``dag_bundle_policy``: Takes a :class:`~airflow.dag_processing.bundles.base.BaseDagBundle` parameter called
+  ``bundle``. It is called from
+  :meth:`~airflow.dag_processing.bundles.base.BaseDagBundle.initialize` right after a DAG bundle has been
+  initialized on disk and before any DAG files from the bundle are parsed. This is the right place to perform
+  bundle-local setup such as appending bundle subdirectories to :data:`sys.path`.
 
 The Dag and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation`
 exception to indicate that the Dag/task they were passed is not compliant and should not be loaded.
@@ -119,7 +124,7 @@ Available Policy Functions
 
 .. autoapimodule:: airflow.policies
   :no-members:
-  :members: task_policy, dag_policy, task_instance_mutation_hook, pod_mutation_hook, get_airflow_context_vars
+  :members: task_policy, dag_policy, task_instance_mutation_hook, pod_mutation_hook, get_airflow_context_vars, dag_bundle_policy
   :member-order: bysource
 
 
@@ -186,6 +191,20 @@ Here's an example of re-routing tasks that are on their second (or greater) retr
 
 Note that since priority weight is determined dynamically using weight rules, you cannot alter the ``priority_weight`` of a task instance within the mutation hook.
 
+Dag bundle policy
+~~~~~~~~~~~~~~~~~
+
+Here's an example that makes a ``shared`` directory inside the DAG bundle importable by adding it to
+:data:`sys.path` once the bundle has been initialized:
+
+.. literalinclude:: /../tests/unit/cluster_policies/__init__.py
+        :language: python
+        :start-after: [START example_dag_bundle_policy]
+        :end-before: [END example_dag_bundle_policy]
+
+The hook is called from :meth:`~airflow.dag_processing.bundles.base.BaseDagBundle.initialize` after the
+bundle's files are available on disk and before any DAG files from the bundle are parsed, so any changes
+made here are visible to DAG file parsing.
 
 Metadata Engine Hooks
 ---------------------

--- a/airflow-core/src/airflow/dag_processing/bundles/base.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/base.py
@@ -346,6 +346,12 @@ class BaseDagBundle(ABC):
                 bundle_path,
             )
 
+        # Apply the dag_bundle cluster policy. Imported lazily to avoid circular imports
+        # during the early stages of Airflow initialization.
+        from airflow import settings
+
+        settings.dag_bundle_policy(self)
+
     @property
     @abstractmethod
     def path(self) -> Path:

--- a/airflow-core/src/airflow/policies.py
+++ b/airflow-core/src/airflow/policies.py
@@ -27,6 +27,7 @@ hookimpl = pluggy.HookimplMarker("airflow.policy")
 __all__: list[str] = ["hookimpl"]
 
 if TYPE_CHECKING:
+    from airflow.dag_processing.bundles.base import BaseDagBundle
     from airflow.models.taskinstance import TaskInstance
 
 
@@ -63,6 +64,28 @@ def dag_policy(dag) -> None:
     * Check if every DAG has configured tags
 
     :param dag: dag to be mutated
+    """
+
+
+@local_settings_hookspec
+def dag_bundle_policy(bundle: BaseDagBundle) -> None:
+    """
+    Allow customizing a DAG bundle after it has been initialized.
+
+    This hook is invoked from :meth:`~airflow.dag_processing.bundles.base.BaseDagBundle.initialize`
+    once the bundle's files are available on disk, and before any DAG files from the bundle
+    are parsed. It is therefore a good place to perform setup that needs to happen against
+    the on-disk contents of the bundle.
+
+    Typical use cases include:
+
+    * Appending paths inside the bundle (for example a ``shared/`` directory next to the DAGs)
+      to :data:`sys.path` so DAG files can import shared helper modules.
+    * Installing or validating bundle-local configuration files.
+    * Performing custom logging or auditing whenever a bundle is initialized.
+
+    :param bundle: the bundle that was just initialized. ``bundle.path`` points to the
+        on-disk location of the bundle contents.
     """
 
 

--- a/airflow-core/src/airflow/policies.py
+++ b/airflow-core/src/airflow/policies.py
@@ -79,8 +79,9 @@ def dag_bundle_policy(bundle: BaseDagBundle) -> None:
 
     Typical use cases include:
 
-    * Appending paths inside the bundle (for example a ``shared/`` directory next to the DAGs)
-      to :data:`sys.path` so DAG files can import shared helper modules.
+    * Appending paths inside the bundle (for example a ``shared/`` directory next to the DAGs,
+      or any named subfolder such as ``libs/`` or ``plugins/``) to :data:`sys.path` so DAG files
+      can import shared helper modules located within the bundle.
     * Installing or validating bundle-local configuration files.
     * Performing custom logging or auditing whenever a bundle is initialized.
 

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -204,6 +204,10 @@ def dag_policy(dag):
     return get_policy_plugin_manager().hook.dag_policy(dag=dag)
 
 
+def dag_bundle_policy(bundle):
+    return get_policy_plugin_manager().hook.dag_bundle_policy(bundle=bundle)
+
+
 def task_instance_mutation_hook(task_instance):
     return get_policy_plugin_manager().hook.task_instance_mutation_hook(task_instance=task_instance)
 

--- a/airflow-core/tests/unit/cluster_policies/__init__.py
+++ b/airflow-core/tests/unit/cluster_policies/__init__.py
@@ -119,15 +119,21 @@ def task_instance_mutation_hook(task_instance: TaskInstance):
 
 
 # [START example_dag_bundle_policy]
+# Names of subdirectories inside the bundle root to add to sys.path.
+# Any of these that exist will be importable by DAG files in the bundle.
+_BUNDLE_SYS_PATH_SUBDIRS = ["shared", "libs", "plugins"]
+
+
 def dag_bundle_policy(bundle: BaseDagBundle):
-    """Add a ``shared`` folder inside the bundle to ``sys.path`` so DAGs can import helpers."""
+    """Add well-known subdirectories inside the bundle root to ``sys.path``."""
     import sys
 
-    shared_dir = bundle.path / "shared"
-    if shared_dir.is_dir():
-        shared_path = str(shared_dir)
-        if shared_path not in sys.path:
-            sys.path.insert(0, shared_path)
+    for subdir in _BUNDLE_SYS_PATH_SUBDIRS:
+        candidate = bundle.path / subdir
+        if candidate.is_dir():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
 
 
 # [END example_dag_bundle_policy]

--- a/airflow-core/tests/unit/cluster_policies/__init__.py
+++ b/airflow-core/tests/unit/cluster_policies/__init__.py
@@ -27,6 +27,7 @@ from airflow.exceptions import AirflowClusterPolicySkipDag, AirflowClusterPolicy
 from airflow.sdk import BaseOperator
 
 if TYPE_CHECKING:
+    from airflow.dag_processing.bundles.base import BaseDagBundle
     from airflow.models.dag import DAG
     from airflow.models.taskinstance import TaskInstance
 
@@ -115,3 +116,18 @@ def task_instance_mutation_hook(task_instance: TaskInstance):
 
 
 # [END example_task_mutation_hook]
+
+
+# [START example_dag_bundle_policy]
+def dag_bundle_policy(bundle: BaseDagBundle):
+    """Add a ``shared`` folder inside the bundle to ``sys.path`` so DAGs can import helpers."""
+    import sys
+
+    shared_dir = bundle.path / "shared"
+    if shared_dir.is_dir():
+        shared_path = str(shared_dir)
+        if shared_path not in sys.path:
+            sys.path.insert(0, shared_path)
+
+
+# [END example_dag_bundle_policy]

--- a/airflow-core/tests/unit/core/test_policies.py
+++ b/airflow-core/tests/unit/core/test_policies.py
@@ -69,3 +69,19 @@ def test_local_settings_misnamed_argument(plugin_manager: pluggy.PluginManager):
     plugin_manager.hook.dag_policy(dag="passed_dag_value")
 
     assert called_with == "passed_dag_value"
+
+
+def test_dag_bundle_policy_hookspec_registered(plugin_manager: pluggy.PluginManager):
+    """A dag_bundle_policy defined in local settings is registered and invoked."""
+    called_with = []
+
+    def dag_bundle_policy(bundle):
+        called_with.append(bundle)
+
+    mod = Namespace(dag_bundle_policy=dag_bundle_policy)
+
+    policies.make_plugin_from_local_settings(plugin_manager, mod, {"dag_bundle_policy"})
+
+    plugin_manager.hook.dag_bundle_policy(bundle="some-bundle")
+
+    assert called_with == ["some-bundle"]

--- a/airflow-core/tests/unit/dag_processing/bundles/test_base.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_base.py
@@ -240,6 +240,30 @@ class FakeBundle(BaseDagBundle):
     def refresh(self) -> None: ...
 
 
+class TestDagBundlePolicy:
+    def test_initialize_invokes_dag_bundle_policy(self, monkeypatch, tmp_path):
+        """The dag_bundle_policy hook should be called when a bundle is initialized."""
+        from airflow import settings
+
+        called_with: list = []
+
+        def fake_policy(bundle):
+            called_with.append(bundle)
+
+        monkeypatch.setattr(settings, "dag_bundle_policy", fake_policy)
+
+        class _Bundle(BasicBundle):
+            @property
+            def path(self) -> Path:  # type: ignore[override]
+                return tmp_path
+
+        bundle = _Bundle(name="policy-test")
+        bundle.initialize()
+
+        assert called_with == [bundle]
+        assert bundle.is_initialized is True
+
+
 class TestBundleUsageTrackingManager:
     @pytest.mark.parametrize(
         ("threshold_hours", "min_versions", "when_hours", "expected_remaining"),


### PR DESCRIPTION
Add a new `dag_bundle_policy` cluster policy hook that is invoked from
`BaseDagBundle.initialize()` after the bundle's files are available on disk
and **before** any DAG files from the bundle are parsed.

## Motivation

Operators sometimes need to perform per-bundle setup at parse time — the most
common example is extending `sys.path` with helper directories that live
inside the bundle root (e.g. `shared/`, `libs/`, `plugins/`) so that DAG files
can import shared modules. There was no clean hook to do this in Airflow today;
users had to resort to patching `BaseDagBundle.initialize` or other unsupported
workarounds.

## Changes

- **`airflow/policies.py`** — new `dag_bundle_policy(bundle: BaseDagBundle)` hook-spec,
  documented alongside the existing `dag_policy`, `task_policy`, etc.
- **`airflow/settings.py`** — thin `dag_bundle_policy(bundle)` dispatcher that calls
  through the pluggy plugin manager, consistent with all other policy dispatchers.
- **`airflow/dag_processing/bundles/base.py`** — `BaseDagBundle.initialize()` now calls
  `settings.dag_bundle_policy(self)` at the very end (after `is_initialized = True`),
  so the hook always runs after initialization and before parsing.
- **`docs/administration-and-deployment/cluster-policies.rst`** — updated the
  "Available Policy Functions" list and added an example section for the new hook.
- **`tests/unit/cluster_policies/__init__.py`** — added a `dag_bundle_policy` example
  that inserts well-known subdirectories (`shared/`, `libs/`, `plugins/`) of the bundle
  into `sys.path`.
- **`tests/unit/core/test_policies.py`** — new test verifying the hook is registered
  and invoked via `make_plugin_from_local_settings`.
- **`tests/unit/dag_processing/bundles/test_base.py`** — new `TestDagBundlePolicy` class
  verifying that `BaseDagBundle.initialize()` calls the policy.

## Example usage

```python
# airflow_local_settings.py

# Names of subdirectories inside the bundle root to add to sys.path.
_BUNDLE_SYS_PATH_SUBDIRS = ["shared", "libs", "plugins"]


def dag_bundle_policy(bundle) -> None:
    """Add well-known subdirectories inside the bundle root to sys.path."""
    import sys

    for subdir in _BUNDLE_SYS_PATH_SUBDIRS:
        candidate = bundle.path / subdir
        if candidate.is_dir():
            candidate_str = str(candidate)
            if candidate_str not in sys.path:
                sys.path.insert(0, candidate_str)
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot CLI (Claude Sonnet 4.6)

Generated-by: GitHub Copilot CLI (Claude Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T09:36:35Z head=26423e0 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @m1racoli** · by `@potiuk` · 2026-06-12 09:36 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts** — [how to fix](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst)
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->