### PR TITLE
Restore `fail_fast` handling when reschedule exceeds `MySQL` `TIMESTAMP` limit

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -641,13 +641,11 @@ def _create_ti_state_update_query_and_update_state(
                 if session.bind is not None:
                     query = TI.duration_expression_update(timezone.utcnow(), query, session.bind)
                 query = query.values(state=TaskInstanceState.FAILED)
-                # We skip fail_fast handling in this error case to avoid fetching the TI object while the row
-                # is still locked from the earlier with_for_update() query, which might cause deadlock issues
-                # in SQLA2. The task is marked as FAILED regardless.
+                ti = session.get(TI, task_instance_id, with_for_update={"of": TI})
+                if ti is not None:
+                    _handle_fail_fast_for_dag(ti=ti, dag_id=dag_id, session=session, dag_bag=dag_bag)
                 return query, TaskInstanceState.FAILED
 
-        # We can directly use task_instance_id instead of fetching the TaskInstance object to avoid SQLA2
-        #  lock contention issues when the TaskInstance row is already locked from before.
         actual_start_date = timezone.utcnow()
         session.add(
             TaskReschedule(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1894,6 +1894,61 @@ class TestTIUpdateState:
         ti1 = session.get(TaskInstance, ti1.id)
         assert ti1.state == State.FAILED
 
+    def test_ti_update_state_reschedule_mysql_limit_triggers_fail_fast(
+        self, client, session, dag_maker, time_machine
+    ):
+        """
+        When a reschedule date exceeds MySQL's TIMESTAMP limit and the DAG has fail_fast=True,
+        sibling tasks must still be stopped. The MySQL-limit branch routes through a different
+        FAILED transition than the regular fail path -- both must honor fail_fast.
+        """
+        instant = timezone.datetime(2024, 10, 30)
+        time_machine.move_to(instant, tick=False)
+
+        with dag_maker(dag_id="test_dag_with_fail_fast_mysql_reschedule", fail_fast=True, serialized=True):
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+
+        dr = dag_maker.create_dagrun()
+        ti1 = dr.get_task_instance(task_id="task1", session=session)
+        ti1.state = State.RUNNING
+        ti1.start_date = instant
+
+        ti2 = dr.get_task_instance(task_id="task2", session=session)
+        ti2.state = State.QUEUED
+        session.commit()
+        session.refresh(ti1)
+        session.refresh(ti2)
+
+        # Date beyond MySQL's TIMESTAMP limit (2038-01-19 03:14:07).
+        future_date = timezone.datetime(2038, 1, 19, 3, 14, 8)
+
+        with (
+            mock.patch(
+                "airflow.api_fastapi.execution_api.routes.task_instances.get_dialect_name",
+                return_value="mysql",
+            ),
+            mock.patch(
+                "airflow.api_fastapi.execution_api.routes.task_instances._stop_remaining_tasks",
+                autospec=True,
+            ) as mock_stop,
+        ):
+            response = client.patch(
+                f"/execution/task-instances/{ti1.id}/state",
+                json={
+                    "state": TaskInstanceState.UP_FOR_RESCHEDULE,
+                    "reschedule_date": future_date.isoformat(),
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                },
+            )
+
+            assert response.status_code == 204
+            mock_stop.assert_called_once()
+
+        session.expire_all()
+        ti1 = session.get(TaskInstance, ti1.id)
+        assert ti1.state == State.FAILED
+
     @pytest.mark.db_test
     @conf_vars({("state_store", "clear_on_success"): "True"})
     def test_ti_update_state_to_success_clears_task_state(self, client, session, create_task_instance):


### PR DESCRIPTION
Restore `_handle_fail_fast_for_dag` in the MySQL-`TIMESTAMP`-limit branch of the
reschedule path. Without this, DAGs with `fail_fast=True` silently fail to stop
sibling tasks when a reschedule date exceeds 2038-01-19 on MySQL.

## What was wrong

PR #59686 removed the fail-fast call here with this rationale:

> We skip fail_fast handling in this error case to avoid fetching the TI object
> while the row is still locked from the earlier with_for_update() query, which
> might cause deadlock issues in SQLA2. The task is marked as FAILED regardless.

That rationale was incorrect on both counts:

- A transaction cannot deadlock with itself. A plain `session.get(TI, id)` on a
  row already locked by the same transaction acquires no new lock and reads
  freely (Postgres, MySQL 8.0+, SQLite all permit this).
- "The task is marked as FAILED regardless" is true for the *failing* TI, but
  silently drops the contract for the rest of the DAG. With `fail_fast=True`,
  sibling non-teardown tasks should be stopped -- the skip turned that into a no-op.

The deadlock that motivated #59686 came from a different code path (`FOR UPDATE`
expanding to the lazy-joined `dag_run` row), fixed in #67246 by scoping the
lock with `with_for_update={"of": TI}`. With that scope in place, the fail-fast
call is safe and matches the file's two existing fail-fast sites.

## Behavior change

- Before: \`fail_fast=True\` DAG that reschedules past 2038-01-19 on MySQL ->
  failing TI is marked FAILED, siblings keep running (or stay queued).
- After: failing TI is marked FAILED *and* sibling non-teardown tasks are stopped.

Silent functional bugfix; MySQL-only code path. The regression test mocks the
dialect gate so it runs on every backend in CI.

Also drops a second misleading comment in the same function claiming \`session.get\`
was avoided to "avoid SQLA2 lock contention issues" -- the code itself is fine;
the rationale was wrong.