### PR TITLE
Go-SDK: Add concurrent-safe coordinator comms, log handler, and client

### DIFF
--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -1,0 +1,239 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/apache/airflow/go-sdk/pkg/api"
+	"github.com/apache/airflow/go-sdk/sdk"
+)
+
+// Supervisor-side error codes carried in the "error" field of an
+// ErrorResponse frame. The Python source of truth is
+// airflow.sdk.exceptions.ErrorType.
+const (
+	errCodeVariableNotFound   = "VARIABLE_NOT_FOUND"
+	errCodeConnectionNotFound = "CONNECTION_NOT_FOUND"
+	errCodeXComNotFound       = "XCOM_NOT_FOUND"
+)
+
+// translateApiError converts a supervisor *ApiError whose Err field matches
+// code into a sentinel-wrapped error (matching the formatting the HTTP-backed
+// sdk.client uses for the same condition). Any other error - including a
+// *ApiError with a different code - is returned unchanged so callers can keep
+// distinguishing transport / server errors from "thing not found".
+func translateApiError(err error, code string, sentinel error, key string) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *ApiError
+	if errors.As(err, &apiErr) && apiErr.Err == code {
+		return fmt.Errorf("%w: %q", sentinel, key)
+	}
+	return err
+}
+
+// CoordinatorClient implements sdk.Client by communicating with the Airflow supervisor
+// over the comm socket using msgpack-framed IPC instead of HTTP.
+type CoordinatorClient struct {
+	comm    *CoordinatorComm
+	details *StartupDetails
+}
+
+var _ sdk.Client = (*CoordinatorClient)(nil)
+
+// NewCoordinatorClient creates a new client backed by the comm socket.
+func NewCoordinatorClient(comm *CoordinatorComm, details *StartupDetails) *CoordinatorClient {
+	return &CoordinatorClient{
+		comm:    comm,
+		details: details,
+	}
+}
+
+// GetVariable requests a variable value from the supervisor.
+func (c *CoordinatorClient) GetVariable(ctx context.Context, key string) (string, error) {
+	// TODO: this duplicates variableFromEnv in sdk/client.go. The env-first
+	// precedence is part of the SDK contract, so both clients should share a
+	// single helper (e.g. an exported sdk.VariableFromEnv) instead of two
+	// independent copies that can drift.
+	if env, ok := os.LookupEnv(sdk.VariableEnvPrefix + strings.ToUpper(key)); ok {
+		return env, nil
+	}
+
+	resp, err := c.comm.Communicate(ctx, GetVariableMsg{Key: key}.toMap())
+	if err != nil {
+		return "", translateApiError(err, errCodeVariableNotFound, sdk.VariableNotFound, key)
+	}
+
+	result, err := decodeVariableResult(resp)
+	if err != nil {
+		return "", fmt.Errorf("decoding variable result: %w", err)
+	}
+
+	if result.Value == nil {
+		return "", fmt.Errorf("%w: %q", sdk.VariableNotFound, key)
+	}
+
+	// TODO: register secret-named variables with a SecretsMasker so the
+	// returned value is automatically redacted from subsequent task logs,
+	// matching Python's airflow.models.variable.Variable.get behaviour.
+	// Pairs with the "TODO: mask secrets here" hook in
+	// pkg/worker/runner.go's task log handler — both halves are needed
+	// before secret masking actually works end-to-end.
+
+	switch v := result.Value.(type) {
+	case string:
+		return v, nil
+	default:
+		// Airflow Variables are stored as strings, but the supervisor
+		// decodes msgpack into native Go types — a supervisor that
+		// returns a list/map/number means the caller stored JSON.
+		// Re-encode it so UnmarshalJSONVariable still works uniformly
+		// across HTTP and coordinator modes.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("marshaling variable value: %w", err)
+		}
+		return string(b), nil
+	}
+}
+
+// UnmarshalJSONVariable gets a variable and unmarshals its JSON value.
+func (c *CoordinatorClient) UnmarshalJSONVariable(
+	ctx context.Context,
+	key string,
+	pointer any,
+) error {
+	val, err := c.GetVariable(ctx, key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(val), pointer)
+}
+
+// GetConnection requests a connection from the supervisor.
+func (c *CoordinatorClient) GetConnection(
+	ctx context.Context,
+	connID string,
+) (sdk.Connection, error) {
+	resp, err := c.comm.Communicate(ctx, GetConnectionMsg{ConnID: connID}.toMap())
+	if err != nil {
+		return sdk.Connection{}, translateApiError(
+			err, errCodeConnectionNotFound, sdk.ConnectionNotFound, connID,
+		)
+	}
+
+	result, err := decodeConnectionResult(resp)
+	if err != nil {
+		return sdk.Connection{}, fmt.Errorf("decoding connection result: %w", err)
+	}
+
+	conn := sdk.Connection{
+		ID:   result.ConnID,
+		Type: result.ConnType,
+		Host: result.Host,
+		Port: result.Port,
+		Path: result.Schema,
+	}
+
+	if result.Login != "" {
+		login := result.Login
+		conn.Login = &login
+	}
+	if result.Password != "" {
+		password := result.Password
+		conn.Password = &password
+	}
+	if result.Extra != "" {
+		conn.Extra = map[string]any{}
+		if err := json.Unmarshal([]byte(result.Extra), &conn.Extra); err != nil {
+			return conn, fmt.Errorf("parsing connection extra: %w", err)
+		}
+	}
+
+	// TODO: register conn.Password and sensitive-keyed entries of conn.Extra
+	// with a SecretsMasker so they are auto-redacted from subsequent task
+	// logs, matching Python's airflow.models.connection.Connection.get
+	// behaviour. Pairs with the "TODO: mask secrets here" hook in
+	// pkg/worker/runner.go's task log handler and the matching TODO on
+	// GetVariable above.
+
+	return conn, nil
+}
+
+// GetXCom requests an XCom value from the supervisor.
+func (c *CoordinatorClient) GetXCom(
+	ctx context.Context,
+	dagId, runId, taskId string,
+	mapIndex *int,
+	key string,
+	_ any,
+) (any, error) {
+	msg := GetXComMsg{
+		Key:    key,
+		DagID:  dagId,
+		TaskID: taskId,
+		RunID:  runId,
+	}
+	if mapIndex != nil {
+		msg.MapIndex = mapIndex
+	}
+
+	resp, err := c.comm.Communicate(ctx, msg.toMap())
+	if err != nil {
+		return nil, translateApiError(err, errCodeXComNotFound, sdk.XComNotFound, key)
+	}
+
+	result, err := decodeXComResult(resp)
+	if err != nil {
+		return nil, fmt.Errorf("decoding xcom result: %w", err)
+	}
+
+	return result.Value, nil
+}
+
+// PushXCom sends an XCom value to the supervisor.
+func (c *CoordinatorClient) PushXCom(
+	ctx context.Context,
+	ti api.TaskInstance,
+	key string,
+	value any,
+) error {
+	mapIndex := -1
+	if ti.MapIndex != nil && *ti.MapIndex != -1 {
+		mapIndex = *ti.MapIndex
+	}
+
+	msg := SetXComMsg{
+		Key:      key,
+		Value:    value,
+		DagID:    ti.DagId,
+		TaskID:   ti.TaskId,
+		RunID:    ti.RunId,
+		MapIndex: mapIndex,
+	}
+
+	_, err := c.comm.Communicate(ctx, msg.toMap())
+	return err
+}

--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -57,17 +57,15 @@ func translateApiError(err error, code string, sentinel error, key string) error
 // CoordinatorClient implements sdk.Client by communicating with the Airflow supervisor
 // over the comm socket using msgpack-framed IPC instead of HTTP.
 type CoordinatorClient struct {
-	comm    *CoordinatorComm
-	details *StartupDetails
+	comm *CoordinatorComm
 }
 
 var _ sdk.Client = (*CoordinatorClient)(nil)
 
 // NewCoordinatorClient creates a new client backed by the comm socket.
