### PR TITLE
Fix wrong changelog entry for PR #66760 in google provider 22.0.0

### DIFF
--- a/providers/google/docs/changelog.rst
+++ b/providers/google/docs/changelog.rst
@@ -58,7 +58,7 @@ Features
 
 * ``Add 'host_key_policy' option to 'ComputeEngineSSHHook' (#66746)``
 * ``Add BigQueryStreamingBufferEmptySensor for DML on streaming tables (#66652)``
-* ``Add persist_xcom option to BigQueryInsertJobOperator (#66760)``
+* ``Deprecate 'job_id_path' XCom push from 'BigQueryInsertJobOperator' (#66760)``
 * ``Migrate BigQueryInsertJobTrigger to on_kill() for user-initiated kills (#66704)``
 * ``Add Cloud SQL Auth Proxy IAM authentication (#66510)``
 * ``Add aliases for rebranded Google services (#66344)``


### PR DESCRIPTION
PR #66760 adds a deprecation warning for the \`job_id_path\` XCom push in
`BigQueryInsertJobOperator`. The changelog entry for 22.0.0 incorrectly
described it as:

> Add persist_xcom option to BigQueryInsertJobOperator

The correct description is:

> Deprecate 'job_id_path' XCom push from 'BigQueryInsertJobOperator'

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)