### PR TITLE
Fix DAG browser tab title in React UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/hooks/useDocumentTitle.tsx
+++ b/airflow-core/src/airflow/ui/src/hooks/useDocumentTitle.tsx
@@ -1,0 +1,59 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from "react";
+
+import { useConfig } from "src/queries/useConfig";
+
+type DocumentTitleContextValue = {
+  readonly setPageTitle: (title: string | undefined) => void;
+};
+
+const DocumentTitleContext = createContext<DocumentTitleContextValue | undefined>(undefined);
+
+const getTitlePart = (title: unknown) => (typeof title === "string" && title.length > 0 ? title : undefined);
+
+export const DocumentTitleProvider = ({ children }: PropsWithChildren) => {
+  const instanceName = getTitlePart(useConfig("instance_name"));
+  const [pageTitle, setPageTitle] = useState<string | undefined>();
+  const value = useMemo(() => ({ setPageTitle }), []);
+
+  useEffect(() => {
+    const title = [pageTitle, instanceName].filter(Boolean).join(" - ");
+
+    if (title.length > 0) {
+      document.title = title;
+    }
+  }, [instanceName, pageTitle]);
+
+  return <DocumentTitleContext.Provider value={value}>{children}</DocumentTitleContext.Provider>;
+};
+
+export const useDocumentTitle = (title: string | undefined) => {
+  const context = useContext(DocumentTitleContext);
+
+  if (context === undefined) {
+    throw new Error("useDocumentTitle must be used within DocumentTitleProvider");
+  }
+
+  useEffect(() => {
+    context.setPageTitle(title);
+
+    return () => context.setPageTitle(undefined);
+  }, [context, title]);
+};

--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -23,13 +23,13 @@ import { Outlet } from "react-router-dom";
 
 import { usePluginServiceGetPlugins } from "openapi/queries";
 import type { ReactAppResponse } from "openapi/requests/types.gen";
