### PR TITLE
fix oudated img links in `dags.rst`

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -26,7 +26,7 @@ Dags
 
 Here's a basic example Dag:
 
-.. image:: /img/ui-light/basic_dag.png
+.. image:: ../img/ui-light/basic_dag.png
 
 It defines four Tasks - A, B, C, and D - and dictates the order in which they have to run, and which tasks depend on what others. It will also say how often to run the Dag - maybe "every 5 minutes starting tomorrow", or "every day since January 1st, 2020".
 
@@ -331,7 +331,7 @@ The task_id returned by the Python function has to reference a task directly dow
 .. note::
     When a Task is downstream of both the branching operator *and* downstream of one or more of the selected tasks, it will not be skipped:
 
-    .. image:: /img/ui-light/branch_note.png
+    .. image:: ../img/ui-light/branch_note.png
 
     The paths of the branching task are ``branch_a``, ``join`` and ``branch_b``. Since ``join`` is a downstream task of ``branch_a``, it will still be run, even though it was not returned as part of the branch decision.
 
@@ -411,7 +411,7 @@ In the case of this Dag:
 * ``task3`` is downstream of ``task1`` and ``task2`` and because of the default :ref:`trigger rule <concepts:trigger-rules>` being ``all_success`` will receive a cascaded skip from ``task1``.
 * ``task4`` is downstream of ``task1`` and ``task2``, but it will not be skipped, since its ``trigger_rule`` is set to ``all_done``.
 
-.. image:: /img/latest_only_with_trigger.png
+.. image:: ../img/latest_only_with_trigger.png
 
 .. _concepts:depends-on-past:
 
@@ -492,11 +492,11 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
 
     ``join`` is downstream of ``follow_branch_a`` and ``branch_false``. The ``join`` task will show up as skipped because its ``trigger_rule`` is set to ``all_success`` by default, and the skip caused by the branching operation cascades down to skip a task marked as ``all_success``.
 
-    .. image:: /img/ui-light/branch_without_trigger.png
+    .. image:: ../img/ui-light/branch_without_trigger.png
 
     By setting ``trigger_rule`` to ``none_failed_min_one_success`` in the ``join`` task, we can instead get the intended behaviour:
 
-    .. image:: /img/ui-light/branch_with_trigger.png
+    .. image:: ../img/ui-light/branch_with_trigger.png
 
 
 Setup and teardown
@@ -554,7 +554,7 @@ Tasks in TaskGroups live on the same original Dag, and honor all the Dag setting
 .. seealso::
    API reference for :class:`~airflow.sdk.TaskGroup` and :class:`~airflow.sdk.task_group`
 
-.. image:: /img/ui-light/task_group.gif
+.. image:: ../img/ui-light/task_group.gif
 
 Dependency relationships can be applied across all tasks in a TaskGroup with the ``>>`` and ``<<`` operators. For example, the following code puts ``task1`` and ``task2`` in TaskGroup ``group1`` and then puts both tasks upstream of ``task3``:
 
@@ -638,7 +638,7 @@ Or, you can pass a Label object to ``set_upstream``/``set_downstream``:
 
 Here's an example Dag which illustrates labeling different branches:
 
-.. image:: /img/ui-light/edge_label_example.png
+.. image:: ../img/ui-light/edge_label_example.png
 
 .. exampleinclude:: /../src/airflow/example_dags/example_branch_labels.py
     :language: python


### PR DESCRIPTION
Hi team,

I found several image links are outdated while reading this doc: [`airflow-core/docs/core-concepts/dags.rst`](https://github.com/apache/airflow/blob/main/airflow-core/docs/core-concepts/dags.rst).

This PR should fix them.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
