### PR TITLE
Fix missing task instance history for failed tasks outside of RUNNING state

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1806,9 +1806,9 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             if task and fail_fast:
                 _stop_remaining_tasks(task_instance=ti, session=session)
         else:
-            if ti.state == TaskInstanceState.RUNNING:
-                # If the task instance is in the running state, it means it raised an exception and
-                # about to retry so we record the task instance history. For other states, the task
+            if ti.state != TaskInstanceState.RESTARTING:
+                # If the task instance is NOT in the restarting state, it means it raised an exception and
+                # about to retry so we record the task instance history. For the restarting state, the task
                 # instance was cleared and already recorded in the task instance history.
                 ti.prepare_db_for_next_try(session)
 

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -2366,7 +2366,7 @@ class TestTaskInstance:
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance(task.task_id)
         ti.state = State.QUEUED
-        session.merge(ti)
+        ti = session.merge(ti)
         session.flush()
         assert ti.state == State.QUEUED
         ti.handle_failure("test queued ti", test_mode=True)


### PR DESCRIPTION
Brief description of the changes.

closes: #67238
closes: #65366

When a task fails from states like QUEUED or DEFERRED, or is failed by the executor or trigger, its state is not RUNNING. The history recording in `fetch_handle_failure_context` incorrectly assumed that only RUNNING tasks needed their history recorded, which led to missing tries in `task_instance_history` when `CeleryExecutor` or `KubernetesExecutor` failed tasks or triggers failed them. Now, we record history for all states except `RESTARTING` (since `RESTARTING` tasks were already cleared and had their history recorded).

---