### PR TITLE
Add incremental refresh support to TableauOperator

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -143,11 +143,13 @@ class TableauOperator(BaseOperator):
                 if self.incremental_refresh:
                     try:
                         response = method(resource_id, incremental=True)
-                    except TypeError:
-                        raise AirflowOptionalProviderFeatureException(
-                            "Incremental refresh requires tableauserverclient>=0.35. "
-                            "Please upgrade: pip install 'tableauserverclient>=0.35'"
-                        )
+                    except TypeError as e:
+                        if "incremental" in str(e):
+                            raise AirflowOptionalProviderFeatureException(
+                                "Incremental refresh requires tableauserverclient>=0.35. "
+                                "Please upgrade: pip install 'tableauserverclient>=0.35'"
+                            ) from e
+                        raise
                 else:
                     response = method(resource_id)
                 job_id = response.id

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -16,13 +16,16 @@
 # under the License.
 from __future__ import annotations
 
-import inspect
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from tableauserverclient import JobItem
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
+from airflow.providers.common.compat.sdk import (
+    AirflowException,
+    AirflowOptionalProviderFeatureException,
+    BaseOperator,
+)
 from airflow.providers.tableau.hooks.tableau import (
     TableauHook,
     TableauJobFailedException,
@@ -137,26 +140,15 @@ class TableauOperator(BaseOperator):
                     raise ValueError("Tableau tasks.run returned no JobItem in response")
                 job_id = job_items[0].id
             elif self.method == "refresh":
-                # For refresh operations, pass incremental_refresh parameter if supported.
-                # The incremental parameter was added in tableauserverclient v0.37.
-                # We check the method signature to ensure compatibility with older versions.
-                try:
-                    sig = inspect.signature(method)
-                    supports_incremental = "incremental" in sig.parameters
-                except (ValueError, TypeError):
-                    # If we can't inspect, assume it's not supported (safer default)
-                    supports_incremental = False
-
-                if supports_incremental:
-                    response = method(resource_id, incremental=self.incremental_refresh)
-                else:
-                    if self.incremental_refresh:
-                        self.log.warning(
-                            "incremental_refresh is True but the installed tableauserverclient version "
-                            "does not support the incremental parameter. "
-                            "Incremental refresh requires tableauserverclient>=0.37. "
-                            "Falling back to full refresh."
+                if self.incremental_refresh:
+                    try:
+                        response = method(resource_id, incremental=True)
+                    except TypeError:
+                        raise AirflowOptionalProviderFeatureException(
+                            "Incremental refresh requires tableauserverclient>=0.35. "
+                            "Please upgrade: pip install 'tableauserverclient>=0.35'"
                         )
+                else:
                     response = method(resource_id)
                 job_id = response.id
             else:

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -62,6 +62,8 @@ class TableauOperator(BaseOperator):
     :param blocking_refresh: By default will be blocking means it will wait until it has finished.
     :param check_interval: time in seconds that the job should wait in
         between each instance state checks until operation is completed
+    :param incremental_refresh: Whether to perform an incremental refresh instead of a full refresh.
+        Only applies to datasource and workbook refresh operations. Defaults to False (full refresh).
     :param tableau_conn_id: The :ref:`Tableau Connection id <howto/connection:tableau>`
         containing the credentials to authenticate to the Tableau Server.
     """
@@ -81,6 +83,7 @@ class TableauOperator(BaseOperator):
         site_id: str | None = None,
         blocking_refresh: bool = True,
         check_interval: float = 20,
+        incremental_refresh: bool = False,
         tableau_conn_id: str = "tableau_default",
         **kwargs,
     ) -> None:
@@ -92,6 +95,7 @@ class TableauOperator(BaseOperator):
         self.check_interval = check_interval
         self.site_id = site_id
         self.blocking_refresh = blocking_refresh
+        self.incremental_refresh = incremental_refresh
         self.tableau_conn_id = tableau_conn_id
 
     def execute(self, context: Context) -> str:
@@ -124,6 +128,10 @@ class TableauOperator(BaseOperator):
                 if not job_items:
                     raise ValueError("Tableau tasks.run returned no JobItem in response")
                 job_id = job_items[0].id
+            elif self.method == "refresh":
+                # For refresh operations, pass incremental_refresh parameter
+                response = method(resource_id, incremental=self.incremental_refresh)
+                job_id = response.id
             else:
                 response = method(resource_id)
                 job_id = response.id

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -136,8 +137,27 @@ class TableauOperator(BaseOperator):
                     raise ValueError("Tableau tasks.run returned no JobItem in response")
                 job_id = job_items[0].id
             elif self.method == "refresh":
-                # For refresh operations, pass incremental_refresh parameter
-                response = method(resource_id, incremental=self.incremental_refresh)
+                # For refresh operations, pass incremental_refresh parameter if supported.
+                # The incremental parameter was added in tableauserverclient v0.37.
+                # We check the method signature to ensure compatibility with older versions.
+                try:
+                    sig = inspect.signature(method)
+                    supports_incremental = "incremental" in sig.parameters
+                except (ValueError, TypeError):
+                    # If we can't inspect, assume it's not supported (safer default)
+                    supports_incremental = False
+
+                if supports_incremental:
+                    response = method(resource_id, incremental=self.incremental_refresh)
+                else:
+                    if self.incremental_refresh:
+                        self.log.warning(
+                            "incremental_refresh is True but the installed tableauserverclient version "
+                            "does not support the incremental parameter. "
+                            "Incremental refresh requires tableauserverclient>=0.37. "
+                            "Falling back to full refresh."
+                        )
+                    response = method(resource_id)
                 job_id = response.id
             else:
                 response = method(resource_id)

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -115,6 +115,13 @@ class TableauOperator(BaseOperator):
             error_message = f"Method not found! Available methods for {self.resource}: {available_methods}"
             raise AirflowException(error_message)
 
+        if self.incremental_refresh and self.method != "refresh":
+            self.log.warning(
+                "incremental_refresh parameter is set to True but method is '%s'. "
+                "This parameter only applies to 'refresh' operations and will be ignored.",
+                self.method,
+            )
+
         with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
             resource = getattr(tableau_hook.server, self.resource)
             method = getattr(resource, self.method)

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -70,7 +70,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -106,7 +106,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -135,7 +135,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -167,7 +167,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -277,3 +277,122 @@ class TestTableauOperator:
         resource_id = "res_id"
         operator = TableauOperator(resource="tasks", find=resource_id, method="run", task_id="t", dag=None)
         assert operator._get_resource_id(Mock()) == resource_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_datasources_incremental_refresh(self, mock_tableau_hook):
+        """
+        Test execute datasources with incremental refresh
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_datasources_full_refresh(self, mock_tableau_hook):
+        """
+        Test execute datasources with full refresh (default behavior)
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=False,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_workbooks_incremental_refresh(self, mock_tableau_hook):
+        """
+        Test execute workbooks with incremental refresh
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="wb_2",
+            resource="workbooks",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_workbooks_full_refresh(self, mock_tableau_hook):
+        """
+        Test execute workbooks with full refresh (default behavior)
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="wb_2",
+            resource="workbooks",
+            incremental_refresh=False,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
+        assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_datasources_incremental_refresh_blocking(self, mock_tableau_hook):
+        """
+        Test execute datasources with incremental refresh blocking
+        """
+        mock_signed_in = [False]
+
+        def mock_hook_enter():
+            mock_signed_in[0] = True
+            return mock_tableau_hook
+
+        def mock_hook_exit(exc_type, exc_val, exc_tb):
+            mock_signed_in[0] = False
+
+        def mock_wait_for_state(job_id, target_state, check_interval):
+            if not mock_signed_in[0]:
+                raise Exception("Not signed in")
+            return True
+
+        mock_tableau_hook.return_value.__enter__ = Mock(side_effect=mock_hook_enter)
+        mock_tableau_hook.return_value.__exit__ = Mock(side_effect=mock_hook_exit)
+        mock_tableau_hook.wait_for_state = Mock(side_effect=mock_wait_for_state)
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+
+        operator = TableauOperator(
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+        mock_tableau_hook.wait_for_state.assert_called_once_with(
+            job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
+        )

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -444,6 +444,28 @@ class TestTableauOperator:
             operator.execute(context={})
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_incremental_refresh_unrelated_type_error_is_raised(self, mock_tableau_hook):
+        """
+        Test that an unrelated TypeError during refresh is re-raised.
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        
+        # Simulate a different TypeError that does NOT contain the string "incremental"
+        mock_tableau_hook.server.datasources.refresh.side_effect = TypeError("Some other type error")
+
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        with pytest.raises(TypeError, match="Some other type error"):
+            operator.execute(context={})
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
     def test_full_refresh_works_on_older_versions(self, mock_tableau_hook):
         """
         Test that full refresh (incremental_refresh=False) works fine on older

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
 from airflow.providers.tableau.hooks.tableau import TableauJobFinishCode
 from airflow.providers.tableau.operators.tableau import TableauOperator
 
@@ -59,37 +59,25 @@ class TestTableauOperator:
             "method": "refresh",
         }
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks(self, mock_tableau_hook, mock_inspect):
+    def test_execute_workbooks(self, mock_tableau_hook):
         """
-        Test Execute Workbooks - mocks signature with incremental support
+        Test Execute Workbooks
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(blocking_refresh=False, find="wb_2", resource="workbooks", **self.kwargs)
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_blocking(self, mock_tableau_hook, mock_inspect):
+    def test_execute_workbooks_blocking(self, mock_tableau_hook):
         """
         Test execute workbooks blocking
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -118,7 +106,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -136,37 +124,25 @@ class TestTableauOperator:
         with pytest.raises(AirflowException):
             operator.execute({})
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources(self, mock_tableau_hook, mock_inspect):
+    def test_execute_datasources(self, mock_tableau_hook):
         """
         Test Execute datasources
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(blocking_refresh=False, find="ds_2", resource="datasources", **self.kwargs)
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_blocking(self, mock_tableau_hook, mock_inspect):
+    def test_execute_datasources_blocking(self, mock_tableau_hook):
         """
         Test execute datasources blocking
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -191,7 +167,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -302,17 +278,11 @@ class TestTableauOperator:
         operator = TableauOperator(resource="tasks", find=resource_id, method="run", task_id="t", dag=None)
         assert operator._get_resource_id(Mock()) == resource_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_incremental_refresh(self, mock_tableau_hook, mock_inspect):
+    def test_execute_datasources_incremental_refresh(self, mock_tableau_hook):
         """
         Test execute datasources with incremental refresh
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -328,17 +298,11 @@ class TestTableauOperator:
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_full_refresh(self, mock_tableau_hook, mock_inspect):
+    def test_execute_datasources_full_refresh(self, mock_tableau_hook):
         """
         Test execute datasources with full refresh (default behavior)
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -351,20 +315,14 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_incremental_refresh(self, mock_tableau_hook, mock_inspect):
+    def test_execute_workbooks_incremental_refresh(self, mock_tableau_hook):
         """
         Test execute workbooks with incremental refresh
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -380,17 +338,11 @@ class TestTableauOperator:
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=True)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_full_refresh(self, mock_tableau_hook, mock_inspect):
+    def test_execute_workbooks_full_refresh(self, mock_tableau_hook):
         """
         Test execute workbooks with full refresh (default behavior)
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -403,20 +355,14 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_incremental_refresh_blocking(self, mock_tableau_hook, mock_inspect):
+    def test_execute_datasources_incremental_refresh_blocking(self, mock_tableau_hook):
         """
         Test execute datasources with incremental refresh blocking
         """
-        # Mock the inspect.signature to indicate incremental parameter is supported
-        mock_sig = Mock()
-        mock_sig.parameters = {"incremental": Mock()}
-        mock_inspect.signature.return_value = mock_sig
-
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -473,23 +419,18 @@ class TestTableauOperator:
         assert "incremental_refresh parameter is set to True but method is 'delete'" in caplog.text
         assert "This parameter only applies to 'refresh' operations" in caplog.text
 
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_refresh_without_incremental_support_incremental_true(
-        self, mock_tableau_hook, mock_inspect, caplog
-    ):
+    def test_incremental_refresh_unsupported_version_raises(self, mock_tableau_hook):
         """
-        Test that when incremental parameter is not supported but incremental_refresh=True,
-        a warning is logged and the method is called without the parameter.
+        Test that AirflowOptionalProviderFeatureException is raised when incremental_refresh=True
+        but the installed tableauserverclient does not support the incremental parameter.
         """
-        # Mock the inspect.signature to indicate incremental parameter is NOT supported
-        # (simulating older tableauserverclient versions)
-        mock_sig = Mock()
-        mock_sig.parameters = {}  # No incremental parameter
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        # Simulate older tableauserverclient that doesn't accept incremental kwarg
+        mock_tableau_hook.server.datasources.refresh.side_effect = TypeError(
+            "refresh() got an unexpected keyword argument 'incremental'"
+        )
 
         operator = TableauOperator(
             blocking_refresh=False,
@@ -499,32 +440,15 @@ class TestTableauOperator:
             **self.kwargs,
         )
 
-        job_id = operator.execute(context={})
+        with pytest.raises(AirflowOptionalProviderFeatureException, match="tableauserverclient>=0.35"):
+            operator.execute(context={})
 
-        # Verify that refresh was called WITHOUT the incremental parameter
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
-        assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
-
-        # Verify that a warning was logged
-        assert (
-            "incremental_refresh is True but the installed tableauserverclient version does not support the incremental parameter"
-            in caplog.text
-        )
-        assert "Incremental refresh requires tableauserverclient>=0.37" in caplog.text
-        assert "Falling back to full refresh" in caplog.text
-
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_refresh_without_incremental_support_incremental_false(self, mock_tableau_hook, mock_inspect):
+    def test_full_refresh_works_on_older_versions(self, mock_tableau_hook):
         """
-        Test that when incremental parameter is not supported but incremental_refresh=False,
-        no warning is logged and the method is called without the parameter.
+        Test that full refresh (incremental_refresh=False) works fine on older
+        tableauserverclient versions since the incremental kwarg is not passed.
         """
-        # Mock the inspect.signature to indicate incremental parameter is NOT supported
-        mock_sig = Mock()
-        mock_sig.parameters = {}  # No incremental parameter
-        mock_inspect.signature.return_value = mock_sig
-
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
 
@@ -541,35 +465,3 @@ class TestTableauOperator:
         # Verify that refresh was called WITHOUT the incremental parameter
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
-
-    @patch("airflow.providers.tableau.operators.tableau.inspect")
-    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_refresh_with_signature_inspection_error(self, mock_tableau_hook, mock_inspect, caplog):
-        """
-        Test that when inspect.signature raises an error, incremental parameter is not passed.
-        """
-        # Mock inspect.signature to raise an error (safer default for compatibility)
-        mock_inspect.signature.side_effect = ValueError("Cannot inspect signature")
-
-        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
-        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
-
-        operator = TableauOperator(
-            blocking_refresh=False,
-            find="ds_2",
-            resource="datasources",
-            incremental_refresh=True,
-            **self.kwargs,
-        )
-
-        job_id = operator.execute(context={})
-
-        # Verify that refresh was called WITHOUT the incremental parameter (safer default)
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
-        assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
-
-        # Verify that a warning was logged
-        assert (
-            "incremental_refresh is True but the installed tableauserverclient version does not support the incremental parameter"
-            in caplog.text
-        )

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -450,7 +450,7 @@ class TestTableauOperator:
         """
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
-        
+
         # Simulate a different TypeError that does NOT contain the string "incremental"
         mock_tableau_hook.server.datasources.refresh.side_effect = TypeError("Some other type error")
 

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -59,11 +59,17 @@ class TestTableauOperator:
             "method": "refresh",
         }
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks(self, mock_tableau_hook):
+    def test_execute_workbooks(self, mock_tableau_hook, mock_inspect):
         """
-        Test Execute Workbooks
+        Test Execute Workbooks - mocks signature with incremental support
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(blocking_refresh=False, find="wb_2", resource="workbooks", **self.kwargs)
@@ -73,11 +79,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_blocking(self, mock_tableau_hook):
+    def test_execute_workbooks_blocking(self, mock_tableau_hook, mock_inspect):
         """
         Test execute workbooks blocking
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -124,11 +136,17 @@ class TestTableauOperator:
         with pytest.raises(AirflowException):
             operator.execute({})
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources(self, mock_tableau_hook):
+    def test_execute_datasources(self, mock_tableau_hook, mock_inspect):
         """
         Test Execute datasources
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(blocking_refresh=False, find="ds_2", resource="datasources", **self.kwargs)
@@ -138,11 +156,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_blocking(self, mock_tableau_hook):
+    def test_execute_datasources_blocking(self, mock_tableau_hook, mock_inspect):
         """
         Test execute datasources blocking
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -278,11 +302,17 @@ class TestTableauOperator:
         operator = TableauOperator(resource="tasks", find=resource_id, method="run", task_id="t", dag=None)
         assert operator._get_resource_id(Mock()) == resource_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_incremental_refresh(self, mock_tableau_hook):
