### PR TITLE
Remove dead auth code from Airflow2 times in Edge

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/worker_api/auth.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/auth.py
@@ -32,7 +32,6 @@ from jwt import (
 
 from airflow.api_fastapi.auth.tokens import JWTValidator
 from airflow.providers.common.compat.sdk import conf
-from airflow.providers.edge3.worker_api.datamodels import JsonRpcRequestBase  # noqa: TCH001
 
 log = logging.getLogger(__name__)
 
@@ -91,13 +90,6 @@ def jwt_token_authorization(method: str, authorization: str):
         )
     except Exception:
         _forbidden_response("Unable to authenticate API via token.")
-
-
-def jwt_token_authorization_rpc(
-    body: JsonRpcRequestBase, authorization: str = Header(description="JWT Authorization Token")
-):
-    """Check if the JWT token is correct for JSON PRC requests."""
-    jwt_token_authorization(body.method, authorization)
 
 
 def jwt_token_authorization_rest(

--- a/providers/edge3/src/airflow/providers/edge3/worker_api/datamodels.py
+++ b/providers/edge3/src/airflow/providers/edge3/worker_api/datamodels.py
@@ -17,10 +17,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import (
-    Annotated,
-    Any,
-)
+from typing import Annotated
 
 from fastapi import Path
 from pydantic import BaseModel, Field
@@ -42,25 +39,6 @@ class WorkerApiDocs:
         description="For dynamically mapped tasks the mapping number, -1 if the task is not mapped.",
     )
     state = Path(title="Task State", description="State of the assigned task under execution.")
-
-
-class JsonRpcRequestBase(BaseModel):
-    """Base JSON RPC request model to define just the method."""
-
-    method: Annotated[
-        str,
-        Field(description="Fully qualified python module method name that is called via JSON RPC."),
-    ]
-
-
-class JsonRpcRequest(JsonRpcRequestBase):
-    """JSON RPC request model."""
-
-    jsonrpc: Annotated[str, Field(description="JSON RPC Version", examples=["2.0"])]
-    params: Annotated[
-        dict[str, Any] | None,
-        Field(description="Dictionary of parameters passed to the method."),
-    ]
 
 
 class EdgeJobBase(BaseModel):


### PR DESCRIPTION
While reviewing auth code in Edge Executor I stumbled over some dead-code which is out of Airflow 2.x times - this can be deleted safely as Airflow 2x is not supported anymore.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
