### PR TITLE
Fix deferrable execution_timeout handling in AirbyteTriggerSyncOperator

### DIFF
--- a/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py
@@ -111,7 +111,7 @@ class AirbyteTriggerSyncOperator(BaseOperator):
             self.log.debug("Running in deferrable mode in job state %s...", state)
             if state in (JobStatusEnum.RUNNING, JobStatusEnum.PENDING, JobStatusEnum.INCOMPLETE):
                 self.defer(
-                    timeout=self.execution_timeout,
+                    timeout=None,
                     trigger=AirbyteSyncTrigger(
                         conn_id=self.airbyte_conn_id,
                         job_id=self.job_id,

--- a/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/operators/test_airbyte.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -67,6 +68,60 @@ class TestAirbyteTriggerSyncOp:
         )
         mock_wait_for_job.assert_called_once_with(
             job_id=self.job_id, wait_seconds=self.wait_seconds, timeout=self.timeout
+        )
+
+    @mock.patch("airflow.providers.airbyte.operators.airbyte.AirbyteTriggerSyncOperator.defer")
+    @mock.patch("airflow.providers.airbyte.operators.airbyte.AirbyteSyncTrigger")
+    @mock.patch("airbyte_api.jobs.Jobs.create_job")
+    def test_execute_deferrable_does_not_pass_execution_timeout_to_defer(
+        self,
+        mock_create_job,
+        mock_airbyte_trigger,
+        mock_defer,
+        create_connection_without_db,
+    ):
+        conn = Connection(conn_id=self.airbyte_conn_id, conn_type="airbyte", host="airbyte.com")
+        create_connection_without_db(conn)
+
+        mock_response = mock.Mock()
+        mock_response.job_response = JobResponse(
+            connection_id="connection-mock",
+            job_id=1,
+            start_time="today",
+            job_type=JobTypeEnum.SYNC,
+            status=JobStatusEnum.RUNNING,
+        )
+        mock_create_job.return_value = mock_response
+
+        op = AirbyteTriggerSyncOperator(
+            task_id="test_airbyte_op",
+            airbyte_conn_id=self.airbyte_conn_id,
+            connection_id=self.connection_id,
+            wait_seconds=self.wait_seconds,
+            timeout=self.timeout,
+            deferrable=True,
+            execution_timeout=timedelta(seconds=30),
+        )
+
+        op.execute({})
+
+        # Explicitly pass timeout=None so Airflow's framework-level deferred
+        # timeout handling does not bypass execute_complete(), which is
+        # responsible for Airbyte job cancellation in deferrable mode.
+        mock_defer.assert_called_once_with(
+            method_name="execute_complete",
+            trigger=mock_airbyte_trigger.return_value,
+            timeout=None,
+        )
+
+        # Ensure the trigger still receives execution_deadline handling for
+        # Airbyte job timeout cancellation processing.
+        mock_airbyte_trigger.assert_called_once_with(
+            conn_id=self.airbyte_conn_id,
+            job_id=self.job_id,
+            end_time=mock.ANY,
+            execution_deadline=mock.ANY,
+            poll_interval=60,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Description**

This change fixes an issue (as reported in Issue #64048) affecting `AirbyteTriggerSyncOperator` in deferrable mode that was not fully resolved by PR #64051.

Previously, `execution_timeout` was passed directly to `defer()`. The operator now explicitly passes `timeout=None` to `defer()` while still preserving `execution_deadline` handling within the trigger/operator flow.

**Rationale**

In deferrable mode, Airbyte job cancellation is performed within `execute_complete()` when the trigger emits a timeout event.

However, framework-level deferred timeout handling bypasses `execute_complete()` entirely and does not invoke `on_kill()` in the triggerer process. As a result, Airbyte jobs could continue running after the Airflow task timed out, leading to leaked workloads and excessive resource consumption.

While this weakens the framework-level deferred timeout guarantee, in this case preventing leaked external workloads takes precedence because there is currently no equivalent cleanup path in the triggerer process.

This change keeps timeout handling within the trigger/operator flow so Airbyte job cancellation can occur correctly.

**Tests**

Added an operator-level regression test verifying that `defer()` is called with `timeout=None` while `execution_deadline` handling remains preserved for Airbyte job timeout cancellation processing.

**Backwards Compatibility**

This change does not modify public APIs or method signatures.

Related: #64048

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [GPT 5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)