### PR TITLE
Enable mapped task argument overrides in `airflow tasks test`

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -38,6 +38,7 @@ from airflow.models.dagrun import DagRun, get_or_create_dagrun
 from airflow.models.expandinput import NotFullyPopulated
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.sdk.definitions.dag import DAG, _run_task
+from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.param import ParamsDict
 from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.serialized_objects import DagSerialization
@@ -429,6 +430,36 @@ def task_test(args, dag: DAG | None = None) -> None:
     if args.task_params:
         passed_in_params = json.loads(args.task_params)
         sdk_task.params.update(passed_in_params)
+
+        if isinstance(sdk_task, MappedOperator):
+            from airflow.sdk.definitions._internal.expandinput import (
+                DictOfListsExpandInput,
+                ListOfDictsExpandInput,
+            )
+
+            expand_input = sdk_task._get_specified_expand_input()
+
+            expand_input_attr = sdk_task._expand_input_attr
+            if isinstance(expand_input, DictOfListsExpandInput):
+                new_expand_input_dict = dict(expand_input.value)
+                for k in expand_input.value:
+                    if k in passed_in_params:
+                        new_param = passed_in_params[k]
+                        new_expand_input_dict[k] = [new_param] * (args.map_index + 1)
+                setattr(sdk_task, expand_input_attr, DictOfListsExpandInput(new_expand_input_dict))
+
+            if isinstance(expand_input, ListOfDictsExpandInput):
+                new_expand_input_list = expand_input.value
+                if not isinstance(new_expand_input_list, list):
+                    new_expand_input_list = [passed_in_params] * (args.map_index + 1)
+
+                current_mapping = new_expand_input_list[args.map_index]
+                if isinstance(current_mapping, dict):
+                    new_expand_input_list[args.map_index] = {**current_mapping, **passed_in_params}
+                else:
+                    new_expand_input_list[args.map_index] = passed_in_params
+
+                setattr(sdk_task, expand_input_attr, ListOfDictsExpandInput(new_expand_input_list))
 
     if sdk_task.params and isinstance(sdk_task.params, ParamsDict):
         sdk_task.params.validate()

--- a/airflow-core/tests/unit/cli/commands/test_task_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_task_command.py
@@ -42,6 +42,8 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.sdk import task
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -443,6 +445,129 @@ class TestCliTasks:
         output = stdout.getvalue()
         assert 'echo "2022-01-01"' in output
         assert 'echo "2022-01-08"' in output
