### PR TITLE
Introduce BaseAIHook to common-ai provider

### DIFF
--- a/providers/common/ai/AGENTS.md
+++ b/providers/common/ai/AGENTS.md
@@ -12,11 +12,12 @@ The hook is a thin bridge between Airflow connections and pydantic-ai's model/pr
   Bedrock, Ollama, etc.) via `infer_model()` and provider classes like `AzureProvider`, `BedrockProvider`.
   Do not re-implement provider-specific logic that pydantic-ai handles.
   Before writing new code, check: https://ai.pydantic.dev/models/
-- **Keep the hook thin.** `PydanticAIHook.get_conn()` maps Airflow connection fields to pydantic-ai
-  constructors. That is the hook's entire job. Do not add abstraction layers (builders, factories,
-  registries, Protocols) on top of pydantic-ai's own abstractions.
-- **No premature abstraction.** Do not add Protocols, builder patterns, or plugin systems for a single
-  code path. Wait until there are 3+ concrete use cases before introducing an abstraction.
+- **Keep LLM hooks thin.** `PydanticAIHook.get_conn()` maps Airflow connection fields to pydantic-ai
+  constructors. That is the hook's entire job for one-shot LLM operators.
+- **Agent backends use `BaseAIHook`.** `AgentOperator` / `@task.agent` resolve
+  `BaseAIHook.get_agent_hook(conn_id)` so the connection ``conn_type`` selects the runtime
+  (e.g. ``pydanticai``, ``pydanticai-bedrock``). New agent frameworks subclass `BaseAIHook` and implement
+  `get_conn`, `create_agent`, and `run_agent`; do not add parallel operator classes per framework.
 - **Operators stay focused.** Each operator does one thing: `LLMOperator` (prompt → output),
   `LLMBranchOperator` (prompt → branch decision), `LLMSQLOperator` (prompt → validated SQL).
 - **One backend per toolset.** A toolset wraps a single execution backend (e.g. `DbApiHook`,
@@ -67,7 +68,8 @@ building a wrapper here.
 
 ## Key Paths
 
-- Hook: `src/airflow/providers/common/ai/hooks/pydantic_ai.py`
+- Hooks: `src/airflow/providers/common/ai/hooks/pydantic_ai.py` (pydantic-ai)
+- Base hook contract: `src/airflow/providers/common/ai/hooks/base_ai.py`
 - Operators: `src/airflow/providers/common/ai/operators/`
 - Decorators: `src/airflow/providers/common/ai/decorators/`
 - Toolsets: `src/airflow/providers/common/ai/toolsets/`

--- a/providers/common/ai/docs/changelog.rst
+++ b/providers/common/ai/docs/changelog.rst
@@ -25,6 +25,15 @@
 Changelog
 ---------
 
+Next release
+............
+
+Features
+^^^^^^^^
+
+* Add ``BaseAIHook`` abstract contract so ``AgentOperator`` selects the agent backend
+  via connection type, with ``PydanticAIHook`` as the first concrete implementation.
+
 0.3.0
 .....
 

--- a/providers/common/ai/docs/hooks/index.rst
+++ b/providers/common/ai/docs/hooks/index.rst
@@ -34,8 +34,9 @@ Choosing a hook
    * - Hook
      - When to use
    * - :class:`~airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook`
-     - Default for ``common.ai`` operators (``LLMOperator``, ``AgentOperator``,
-       ``LLMBranchOperator``, ...). Returns a pydantic-ai ``Agent`` / ``Model``.
+     - Default for one-shot LLM operators (``LLMOperator``, ``LLMBranchOperator``, ...).
+       Also used by ``AgentOperator`` when ``conn_type`` is ``pydanticai`` (or
+       ``pydanticai-bedrock``, ``pydanticai-azure``, ``pydanticai-vertex``).
    * - :class:`~airflow.providers.common.ai.hooks.langchain.LangChainHook`
      - Direct LangChain access for tasks that compose ``Runnable``\\s, use the
        LangChain agent surface, or need LangChain-native chat / embedding model

--- a/providers/common/ai/docs/operators/agent.rst
+++ b/providers/common/ai/docs/operators/agent.rst
@@ -31,7 +31,10 @@ a single prompt and returns the output. ``AgentOperator`` manages a stateful
 tool-call loop where the LLM decides which tools to call and when to stop.
 
 .. seealso::
-    :ref:`Connection configuration <howto/connection:pydanticai>`
+    :ref:`Pydantic AI connection <howto/connection:pydanticai>`
+
+The agent backend is selected by the Airflow connection ``conn_type`` (for example
+``pydanticai`` or ``pydanticai-bedrock``). You do not choose a different operator class.
 
 
 SQL Agent

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/base_ai.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/base_ai.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared contract for agent-framework hooks used by :class:`~airflow.providers.common.ai.operators.agent.AgentOperator`."""
+
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from airflow.providers.common.compat.sdk import BaseHook
+
+
+@dataclass
+class AgentUsage:
+    """Token and request usage from an agent run, when the backend exposes it."""
+
+    requests: int = 0
+    tool_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+@dataclass
+class AgentRunResult:
+    """
+    Backend-neutral result from :meth:`BaseAIHook.run_agent`.
+
+    :param output: Final agent output (``str``, Pydantic model instance, etc.).
+    :param message_history: Opaque conversation state for HITL regeneration; only pass back to the
+        same hook implementation that produced it.
+    :param model_name: Resolved model identifier, when available.
+    :param usage: Usage counters when the backend exposes them.
+    :param tool_names: Ordered tool names invoked during the run, when known.
+    """
+
+    output: Any
+    message_history: Any = None
+    model_name: str | None = None
+    usage: AgentUsage | None = None
+    tool_names: list[str] | None = None
+
+
+class BaseAIHook(BaseHook, metaclass=ABCMeta):
+    """
+    Abstract hook for multi-turn LLM agents.
+
+    :class:`~airflow.providers.common.ai.operators.agent.AgentOperator` resolves the concrete hook
+    from the Airflow connection ``conn_type`` (for example ``pydanticai`` or ``pydanticai-bedrock``).
+
+    Subclasses implement :meth:`get_conn`, :meth:`create_agent`, and :meth:`run_agent` for their agent
+    runtime.
+    """
+
+    conn_name_attr = "llm_conn_id"
+
+    supports_toolsets: ClassVar[bool] = False
+    supports_durable: ClassVar[bool] = False
+    supports_usage_limits: ClassVar[bool] = False
+
+    @classmethod
+    def get_agent_hook(cls, conn_id: str, *, hook_params: dict[str, Any] | None = None) -> BaseAIHook:
+        """
+        Return an agent hook for *conn_id*, verifying it implements this contract.
+
+        Uses the connection's ``conn_type`` to select the hook class registered in
+        ``provider.yaml``.
+        """
+        hook = cls.get_hook(conn_id, hook_params=hook_params)
+        if not isinstance(hook, BaseAIHook):
+            raise TypeError(
+                f"Connection {conn_id!r} resolved to {type(hook).__name__}, which is not a BaseAIHook. "
+                "Use a connection type registered for agent frameworks (e.g. pydanticai, pydanticai-bedrock)."
+            )
+        return hook
+
+    @abstractmethod
+    def get_conn(self) -> Any:
+        """Return the backend model/client used to construct agents."""
+
+    @abstractmethod
+    def create_agent(
+        self,
+        *,
+        output_type: type[Any] = str,
+        instructions: str = "",
+        **agent_kwargs: Any,
+    ) -> Any:
+        """
+        Build an agent instance for this backend.
+
+        :param output_type: Expected structured output type (``str`` or a Pydantic ``BaseModel`` subclass).
+        :param instructions: System-level instructions for the agent.
+        :param agent_kwargs: Backend-specific options (e.g. pydantic-ai ``toolsets``).
+        """
+
+    @abstractmethod
+    def run_agent(
+        self,
+        agent: Any,
+        *,
+        prompt: str,
+        usage_limits: Any = None,
+        message_history: Any = None,
+    ) -> AgentRunResult:
+        """
+        Run *agent* with *prompt* and return a normalized :class:`AgentRunResult`.
+
+        :param agent: Object returned by :meth:`create_agent`.
+        :param prompt: User prompt for this invocation.
+        :param usage_limits: Backend-specific usage limits (pydantic-ai ``UsageLimits`` only today).
+        :param message_history: Prior conversation state from a previous :class:`AgentRunResult`.
+        """

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/pydantic_ai.py
@@ -22,7 +22,7 @@ from pydantic_ai import Agent
 from pydantic_ai.models import infer_model
 from pydantic_ai.providers import infer_provider, infer_provider_class
 
-from airflow.providers.common.compat.sdk import BaseHook
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, AgentUsage, BaseAIHook
 
 OutputT = TypeVar("OutputT")
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from pydantic_ai.models import KnownModelName, Model
 
 
-class PydanticAIHook(BaseHook):
+class PydanticAIHook(BaseAIHook):
     """
     Hook for LLM access via pydantic-ai.
 
@@ -55,6 +55,10 @@ class PydanticAIHook(BaseHook):
     default_conn_name = "pydanticai_default"
     conn_type = "pydanticai"
     hook_name = "Pydantic AI"
+
+    supports_toolsets = True
+    supports_durable = True
+    supports_usage_limits = True
 
     def __init__(
         self,
@@ -190,6 +194,43 @@ class PydanticAIHook(BaseHook):
         :param agent_kwargs: Additional keyword arguments passed to the Agent constructor.
         """
         return Agent(self.get_conn(), output_type=output_type, instructions=instructions, **agent_kwargs)
+
+    def run_agent(
+        self,
+        agent: Agent[None, Any],
+        *,
+        prompt: str,
+        usage_limits: Any = None,
+        message_history: Any = None,
+    ) -> AgentRunResult:
+        """Run a pydantic-ai agent and return a normalized :class:`~airflow.providers.common.ai.hooks.base_ai.AgentRunResult`."""
+        from pydantic_ai.messages import ToolCallPart
+
+        if message_history is not None:
+            result = agent.run_sync(prompt, message_history=message_history, usage_limits=usage_limits)
+        else:
+            result = agent.run_sync(prompt, usage_limits=usage_limits)
+
+        usage = result.usage()
+        tool_names: list[str] = []
+        for message in result.all_messages():
+            for part in getattr(message, "parts", []):
+                if isinstance(part, ToolCallPart):
+                    tool_names.append(part.tool_name)
+
+        return AgentRunResult(
+            output=result.output,
+            message_history=result.all_messages(),
+            model_name=getattr(result.response, "model_name", None),
+            usage=AgentUsage(
+                requests=usage.requests,
+                tool_calls=usage.tool_calls,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                total_tokens=usage.total_tokens,
+            ),
+            tool_names=tool_names or None,
+        )
 
     def test_connection(self) -> tuple[bool, str]:
         """

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Operator for running pydantic-ai agents with tools and multi-turn reasoning."""
+"""Operator for running LLM agents with tools and multi-turn reasoning."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from airflow.providers.common.ai.hooks.pydantic_ai import PydanticAIHook
+from airflow.providers.common.ai.hooks.base_ai import BaseAIHook
 from airflow.providers.common.ai.mixins.hitl_review import HITLReviewMixin
 from airflow.providers.common.ai.utils.logging import log_run_summary, wrap_toolsets_for_logging
 from airflow.providers.common.compat.sdk import (
@@ -83,14 +83,17 @@ class HITLReviewLink(BaseOperatorLink):
 
 class AgentOperator(BaseOperator, HITLReviewMixin):
     """
-    Run a pydantic-ai Agent with tools and multi-turn reasoning.
+    Run an LLM agent with tools and multi-turn reasoning.
 
     Provide ``llm_conn_id`` and optional ``toolsets`` to let the operator build
     and run the agent. The agent reasons about the prompt, calls tools in a
     multi-turn loop, and returns a final answer.
 
+    The agent backend is selected by the connection ``conn_type`` (for example
+    ``pydanticai``, ``pydanticai-bedrock``, or ``pydanticai-azure``).
+
     :param prompt: The prompt to send to the agent.
-    :param llm_conn_id: Connection ID for the LLM provider.
+    :param llm_conn_id: Connection ID for the agent provider.
     :param model_id: Model identifier (e.g. ``"openai:gpt-5"``).
         Overrides the model stored in the connection's extra field.
     :param system_prompt: System-level instructions for the agent.
@@ -191,12 +194,32 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             )
 
     @cached_property
-    def llm_hook(self) -> PydanticAIHook:
-        """Return PydanticAIHook for the configured LLM connection."""
+    def llm_hook(self) -> BaseAIHook:
+        """Return the agent hook for the configured connection (resolved from ``conn_type``)."""
         hook_params = {
             "model_id": self.model_id,
         }
-        return PydanticAIHook.get_hook(self.llm_conn_id, hook_params=hook_params)
+        return BaseAIHook.get_agent_hook(self.llm_conn_id, hook_params=hook_params)
+
+    def _validate_hook_capabilities(self) -> None:
+        """Raise if operator options are incompatible with the resolved agent hook."""
+        hook = self.llm_hook
+        if self.toolsets and not hook.supports_toolsets:
+            raise ValueError(
+                f"toolsets are not supported for connection {self.llm_conn_id!r} "
+                f"(conn_type resolves to {type(hook).__name__}). "
+                "Use a pydantic-ai connection type (e.g. pydanticai, pydanticai-bedrock)."
+            )
+        if self.usage_limits is not None and not hook.supports_usage_limits:
+            raise ValueError(
+                f"usage_limits are not supported for connection {self.llm_conn_id!r} "
+                f"(conn_type resolves to {type(hook).__name__})."
+            )
+        if self.durable and not hook.supports_durable:
+            raise ValueError(
+                f"durable=True requires a pydantic-ai connection type; got {type(hook).__name__} "
+                f"for connection {self.llm_conn_id!r}."
+            )
 
     def _build_agent(self) -> Agent[None, Any]:
         """Build and return a pydantic-ai Agent from the operator's config."""
@@ -225,6 +248,8 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         return [CachingToolset(wrapped=ts, storage=storage, counter=counter) for ts in toolsets]
 
     def execute(self, context: Context) -> Any:
+        self._validate_hook_capabilities()
+
         self._durable_storage = None
         self._durable_counter = None
 
@@ -255,11 +280,19 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
             resolved_model = infer_model(agent.model)
             caching_model = CachingModel(resolved_model, storage=storage, counter=counter)
             with agent.override(model=caching_model):
-                result = agent.run_sync(self.prompt, usage_limits=self.usage_limits)
+                run_result = self.llm_hook.run_agent(
+                    agent,
+                    prompt=self.prompt,
+                    usage_limits=self.usage_limits,
+                )
         else:
-            result = agent.run_sync(self.prompt, usage_limits=self.usage_limits)
+            run_result = self.llm_hook.run_agent(
+                agent,
+                prompt=self.prompt,
+                usage_limits=self.usage_limits,
+            )
 
-        log_run_summary(self.log, result)
+        log_run_summary(self.log, run_result)
 
         if self._durable_counter is not None:
             c = self._durable_counter
@@ -280,13 +313,13 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         if self._durable_storage is not None:
             self._durable_storage.cleanup()
 
-        output = result.output
+        output = run_result.output
 
         if self.enable_hitl_review:
             result_str = self.run_hitl_review(  # type: ignore[misc]
                 context,
                 output,
-                message_history=result.all_messages(),
+                message_history=run_result.message_history,
             )
             # Deserialize back to dict
             try:
@@ -301,11 +334,15 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
     def regenerate_with_feedback(self, *, feedback: str, message_history: Any) -> tuple[str, Any]:
         """Re-run the agent with *feedback* appended to the conversation history."""
         agent = self._build_agent()
-        messages = message_history or []
-        result = agent.run_sync(feedback, message_history=messages, usage_limits=self.usage_limits)
-        log_run_summary(self.log, result)
+        run_result = self.llm_hook.run_agent(
+            agent,
+            prompt=feedback,
+            message_history=message_history,
+            usage_limits=self.usage_limits,
+        )
+        log_run_summary(self.log, run_result)
 
-        output = result.output
+        output = run_result.output
         if isinstance(output, BaseModel):
             output = output.model_dump_json()
-        return str(output), result.all_messages()
+        return str(output), run_result.message_history

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm.py
@@ -126,7 +126,7 @@ class LLMOperator(BaseOperator, LLMApprovalMixin):
         agent: Agent[None, Any] = self.llm_hook.create_agent(
             output_type=self.output_type, instructions=self.system_prompt, **self.agent_params
         )
-        result = agent.run_sync(self.prompt, usage_limits=self.usage_limits)
+        result = self.llm_hook.run_agent(agent, prompt=self.prompt, usage_limits=self.usage_limits)
         log_run_summary(self.log, result)
         output = result.output
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
@@ -134,7 +134,7 @@ class LLMFileAnalysisOperator(LLMOperator):
             instructions=self._build_system_prompt(),
             **self.agent_params,
         )
-        result = agent.run_sync(request.user_content, usage_limits=self.usage_limits)
+        result = self.llm_hook.run_agent(agent, prompt=request.user_content, usage_limits=self.usage_limits)
         log_run_summary(self.log, result)
         output = result.output
 

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/logging.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/logging.py
@@ -14,19 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Logging utilities for pydantic-ai agent runs."""
+"""Logging utilities for agent runs."""
 
 from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
 
-from pydantic_ai.messages import ToolCallPart
-
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult
 from airflow.providers.common.ai.toolsets.logging import LoggingToolset
 
 if TYPE_CHECKING:
-    from pydantic_ai.result import AgentRunResult
     from pydantic_ai.toolsets.abstract import AbstractToolset
 
     from airflow.sdk.types import Logger
@@ -34,24 +32,26 @@ if TYPE_CHECKING:
 _MAX_OUTPUT_LEN = 500
 
 
-def log_run_summary(logger: Logger | logging.Logger, result: AgentRunResult[Any]) -> None:
+def log_run_summary(logger: Logger | logging.Logger, result: AgentRunResult) -> None:
     """Log model name, token usage, and tool call sequence from an agent run."""
-    usage = result.usage()
-    model_name = getattr(result.response, "model_name", "unknown")
-    logger.info(
-        "::group::LLM run complete: model=%s, requests=%s, tool_calls=%s, "
-        "input_tokens=%s, output_tokens=%s, total_tokens=%s",
-        model_name,
-        usage.requests,
-        usage.tool_calls,
-        usage.input_tokens,
-        usage.output_tokens,
-        usage.total_tokens,
-    )
+    model_name = result.model_name or "unknown"
+    usage = result.usage
+    if usage is not None:
+        logger.info(
+            "::group::LLM run complete: model=%s, requests=%s, tool_calls=%s, "
+            "input_tokens=%s, output_tokens=%s, total_tokens=%s",
+            model_name,
+            usage.requests,
+            usage.tool_calls,
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.total_tokens,
+        )
+    else:
+        logger.info("::group::LLM run complete: model=%s", model_name)
 
-    tool_names = _extract_tool_sequence(result)
-    if tool_names:
-        logger.info("Tool call sequence: %s", " -> ".join(tool_names))
+    if result.tool_names:
+        logger.info("Tool call sequence: %s", " -> ".join(result.tool_names))
 
     _log_output_debug(logger, result.output)
     logger.info("::endgroup::")
@@ -70,16 +70,6 @@ def _log_output_debug(logger: Logger | logging.Logger, output: Any) -> None:
     if len(text) > _MAX_OUTPUT_LEN:
         text = text[:_MAX_OUTPUT_LEN] + "..."
     logger.debug("Output: %s", text)
-
-
-def _extract_tool_sequence(result: AgentRunResult[Any]) -> list[str]:
-    """Extract ordered tool names from the message history."""
-    tool_names: list[str] = []
-    for message in result.all_messages():
-        for part in getattr(message, "parts", []):
-            if isinstance(part, ToolCallPart):
-                tool_names.append(part.tool_name)
-    return tool_names
 
 
 def wrap_toolsets_for_logging(

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_base_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_base_ai.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, AgentUsage, BaseAIHook
+from airflow.providers.common.compat.sdk import BaseHook
+
+
+class TestBaseAIHookGetAgentHook:
+    @patch("airflow.providers.common.ai.hooks.base_ai.BaseHook.get_hook", autospec=True)
+    def test_returns_hook_when_instance_is_base_ai_hook(self, mock_get_hook):
+        mock_hook = MagicMock(spec=BaseAIHook)
+        mock_get_hook.return_value = mock_hook
+
+        result = BaseAIHook.get_agent_hook("my_conn")
+
+        assert result is mock_hook
+        mock_get_hook.assert_called_once_with("my_conn", hook_params=None)
+
+    @patch("airflow.providers.common.ai.hooks.base_ai.BaseHook.get_hook", autospec=True)
+    def test_raises_when_hook_is_not_base_ai_hook(self, mock_get_hook):
+        mock_get_hook.return_value = MagicMock(spec=BaseHook)
+
+        with pytest.raises(TypeError, match="not a BaseAIHook"):
+            BaseAIHook.get_agent_hook("my_conn")
+
+
+class TestAgentRunResult:
+    def test_dataclass_fields(self):
+        usage = AgentUsage(requests=1, tool_calls=2, total_tokens=10)
+        result = AgentRunResult(
+            output="answer",
+            message_history=["msg"],
+            model_name="test-model",
+            usage=usage,
+            tool_names=["query"],
+        )
+        assert result.output == "answer"
+        assert result.message_history == ["msg"]
+        assert result.model_name == "test-model"
+        assert result.usage == usage
+        assert result.tool_names == ["query"]

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_pydantic_ai.py
@@ -24,12 +24,23 @@ import pytest
 from pydantic_ai.models import Model
 
 from airflow.models.connection import Connection
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, BaseAIHook
 from airflow.providers.common.ai.hooks.pydantic_ai import (
     PydanticAIAzureHook,
     PydanticAIBedrockHook,
     PydanticAIHook,
     PydanticAIVertexHook,
 )
+
+
+class TestPydanticAIHookBaseContract:
+    def test_is_base_ai_hook(self):
+        assert issubclass(PydanticAIHook, BaseAIHook)
+
+    def test_capability_flags(self):
+        assert PydanticAIHook.supports_toolsets is True
+        assert PydanticAIHook.supports_durable is True
+        assert PydanticAIHook.supports_usage_limits is True
 
 
 class TestPydanticAIHookInit:
@@ -652,3 +663,41 @@ class TestPydanticAIVertexHook:
         factory = mock_infer_model.call_args[1]["provider_factory"]
         factory("google-vertex")
         mock_provider_cls.assert_called_with(project="my-project", location="europe-west4")
+
+
+class TestPydanticAIHookRunAgent:
+    def test_run_agent_returns_agent_run_result(self):
+        hook = PydanticAIHook()
+        mock_agent = MagicMock()
+        mock_usage = MagicMock(requests=1, tool_calls=0, input_tokens=5, output_tokens=10, total_tokens=15)
+        mock_result = MagicMock()
+        mock_result.output = "done"
+        mock_result.usage.return_value = mock_usage
+        mock_result.response = MagicMock(model_name="openai:gpt-5")
+        mock_result.all_messages.return_value = []
+        mock_agent.run_sync.return_value = mock_result
+
+        run_result = hook.run_agent(mock_agent, prompt="hello")
+
+        assert isinstance(run_result, AgentRunResult)
+        assert run_result.output == "done"
+        assert run_result.model_name == "openai:gpt-5"
+        mock_agent.run_sync.assert_called_once_with("hello", usage_limits=None)
+
+    def test_run_agent_forwards_message_history_and_usage_limits(self):
+        hook = PydanticAIHook()
+        mock_agent = MagicMock()
+        mock_result = MagicMock()
+        mock_result.output = "ok"
+        mock_result.usage.return_value = MagicMock(
+            requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0
+        )
+        mock_result.response = MagicMock(model_name="m")
+        mock_result.all_messages.return_value = ["history"]
+        mock_agent.run_sync.return_value = mock_result
+        limits = MagicMock()
+        history = ["prior"]
+
+        hook.run_agent(mock_agent, prompt="more", message_history=history, usage_limits=limits)
+
+        mock_agent.run_sync.assert_called_once_with("more", message_history=history, usage_limits=limits)

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -23,29 +23,51 @@ import pytest
 from pydantic import BaseModel
 from pydantic_ai.usage import UsageLimits
 
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, AgentUsage, BaseAIHook
 from airflow.providers.common.ai.operators.agent import AgentOperator, HITLReviewLink
 from airflow.providers.common.ai.toolsets.logging import LoggingToolset
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
 
-def _make_mock_run_result(output):
-    """Create a mock AgentRunResult compatible with log_run_summary."""
-    mock_result = MagicMock()
-    mock_result.output = output
-    mock_result.usage.return_value = MagicMock(
-        requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0
+def _make_agent_run_result(output, *, message_history=None) -> AgentRunResult:
+    return AgentRunResult(
+        output=output,
+        message_history=[] if message_history is None else message_history,
+        model_name="test-model",
+        usage=AgentUsage(requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0),
     )
-    mock_result.response = MagicMock(model_name="test-model")
-    mock_result.all_messages.return_value = []
-    return mock_result
 
 
-def _make_mock_agent(output):
-    """Create a mock agent that returns the given output."""
-    mock_agent = MagicMock(spec=["run_sync"])
-    mock_agent.run_sync.return_value = _make_mock_run_result(output)
-    return mock_agent
+def _make_mock_hook(output, *, message_history=None):
+    """Return (mock_hook, mock_agent) wired for AgentOperator.execute."""
+    mock_hook = MagicMock(spec=BaseAIHook)
+    mock_hook.supports_toolsets = True
+    mock_hook.supports_durable = True
+    mock_hook.supports_usage_limits = True
+    mock_agent = MagicMock()
+    mock_hook.create_agent.return_value = mock_agent
+    mock_hook.run_agent.return_value = _make_agent_run_result(output, message_history=message_history)
+    return mock_hook, mock_agent
+
+
+class TestAgentOperatorHookCapabilities:
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
+    def test_execute_rejects_toolsets_when_hook_does_not_support_them(self, mock_hook_cls):
+        mock_hook = MagicMock(spec=BaseAIHook)
+        mock_hook.supports_toolsets = False
+        mock_hook.supports_durable = False
+        mock_hook.supports_usage_limits = False
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="no_toolsets_conn",
+            toolsets=[MagicMock()],
+        )
+        with pytest.raises(ValueError, match="toolsets are not supported"):
+            op.execute(context=MagicMock())
 
 
 class TestAgentOperatorValidation:
@@ -80,11 +102,11 @@ class TestAgentOperatorTemplateFields:
 
 
 class TestAgentOperatorExecute:
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_forwards_usage_limits_to_run_sync(self, mock_hook_cls):
-        """``usage_limits`` is forwarded to ``agent.run_sync`` on the non-durable path."""
-        mock_agent = _make_mock_agent("ok")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        """``usage_limits`` is forwarded to ``run_agent`` on the non-durable path."""
+        mock_hook, mock_agent = _make_mock_hook("ok")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         limits = UsageLimits(request_limit=3, tool_calls_limit=5)
         op = AgentOperator(
@@ -95,13 +117,13 @@ class TestAgentOperatorExecute:
         )
         op.execute(context=MagicMock())
 
-        mock_agent.run_sync.assert_called_once_with("run", usage_limits=limits)
+        mock_hook.run_agent.assert_called_once_with(mock_agent, prompt="run", usage_limits=limits)
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_regenerate_with_feedback_forwards_usage_limits(self, mock_hook_cls):
         """``usage_limits`` is also forwarded by ``regenerate_with_feedback``."""
-        mock_agent = _make_mock_agent("revised")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, mock_agent = _make_mock_hook("revised")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         limits = UsageLimits(request_limit=1)
         op = AgentOperator(
@@ -112,16 +134,17 @@ class TestAgentOperatorExecute:
         )
         op.regenerate_with_feedback(feedback="Add detail", message_history=[])
 
-        mock_agent.run_sync.assert_called_once_with(
-            "Add detail",
+        mock_hook.run_agent.assert_called_once_with(
+            mock_agent,
+            prompt="Add detail",
             message_history=[],
             usage_limits=limits,
         )
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_creates_agent_from_hook(self, mock_hook_cls):
-        mock_agent = _make_mock_agent("The answer is 42.")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, mock_agent = _make_mock_hook("The answer is 42.")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
@@ -132,16 +155,17 @@ class TestAgentOperatorExecute:
         result = op.execute(context=MagicMock())
 
         assert result == "The answer is 42."
-        mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": None})
-        mock_hook_cls.get_hook.return_value.create_agent.assert_called_once_with(
-            output_type=str, instructions="You are helpful."
+        mock_hook_cls.get_agent_hook.assert_called_once_with("my_llm", hook_params={"model_id": None})
+        mock_hook.create_agent.assert_called_once_with(output_type=str, instructions="You are helpful.")
+        mock_hook.run_agent.assert_called_once_with(
+            mock_agent, prompt="What is the answer?", usage_limits=None
         )
-        mock_agent.run_sync.assert_called_once_with("What is the answer?", usage_limits=None)
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_passes_toolsets_in_agent_kwargs(self, mock_hook_cls):
         """Toolsets are passed through to the agent constructor."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+        mock_hook, _ = _make_mock_hook("done")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         mock_toolset = MagicMock()
         op = AgentOperator(
@@ -152,16 +176,17 @@ class TestAgentOperatorExecute:
         )
         op.execute(context=MagicMock())
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         passed_toolsets = create_call[1]["toolsets"]
         assert len(passed_toolsets) == 1
         assert isinstance(passed_toolsets[0], LoggingToolset)
         assert passed_toolsets[0].wrapped is mock_toolset
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_enable_tool_logging_false_skips_wrapping(self, mock_hook_cls):
         """enable_tool_logging=False passes toolsets through unwrapped."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("done")
+        mock_hook, _ = _make_mock_hook("done")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         mock_toolset = MagicMock()
         op = AgentOperator(
@@ -173,13 +198,14 @@ class TestAgentOperatorExecute:
         )
         op.execute(context=MagicMock())
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         assert create_call[1]["toolsets"] == [mock_toolset]
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_passes_agent_params(self, mock_hook_cls):
         """agent_params are unpacked into create_agent."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
+        mock_hook, _ = _make_mock_hook("ok")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
@@ -189,11 +215,11 @@ class TestAgentOperatorExecute:
         )
         op.execute(context=MagicMock())
 
-        create_call = mock_hook_cls.get_hook.return_value.create_agent.call_args
+        create_call = mock_hook.create_agent.call_args
         assert create_call[1]["retries"] == 3
         assert create_call[1]["model_settings"] == {"temperature": 0}
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_structured_output(self, mock_hook_cls):
         """Structured output via BaseModel is serialized with model_dump."""
 
@@ -201,9 +227,8 @@ class TestAgentOperatorExecute:
             text: str
             score: float
 
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent(
-            Summary(text="Great", score=0.95)
-        )
+        mock_hook, _ = _make_mock_hook(Summary(text="Great", score=0.95))
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
@@ -215,10 +240,11 @@ class TestAgentOperatorExecute:
 
         assert result == {"text": "Great", "score": 0.95}
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_with_model_id(self, mock_hook_cls):
-        """model_id is passed to PydanticAIHook."""
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = _make_mock_agent("ok")
+        """model_id is passed to the agent hook."""
+        mock_hook, _ = _make_mock_hook("ok")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
@@ -228,21 +254,20 @@ class TestAgentOperatorExecute:
         )
         op.execute(context=MagicMock())
 
