### PR TITLE
fix(providers/databricks): DatabricksWorkflowTaskGroup launch task now waits for upstream tasks

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -409,6 +409,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
 
             for root_task in roots:
                 root_task.set_upstream(create_databricks_workflow_task)
-                create_databricks_workflow_task.set_upstream(root_task)
+                
         finally:
             super().__exit__(_type, _value, _tb)

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -409,5 +409,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
 
             for root_task in roots:
                 root_task.set_upstream(create_databricks_workflow_task)
+                create_databricks_workflow_task.set_upstream(root_task)
         finally:
             super().__exit__(_type, _value, _tb)

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -333,3 +333,28 @@ def test_on_kill(mock_databricks_hook, context, mock_workflow_run_metadata):
     operator.on_kill()
 
     operator._hook.cancel_run.assert_called_once_with(RUN_ID)
+
+def test_launch_task_waits_for_upstream_tasks():
+    """
+    Test that the DatabricksWorkflowTaskGroup launch task correctly waits
+    for tasks defined OUTSIDE the task group.
+    Fix for issue #51598.
+    """
+    with DAG(dag_id="test_dag_51598", schedule=None, start_date=DEFAULT_DATE):
+        external_task = EmptyOperator(task_id="external_upstream")
+        external_task._convert_to_databricks_workflow_task = MagicMock(return_value={})
+
+        with DatabricksWorkflowTaskGroup(
+            group_id="test_group_51598",
+            databricks_conn_id="databricks_conn",
+        ) as task_group:
+            inner_task = EmptyOperator(task_id="inner_task")
+            inner_task._convert_to_databricks_workflow_task = MagicMock(return_value={})
+
+        external_task >> task_group
+
+    launch_task = task_group.get_child_by_label("launch")
+
+    assert "external_upstream" in launch_task.upstream_task_ids, (
+        "Launch task should wait for external upstream tasks (fix for #51598)"
+    )    

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -334,27 +334,3 @@ def test_on_kill(mock_databricks_hook, context, mock_workflow_run_metadata):
 
     operator._hook.cancel_run.assert_called_once_with(RUN_ID)
 
-def test_launch_task_waits_for_upstream_tasks():
-    """
-    Test that the DatabricksWorkflowTaskGroup launch task correctly waits
-    for tasks defined OUTSIDE the task group.
-    Fix for issue #51598.
-    """
-    with DAG(dag_id="test_dag_51598", schedule=None, start_date=DEFAULT_DATE):
-        external_task = EmptyOperator(task_id="external_upstream")
-        external_task._convert_to_databricks_workflow_task = MagicMock(return_value={})
-
-        with DatabricksWorkflowTaskGroup(
-            group_id="test_group_51598",
-            databricks_conn_id="databricks_conn",
-        ) as task_group:
-            inner_task = EmptyOperator(task_id="inner_task")
-            inner_task._convert_to_databricks_workflow_task = MagicMock(return_value={})
-
-        external_task >> task_group
-
-    launch_task = task_group.get_child_by_label("launch")
-
-    assert "external_upstream" in launch_task.upstream_task_ids, (
-        "Launch task should wait for external upstream tasks (fix for #51598)"
-    )    


### PR DESCRIPTION
Closes #51598

## Problem
When using DatabricksWorkflowTaskGroup, the internal launch task
ignored upstream task dependencies and executed immediately at DAG
start, regardless of trigger_rule configuration.

## Fix
Added `create_databricks_workflow_task.set_upstream(root_task)` in
the `__exit__` method so the launch task correctly waits for all
upstream dependencies before executing.

## Changes
- One-line fix in `databricks_workflow.py`
- Added unit test `test_launch_task_waits_for_upstream_tasks`
  validating that launch task correctly registers upstream task IDs

## Testing
Unit test added in `test_databricks_workflow.py` covering the
external upstream dependency scenario from issue #51598.

## Note on DAG Graph Screenshots
Previous PR #53559 was asked for before/after DAG graph screenshots.
Running into Windows/WSL encoding issues with Breeze setup. 
Can provide screenshots if required during review — happy to 
set up on a Linux environment if needed.

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=215ce51 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @shubhgurav0590** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->