### PR TITLE
breeze: fix localhost access regression in dual-stack API server startup

### DIFF
--- a/scripts/in_container/bin/generate_mprocs_config.py
+++ b/scripts/in_container/bin/generate_mprocs_config.py
@@ -71,7 +71,9 @@ def generate_mprocs_config() -> str:
         # forwards both IPv4 and IPv6 host ports into the container). The default `0.0.0.0`
         # binds IPv4 only, causing the IPv6 attempt to land inside the container with no
         # listener and TCP RST → opaque chrome-error://chromewebdata/ page.
-        api_host_arg = "--host '::'"
+
+        # If host is empty or None, uvicorn listens on all available (IPv4 and IPv6) interfaces.
+        api_host_arg = "--host ''"
         if get_env_bool("BREEZE_DEBUG_APISERVER"):
             port = get_env("BREEZE_DEBUG_APISERVER_PORT", "5679")
             api_cmd = (

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -70,13 +70,13 @@ if [[ ! ${USE_AIRFLOW_VERSION=} =~ ^2\..*  ]]; then
     # IPv4 and IPv6 host ports into the container). The default `0.0.0.0` binds IPv4 only.
     if [[ ${BREEZE_DEBUG_APISERVER} == "true" ]]; then
         tmux set-option -p @airflow_component "API Server(Debug Mode)"
-        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server --host '::' -d" C-m
+        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server --host '' -d" C-m
     else
   tmux set-option -p @airflow_component "API Server"
     if [[ ${DEV_MODE=} == "true" ]]; then
-        tmux send-keys "airflow api-server --host '::' -d" C-m
+        tmux send-keys "airflow api-server --host '' -d" C-m
     else
-        tmux send-keys "airflow api-server --host '::'" C-m
+        tmux send-keys "airflow api-server --host ''" C-m
     fi
     fi
 else


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related: #67320

As mentioned in [this comment](https://github.com/apache/airflow/pull/67320#issuecomment-4522455831), I can't open the Airflow UI after starting Breeze as well. This issue occurs because Uvicorn requires the host to be set to an [empty string](https://github.com/Kludex/uvicorn/discussions/1529#discussioncomment-3061823) in order to bind correctly to both IPv4 and IPv6 interfaces. 

The result has been verified by accessing the api server from both host side and inside container
 - Inside container:
      - http://127.0.0.1:8080/ -> 200 OK
      - http://[::1]:8080/ -> 200 OK
  - From host:
      - http://127.0.0.1:28080/ -> 200 OK
      - http://[::1]:28080/ -> 200 OK

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