-        mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": "openai:gpt-5"})
+        mock_hook_cls.get_agent_hook.assert_called_once_with(
+            "my_llm", hook_params={"model_id": "openai:gpt-5"}
+        )
 
     @pytest.mark.skipif(
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
     )
     @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_with_enable_hitl_review_delegates_to_run_hitl_review(self, mock_hook_cls, mock_run_hitl):
         """When enable_hitl_review=True, execute delegates to run_hitl_review with output and message_history."""
         msg_history = [MagicMock()]
-        mock_result = _make_mock_run_result("Initial output")
-        mock_result.all_messages.return_value = msg_history
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, _ = _make_mock_hook("Initial output", message_history=msg_history)
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
         mock_run_hitl.return_value = "Approved output"
 
         op = AgentOperator(
@@ -262,7 +287,7 @@ class TestAgentOperatorExecute:
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
     )
     @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_with_hitl_deserializes_base_model_to_dict(self, mock_hook_cls, mock_run_hitl):
         """When enable_hitl_review=True and output_type is BaseModel, execute deserializes JSON to dict."""
 
@@ -270,10 +295,8 @@ class TestAgentOperatorExecute:
             text: str
             score: float
 
-        mock_result = _make_mock_run_result(Summary(text="Approved summary", score=0.9))
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, _ = _make_mock_hook(Summary(text="Approved summary", score=0.9))
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
         # run_hitl_review returns JSON string (as stored in session.current_output)
         mock_run_hitl.return_value = '{"text": "Approved summary", "score": 0.9}'
 