+
+    @pytest.mark.parametrize(
+        ("task_id", "task_params", "expected_output"),
+        [
+            pytest.param("consumer", '{"op_args": [10]}', "output=10", id="xcom_args_override"),
+            pytest.param("consumer_literal", '{"op_args": [10]}', "output=10", id="literal_args_override"),
+            pytest.param("consumer_literal", "", "output=3", id="literal_args_remain_default"),
+        ],
+    )
+    def test_mapped_task_test_with_expand_args_override(
+        self, task_id, task_params, expected_output, request, capsys, dag_maker
+    ):
+        dag_id = f"test_mapped_dag_{request.node.callspec.id}"
+        with dag_maker(dag_id) as dag:
+
+            @task
+            def produce():
+                return [[1], [2], [3]]
+
+            def consume(value):
+                print(f"output={value}")
+
+            PythonOperator.partial(task_id="consumer", python_callable=consume).expand(op_args=produce())
+            PythonOperator.partial(task_id="consumer_literal", python_callable=consume).expand(
+                op_args=[[1], [2], [3]]
+            )
+
+        dr = dag_maker.create_dagrun(
+            run_id="test_run",
+            state=State.RUNNING,
+            logical_date=DEFAULT_DATE,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.CLI,
+        )
+
+        args = ["tasks", "test", dag_id, task_id, DEFAULT_DATE.isoformat(), "--map-index", "2"]
+        if task_params:
+            args += ["--task-params", task_params]
+
+        task_command.task_test(self.parser.parse_args(args), dag=dag)
+
+        ti = dr.get_task_instance(task_id=task_id, map_index=2)
+        assert ti is not None
+        assert ti.state == State.SUCCESS
+        captured = capsys.readouterr()
+        assert expected_output in captured.out
+
+    @pytest.mark.parametrize(
+        ("task_id", "task_params", "expected_output"),
+        [
+            pytest.param(
+                "consumer",
+                '{"op_args": [10], "op_kwargs": {"value2": 20}}',
+                "output=(10, 20)",
+                id="xcom_kwargs_full_override",
+            ),
+            pytest.param(
+                "consumer_literal",
+                '{"op_args": [10], "op_kwargs": {"value2": 20}}',
+                "output=(10, 20)",
+                id="literal_kwargs_full_override",
+            ),
+            pytest.param(
+                "consumer_literal",
+                '{"op_kwargs": {"value2": 10}}',
+                "output=(3, 10)",
+                id="literal_kwargs_partial_override",
+            ),
+            pytest.param(
+                "consumer_literal",
+                "",
+                "output=(3, 2)",
+                id="literal_kwargs_remain_default",
+            ),
+        ],
+    )
+    def test_mapped_task_test_with_expand_kwargs_override(
+        self, task_id, task_params, expected_output, request, capsys, dag_maker
+    ):
+        dag_id = f"test_mapped_kwargs_dag_{request.node.callspec.id}"
+        with dag_maker(dag_id) as dag:
+
+            @task
+            def produce_kwargs():
+                return [
+                    {"op_args": [1], "op_kwargs": {"value2": 2}},
+                    {"op_args": [2], "op_kwargs": {"value2": 2}},
+                    {"op_args": [3], "op_kwargs": {"value2": 2}},
+                ]
+
+            def consume(value1, value2=2):
+                print(f"output=({value1}, {value2})")
+
+            PythonOperator.partial(task_id="consumer", python_callable=consume).expand_kwargs(
+                produce_kwargs()
+            )
+            PythonOperator.partial(task_id="consumer_literal", python_callable=consume).expand_kwargs(
+                [
+                    {"op_args": [1], "op_kwargs": {"value2": 2}},
+                    {"op_args": [2], "op_kwargs": {"value2": 2}},
+                    {"op_args": [3], "op_kwargs": {"value2": 2}},
+                ]
+            )
+
+        dr = dag_maker.create_dagrun(
+            run_id="test_run",
+            state=State.RUNNING,
+            logical_date=DEFAULT_DATE,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.CLI,
+        )
+
+        args = ["tasks", "test", dag_id, task_id, DEFAULT_DATE.isoformat(), "--map-index", "2"]
+        if task_params:
+            args += ["--task-params", task_params]
+
+        task_command.task_test(self.parser.parse_args(args), dag=dag)
+
+        ti = dr.get_task_instance(task_id=task_id, map_index=2)
+        assert ti is not None
+        assert ti.state == State.SUCCESS
+        captured = capsys.readouterr()
+        assert expected_output in captured.out
 
     def test_task_state(self):
         task_command.task_state(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Summary

Task parameters were immutable when debugging dynamic task mappings using the CLI `airflow tasks test`. This meant we couldn't override parameters on the fly, nor could we easily test mapped tasks that relied on upstream XCom arguments. This PR updates the Airflow CLI to support local testing of dynamically mapped tasks.

closes: #56953 

## Params Overrides Behavior 

The tables below outline how our updated `airflow tasks test` handles combinations of expansion types, argument sources, and the presence of CLI task parameter overrides.

#### 1. Positional Arguments from `expand()`

| Argument Type | With CLI Task Params | Without CLI Task Params |
| :--- | :--- | :--- |
| **Literal Values** | Overrides the original task parameters with the single provided parameter value. | Runs tests using the original values defined for that specific map index in the DAG. |
| **XCom Arguments** | Uses the user-provided input value to successfully execute and test the task. | Fails immediately with the expected `XCom not found` exception. |

#### 2. Keyword Arguments from `expand_kwargs()`

| Argument Type | With CLI Task Params | Without CLI Task Params |
| :--- | :--- | :--- |
| **Literal Values** | Updates the mapped keyword arguments for that index with the new CLI task parameters. | Runs tests using the baseline keyword arguments defined for that map index in the DAG. |
| **XCom Arguments** | Uses the user-provided input dictionary to successfully execute and test the task. | Fails immediately with the expected `XCom not found` exception. |

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)


<!--Generated-by: [] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)-->




---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
