### PR TITLE
Fix DAG_DISCOVERY_SAFE_MODE config not being respected

### DIFF
--- a/airflow-core/src/airflow/utils/file.py
+++ b/airflow-core/src/airflow/utils/file.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import overload
 
 from airflow.configuration import conf
+from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 
 log = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ def open_maybe_zipped(fileloc, mode="r"):
 
 def list_py_file_paths(
     directory: str | os.PathLike[str] | None,
-    safe_mode: bool = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True),
+    safe_mode: bool | ArgNotSet = NOTSET,
 ) -> list[str]:
     """
     Traverse a directory and look for Python files.
@@ -88,6 +89,8 @@ def list_py_file_paths(
         to safe.
     :return: a list of paths to Python files in the specified directory
     """
+    if not is_arg_set(safe_mode):
+        safe_mode = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True)
     file_paths: list[str] = []
     if directory is None:
         file_paths = []

--- a/airflow-core/tests/unit/utils/test_file.py
+++ b/airflow-core/tests/unit/utils/test_file.py
@@ -212,6 +212,39 @@ class TestListPyFilesPath:
             f"Detected files mismatched expected files:\ndetected_files: {pformat(detected_files)}\nexpected_files: {pformat(expected_files)}"
         )
 
+    def test_list_py_file_paths_safe_mode_default_argument(self, tmp_path):
+        """
+        Test that list_py_file_paths safe_mode default argument respects config.
+
+        When a Python file doesn't contain 'airflow' and 'dag'/'asset' keywords,
+        it's skipped when safe_mode=True. The default argument should read from
+        config at call time, not at module load time.
+        """
+        # Create a Python file without relevant keywords
+        test_file = tmp_path / "no_keywords.py"
+        test_file.write_text("# empty file")
+
+        # Verify no keywords
+        content = test_file.read_text().lower()
+        assert "airflow" not in content
+        assert "dag" not in content
+
+        # safe_mode=True explicitly: file should be skipped
+        result_safe = list_py_file_paths(str(tmp_path), safe_mode=True)
+        assert len(result_safe) == 0
+
+        # safe_mode=False explicitly: file should be found
+        result_unsafe = list_py_file_paths(str(tmp_path), safe_mode=False)
+        assert len(result_unsafe) == 1
+
+        # Test default argument respects config
+        with conf_vars({("core", "dag_discovery_safe_mode"): "False"}):
+            result = list_py_file_paths(str(tmp_path))
+            assert len(result) == 1, (
+                f"Expected 1 file with DAG_DISCOVERY_SAFE_MODE=False, got {len(result)}. "
+                f"The default argument should read config at call time."
+            )
+
 
 @pytest.mark.parametrize(
     ("edge_filename", "expected_modification"),


### PR DESCRIPTION
closes: #66104

## Problem

When `DAG_DISCOVERY_SAFE_MODE` is set to `False` in the config, Python files 
without "airflow" or "dag" keywords are still being skipped during DAG discovery.

This happens because the default argument `safe_mode=conf.getboolean(...)` in 
`list_py_file_paths()` is evaluated at module load time, not at call time. 
Once evaluated, the value is fixed and subsequent config changes are ignored.

## Solution

Use the existing `NOTSET` sentinel pattern (already used in `DagBag`) to defer 
config reading to runtime:

```python
def list_py_file_paths(
    directory: str | os.PathLike[str] | None,
    safe_mode: bool | ArgNotSet = NOTSET,
) -> list[str]:
    if not is_arg_set(safe_mode):
        safe_mode = conf.getboolean("core", "DAG_DISCOVERY_SAFE_MODE", fallback=True)
    ...
```

This ensures the config value is read at call time, allowing runtime config 
changes to take effect.

## Testing

Added a test that would fail without this fix, verifying that:
- Files without keywords are skipped with `safe_mode=True`
- Files without keywords are found with `safe_mode=False`
- Config setting is now respected when using default argument

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GLM-5

Generated-by: GLM-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)