### PR TITLE
Cleanup older/outddated uv cooldown exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1530,18 +1530,6 @@ apache-airflow-task-sdk-integration-tests = false
 apache-aurflow-docker-stack = false
 # End of automatically generated exclude-newer-package entries
 
-# Manual overrides (kept outside the auto-generated block above so the
-# update_airflow_pyproject_toml.py script doesn't clobber them).
-# uv 0.11.8 lifted the timestamp from `uv.lock` for relative `exclude-newer`
-# (https://github.com/astral-sh/uv/issues/18708, fixed in
-# https://github.com/astral-sh/uv/pull/19022) — we want that fix, but the
-# global 4-day cooldown above would otherwise block a freshly-published uv
-# from being adopted as the floor. Drop uv's cooldown to 12 hours so the
-# pinned `required-version` floor isn't gated by the project-wide window.
-# REMOVE BY 2026-05-01 — once 0.11.8 is older than the global 4-day cooldown
-# this override is redundant and should be deleted along with the line below.
-uv = "12 hours"
-
 [tool.uv.pip]
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
 exclude-newer = "4 days"
@@ -1680,11 +1668,6 @@ apache-airflow-task-sdk = false
 apache-airflow-task-sdk-integration-tests = false
 apache-aurflow-docker-stack = false
 # End of automatically generated exclude-newer-package-pip entries
-
-# Manual overrides — see the matching block under
-# `[tool.uv.exclude-newer-package]` above for rationale.
-# REMOVE BY 2026-05-01 along with the matching entry above.
-uv = "12 hours"
 
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -106,7 +106,6 @@ apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "PT12H" }
 apache-airflow-kubernetes-tests = false
 apache-airflow-providers-grpc = false
 apache-airflow-providers-apache-druid = false


### PR DESCRIPTION
While reviewing #67326 noticed there is some cleanup close-by possible. Should keep it clean.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
