### PR TITLE
Updated verbiage for backfill runs being deprioritized

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -15,6 +15,7 @@
     "reprocessBehavior": "Reprocess Behavior",
     "run": "Run Backfill",
     "scheduleNotBackfillable": "This Dag's schedule does not support backfills",
+    "schedulerPriorityHint": "Backfill Dag runs are ordered after non-backfill Dag runs in each scheduler cycle. Backfill runs may remain queued longer if other non-backfill runs are present.",
     "selectDescription": "Run this Dag for a range of dates",
     "selectLabel": "Backfill",
     "title": "Run Backfill",
@@ -31,7 +32,7 @@
     }
   },
   "banner": {
-    "backfillInProgress": "Backfill in progress",
+    "backfillInProgress": "Backfill in progress, backfill runs may get delayed as non-backfill runs takes priority over backfill runs in each scheduler cycle.",
     "cancel": "Cancel backfill",
     "pause": "Pause backfill",
     "unpause": "Unpause backfill"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -32,7 +32,7 @@
     }
   },
   "banner": {
-    "backfillInProgress": "Backfill in progress, backfill runs may get delayed as non-backfill runs takes priority over backfill runs in each scheduler cycle.",
+    "backfillInProgress": "Backfill in progress",
     "cancel": "Cancel backfill",
     "pause": "Pause backfill",
     "unpause": "Unpause backfill"

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -19,8 +19,10 @@
 import { Box, Button, HStack, Spacer, Text, type ButtonProps } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { MdPause, MdPlayArrow, MdStop } from "react-icons/md";
+import { MdInfo, MdPause, MdPlayArrow, MdStop } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
+
+import { Tooltip } from "src/components/ui";
 
 import {
   useBackfillServiceCancelBackfill,
@@ -107,6 +109,11 @@ const BackfillBanner = ({ dagId }: Props) => {
       <HStack alignItems="center" ml={3}>
         <RiArrowGoBackFill />
         <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>
+        <Tooltip content={translate("backfill.schedulerPriorityHint")} showArrow>
+          <span>
+            <MdInfo />
+          </span>
+        </Tooltip>
         <Text fontSize="sm">
           {" "}
           <Time datetime={backfill.from_date} /> - <Time datetime={backfill.to_date} />

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -22,8 +22,6 @@ import { useTranslation } from "react-i18next";
 import { MdInfo, MdPause, MdPlayArrow, MdStop } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 
-import { Tooltip } from "src/components/ui";
-
 import {
   useBackfillServiceCancelBackfill,
   useBackfillServiceListBackfillsUi,
@@ -32,6 +30,7 @@ import {
   useBackfillServiceUnpauseBackfill,
 } from "openapi/queries";
 import type { BackfillResponse } from "openapi/requests/types.gen";
+import { Tooltip } from "src/components/ui";
 import { useAutoRefresh } from "src/utils";
 
 import Time from "../Time";

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -155,6 +155,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
         <ErrorAlert error={errors.date ?? dryRunError ?? error} />
       )}
       <VStack alignItems="stretch" gap={2} pt={4}>
+        <Alert status="info">{translate("backfill.schedulerPriorityHint")}</Alert>
         <Box>
           <Text fontSize="md" fontWeight="semibold" mb={3}>
             {translate("backfill.dateRange")}


### PR DESCRIPTION
Adds UI messaging to inform users that backfill DAG runs are
deprioritized behind scheduled and manual runs in the scheduler loop.

Backfill runs have always been lower priority than non-backfill runs due
to how the scheduler orders DAG runs each cycle, but this was not
communicated anywhere in the UI. Users were left confused when backfill
runs remained in a queued/scheduled state longer than expected.

This PR surfaces that context in two places:
- An info alert on the **Run Backfill** form, shown before a user triggers a backfill
- The **backfill in progress** banner, so users are reminded while a backfill is running

This is what the new banner looks like:
<img width="919" height="377" alt="Screenshot 2026-05-22 at 8 36 12 AM" src="https://github.com/user-attachments/assets/4a3d773b-315d-4268-8231-539f545807e6" />

<img width="1451" height="486" alt="Screenshot 2026-05-22 at 8 36 00 AM" src="https://github.com/user-attachments/assets/437f192e-fb9c-4aba-9bc8-1506e7322288" />


Closes: #66729