### PR TITLE
Standardize Execution API error responses to RFC 9457

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -97,6 +97,9 @@ from airflow.utils.state import DagRunState, TaskInstanceState, TerminalTIState
 if TYPE_CHECKING:
     from sqlalchemy.sql.dml import Update
 
+# https://datatracker.ietf.org/doc/html/rfc9457
+# FastAPI wraps error responses in {"detail": ...} instead of a native RFC 9457 response.
+# Tracked in: https://github.com/fastapi/fastapi/issues/10370
 router = VersionedAPIRouter()
 
 ti_id_router = VersionedAPIRouter(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -183,8 +183,10 @@ def ti_run(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": "Task Instance not found",
                 "reason": "not_found",
-                "message": "Task Instance not found",
             },
         )
 
@@ -214,16 +216,13 @@ def ti_run(
             previous_state=previous_state,
         )
 
-        # TODO: Pass a RFC 9457 compliant error message in "detail" field
-        # https://datatracker.ietf.org/doc/html/rfc9457
-        # to provide more information about the error
-        # FastAPI will automatically convert this to a JSON response
-        # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "about:blank",
+                "title": "Conflict",
+                "detail": "TI was not in a state where it could be marked as running",
                 "reason": "invalid_state",
-                "message": "TI was not in a state where it could be marked as running",
                 "previous_state": previous_state,
             },
         )
@@ -321,7 +320,12 @@ def ti_run(
     except SQLAlchemyError:
         log.exception("Error marking Task Instance state as running")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "type": "about:blank",
+                "title": "Internal Server Error",
+                "detail": "Database error occurred",
+            },
         )
 
     # JWTReissueMiddleware also writes Refreshed-API-Token but skips workload tokens, so we set it here for the workload→execution swap.
@@ -401,8 +405,10 @@ def ti_update_state(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": "Task Instance not found",
                 "reason": "not_found",
-                "message": "Task Instance not found",
             },
         )
 
@@ -426,8 +432,10 @@ def ti_update_state(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "about:blank",
+                "title": "Conflict",
+                "detail": "TI was not in the running state so it cannot be updated",
                 "reason": "invalid_state",
-                "message": "TI was not in the running state so it cannot be updated",
                 "previous_state": previous_state,
             },
         )
@@ -505,7 +513,12 @@ def ti_update_state(
     except SQLAlchemyError as e:
         log.error("Error updating Task Instance state", error=str(e))
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "type": "about:blank",
+                "title": "Internal Server Error",
+                "detail": "Database error occurred",
+            },
         )
 
     if updated_state == TaskInstanceState.SUCCESS:
@@ -823,7 +836,12 @@ def ti_skip_downstream(
     if row_result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={"reason": "not_found", "message": "Task Instance not found"},
+            detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": "Task Instance not found",
+                "reason": "not_found",
+            },
         )
     dag_id, run_id = row_result
     log.debug("Retrieved DAG and run info", dag_id=dag_id, run_id=run_id)
@@ -869,16 +887,20 @@ def _raise_ti_not_in_live_table(task_instance_id: UUID, session: SessionDep) -> 
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail={
+                "type": "about:blank",
+                "title": "Gone",
+                "detail": "Task Instance not found, it may have been moved to the Task Instance History table",
                 "reason": "not_found",
-                "message": "Task Instance not found, it may have been moved to the Task Instance History table",
             },
         )
     log.error("Task Instance not found", ti_id=str(task_instance_id))
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail={
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task Instance not found",
             "reason": "not_found",
-            "message": "Task Instance not found",
         },
     )
 
@@ -956,8 +978,10 @@ def ti_heartbeat(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "about:blank",
+                "title": "Conflict",
+                "detail": "TI is already running elsewhere",
                 "reason": "running_elsewhere",
-                "message": "TI is already running elsewhere",
                 "current_hostname": hostname,
                 "current_pid": pid,
             },
@@ -968,8 +992,10 @@ def ti_heartbeat(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "about:blank",
+                "title": "Conflict",
+                "detail": "TI is no longer in the running state and task should terminate",
                 "reason": "not_running",
-                "message": "TI is no longer in the running state and task should terminate",
                 "current_state": previous_state,
             },
         )
