### PR TITLE
Remove unused isLoggedIn and expectLoginSuccess from UI e2e page objects

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/BasePage.ts
@@ -34,16 +34,6 @@ export class BasePage {
     });
   }
 
-  public async isLoggedIn(): Promise<boolean> {
-    try {
-      await expect(this.welcomeHeading).toBeVisible({ timeout: 30_000 });
-
-      return true;
-    } catch {
-      return !this.page.url().includes("/login");
-    }
-  }
-
   public async maximizeBrowser(): Promise<void> {
     try {
       await this.page.setViewportSize({ height: 1080, width: 1920 });

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/LoginPage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/LoginPage.ts
@@ -43,17 +43,6 @@ export class LoginPage extends BasePage {
     this.errorMessage = page.getByText("Invalid credentials");
   }
 
-  public async expectLoginSuccess(): Promise<void> {
-    const currentUrl: string = this.page.url();
-
-    if (currentUrl.includes("/login")) {
-      throw new Error(`Expected to be redirected after login, but still on: ${currentUrl}`);
-    }
-
-    const isLoggedIn: boolean = await this.isLoggedIn();
-
-    expect(isLoggedIn).toBe(true);
-  }
   public async login(username: string, password: string): Promise<void> {
     await this.usernameInput.fill(username);
     await this.passwordInput.fill(password);


### PR DESCRIPTION
Remove two unused helpers in the UI e2e page objects: `BasePage.isLoggedIn()` and `LoginPage.expectLoginSuccess()`. Neither has any callers. `LoginPage.login()` already verifies success via `waitForURL`.