### PR TITLE
Fix SageMaker processing stopped state handling

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -335,7 +335,7 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
         if self.deferrable and self.wait_for_completion:
             response = self.hook.describe_processing_job(self.config["ProcessingJobName"])
             status = response["ProcessingJobStatus"]
-            if status in self.hook.failed_states:
+            if status in self.hook.processing_job_failed_states:
                 raise AirflowException(f"SageMaker job failed because {response['FailureReason']}")
             if status == "Completed":
                 self.log.info("%s completed successfully.", self.task_id)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_processing.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_processing.py
@@ -319,6 +319,34 @@ class TestSageMakerProcessingOperator:
 
         assert not mock_defer.called
 
+    @mock.patch("airflow.providers.amazon.aws.operators.sagemaker.SageMakerProcessingOperator.defer")
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_processing_job",
+        return_value={"ProcessingJobStatus": "Stopped", "FailureReason": "It stopped"},
+    )
+    @mock.patch.object(
+        SageMakerHook,
+        "create_processing_job",
+        return_value={"ProcessingJobArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 200}},
+    )
+    @mock.patch.object(SageMakerBaseOperator, "_check_if_job_exists", return_value=False)
+    def test_operator_stopped_before_defer(
+        self,
+        mock_job_exists,
+        mock_processing,
+        mock_describe,
+        mock_defer,
+    ):
+        sagemaker_operator = SageMakerProcessingOperator(
+            **self.defer_processing_config_kwargs,
+            config=CREATE_PROCESSING_PARAMS,
+        )
+        with pytest.raises(AirflowException):
+            sagemaker_operator.execute(context=None)
+
+        assert not mock_defer.called
+
     @mock.patch.object(
         SageMakerHook,
         "describe_processing_job",


### PR DESCRIPTION
This PR fixes SageMakerProcessingOperator so that Processing jobs ending in the Stopped state are treated as failed terminal states when deferrable=True and wait_for_completion=True.

The operator was checking the generic SageMaker failed_states, which does not include Stopped. This updates it to use processing_job_failed_states and adds a unit test for the Stopped state before deferral.

Closes #67281

Tests:
- Not run locally: uv test environment failed while building jpype1 because Java runtime is not installed on my machine.