@@ -1045,7 +1071,11 @@ def ti_patch_rendered_map_index(
         log.error("rendered_map_index cannot be empty")
         raise HTTPException(
             status_code=HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="rendered_map_index cannot be empty",
+            detail={
+                "type": "about:blank",
+                "title": "Unprocessable Content",
+                "detail": "rendered_map_index cannot be empty",
+            },
         )
 
     log.debug("Updating rendered_map_index", length=len(rendered_map_index))
@@ -1058,7 +1088,11 @@ def ti_patch_rendered_map_index(
         log.error("Task Instance not found")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Task Instance not found",
+            detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": "Task Instance not found",
+            },
         )
 
 
@@ -1311,8 +1345,10 @@ def _get_group_tasks(
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": f"Task group {task_group_id} not found in DAG {dag_id}",
                 "reason": "not_found",
-                "message": f"Task group {task_group_id} not found in DAG {dag_id}",
             },
         )
 
@@ -1353,8 +1389,10 @@ def validate_inlets_and_outlets(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
+                "type": "about:blank",
+                "title": "Not Found",
+                "detail": "Task Instance not found",
                 "reason": "not_found",
-                "message": "Task Instance not found",
             },
         )
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -857,7 +857,9 @@ class TestTIRunState:
         assert response.status_code == 409
         assert response.json() == {
             "detail": {
-                "message": "TI was not in a state where it could be marked as running",
+                "type": "about:blank",
+                "title": "Conflict",
+                "detail": "TI was not in a state where it could be marked as running",
                 "previous_state": initial_ti_state,
                 "reason": "invalid_state",
             }
@@ -1418,8 +1420,10 @@ class TestTIUpdateState:
         response = client.patch(f"/execution/task-instances/{task_instance_id}/state", json=payload)
         assert response.status_code == 404
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task Instance not found",
             "reason": "not_found",
-            "message": "Task Instance not found",
         }
 
     def test_ti_update_state_running_errors(self, client, session, create_task_instance, time_machine):
@@ -1497,7 +1501,11 @@ class TestTIUpdateState:
             mock_register_asset_changes_in_db.return_value = None
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
-            assert response.json()["detail"] == "Database error occurred"
+            assert response.json()["detail"] == {
+                "type": "about:blank",
+                "title": "Internal Server Error",
+                "detail": "Database error occurred",
+            }
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(
@@ -2130,8 +2138,10 @@ class TestTIUpdateState:
         response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
         assert response.status_code == 409
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Conflict",
+            "detail": "TI was not in the running state so it cannot be updated",
             "reason": "invalid_state",
-            "message": "TI was not in the running state so it cannot be updated",
             "previous_state": State.SUCCESS,
         }
 
@@ -2186,9 +2196,11 @@ class TestTIUpdateState:
         )
         assert response.status_code == 409
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Conflict",
+            "detail": "TI was not in the running state so it cannot be updated",
             "reason": "invalid_state",
-            "message": "TI was not in the running state so it cannot be updated",
-            "previous_state": State.SUCCESS,
+            "previous_state": State.SUCCESS.value,
         }
 
         session.refresh(ti)
@@ -2539,8 +2551,10 @@ class TestTIHealthEndpoint:
                 1789,
                 409,
                 {
+                    "type": "about:blank",
+                    "title": "Conflict",
+                    "detail": "TI is already running elsewhere",
                     "reason": "running_elsewhere",
-                    "message": "TI is already running elsewhere",
                     "current_hostname": "random-hostname",
                     "current_pid": 1789,
                 },
@@ -2551,8 +2565,10 @@ class TestTIHealthEndpoint:
                 1054,
                 409,
                 {
+                    "type": "about:blank",
+                    "title": "Conflict",
+                    "detail": "TI is already running elsewhere",
                     "reason": "running_elsewhere",
-                    "message": "TI is already running elsewhere",
                     "current_hostname": "random-hostname",
                     "current_pid": 1789,
                 },
@@ -2619,8 +2635,10 @@ class TestTIHealthEndpoint:
 
         assert response.status_code == 404
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task Instance not found",
             "reason": "not_found",
-            "message": "Task Instance not found",
         }
 
     def test_ti_heartbeat_cleared_task_returns_410(self, client, session, create_task_instance):
@@ -2653,8 +2671,10 @@ class TestTIHealthEndpoint:
 
         assert response.status_code == 410
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Gone",
+            "detail": "Task Instance not found, it may have been moved to the Task Instance History table",
             "reason": "not_found",
