### PR TITLE
Restore Monaco find widget in Dag Code view

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -25,13 +25,13 @@ type MonacoEnvironment = {
 let configurationPromise: Promise<void> | undefined;
 
 const loadMonacoModules = async () => {
-  // `editor.api` is API-only — also load the folding contribution so `editor.foldAll` /
-  // `editor.unfoldAll` actions and the fold-gutter UI are actually registered, and the
-  // codicon styles so the gutter glyph (the `>` arrow) renders instead of an empty box.
-  // The CDN bundle used to pull these in transitively; the local ESM `editor.api` does not.
+  // `editor.api` is API-only — the contribs/styles below must be side-effect imported
+  // to register their actions and render their glyphs. The CDN bundle pulled these in
+  // transitively; the local ESM build does not.
   const monacoApi = Promise.all([
     import("monaco-editor/esm/vs/editor/editor.api"),
     import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
+    import("monaco-editor/esm/vs/editor/contrib/find/browser/findController"),
     import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Cmd/Ctrl+F in the Dag Code view opened the browser's native find bar instead of Monaco's find widget, and the widget icons rendered incorrectly in `DEV_MODE=true`.

## Root cause

* `configureMonaco.ts` imported only `editor.api`, which does not include
  the standalone find contribution or codicon font styles.

## Fix

* Explicitly import `findController` in
  `configureMonaco.ts`.

## Before
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/9cd9260f-bdd1-4d42-84da-702e185928f5" />


## After
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/3b4bf8d6-597f-4c60-ab87-ab93964ed474" />


part of: #67359



<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

opus 4.7

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
