### PR TITLE
UI: Fix Expand/Collapse All on XComs and Audit Log JSON cells

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -26,11 +26,13 @@ let configurationPromise: Promise<void> | undefined;
 
 const loadMonacoModules = async () => {
   // `editor.api` is API-only — also load the folding contribution so `editor.foldAll` /
-  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered. The CDN
-  // bundle used to pull this in transitively; the local ESM `editor.api` does not.
+  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered, and the
+  // codicon styles so the gutter glyph (the `>` arrow) renders instead of an empty box.
+  // The CDN bundle used to pull these in transitively; the local ESM `editor.api` does not.
   const monacoApi = Promise.all([
     import("monaco-editor/esm/vs/editor/editor.api"),
     import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
+    import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 
   const workerConstructors = Promise.all([

--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { loader } from "@monaco-editor/react";
+import codiconFontUrl from "monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.ttf?url";
 
 type MonacoEnvironment = {
   readonly getWorker: (_moduleId: string, label: string) => Worker;
@@ -24,15 +25,52 @@ type MonacoEnvironment = {
 
 let configurationPromise: Promise<void> | undefined;
 
+// Inject the codicon @font-face + base class rule with an absolute font URL. Monaco's own
+// `codiconStyles` module imports `codicon.css` which references the font as `url(./codicon.ttf)`;
+// when the project's `vite-plugin-css-injected-by-js` inlines that CSS into a `<style>` tag the
+// relative URL ends up resolved against the page origin instead of the asset directory. Resolving
+// the font URL through Vite's `?url` import sidesteps that — and avoids the phantom CSS-chunk
+// preload the plugin leaves behind, which otherwise rejects the configureMonaco promise in
+// production builds. Monaco still registers the per-icon `::before { content: ... }` rules at
+// runtime via its theme service, so we only need the @font-face + base class here.
+const injectCodiconStyles = () => {
+  if (document.querySelector('style[data-airflow="codicon-font"]') !== null) {
+    return;
+  }
+  const style = document.createElement("style");
+
+  style.dataset.airflow = "codicon-font";
+  style.textContent = `
+    @font-face {
+      font-family: "codicon";
+      font-display: block;
+      src: url("${codiconFontUrl}") format("truetype");
+    }
+    .codicon[class*="codicon-"] {
+      font: normal normal normal 16px/1 codicon;
+      display: inline-block;
+      text-decoration: none;
+      text-rendering: auto;
+      text-align: center;
+      text-transform: none;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+  `;
+  document.head.append(style);
+};
+
 const loadMonacoModules = async () => {
+  injectCodiconStyles();
+
   // `editor.api` is API-only — also load the folding contribution so `editor.foldAll` /
-  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered, and the
-  // codicon styles so the gutter glyph (the `>` arrow) renders instead of an empty box.
-  // The CDN bundle used to pull these in transitively; the local ESM `editor.api` does not.
+  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered. The CDN
+  // bundle used to pull this in transitively; the local ESM `editor.api` does not.
   const monacoApi = Promise.all([
     import("monaco-editor/esm/vs/editor/editor.api"),
     import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
-    import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 
   const workerConstructors = Promise.all([

--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 import { loader } from "@monaco-editor/react";
-import codiconFontUrl from "monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.ttf?url";
 
 type MonacoEnvironment = {
   readonly getWorker: (_moduleId: string, label: string) => Worker;
@@ -25,52 +24,15 @@ type MonacoEnvironment = {
 
 let configurationPromise: Promise<void> | undefined;
 
-// Inject the codicon @font-face + base class rule with an absolute font URL. Monaco's own
-// `codiconStyles` module imports `codicon.css` which references the font as `url(./codicon.ttf)`;
-// when the project's `vite-plugin-css-injected-by-js` inlines that CSS into a `<style>` tag the
-// relative URL ends up resolved against the page origin instead of the asset directory. Resolving
-// the font URL through Vite's `?url` import sidesteps that — and avoids the phantom CSS-chunk
-// preload the plugin leaves behind, which otherwise rejects the configureMonaco promise in
-// production builds. Monaco still registers the per-icon `::before { content: ... }` rules at
-// runtime via its theme service, so we only need the @font-face + base class here.
-const injectCodiconStyles = () => {
-  if (document.querySelector('style[data-airflow="codicon-font"]') !== null) {
-    return;
-  }
-  const style = document.createElement("style");
-
-  style.dataset.airflow = "codicon-font";
-  style.textContent = `
-    @font-face {
-      font-family: "codicon";
-      font-display: block;
-      src: url("${codiconFontUrl}") format("truetype");
-    }
-    .codicon[class*="codicon-"] {
-      font: normal normal normal 16px/1 codicon;
-      display: inline-block;
-      text-decoration: none;
-      text-rendering: auto;
-      text-align: center;
-      text-transform: none;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      user-select: none;
-      -webkit-user-select: none;
-    }
-  `;
-  document.head.append(style);
-};
-
 const loadMonacoModules = async () => {
-  injectCodiconStyles();
-
   // `editor.api` is API-only — also load the folding contribution so `editor.foldAll` /
-  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered. The CDN
-  // bundle used to pull this in transitively; the local ESM `editor.api` does not.
+  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered, and the
+  // codicon styles so the gutter glyph (the `>` arrow) renders instead of an empty box.
+  // The CDN bundle used to pull these in transitively; the local ESM `editor.api` does not.
   const monacoApi = Promise.all([
     import("monaco-editor/esm/vs/editor/editor.api"),
     import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
+    import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 
   const workerConstructors = Promise.all([

--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -25,7 +25,13 @@ type MonacoEnvironment = {
 let configurationPromise: Promise<void> | undefined;
 
 const loadMonacoModules = async () => {
-  const monacoApi = import("monaco-editor/esm/vs/editor/editor.api");
+  // `editor.api` is API-only — also load the folding contribution so `editor.foldAll` /
+  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered. The CDN
+  // bundle used to pull this in transitively; the local ESM `editor.api` does not.
+  const monacoApi = Promise.all([
+    import("monaco-editor/esm/vs/editor/editor.api"),
+    import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
+  ]).then(([api]) => api);
 
   const workerConstructors = Promise.all([
     import("monaco-editor/esm/vs/editor/editor.worker?worker").then((module) => module.default),

--- a/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Flex, type FlexProps } from "@chakra-ui/react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import Editor, { type OnMount } from "src/components/MonacoEditor";
 import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
@@ -25,6 +25,8 @@ import { useMonacoTheme } from "src/context/colorMode";
 
 const MAX_HEIGHT = 300;
 const MIN_HEIGHT = 40;
+
+type EditorInstance = Parameters<OnMount>[0];
 
 type Props = {
   readonly collapsed?: boolean;
@@ -39,9 +41,12 @@ const RenderedJsonField = ({ collapsed = false, content, enableClipboard = true,
   const expandedHeight = Math.min(Math.max(lineCount * 19 + 10, MIN_HEIGHT), MAX_HEIGHT);
   const [editorHeight, setEditorHeight] = useState(collapsed ? MIN_HEIGHT : expandedHeight);
   const [isReady, setIsReady] = useState(!collapsed);
+  const editorRef = useRef<EditorInstance | null>(null);
 
   const handleMount: OnMount = useCallback(
     (editorInstance) => {
+      editorRef.current = editorInstance;
+
       editorInstance.onDidContentSizeChange(() => {
         const contentHeight = editorInstance.getContentHeight();
 
@@ -62,6 +67,21 @@ const RenderedJsonField = ({ collapsed = false, content, enableClipboard = true,
     },
     [collapsed],
   );
+
+  // Sync fold state when the `collapsed` prop changes after mount (e.g. via Expand/Collapse All).
+  // The initial fold is handled in `handleMount` to avoid the unfolded->folded flicker.
+  useEffect(() => {
+    const editor = editorRef.current;
+
+    if (editor === null || !isReady) {
+      return;
+    }
+    const action = editor.getAction(collapsed ? "editor.foldAll" : "editor.unfoldAll");
+
+    if (action) {
+      void action.run();
+    }
+  }, [collapsed, isReady]);
 
   return (
     <Flex

--- a/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
@@ -54,16 +54,12 @@ const RenderedJsonField = ({ collapsed = false, content, enableClipboard = true,
       });
 
       if (collapsed) {
-        const action = editorInstance.getAction("editor.foldAll");
-
-        if (action) {
-          void action.run().then(() => {
-            setIsReady(true);
-          });
-        } else {
-          setIsReady(true);
-        }
+        // `editor.foldAll`'s promise awaits the FoldingModel, which can stay pending
+        // when the JSON syntax range provider's worker is unavailable. Fire the action
+        // but unblock visibility on the next tick so we don't leave the editor hidden.
+        void editorInstance.getAction("editor.foldAll")?.run();
       }
+      setIsReady(true);
     },
     [collapsed],
   );

--- a/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
+++ b/airflow-core/src/airflow/ui/src/components/RenderedJsonField.tsx
@@ -54,12 +54,16 @@ const RenderedJsonField = ({ collapsed = false, content, enableClipboard = true,
       });
 
       if (collapsed) {
-        // `editor.foldAll`'s promise awaits the FoldingModel, which can stay pending
-        // when the JSON syntax range provider's worker is unavailable. Fire the action
-        // but unblock visibility on the next tick so we don't leave the editor hidden.
-        void editorInstance.getAction("editor.foldAll")?.run();
+        const action = editorInstance.getAction("editor.foldAll");
+
+        if (action) {
+          void action.run().then(() => {
+            setIsReady(true);
+          });
+        } else {
+          setIsReady(true);
+        }
       }
-      setIsReady(true);
     },
     [collapsed],
   );

--- a/airflow-core/src/airflow/ui/src/vite-env.d.ts
+++ b/airflow-core/src/airflow/ui/src/vite-env.d.ts
@@ -28,4 +28,3 @@ interface ImportMeta {
 // monaco-editor ships .d.ts only for `editor.api`; contribution side-effect imports have
 // no typings of their own.
 declare module "monaco-editor/esm/vs/editor/contrib/folding/browser/folding";
-declare module "monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles";

--- a/airflow-core/src/airflow/ui/src/vite-env.d.ts
+++ b/airflow-core/src/airflow/ui/src/vite-env.d.ts
@@ -28,3 +28,4 @@ interface ImportMeta {
 // monaco-editor ships .d.ts only for `editor.api`; contribution side-effect imports have
 // no typings of their own.
 declare module "monaco-editor/esm/vs/editor/contrib/folding/browser/folding";
+declare module "monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles";

--- a/airflow-core/src/airflow/ui/src/vite-env.d.ts
+++ b/airflow-core/src/airflow/ui/src/vite-env.d.ts
@@ -24,3 +24,7 @@
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// monaco-editor ships .d.ts only for `editor.api`; contribution side-effect imports have
+// no typings of their own.
+declare module "monaco-editor/esm/vs/editor/contrib/folding/browser/folding";

--- a/airflow-core/src/airflow/ui/vite.config.ts
+++ b/airflow-core/src/airflow/ui/vite.config.ts
@@ -39,7 +39,16 @@ export default defineConfig({
       transformIndexHtml: (html) =>
         html.replace(`src="./assets/`, `src="./static/assets/`).replace(`href="/`, `href="./`),
     },
-    cssInjectedByJsPlugin(),
+    // Keep Monaco's codicon CSS as a real CSS file (rather than inlined into JS).
+    // The codicon stylesheet references `codicon.ttf` with a CSS-relative URL — when
+    // it gets inlined into a `<style>` tag the URL resolves against the page origin
+    // (the api-server) instead of the asset directory and the font fails to load.
+    // Keeping the CSS as an emitted file lets the browser resolve the URL relative
+    // to the stylesheet's own location (`/static/assets/`). Vite still chunks it so
+    // it only loads on the routes that pull Monaco in.
+    cssInjectedByJsPlugin({
+      cssAssetsFilterFunction: (asset: { fileName: string }) => !asset.fileName.includes("codicon"),
+    }),
   ],
   resolve: { alias: { openapi: "/openapi-gen", src: "/src" } },
   server: {

--- a/airflow-core/src/airflow/ui/vite.config.ts
+++ b/airflow-core/src/airflow/ui/vite.config.ts
@@ -44,6 +44,11 @@ export default defineConfig({
   resolve: { alias: { openapi: "/openapi-gen", src: "/src" } },
   server: {
     cors: true, // Only used by the dev server.
+    // The dev SPA shell is served by the airflow api-server (a different origin), so
+    // Vite must emit fully-qualified URLs — otherwise asset paths (notably worker
+    // module URLs) resolve against the api-server origin and 404. The `dev` script
+    // pins this port via --strictPort.
+    origin: "http://localhost:5173",
     proxy: {
       "/hitl-review": {
         changeOrigin: true,


### PR DESCRIPTION
closes: #67310

The Expand/Collapse All toggle on the XComs and Audit Log pages was a
no-op: clicking the buttons updated the toggle state in the header but
the JSON content in each row stayed in its initial fold state.

Four layered issues had to be fixed for both prod and dev mode:

1. **`RenderedJsonField` only folded once at mount.** The original
   `handleMount` called `editor.foldAll` based on the initial `collapsed`
   prop, but never reacted to prop changes. Save the editor instance in
   a ref and add a `useEffect` that runs `editor.foldAll` /
   `editor.unfoldAll` whenever `collapsed` changes after mount.

2. **The `editor.foldAll` action wasn't registered.** #66647 switched
   Monaco from the CDN bundle (which auto-loads all editor contributions)
   to a local `editor.api` import — which is API-only. Side-effect-import
   the folding contribution so the FoldingController and its `foldAll` /
   `unfoldAll` actions are actually available.

3. **`foldAll`'s promise can stay pending.** `editor.foldAll` awaits
   the FoldingModel, which waits for the JSON syntax range provider's
   worker. Fire the action and set `isReady` immediately rather than
   gating visibility on a promise that might never resolve.

4. **Dev-mode worker URLs resolved against the wrong origin.** When the
   dev SPA shell is served by the airflow api-server (different origin
   from Vite), Vite emitted absolute-path worker URLs that the browser
   resolved against the api-server and got 404s. Setting `server.origin`
   to `localhost:5173` (matching the `--strictPort` on the dev script)
   makes Vite emit fully-qualified URLs so workers load from Vite
   directly.


Tested both in dev mode and non dev mode.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)