### PR TITLE
Fix MySQL HITL responded-by filters

### DIFF
--- a/airflow-core/src/airflow/models/hitl.py
+++ b/airflow-core/src/airflow/models/hitl.py
@@ -61,11 +61,21 @@ def compile_postgres(element: JSONExtract, compiler: SQLCompiler, **kwargs: dict
     return compiler.process(func.json_extract_path_text(column, key), **kwargs)
 
 
-@compiles(JSONExtract, "sqlite")
 @compiles(JSONExtract, "mysql")
-def compile_sqlite_mysql(element: JSONExtract, compiler: SQLCompiler, **kwargs: dict[str, Any]) -> str:
+def compile_mysql(element: JSONExtract, compiler: SQLCompiler, **kwargs: dict[str, Any]) -> str:
     """
-    Compile JSONExtract for SQLite/MySQL.
+    Compile JSONExtract for MySQL.
+
+    :meta: private
+    """
+    column, key = element.clauses
+    return compiler.process(func.json_unquote(func.json_extract(column, f"$.{key.value}")), **kwargs)
+
+
+@compiles(JSONExtract, "sqlite")
+def compile_sqlite(element: JSONExtract, compiler: SQLCompiler, **kwargs: dict[str, Any]) -> str:
+    """
+    Compile JSONExtract for SQLite.
 
     :meta: private
     """

--- a/airflow-core/src/airflow/models/hitl.py
+++ b/airflow-core/src/airflow/models/hitl.py
@@ -69,7 +69,8 @@ def compile_mysql(element: JSONExtract, compiler: SQLCompiler, **kwargs: dict[st
     :meta: private
     """
     column, key = element.clauses
-    return compiler.process(func.json_unquote(func.json_extract(column, f"$.{key.value}")), **kwargs)
+    extracted = func.json_extract(column, f"$.{key.value}")
+    return compiler.process(func.json_unquote(extracted), **kwargs)
 
 
 @compiles(JSONExtract, "sqlite")

--- a/airflow-core/tests/unit/models/test_hitl.py
+++ b/airflow-core/tests/unit/models/test_hitl.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.dialects import mysql, postgresql, sqlite
+
+from airflow.models.hitl import HITLDetail
+
+
+class TestJSONExtract:
+    """The HITL responded-by filters compare against plain strings, so every dialect must yield text."""
+
+    @pytest.mark.parametrize("key", ["id", "name"])
+    @pytest.mark.parametrize(
+        ("dialect", "expected_sql"),
+        [
+            pytest.param(
+                mysql.dialect(),
+                "json_unquote(json_extract(hitl_detail.responded_by, '$.{key}'))",
+                id="mysql",
+            ),
+            pytest.param(
+                sqlite.dialect(),
+                "json_extract(hitl_detail.responded_by, '$.{key}')",
+                id="sqlite",
+            ),
+            pytest.param(
+                postgresql.dialect(),
+                "json_extract_path_text(hitl_detail.responded_by, '{key}')",
+                id="postgresql",
+            ),
+        ],
+    )
+    def test_compiles_to_text_returning_sql_per_dialect(self, dialect, expected_sql: str, key: str) -> None:
+        expression = getattr(HITLDetail, f"responded_by_user_{key}")
+
+        compiled = expression.compile(dialect=dialect, compile_kwargs={"literal_binds": True})
+
+        assert str(compiled) == expected_sql.format(key=key)


### PR DESCRIPTION
In MySQL, `JSON_EXTRACT(`) returns a JSON value, so extracting responded_by.id can produce a JSON string such as `"test"` rather than plain text `test`. Wrap the extraction with `JSON_UNQUOTE()` so HITL responded-by filters compare plain strings consistently.
https://dev.mysql.com/doc/refman/8.0/en/json.html

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
