### PR TITLE
Bring back edge worker metric compatibility with Airflow 3.2

### DIFF
--- a/providers/edge3/docs/edge_executor.rst
+++ b/providers/edge3/docs/edge_executor.rst
@@ -222,7 +222,7 @@ Current Limitations Edge Executor
 Metrics Export Compatibility
 -----------------------------
 
-The Edge Worker integrates with Airflow's statsd metrics system to export runtime metrics. Compatibility
+The Edge Worker integrates with Airflow's metrics system to export runtime metrics. Compatibility
 between Edge provider versions and Airflow versions varies due to changes in the metrics initialization
 pipeline. The table below documents known compatibility issues and workarounds:
 

--- a/providers/edge3/docs/edge_executor.rst
+++ b/providers/edge3/docs/edge_executor.rst
@@ -217,3 +217,30 @@ Current Limitations Edge Executor
   - Multi-team isolation is logical only — all teams share a single authentication secret. A worker
     administrator could change the team name and access another team's jobs. See
     :ref:`edge_executor:multi_team` for details and planned improvements.
+
+
+Metrics Export Compatibility
+-----------------------------
+
+The Edge Worker integrates with Airflow's statsd metrics system to export runtime metrics. Compatibility
+between Edge provider versions and Airflow versions varies due to changes in the metrics initialization
+pipeline. The table below documents known compatibility issues and workarounds:
+
+.. list-table::
+     :header-rows: 1
+
+     * - Provider version
+         - Airflow 3.3
+         - Airflow 3.2
+         - Airflow 3.1
+     * - >= 3.6.0
+         - Working
+         - Broken: webserver statsd initialization is missing (DualStatsManager removed)
+         - Broken: statsd metric tags
+     * - <= 3.5.0
+         - Working
+         - Requires manual patch of ``metrics_template.yaml`` to match previous statsd export schema
+         - Working
+
+**For Airflow 3.2 users:** If upgrading to Edge provider >= 3.6.0 breaks metrics export, either
+(1) upgrade Airflow to 3.3+, or (2) downgrade to Edge provider <= 3.5.0 with the workaround above.

--- a/providers/edge3/docs/edge_executor.rst
+++ b/providers/edge3/docs/edge_executor.rst
@@ -235,11 +235,11 @@ pipeline. The table below documents known compatibility issues and workarounds:
          - Airflow 3.1
      * - >= 3.6.0
          - Working
-         - Broken: webserver statsd initialization is missing (DualStatsManager removed)
-         - Broken: statsd metric tags
+         - Broken: webserver missing a `stats.initialize(...)` call -- DualStatsManager removed, missing legacy metric names
+         - Broken: metric tags
      * - <= 3.5.0
          - Working
-         - Requires manual patch of ``metrics_template.yaml`` to match previous statsd export schema
+         - Requires manual patch of ``metrics_template.yaml`` to match previous export schema
          - Working
 
 **For Airflow 3.2 users:** If upgrading to Edge provider >= 3.6.0 breaks metrics export, either

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -28,11 +28,8 @@ from sqlalchemy.orm import Mapped
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
 from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.providers.edge3.models.edge_base import Base
-<<<<<<< HEAD
-from airflow.utils.helpers import prune_dict
-=======
 from airflow.providers.edge3.version_compat import AIRFLOW_V_3_3_PLUS
->>>>>>> 366552b881 (Reworked statsd taging for pre airflow 3.3 versions)
+from airflow.utils.helpers import prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -189,9 +186,7 @@ def set_metrics(
     if not isinstance(status, (int, float)):
         status = logging.NOTSET
 
-    Stats.gauge(
-        "edge_worker.status", status, tags=metric_tags
-    )  # type: ignore
+    Stats.gauge("edge_worker.status", status, tags=metric_tags)
     Stats.gauge("edge_worker.connected", int(connected), tags=metric_tags)
     Stats.gauge("edge_worker.maintenance", int(maintenance), tags=metric_tags)
     Stats.gauge("edge_worker.jobs_active", jobs_active, tags=metric_tags)

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -34,6 +34,11 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
+try:
+    from airflow.sdk.observability.stats import DualStatsManager
+except ImportError:
+    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -185,13 +185,13 @@ def set_metrics(
         "free_concurrency",
     }
     metric_tags = prune_dict({"worker_name": worker_name, "team_name": team_name})
+    status = sysinfo.get("status", logging.NOTSET)
+    if not isinstance(status, (int, float)):
+        status = logging.NOTSET
 
     Stats.gauge(
-<<<<<<< HEAD
-        "edge_worker.status",
-        sysinfo.get("status", logging.NOTSET),  # type: ignore
-        tags=metric_tags,
-    )
+        "edge_worker.status", status, tags=metric_tags
+    )  # type: ignore
     Stats.gauge("edge_worker.connected", int(connected), tags=metric_tags)
     Stats.gauge("edge_worker.maintenance", int(maintenance), tags=metric_tags)
     Stats.gauge("edge_worker.jobs_active", jobs_active, tags=metric_tags)
