### PR TITLE
workflows: use `task-sdk` alias in publish-docs NON_PROVIDER_TOKENS

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           # Keep the non-provider list in sync with NON_PROVIDER_TOKENS in
           # dev/registry/derive_wave_providers.py.
-          NON_PROVIDER_TOKENS=("apache-airflow" "apache-airflow-ctl" "apache-airflow-task-sdk" "helm-chart" "docker-stack")
+          NON_PROVIDER_TOKENS=("apache-airflow" "apache-airflow-ctl" "task-sdk" "helm-chart" "docker-stack")
           has_provider=false
           for token in $INCLUDE_DOCS; do
             is_non_provider=false

--- a/dev/registry/derive_wave_providers.py
+++ b/dev/registry/derive_wave_providers.py
@@ -59,7 +59,7 @@ NON_PROVIDER_TOKENS = frozenset(
         "helm-chart",
         "docker-stack",
         "apache-airflow-ctl",
-        "apache-airflow-task-sdk",
+        "task-sdk",
     }
 )
 PROVIDER_PREFIX = "apache-airflow-providers-"


### PR DESCRIPTION
## Summary

`publish-docs-to-s3.yml` filters distributions through a `NON_PROVIDER_TOKENS`
bash array, with a matching `frozenset` in `dev/registry/derive_wave_providers.py`.
Both lists currently use the PyPI distribution name `apache-airflow-task-sdk`,
but `docs.build_docs` itself accepts the docs-folder alias `task-sdk` (see its
`click` choices). Invoking the workflow with either name fails:

- `task-sdk`: not in `NON_PROVIDER_TOKENS`, falls through to
  `dev/registry/derive_wave_providers.py` — which does not exist on older
  release branches like `v3-2-stable`.
- `apache-airflow-task-sdk`: passes the filter but `docs.build_docs` rejects
  the name with `Invalid value for '[apache-airflow | ... | task-sdk | ...]': 'apache-airflow-task-sdk' is not one of ...`.

This PR replaces `apache-airflow-task-sdk` with `task-sdk` in both lists so
the workflow can publish task-sdk docs end-to-end. The other references to
`apache-airflow-task-sdk` in the repo (pyproject templates, pip install
commands, PyPI URLs) are intentional PyPI distribution-name uses and are
left alone.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)