-func NewCoordinatorClient(comm *CoordinatorComm, details *StartupDetails) *CoordinatorClient {
+func NewCoordinatorClient(comm *CoordinatorComm) *CoordinatorClient {
 	return &CoordinatorClient{
-		comm:    comm,
-		details: details,
+		comm: comm,
 	}
 }
 
@@ -157,14 +155,12 @@ func (c *CoordinatorClient) GetConnection(
 		Path: result.Schema,
 	}
 
-	if result.Login != "" {
-		login := result.Login
-		conn.Login = &login
-	}
-	if result.Password != "" {
-		password := result.Password
-		conn.Password = &password
-	}
+	// Pass the *string straight through so an explicitly empty credential
+	// (distinct from "no credential set") survives the coordinator hop and
+	// reaches sdk.Connection's URI-building code the same way it does in the
+	// HTTP-backed SDK.
+	conn.Login = result.Login
+	conn.Password = result.Password
 	if result.Extra != "" {
 		conn.Extra = map[string]any{}
 		if err := json.Unmarshal([]byte(result.Extra), &conn.Extra); err != nil {
@@ -220,18 +216,15 @@ func (c *CoordinatorClient) PushXCom(
 	key string,
 	value any,
 ) error {
-	mapIndex := -1
-	if ti.MapIndex != nil && *ti.MapIndex != -1 {
-		mapIndex = *ti.MapIndex
-	}
-
 	msg := SetXComMsg{
-		Key:      key,
-		Value:    value,
-		DagID:    ti.DagId,
-		TaskID:   ti.TaskId,
-		RunID:    ti.RunId,
-		MapIndex: mapIndex,
+		Key:    key,
+		Value:  value,
+		DagID:  ti.DagId,
+		TaskID: ti.TaskId,
+		RunID:  ti.RunId,
+	}
+	if ti.MapIndex != nil && *ti.MapIndex != -1 {
+		msg.MapIndex = ti.MapIndex
 	}
 
 	_, err := c.comm.Communicate(ctx, msg.toMap())

--- a/go-sdk/pkg/execution/client_test.go
+++ b/go-sdk/pkg/execution/client_test.go
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/airflow/go-sdk/sdk"
+)
+
+// TestCoordinatorClientGetVariableEnvOverride verifies that an
+// AIRFLOW_VAR_<UPPER(key)> environment override short-circuits the comm
+// socket, matching the HTTP-backed sdk.client behaviour.
+func TestCoordinatorClientGetVariableEnvOverride(t *testing.T) {
+	t.Setenv("AIRFLOW_VAR_MY_KEY", "env_value")
+
+	// A nil reader would panic if the dispatcher ever read; an empty
+	// io.Discard write target would silently accept any request. Use both
+	// to assert *no* IO occurred by failing if anything is read or written.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(assertNoReadReader{t: t}, assertNoWriteWriter{t: t}, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	val, err := client.GetVariable(context.Background(), "my_key")
+	require.NoError(t, err)
+	assert.Equal(t, "env_value", val)
+}
+
+// TestCoordinatorClientGetVariableNoEnvOverride verifies the supervisor
+// round trip still runs when no env override is set.
+func TestCoordinatorClientGetVariableNoEnvOverride(t *testing.T) {
+	responsePayload, err := encodeRequest(0, map[string]any{
+		"type":  "VariableResult",
+		"key":   "my_key",
+		"value": "supervisor_value",
+	})
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	val, err := client.GetVariable(context.Background(), "my_key")
+	require.NoError(t, err)
+	assert.Equal(t, "supervisor_value", val)
+}
+
+// TestCoordinatorClientErrorTranslation verifies that GetVariable,
+// GetConnection, and GetXCom translate the supervisor's *_NOT_FOUND error
+// codes into the SDK sentinel errors so call-site `errors.Is` checks behave
+// the same in coordinator and HTTP mode.
+func TestCoordinatorClientErrorTranslation(t *testing.T) {
+	tests := []struct {
+		name      string
+		errorCode string
+		sentinel  error
+		call      func(client *CoordinatorClient) error
+	}{
+		{
+			name:      "GetVariable maps VARIABLE_NOT_FOUND",
+			errorCode: "VARIABLE_NOT_FOUND",
+			sentinel:  sdk.VariableNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetVariable(context.Background(), "missing")
+				return err
+			},
+		},
+		{
+			name:      "GetConnection maps CONNECTION_NOT_FOUND",
+			errorCode: "CONNECTION_NOT_FOUND",
+			sentinel:  sdk.ConnectionNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetConnection(context.Background(), "missing")
+				return err
+			},
+		},
+		{
+			name:      "GetXCom maps XCOM_NOT_FOUND",
+			errorCode: "XCOM_NOT_FOUND",
+			sentinel:  sdk.XComNotFound,
+			call: func(client *CoordinatorClient) error {
+				_, err := client.GetXCom(
+					context.Background(), "dag", "run", "task", nil, "missing", nil,
+				)
+				return err
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+				"type":   "ErrorResponse",
+				"error":  tc.errorCode,
+				"detail": "supervisor said no",
+			})
+			var responseBuf bytes.Buffer
+			require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+			client := NewCoordinatorClient(comm, nil)
+
+			err := tc.call(client)
+			require.Error(t, err)
+			require.True(
+				t,
+				errors.Is(err, tc.sentinel),
+				"expected errors.Is(%v, %v) to be true", err, tc.sentinel,
+			)
+		})
+	}
+}
+
+// TestCoordinatorClientErrorPassThrough verifies that unrelated *ApiError
+// values (e.g. a generic API_SERVER_ERROR) are returned unchanged.
+func TestCoordinatorClientErrorPassThrough(t *testing.T) {
+	responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "API_SERVER_ERROR",
+		"detail": "boom",
+	})
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+	client := NewCoordinatorClient(comm, nil)
+
+	_, err := client.GetVariable(context.Background(), "any_key")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, sdk.VariableNotFound),
+		"generic supervisor errors must not be translated to VariableNotFound")
+	var apiErr *ApiError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "API_SERVER_ERROR", apiErr.Err)
+}
+
+// assertNoReadReader fails the test on any Read call.
+type assertNoReadReader struct{ t *testing.T }
+
+func (f assertNoReadReader) Read(p []byte) (int, error) {
+	f.t.Helper()
+	f.t.Fatalf("unexpected Read on comm socket: env override should have short-circuited")
+	return 0, nil
+}
+
+// assertNoWriteWriter fails the test on any Write call.
+type assertNoWriteWriter struct{ t *testing.T }
+
+func (f assertNoWriteWriter) Write(p []byte) (int, error) {
+	f.t.Helper()
+	f.t.Fatalf("unexpected Write on comm socket: env override should have short-circuited")
+	return 0, nil
+}

--- a/go-sdk/pkg/execution/client_test.go
+++ b/go-sdk/pkg/execution/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/apache/airflow/go-sdk/pkg/api"
 	"github.com/apache/airflow/go-sdk/sdk"
 )
 
