### PR TITLE
Fix provider executor tests broken in main

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -345,8 +345,9 @@ class AwsLambdaExecutor(BaseExecutor):
             try:
                 ser_workload_key = json.dumps(workload_key._asdict())
             except AttributeError:
-                # Callback workloads use string id.
-                ser_workload_key = workload_key
+                # Callback workloads use CallbackKey (or legacy string id); both have a
+                # str() representation that round-trips through JSON.
+                ser_workload_key = str(workload_key)
 
             payload = {
                 "task_key": ser_workload_key,

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
     from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
+    from airflow.providers.amazon.aws.executors.batch.utils import BatchJobWorkloadKey
 
 
 from airflow.providers.amazon.aws.executors.batch.boto_schema import (
@@ -402,9 +403,7 @@ class AwsBatchExecutor(BaseExecutor):
             all_jobs.extend(describe_workloads_response["jobs"])
         return all_jobs
 
-    def execute_async(
-        self, key: TaskInstanceKey | str, command: CommandType, queue=None, executor_config=None
-    ):
+    def execute_async(self, key: BatchJobWorkloadKey, command: CommandType, queue=None, executor_config=None):
         """Save the workload to be executed in the next sync using Boto3's RunTask API."""
         if executor_config and "command" in executor_config:
             raise ValueError('Executor Config should never override "command"')

--- a/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
@@ -25,7 +25,6 @@ from botocore.exceptions import ClientError
 from semver import VersionInfo
 
 from airflow.executors.base_executor import BaseExecutor
-from airflow.models.callback import CallbackKey
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.amazon.aws.executors.aws_lambda import lambda_executor
@@ -181,8 +180,9 @@ class TestAwsLambdaExecutor:
     def test_task_sdk_callback(self, mock_executor):
         """Test task sdk callback execution end-to-end."""
         from airflow.executors.workloads import ExecuteCallback
+        from airflow.models.callback import CallbackKey
 
-        callback_id = CallbackKey(id="callback_123")
+        callback_id = CallbackKey("callback_123")
 
         workload = mock.Mock(spec=ExecuteCallback)
         workload.key = callback_id

--- a/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/aws_lambda/test_lambda_executor.py
@@ -25,6 +25,7 @@ from botocore.exceptions import ClientError
 from semver import VersionInfo
 
 from airflow.executors.base_executor import BaseExecutor
+from airflow.models.callback import CallbackKey
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.amazon.aws.executors.aws_lambda import lambda_executor
@@ -64,7 +65,7 @@ def set_env_vars():
 @pytest.fixture
 def mock_airflow_key():
     def _key():
-        key_mock = mock.Mock()
+        key_mock = mock.Mock(spec=TaskInstanceKey)
         # Use a "random" value (memory id of the mock obj) so each key serializes uniquely
         key_mock._asdict = mock.Mock(return_value={"mock_key": id(key_mock)})
         return key_mock
@@ -181,9 +182,10 @@ class TestAwsLambdaExecutor:
         """Test task sdk callback execution end-to-end."""
         from airflow.executors.workloads import ExecuteCallback
 
-        callback_id = "callback_123"
+        callback_id = CallbackKey(id="callback_123")
 
         workload = mock.Mock(spec=ExecuteCallback)
+        workload.key = callback_id
         workload.callback = mock.Mock()
         workload.callback.key = callback_id
         workload.callback.data = {}
@@ -212,7 +214,7 @@ class TestAwsLambdaExecutor:
         mock_executor.attempt_workload_runs()
         mock_executor.lambda_client.invoke.assert_called_once()
         payload = json.loads(mock_executor.lambda_client.invoke.call_args.kwargs["Payload"])
-        assert payload["task_key"] == callback_id
+        assert payload["task_key"] == str(callback_id)
         assert payload["command"] == [
             "python",
             "-m",
@@ -223,7 +225,7 @@ class TestAwsLambdaExecutor:
 
         # Callback is stored in running workloads.
         assert len(mock_executor.running_workloads) == 1
-        assert callback_id in mock_executor.running_workloads
+        assert str(callback_id) in mock_executor.running_workloads
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="Test requires Airflow 3.3+")
     def test_task_sdk_callback_with_queue(self, mock_airflow_key, mock_executor):

--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -88,7 +88,7 @@ def mock_executor(set_env_vars) -> AwsBatchExecutor:
 
 @pytest.fixture(autouse=True)
 def mock_airflow_key():
-    return mock.Mock(spec=list)
+    return mock.Mock(spec=TaskInstanceKey)
 
 
 @pytest.fixture(autouse=True)
@@ -108,7 +108,7 @@ class TestBatchJobCollection:
         self.collection = BatchJobCollection()
         # Add first task
         self.first_job_id = "001"
-        self.first_airflow_key = mock.Mock(spec=tuple)
+        self.first_airflow_key = mock.Mock(spec=TaskInstanceKey)
         self.collection.add_job(
             job_id=self.first_job_id,
             airflow_workload_key=self.first_airflow_key,
@@ -119,7 +119,7 @@ class TestBatchJobCollection:
         )
         # Add second task
         self.second_job_id = "002"
-        self.second_airflow_key = mock.Mock(spec=tuple)
+        self.second_airflow_key = mock.Mock(spec=TaskInstanceKey)
         self.collection.add_job(
             job_id=self.second_job_id,
             airflow_workload_key=self.second_airflow_key,
@@ -190,7 +190,7 @@ class TestAwsBatchExecutor:
 
     def test_execute(self, mock_executor):
         """Test execution from end-to-end"""
-        airflow_key = mock.Mock(spec=tuple)
+        airflow_key = mock.Mock(spec=TaskInstanceKey)
         airflow_cmd = ["1", "2"]
 
         mock_executor.batch.submit_job.return_value = {"jobId": MOCK_JOB_ID, "jobName": "some-job-name"}
@@ -480,7 +480,7 @@ class TestAwsBatchExecutor:
 
     def test_attempt_submit_jobs_failure(self, mock_executor):
         mock_executor.batch.submit_job.side_effect = NoCredentialsError()
-        mock_executor.execute_async("airflow_key", "airflow_cmd")
+        mock_executor.execute_async(mock.Mock(spec=TaskInstanceKey), "airflow_cmd")
         assert len(mock_executor.pending_jobs) == 1
         with pytest.raises(NoCredentialsError, match="Unable to locate credentials"):
             mock_executor.attempt_submit_jobs()
@@ -501,7 +501,10 @@ class TestAwsBatchExecutor:
     @mock.patch.object(batch_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_task_retry_on_api_failure(self, _, mock_executor, caplog):
         """Test API failure retries"""
-        airflow_keys = ["TaskInstanceKey1", "TaskInstanceKey2"]
+        airflow_keys = [
+            TaskInstanceKey("dag", "task1", "run", 1, -1),
+            TaskInstanceKey("dag", "task2", "run", 1, -1),
+        ]
         airflow_cmds = [["1", "2"], ["3", "4"]]
 
         mock_executor.execute_async(airflow_keys[0], airflow_cmds[0])
@@ -575,7 +578,7 @@ class TestAwsBatchExecutor:
         assert "No active Airflow workloads, skipping sync" in caplog.messages[0]
 
     def test_sync_client_error(self, mock_executor, caplog):
-        mock_executor.execute_async("airflow_key", "airflow_cmd")
+        mock_executor.execute_async(mock.Mock(spec=TaskInstanceKey), "airflow_cmd")
         assert len(mock_executor.pending_jobs) == 1
         mock_resp = {
             "Error": {
@@ -1053,7 +1056,7 @@ class TestBatchExecutorConfig:
         )
         os.environ[submit_job_kwargs_env_key] = json.dumps(submit_job_kwargs)
 
-        mock_ti_key = mock.Mock(spec=tuple)
+        mock_ti_key = mock.Mock(spec=TaskInstanceKey)
         command = ["command"]
 
         executor = AwsBatchExecutor()

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -110,7 +110,7 @@ def mock_task(arn=ARN1, state=State.RUNNING):
 @pytest.fixture(autouse=True)
 def mock_airflow_key():
     def _key():
-        return mock.Mock(spec=tuple)
+        return mock.Mock(spec=TaskInstanceKey)
 
     return _key
 
@@ -519,7 +519,7 @@ class TestAwsEcsExecutor:
             "failures": [],
         }
         mock_executor.ecs.run_task.side_effect = [run_task_exception, run_task_exception, run_task_success]
-        mock_executor.execute_async(mock_airflow_key, mock_cmd)
+        mock_executor.execute_async(mock.Mock(spec=TaskInstanceKey), mock_cmd)
         expected_retry_count = 2
 
         # Fail 2 times
@@ -669,7 +669,7 @@ class TestAwsEcsExecutor:
         mock_executor.ecs.run_task.call_args_list.clear()
 
         # queue new task
-        airflow_keys[1] = mock.Mock(spec=tuple)
+        airflow_keys[1] = mock.Mock(spec=TaskInstanceKey)
         airflow_commands[1] = _generate_mock_cmd()
         mock_executor.execute_async(airflow_keys[1], airflow_commands[1])
 
@@ -710,7 +710,10 @@ class TestAwsEcsExecutor:
         Test API failure retries.
         """
         mock_executor.max_run_task_attempts = "2"
-        airflow_keys = ["TaskInstanceKey1", "TaskInstanceKey2"]
+        airflow_keys = [
+            TaskInstanceKey("dag", "task1", "run", 1, -1),
+            TaskInstanceKey("dag", "task2", "run", 1, -1),
+        ]
         airflow_commands = [_generate_mock_cmd(), _generate_mock_cmd()]
 
         mock_executor.execute_async(airflow_keys[0], airflow_commands[0])
@@ -955,7 +958,7 @@ class TestAwsEcsExecutor:
     @mock.patch.object(ecs_executor, "calculate_next_attempt_delay", return_value=dt.timedelta(seconds=0))
     def test_failed_sync_api(self, _, success_mock, fail_mock, mock_executor, mock_cmd):
         """Test what happens when ECS sync fails for certain tasks repeatedly."""
-        airflow_key = "test-key"
+        airflow_key = TaskInstanceKey("dag", "task", "run", 1, -1)
         mock_executor.execute_async(airflow_key, mock_cmd)
         assert len(mock_executor.pending_tasks) == 1
 
@@ -1148,7 +1151,9 @@ class TestAwsEcsExecutor:
     @staticmethod
     def _add_mock_task(executor: AwsEcsExecutor, arn: str, state=TaskInstanceState.RUNNING):
         task = mock_task(arn, state)
-        executor.active_workers.add_task(task, mock.Mock(spec=tuple), mock_queue, mock_cmd, mock_config, 1)  # type:ignore[arg-type]
+        executor.active_workers.add_task(
+            task, mock.Mock(spec=TaskInstanceKey), mock_queue, mock_cmd, mock_config, 1
+        )  # type:ignore[arg-type]
 
     def _sync_mock_with_call_counts(self, sync_func: Callable):
         """Mock won't work here, because we actually want to call the 'sync' func."""

--- a/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/ecs/test_ecs_executor.py
@@ -1152,8 +1152,13 @@ class TestAwsEcsExecutor:
     def _add_mock_task(executor: AwsEcsExecutor, arn: str, state=TaskInstanceState.RUNNING):
         task = mock_task(arn, state)
         executor.active_workers.add_task(
-            task, mock.Mock(spec=TaskInstanceKey), mock_queue, mock_cmd, mock_config, 1
-        )  # type:ignore[arg-type]
+            task,
+            mock.Mock(spec=TaskInstanceKey),
+            mock_queue,  # type:ignore[arg-type]
+            mock_cmd,  # type:ignore[arg-type]
+            mock_config,  # type:ignore[arg-type]
+            1,
+        )
 
     def _sync_mock_with_call_counts(self, sync_func: Callable):
         """Mock won't work here, because we actually want to call the 'sync' func."""

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -919,7 +919,7 @@ def test_process_workloads_routes_execute_callback(mock_send_workloads, callback
     executor = celery_executor.CeleryExecutor()
     executor._process_workloads([workload])
 
-    mock_send_workloads.assert_called_once_with([(callback_id, workload, expected_queue, None)])
+    mock_send_workloads.assert_called_once_with([(workload.callback.key, workload, expected_queue, None)])
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="execute_workload is only used for Airflow 3+")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -808,7 +808,7 @@ class TestKubernetesExecutor:
         try:
             assert executor.event_buffer == {}
             executor.execute_async(
-                key=("dag", "task", timezone.utcnow(), 1),
+                key=TaskInstanceKey("dag", "task", "run_id", 1, -1),
                 queue=None,
                 command=["airflow", "tasks", "run", "true", "some_parameter"],
                 executor_config=k8s.V1Pod(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Several amazon (batch/ecs/lambda) and cncf/kubernetes executor tests pass `Mock(spec=tuple)`, tuple literals, or bare strings as workload keys, which now fail with `TypeError: Unknown workload key type` after the `state_class_for_key` guard was tightened.

Swaps them for `Mock(spec=TaskInstanceKey)` / real `TaskInstanceKey(...)` / `CallbackKey(...)`. Also fixes the Lambda executor's callback serialization which fed a `CallbackKey` dataclass into `json.dumps` , now uses `str(workload_key)`.

related: https://github.com/apache/airflow/pull/66973

cc: @ferruzzi 

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