+import { DocumentTitleProvider } from "src/hooks/useDocumentTitle";
 import { ReactPlugin } from "src/pages/ReactPlugin";
 import { useConfig } from "src/queries/useConfig";
 
 import { Nav } from "./Nav";
 
 export const BaseLayout = ({ children }: PropsWithChildren) => {
-  const instanceName = useConfig("instance_name");
   const { i18n } = useTranslation();
   const { data: pluginData } = usePluginServiceGetPlugins();
   const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
@@ -38,10 +38,6 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
     pluginData?.plugins
       .flatMap((plugin) => plugin.react_apps)
       .filter((reactApp: ReactAppResponse) => reactApp.destination === "base") ?? [];
-
-  if (typeof instanceName === "string") {
-    document.title = instanceName;
-  }
 
   useEffect(() => {
     const html = document.documentElement;
@@ -102,26 +98,28 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   }, [theme?.icon, theme?.icon_dark_mode]);
 
   return (
-    <LocaleProvider locale={i18n.language || "en"}>
-      <Box display="flex" flexDirection="column" h="100vh">
-        <Nav />
-        <Box
-          _ltr={{ ml: 16 }}
-          _rtl={{ mr: 16 }}
-          data-testid="main-content"
-          display="flex"
-          flex={1}
-          flexDirection="column"
-          minH={0}
-          overflow="auto"
-          p={3}
-        >
-          {baseReactPlugins.map((plugin) => (
-            <ReactPlugin key={plugin.name} reactApp={plugin} />
-          ))}
-          {children ?? <Outlet />}
+    <DocumentTitleProvider>
+      <LocaleProvider locale={i18n.language || "en"}>
+        <Box display="flex" flexDirection="column" h="100vh">
+          <Nav />
+          <Box
+            _ltr={{ ml: 16 }}
+            _rtl={{ mr: 16 }}
+            data-testid="main-content"
+            display="flex"
+            flex={1}
+            flexDirection="column"
+            minH={0}
+            overflow="auto"
+            p={3}
+          >
+            {baseReactPlugins.map((plugin) => (
+              <ReactPlugin key={plugin.name} reactApp={plugin} />
+            ))}
+            {children ?? <Outlet />}
+          </Box>
         </Box>
-      </Box>
-    </LocaleProvider>
+      </LocaleProvider>
+    </DocumentTitleProvider>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.test.tsx
@@ -1,0 +1,108 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDocumentTitle, DocumentTitleProvider } from "src/hooks/useDocumentTitle";
+import { BaseWrapper } from "src/utils/Wrapper";
+
+import { Dag } from "./Dag";
+
+const mockDagWithDisplayName = vi.hoisted(() => ({
+  active_runs_count: 0,
+  allowed_run_types: [],
+  dag_display_name: "TaskFlow Tutorial",
+  dag_id: "display_name_dag",
+  is_paused: false,
+  is_stale: false,
+  timetable_summary: null,
+}));
+
+vi.mock("openapi/queries", () => ({
+  useConfigServiceGetConfigs: () => ({ data: { instance_name: "Airflow" } }),
+  useDagRunServiceGetDagRuns: () => ({ data: { dag_runs: [] } }),
+  useDagServiceGetDagDetails: () => ({ data: mockDagWithDisplayName, isLoading: false }),
+  useDagServiceGetLatestRunInfo: () => ({ data: null, isLoading: false }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => Object.fromEntries([["t", (translationKey: string) => translationKey]]),
+}));
+vi.mock("src/hooks/usePluginTabs", () => ({ usePluginTabs: () => [] }));
+vi.mock("src/hooks/useRequiredActionTabs", () => ({
+  useRequiredActionTabs: (_params: unknown, tabs: unknown) => ({ tabs }),
+}));
+vi.mock("src/layouts/Details/DetailsLayout", () => ({
+  DetailsLayout: ({ children }: { readonly children?: ReactNode }) => children,
+}));
+vi.mock("./Header", () => ({ Header: () => null }));
+
+const renderDag = (initialEntry: string) =>
+  render(
+    <BaseWrapper>
+      <DocumentTitleProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route element={<Dag />} path="/dags/:dagId" />
+          </Routes>
+        </MemoryRouter>
+      </DocumentTitleProvider>
+    </BaseWrapper>,
+  );
+
+const RouteWithoutPageTitle = () => {
+  useDocumentTitle(undefined);
+
+  return null;
+};
+
+const renderTitleRoutes = (initialEntry: string) =>
+  render(
+    <BaseWrapper>
+      <DocumentTitleProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route element={<Dag />} path="/dags/:dagId" />
+            <Route element={<RouteWithoutPageTitle />} path="/" />
+          </Routes>
+        </MemoryRouter>
+      </DocumentTitleProvider>
+    </BaseWrapper>,
+  );
+
+describe("Dag", () => {
+  it("updates the browser title with the dag display name and instance name", async () => {
+    renderDag("/dags/display_name_dag");
+
+    await waitFor(() => expect(document.title).toBe("TaskFlow Tutorial - Airflow"));
+  });
+
+  it("restores the instance name when leaving the dag route", async () => {
+    const { unmount } = renderTitleRoutes("/dags/display_name_dag");
+
+    await waitFor(() => expect(document.title).toBe("TaskFlow Tutorial - Airflow"));
+    unmount();
+
+    renderTitleRoutes("/");
+
+    await waitFor(() => expect(document.title).toBe("Airflow"));
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Dag.tsx
@@ -28,6 +28,7 @@ import { useParams } from "react-router-dom";
 import { useDagServiceGetDagDetails, useDagServiceGetLatestRunInfo } from "openapi/queries";
 import { ApiError } from "openapi/requests/core/ApiError";
 import { TaskIcon } from "src/assets/TaskIcon";
+import { useDocumentTitle } from "src/hooks/useDocumentTitle";
 import { usePluginTabs } from "src/hooks/usePluginTabs";
 import { useRequiredActionTabs } from "src/hooks/useRequiredActionTabs";
 import { DetailsLayout } from "src/layouts/Details/DetailsLayout";
@@ -135,6 +136,8 @@ export const Dag = () => {
 
     return true;
   });
+
+  useDocumentTitle(dag?.dag_display_name ?? dagId);
 
   // Handle 404 error when Dag is not found
   if (error instanceof ApiError && error.status === 404) {


### PR DESCRIPTION
Fix DAG pages in the React UI so the browser tab title reflects the selected DAG again instead of always remaining the generic Airflow title.

closes: #67145

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex following the guidelines

---

## Summary

- Add a shared document-title hook that composes page-specific titles with the Airflow instance name.
- Use the hook from the base layout and DAG page so DAG views update the browser tab to the DAG display name.
- Add focused React tests covering DAG-specific document title behavior.

## Verification

- Focused Vitest command for `airflow-core/src/airflow/ui/src/pages/Dag/Dag.test.tsx` passed in an isolated writable rerun after the initial read-only repository mount prevented test output writes.
- `git diff --check HEAD~1 HEAD` passed.
- Final branch status is clean at `82063a39ee019210f9f8441b377a9381080192eb`.

## Reviewer Notes

- The change is scoped to browser document-title handling in the React UI and does not change routing or DAG data loading behavior.