@@ -42,7 +43,7 @@ func TestCoordinatorClientGetVariableEnvOverride(t *testing.T) {
 	// to assert *no* IO occurred by failing if anything is read or written.
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(assertNoReadReader{t: t}, assertNoWriteWriter{t: t}, logger)
-	client := NewCoordinatorClient(comm, nil)
+	client := NewCoordinatorClient(comm)
 
 	val, err := client.GetVariable(context.Background(), "my_key")
 	require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestCoordinatorClientGetVariableNoEnvOverride(t *testing.T) {
 	var requestBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
-	client := NewCoordinatorClient(comm, nil)
+	client := NewCoordinatorClient(comm)
 
 	val, err := client.GetVariable(context.Background(), "my_key")
 	require.NoError(t, err)
@@ -125,7 +126,7 @@ func TestCoordinatorClientErrorTranslation(t *testing.T) {
 
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
-			client := NewCoordinatorClient(comm, nil)
+			client := NewCoordinatorClient(comm)
 
 			err := tc.call(client)
 			require.Error(t, err)
@@ -151,7 +152,7 @@ func TestCoordinatorClientErrorPassThrough(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
-	client := NewCoordinatorClient(comm, nil)
+	client := NewCoordinatorClient(comm)
 
 	_, err := client.GetVariable(context.Background(), "any_key")
 	require.Error(t, err)
@@ -160,6 +161,112 @@ func TestCoordinatorClientErrorPassThrough(t *testing.T) {
 	var apiErr *ApiError
 	require.True(t, errors.As(err, &apiErr))
 	assert.Equal(t, "API_SERVER_ERROR", apiErr.Err)
+}
+
+// TestCoordinatorClientGetConnectionPreservesEmptyCredentials verifies the
+// coordinator client forwards an explicitly empty login/password as a
+// pointer-to-"" on sdk.Connection rather than nil. Connections that use
+// empty credentials intentionally (e.g. a default-blank password) would
+// otherwise fall back to "no login set" URI behaviour.
+func TestCoordinatorClientGetConnectionPreservesEmptyCredentials(t *testing.T) {
+	responsePayload := encodeResponseFrame(t, 0, map[string]any{
+		"type":     "ConnectionResult",
+		"conn_id":  "c",
+		"login":    "",
+		"password": "",
+	}, nil)
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+	client := NewCoordinatorClient(comm)
+
+	conn, err := client.GetConnection(context.Background(), "c")
+	require.NoError(t, err)
+	require.NotNil(t, conn.Login, "explicit empty-string login must round-trip as &\"\"")
+	assert.Equal(t, "", *conn.Login)
+	require.NotNil(t, conn.Password, "explicit empty-string password must round-trip as &\"\"")
+	assert.Equal(t, "", *conn.Password)
+}
+
+// TestCoordinatorClientGetConnectionAbsentCredentials verifies the
+// coordinator client leaves sdk.Connection's Login/Password as nil when the
+// supervisor omits or sends null for those fields.
+func TestCoordinatorClientGetConnectionAbsentCredentials(t *testing.T) {
+	responsePayload := encodeResponseFrame(t, 0, map[string]any{
+		"type":    "ConnectionResult",
+		"conn_id": "c",
+	}, nil)
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, io.Discard, logger)
+	client := NewCoordinatorClient(comm)
+
+	conn, err := client.GetConnection(context.Background(), "c")
+	require.NoError(t, err)
+	assert.Nil(t, conn.Login, "absent login must remain nil")
+	assert.Nil(t, conn.Password, "absent password must remain nil")
+}
+
+// TestCoordinatorClientPushXComMapIndex verifies the SetXCom frame omits
+// map_index for unmapped task instances and propagates a real index when the
+// task is dynamically mapped. Sending the -1 sentinel on the wire would be
+// silently treated as a separate map element by the supervisor.
+func TestCoordinatorClientPushXComMapIndex(t *testing.T) {
+	mapped := -1
+	dynamic := 3
+
+	tests := []struct {
+		name            string
+		mapIndex        *int
+		wantHasMapIndex bool
+		wantMapIndexVal int
+	}{
+		{name: "nil map_index is omitted", mapIndex: nil, wantHasMapIndex: false},
+		{name: "-1 map_index is omitted", mapIndex: &mapped, wantHasMapIndex: false},
+		{
+			name:            "non-negative map_index is sent",
+			mapIndex:        &dynamic,
+			wantHasMapIndex: true,
+			wantMapIndexVal: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			responsePayload := encodeResponseFrame(t, 0, map[string]any{"type": "OKResponse"}, nil)
+			var responseBuf bytes.Buffer
+			require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+			var requestBuf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+			client := NewCoordinatorClient(comm)
+
+			ti := api.TaskInstance{
+				DagId:    "d",
+				RunId:    "r",
+				TaskId:   "t",
+				MapIndex: tc.mapIndex,
+			}
+			require.NoError(t, client.PushXCom(context.Background(), ti, "k", "v"))
+
+			sent, err := readFrame(&requestBuf)
+			require.NoError(t, err)
+			assert.Equal(t, "SetXCom", sent.Body["type"])
+			if tc.wantHasMapIndex {
+				require.Contains(t, sent.Body, "map_index")
+				// msgpack decodes small ints as int8.
+				assert.EqualValues(t, tc.wantMapIndexVal, sent.Body["map_index"])
+			} else {
+				assert.NotContains(t, sent.Body, "map_index",
+					"map_index must be omitted for unmapped task instances")
+			}
+		})
+	}
 }
 
 // assertNoReadReader fails the test on any Read call.

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -252,7 +252,10 @@ func (c *CoordinatorComm) readLoop() {
 		}
 		c.mu.Unlock()
 		if !ok {
-			c.logger.Warn("Discarding frame with no matching waiter", "id", frame.ID)
+			// A waiter whose caller cancelled or timed out is deliberately
+			// removed by Communicate, leaving its late reply to land here. That
+			// is the expected deadline path, not a protocol bug, so log at Debug.
+			c.logger.Debug("Discarding frame with no matching waiter", "id", frame.ID)
 			continue
 		}
 		ch <- frameResult{frame: frame}

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -1,0 +1,247 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// CoordinatorComm manages bidirectional communication with the Airflow
+// supervisor over a length-prefixed msgpack socket connection.
+//
+// Reads are multiplexed by frame ID. A single background reader goroutine,
+// lazily started on the first Communicate call, consumes inbound frames and
+// dispatches each one to the Communicate caller whose request used that ID.
+// This lets multiple goroutines call Communicate concurrently without
+// serialising the full send-then-read round trip behind a single mutex, and
+// guarantees the response a caller receives matches the request it sent.
+//
+// The supervisor's initial StartupDetails frame arrives unsolicited, before
+// any client request is in flight, and is read synchronously via
+// ReadMessage; ReadMessage must not be called after the dispatcher has been
+// started.
+type CoordinatorComm struct {
+	reader io.Reader
+	writer io.Writer
+	nextID atomic.Int64
+	logger *slog.Logger
+
+	wmu sync.Mutex // serialises writes
+
+	// Multiplexer state. mu protects every field below.
+	mu      sync.Mutex
+	pending map[int]chan frameResult
+	started bool
+	readErr error
+}
+
+// frameResult is the value the dispatcher delivers to a Communicate caller.
+type frameResult struct {
+	frame IncomingFrame
+	err   error
+}
+
+// ErrDispatcherClosed is wrapped into the error Communicate returns once the
+// background reader goroutine has exited — typically because the supervisor
+// closed the comm socket.
+var ErrDispatcherClosed = errors.New("coordinator comm: dispatcher closed")
+
+// NewCoordinatorComm creates a new communication channel.
+func NewCoordinatorComm(reader io.Reader, writer io.Writer, logger *slog.Logger) *CoordinatorComm {
+	return &CoordinatorComm{
+		reader:  reader,
+		writer:  writer,
+		logger:  logger,
+		pending: make(map[int]chan frameResult),
+	}
+}
+
+// ReadMessage reads and decodes one frame directly from the comm socket.
+// It is used to read the supervisor's initial frame before any request/response
+// traffic begins. Calling it after the dispatcher has started would race the
+// reader goroutine for input bytes, so it returns an error in that case.
+func (c *CoordinatorComm) ReadMessage() (IncomingFrame, error) {
+	c.mu.Lock()
+	started := c.started
+	c.mu.Unlock()
+	if started {
+		return IncomingFrame{}, errors.New(
+			"coordinator comm: ReadMessage cannot be used after the dispatcher has started",
+		)
+	}
+
+	frame, err := readFrame(c.reader)
+	if err != nil {
+		return IncomingFrame{}, fmt.Errorf("reading frame: %w", err)
+	}
+	c.logger.Debug("Received frame", "id", frame.ID)
+	return frame, nil
+}
+
+// SendRequest writes a request frame (2-element [id, body]) to the supervisor.
+// Concurrent calls are serialised so frames are never interleaved on the wire.
+func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
+	payload, err := encodeRequest(id, body)
+	if err != nil {
+		return fmt.Errorf("encoding request: %w", err)
+	}
+	c.logger.Debug("Sending request", "id", id)
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	return writeFrame(c.writer, payload)
+}
+
+// Communicate sends a request and blocks until the supervisor's response with
+// the matching frame ID is delivered by the dispatcher, ctx is cancelled, or
+// its deadline expires. Safe to call concurrently from multiple goroutines.
+//
+// If the response carries an error (either as the third element of a 3-tuple
+// frame or as a body whose "type" is "ErrorResponse") it is returned as an
+// *ApiError. If the dispatcher's read loop has terminated, the underlying read
+// error is returned wrapped in ErrDispatcherClosed.
+func (c *CoordinatorComm) Communicate(
+	ctx context.Context,
+	body map[string]any,
+) (map[string]any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	id := int(c.nextID.Add(1) - 1)
+	ch := make(chan frameResult, 1)
+
+	// Register the waiter under the same lock the dispatcher uses, and before
+	// sending the request, so the dispatcher can never deliver the response
+	// (or a terminal read error) before this caller is ready to receive it.
+	c.mu.Lock()
+	if !c.started {
+		c.started = true
+		go c.readLoop()
+	}
+	if c.readErr != nil {
+		err := c.readErr
+		c.mu.Unlock()
+		return nil, fmt.Errorf("%w: %w", ErrDispatcherClosed, err)
+	}
+	c.pending[id] = ch
+	c.mu.Unlock()
+
+	if err := c.SendRequest(id, body); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+
+	var result frameResult
+	select {
+	case result = <-ch:
+	case <-ctx.Done():
+		// Drop the waiter so a late supervisor reply is logged-and-discarded
+		// by the dispatcher rather than piling up in c.pending. The dispatcher
+		// may have already delivered the response into the buffered channel
+		// between the select and this delete; that delivery is harmless (the
+		// channel is buffered to 1 and the caller has already given up).
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	}
+	if result.err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDispatcherClosed, result.err)
+	}
+	frame := result.frame
+
+	// Check for error in the third element of a response frame.
+	if frame.Err != nil {
+		errResp := decodeErrorResponse(frame.Err)
+		if errResp != nil {
+			return nil, &ApiError{
+				Err:    errResp.Error,
+				Detail: errResp.Detail,
+			}
+		}
+	}
+
+	// Also check if the body itself is an ErrorResponse.
+	if frame.Body != nil {
+		if typ, _ := frame.Body["type"].(string); typ == "ErrorResponse" {
+			errResp := decodeErrorResponse(frame.Body)
+			return nil, &ApiError{
+				Err:    errResp.Error,
+				Detail: errResp.Detail,
+			}
+		}
+	}
+
+	return frame.Body, nil
+}
+
+// readLoop is the dispatcher: it reads frames from the comm socket and routes
+// each one to the channel registered by the matching Communicate caller. When
+// readFrame returns an error (typically io.EOF on supervisor shutdown), it
+// fans the error out to every pending waiter and exits; any subsequent
+// Communicate call sees the error via readErr and returns immediately.
+func (c *CoordinatorComm) readLoop() {
+	for {
+		frame, err := readFrame(c.reader)
+		if err != nil {
+			c.mu.Lock()
+			c.readErr = err
+			pending := c.pending
+			c.pending = nil
+			c.mu.Unlock()
+			for _, ch := range pending {
+				ch <- frameResult{err: err}
+			}
+			return
+		}
+		c.logger.Debug("Received frame", "id", frame.ID)
+
+		c.mu.Lock()
+		ch, ok := c.pending[frame.ID]
+		if ok {
+			delete(c.pending, frame.ID)
+		}
+		c.mu.Unlock()
+		if !ok {
+			c.logger.Warn("Discarding frame with no matching waiter", "id", frame.ID)
+			continue
+		}
+		ch <- frameResult{frame: frame}
+	}
+}
+
+// ApiError represents an error returned by the supervisor over the comm socket.
+type ApiError struct {
+	Err    string
+	Detail any
+}
+
+func (e *ApiError) Error() string {
+	if e.Detail != nil {
+		return fmt.Sprintf("[%s] %v", e.Err, e.Detail)
+	}
+	return e.Err
+}

--- a/go-sdk/pkg/execution/comms.go
+++ b/go-sdk/pkg/execution/comms.go
@@ -51,7 +51,7 @@ type CoordinatorComm struct {
 
 	// Multiplexer state. mu protects every field below.
 	mu      sync.Mutex
-	pending map[int]chan frameResult
+	pending map[int64]chan frameResult
 	started bool
 	readErr error
 }
@@ -73,7 +73,7 @@ func NewCoordinatorComm(reader io.Reader, writer io.Writer, logger *slog.Logger)
 		reader:  reader,
 		writer:  writer,
 		logger:  logger,
-		pending: make(map[int]chan frameResult),
+		pending: make(map[int64]chan frameResult),
 	}
 }
 
