### PR TITLE
Add prek hook to enforce HTTPException is imported from fastapi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -490,20 +490,6 @@ repos:
           ^providers/.*/src/.*\.py$|
           ^task-sdk/src/.*\.py$|
           ^shared/.*/src/.*\.py$
-      - id: check-http-exception-import-from-fastapi
-        name: Check HTTPException is imported from fastapi in fastapi-using trees
-        entry: ./scripts/ci/prek/check_http_exception_import_from_fastapi.py
-        language: python
-        pass_filenames: true
-        files: >
-          (?x)
-          ^airflow-core/src/airflow/api_fastapi/.*\.py$|
-          ^airflow-core/tests/unit/api_fastapi/.*\.py$|
-          ^providers/amazon/(src|tests)/.*\.py$|
-          ^providers/common/ai/(src|tests)/.*\.py$|
-          ^providers/edge3/(src|tests)/.*\.py$|
-          ^providers/fab/(src|tests)/.*\.py$|
-          ^providers/keycloak/(src|tests)/.*\.py$
       - id: check-secrets-search-path-sync
         name: Check sync between sdk and core
         entry: ./scripts/ci/prek/check_secrets_search_path_sync.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -490,6 +490,20 @@ repos:
           ^providers/.*/src/.*\.py$|
           ^task-sdk/src/.*\.py$|
           ^shared/.*/src/.*\.py$
+      - id: check-http-exception-import-from-fastapi
+        name: Check HTTPException is imported from fastapi in fastapi-using trees
+        entry: ./scripts/ci/prek/check_http_exception_import_from_fastapi.py
+        language: python
+        pass_filenames: true
+        files: >
+          (?x)
+          ^airflow-core/src/airflow/api_fastapi/.*\.py$|
+          ^airflow-core/tests/unit/api_fastapi/.*\.py$|
+          ^providers/amazon/(src|tests)/.*\.py$|
+          ^providers/common/ai/(src|tests)/.*\.py$|
+          ^providers/edge3/(src|tests)/.*\.py$|
+          ^providers/fab/(src|tests)/.*\.py$|
+          ^providers/keycloak/(src|tests)/.*\.py$
       - id: check-secrets-search-path-sync
         name: Check sync between sdk and core
         entry: ./scripts/ci/prek/check_secrets_search_path_sync.py

--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -148,6 +148,15 @@ repos:
         language: python
         pass_filenames: true
         files: ^src/airflow/.*\.py$
+      - id: check-http-exception-import-from-fastapi
+        name: Check HTTPException is imported from fastapi
+        entry: ../scripts/ci/prek/check_http_exception_import_from_fastapi.py
+        language: python
+        pass_filenames: true
+        files: >
+          (?x)
+          ^src/airflow/api_fastapi/.*\.py$|
+          ^tests/unit/api_fastapi/.*\.py$
       - id: create-missing-init-py-files-tests
         name: Create missing init.py files in tests
         entry: ../scripts/ci/prek/check_init_in_tests.py

--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -156,7 +156,9 @@ repos:
         files: >
           (?x)
           ^src/airflow/api_fastapi/.*\.py$|
-          ^tests/unit/api_fastapi/.*\.py$
+          ^src/airflow/utils/serve_logs/.*\.py$|
+          ^tests/unit/api_fastapi/.*\.py$|
+          ^tests/unit/utils/test_serve_logs\.py$
       - id: create-missing-init-py-files-tests
         name: Create missing init.py files in tests
         entry: ../scripts/ci/prek/check_init_in_tests.py

--- a/providers/amazon/.pre-commit-config.yaml
+++ b/providers/amazon/.pre-commit-config.yaml
@@ -24,12 +24,6 @@ default_language_version:
 repos:
   - repo: local
     hooks:
-      - id: generate-openapi-spec-keycloak
-        name: Generate the FastAPI API spec for Keycloak
-        language: python
-        entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py keycloak
-        pass_filenames: false
-        files: ^src/airflow/providers/keycloak/auth_manager/.*\.py$
       - id: check-http-exception-import-from-fastapi
         name: Check HTTPException is imported from fastapi
         entry: ../../scripts/ci/prek/check_http_exception_import_from_fastapi.py
@@ -37,5 +31,5 @@ repos:
         pass_filenames: true
         files: >
           (?x)