@@ -294,13 +317,11 @@ class TestAgentOperatorExecute:
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
     )
     @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_with_hitl_returns_string_unchanged(self, mock_hook_cls, mock_run_hitl):
         """When enable_hitl_review=True and output_type is str, execute returns string as-is."""
-        mock_result = _make_mock_run_result("Initial output")
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, _ = _make_mock_hook("Initial output")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
         mock_run_hitl.return_value = "Approved output"
 
         op = AgentOperator(
@@ -320,15 +341,13 @@ class TestAgentOperatorExecute:
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
     )
     @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_propagates_hitl_max_iterations_error(self, mock_hook_cls, mock_run_hitl):
         """When run_hitl_review raises HITLMaxIterationsError, execute propagates it."""
         from airflow.providers.common.ai.exceptions import HITLMaxIterationsError
 
-        mock_result = _make_mock_run_result("Initial output")
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, _ = _make_mock_hook("Initial output")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
         mock_run_hitl.side_effect = HITLMaxIterationsError("Task exceeded max iterations.")
 
         op = AgentOperator(
@@ -392,46 +411,42 @@ class TestHITLReviewLink:
     not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
 )
 class TestAgentOperatorRegenerateWithFeedback:
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_regenerate_with_feedback_calls_agent_with_feedback_and_history(self, mock_hook_cls):
-        """regenerate_with_feedback builds agent and calls run_sync with feedback and message_history."""
+        """regenerate_with_feedback builds agent and calls run_agent with feedback and message_history."""
         msg_history = [MagicMock()]