@@ -101,7 +101,7 @@ func (c *CoordinatorComm) ReadMessage() (IncomingFrame, error) {
 
 // SendRequest writes a request frame (2-element [id, body]) to the supervisor.
 // Concurrent calls are serialised so frames are never interleaved on the wire.
-func (c *CoordinatorComm) SendRequest(id int, body map[string]any) error {
+func (c *CoordinatorComm) SendRequest(id int64, body map[string]any) error {
 	payload, err := encodeRequest(id, body)
 	if err != nil {
 		return fmt.Errorf("encoding request: %w", err)
@@ -128,7 +128,7 @@ func (c *CoordinatorComm) Communicate(
 		return nil, err
 	}
 
-	id := int(c.nextID.Add(1) - 1)
+	id := c.nextID.Add(1) - 1
 	ch := make(chan frameResult, 1)
 
 	// Register the waiter under the same lock the dispatcher uses, and before
@@ -147,11 +147,32 @@ func (c *CoordinatorComm) Communicate(
 	c.pending[id] = ch
 	c.mu.Unlock()
 
-	if err := c.SendRequest(id, body); err != nil {
+	// Run the send in a goroutine so ctx cancellation can interrupt a blocked
+	// write. We deliberately do not touch the underlying connection on cancel
+	// (no SetWriteDeadline, no Close): manipulating the stream mid-write would
+	// either poison future writes with a stale deadline or risk a partial
+	// length-prefixed frame on the wire. Instead, we let the send goroutine
+	// run to completion in the background. If it eventually succeeds the
+	// supervisor's response has no waiter and is discarded by the dispatcher;
+	// if it fails the dispatcher will surface the error to other callers.
+	sendErr := make(chan error, 1)
+	go func() {
+		sendErr <- c.SendRequest(id, body)
+	}()
+
+	select {
+	case err := <-sendErr:
+		if err != nil {
+			c.mu.Lock()
+			delete(c.pending, id)
+			c.mu.Unlock()
+			return nil, err
+		}
+	case <-ctx.Done():
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
-		return nil, err
+		return nil, ctx.Err()
 	}
 
 	var result frameResult
@@ -173,29 +194,34 @@ func (c *CoordinatorComm) Communicate(
 	}
 	frame := result.frame
 
-	// Check for error in the third element of a response frame.
-	if frame.Err != nil {
-		errResp := decodeErrorResponse(frame.Err)
-		if errResp != nil {
-			return nil, &ApiError{
-				Err:    errResp.Error,
-				Detail: errResp.Detail,
-			}
-		}
-	}
-
-	// Also check if the body itself is an ErrorResponse.
-	if frame.Body != nil {
-		if typ, _ := frame.Body["type"].(string); typ == "ErrorResponse" {
-			errResp := decodeErrorResponse(frame.Body)
-			return nil, &ApiError{
-				Err:    errResp.Error,
-				Detail: errResp.Detail,
-			}
+	// An error reply can arrive in two shapes: the third element of a 3-tuple
+	// response frame, or the body of a 2-tuple frame whose "type" is
+	// "ErrorResponse". Pick whichever the supervisor used and decode once.
+	if errMap := errMapFromFrame(frame); errMap != nil {
+		errResp := decodeErrorResponse(errMap)
+		return nil, &ApiError{
+			Err:    errResp.Error,
+			Detail: errResp.Detail,
 		}
 	}
 
 	return frame.Body, nil
+}
+
+// errMapFromFrame returns the error-shaped map carried by a response frame, or
+// nil if the frame is not an error reply. The supervisor may surface an error
+// either as the dedicated third element of a 3-tuple frame (frame.Err) or as
+// the body of a 2-tuple frame whose "type" is "ErrorResponse".
+func errMapFromFrame(f IncomingFrame) map[string]any {
+	if f.Err != nil {
+		return f.Err
+	}
+	if f.Body != nil {
+		if typ, _ := f.Body["type"].(string); typ == "ErrorResponse" {
+			return f.Body
+		}
+	}
+	return nil
 }
 
 // readLoop is the dispatcher: it reads frames from the comm socket and routes

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -1,0 +1,668 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestCoordinatorCommReadMessage(t *testing.T) {
+	body := map[string]any{
+		"type": "StartupDetails",
+		"ti": map[string]any{
+			"id":      "550e8400-e29b-41d4-a716-446655440000",
+			"task_id": "t", "dag_id": "d", "run_id": "r",
+		},
+	}
+	payload, err := encodeRequest(0, body)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, writeFrame(&buf, payload))
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&buf, io.Discard, logger)
+
+	frame, err := comm.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, 0, frame.ID)
+	assert.Equal(t, "StartupDetails", frame.Body["type"])
+}
+
+func TestCoordinatorCommSendRequest(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), &buf, logger)
+
+	body := map[string]any{
+		"type": "GetVariable",
+		"key":  "test_key",
+	}
+	err := comm.SendRequest(5, body)
+	require.NoError(t, err)
+
+	frame, err := readFrame(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, 5, frame.ID)
+	assert.Equal(t, "GetVariable", frame.Body["type"])
+	assert.Equal(t, "test_key", frame.Body["key"])
+}
+
+func TestCoordinatorCommCommunicate(t *testing.T) {
+	// Prepare a response frame for the mock supervisor to "return".
+	responseBody := map[string]any{
+		"type":  "VariableResult",
+		"key":   "my_var",
+		"value": "my_value",
+	}
+	responsePayload, err := encodeRequest(0, responseBody)
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	result, err := comm.Communicate(context.Background(), GetVariableMsg{Key: "my_var"}.toMap())
+	require.NoError(t, err)
+	assert.Equal(t, "VariableResult", result["type"])
+	assert.Equal(t, "my_value", result["value"])
+
+	// Verify the request was sent.
+	sentFrame, err := readFrame(&requestBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "GetVariable", sentFrame.Body["type"])
+}
+
+func TestCoordinatorCommCommunicateError(t *testing.T) {
+	// Build a 3-element response frame with an error.
+	responsePayload := encodeResponseFrame(t, 0, nil, map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "not_found",
+		"detail": "Variable not found",
+	})
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	_, err := comm.Communicate(context.Background(), GetVariableMsg{Key: "missing"}.toMap())
+	require.Error(t, err)
+
+	apiErr, ok := err.(*ApiError)
+	require.True(t, ok)
+	assert.Equal(t, "not_found", apiErr.Err)
+}
+
+func TestCoordinatorCommCommunicateBodyError(t *testing.T) {
+	// Error can also come in the body element of a 2-element frame.
+	errorBody := map[string]any{
+		"type":   "ErrorResponse",
+		"error":  "server_error",
+		"detail": "internal failure",
+	}
+	responsePayload, err := encodeRequest(0, errorBody)
+	require.NoError(t, err)
+
+	var responseBuf bytes.Buffer
+	require.NoError(t, writeFrame(&responseBuf, responsePayload))
+
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(&responseBuf, &requestBuf, logger)
+
+	_, err = comm.Communicate(context.Background(), GetVariableMsg{Key: "test"}.toMap())
+	require.Error(t, err)
+
+	apiErr, ok := err.(*ApiError)
+	require.True(t, ok)
+	assert.Equal(t, "server_error", apiErr.Err)
+}
+
+func TestApiErrorFormat(t *testing.T) {
+	err := &ApiError{Err: "not_found", Detail: "Variable 'x' not found"}
+	assert.Equal(t, "[not_found] Variable 'x' not found", err.Error())
+
+	err2 := &ApiError{Err: "server_error"}
+	assert.Equal(t, "server_error", err2.Error())
+}
+
+// encodeResponseFrame encodes a 3-element response frame for testing.
+func encodeResponseFrame(t *testing.T, id int, body, errBody map[string]any) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := msgpack.NewEncoder(&buf)
+	enc.UseCompactInts(true)
+
+	require.NoError(t, enc.EncodeArrayLen(3))
+	require.NoError(t, enc.EncodeInt(int64(id)))
+	require.NoError(t, enc.Encode(body))
+	require.NoError(t, enc.Encode(errBody))
+	return buf.Bytes()
+}
+
+// TestCoordinatorCommCommunicateConcurrentOutOfOrder exercises the dispatcher:
+// it fires Communicate from N goroutines concurrently, then has a mock
+// supervisor respond in reverse order. Each caller must receive the response
+// whose ID matches the request it sent, even though responses arrive in a
+// different order than requests.
+func TestCoordinatorCommCommunicateConcurrentOutOfOrder(t *testing.T) {
+	const N = 8
+
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Mock supervisor: read N request frames, then write the responses back in
+	// reverse order. Each response echoes the request id so the client can
+	// verify the response matches the request.
+	supervisorDone := make(chan error, 1)
+	go func() {
+		ids := make([]int, 0, N)
+		for i := 0; i < N; i++ {
+			frame, err := readFrame(reqR)
+			if err != nil {
+				supervisorDone <- err
+				return
+			}
+			ids = append(ids, frame.ID)
+		}
+		for i := len(ids) - 1; i >= 0; i-- {
+			payload, err := encodeRequest(ids[i], map[string]any{
+				"type": "VariableResult",
+				"key":  "k",
+				"echo": ids[i],
+			})
+			if err != nil {
+				supervisorDone <- err
+				return
+			}
+			if err := writeFrame(respW, payload); err != nil {
+				supervisorDone <- err
+				return
+			}
+		}
+		supervisorDone <- nil
+	}()
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, N)
+	echoCh := make(chan int, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := comm.Communicate(
+				context.Background(),
+				map[string]any{"type": "GetVariable"},
+			)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			// The "echo" field carries the request id the supervisor used; the
+			// dispatcher must have routed each caller to its own response.
+			echo, err := toInt(resp["echo"])
+			if err != nil {
+				errCh <- err
+				return
+			}
+			echoCh <- echo
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	close(echoCh)
+
+	require.NoError(t, <-supervisorDone)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	// Each caller must have received exactly one of the N supervisor responses,
+	// with no duplicates. A broken dispatcher that delivered the same response
+	// to two callers would either show up as a missing id here or, in the worst
+	// case, as a deadlock that fails the test by timeout.
+	seen := make(map[int]bool, N)
+	for echo := range echoCh {
+		require.False(
+			t,
+			seen[echo],
+			"duplicate echo id %d — dispatcher routed one response to multiple callers",
+			echo,
+		)
+		seen[echo] = true
+	}
+	require.Len(t, seen, N, "expected %d distinct echo ids, got %d", N, len(seen))
+	for i := 0; i < N; i++ {
+		require.True(t, seen[i], "missing echo id %d from supervisor responses", i)
+	}
+}
+
+// TestCoordinatorCommCommunicateResponseIDMatch verifies that a caller blocks
+// on its own ID even when the supervisor delivers another caller's response
+// first. The single-mutex baseline would have returned the wrong response
+// here.
+func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// The supervisor reads exactly two request frames and reports each id back
+	// through reqIDs. A successful readFrame is proof the caller already
+	// registered its waiter (Communicate registers before it calls
+	// SendRequest), so the test can sequence id allocation deterministically
+	// instead of relying on sleeps.
+	reqIDs := make(chan int, 2)
+	go func() {
+		for i := 0; i < 2; i++ {
+			frame, err := readFrame(reqR)
+			if err != nil {
+				return
+			}
+			reqIDs <- frame.ID
+		}
+	}()
+
+	results := make(chan map[string]any, 2)
+	go func() {
+		resp, err := comm.Communicate(
+			context.Background(),
+			map[string]any{"type": "GetVariable", "key": "first"},
+		)
+		require.NoError(t, err)
+		results <- resp
+	}()
+	firstID := <-reqIDs
+	go func() {
+		resp, err := comm.Communicate(
+			context.Background(),
+			map[string]any{"type": "GetVariable", "key": "second"},
+		)
+		require.NoError(t, err)
+		results <- resp
+	}()
+	secondID := <-reqIDs
+
+	// Reply to the SECOND caller first. The first caller must keep waiting;
+	// only the second caller unblocks.
+	payload, err := encodeRequest(secondID, map[string]any{
+		"type": "VariableResult",
+		"key":  "second",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-results:
+		assert.Equal(t, "second", resp["key"])
+	case <-time.After(time.Second):
+		t.Fatal("second caller did not receive its response")
+	}
+
+	// First caller must still be blocked.
+	select {
+	case <-results:
+		t.Fatal("first caller unblocked before its response was delivered")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Now reply to the first caller.
+	payload, err = encodeRequest(firstID, map[string]any{
+		"type": "VariableResult",
+		"key":  "first",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-results:
+		assert.Equal(t, "first", resp["key"])
+	case <-time.After(time.Second):
+		t.Fatal("first caller did not receive its response")
+	}
+}
+
+// TestCoordinatorCommCommunicateDispatcherClosed verifies that a Communicate
+// caller blocked on a response returns wrapped ErrDispatcherClosed when the
+// reader side of the connection is closed without delivering a response.
+func TestCoordinatorCommCommunicateDispatcherClosed(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// registered fires once the supervisor has read the caller's request
+	// frame, which guarantees Communicate has already registered its waiter
+	// (registration precedes SendRequest).
+	registered := make(chan struct{})
+	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(registered)
+		}
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
+		errCh <- err
+	}()
+
+	<-registered
+
+	// Close the response stream; the dispatcher's read returns io.EOF (or
+	// io.ErrClosedPipe) and must fan that error out to the pending waiter.
+	require.NoError(t, respW.Close())
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDispatcherClosed)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return after dispatcher closed")
+	}
+
+	// A subsequent Communicate must short-circuit on the cached read error.
+	_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDispatcherClosed)
+}
+
+// TestCoordinatorCommReadMessageAfterDispatcherStarted ensures we surface a
+// clear error instead of silently racing the dispatcher for input bytes.
+func TestCoordinatorCommReadMessageAfterDispatcherStarted(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Signal once Communicate's request has reached the wire; by then the
+	// dispatcher goroutine has been started (Communicate starts it before
+	// SendRequest under the same lock).
+	dispatcherUp := make(chan struct{})
+	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(dispatcherUp)
+		}
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	// First Communicate starts the dispatcher (lazily).
+	go func() {
+		_, _ = comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
+	}()
+	<-dispatcherUp
+
+	_, err := comm.ReadMessage()
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"coordinator comm: ReadMessage cannot be used after the dispatcher has started",
+	)
+}
+
+// TestCoordinatorCommUnknownIDDiscarded verifies that a frame whose ID does
+// not match any pending waiter is logged and skipped rather than confusing the
+// next caller.
+func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Report the caller's allocated request id as soon as the supervisor sees
+	// its frame on the wire. By then Communicate has registered its waiter,
+	// so we can safely send the stray frame and then the matching response.
+	reqIDs := make(chan int, 1)
+	go func() {
+		if frame, err := readFrame(reqR); err == nil {
+			reqIDs <- frame.ID
+		}
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Inject a stray frame with an ID nobody is waiting on. The dispatcher
+	// must read this without crashing or corrupting state.
+	stray, err := encodeRequest(999, map[string]any{"type": "Junk"})
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	respCh := make(chan map[string]any, 1)
+	go func() {
+		resp, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		respCh <- resp
+	}()
+	id := <-reqIDs
+	require.NoError(t, writeFrame(respW, stray))
+
+	// Now send the real response.
+	payload, err := encodeRequest(id, map[string]any{
+		"type": "VariableResult",
+		"key":  "ok",
+	})
+	require.NoError(t, err)
+	require.NoError(t, writeFrame(respW, payload))
+
+	select {
+	case resp := <-respCh:
+		assert.Equal(t, "ok", resp["key"])
+	case err := <-errCh:
+		t.Fatalf("Communicate returned error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return")
+	}
+}
+
+// failingWriter is an io.Writer that always returns the same error. Used by
+// TestCoordinatorCommSendRequestErrorCleansPending to force SendRequest to
+// fail after a Communicate caller has already registered its waiter.
+type failingWriter struct {
+	err error
+}
+
+func (w *failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+// TestCoordinatorCommSendRequestErrorCleansPending verifies that when
+// SendRequest fails (e.g. the underlying socket has died), Communicate removes
+// the waiter it registered before sending. If the cleanup path were ever
+// dropped, the entry would leak in c.pending and a stale supervisor reply
+// arriving on that id would silently land on a channel nobody is reading.
+func TestCoordinatorCommSendRequestErrorCleansPending(t *testing.T) {
+	// The reader side is a never-fed pipe; the dispatcher started by
+	// Communicate parks on readFrame until t.Cleanup closes it.
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		respR.Close()
+		respW.Close()
+	})
+
+	writeErr := errors.New("simulated write failure")
+	comm := NewCoordinatorComm(
+		respR,
+		&failingWriter{err: writeErr},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	_, err := comm.Communicate(context.Background(), map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	comm.mu.Lock()
+	pendingLen := len(comm.pending)
+	comm.mu.Unlock()
+	assert.Equal(
+		t,
+		0,
+		pendingLen,
+		"pending map should be empty after SendRequest failure, got %d entries",
+		pendingLen,
+	)
+}
+
+// TestCoordinatorCommCommunicateContextCancelled verifies that a Communicate
+// caller whose context is cancelled while waiting for a response returns
+// promptly with the context error and removes its entry from c.pending so a
+// late supervisor reply lands in the dispatcher's "no matching waiter" path
+// instead of leaking memory.
+func TestCoordinatorCommCommunicateContextCancelled(t *testing.T) {
+	reqR, reqW := io.Pipe()
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		reqR.Close()
+		reqW.Close()
+		respR.Close()
+		respW.Close()
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, reqW, logger)
+
+	// Drain the request side so SendRequest does not block; signal once the
+	// caller's request frame has reached the wire so we know its waiter is
+	// registered before we cancel ctx.
+	registered := make(chan struct{})
+	go func() {
+		if _, err := readFrame(reqR); err == nil {
+			close(registered)
+		}
+		for {
+			if _, err := readFrame(reqR); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := comm.Communicate(ctx, map[string]any{"type": "GetVariable"})
+		errCh <- err
+	}()
+
+	<-registered
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return after ctx was cancelled")
+	}
+
+	comm.mu.Lock()
+	pendingLen := len(comm.pending)
+	comm.mu.Unlock()
+	assert.Equal(
+		t,
+		0,
+		pendingLen,
+		"pending map should be empty after ctx cancellation, got %d entries",
+		pendingLen,
+	)
+}
+
+// TestCoordinatorCommCommunicateContextAlreadyDone verifies that a Communicate
+// call whose context is already cancelled returns immediately without sending
+// a request frame or starting the dispatcher.
+func TestCoordinatorCommCommunicateContextAlreadyDone(t *testing.T) {
+	var requestBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(bytes.NewReader(nil), &requestBuf, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := comm.Communicate(ctx, map[string]any{"type": "GetVariable"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, requestBuf.Len(), "no request frame should have been sent")
+}

--- a/go-sdk/pkg/execution/comms_test.go
+++ b/go-sdk/pkg/execution/comms_test.go
@@ -51,7 +51,7 @@ func TestCoordinatorCommReadMessage(t *testing.T) {
 
 	frame, err := comm.ReadMessage()
 	require.NoError(t, err)
-	assert.Equal(t, 0, frame.ID)
+	assert.Equal(t, int64(0), frame.ID)
 	assert.Equal(t, "StartupDetails", frame.Body["type"])
 }
 
@@ -69,7 +69,7 @@ func TestCoordinatorCommSendRequest(t *testing.T) {
 
 	frame, err := readFrame(&buf)
 	require.NoError(t, err)
-	assert.Equal(t, 5, frame.ID)
+	assert.Equal(t, int64(5), frame.ID)
 	assert.Equal(t, "GetVariable", frame.Body["type"])
 	assert.Equal(t, "test_key", frame.Body["key"])
 }
@@ -159,14 +159,14 @@ func TestApiErrorFormat(t *testing.T) {
 }
 
 // encodeResponseFrame encodes a 3-element response frame for testing.
-func encodeResponseFrame(t *testing.T, id int, body, errBody map[string]any) []byte {
+func encodeResponseFrame(t *testing.T, id int64, body, errBody map[string]any) []byte {
 	t.Helper()
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)
 	enc.UseCompactInts(true)
 
 	require.NoError(t, enc.EncodeArrayLen(3))
-	require.NoError(t, enc.EncodeInt(int64(id)))
+	require.NoError(t, enc.EncodeInt(id))
 	require.NoError(t, enc.Encode(body))
 	require.NoError(t, enc.Encode(errBody))
 	return buf.Bytes()
@@ -197,7 +197,7 @@ func TestCoordinatorCommCommunicateConcurrentOutOfOrder(t *testing.T) {
 	// verify the response matches the request.
 	supervisorDone := make(chan error, 1)
 	go func() {
-		ids := make([]int, 0, N)
+		ids := make([]int64, 0, N)
 		for i := 0; i < N; i++ {
 			frame, err := readFrame(reqR)
 			if err != nil {
@@ -300,7 +300,7 @@ func TestCoordinatorCommCommunicateResponseIDMatch(t *testing.T) {
 	// registered its waiter (Communicate registers before it calls
 	// SendRequest), so the test can sequence id allocation deterministically
 	// instead of relying on sleeps.
-	reqIDs := make(chan int, 2)
+	reqIDs := make(chan int64, 2)
 	go func() {
 		for i := 0; i < 2; i++ {
 			frame, err := readFrame(reqR)
@@ -491,7 +491,7 @@ func TestCoordinatorCommUnknownIDDiscarded(t *testing.T) {
 	// Report the caller's allocated request id as soon as the supervisor sees
 	// its frame on the wire. By then Communicate has registered its waiter,
 	// so we can safely send the stray frame and then the matching response.
-	reqIDs := make(chan int, 1)
+	reqIDs := make(chan int64, 1)
 	go func() {
 		if frame, err := readFrame(reqR); err == nil {
 			reqIDs <- frame.ID
@@ -648,6 +648,91 @@ func TestCoordinatorCommCommunicateContextCancelled(t *testing.T) {
 		"pending map should be empty after ctx cancellation, got %d entries",
 		pendingLen,
 	)
+}
+
+// TestCoordinatorCommCommunicateCancelDuringSend verifies that Communicate
+// returns when ctx is cancelled while the request write is still blocked.
+// The caller must escape with ctx.Err() and its waiter must be cleaned up;
+// the send goroutine is allowed to remain parked on the wedged writer (it
+// would otherwise corrupt the stream if force-unblocked mid-frame).
+func TestCoordinatorCommCommunicateCancelDuringSend(t *testing.T) {
+	respR, respW := io.Pipe()
+	t.Cleanup(func() {
+		respR.Close()
+		respW.Close()
+	})
+
+	writer := newBlockingWriter()
+	t.Cleanup(writer.release)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	comm := NewCoordinatorComm(respR, writer, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := comm.Communicate(ctx, map[string]any{"type": "GetVariable"})
+		errCh <- err
+	}()
+
+	// Wait until the goroutine has actually entered the blocked Write so the
+	// cancel below targets the in-flight send, not the pre-write ctx check.
+	writer.waitForWrite(t)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Communicate did not return while the request write was blocked")
+	}
+
+	comm.mu.Lock()
+	pendingLen := len(comm.pending)
+	comm.mu.Unlock()
+	assert.Equal(t, 0, pendingLen,
+		"pending map should be empty after ctx cancellation during send")
+}
+
+// blockingWriter blocks every Write call until release() is called. It is used
+// to simulate a stalled coordinator socket so a cancelled Communicate has to
+// unblock the caller via context handling rather than the writer completing.
+type blockingWriter struct {
+	once    sync.Once
+	release func()
+	gate    chan struct{}
+	entered chan struct{}
+}
+
+func newBlockingWriter() *blockingWriter {
+	w := &blockingWriter{
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	w.release = func() {
+		w.once.Do(func() { close(w.gate) })
+	}
+	return w
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	select {
+	case <-w.entered:
+	default:
+		close(w.entered)
+	}
+	<-w.gate
+	return len(p), nil
+}
+
+func (w *blockingWriter) waitForWrite(t *testing.T) {
+	t.Helper()
+	select {
+	case <-w.entered:
+	case <-time.After(time.Second):
+		t.Fatal("blockingWriter.Write was never called")
+	}
 }
 
 // TestCoordinatorCommCommunicateContextAlreadyDone verifies that a Communicate

--- a/go-sdk/pkg/execution/frames.go
+++ b/go-sdk/pkg/execution/frames.go
@@ -32,14 +32,16 @@ import (
 const MaxFrameSize = 1<<32 - 1
 
 // IncomingFrame represents a decoded frame received from the comm socket.
+// ID is int64 to match the wire encoding and CoordinatorComm.nextID; narrowing
+// to int would reintroduce wraparound on 32-bit GOARCH.
 type IncomingFrame struct {
-	ID   int
+	ID   int64
 	Body map[string]any
 	Err  map[string]any // non-nil only for response frames (3-element arrays)
 }
 
 // encodeRequest encodes a request frame (2-element msgpack array: [id, body]).
-func encodeRequest(id int, body map[string]any) ([]byte, error) {
+func encodeRequest(id int64, body map[string]any) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)
 	enc.UseCompactInts(true)
@@ -47,7 +49,7 @@ func encodeRequest(id int, body map[string]any) ([]byte, error) {
 	if err := enc.EncodeArrayLen(2); err != nil {
 		return nil, err
 	}
-	if err := enc.EncodeInt(int64(id)); err != nil {
+	if err := enc.EncodeInt(id); err != nil {
 		return nil, err
 	}
 	if err := enc.Encode(body); err != nil {
@@ -156,7 +158,7 @@ func decodeFrame(data []byte) (IncomingFrame, error) {
 	}
 
 	return IncomingFrame{
-		ID:   int(id64),
+		ID:   id64,
 		Body: body,
 		Err:  errMap,
 	}, nil
@@ -238,6 +240,23 @@ func mapStringOr(m map[string]any, key string, def string) string {
 		return def
 	}
 	return s
+}
+
+// mapStringPtr extracts a nullable string value from a map. It returns nil
+// when the key is missing or the value is nil (i.e. JSON null / Python None),
+// and a pointer to the string when a value is present. Use this for fields
+// where presence-with-empty must be distinguished from absence (e.g. a
+// connection password explicitly set to "").
+func mapStringPtr(m map[string]any, key string) *string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	return &s
 }
 
 // mapMap extracts a nested map from a map.

--- a/go-sdk/pkg/execution/frames_test.go
+++ b/go-sdk/pkg/execution/frames_test.go
@@ -75,7 +75,7 @@ func TestWriteAndReadFrame(t *testing.T) {
 	// Read back.
 	frame, err := readFrame(&buf)
 	require.NoError(t, err)
-	assert.Equal(t, 7, frame.ID)
+	assert.Equal(t, int64(7), frame.ID)
 	assert.Equal(t, "GetConnection", frame.Body["type"])
 	assert.Equal(t, "my_db", frame.Body["conn_id"])
 	assert.Nil(t, frame.Err)
@@ -98,7 +98,7 @@ func TestDecodeResponseFrame(t *testing.T) {
 
 	frame, err := decodeFrame(buf.Bytes())
 	require.NoError(t, err)
-	assert.Equal(t, 5, frame.ID)
+	assert.Equal(t, int64(5), frame.ID)
 	assert.Equal(t, "ConnectionResult", frame.Body["type"])
 	assert.Equal(t, "localhost", frame.Body["host"])
 	assert.Nil(t, frame.Err)
@@ -120,7 +120,7 @@ func TestDecodeResponseFrameWithError(t *testing.T) {
 
 	frame, err := decodeFrame(buf.Bytes())
 	require.NoError(t, err)
-	assert.Equal(t, 3, frame.ID)
+	assert.Equal(t, int64(3), frame.ID)
 	assert.Nil(t, frame.Body)
 	assert.NotNil(t, frame.Err)
 	assert.Equal(t, "not_found", frame.Err["error"])
@@ -167,7 +167,7 @@ func TestRoundTripMultipleFrames(t *testing.T) {
 		{"type": "GetVariable", "key": "v2"},
 	}
 	for i, body := range bodies {
-		payload, err := encodeRequest(i, body)
+		payload, err := encodeRequest(int64(i), body)
 		require.NoError(t, err)
 		require.NoError(t, writeFrame(&buf, payload))
 	}
@@ -176,7 +176,7 @@ func TestRoundTripMultipleFrames(t *testing.T) {
 	for i, expected := range bodies {
 		frame, err := readFrame(&buf)
 		require.NoError(t, err)
-		assert.Equal(t, i, frame.ID)
+		assert.Equal(t, int64(i), frame.ID)
 		assert.Equal(t, expected["key"], frame.Body["key"])
 	}
 }

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SocketLogHandler is an slog.Handler that streams structured JSON log lines
+// to the logs TCP socket. Each log entry is a single JSON object followed by
+// a newline, matching the Airflow log streaming format.
+//
+// Key mapping:
+//   - "event" for the log message (not "msg")
+//   - "level" in lowercase (not "INFO"/"ERROR")
+//   - "timestamp" in RFC3339Nano format (not "time")
+//   - Additional attributes are included as top-level fields
+type SocketLogHandler struct {
+	shared *socketLogHandlerShared
+	level  slog.Level
+	attrs  []slog.Attr
+	groups []string
+}
+
+// socketLogHandlerShared holds the writer and buffer that must remain shared
+// across WithAttrs / WithGroup clones; otherwise the sync.Mutex would be
+// copied (which the runtime detector flags as a bug).
+type socketLogHandlerShared struct {
+	mu        sync.Mutex
+	writer    io.Writer
+	buf       [][]byte
+	connected bool
+}
+
+var _ slog.Handler = (*SocketLogHandler)(nil)
+
+// NewSocketLogHandler creates a new handler. If writer is nil, messages are
+// buffered until Connect() is called.
+func NewSocketLogHandler(writer io.Writer, level slog.Level) *SocketLogHandler {
+	shared := &socketLogHandlerShared{}
+	if writer != nil {
+		shared.writer = writer
+		shared.connected = true
+	}
+	return &SocketLogHandler{
+		shared: shared,
+		level:  level,
+	}
+}
+
+// Connect sets the writer and flushes any buffered log messages.
+func (h *SocketLogHandler) Connect(w io.Writer) {
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	h.shared.writer = w
+	h.shared.connected = true
+
+	for _, line := range h.shared.buf {
+		_, _ = w.Write(line)
+	}
+	h.shared.buf = nil
+}
+
+func (h *SocketLogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := make(map[string]any)
+
+	// Set standard fields.
+	entry["event"] = r.Message
+	entry["level"] = strings.ToLower(r.Level.String())
+	if !r.Time.IsZero() {
+		entry["timestamp"] = r.Time.Format(time.RFC3339Nano)
+	}
+
+	// Apply pre-configured attrs.
+	for _, a := range h.attrs {
+		key := h.prefixedKey(a.Key)
+		entry[key] = resolveAttrValue(a.Value)
+	}
+
+	// Apply record attrs.
+	r.Attrs(func(a slog.Attr) bool {
+		key := h.prefixedKey(a.Key)
+		entry[key] = resolveAttrValue(a.Value)
+		return true
+	})
+
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	line = append(line, '\n')
+
+	h.shared.mu.Lock()
+	defer h.shared.mu.Unlock()
+
+	if !h.shared.connected {
+		h.shared.buf = append(h.shared.buf, line)
+		return nil
+	}
+
+	_, err = h.shared.writer.Write(line)
+	return err
+}
+
+func (h *SocketLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &SocketLogHandler{
+		shared: h.shared,
+		level:  h.level,
+		attrs:  append(append([]slog.Attr{}, h.attrs...), attrs...),
+		groups: h.groups,
+	}
+}
+
+func (h *SocketLogHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &SocketLogHandler{
+		shared: h.shared,
+		level:  h.level,
+		attrs:  h.attrs,
+		groups: append(append([]string{}, h.groups...), name),
+	}
+}
+
+// prefixedKey prepends any active group names to the attribute key.
+func (h *SocketLogHandler) prefixedKey(key string) string {
+	if len(h.groups) == 0 {
+		return key
+	}
+	return strings.Join(h.groups, ".") + "." + key
+}
+
+// resolveAttrValue returns the JSON-friendly representation of a slog.Value.
+// It dereferences slog.LogValuer via Resolve() and then stringifies an error
+// (whose unexported fields would otherwise marshal as "{}"), matching the
+// behaviour of slog.NewJSONHandler. Non-error values pass through unchanged.
+func resolveAttrValue(v slog.Value) any {
+	resolved := v.Resolve().Any()
+	if err, ok := resolved.(error); ok {
+		return err.Error()
+	}
+	return resolved
+}

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -119,15 +119,18 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 
 	// Apply pre-configured attrs. Keys are already qualified with the groups
 	// active at the WithAttrs call site, so the current h.groups is NOT
-	// applied here — only to record-level attrs below.
+	// applied here — only to record-level attrs below. The stored key already
+	// carries its prefix, so append with an empty prefix; any group value is
+	// still expanded under that key.
 	for _, a := range h.attrs {
-		entry[a.key] = resolveAttrValue(a.value)
+		appendAttr(entry, "", slog.Attr{Key: a.key, Value: a.value})
 	}
 
 	// Apply record attrs. These were added at Handle time, so they pick up
 	// the currently-active group prefix.
+	prefix := h.groupPrefix()
 	r.Attrs(func(a slog.Attr) bool {
-		entry[h.prefixedKey(a.Key)] = resolveAttrValue(a.Value)
+		appendAttr(entry, prefix, a)
 		return true
 	})
 
@@ -195,11 +198,32 @@ func (h *SocketLogHandler) groupPrefix() string {
 	return strings.Join(h.groups, ".") + "."
 }
 
-// prefixedKey prepends any active group names to the attribute key. Only
-// used for record-level attrs, since attrs added via WithAttrs are stored
-// with their key already qualified.
-func (h *SocketLogHandler) prefixedKey(key string) string {
-	return h.groupPrefix() + key
+// appendAttr writes a single attribute into entry under prefix+key. A group
+// value is expanded recursively into dotted keys (matching WithGroup), so an
+// inline slog.Group("req", slog.String("method", "GET")) becomes
+// {"req.method": "GET"} rather than being dropped as "{}". Following the
+// slog.Handler contract, an empty attr is skipped, a group with no attrs is
+// ignored, and a group with an empty key is inlined at the current prefix.
+func appendAttr(entry map[string]any, prefix string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+	if a.Value.Kind() == slog.KindGroup {
+		groupAttrs := a.Value.Group()
+		if len(groupAttrs) == 0 {
+			return
+		}
+		groupPrefix := prefix
+		if a.Key != "" {
+			groupPrefix = prefix + a.Key + "."
+		}
+		for _, ga := range groupAttrs {
+			appendAttr(entry, groupPrefix, ga)
+		}
+		return
+	}
+	entry[prefix+a.Key] = resolveAttrValue(a.Value)
 }
 
 // resolveAttrValue returns the JSON-friendly representation of a slog.Value.

--- a/go-sdk/pkg/execution/logger.go
+++ b/go-sdk/pkg/execution/logger.go
@@ -36,11 +36,31 @@ import (
 //   - "level" in lowercase (not "INFO"/"ERROR")
 //   - "timestamp" in RFC3339Nano format (not "time")
 //   - Additional attributes are included as top-level fields
+//
+// Groups are encoded as dotted key prefixes on a flat JSON object
+// (`{"grp.key": "val"}`), not as nested objects. The Airflow supervisor's
+// log-streaming format consumes flat top-level fields, so emitting nested
+// objects here would not be parsed correctly. Do not change this without
+// updating the supervisor side in lockstep.
 type SocketLogHandler struct {
 	shared *socketLogHandlerShared
 	level  slog.Level
-	attrs  []slog.Attr
+	// attrs is the list of attributes accumulated via WithAttrs. Each entry's
+	// key has already been qualified with whatever groups were active at the
+	// WithAttrs call site, so a later WithGroup does NOT retroactively prefix
+	// them — matching the slog.Handler contract that groups apply only to
+	// subsequently-added attributes.
+	attrs  []prefixedAttr
 	groups []string
+}
+
+// prefixedAttr is an attribute whose key has been pre-qualified with the
+// dotted prefix of the groups that were active when it was added via
+// WithAttrs. The slog.Value is kept unresolved so LogValuer attributes are
+// still evaluated lazily at Handle time.
+type prefixedAttr struct {
+	key   string
+	value slog.Value
 }
 
 // socketLogHandlerShared holds the writer and buffer that must remain shared
@@ -97,16 +117,17 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 		entry["timestamp"] = r.Time.Format(time.RFC3339Nano)
 	}
 
-	// Apply pre-configured attrs.
+	// Apply pre-configured attrs. Keys are already qualified with the groups
+	// active at the WithAttrs call site, so the current h.groups is NOT
+	// applied here — only to record-level attrs below.
 	for _, a := range h.attrs {
-		key := h.prefixedKey(a.Key)
-		entry[key] = resolveAttrValue(a.Value)
+		entry[a.key] = resolveAttrValue(a.value)
 	}
 
-	// Apply record attrs.
+	// Apply record attrs. These were added at Handle time, so they pick up
+	// the currently-active group prefix.
 	r.Attrs(func(a slog.Attr) bool {
-		key := h.prefixedKey(a.Key)
-		entry[key] = resolveAttrValue(a.Value)
+		entry[h.prefixedKey(a.Key)] = resolveAttrValue(a.Value)
 		return true
 	})
 
@@ -129,10 +150,25 @@ func (h *SocketLogHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *SocketLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	// Qualify each new attr's key with the groups active right now, then
+	// freeze the result. A later WithGroup must not retroactively re-prefix
+	// these.
+	prefix := h.groupPrefix()
+	newAttrs := make([]prefixedAttr, len(h.attrs), len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	for _, a := range attrs {
+		newAttrs = append(newAttrs, prefixedAttr{
+			key:   prefix + a.Key,
+			value: a.Value,
+		})
+	}
 	return &SocketLogHandler{
 		shared: h.shared,
 		level:  h.level,
-		attrs:  append(append([]slog.Attr{}, h.attrs...), attrs...),
+		attrs:  newAttrs,
 		groups: h.groups,
 	}
 }
@@ -149,12 +185,21 @@ func (h *SocketLogHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-// prefixedKey prepends any active group names to the attribute key.
-func (h *SocketLogHandler) prefixedKey(key string) string {
+// groupPrefix returns the dotted prefix (including trailing ".") to apply to
+// attribute keys for the currently-active groups, or "" if no group is
+// active.
+func (h *SocketLogHandler) groupPrefix() string {
 	if len(h.groups) == 0 {
-		return key
+		return ""
 	}
-	return strings.Join(h.groups, ".") + "." + key
+	return strings.Join(h.groups, ".") + "."
+}
+
+// prefixedKey prepends any active group names to the attribute key. Only
+// used for record-level attrs, since attrs added via WithAttrs are stored
+// with their key already qualified.
+func (h *SocketLogHandler) prefixedKey(key string) string {
+	return h.groupPrefix() + key
 }
 
 // resolveAttrValue returns the JSON-friendly representation of a slog.Value.

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package execution
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSocketLogHandlerBasicOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("test message", "key1", "val1")
+
+	// Parse the output.
+	output := buf.String()
+	assert.True(t, strings.HasSuffix(output, "\n"), "output should end with newline")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &entry))
+
+	assert.Equal(t, "test message", entry["event"])
+	assert.Equal(t, "info", entry["level"])
+	assert.Equal(t, "val1", entry["key1"])
+	assert.Contains(t, entry, "timestamp")
+}
+
+func TestSocketLogHandlerLevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelWarn)
+	logger := slog.New(handler)
+
+	logger.Debug("should be filtered")
+	logger.Info("also filtered")
+	logger.Warn("should appear")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 1)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &entry))
+	assert.Equal(t, "should appear", entry["event"])
+	assert.Equal(t, "warn", entry["level"])
+}
+
+func TestSocketLogHandlerBuffering(t *testing.T) {
+	// Create handler without a writer — messages should be buffered.
+	handler := NewSocketLogHandler(nil, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("buffered message 1")
+	logger.Info("buffered message 2")
+
+	// Connect the writer — buffered messages should flush.
+	var buf bytes.Buffer
+	handler.Connect(&buf)
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Len(t, lines, 2)
+
+	// New messages should write directly.
+	logger.Info("direct message")
+	lines = strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Len(t, lines, 3)
+}
+
+func TestSocketLogHandlerWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).With("component", "test")
+
+	logger.Info("with attrs")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "test", entry["component"])
+}
+
+func TestSocketLogHandlerWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).WithGroup("grp")
+
+	logger.Info("grouped", "key", "val")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "val", entry["grp.key"])
+}
+
+func TestSocketLogHandlerKeyMapping(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Error("an error occurred")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+
+	// Check key mapping: "event" not "msg", "level" lowercase, "timestamp" not "time"
+	assert.Equal(t, "an error occurred", entry["event"])
+	assert.Equal(t, "error", entry["level"])
+	_, hasTimestamp := entry["timestamp"]
+	assert.True(t, hasTimestamp)
+	_, hasMsg := entry["msg"]
+	assert.False(t, hasMsg)
+	_, hasTime := entry["time"]
+	assert.False(t, hasTime)
+}
+
+// TestSocketLogHandlerStringifiesErrorAttr verifies that an attribute whose
+// value is a stock `error` is rendered as its .Error() string. Without value
+// resolution the underlying struct's unexported fields would be marshaled as
+// "{}", silently dropping the message.
+func TestSocketLogHandlerStringifiesErrorAttr(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Error("task failed", "error", errors.New("boom"))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "boom", entry["error"])
+}
+
+// logValuerAttr is an slog.LogValuer that resolves to a string. Used to
+// confirm Resolve() is called before JSON marshaling.
+type logValuerAttr string
+
+func (l logValuerAttr) LogValue() slog.Value {
+	return slog.StringValue(string(l) + ":resolved")
+}
+
+// TestSocketLogHandlerResolvesLogValuer verifies that an attribute whose
+// value implements slog.LogValuer has Resolve() called before marshaling,
+// matching the behaviour of slog.NewJSONHandler.
+func TestSocketLogHandlerResolvesLogValuer(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("with valuer", "field", logValuerAttr("hello"))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "hello:resolved", entry["field"])
+}

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -113,6 +113,73 @@ func TestSocketLogHandlerWithGroup(t *testing.T) {
 	assert.Equal(t, "val", entry["grp.key"])
 }
 
+// TestSocketLogHandlerInlineGroup verifies that an inline slog.Group passed as
+// a record-level attr is expanded into dotted keys (req.method) rather than
+// being marshaled as "{}". A KindGroup value resolves to []slog.Attr whose
+// unexported slog.Value would otherwise drop every field, so task code logging
+// with slog.Group would silently lose data.
+func TestSocketLogHandlerInlineGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info(
+		"inline group",
+		slog.Group("req", slog.String("method", "GET"), slog.Int("code", 200)),
+	)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "GET", entry["req.method"])
+	assert.EqualValues(t, 200, entry["req.code"])
+	assert.NotContains(t, entry, "req")
+}
+
+// TestSocketLogHandlerInlineGroupUnderActiveGroup verifies that an inline group
+// is further qualified by any group active at Handle time, so the dotted prefix
+// stacks (outer.req.method).
+func TestSocketLogHandlerInlineGroupUnderActiveGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).WithGroup("outer")
+
+	logger.Info("nested inline group", slog.Group("req", slog.String("method", "GET")))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "GET", entry["outer.req.method"])
+}
+
+// TestSocketLogHandlerGroupViaWithAttrs verifies that a group added through
+// With() (a pre-configured attr) is expanded the same way as an inline group.
+func TestSocketLogHandlerGroupViaWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).With(slog.Group("req", slog.String("method", "GET")))
+
+	logger.Info("group via with")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.Equal(t, "GET", entry["req.method"])
+	assert.NotContains(t, entry, "req")
+}
+
+// TestSocketLogHandlerEmptyGroupOmitted verifies that a group with no attrs is
+// dropped entirely, matching the slog.Handler contract.
+func TestSocketLogHandlerEmptyGroupOmitted(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler)
+
+	logger.Info("empty group", slog.Group("empty"), "kept", "yes")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+	assert.NotContains(t, entry, "empty")
+	assert.Equal(t, "yes", entry["kept"])
+}
+
 func TestSocketLogHandlerKeyMapping(t *testing.T) {
 	var buf bytes.Buffer
 	handler := NewSocketLogHandler(&buf, slog.LevelDebug)

--- a/go-sdk/pkg/execution/logger_test.go
+++ b/go-sdk/pkg/execution/logger_test.go
@@ -172,3 +172,66 @@ func TestSocketLogHandlerResolvesLogValuer(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
 	assert.Equal(t, "hello:resolved", entry["field"])
 }
+
+// TestSocketLogHandlerWithAttrsBeforeWithGroup verifies that attributes added
+// via With() before a WithGroup() call are NOT retroactively qualified by
+// that group. Per the slog.Handler contract: "All attributes added
+// subsequently to that handler will be qualified by the group" — emphasis on
+// subsequently. A naive implementation that stores attrs raw and applies the
+// current group prefix at Handle time would break this and silently re-key
+// pre-group attrs.
+func TestSocketLogHandlerWithAttrsBeforeWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).With("a", 1).WithGroup("g").With("b", 2)
+
+	logger.Info("interleaved", "c", 3)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+
+	// a was added before WithGroup("g") — must stay at top level.
+	assert.EqualValues(
+		t,
+		1,
+		entry["a"],
+		"pre-group attr must not be re-qualified by a later WithGroup",
+	)
+	assert.NotContains(
+		t,
+		entry,
+		"g.a",
+		"pre-group attr must not appear under the later group prefix",
+	)
+
+	// b was added after WithGroup("g") — must be under g.
+	assert.EqualValues(t, 2, entry["g.b"], "post-group attr must be qualified by the active group")
+	assert.NotContains(t, entry, "b", "post-group attr must not appear at top level")
+
+	// c is a record-level attr handled while "g" is active — also under g.
+	assert.EqualValues(
+		t,
+		3,
+		entry["g.c"],
+		"record-level attr must be qualified by the active group",
+	)
+}
+
+// TestSocketLogHandlerNestedGroups verifies that nested WithGroup calls
+// produce dotted prefixes in declaration order, and that an attr added
+// between two WithGroup calls only sees the groups that were active at its
+// WithAttrs call site (not the later one).
+func TestSocketLogHandlerNestedGroups(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewSocketLogHandler(&buf, slog.LevelDebug)
+	logger := slog.New(handler).WithGroup("outer").With("a", 1).WithGroup("inner").With("b", 2)
+
+	logger.Info("nested", "c", 3)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &entry))
+
+	assert.EqualValues(t, 1, entry["outer.a"], "a was added under outer only")
+	assert.EqualValues(t, 2, entry["outer.inner.b"], "b was added under outer.inner")
+	assert.EqualValues(t, 3, entry["outer.inner.c"], "record attr inherits outer.inner")
+}