-            "message": "Task Instance not found, it may have been moved to the Task Instance History table",
         }
 
     @pytest.mark.parametrize(
@@ -2680,8 +2700,10 @@ class TestTIHealthEndpoint:
 
         assert response.status_code == 409
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Conflict",
+            "detail": "TI is no longer in the running state and task should terminate",
             "reason": "not_running",
-            "message": "TI is no longer in the running state and task should terminate",
             "current_state": ti_state,
         }
 
@@ -2922,8 +2944,10 @@ class TestTIPutRTIF:
         response = client.put(f"/execution/task-instances/{random_id}/rtif", json=payload)
         assert response.status_code == 404
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task Instance not found",
             "reason": "not_found",
-            "message": "Task Instance not found",
         }
 
     def test_ti_put_rtif_archived_ti_returns_410(self, client, session, create_task_instance):
@@ -2949,8 +2973,10 @@ class TestTIPutRTIF:
 
         assert response.status_code == 410
         assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Gone",
+            "detail": "Task Instance not found, it may have been moved to the Task Instance History table",
             "reason": "not_found",
-            "message": "Task Instance not found, it may have been moved to the Task Instance History table",
         }
 
 
@@ -3205,7 +3231,9 @@ class TestGetCount:
         assert response.status_code == 404
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": "Task group non_existent_group not found in DAG test_get_count_task_group_not_found",
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task group non_existent_group not found in DAG test_get_count_task_group_not_found",
         }
 
     def test_get_count_dag_not_found(self, client, session):
@@ -3759,7 +3787,9 @@ class TestGetTaskStates:
         assert response.status_code == 404
         assert response.json()["detail"] == {
             "reason": "not_found",
-            "message": "Task group non_existent_group not found in DAG test_get_task_states_task_group_not_found",
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task group non_existent_group not found in DAG test_get_task_states_task_group_not_found",
         }
 
     def test_get_task_states_dag_not_found(self, client, session):
@@ -4152,6 +4182,11 @@ class TestTIPatchRenderedMapIndex:
         )
 
         assert response.status_code == 404
+        assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Not Found",
+            "detail": "Task Instance not found",
+        }
 
     def test_ti_patch_rendered_map_index_empty_string(self, client, session, create_task_instance):
         """Test that empty string is accepted (clears the rendered_map_index)."""
@@ -4168,6 +4203,11 @@ class TestTIPatchRenderedMapIndex:
         )
 
         assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "type": "about:blank",
+            "title": "Unprocessable Content",
+            "detail": "rendered_map_index cannot be empty",
+        }
 
 
 @pytest.mark.usefixtures("_use_real_jwt_bearer")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->


This PR standardizes the Airflow Execution API error responses to follow the RFC 9457 (Problem Details for HTTP APIs) specification.

## Description

Exceptions in the Execution API are caught at the FastAPI route boundary in `task_instances.py` and re-raised as standard `HTTPException`s. The Execution API now returns RFC 9457 Problem Details-shaped payloads under the `detail` key of the `HTTPException`.

> [!NOTE]
> FastAPI wraps the payload in `{"detail": ...}` instead of a flat response. This is a known limitation tracked in fastapi/fastapi#10370.

### Error Response Examples

This PR demonstrates two key improvements in error handling:

#### Case 1: Upgrading plain string messages to structured objects
**Before:**
```json
{
  "detail": "Database error occurred"
}
```
**After:**
```json
{
  "detail": {
    "type": "about:blank",
    "title": "Internal Server Error",
    "detail": "Database error occurred"
  }
}
```

#### Case 2: Standardizing dictionaries while retaining custom context
**Before:**
```json
{
  "detail": {
    "reason": "running_elsewhere",
    "message": "TI is already running elsewhere",
    "current_hostname": "worker-1",
    "current_pid": 12345
  }
}
```
**After:**
```json
{
  "detail": {
    "type": "about:blank",
    "title": "Conflict",
    "detail": "TI is already running elsewhere",
    "reason": "running_elsewhere",
    "current_hostname": "worker-1",
    "current_pid": 12345
  }
}
```

## Verification Results

I have verified the changes using `prek` and `breeze`.
* **Static Checks (Prek):** Passed
* **Unit Tests (Breeze):** Passed

---

related: #62107

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.


<!-- pr-triage-fold: triaged=2026-07-18T15:46:56Z head=42fc2f0 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @23tae** · by `@potiuk` · 2026-07-18 15:46 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**: with `main`. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for details.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
