### PR TITLE
Breeze: bind api-server dual-stack so http://localhost works in Chrome/Safari

### DIFF
--- a/scripts/in_container/bin/generate_mprocs_config.py
+++ b/scripts/in_container/bin/generate_mprocs_config.py
@@ -66,12 +66,22 @@ def generate_mprocs_config() -> str:
     use_airflow_version = get_env("USE_AIRFLOW_VERSION", "")
     if not use_airflow_version.startswith("2."):
         # API Server (Airflow 3.x+)
+        # Bind dual-stack (IPv6 + IPv4) so http://localhost:28080 works from browsers that
+        # resolve `localhost` to ::1 first (e.g. Chrome/Safari on macOS with OrbStack, which
+        # forwards both IPv4 and IPv6 host ports into the container). The default `0.0.0.0`
+        # binds IPv4 only, causing the IPv6 attempt to land inside the container with no
+        # listener and TCP RST → opaque chrome-error://chromewebdata/ page.
+        api_host_arg = "--host '::'"
         if get_env_bool("BREEZE_DEBUG_APISERVER"):
             port = get_env("BREEZE_DEBUG_APISERVER_PORT", "5679")
-            api_cmd = f"debugpy --listen 0.0.0.0:{port} --wait-for-client -m airflow api-server -d"
+            api_cmd = (
+                f"debugpy --listen 0.0.0.0:{port} --wait-for-client -m airflow api-server {api_host_arg} -d"
+            )
         else:
             dev_mode = get_env_bool("DEV_MODE")
-            api_cmd = "airflow api-server -d" if dev_mode else "airflow api-server"
+            api_cmd = (
+                f"airflow api-server {api_host_arg} -d" if dev_mode else f"airflow api-server {api_host_arg}"
+            )
         procs["api_server"] = {"shell": api_cmd, "restart": "always", "scrollback": 100000}
     else:
         # Webserver (Airflow 2.x)

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -65,15 +65,18 @@ fi
 if [[ ! ${USE_AIRFLOW_VERSION=} =~ ^2\..*  ]]; then
   tmux split-window -h
   tmux select-pane -t 2
+    # Bind dual-stack (IPv6 + IPv4) so http://localhost:28080 works from browsers that resolve
+    # `localhost` to ::1 first (e.g. Chrome/Safari on macOS with OrbStack, which forwards both
+    # IPv4 and IPv6 host ports into the container). The default `0.0.0.0` binds IPv4 only.
     if [[ ${BREEZE_DEBUG_APISERVER} == "true" ]]; then
         tmux set-option -p @airflow_component "API Server(Debug Mode)"
-        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server -d" C-m
+        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server --host '::' -d" C-m
     else
   tmux set-option -p @airflow_component "API Server"
     if [[ ${DEV_MODE=} == "true" ]]; then
-        tmux send-keys 'airflow api-server -d' C-m
+        tmux send-keys "airflow api-server --host '::' -d" C-m
     else
-        tmux send-keys 'airflow api-server' C-m
+        tmux send-keys "airflow api-server --host '::'" C-m
     fi
     fi
 else


### PR DESCRIPTION
## Summary

`breeze start-airflow` launches `airflow api-server` with no `--host` override, so it picks up the default `[api] host = 0.0.0.0` — **IPv4 only**. On macOS with OrbStack (and any other dual-stack-forwarding runtime), this breaks `http://localhost:28080` in Chrome and Safari but not Firefox — a confusing failure mode hidden behind an opaque `chrome-error://chromewebdata/...` page.

This change makes the breeze-spawned api-server bind `::` (the IPv6 wildcard), which on Linux/macOS dual-stack sockets accepts both IPv4 and IPv6 connections. One-line behavior fix; no public Airflow config changes.

## Why this happens

- macOS `/etc/hosts` resolves `localhost` to both `127.0.0.1` (A) and `::1` (AAAA).
- **Chrome / Safari** prefer the IPv6 address — they try `[::1]:28080` first.
- **OrbStack** binds the host-side port-forward dual-stack: `OrbStack ... TCP *:28080 (LISTEN)` on both IPv4 and IPv6. The IPv6 TCP handshake therefore succeeds at the host…
- …but the api-server inside the container is bound to `0.0.0.0` only, so there's no listener on `[::]:8080`. The container responds with TCP RST.
- The browser then renders `chrome-error://chromewebdata/` and emits the misleading *"Unsafe attempt to load URL ... from frame with URL chrome-error://chromewebdata/"* console message.
- **Firefox** prefers IPv4, so it hits `127.0.0.1:28080` and never sees this. **Docker Desktop** historically only forwards IPv4, so happy-eyeballs falls back cleanly to IPv4 there too. The combo of Chrome + macOS + OrbStack is what surfaces it.

## Reproduce (before this patch)

```bash
breeze start-airflow
curl -v http://localhost:28080/        # → Recv failure: Connection reset by peer
curl -v http://127.0.0.1:28080/        # → 200 OK
# open http://localhost:28080/ in Chrome  → chrome-error page
# open http://localhost:28080/ in Firefox → works
```

## After this patch

The api-server binds dual-stack inside the container, so `localhost` reaches it regardless of which family the browser picks.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)