### PR TITLE
Fix dags test DagRun start date

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -967,15 +967,11 @@ class TestCliDags:
         assert "data_interval" in mock_get_or_create_dagrun.call_args.kwargs
 
     @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
-    def test_dag_test_uses_current_time_as_dagrun_start_date(
-        self, mock_get_or_create_dagrun, time_machine
-    ):
+    def test_dag_test_uses_current_time_as_dagrun_start_date(self, mock_get_or_create_dagrun, time_machine):
         run_started_at = timezone.make_aware(datetime(2026, 4, 29, 21, 4), timezone=timezone.utc)
         time_machine.move_to(run_started_at, tick=False)
 
-        cli_args = self.parser.parse_args(
-            ["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat()]
-        )
+        cli_args = self.parser.parse_args(["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat()])
 
         dag_command.dag_test(cli_args)
 

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -967,6 +967,23 @@ class TestCliDags:
         assert "data_interval" in mock_get_or_create_dagrun.call_args.kwargs
 
     @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
+    def test_dag_test_uses_current_time_as_dagrun_start_date(
+        self, mock_get_or_create_dagrun, time_machine
+    ):
+        run_started_at = timezone.make_aware(datetime(2026, 4, 29, 21, 4), timezone=timezone.utc)
+        time_machine.move_to(run_started_at, tick=False)
+
+        cli_args = self.parser.parse_args(
+            ["dags", "test", "example_bash_operator", DEFAULT_DATE.isoformat()]
+        )
+
+        dag_command.dag_test(cli_args)
+
+        assert mock_get_or_create_dagrun.call_args.kwargs["logical_date"] == DEFAULT_DATE
+        assert mock_get_or_create_dagrun.call_args.kwargs["run_after"] == run_started_at
+        assert mock_get_or_create_dagrun.call_args.kwargs["start_date"] == run_started_at
+
+    @mock.patch("airflow.models.dagrun.get_or_create_dagrun")
     def test_dag_with_parsing_context(
         self, mock_get_or_create_dagrun, testing_dag_bundle, configure_testing_dag_bundle
     ):

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -1357,7 +1357,7 @@ class DAG:
 
             dr: DagRun = get_or_create_dagrun(
                 dag=scheduler_dag,
-                start_date=logical_date or run_after,
+                start_date=run_after,
                 logical_date=logical_date,
                 data_interval=data_interval,
                 run_after=run_after,


### PR DESCRIPTION
Fixes #66127

`DAG.test()` currently passes `start_date=logical_date or run_after` when creating the test DagRun. When `airflow dags test` is invoked with an old logical date, the DagRun start date is recorded as that logical date, which inflates the reported run duration.

This changes `DAG.test()` to use `run_after` as the DagRun start date while preserving the requested logical date, and adds a regression test for the CLI path.

Testing:
- `python3 -m py_compile airflow-core/tests/unit/cli/commands/test_dag_command.py task-sdk/src/airflow/sdk/definitions/dag.py`
- `git diff --check`
- Targeted pytest could not be run locally because the system pytest is too old for Airflow's current `tests_common` plugin; full `uv` setup needs Java for `jpype1`/JDBC provider.