-          ^src/airflow/providers/keycloak/auth_manager/.*\.py$|
-          ^tests/unit/keycloak/auth_manager/.*\.py$
+          ^src/airflow/providers/amazon/aws/auth_manager/.*\.py$|
+          ^tests/unit/amazon/aws/auth_manager/.*\.py$

--- a/providers/common/ai/.pre-commit-config.yaml
+++ b/providers/common/ai/.pre-commit-config.yaml
@@ -47,3 +47,12 @@ repos:
         entry: ../../../scripts/ci/prek/compile_provider_assets.py ai
         pass_filenames: false
         additional_dependencies: ['pnpm@10.25.0']
+      - id: check-http-exception-import-from-fastapi
+        name: Check HTTPException is imported from fastapi
+        entry: ../../../scripts/ci/prek/check_http_exception_import_from_fastapi.py
+        language: python
+        pass_filenames: true
+        files: >
+          (?x)
+          ^src/airflow/providers/common/ai/plugins/.*\.py$|
+          ^tests/unit/common/ai/plugins/.*\.py$

--- a/providers/edge3/.pre-commit-config.yaml
+++ b/providers/edge3/.pre-commit-config.yaml
@@ -30,6 +30,15 @@ repos:
         entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py edge
         pass_filenames: false
         files: ^src/airflow/providers/edge3/worker_api/.*\.py$
+      - id: check-http-exception-import-from-fastapi
+        name: Check HTTPException is imported from fastapi
+        entry: ../../scripts/ci/prek/check_http_exception_import_from_fastapi.py
+        language: python
+        pass_filenames: true
+        files: >
+          (?x)
+          ^src/airflow/providers/edge3/(worker_api|plugins)/.*\.py$|
+          ^tests/unit/edge3/(worker_api|plugins)/.*\.py$
       - id: ts-compile-lint-edge-ui
         name: Compile / format / lint edge UI
         description: TS types generation / ESLint / Prettier new UI files in Edge Provider

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -42,6 +42,15 @@ repos:
         entry: ../../scripts/ci/prek/generate_openapi_spec_providers.py fab
         pass_filenames: false
         files: ^src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$
+      - id: check-http-exception-import-from-fastapi
+        name: Check HTTPException is imported from fastapi
+        entry: ../../scripts/ci/prek/check_http_exception_import_from_fastapi.py
+        language: python
+        pass_filenames: true
+        files: >
+          (?x)
+          ^src/airflow/providers/fab/auth_manager/api_fastapi/.*\.py$|
+          ^tests/unit/fab/auth_manager/api_fastapi/.*\.py$
       - id: update-migration-references-fab
         name: Update migration ref doc for FAB
         language: python

