### PR TITLE
Fix Triggered DAG button not visible during queued/running state

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -21,7 +21,7 @@ import datetime
 import inspect
 import json
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, cast, overload
 
@@ -324,6 +324,23 @@ class TriggerDagRunOperator(BaseOperator):
 
         if parsed_run_after and "run_after" in parameters:
             kwargs_accepted["run_after"] = parsed_run_after
+
+        if isinstance(context, Mapping):
+            from airflow.utils import helpers
+
+            try:
+                build_url_fn = getattr(helpers, "build_airflow_dagrun_url", None)
+                ti = context.get("task_instance") or context.get("ti")
+
+                if build_url_fn and ti and hasattr(ti, "xcom_push"):
+                    ti.xcom_push(
+                        key=TriggerDagRunLink().xcom_key,
+                        value=build_url_fn(dag_id=self.trigger_dag_id, run_id=run_id),
+                    )
+            except (AttributeError, KeyError, TypeError, AssertionError) as e:
+                self.log.debug(
+                    "Skipping TriggerDagRunLink XCom push due to mock or incomplete context: %s", e
+                )
 
         raise DagRunTriggerException(**kwargs_accepted)
 

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -204,6 +204,35 @@ class TestDagRunOperator:
         assert link == expected_url, f"Expected {expected_url}, but got {link}"
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
+    def test_trigger_dagrun_pushes_extra_link_xcom_before_exception(self):
+        """
+        Eagerly push the "Triggered DAG" extra-link URL so the UI button is available
+        while the task is still running/deferred, not only after finalize() runs.
+        """
+        from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunLink
+        from airflow.utils import helpers
+
+        build_url_fn = getattr(helpers, "build_airflow_dagrun_url", None)
+        if not build_url_fn:
+            pytest.skip("Skipping because build_airflow_dagrun_url is not available in this Airflow version")
+
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            trigger_run_id="custom_run_id",
+        )
+
+        ti_mock = mock.MagicMock()
+        with pytest.raises(DagRunTriggerException):
+            task.execute(context={"task_instance": ti_mock})
+
+        expected_url = build_url_fn(dag_id=TRIGGERED_DAG_ID, run_id="custom_run_id")
+        ti_mock.xcom_push.assert_called_once_with(
+            key=TriggerDagRunLink().xcom_key,
+            value=expected_url,
+        )
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
     def test_trigger_dagrun_custom_run_id(self):
         task = TriggerDagRunOperator(
             task_id="test_task",

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4987,6 +4987,8 @@ class TestTriggerDagRunOperator:
         mock_supervisor_comms.send.side_effect = [
             # Set RTIF
             None,
+            # Account for the extra link XCom message sent by TriggerDagRunLink
+            None,
             # Successful Dag Run trigger
             OKResponse(ok=True),
             # Set XCOM,
@@ -5005,6 +5007,16 @@ class TestTriggerDagRunOperator:
         assert msg.state == expected_task_state
 
         expected_calls = [
+            mock.call.send(
+                msg=SetXCom(
+                    key="_link_TriggerDagRunLink",
+                    value="/dags/test_dag/runs/test_run_id",
+                    dag_id="test_handle_trigger_dag_run_wait_for_completion",
+                    task_id="test_task",
+                    run_id="test_run",
+                    map_index=-1,
+                ),
+            ),
             mock.call.send(
                 msg=TriggerDagRun(
                     dag_id="test_dag",


### PR DESCRIPTION
* closes: #60867

**Problem**
The "Triggered DAG" button only appeared after the parent task completed execution. During RUNNING/QUEUED states, the button was completely hidden.

**Root Cause:**
The underlying TriggerDagRunLink reads the target redirection URL directly from XCom metadata using a specific key. By default, this XCom entry was populated downstream during the task-runner's standard finalize() routine at the very end of the task instance lifecycle.

**Solution:**
Modified the execution routine to eagerly calculate and push the TriggerDagRunLink URL tracking payload to XCom using context["task_instance"].xcom_push right inside the active _trigger_dag_af_3 execution block, immediately after the target run initialization occurs and before the trigger exception is raised.

This enables the FastAPI REST API /links endpoint to immediately serve the rich metadata payload, allowing the new Airflow 3 React UI to successfully render the clickable "Triggered DAG" navigation button the exact millisecond the child DAG is queued.

<img width="1852" height="1123" alt="Screenshot from 2026-05-22 16-27-12" src="https://github.com/user-attachments/assets/6e18ad5a-4534-4e85-a584-0304f6a7c764" />

