### PR TITLE
UI: Fix HTTPException import that turned a 400 into a 500 in ui/dags 

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -17,10 +17,9 @@
 
 from __future__ import annotations
 
-from http.client import HTTPException
 from typing import Annotated
 
-from fastapi import Depends, status
+from fastapi import Depends, HTTPException, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import defaultload
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -352,6 +352,13 @@ class TestGetDagRuns(TestPublicDagEndpoint):
         response = unauthorized_test_client.get(f"/dags/{DAG1_ID}/latest_run")
         assert response.status_code == 403
 
+    def test_latest_run_should_response_400_when_dag_id_is_tilde(self, test_client):
+        response = test_client.get("/dags/~/latest_run")
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": "`~` was supplied as dag_id, but querying multiple dags is not supported."
+        }
+
     @pytest.mark.parametrize(
         ("query_params", "expected_dag_count"),
         [


### PR DESCRIPTION
The `ui/dags.py` route file imported `HTTPException` from `http.client` (the stdlib base class) instead of `fastapi`. FastAPI's exception handlers only translate `fastapi.HTTPException`, so the 400-branch in `get_latest_run_info` (when `dag_id == "~"`) escaped uncaught and the API returned **500 Internal Server Error** instead of the intended **400 Bad Request** with the documented detail message.

Fix is one line: drop `from http.client import HTTPException` and add `HTTPException` to the existing `from fastapi import ...` line. Added a regression test asserting `GET /dags/~/latest_run` returns 400 with the expected detail body.

##### Was generative AI tooling used to co-author this PR?
- [X] Yes, (Cursor)
 [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