--- a/scripts/ci/prek/check_http_exception_import_from_fastapi.py
+++ b/scripts/ci/prek/check_http_exception_import_from_fastapi.py
@@ -18,11 +18,15 @@
 # under the License.
 """Check that ``HTTPException`` is imported from ``fastapi`` in fastapi-using trees.
 
-In code that targets FastAPI (``airflow-core/src/airflow/api_fastapi/``, the
-matching tests under ``airflow-core/tests/unit/api_fastapi/``, and the
-provider trees that wire FastAPI apps), every ``HTTPException`` must come
-from ``fastapi`` (which re-exports the Starlette class). Two common mistakes
-this hook catches:
+The hook is wired into per-distribution ``.pre-commit-config.yaml`` files
+(``airflow-core``, ``providers/amazon``, ``providers/common/ai``,
+``providers/edge3``, ``providers/fab``, ``providers/keycloak``), each
+scoped to the subtree that actually wires a FastAPI app. Provider trees
+that mix client and server code (e.g. edge3's ``cli/`` is a client) are
+scoped to the server-side subfolders only to avoid false positives on
+stdlib HTTP usage in the client. Within those scopes, every
+``HTTPException`` must come from ``fastapi`` (which re-exports the
+Starlette class). Two common mistakes this hook catches:
 
 * ``from starlette.exceptions import HTTPException`` — a different class at
   runtime; ``isinstance(exc, fastapi.HTTPException)`` and
@@ -80,9 +84,7 @@ def check_file(file_path: Path) -> list[tuple[int, str]]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Check that HTTPException is imported from fastapi"
-    )
+    parser = argparse.ArgumentParser(description="Check that HTTPException is imported from fastapi")
     parser.add_argument("files", nargs="*", help="Files to check")
     args = parser.parse_args()
 

--- a/scripts/ci/prek/check_http_exception_import_from_fastapi.py
+++ b/scripts/ci/prek/check_http_exception_import_from_fastapi.py
@@ -21,12 +21,14 @@
 The hook is wired into per-distribution ``.pre-commit-config.yaml`` files
 (``airflow-core``, ``providers/amazon``, ``providers/common/ai``,
 ``providers/edge3``, ``providers/fab``, ``providers/keycloak``), each
-scoped to the subtree that actually wires a FastAPI app. Provider trees
-that mix client and server code (e.g. edge3's ``cli/`` is a client) are
-scoped to the server-side subfolders only to avoid false positives on
-stdlib HTTP usage in the client. Within those scopes, every
-``HTTPException`` must come from ``fastapi`` (which re-exports the
-Starlette class). Two common mistakes this hook catches:
+scoped to the subtree that actually wires a FastAPI app. In
+``airflow-core`` that includes ``api_fastapi/`` and
+``utils/serve_logs/`` (the worker log-serving FastAPI app). Provider
+trees that mix client and server code (e.g. edge3's ``cli/`` is a
+client) are scoped to the server-side subfolders only to avoid false
+positives on stdlib HTTP usage in the client. Within those scopes,
+every ``HTTPException`` must come from ``fastapi`` (which re-exports
+the Starlette class). Two common mistakes this hook catches:
 
 * ``from starlette.exceptions import HTTPException`` — a different class at
   runtime; ``isinstance(exc, fastapi.HTTPException)`` and

--- a/scripts/ci/prek/check_http_exception_import_from_fastapi.py
+++ b/scripts/ci/prek/check_http_exception_import_from_fastapi.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Check that ``HTTPException`` is imported from ``fastapi`` in fastapi-using trees.
+
+In code that targets FastAPI (``airflow-core/src/airflow/api_fastapi/``, the
+matching tests under ``airflow-core/tests/unit/api_fastapi/``, and the
+provider trees that wire FastAPI apps), every ``HTTPException`` must come
+from ``fastapi`` (which re-exports the Starlette class). Two common mistakes
+this hook catches:
+
+* ``from starlette.exceptions import HTTPException`` — a different class at
+  runtime; ``isinstance(exc, fastapi.HTTPException)`` and
+  ``pytest.raises(fastapi.HTTPException)`` will not match it.
+* ``from http.client import HTTPException`` — an unrelated stdlib exception
+  whose constructor signature differs, so the route returns 500 instead of
+  the intended HTTP status.
+"""
+
+# /// script
+# requires-python = ">=3.10,<3.11"
+# dependencies = [
+#   "rich>=13.6.0",
+# ]
+# ///
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+from common_prek_utils import console
+
+
+def _is_fastapi_module(module: str) -> bool:
+    """Return True if *module* is ``fastapi`` or a submodule of it."""
+    return module == "fastapi" or module.startswith("fastapi.")
+
+
+def check_file(file_path: Path) -> list[tuple[int, str]]:
+    """Return list of ``(line_number, import_statement)`` violations."""
+    try:
+        source = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(file_path))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return []
+
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or not node.module:
+            continue
+        if _is_fastapi_module(node.module):
+            continue
+        bad_aliases = [alias for alias in node.names if alias.name == "HTTPException"]
+        if not bad_aliases:
+            continue
+        rendered = ", ".join(
+            alias.name if not alias.asname else f"{alias.name} as {alias.asname}" for alias in bad_aliases
+        )
+        violations.append((node.lineno, f"from {node.module} import {rendered}"))
+
+    return violations
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check that HTTPException is imported from fastapi"
+    )
+    parser.add_argument("files", nargs="*", help="Files to check")
+    args = parser.parse_args()
+
+    if not args.files:
+        return
+
+    total_violations = 0
+
+    for file_path in [Path(f) for f in args.files]:
+        violations = check_file(file_path)
+        if not violations:
+            continue
+        if console:
+            console.print(f"[red]{file_path}[/red]:")
+            for line_num, statement in violations:
+                console.print(f"  [yellow]Line {line_num}[/yellow]: {statement}")
+        else:
+            print(f"{file_path}:")
+            for line_num, statement in violations:
+                print(f"  Line {line_num}: {statement}")
+        total_violations += len(violations)
+
+    if total_violations:
+        message = (
+            f"Found {total_violations} HTTPException import(s) not coming from `fastapi`.\n"
+            "Use `from fastapi import HTTPException` instead. Importing it from "
+            "`starlette.exceptions`, `http.client`, or any other module yields a "
+            "different class at runtime and breaks `isinstance` / `pytest.raises` "
+            "checks against `fastapi.HTTPException` (and, for `http.client`, calls "
+            "the wrong constructor so the route returns 500 instead of the intended "
+            "status)."
+        )
+        if console:
+            console.print()
+            console.print(f"[red]{message}[/red]")
+        else:
+            print()
+            print(message)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/scripts/tests/ci/prek/test_check_http_exception_import_from_fastapi.py
+++ b/scripts/tests/ci/prek/test_check_http_exception_import_from_fastapi.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from check_http_exception_import_from_fastapi import check_file
+
+
+class TestCheckFile:
+    @pytest.mark.parametrize(
+        "code, expected",
+        [
+            pytest.param(
+                "from starlette.exceptions import HTTPException\n",
+                [(1, "from starlette.exceptions import HTTPException")],
+                id="starlette-exceptions",
+            ),
+            pytest.param(
+                "from http.client import HTTPException\n",
+                [(1, "from http.client import HTTPException")],
+                id="http-client",
+            ),
+            pytest.param(
+                "from starlette.exceptions import HTTPException as StarletteHTTPException\n",
+                [(1, "from starlette.exceptions import HTTPException as StarletteHTTPException")],
+                id="aliased-starlette",
+            ),
+            pytest.param(
+                "from http.client import HTTPException, HTTPSConnection\n",
+                [(1, "from http.client import HTTPException")],
+                id="mixed-import-with-extra-names",
+            ),
+            pytest.param(
+                "from fastapi import HTTPException\n"
+                "from starlette.exceptions import HTTPException as StarletteHTTPException\n",
+                [(2, "from starlette.exceptions import HTTPException as StarletteHTTPException")],
+                id="good-and-bad-mixed",
+            ),
+        ],
+    )
+    def test_violations_detected(self, write_python_file, code: str, expected: list[tuple[int, str]]):
+        f = write_python_file(code)
+        assert check_file(f) == expected
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            pytest.param("from fastapi import HTTPException\n", id="from-fastapi"),
+            pytest.param(
+                "from fastapi.exceptions import HTTPException\n",
+                id="from-fastapi-exceptions",
+            ),
+            pytest.param(
+                "from fastapi import Depends, HTTPException, status\n",
+                id="multi-name-from-fastapi",
+            ),
+            pytest.param(
+                "from fastapi import HTTPException as HTTPExc\n",
+                id="aliased-from-fastapi",
+            ),
+            pytest.param("import fastapi\n", id="import-fastapi-module"),
+            pytest.param("from http.client import HTTPSConnection\n", id="unrelated-import"),
+            pytest.param("x = 1\n", id="no-imports"),
+        ],
+    )
+    def test_no_violation(self, write_python_file, code: str):
+        f = write_python_file(code)
+        assert check_file(f) == []
+
+    def test_syntax_error_is_silently_skipped(self, write_python_file):
+        f = write_python_file("def broken(:\n")
+        assert check_file(f) == []
+
+    def test_missing_file_is_silently_skipped(self, tmp_path: Path):
+        assert check_file(tmp_path / "does_not_exist.py") == []


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/67363

## Why

`fastapi.HTTPException`, `starlette.exceptions.HTTPException`, and `http.client.HTTPException` are three different classes — mixing them silently breaks `isinstance` / `pytest.raises` checks, and `http.client.HTTPException` has a different constructor so routes return 500 instead of the intended status (the exact bug #67363 fixed in `core_api/routes/ui/dags.py`).

## What

- Add `scripts/ci/prek/check_http_exception_import_from_fastapi.py` — an AST-based prek hook that flags any `from <module> import HTTPException` where `<module>` is not `fastapi` (or a `fastapi.*` submodule).
- Register it in `.pre-commit-config.yaml`, scoped to the FastAPI-using trees: `airflow-core/src/airflow/api_fastapi/`, `airflow-core/tests/unit/api_fastapi/`, and the `src/` + `tests/` of the providers that wire FastAPI apps (`amazon`, `common/ai`, `edge3`, `fab`, `keycloak`).

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