-        mock_result = _make_mock_run_result("Revised output")
-        mock_result.all_messages.return_value = msg_history + [MagicMock()]
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        new_history = msg_history + [MagicMock()]
+        mock_hook, mock_agent = _make_mock_hook("Revised output", message_history=new_history)
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
             prompt="Summarize",
             llm_conn_id="my_llm",
         )
-        output, new_history = op.regenerate_with_feedback(
+        output, returned_history = op.regenerate_with_feedback(
             feedback="Add more detail",
             message_history=msg_history,
         )
 
         assert output == "Revised output"
-        assert new_history == mock_result.all_messages.return_value
-        mock_agent.run_sync.assert_called_once_with(
-            "Add more detail",
+        assert returned_history == new_history
+        mock_hook.run_agent.assert_called_once_with(
+            mock_agent,
+            prompt="Add more detail",
             message_history=msg_history,
             usage_limits=None,
         )
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_regenerate_with_feedback_serializes_base_model_output(self, mock_hook_cls):
         """regenerate_with_feedback returns JSON string for BaseModel output."""
 
         class Summary(BaseModel):
             text: str
 
-        mock_result = _make_mock_run_result(Summary(text="Revised"))
-        mock_result.all_messages.return_value = []
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = mock_result
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, _ = _make_mock_hook(Summary(text="Revised"))
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(
             task_id="test",
@@ -459,7 +474,7 @@ class TestAgentOperatorDurable:
     @patch("pydantic_ai.models.wrapper.infer_model", side_effect=lambda m: m)
     @patch("pydantic_ai.models.infer_model", autospec=True)
     @patch("airflow.providers.common.ai.durable.storage._get_base_path")
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_durable_wraps_model_and_cleans_up(
         self, mock_hook_cls, mock_base_path, mock_infer, _, tmp_path
     ):
@@ -468,13 +483,12 @@ class TestAgentOperatorDurable:
 
         mock_base_path.return_value = ObjectStoragePath(f"file://{tmp_path.as_posix()}")
 
-        mock_agent = MagicMock()
-        mock_agent.run_sync.return_value = _make_mock_run_result("ok")
+        mock_hook, mock_agent = _make_mock_hook("ok")
         mock_agent.model = "test-model"
         mock_agent.override = MagicMock()
         mock_agent.override.return_value.__enter__ = MagicMock(return_value=None)
         mock_agent.override.return_value.__exit__ = MagicMock(return_value=False)
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         mock_resolved = MagicMock()
         mock_infer.return_value = mock_resolved
@@ -492,14 +506,14 @@ class TestAgentOperatorDurable:
         override_kwargs = mock_agent.override.call_args[1]
         assert "model" in override_kwargs
 
-    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.BaseAIHook", autospec=True)
     def test_execute_non_durable_does_not_wrap(self, mock_hook_cls):
         """Default (durable=False) does not use override."""
-        mock_agent = _make_mock_agent("ok")
-        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook, mock_agent = _make_mock_hook("ok")
+        mock_hook_cls.get_agent_hook.return_value = mock_hook
 
         op = AgentOperator(task_id="test", prompt="test", llm_conn_id="my_llm")
         op.execute(context=MagicMock())
 
-        # run_sync called directly, no override
-        mock_agent.run_sync.assert_called_once_with("test", usage_limits=None)
+        mock_hook.run_agent.assert_called_once_with(mock_agent, prompt="test", usage_limits=None)
+        mock_agent.override.assert_not_called()

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import BaseModel
 from pydantic_ai.usage import UsageLimits
 
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, AgentUsage
 from airflow.providers.common.ai.mixins.approval import (
     LLMApprovalMixin,
 )
@@ -33,15 +34,12 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
 
 def _make_mock_run_result(output):
-    """Create a mock AgentRunResult compatible with log_run_summary."""
-    mock_result = MagicMock()
-    mock_result.output = output
-    mock_result.usage.return_value = MagicMock(
-        requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0
+    """Create an AgentRunResult compatible with log_run_summary."""
+    return AgentRunResult(
+        output=output,
+        model_name="test-model",
+        usage=AgentUsage(requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0),
     )
-    mock_result.response = MagicMock(model_name="test-model")
-    mock_result.all_messages.return_value = []
-    return mock_result
 
 
 class TestLLMOperator:
@@ -52,26 +50,30 @@ class TestLLMOperator:
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     def test_execute_returns_string_output(self, mock_hook_cls):
         """Default output_type=str returns the LLM string directly."""
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("Paris is the capital of France.")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            "Paris is the capital of France."
+        )
 
         op = LLMOperator(task_id="test", prompt="What is the capital of France?", llm_conn_id="my_llm")
         result = op.execute(context=MagicMock())
 
         assert result == "Paris is the capital of France."
-        mock_agent.run_sync.assert_called_once_with("What is the capital of France?", usage_limits=None)
+        mock_hook_cls.get_hook.return_value.run_agent.assert_called_once_with(
+            mock_agent, prompt="What is the capital of France?", usage_limits=None
+        )
         mock_hook_cls.get_hook.return_value.create_agent.assert_called_once_with(
             output_type=str, instructions=""
         )
         mock_hook_cls.get_hook.assert_called_once_with("my_llm", hook_params={"model_id": None})
 
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
-    def test_execute_forwards_usage_limits_to_run_sync(self, mock_hook_cls):
-        """``usage_limits`` is forwarded verbatim to ``agent.run_sync``."""
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("ok")
+    def test_execute_forwards_usage_limits_to_run_agent(self, mock_hook_cls):
+        """``usage_limits`` is forwarded verbatim to ``hook.run_agent``."""
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("ok")
 
         limits = UsageLimits(request_limit=2, output_tokens_limit=100)
         op = LLMOperator(
@@ -82,7 +84,9 @@ class TestLLMOperator:
         )
         op.execute(context=MagicMock())
 
-        mock_agent.run_sync.assert_called_once_with("Summarize", usage_limits=limits)
+        mock_hook_cls.get_hook.return_value.run_agent.assert_called_once_with(
+            mock_agent, prompt="Summarize", usage_limits=limits
+        )
 
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     def test_execute_structured_output_with_all_params(self, mock_hook_cls):
@@ -91,9 +95,11 @@ class TestLLMOperator:
         class Entities(BaseModel):
             names: list[str]
 
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result(Entities(names=["Alice", "Bob"]))
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            Entities(names=["Alice", "Bob"])
+        )
 
         op = LLMOperator(
             task_id="test",
@@ -145,9 +151,9 @@ class TestLLMOperatorApproval:
         """When require_approval=True, execute() defers instead of returning output."""
         from airflow.providers.common.compat.sdk import TaskDeferred
 
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("LLM response")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("LLM response")
 
         op = LLMOperator(
             task_id="approval_test",
@@ -171,9 +177,9 @@ class TestLLMOperatorApproval:
         """allow_modifications=True passes an editable 'output' param."""
         from airflow.providers.common.compat.sdk import TaskDeferred
 
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("draft output")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("draft output")
 
         op = LLMOperator(
             task_id="mod_test",
@@ -197,9 +203,9 @@ class TestLLMOperatorApproval:
         """approval_timeout is passed to the trigger."""
         from airflow.providers.common.compat.sdk import TaskDeferred
 
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("output")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("output")
 
         timeout = timedelta(hours=1)
         op = LLMOperator(
@@ -226,9 +232,11 @@ class TestLLMOperatorApproval:
         class Summary(BaseModel):
             text: str
 
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result(Summary(text="hello"))
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            Summary(text="hello")
+        )
 
         op = LLMOperator(
             task_id="struct_test",
@@ -247,9 +255,9 @@ class TestLLMOperatorApproval:
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     def test_execute_without_approval_returns_normally(self, mock_hook_cls):
         """When require_approval=False, execute() returns output directly."""
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("plain output")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("plain output")
 
         op = LLMOperator(task_id="no_approval", prompt="p", llm_conn_id="my_llm", require_approval=False)
         result = op.execute(context={})

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
@@ -23,6 +23,7 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel
 
+from airflow.providers.common.ai.hooks.base_ai import AgentRunResult, AgentUsage
 from airflow.providers.common.ai.operators.llm_file_analysis import LLMFileAnalysisOperator
 from airflow.providers.common.ai.utils.file_analysis import FileAnalysisRequest
 
@@ -30,19 +31,11 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_1_PLUS
 
 
 def _make_mock_run_result(output):
-    mock_result = MagicMock(spec=["output", "usage", "response", "all_messages"])
-    mock_result.output = output
-    mock_result.usage.return_value = MagicMock(
-        spec=["requests", "tool_calls", "input_tokens", "output_tokens", "total_tokens"],
-        requests=1,
-        tool_calls=0,
-        input_tokens=0,
-        output_tokens=0,
-        total_tokens=0,
+    return AgentRunResult(
+        output=output,
+        model_name="test-model",
+        usage=AgentUsage(requests=1, tool_calls=0, input_tokens=0, output_tokens=0, total_tokens=0),
     )
-    mock_result.response = MagicMock(spec=["model_name"], model_name="test-model")
-    mock_result.all_messages.return_value = []
-    return mock_result
 
 
 def _make_context(ti_id=None):
@@ -77,9 +70,11 @@ class TestLLMFileAnalysisOperator:
             resolved_paths=["/tmp/app.log"],
             total_size_bytes=10,
         )
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("Analysis complete")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            "Analysis complete"
+        )
 
         op = LLMFileAnalysisOperator(
             task_id="test",
@@ -101,7 +96,9 @@ class TestLLMFileAnalysisOperator:
             max_text_chars=100_000,
             sample_rows=10,
         )
-        mock_agent.run_sync.assert_called_once_with("prepared prompt", usage_limits=None)
+        mock_hook_cls.get_hook.return_value.run_agent.assert_called_once_with(
+            mock_agent, prompt="prepared prompt", usage_limits=None
+        )
 
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     @patch(
@@ -116,9 +113,11 @@ class TestLLMFileAnalysisOperator:
             resolved_paths=["/tmp/app.log"],
             total_size_bytes=10,
         )
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result(Summary(findings=["error spike"]))
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            Summary(findings=["error spike"])
+        )
 
         op = LLMFileAnalysisOperator(
             task_id="test",
@@ -177,9 +176,9 @@ class TestLLMFileAnalysisOperatorApproval:
             resolved_paths=["/tmp/app.log"],
             total_size_bytes=10,
         )
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("LLM response")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("LLM response")
 
         op = LLMFileAnalysisOperator(
             task_id="approval_test",
@@ -213,9 +212,11 @@ class TestLLMFileAnalysisOperatorApproval:
             resolved_paths=["/tmp/app.log"],
             total_size_bytes=10,
         )
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result(self.Summary(findings=["error spike"]))
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result(
+            self.Summary(findings=["error spike"])
+        )
 
         op = LLMFileAnalysisOperator(
             task_id="approval_structured_test",
@@ -283,9 +284,9 @@ class TestLLMFileAnalysisOperatorApproval:
             resolved_paths=["/tmp/app.log"],
             total_size_bytes=10,
         )
-        mock_agent = MagicMock(spec=["run_sync"])
-        mock_agent.run_sync.return_value = _make_mock_run_result("output")
+        mock_agent = MagicMock()
         mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_hook_cls.get_hook.return_value.run_agent.return_value = _make_mock_run_result("output")
 
         timeout = timedelta(hours=1)
         op = LLMFileAnalysisOperator(


### PR DESCRIPTION
  Introduces `BaseAIHook`, an abstract hook that defines the contract every
  agent-framework backend must implement.  `AgentOperator` (and the `@task.agent`
  decorator) now selects the backend at runtime from the Airflow connection's
  `conn_type` — no new operator class is needed when adding another framework.

  ## What changed

  ### New: `BaseAIHook` contract (`hooks/base_ai.py`)
  
  - `BaseAIHook(BaseHook)` — abstract base with three abstract methods:
    - `get_conn()` — return the backend model/client
    - `create_agent(output_type, instructions, **kwargs)` — build an agent
    - `run_agent(agent, *, prompt, usage_limits, message_history) → AgentRunResult`
  - `AgentRunResult` dataclass — backend-neutral result:
    `output`, `message_history`, `model_name`, `usage`, `tool_names`
  - `AgentUsage` dataclass — normalized token/request counters:
    `requests`, `tool_calls`, `input_tokens`, `output_tokens`, `total_tokens`
  - Class-level capability flags: `supports_toolsets`, `supports_durable`,
    `supports_usage_limits`
  - `BaseAIHook.get_agent_hook(conn_id)` — resolves the registered hook from
    `conn_type` and raises `TypeError` if it is not a `BaseAIHook`

  ### Refactor: `PydanticAIHook(BaseAIHook)`

  `PydanticAIHook` (and its subclasses `PydanticAIAzureHook`,
  `PydanticAIBedrockHook`, `PydanticAIVertexHook`) now subclass `BaseAIHook`.
  `run_agent()` wraps the pydantic-ai `RunResult` into `AgentRunResult`, so all
  callers receive a backend-neutral object.
  
  ### `AgentOperator` dispatch via `get_agent_hook()`
  
  `AgentOperator.execute()` calls `BaseAIHook.get_agent_hook(conn_id)` instead of
  importing `PydanticAIHook` directly.  This is the main extensibility seam:
  a future hook registered under a new `conn_type` is picked up with no operator
  changes.
  
  ### `LLMOperator` / `LLMFileAnalysisOperator` aligned
  
  Both operators previously called `agent.run_sync()` directly, bypassing the hook
  abstraction and receiving a pydantic-ai `RunResult` rather than an
  `AgentRunResult`.  They now call `self.llm_hook.run_agent(agent, prompt=…)`,
  which means:
  - `log_run_summary()` receives a consistent `AgentRunResult` from all operators
  - The operators are backend-agnostic alongside `AgentOperator`

  ### `logging.py` backend-agnostic

  `log_run_summary()` now reads `result.model_name`, `result.usage.*`, and
  `result.tool_names` from `AgentRunResult` directly — no more pydantic-ai
  `result.response.model_name` or `result.usage()` callable.

  ### Tests
  
  - New `tests/unit/common/ai/hooks/test_base_ai.py` covering the contract,
    `get_agent_hook()` dispatch, and `TypeError` on non-agent hook
  - Updated `test_pydantic_ai.py`, `test_agent.py`, `test_llm.py`,
    `test_llm_file_analysis.py` to mock `hook.run_agent()` returning
    `AgentRunResult` instead of a raw pydantic-ai `RunResult`





<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