+    def test_execute_datasources_incremental_refresh(self, mock_tableau_hook, mock_inspect):
         """
         Test execute datasources with incremental refresh
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -298,11 +328,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_full_refresh(self, mock_tableau_hook):
+    def test_execute_datasources_full_refresh(self, mock_tableau_hook, mock_inspect):
         """
         Test execute datasources with full refresh (default behavior)
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -318,11 +354,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_incremental_refresh(self, mock_tableau_hook):
+    def test_execute_workbooks_incremental_refresh(self, mock_tableau_hook, mock_inspect):
         """
         Test execute workbooks with incremental refresh
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -338,11 +380,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=True)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_workbooks_full_refresh(self, mock_tableau_hook):
+    def test_execute_workbooks_full_refresh(self, mock_tableau_hook, mock_inspect):
         """
         Test execute workbooks with full refresh (default behavior)
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
         mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(
@@ -358,11 +406,17 @@ class TestTableauOperator:
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
-    def test_execute_datasources_incremental_refresh_blocking(self, mock_tableau_hook):
+    def test_execute_datasources_incremental_refresh_blocking(self, mock_tableau_hook, mock_inspect):
         """
         Test execute datasources with incremental refresh blocking
         """
+        # Mock the inspect.signature to indicate incremental parameter is supported
+        mock_sig = Mock()
+        mock_sig.parameters = {"incremental": Mock()}
+        mock_inspect.signature.return_value = mock_sig
+
         mock_signed_in = [False]
 
         def mock_hook_enter():
@@ -418,3 +472,104 @@ class TestTableauOperator:
 
         assert "incremental_refresh parameter is set to True but method is 'delete'" in caplog.text
         assert "This parameter only applies to 'refresh' operations" in caplog.text
+
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_refresh_without_incremental_support_incremental_true(
+        self, mock_tableau_hook, mock_inspect, caplog
+    ):
+        """
+        Test that when incremental parameter is not supported but incremental_refresh=True,
+        a warning is logged and the method is called without the parameter.
+        """
+        # Mock the inspect.signature to indicate incremental parameter is NOT supported
+        # (simulating older tableauserverclient versions)
+        mock_sig = Mock()
+        mock_sig.parameters = {}  # No incremental parameter
+        mock_inspect.signature.return_value = mock_sig
+
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        # Verify that refresh was called WITHOUT the incremental parameter
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
+
+        # Verify that a warning was logged
+        assert (
+            "incremental_refresh is True but the installed tableauserverclient version does not support the incremental parameter"
+            in caplog.text
+        )
+        assert "Incremental refresh requires tableauserverclient>=0.37" in caplog.text
+        assert "Falling back to full refresh" in caplog.text
+
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_refresh_without_incremental_support_incremental_false(self, mock_tableau_hook, mock_inspect):
+        """
+        Test that when incremental parameter is not supported but incremental_refresh=False,
+        no warning is logged and the method is called without the parameter.
+        """
+        # Mock the inspect.signature to indicate incremental parameter is NOT supported
+        mock_sig = Mock()
+        mock_sig.parameters = {}  # No incremental parameter
+        mock_inspect.signature.return_value = mock_sig
+
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=False,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        # Verify that refresh was called WITHOUT the incremental parameter
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
+
+    @patch("airflow.providers.tableau.operators.tableau.inspect")
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_refresh_with_signature_inspection_error(self, mock_tableau_hook, mock_inspect, caplog):
+        """
+        Test that when inspect.signature raises an error, incremental parameter is not passed.
+        """
+        # Mock inspect.signature to raise an error (safer default for compatibility)
+        mock_inspect.signature.side_effect = ValueError("Cannot inspect signature")
+
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+
+        operator = TableauOperator(
+            blocking_refresh=False,
+            find="ds_2",
+            resource="datasources",
+            incremental_refresh=True,
+            **self.kwargs,
+        )
+
+        job_id = operator.execute(context={})
+
+        # Verify that refresh was called WITHOUT the incremental parameter (safer default)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        assert job_id == mock_tableau_hook.server.datasources.refresh.return_value.id
+
+        # Verify that a warning was logged
+        assert (
+            "incremental_refresh is True but the installed tableauserverclient version does not support the incremental parameter"
+            in caplog.text
+        )

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -396,3 +396,25 @@ class TestTableauOperator:
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
         )
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_incremental_refresh_warning_on_non_refresh_method(self, mock_tableau_hook, caplog):
+        """
+        Test that a warning is logged when incremental_refresh is set but method is not 'refresh'
+        """
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+
+        operator = TableauOperator(
+            find="ds_2",
+            resource="datasources",
+            method="delete",
+            incremental_refresh=True,
+            dag=None,
+            task_id="test",
+        )
+
+        operator.execute(context={})
+
+        assert "incremental_refresh parameter is set to True but method is 'delete'" in caplog.text
+        assert "This parameter only applies to 'refresh' operations" in caplog.text


### PR DESCRIPTION
The TableauOperator only supported full refreshes of datasources and workbooks because it didn't pass the incremental parameter to the Tableau Server Client API.

We added an incremental_refresh parameter (defaults to False for backward compatibility) and modified the execute method to pass it to the refresh API call. This enables users to perform incremental refreshes when supported by their Tableau datasources.

closes: #67335

Was generative AI tooling used to co-author this PR?

Yes — Claude (for pr description)
