### PR TITLE
Add `.github/skills/issue-*` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ dev/registry/providers.json
 /.github/skills/setup-override-upstream
 /.github/skills/setup-shared-config-sync
 /.github/skills/list-steward-*
+/.github/skills/issue-*


### PR DESCRIPTION
The apache-steward framework wires up gitignored symlinks under `.github/skills/` for each skill family it installs. The existing `.gitignore` already covered `security-*`, `pr-management-*`, and `setup-isolated-setup-*` symlinks but was missing the `issue-*` family, causing those symlinks to appear as untracked files after running `/setup-steward`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)