### PR TITLE
Fix deferrable execution_timeout regression in DbtCloudRunJobOperator

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -259,7 +259,7 @@ class DbtCloudRunJobOperator(BaseOperator):
             job_run_status = self.hook.get_job_run_status(**job_run_info)
             if not DbtCloudJobRunStatus.is_terminal(job_run_status):
                 self.defer(
-                    timeout=self.execution_timeout,
+                    timeout=None,
                     trigger=DbtCloudRunJobTrigger(
                         conn_id=self.dbt_cloud_conn_id,
                         run_id=self.run_id,

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -179,6 +179,58 @@ class TestDbtCloudRunJobOperator:
         with pytest.raises(DbtCloudJobRunException):
             dbt_op.execute(MagicMock())
         assert not mock_defer.called
+
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_status",
+        return_value=DbtCloudJobRunStatus.QUEUED.value,
+    )
+    @patch("airflow.providers.dbt.cloud.operators.dbt.DbtCloudRunJobOperator.defer")
+    @patch("airflow.providers.dbt.cloud.operators.dbt.DbtCloudRunJobTrigger")
+    @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_connection")
+    @patch(
+        "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.trigger_job_run",
+        return_value=mock_response_json(DEFAULT_ACCOUNT_JOB_RUN_RESPONSE),
+    )
+    def test_execute_deferrable_does_not_pass_execution_timeout_to_defer(
+        self,
+        mock_trigger_job_run,
+        mock_dbt_hook,
+        mock_dbt_trigger,
+        mock_defer,
+        mock_job_run_status,
+    ):
+        dbt_op = DbtCloudRunJobOperator(
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            task_id=TASK_ID,
+            job_id=JOB_ID,
+            check_interval=1,
+            timeout=3,
+            dag=self.dag,
+            deferrable=True,
+            execution_timeout=timedelta(seconds=3),
+        )
+
+        dbt_op.execute(MagicMock())
+
+        # Explicitly pass timeout=None to defer() so Airflow's framework-level
+        # deferred timeout handling does not raise TaskDeferredTimeout before
+        # execute_complete() can perform dbt job cancellation.
+        mock_defer.assert_called_once_with(
+            method_name="execute_complete",
+            trigger=mock_dbt_trigger.return_value,
+            timeout=None,
+        )
+
+        # The dbt trigger should still receive the calculated execution deadline
+        # used for dbt job cancellation handling within execute_complete().
+        mock_dbt_trigger.assert_called_once_with(
+            conn_id=ACCOUNT_ID_CONN,
+            run_id=5555,
+            end_time=ANY,
+            execution_deadline=ANY,
+            account_id=None,
+            poll_interval=1,
+        )
 
     @pytest.mark.parametrize(
         "status",


### PR DESCRIPTION
**Description**

This change fixes a regression introduced in PR #66449 affecting `DbtCloudRunJobOperator` in deferrable mode.

Previously, `execution_timeout` was passed directly to `defer()`. The operator now explicitly passes `timeout=None` to `defer()` while still preserving `execution_deadline` handling within the trigger/operator flow.

**Rationale**

In deferrable mode, dbt job cancellation is performed within `execute_complete()` when the trigger emits a timeout event.

However, framework-level deferred timeout handling bypasses `execute_complete()` entirely and does not invoke `on_kill()` in the triggerer process. As a result, dbt jobs could continue running after the Airflow task timed out, leading to leaked workloads and excessive resource consumption.

While this weakens the framework-level deferred timeout guarantee, in this case preventing leaked external workloads takes precedence because there is currently no equivalent cleanup path in the triggerer process.

**Tests**

Added an operator-level regression test verifying that `defer()` is called with `timeout=None` while `execution_deadline` handling remains preserved for dbt job timeout cancellation processing.

**Backwards Compatibility**

This change does not modify public APIs or method signatures.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [GPT 5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)