### PR TITLE
Update Weaviate examples for client 4.16 API

### DIFF
--- a/providers/weaviate/README.rst
+++ b/providers/weaviate/README.rst
@@ -56,7 +56,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``httpx``                                   ``>=0.25.0``
-``weaviate-client``                         ``!=4.16.7,>=4.4.0``
+``weaviate-client``                         ``>=4.16.0,!=4.16.7``
 ``pandas``                                  ``>=2.1.2; python_version < "3.13"``
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``

--- a/providers/weaviate/docs/index.rst
+++ b/providers/weaviate/docs/index.rst
@@ -105,7 +105,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``httpx``                                   ``>=0.25.0``
-``weaviate-client``                         ``!=4.16.7,>=4.4.0``
+``weaviate-client``                         ``>=4.16.0,!=4.16.7``
 ``pandas``                                  ``>=2.1.2; python_version < "3.13"``
 ``pandas``                                  ``>=2.2.3; python_version >= "3.13" and python_version < "3.14"``
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``

--- a/providers/weaviate/pyproject.toml
+++ b/providers/weaviate/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
     "httpx>=0.25.0",
-    "weaviate-client>=4.4.0,!=4.16.7",
+    "weaviate-client>=4.16.0,!=4.16.7",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"',
     'pandas>=2.3.3; python_version >="3.14"',

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_cohere.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_cohere.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
+from weaviate.classes.config import Configure
 
 try:
     from airflow.sdk import dag, setup, task, teardown
@@ -59,7 +60,7 @@ def example_weaviate_cohere():
 
         weaviate_hook = WeaviateHook()
         # Collection definition object. Weaviate's autoschema feature will infer properties when importing.
-        weaviate_hook.create_collection(name=COLLECTION_NAME, vectorizer_config=None)
+        weaviate_hook.create_collection(name=COLLECTION_NAME, vector_config=Configure.Vectors.self_provided())
 
     @setup
     @task

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_dynamic_mapping_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_dynamic_mapping_dag.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
-from weaviate.collections.classes.config import Configure
+from weaviate.classes.config import Configure
 
 try:
     from airflow.sdk import dag, setup, task, teardown
@@ -58,7 +58,7 @@ def example_weaviate_dynamic_mapping_dag():
 
         weaviate_hook = WeaviateHook()
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
-        weaviate_hook.create_collection(data[0], vectorizer_config=data[1])
+        weaviate_hook.create_collection(data[0], vector_config=data[1])
 
     @setup
     @task