--- a/go-sdk/pkg/execution/messages.go
+++ b/go-sdk/pkg/execution/messages.go
@@ -171,14 +171,16 @@ func decodeStartupDetails(m map[string]any) (*StartupDetails, error) {
 
 // Response types (for runtime-initiated requests).
 
-// ConnectionResult is the response to GetConnection.
+// ConnectionResult is the response to GetConnection. Login and Password are
+// nullable in the supervisor schema (None vs "" are distinct), so they are
+// decoded as *string to preserve that distinction.
 type ConnectionResult struct {
 	ConnID   string
 	ConnType string
 	Host     string
 	Schema   string
-	Login    string
-	Password string
+	Login    *string
+	Password *string
 	Port     int
 	Extra    string
 }
@@ -189,8 +191,8 @@ func decodeConnectionResult(m map[string]any) (*ConnectionResult, error) {
 		ConnType: mapStringOr(m, "conn_type", ""),
 		Host:     mapStringOr(m, "host", ""),
 		Schema:   mapStringOr(m, "schema", ""),
-		Login:    mapStringOr(m, "login", ""),
-		Password: mapStringOr(m, "password", ""),
+		Login:    mapStringPtr(m, "login"),
+		Password: mapStringPtr(m, "password"),
 		Port:     mapIntOr(m, "port", 0),
 		Extra:    mapStringOr(m, "extra", ""),
 	}, nil

--- a/go-sdk/pkg/execution/messages_test.go
+++ b/go-sdk/pkg/execution/messages_test.go
@@ -173,9 +173,95 @@ func TestDecodeConnectionResult(t *testing.T) {
 	assert.Equal(t, "postgres", result.ConnType)
 	assert.Equal(t, "db.example.com", result.Host)
 	assert.Equal(t, "mydb", result.Schema)
-	assert.Equal(t, "user", result.Login)
-	assert.Equal(t, "secret", result.Password)
+	require.NotNil(t, result.Login)
+	assert.Equal(t, "user", *result.Login)
+	require.NotNil(t, result.Password)
+	assert.Equal(t, "secret", *result.Password)
 	assert.Equal(t, 5432, result.Port)
+}
+
+// TestDecodeConnectionResultNullableCredentials covers the four shapes login /
+// password can take on the wire: absent, explicit None, explicit "", and a
+// real value. Empty-string and absent must be distinguishable so URI building
+// in sdk.Connection picks the same branch the HTTP-backed SDK would.
+func TestDecodeConnectionResultNullableCredentials(t *testing.T) {
+	empty := ""
+	user := "user"
+	tests := []struct {
+		name         string
+		body         map[string]any
+		wantLogin    *string
+		wantPassword *string
+	}{
+		{
+			name: "absent keys decode to nil",
+			body: map[string]any{
+				"type":    "ConnectionResult",
+				"conn_id": "c",
+			},
+			wantLogin:    nil,
+			wantPassword: nil,
+		},
+		{
+			name: "explicit nil decodes to nil",
+			body: map[string]any{
+				"type":     "ConnectionResult",
+				"conn_id":  "c",
+				"login":    nil,
+				"password": nil,
+			},
+			wantLogin:    nil,
+			wantPassword: nil,
+		},
+		{
+			name: "empty string is preserved",
+			body: map[string]any{
+				"type":     "ConnectionResult",
+				"conn_id":  "c",
+				"login":    "",
+				"password": "",
+			},
+			wantLogin:    &empty,
+			wantPassword: &empty,
+		},
+		{
+			name: "non-empty string is preserved",
+			body: map[string]any{
+				"type":     "ConnectionResult",
+				"conn_id":  "c",
+				"login":    "user",
+				"password": "secret",
+			},
+			wantLogin:    &user,
+			wantPassword: nil, // checked below
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := decodeConnectionResult(tc.body)
+			require.NoError(t, err)
+
+			if tc.wantLogin == nil {
+				assert.Nil(t, result.Login)
+			} else {
+				require.NotNil(t, result.Login)
+				assert.Equal(t, *tc.wantLogin, *result.Login)
+			}
+
+			if tc.name == "non-empty string is preserved" {
+				require.NotNil(t, result.Password)
+				assert.Equal(t, "secret", *result.Password)
+				return
+			}
+			if tc.wantPassword == nil {
+				assert.Nil(t, result.Password)
+			} else {
+				require.NotNil(t, result.Password)
+				assert.Equal(t, *tc.wantPassword, *result.Password)
+			}
+		})
+	}
 }
 
 func TestDecodeVariableResult(t *testing.T) {


### PR DESCRIPTION

- **Depends on https://github.com/apache/airflow/pull/67315 get merged first**
- **Diff for early review**: https://github.com/jason810496/airflow/compare/refactor/go-sdk/coordinator-protocol...jason810496:refactor/go-sdk/coordinator-comms
- related: split out of https://github.com/apache/airflow/pull/67154 to land it in three reviewable PRs (protocol primitives -> comms layer -> runtime entry point).

## Why

Second PR in a 3-PR stack carved out of #67154.

The Go runtime can send a `GetVariable` request and await a matching reply at any time (e.g. spawn goroutines that get XComs) -- so a naive read-one / write-one loop would either serialise everything (no concurrent task code) or require every caller to multiplex frames by hand.

## How

`CoordinatorComm` solves this once: a single dispatcher goroutine demuxes inbound frames to per-request reply channels keyed by a monotonic id, propagates `ctx.Err()` to outstanding requests on cancellation, and tears down pending requests cleanly on `SendRequest` failure.

`SocketLogHandler` exists so the supervisor demuxes task logs the same way it demuxes everything else -- structured JSON over the dedicated logs socket -- instead of having to parse stderr. 

`CoordinatorClient` lets the task runner in the next PR reuse the existing `sdk.Client` API by re-implementing it on top of the dispatcher, so tasks written against `sdk.Client` run unchanged under coordinator mode. The comm-layer dispatcher pattern is inspired by https://github.com/apache/airflow/pull/66412.

Still no entry point in this PR -- that arrives in the third PR of the stack -- so this PR has no user-visible effect on its own.

## What

- `pkg/execution/comms.go` -- `CoordinatorComm` runs one dispatcher goroutine that demuxes inbound frames to per-request reply channels (keyed by an `atomic.Int64` id, guarded by a mutex). `SendRequest` registers a channel, writes the frame, and returns on either the reply or `ctx.Err()`, cleaning up afterward; the dispatcher fails all pending requests on `io.EOF`.
- `pkg/execution/logger.go` -- `SocketLogHandler` implements `slog.Handler`, writing one resolved JSON record per line to the logs socket and surfacing socket write errors through `slog` instead of panicking (the buffered-flush path in `Connect()` swallows them, as those records have nowhere to go).
- `pkg/execution/client.go` -- `CoordinatorClient` implements `sdk.Client` over `CoordinatorComm`, serialising each call into its `messages.go` envelope. `GetVariable` honours `AIRFLOW_VAR_*` overrides; `GetConnection`/`GetVariable` map "not found" replies to the SDK sentinel errors.
- Tests cover the concurrent paths: race-free dispatch, cancelled-context cleanup, EOF teardown, and round-tripping every message variant.

## Next

- refactor/go-sdk/coordinator-runtime-server (#67318)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