@@ -201,19 +201,6 @@ def set_metrics(
         "edge_worker.num_queues",
         len(queues),
         tags={**metric_tags, "queues": ",".join(queues)},
-=======
-        "edge_worker.status", sysinfo.get("status", logging.NOTSET), tags={"worker_name": worker_name}
-    )  # type: ignore
-    Stats.gauge("edge_worker.connected", int(connected), tags={"worker_name": worker_name})
-    Stats.gauge("edge_worker.maintenance", int(maintenance), tags={"worker_name": worker_name})
-    Stats.gauge("edge_worker.jobs_active", jobs_active, tags={"worker_name": worker_name})
-    Stats.gauge("edge_worker.concurrency", concurrency, tags={"worker_name": worker_name})
-    Stats.gauge("edge_worker.free_concurrency", free_concurrency, tags={"worker_name": worker_name})
-    Stats.gauge(
-        "edge_worker.num_queues",
-        len(queues),
-        tags={"worker_name": worker_name, "queues": ",".join(queues)},
->>>>>>> 366552b881 (Reworked statsd taging for pre airflow 3.3 versions)
     )
 
     for key in additional_keys:
@@ -223,7 +210,7 @@ def set_metrics(
 
     if not AIRFLOW_V_3_3_PLUS:
         # Airflow < 3.3: export legacy per-worker metrics (no auto-tag expansion).
-        Stats.gauge(f"edge_worker.status.{worker_name}", sysinfo.get("status", logging.NOTSET))  # type: ignore
+        Stats.gauge(f"edge_worker.status.{worker_name}", int(status))
         Stats.gauge(f"edge_worker.connected.{worker_name}", int(connected))
         Stats.gauge(f"edge_worker.maintenance.{worker_name}", int(maintenance))
         Stats.gauge(f"edge_worker.jobs_active.{worker_name}", jobs_active)

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -28,16 +28,15 @@ from sqlalchemy.orm import Mapped
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
 from airflow.providers.common.compat.sqlalchemy.orm import mapped_column
 from airflow.providers.edge3.models.edge_base import Base
+<<<<<<< HEAD
 from airflow.utils.helpers import prune_dict
+=======
+from airflow.providers.edge3.version_compat import AIRFLOW_V_3_3_PLUS
+>>>>>>> 366552b881 (Reworked statsd taging for pre airflow 3.3 versions)
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
-
-try:
-    from airflow.sdk.observability.stats import DualStatsManager
-except ImportError:
-    DualStatsManager = None  # type: ignore[assignment,misc]  # Airflow < 3.2 compat
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -188,6 +187,7 @@ def set_metrics(
     metric_tags = prune_dict({"worker_name": worker_name, "team_name": team_name})
 
     Stats.gauge(
+<<<<<<< HEAD
         "edge_worker.status",
         sysinfo.get("status", logging.NOTSET),  # type: ignore
         tags=metric_tags,
@@ -201,12 +201,40 @@ def set_metrics(
         "edge_worker.num_queues",
         len(queues),
         tags={**metric_tags, "queues": ",".join(queues)},
+=======
+        "edge_worker.status", sysinfo.get("status", logging.NOTSET), tags={"worker_name": worker_name}
+    )  # type: ignore
+    Stats.gauge("edge_worker.connected", int(connected), tags={"worker_name": worker_name})
+    Stats.gauge("edge_worker.maintenance", int(maintenance), tags={"worker_name": worker_name})
+    Stats.gauge("edge_worker.jobs_active", jobs_active, tags={"worker_name": worker_name})
+    Stats.gauge("edge_worker.concurrency", concurrency, tags={"worker_name": worker_name})
+    Stats.gauge("edge_worker.free_concurrency", free_concurrency, tags={"worker_name": worker_name})
+    Stats.gauge(
+        "edge_worker.num_queues",
+        len(queues),
+        tags={"worker_name": worker_name, "queues": ",".join(queues)},
+>>>>>>> 366552b881 (Reworked statsd taging for pre airflow 3.3 versions)
     )
 
     for key in additional_keys:
         value = sysinfo.get(key)
         if isinstance(value, (int, float)):
             Stats.gauge(f"edge_worker.{key}", value, tags=metric_tags)
+
+    if not AIRFLOW_V_3_3_PLUS:
+        # Airflow < 3.3: export legacy per-worker metrics (no auto-tag expansion).
+        Stats.gauge(f"edge_worker.status.{worker_name}", sysinfo.get("status", logging.NOTSET))  # type: ignore
+        Stats.gauge(f"edge_worker.connected.{worker_name}", int(connected))
+        Stats.gauge(f"edge_worker.maintenance.{worker_name}", int(maintenance))
+        Stats.gauge(f"edge_worker.jobs_active.{worker_name}", jobs_active)
+        Stats.gauge(f"edge_worker.concurrency.{worker_name}", concurrency)
+        Stats.gauge(f"edge_worker.free_concurrency.{worker_name}", free_concurrency)
+        Stats.gauge(f"edge_worker.num_queues.{worker_name}", len(queues))
+
+        for key in additional_keys:
+            value = sysinfo.get(key)
+            if isinstance(value, (int, float)):
+                Stats.gauge(f"edge_worker.{key}.{worker_name}", value)
 
 
 def reset_metrics(worker_name: str, team_name: str | None = None) -> None:

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -164,6 +164,13 @@ class TestEdgeWorker:
                 importlib.reload(cli_parser)
                 self.parser = cli_parser.get_parser()
 
+    @pytest.fixture(autouse=True)
+    def reset_edge_worker_class_attrs(self):
+        yield
+        EdgeWorker.jobs = []
+        EdgeWorker.drain = False
+        EdgeWorker.maintenance_mode = False
+
     @pytest.fixture
     def cli_worker_with_team(self, tmp_path: Path) -> EdgeWorker:
         test_worker = EdgeWorker(str(tmp_path / "mock.pid"), "mock", None, 8, team_name="team_a")

--- a/providers/edge3/tests/unit/edge3/models/test_edge_worker.py
+++ b/providers/edge3/tests/unit/edge3/models/test_edge_worker.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow.providers.common.compat.sdk import Stats
+from airflow.providers.edge3.models.edge_worker import EdgeWorkerState, set_metrics
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
+stats_reference = f"{Stats.__module__}.Stats"
+
+
+def test_set_metrics():
+    worker_name = "test_worker1"
+    if AIRFLOW_V_3_3_PLUS:
+        with mock.patch("airflow.sdk._shared.observability.metrics.stats._get_backend") as mock_get_backend:
+            mock_backend = mock.MagicMock()
+            mock_get_backend.return_value = mock_backend
+
+            set_metrics(
+                worker_name=worker_name,
+                state=EdgeWorkerState.IDLE,
+                jobs_active=0,
+                concurrency=1,
+                free_concurrency=1,
+                queues=None,
+                sysinfo={"status": 1},
+            )
+
+            metric_names = [call.args[0] for call in mock_backend.gauge.call_args_list]
+    else:
+        with mock.patch(f"{stats_reference}.gauge") as mock_gauge:
+            set_metrics(
+                worker_name=worker_name,
+                state=EdgeWorkerState.IDLE,
+                jobs_active=0,
+                concurrency=1,
+                free_concurrency=1,
+                queues=None,
+                sysinfo={"status": 1},
+            )
+
+            metric_names = [call.args[0] for call in mock_gauge.call_args_list]
+
+    assert "edge_worker.status" in metric_names
+
+    legacy_metric_name = f"edge_worker.status.{worker_name}"
+    assert legacy_metric_name in metric_names

--- a/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/worker_api/routes/test_worker.py
@@ -45,6 +45,7 @@ from airflow.providers.edge3.worker_api.routes.worker import (
 )
 
 from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -423,7 +424,21 @@ class TestWorkerApiRoutes:
             tags={**expected_worker_tags, "queues": ",".join(queues)},
         )
         mock_stats_gauge.assert_any_call("edge_worker.disk_usage", 42.5, tags=expected_worker_tags)
-        assert mock_stats_gauge.call_count == 8
+        if AIRFLOW_V_3_3_PLUS:
+            assert mock_stats_gauge.call_count == 8
+        else:
+            mock_stats_gauge.assert_any_call(
+                "edge_worker.status.test2_worker",
+                self.MOCK_SYSINFO["status"],
+            )
+            mock_stats_gauge.assert_any_call("edge_worker.connected.test2_worker", 1)
+            mock_stats_gauge.assert_any_call("edge_worker.maintenance.test2_worker", 0)
+            mock_stats_gauge.assert_any_call("edge_worker.jobs_active.test2_worker", 1)
+            mock_stats_gauge.assert_any_call("edge_worker.concurrency.test2_worker", 8)
+            mock_stats_gauge.assert_any_call("edge_worker.free_concurrency.test2_worker", 8)
+            mock_stats_gauge.assert_any_call("edge_worker.num_queues.test2_worker", len(queues))
+            mock_stats_gauge.assert_any_call("edge_worker.disk_usage.test2_worker", 42.5)
+            assert mock_stats_gauge.call_count == 16
 
     def test_set_state_returns_concurrency(self, session: Session, cli_worker: EdgeWorker):
         """set_state includes the DB-stored concurrency override in its response."""


### PR DESCRIPTION
# Overview

After switching to edge3 provider version 3.6.0, we observed that edge metrics were exposed without worker_name tags. During root-cause analysis, we found that metrics were no longer exported through DualStatsManager. As a result, StatsD mappings broke because the worker name was no longer included in the metric name.

In Airflow version 3.2.1, this behavior was handled by DualStatsManager. As we understand it, the new implementation that replaces DualStatsManager will address this, but it is planned for Airflow 3.3. Therefore, this change reintroduces the DualStatsManager check to keep edge worker metrics compatible with Airflow 3.2.


# Details of change:

* Add DualStatsManager check for Airflow 3.2 compatibility

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=bcf527e action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @AutomationDev85** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@xBis7` is waiting on you:
> - 1 unresolved review thread(s) from `@xBis7` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->