### PR TITLE
Fix KubernetesPodTrigger.get_task_state KeyError on mapped TIs (#67296)

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/triggers/pod.py
@@ -397,8 +397,16 @@ class KubernetesPodTrigger(BaseTrigger):
                 run_ids=[self.task_instance.run_id],
                 map_index=self.task_instance.map_index,
             )
+            # The /states endpoint suffixes the response key with ``_{map_index}`` for mapped TIs
+            # (see ``get_task_instance_states`` in airflow-core's execution_api routes); non-mapped
+            # TIs keep the plain ``task_id``.
+            ti_key = (
+                f"{self.task_instance.task_id}_{self.task_instance.map_index}"
+                if self.task_instance.map_index >= 0
+                else self.task_instance.task_id
+            )
             try:
-                return task_states_response[self.task_instance.run_id][self.task_instance.task_id]
+                return task_states_response[self.task_instance.run_id][ti_key]
             except KeyError:
                 raise AirflowException(
                     "TaskInstance with dag_id: %s, task_id: %s, run_id: %s and map_index: %s is not found",

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py
@@ -34,7 +34,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.state import TaskInstanceState
 
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 
 TRIGGER_PATH = "airflow.providers.cncf.kubernetes.triggers.pod.KubernetesPodTrigger"
 HOOK_PATH = "airflow.providers.cncf.kubernetes.hooks.kubernetes.AsyncKubernetesHook"
@@ -826,6 +826,90 @@ class TestKubernetesPodTrigger:
             schedule_timeout=STARTUP_TIMEOUT_SECS,
         )
         assert await trigger.safe_to_cancel() is False
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS,
+        reason="get_task_state uses RuntimeTaskInstance.get_task_states on Airflow 3.0+",
+    )
+    @pytest.mark.asyncio
+    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
+    async def test_get_task_state_uses_task_id_for_non_mapped_ti(self, mock_get_task_states):
+        # Non-mapped TIs (``map_index < 0``) are keyed by plain ``task_id`` in the
+        # response, matching the dict-key construction in the execution API's
+        # ``get_task_instance_states`` handler.
+        run_id = "manual__2026-05-21T00:00:00+00:00"
+        mock_get_task_states.return_value = {run_id: {"my_task": TaskInstanceState.SUCCESS}}
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+        )
+        trigger.task_instance = MagicMock(dag_id="my_dag", task_id="my_task", run_id=run_id, map_index=-1)
+
+        assert await trigger.get_task_state() == TaskInstanceState.SUCCESS
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS,
+        reason="get_task_state uses RuntimeTaskInstance.get_task_states on Airflow 3.0+",
+    )
+    @pytest.mark.asyncio
+    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
+    async def test_get_task_state_uses_composite_key_for_mapped_ti(self, mock_get_task_states):
+        # Regression guard for #67296: mapped TIs (``map_index >= 0``) are
+        # keyed by ``f"{task_id}_{map_index}"`` in the response. Without the
+        # suffix this lookup would KeyError, which ``cleanup()`` would
+        # defensively swallow and skip ``hook.delete_pod()`` -- leaking the
+        # pod until ``active_deadline_seconds`` expires on user mark-failed.
+        run_id = "manual__2026-05-21T00:00:00+00:00"
+        mock_get_task_states.return_value = {run_id: {"map_group.task_a_2": TaskInstanceState.FAILED}}
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+        )
+        trigger.task_instance = MagicMock(
+            dag_id="my_dag", task_id="map_group.task_a", run_id=run_id, map_index=2
+        )
+
+        assert await trigger.get_task_state() == TaskInstanceState.FAILED
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_0_PLUS,
+        reason="get_task_state uses RuntimeTaskInstance.get_task_states on Airflow 3.0+",
+    )
+    @pytest.mark.asyncio
+    @mock.patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
+    async def test_get_task_state_raises_when_mapped_key_missing(self, mock_get_task_states):
+        # The wrapped ``AirflowException`` shape is preserved when the
+        # response is missing the expected (composite) key, so callers
+        # like ``safe_to_cancel`` keep the same behaviour they had before
+        # the lookup was fixed.
+        from airflow.exceptions import AirflowException
+
+        run_id = "manual__2026-05-21T00:00:00+00:00"
+        # Response has the run_id but not the (``map_group.task_a``, ``2``)
+        # entry -- e.g. supervisor has not observed the TI yet.
+        mock_get_task_states.return_value = {run_id: {"map_group.task_a_5": "running"}}
+
+        trigger = KubernetesPodTrigger(
+            pod_name=POD_NAME,
+            pod_namespace=NAMESPACE,
+            base_container_name=BASE_CONTAINER_NAME,
+            trigger_start_time=TRIGGER_START_TIME,
+            schedule_timeout=STARTUP_TIMEOUT_SECS,
+        )
+        trigger.task_instance = MagicMock(
+            dag_id="my_dag", task_id="map_group.task_a", run_id=run_id, map_index=2
+        )
+
+        with pytest.raises(AirflowException, match="TaskInstance with dag_id"):
+            await trigger.get_task_state()
 
     @pytest.mark.skipif(
         AIRFLOW_V_3_3_PLUS,


### PR DESCRIPTION
Fix a key-shape mismatch between the execution API's ``/states`` endpoint and
``KubernetesPodTrigger.get_task_state``: the endpoint suffixes the response
key with ``_{map_index}`` for mapped TIs, but the trigger looked the value
up by plain ``task_id``, so the lookup ``KeyError``-ed for every mapped
deferrable ``KubernetesPodOperator`` task. ``cleanup()``'s broad
``except Exception`` swallowed the error and defensively skipped
``hook.delete_pod()`` -- leaving Mark Failed in the UI useless on mapped
deferrable KPO tasks. The pod stayed ``Running`` until
``active_deadline_seconds`` expired (often hours).

For continuous deferrable pollers expanded via ``.expand(...)`` this also
caused overlapping-writer races against external systems on the next
schedule, because the failed run's pod was still alive when the next run
spawned its own pod.

This PR composes the lookup key with the ``_{map_index}`` suffix when the
TI is mapped, matching how the API serialises the response.

closes: #67296

## Test plan

### Unit tests

Three new tests in ``providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py``:

- ``test_get_task_state_uses_task_id_for_non_mapped_ti`` -- regression guard for the non-mapped branch (response keyed by plain ``task_id``).
- ``test_get_task_state_uses_composite_key_for_mapped_ti`` -- the bug repro: mapped TI with ``task_id=\"map_group.task_a\"`` + ``map_index=2`` returns the state stored under key ``\"map_group.task_a_2\"``.
- ``test_get_task_state_raises_when_mapped_key_missing`` -- pins the wrapped ``AirflowException`` shape so callers (e.g. ``safe_to_cancel``'s ``except Exception``) keep matching.

Local run:

\`\`\`
uv run --no-sync --project providers/cncf/kubernetes pytest \\
  providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_pod.py \\
  -k \"get_task_state or safe_to_cancel\"
\`\`\`

Result: ``5 passed, 2 skipped, 1 warning in 2.40s`` (2 skips are legacy Airflow < 3.3 paths unrelated to this PR).

### End-to-end smoke test on an EKS sandbox cluster

Airflow 3.2.1 with ``apache-airflow-providers-cncf-kubernetes==10.16.0``, deferrable KPO tasks inside a mapped ``@task_group.expand(...)`` (the same shape as the issue's repro DAG).

**Before this PR** (provider 10.16.0 unpatched) -- one of three TI logs after Mark Failed:

\`\`\`
[17:46:25.889914Z] WARNING - Could not determine task state during cleanup;
skipping pod deletion to be safe.
AirflowException: ('TaskInstance with dag_id: %s, ...', '...',
                   'map_group.task_a', '...', 2)
,KeyError: 'map_group.task_a'
    File pod.py, line 399 in get_task_state
\`\`\`

Pods stayed ``Running`` for the full 600s sleep; nothing in the kubelet event stream until ``active_deadline_seconds`` (would have been 7200s here).

**After this PR** -- same DAG, same Mark Failed:

\`\`\`
18:17:54  pod:      starting task_a-0 (duration=600s exit_code=0)  (x3)
18:20:07  kubelet:  Killing: Stopping container base               (x3)
18:20:07  pod:      received SIGTERM                               (x3)
18:20:07  runtime:  Task ... deleted with exit code 0              (x3)
\`\`\`

End-to-end ``Mark Failed`` -> ``delete_pod`` -> kubelet ``SIGTERM`` -> pod-side
trap -> container ``exit 0`` -> kubelet cleanup completes in **~1 second** for
all three mapped TIs. The previous ``Could not determine task state`` warning
no longer fires.

### Static checks

- ``prek run ruff --files <changed>``: pass
- ``prek run ruff-format --files <changed>``: pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes -- Cursor / Claude Opus 4.7

Generated-by: Cursor / Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Made with [Cursor](https://cursor.com)