@@ -96,7 +96,10 @@ def example_weaviate_dynamic_mapping_dag():
 
     (
         create_weaviate_collection.expand(
-            data=[[COLLECTION_NAMES[0], None], [COLLECTION_NAMES[1], Configure.Vectorizer.text2vec_openai()]]
+            data=[
+                [COLLECTION_NAMES[0], Configure.Vectors.self_provided()],
+                [COLLECTION_NAMES[1], Configure.Vectors.text2vec_openai(vectorize_collection_name=True)],
+            ]
         )
         >> perform_ingestion
         >> delete_weaviate_collection.expand(collection_name=COLLECTION_NAMES)

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_openai.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_openai.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 from pathlib import Path
 
 import pendulum
+from weaviate.classes.config import Configure
 
 try:
     from airflow.sdk import dag, setup, task, teardown
@@ -60,7 +61,7 @@ def example_weaviate_openai():
         """
         weaviate_hook = WeaviateHook()
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
-        weaviate_hook.create_collection(COLLECTION_NAME)
+        weaviate_hook.create_collection(COLLECTION_NAME, vector_config=Configure.Vectors.self_provided())
 
     @setup
     @task

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_operator.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_operator.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
-from weaviate.classes.config import DataType, Property
-from weaviate.collections.classes.config import Configure
+from weaviate.classes.config import Configure, DataType, Property
 
 try:
     from airflow.sdk import dag, task, teardown
@@ -124,7 +123,7 @@ def example_weaviate_using_operator():
 
         weaviate_hook = WeaviateHook()
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
-        weaviate_hook.create_collection(COLLECTION_NAME)
+        weaviate_hook.create_collection(COLLECTION_NAME, vector_config=Configure.Vectors.self_provided())
 
     @task(trigger_rule="all_done")
     def store_data_with_vectors_in_xcom():
@@ -168,7 +167,7 @@ def example_weaviate_using_operator():
                 Property(name="answer", description="The answer", data_type=DataType.TEXT),
                 Property(name="category", description="The category", data_type=DataType.TEXT),
             ],
-            vectorizer_config=Configure.Vectorizer.text2vec_openai(),
+            vector_config=Configure.Vectors.text2vec_openai(),
         )
 
     @task()
@@ -188,7 +187,7 @@ def example_weaviate_using_operator():
                 Property(name="category", description="The category", data_type=DataType.TEXT),
                 Property(name="docLink", description="URL for source document", data_type=DataType.TEXT),
             ],
-            vectorizer_config=Configure.Vectorizer.text2vec_openai(),
+            vector_config=Configure.Vectors.text2vec_openai(),
         )
 
     @task(trigger_rule="all_done")

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_using_hook.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_using_hook.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
-from weaviate.classes.config import DataType, Property
-from weaviate.collections.classes.config import Configure
+from weaviate.classes.config import Configure, DataType, Property
 
 try:
     from airflow.sdk import dag, task, teardown
@@ -63,7 +62,7 @@ def example_weaviate_dag_using_hook():
                 Property(name="answer", description="The answer", data_type=DataType.TEXT),
                 Property(name="category", description="The category", data_type=DataType.TEXT),
             ],
-            vectorizer_config=Configure.Vectorizer.text2vec_openai(),
+            vector_config=Configure.Vectors.text2vec_openai(),
         )
 
     @task()
@@ -77,7 +76,7 @@ def example_weaviate_dag_using_hook():
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
         weaviate_hook.create_collection(
             "QuestionWithoutVectorizerUsingHook",
-            vectorizer_config=None,
+            vector_config=Configure.Vectors.self_provided(),
         )
 
     @task(trigger_rule="all_done")

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_vectorizer_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_vectorizer_dag.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
-from weaviate.collections.classes.config import Configure
+from weaviate.classes.config import Configure
 
 try:
     from airflow.sdk import dag, setup, task, teardown
@@ -61,7 +61,7 @@ def example_weaviate_vectorizer_dag():
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
         weaviate_hook.create_collection(
             COLLECTION_NAME,
-            vectorizer_config=Configure.Vectorizer.text2vec_openai(),
+            vector_config=Configure.Vectors.text2vec_openai(vectorize_collection_name=True),
         )
 
     @setup

--- a/providers/weaviate/tests/system/weaviate/example_weaviate_without_vectorizer_dag.py
+++ b/providers/weaviate/tests/system/weaviate/example_weaviate_without_vectorizer_dag.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pendulum
+from weaviate.classes.config import Configure
 
 try:
     from airflow.sdk import dag, setup, task, teardown
@@ -59,7 +60,7 @@ def example_weaviate_without_vectorizer_dag():
 
         weaviate_hook = WeaviateHook()
         # collection definition object. Weaviate's autoschema feature will infer properties when importing.
-        weaviate_hook.create_collection(COLLECTION_NAME, vectorizer_config=None)
+        weaviate_hook.create_collection(COLLECTION_NAME, vector_config=Configure.Vectors.self_provided())
 
     @setup
     @task

--- a/uv.lock
+++ b/uv.lock
@@ -8293,7 +8293,7 @@ requires-dist = [
     { name = "pandas", marker = "python_full_version < '3.13'", specifier = ">=2.1.2" },
     { name = "pandas", marker = "python_full_version == '3.13.*'", specifier = ">=2.2.3" },
     { name = "pandas", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
-    { name = "weaviate-client", specifier = ">=4.4.0,!=4.16.7" },
+    { name = "weaviate-client", specifier = ">=4.16.0,!=4.16.7" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What
 Update Weaviate system example Dags for the Python client 4.16 vector configuration API.

  The examples now use `vector_config` / `Configure.Vectors` instead of the deprecated
  `vectorizer_config` / `Configure.Vectorizer`, and explicitly use
  `Configure.Vectors.self_provided()` where vectors are supplied by the Dag.

  The provider now requires `weaviate-client>=4.16.4,!=4.16.7` to use the new API
  while avoiding the documented 4.16.0-4.16.3 invalid-properties behavior and the
  known 4.16.7 protobuf issue.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=3964e53 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @henry3260** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - **Failing test jobs**: `Additional CI image checks / Check that image builds quickly`. Reproduce and fix locally, then push.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->