### PR TITLE
UI: Fix opposite layout rendering after browser refresh

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -53,6 +53,7 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
       }
     };
 
+    updateHtml(i18n.language);
     i18n.on("languageChanged", updateHtml);
 
     return () => {


### PR DESCRIPTION
The HTML dir and lang attributes were not being set on initial page load, only when the language was changed. This caused RTL language users to see LTR layout after refreshing the page.

Fixed by calling updateHtml() with the current language immediately on effect mount, ensuring correct layout direction on every page load.

closes: #67309

---

Was generative AI tooling used to co-author this PR?
- [X] No