### PR TITLE
Replace Sphinx Redoc with Swagger API Docs

### DIFF
--- a/airflow-core/docs/.gitignore
+++ b/airflow-core/docs/.gitignore
@@ -2,4 +2,3 @@
 /logs
 /plugins
 /.env
-static/mirrored

--- a/airflow-core/docs/.gitignore
+++ b/airflow-core/docs/.gitignore
@@ -2,3 +2,4 @@
 /logs
 /plugins
 /.env
+static/mirrored

--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -37,12 +37,14 @@ from docs.utils.conf_constants import (
     AUTOAPI_OPTIONS,
     BASIC_AUTOAPI_IGNORE_PATTERNS,
     BASIC_SPHINX_EXTENSIONS,
-    REDOC_SCRIPT_URL,
     SMARTQUOTES_EXCLUDES,
     SPELLING_WORDLIST_PATH,
     SPHINX_DESIGN_STATIC_PATH,
-    SPHINX_REDOC_EXTENSIONS,
+    SPHINX_SWAGGER_EXTENSION,
     SUPPRESS_WARNINGS,
+    SWAGGER_BUNDLE_URI,
+    SWAGGER_CSS_URI,
+    SWAGGER_PRESENT_URI,
     filter_autoapi_ignore_entries,
     get_autodoc_mock_imports,
     get_configs_and_deprecations,
@@ -53,13 +55,12 @@ from docs.utils.conf_constants import (
     get_intersphinx_mapping,
     get_rst_epilogue,
     get_rst_filepath_from_path,
+    mirror_artifact_locally,
     skip_util_classes_extension,
 )
 from packaging.version import Version, parse as parse_version
 
 import airflow
-from airflow.api_fastapi.auth.managers.simple.openapi import __file__ as sam_openapi_file
-from airflow.api_fastapi.core_api.openapi import __file__ as main_openapi_file
 from airflow.configuration import retrieve_configuration_description
 
 PACKAGE_NAME = "apache-airflow"
@@ -91,11 +92,11 @@ smartquotes_excludes = SMARTQUOTES_EXCLUDES
 # ones.
 extensions = BASIC_SPHINX_EXTENSIONS
 
-# -- Options for sphinxcontrib.redoc -------------------------------------------
-# See: https://sphinxcontrib-redoc.readthedocs.io/en/stable/
+extensions.append(SPHINX_SWAGGER_EXTENSION)
 
-extensions.extend(SPHINX_REDOC_EXTENSIONS)
-redoc_script_url = REDOC_SCRIPT_URL
+swagger_present_uri = mirror_artifact_locally(SWAGGER_PRESENT_URI, Path(__file__).parent)
+swagger_bundle_uri = mirror_artifact_locally(SWAGGER_BUNDLE_URI, Path(__file__).parent)
+swagger_css_uri = mirror_artifact_locally(SWAGGER_CSS_URI, Path(__file__).parent)
 
 extensions.extend(
     [
@@ -356,27 +357,6 @@ spelling_ignore_contributor_names = False
 spelling_ignore_importable_modules = True
 
 graphviz_output_format = "svg"
-
-main_openapi_path = Path(main_openapi_file).parent.joinpath("v2-rest-api-generated.yaml")
-sam_openapi_path = Path(sam_openapi_file).parent.joinpath("v2-simple-auth-manager-generated.yaml")
-redoc = [
-    {
-        "name": "Simple auth manager token API",
-        "page": "core-concepts/auth-manager/simple/sam-token-api-ref",
-        "spec": sam_openapi_path.as_posix(),
-        "opts": {
-            "hide-hostname": True,
-        },
-    },
-    {
-        "name": "Airflow REST API",
-        "page": "stable-rest-api-ref",
-        "spec": main_openapi_path.as_posix(),
-        "opts": {
-            "hide-hostname": True,
-        },
-    },
-]
 
 
 def setup(sphinx):

--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -95,7 +95,7 @@ extensions.append(SPHINX_SWAGGER_EXTENSION)
 swagger_present_uri = SWAGGER_PRESENT_URI
 swagger_bundle_uri = SWAGGER_BUNDLE_URI
 swagger_css_uri = SWAGGER_CSS_URI
-swagger_mirror_external_resources = True
+swagger_mirror_external_resources = True  # Ensure we embed external resources prevent tracking
 
 extensions.extend(
     [

--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -24,7 +24,6 @@ import logging
 import os
 import pathlib
 import re
-from pathlib import Path
 from typing import Any
 
 from docs.utils.conf_constants import (
@@ -55,7 +54,6 @@ from docs.utils.conf_constants import (
     get_intersphinx_mapping,
     get_rst_epilogue,
     get_rst_filepath_from_path,
-    mirror_artifact_locally,
     skip_util_classes_extension,
 )
 from packaging.version import Version, parse as parse_version
@@ -94,9 +92,10 @@ extensions = BASIC_SPHINX_EXTENSIONS
 
 extensions.append(SPHINX_SWAGGER_EXTENSION)
 
-swagger_present_uri = mirror_artifact_locally(SWAGGER_PRESENT_URI, Path(__file__).parent)
-swagger_bundle_uri = mirror_artifact_locally(SWAGGER_BUNDLE_URI, Path(__file__).parent)
-swagger_css_uri = mirror_artifact_locally(SWAGGER_CSS_URI, Path(__file__).parent)
+swagger_present_uri = SWAGGER_PRESENT_URI
+swagger_bundle_uri = SWAGGER_BUNDLE_URI
+swagger_css_uri = SWAGGER_CSS_URI
+swagger_mirror_external_resources = True
 
 extensions.extend(
     [

--- a/airflow-core/docs/stable-rest-api-ref.rst
+++ b/airflow-core/docs/stable-rest-api-ref.rst
@@ -16,8 +16,10 @@
     specific language governing permissions and limitations
     under the License.
 
-Airflow public API reference
-============================
+Airflow public REST API reference
+=================================
 
-It's a stub file. It will be converted automatically during the build process
-to the valid documentation by the Sphinx plugin. See: airflow-core/docs/conf.py
+.. swagger-plugin:: ../src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+    :id: core-rest-api-ref
+    :page-title: Airflow public REST API
+    :swagger-options: { "tryItOutEnabled": "false", "supportedSubmitMethods": [] }

--- a/airflow-ctl/docs/conf.py
+++ b/airflow-ctl/docs/conf.py
@@ -33,11 +33,9 @@ from docs.utils.conf_constants import (
     AUTOAPI_OPTIONS,
     BASIC_AUTOAPI_IGNORE_PATTERNS,
     BASIC_SPHINX_EXTENSIONS,
-    REDOC_SCRIPT_URL,
     SMARTQUOTES_EXCLUDES,
     SPELLING_WORDLIST_PATH,
     SPHINX_DESIGN_STATIC_PATH,
-    SPHINX_REDOC_EXTENSIONS,
     SUPPRESS_WARNINGS,
     filter_autoapi_ignore_entries,
     get_autodoc_mock_imports,
@@ -88,11 +86,6 @@ smartquotes_excludes = SMARTQUOTES_EXCLUDES
 # ones.
 extensions = BASIC_SPHINX_EXTENSIONS
 
-# -- Options for sphinxcontrib.redoc -------------------------------------------
-# See: https://sphinxcontrib-redoc.readthedocs.io/en/stable/
-
-extensions.extend(SPHINX_REDOC_EXTENSIONS)
-redoc_script_url = REDOC_SCRIPT_URL
 
 extensions.extend(
     [

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -98,12 +98,9 @@ dependencies = [
     "sphinxcontrib-jsmath>=1.0.1",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-qthelp>=1.0.3",
-    "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-serializinghtml>=1.1.5",
     "sphinxcontrib-spelling>=8.0.0",
-    # setuptools 82.0.0+ causes redoc to fail due to pkg_resources removal
-    # until https://github.com/sphinx-contrib/redoc/issues/53 is resolved
-    "setuptools<82.0.0",
+    "swagger-plugin-for-sphinx>=7.0.0",
 ]
 "docs-gen" = [
     "diagrams>=0.24.4",

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -100,7 +100,7 @@ dependencies = [
     "sphinxcontrib-qthelp>=1.0.3",
     "sphinxcontrib-serializinghtml>=1.1.5",
     "sphinxcontrib-spelling>=8.0.0",
-    "swagger-plugin-for-sphinx>=7.0.0",
+    "swagger-plugin-for-sphinx>=7.1.0",
 ]
 "docs-gen" = [
     "diagrams>=0.24.4",

--- a/devel-common/sphinx_design/.gitignore
+++ b/devel-common/sphinx_design/.gitignore
@@ -1,0 +1,1 @@
+static/mirrored

--- a/devel-common/sphinx_design/.gitignore
+++ b/devel-common/sphinx_design/.gitignore
@@ -1,1 +1,0 @@
-static/mirrored

--- a/devel-common/sphinx_design/static/custom.css
+++ b/devel-common/sphinx_design/static/custom.css
@@ -97,3 +97,53 @@ a.headerlink svg {
     margin: -117px 0 0; /* negative fixed header height */
   }
 }
+
+/*
+Some layout optimization especially for dark mode for Swagger API reference
+*/
+
+/* Hide the authorize button which is use-less in docs w/o API running behind */
+.swagger-ui div.scheme-container {
+  display: none;
+}
+
+/* Set text color to white in dark mode for better readability */
+[data-bs-theme="dark"] .swagger-ui .title,
+[data-bs-theme="dark"] .swagger-ui h4,
+[data-bs-theme="dark"] .swagger-ui .opblock .opblock-section-header h4,
+[data-bs-theme="dark"] .swagger-ui .parameter__name,
+[data-bs-theme="dark"]  .swagger-ui .parameter__type,
+[data-bs-theme="dark"] .swagger-ui p {
+  color: var(--bs-emphasis-color);
+}
+
+[data-bs-theme="dark"] .swagger-ui a.nostyle {
+  color: var(--bs-link-color);
+}
+
+[data-bs-theme="dark"] .swagger-ui .opblock .opblock-summary-description {
+  color: var(--bs-secondary-color);
+}
+
+[data-bs-theme="dark"] .swagger-ui svg {
+  stroke: var(--bs-emphasis-color);
+}
+
+[data-bs-theme="dark"] .swagger-ui .opblock .opblock-section-header {
+  color: var(--bs-emphasis-color);
+  background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .swagger-ui input[disabled],
+[data-bs-theme="dark"] .swagger-ui select[disabled],
+[data-bs-theme="dark"] .swagger-ui select,
+[data-bs-theme="dark"] .swagger-ui textarea[disabled]  {
+  border: 1px solid var(--bs-border-color)  ;
+  color: var(--bs-emphasis-color);
+  background-color: var(--bs-secondary-bg);
+}
+
+/* Somehow some dark mode is showing-up also in light mode for code areas, fix it here */
+.swagger-ui pre code {
+  background-color: rgb(51, 51, 51);
+}

--- a/devel-common/src/docs/provider_conf.py
+++ b/devel-common/src/docs/provider_conf.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 # serve to show the default.
 import logging
 import os
-from pathlib import Path
 from typing import Any
 
 import rich
@@ -47,11 +46,14 @@ from docs.utils.conf_constants import (
     AUTOAPI_OPTIONS,
     BASIC_AUTOAPI_IGNORE_PATTERNS,
     BASIC_SPHINX_EXTENSIONS,
-    REDOC_SCRIPT_URL,
     SMARTQUOTES_EXCLUDES,
     SPELLING_WORDLIST_PATH,
     SPHINX_DESIGN_STATIC_PATH,
+    SPHINX_SWAGGER_EXTENSION,
     SUPPRESS_WARNINGS,
+    SWAGGER_BUNDLE_URI,
+    SWAGGER_CSS_URI,
+    SWAGGER_PRESENT_URI,
     filter_autoapi_ignore_entries,
     get_autodoc_mock_imports,
     get_configs_and_deprecations,
@@ -61,6 +63,7 @@ from docs.utils.conf_constants import (
     get_html_theme_options,
     get_intersphinx_mapping,
     get_rst_epilogue,
+    mirror_artifact_locally,
 )
 from sphinx_exts.provider_yaml_utils import load_package_data
 
@@ -119,25 +122,21 @@ smartquotes_excludes = SMARTQUOTES_EXCLUDES
 # ones.
 extensions = BASIC_SPHINX_EXTENSIONS
 
-PROVIDER_PACKAGES_WITH_REDOC = ["apache-airflow-providers-fab", "apache-airflow-providers-keycloak"]
+PROVIDER_PACKAGES_WITH_API_REFERENCE = [
+    "apache-airflow-providers-edge3",
+    "apache-airflow-providers-fab",
+    "apache-airflow-providers-keycloak",
+]
 
-if PACKAGE_NAME in PROVIDER_PACKAGES_WITH_REDOC:
-    extensions.extend(
-        [
-            "autoapi.extension",
-            # First, generate redoc
-            "sphinxcontrib.redoc",
-            # Second, update redoc script
-            "sphinx_script_update",
-        ]
-    )
-    redoc_script_url = REDOC_SCRIPT_URL
-else:
-    extensions.extend(
-        [
-            "autoapi.extension",
-        ]
-    )
+if PACKAGE_NAME in PROVIDER_PACKAGES_WITH_API_REFERENCE:
+    extensions.append(SPHINX_SWAGGER_EXTENSION)
+    _DOCS_TARGET_ROOT_PATH = SPHINX_DESIGN_STATIC_PATH.parent
+
+    swagger_present_uri = mirror_artifact_locally(SWAGGER_PRESENT_URI, _DOCS_TARGET_ROOT_PATH)
+    swagger_bundle_uri = mirror_artifact_locally(SWAGGER_BUNDLE_URI, _DOCS_TARGET_ROOT_PATH)
+    swagger_css_uri = mirror_artifact_locally(SWAGGER_CSS_URI, _DOCS_TARGET_ROOT_PATH)
+
+extensions.append("autoapi.extension")
 
 extensions.extend(
     [
@@ -357,38 +356,3 @@ spelling_ignore_contributor_names = False
 spelling_ignore_importable_modules = True
 
 graphviz_output_format = "svg"
-
-if PACKAGE_NAME in PROVIDER_PACKAGES_WITH_REDOC:
-    from airflow.providers.fab.auth_manager.api_fastapi.openapi import (
-        __file__ as fab_auth_manager_fastapi_api_file,
-    )
-    from airflow.providers.keycloak.auth_manager.openapi import (
-        __file__ as keycloak_auth_manager_fastapi_api_file,
-    )
-
-    fab_auth_manager_fastapi_api_path = Path(fab_auth_manager_fastapi_api_file).parent.joinpath(
-        "v2-fab-auth-manager-generated.yaml"
-    )
-    keycloak_auth_manager_fastapi_api_path = Path(keycloak_auth_manager_fastapi_api_file).parent.joinpath(
-        "v2-keycloak-auth-manager-generated.yaml"
-    )
-    redoc = [
-        {
-            "name": "Fab auth manager API",
-            "page": "api-ref/fab-api-ref",
-            "spec": fab_auth_manager_fastapi_api_path.as_posix(),
-            "opts": {
-                "hide-hostname": True,
-                "no-auto-auth": True,
-            },
-        },
-        {
-            "name": "Keycloak auth manager token API",
-            "page": "api-ref/token-api-ref",
-            "spec": keycloak_auth_manager_fastapi_api_path.as_posix(),
-            "opts": {
-                "hide-hostname": True,
-                "no-auto-auth": True,
-            },
-        },
-    ]

--- a/devel-common/src/docs/provider_conf.py
+++ b/devel-common/src/docs/provider_conf.py
@@ -133,7 +133,7 @@ if PACKAGE_NAME in PROVIDER_PACKAGES_WITH_API_REFERENCE:
     swagger_present_uri = SWAGGER_PRESENT_URI
     swagger_bundle_uri = SWAGGER_BUNDLE_URI
     swagger_css_uri = SWAGGER_CSS_URI
-    swagger_mirror_external_resources = True
+    swagger_mirror_external_resources = True  # Ensure we embed external resources prevent tracking
 
 extensions.append("autoapi.extension")
 

--- a/devel-common/src/docs/provider_conf.py
+++ b/devel-common/src/docs/provider_conf.py
@@ -63,7 +63,6 @@ from docs.utils.conf_constants import (
     get_html_theme_options,
     get_intersphinx_mapping,
     get_rst_epilogue,
-    mirror_artifact_locally,
 )
 from sphinx_exts.provider_yaml_utils import load_package_data
 
@@ -130,11 +129,11 @@ PROVIDER_PACKAGES_WITH_API_REFERENCE = [
 
 if PACKAGE_NAME in PROVIDER_PACKAGES_WITH_API_REFERENCE:
     extensions.append(SPHINX_SWAGGER_EXTENSION)
-    _DOCS_TARGET_ROOT_PATH = SPHINX_DESIGN_STATIC_PATH.parent
 
-    swagger_present_uri = mirror_artifact_locally(SWAGGER_PRESENT_URI, _DOCS_TARGET_ROOT_PATH)
-    swagger_bundle_uri = mirror_artifact_locally(SWAGGER_BUNDLE_URI, _DOCS_TARGET_ROOT_PATH)
-    swagger_css_uri = mirror_artifact_locally(SWAGGER_CSS_URI, _DOCS_TARGET_ROOT_PATH)
+    swagger_present_uri = SWAGGER_PRESENT_URI
+    swagger_bundle_uri = SWAGGER_BUNDLE_URI
+    swagger_css_uri = SWAGGER_CSS_URI
+    swagger_mirror_external_resources = True
 
 extensions.append("autoapi.extension")
 

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -123,7 +123,7 @@ def mirror_artifact_locally(source_uri: str, doc_root: pathlib.Path) -> str:
     return f"mirrored/{filename}"
 
 
-_SWAGGER_VERSION = "5.11.0"
+_SWAGGER_VERSION = "5.32.6"
 SWAGGER_PRESENT_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui-standalone-preset.js"
 SWAGGER_BUNDLE_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui-bundle.js"
 SWAGGER_CSS_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui.css"

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -22,7 +22,6 @@ import re
 import sys
 from collections import defaultdict
 from typing import Any
-from urllib import request
 
 from packaging.version import Version, parse as parse_version
 
@@ -101,27 +100,6 @@ BASIC_SPHINX_EXTENSIONS = [
 # Properties for Swagger OpenAPI generation:
 # See https://github.com/SAP/swagger-plugin-for-sphinx
 SPHINX_SWAGGER_EXTENSION = "swagger_plugin_for_sphinx"
-
-
-def mirror_artifact_locally(source_uri: str, doc_root: pathlib.Path) -> str:
-    """
-    Mirror (Swagger UI or other) artifacts locally to avoid relying on external CDNs.
-
-    Note: This is not needed if https://github.com/SAP/swagger-plugin-for-sphinx/issues/508
-          is implemented and the mirroring can be just a feature flag in the plugin itself.
-
-    :param source_uri: The original URI of the Swagger UI artifact.
-    :param doc_root: The root path of the documentation.
-    :return: The local URI of the mirrored Swagger UI artifact.
-    """
-    filename = pathlib.Path(source_uri).name
-    local_path = doc_root / "static" / "mirrored" / filename
-    if not local_path.exists():
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        request.urlretrieve(source_uri, local_path)
-
-    return f"mirrored/{filename}"
-
 
 _SWAGGER_VERSION = "5.32.6"
 SWAGGER_PRESENT_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui-standalone-preset.js"

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -22,6 +22,7 @@ import re
 import sys
 from collections import defaultdict
 from typing import Any
+from urllib import request
 
 from packaging.version import Version, parse as parse_version
 
@@ -97,15 +98,35 @@ BASIC_SPHINX_EXTENSIONS = [
     "metrics_tables_from_registry",
 ]
 
-SPHINX_REDOC_EXTENSIONS = [
-    "autoapi.extension",
-    # First, generate redoc
-    "sphinxcontrib.redoc",
-    # Second, update redoc script
-    "sphinx_script_update",
-]
+# Properties for Swagger OpenAPI generation:
+# See https://github.com/SAP/swagger-plugin-for-sphinx
+SPHINX_SWAGGER_EXTENSION = "swagger_plugin_for_sphinx"
 
-REDOC_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.48/bundles/redoc.standalone.js"
+
+def mirror_artifact_locally(source_uri: str, doc_root: pathlib.Path) -> str:
+    """
+    Mirror (Swagger UI or other) artifacts locally to avoid relying on external CDNs.
+
+    Note: This is not needed if https://github.com/SAP/swagger-plugin-for-sphinx/issues/508
+          is implemented and the mirroring can be just a feature flag in the plugin itself.
+
+    :param source_uri: The original URI of the Swagger UI artifact.
+    :param doc_root: The root path of the documentation.
+    :return: The local URI of the mirrored Swagger UI artifact.
+    """
+    filename = pathlib.Path(source_uri).name
+    local_path = doc_root / "static" / "mirrored" / filename
+    if not local_path.exists():
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        request.urlretrieve(source_uri, local_path)
+
+    return f"mirrored/{filename}"
+
+
+_SWAGGER_VERSION = "5.11.0"
+SWAGGER_PRESENT_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui-standalone-preset.js"
+SWAGGER_BUNDLE_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui-bundle.js"
+SWAGGER_CSS_URI = f"https://unpkg.com/swagger-ui-dist@{_SWAGGER_VERSION}/swagger-ui.css"
 
 
 def get_rst_filepath_from_path(filepath: pathlib.Path, root: pathlib.Path):

--- a/providers/edge3/docs/edge-api-ref.rst
+++ b/providers/edge3/docs/edge-api-ref.rst
@@ -16,10 +16,10 @@
     specific language governing permissions and limitations
     under the License.
 
-Simple auth manager token API
-=============================
+Edge Worker REST API
+====================
 
-.. swagger-plugin:: ../../../../src/airflow/api_fastapi/auth/managers/simple/openapi/v2-simple-auth-manager-generated.yaml
-    :id: sam-token-api-ref
-    :page-title: Simple auth manager token API
+.. swagger-plugin:: ../src/airflow/providers/edge3/worker_api/v2-edge-generated.yaml
+    :id: edge-worker-api-ref
+    :page-title: Edge Worker REST API
     :swagger-options: { "tryItOutEnabled": "false", "supportedSubmitMethods": [] }

--- a/providers/edge3/docs/index.rst
+++ b/providers/edge3/docs/index.rst
@@ -58,6 +58,7 @@
     Configuration <configurations-ref>
     CLI <cli-ref>
     Python API <_api/airflow/providers/edge3/index>
+    Edge Worker REST API <edge-api-ref>
 
 .. toctree::
     :hidden:

--- a/providers/fab/docs/api-ref/fab-api-ref.rst
+++ b/providers/fab/docs/api-ref/fab-api-ref.rst
@@ -19,4 +19,7 @@
 FAB auth manager token API
 ==========================
 
-It's a stub file. It will be automatically converted during the build process into valid documentation by the Sphinx plugin. See: /docs/conf.py
+.. swagger-plugin:: ../../src/airflow/providers/fab/auth_manager/api_fastapi/openapi/v2-fab-auth-manager-generated.yaml
+    :id: fab-auth-manager-api-ref
+    :page-title: FAB auth manager token API
+    :swagger-options: { "tryItOutEnabled": "false", "supportedSubmitMethods": [] }

--- a/providers/keycloak/docs/api-ref/token-api-ref.rst
+++ b/providers/keycloak/docs/api-ref/token-api-ref.rst
@@ -19,4 +19,7 @@
 Keycloak auth manager token API
 ===============================
 
-It's a stub file. It will be automatically converted during the build process into valid documentation by the Sphinx plugin. See: /docs/conf.py
+.. swagger-plugin:: ../../src/airflow/providers/keycloak/auth_manager/openapi/v2-keycloak-auth-manager-generated.yaml
+    :id: keycloak-auth-manager-api-ref
+    :page-title: Keycloak auth manager token API
+    :swagger-options: { "tryItOutEnabled": "false", "supportedSubmitMethods": [] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1541,6 +1541,9 @@ apache-aurflow-docker-stack = false
 # this override is redundant and should be deleted along with the line below.
 starlette = "6 hours"
 
+# TEMP, remove prior merge
+swagger-plugin-for-sphinx = "2 hours"
+
 [tool.uv.pip]
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
 exclude-newer = "4 days"
@@ -1684,6 +1687,9 @@ apache-aurflow-docker-stack = false
 # `[tool.uv.exclude-newer-package]` above for rationale.
 # REMOVE BY 2026-05-26 along with the matching entry above.
 starlette = "6 hours"
+
+# TEMP, remove prior merge
+swagger-plugin-for-sphinx = "2 hours"
 
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1541,8 +1541,9 @@ apache-aurflow-docker-stack = false
 # this override is redundant and should be deleted along with the line below.
 starlette = "6 hours"
 
-# TEMP, remove prior merge
-swagger-plugin-for-sphinx = "2 hours"
+# REMOVE BY 2026-05-31 — once 7.1.0 is older than the global 4-day cooldown
+# this override is redundant and should be deleted along with the line below.
+swagger-plugin-for-sphinx = "8 hours"
 
 [tool.uv.pip]
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
@@ -1688,8 +1689,8 @@ apache-aurflow-docker-stack = false
 # REMOVE BY 2026-05-26 along with the matching entry above.
 starlette = "6 hours"
 
-# TEMP, remove prior merge
-swagger-plugin-for-sphinx = "2 hours"
+# REMOVE BY 2026-05-31 along with the matching entry above.
+swagger-plugin-for-sphinx = "8 hours"
 
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -2450,7 +2450,6 @@ docs = [
     { name = "pagefind" },
     { name = "pagefind-bin" },
     { name = "rich-click" },
-    { name = "setuptools" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2472,9 +2471,9 @@ docs = [
     { name = "sphinxcontrib-jsmath" },
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-redoc" },
     { name = "sphinxcontrib-serializinghtml" },
     { name = "sphinxcontrib-spelling" },
+    { name = "swagger-plugin-for-sphinx" },
 ]
 docs-gen = [
     { name = "diagrams" },
@@ -2643,7 +2642,6 @@ requires-dist = [
     { name = "ruff", specifier = "==0.15.14" },
     { name = "semver", specifier = ">=3.0.2" },
     { name = "semver", marker = "extra == 'devscripts'", specifier = ">=3.0.2" },
-    { name = "setuptools", marker = "extra == 'docs'", specifier = "<82.0.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7" },
     { name = "sphinx-airflow-theme", marker = "extra == 'docs'", url = "https://airflow.apache.org/sphinx-airflow-theme/sphinx_airflow_theme-0.3.10-py3-none-any.whl" },
     { name = "sphinx-argparse", marker = "extra == 'docs'", specifier = ">=0.4.0" },
@@ -2661,11 +2659,11 @@ requires-dist = [
     { name = "sphinxcontrib-jsmath", marker = "extra == 'docs'", specifier = ">=1.0.1" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0.0" },
     { name = "sphinxcontrib-qthelp", marker = "extra == 'docs'", specifier = ">=1.0.3" },
-    { name = "sphinxcontrib-redoc", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "sphinxcontrib-serializinghtml", marker = "extra == 'docs'", specifier = ">=1.1.5" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'docs'", specifier = ">=8.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sqlalchemy'", specifier = ">=1.4.49" },
     { name = "sqlalchemy-utils", marker = "extra == 'sqlalchemy'", specifier = ">=0.41.2" },
+    { name = "swagger-plugin-for-sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "time-machine", extras = ["dateutil"], specifier = ">=3.0.0" },
     { name = "towncrier", marker = "extra == 'devscripts'", specifier = ">=23.11.0" },
     { name = "twine", marker = "extra == 'devscripts'", specifier = ">=4.0.2" },
@@ -21819,21 +21817,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinxcontrib-redoc"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "pyyaml" },
-    { name = "six" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/73/872189269380d0271d575771986db8a77f06bc4565c1a971bebd54f38d2c/sphinxcontrib-redoc-1.6.0.tar.gz", hash = "sha256:e358edbe23927d36432dde748e978cf897283a331a03e93d3ef02e348dee4561", size = 350482, upload-time = "2020-04-17T19:46:48.041Z" }
-
-[[package]]
 name = "sphinxcontrib-serializinghtml"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -22128,6 +22111,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/e1/2d56ec21820cae24a6215dc1d6a224167b0e24368bf53166551064742e0d/svcs-25.1.0.tar.gz", hash = "sha256:64dd74d0c4e8fee79a9ac7550a9d824670b228df390ba1911614e29b59b3f2c2", size = 714086, upload-time = "2025-01-25T13:15:21.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/1c/a6b5d90a9ca479805798276728ccbbdff0c7228e2ea93b1f731779d635e3/svcs-25.1.0-py3-none-any.whl", hash = "sha256:df49cb7d1a05dfd2dd60af1a2cb84b9c3bb0a74728833cb8c54a7ceeecce6c97", size = 19456, upload-time = "2025-01-25T13:15:19.677Z" },
+]
+
+[[package]]
+name = "swagger-plugin-for-sphinx"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jinja2" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/14/36a4b2172fd6496c646d58dcb11c2877e09cc38e6d206eaa822dad0d0eab/swagger_plugin_for_sphinx-7.0.0.tar.gz", hash = "sha256:86a18b9ec1da2b78a80772fbd5d10549bf393b072f07da9edb5d1eaac02b8d44", size = 106931, upload-time = "2026-02-20T09:10:17.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/2d/534436c46a992b8f31bb56e591422519e218b970db1d596ff96142776613/swagger_plugin_for_sphinx-7.0.0-py3-none-any.whl", hash = "sha256:e5207f385f5061bf05eb37355a3a83794bab6e41c5404f5cf4905b90efc9684f", size = 11170, upload-time = "2026-02-20T09:10:15.479Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -107,6 +107,7 @@ apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
+swagger-plugin-for-sphinx = { timestamp = "0001-01-01T00:00:00Z", span = "PT2H" }
 apache-airflow-kubernetes-tests = false
 apache-airflow-providers-grpc = false
 apache-airflow-providers-apache-druid = false
@@ -2663,7 +2664,7 @@ requires-dist = [
     { name = "sphinxcontrib-spelling", marker = "extra == 'docs'", specifier = ">=8.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sqlalchemy'", specifier = ">=1.4.49" },
     { name = "sqlalchemy-utils", marker = "extra == 'sqlalchemy'", specifier = ">=0.41.2" },
-    { name = "swagger-plugin-for-sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
+    { name = "swagger-plugin-for-sphinx", marker = "extra == 'docs'", specifier = ">=7.1.0" },
     { name = "time-machine", extras = ["dateutil"], specifier = ">=3.0.0" },
     { name = "towncrier", marker = "extra == 'devscripts'", specifier = ">=23.11.0" },
     { name = "twine", marker = "extra == 'devscripts'", specifier = ">=4.0.2" },
@@ -22115,7 +22116,7 @@ wheels = [
 
 [[package]]
 name = "swagger-plugin-for-sphinx"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -22126,9 +22127,9 @@ dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/14/36a4b2172fd6496c646d58dcb11c2877e09cc38e6d206eaa822dad0d0eab/swagger_plugin_for_sphinx-7.0.0.tar.gz", hash = "sha256:86a18b9ec1da2b78a80772fbd5d10549bf393b072f07da9edb5d1eaac02b8d44", size = 106931, upload-time = "2026-02-20T09:10:17.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/00/1b2ea76705a887b47d2ba1fa38bb01222431697e6fd020f25c95d6a44615/swagger_plugin_for_sphinx-7.1.0.tar.gz", hash = "sha256:8a054d69600767721f8920f90f87e9078e1736d8c89a6fe74d38ea930f95c9e2", size = 118298, upload-time = "2026-05-27T08:10:11.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/2d/534436c46a992b8f31bb56e591422519e218b970db1d596ff96142776613/swagger_plugin_for_sphinx-7.0.0-py3-none-any.whl", hash = "sha256:e5207f385f5061bf05eb37355a3a83794bab6e41c5404f5cf4905b90efc9684f", size = 11170, upload-time = "2026-02-20T09:10:15.479Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/14/43f25438e93fd40f172535b0fac0ab2a4827e13a74f62c35860ba04fc891/swagger_plugin_for_sphinx-7.1.0-py3-none-any.whl", hash = "sha256:1a6369c6e9ee5bca88c11a327e58c134a457401a6a7f8bb97e166d3a2568d4d7", size = 11644, upload-time = "2026-05-27T08:10:10.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
As we have the Sphinx-Redoc issue with setuptools still not fixed and it seems the plugin is not maintained (see https://github.com/sphinx-contrib/redoc/pull/54) this PR attempts to replace it with swagger. As this is better maintained.

What is does:

- Remove redoc, allows to bump setuptools again! (<-- Wohoo!!!)
- Add swagger rendering from another lib (see https://pypi.org/project/swagger-plugin-for-sphinx/)
- Adjust to mirror swagger code into the doctree for privacy
- Adjust core, simple-auth-manager, fab and keycloak to new doc rendering
- Add Edge REST API generation

Note:

- Need to reduce cooldown to 8h for swagger-plugin-for-sphinx - or we need to wait for another 3.5. days to merge
- Is it okay to adjust this or discussion on devlist needed?

Some examples on Staged Docs server:

- Airflow Core: https://airflow.staged.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html
- Simple Auth Manager API: https://airflow.staged.apache.org/docs/apache-airflow/stable/core-concepts/auth-manager/simple/sam-token-api-ref.html
- FAB: https://airflow.staged.apache.org/docs/apache-airflow-providers-fab/stable/api-ref/fab-api-ref.html
- Keycloak: https://airflow.staged.apache.org/docs/apache-airflow-providers-keycloak/stable/api-ref/token-api-ref.html
- Edge3 (new! in this PR, now also has API docs!): https://airflow.staged.apache.org/docs/apache-airflow-providers-edge3/stable/edge-api-ref.html

New look as screenshot: 

<img width="1920" height="1058" alt="image" src="https://github.com/user-attachments/assets/6b29e053-76b8-451e-80cf-3010d7b6ae47" />

<img width="1920" height="1058" alt="image" src="https://github.com/user-attachments/assets/98615e49-ac8b-4f9e-9d6c-eaf69309c736" />



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
