### PR TITLE
Clarify AssetAlias usage

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -360,12 +360,18 @@ The shorthand for this is ``@asset.multi``:
 
 Dynamic data events emitting and asset creation through AssetAlias
 -----------------------------------------------------------------------
-An asset alias can be used to emit asset events of assets with association to the aliases. Downstreams can depend on resolved asset. This feature allows you to define complex dependencies for Dag executions based on asset updates.
+Use ``AssetAlias`` when a task must declare an asset dependency before the concrete asset URI is
+known. The alias is listed in ``outlets`` as a stable name, and the task resolves it at runtime by
+adding one or more concrete ``Asset`` objects through ``outlet_events`` or yielded ``Metadata``.
+Downstream Dags can depend on the alias, and Airflow triggers them when events are emitted for the
+resolved assets.
 
 How to use AssetAlias
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``AssetAlias`` has one single argument ``name`` that uniquely identifies the asset. The task must first declare the alias as an outlet, and use ``outlet_events`` or yield ``Metadata`` to add events to it.
+``AssetAlias`` has one single argument ``name`` that uniquely identifies the alias. The task must
+first declare the alias as an outlet, and then use ``outlet_events`` or yield ``Metadata`` during
+execution to associate the alias with the concrete assets it produced.
 
 The following example creates an asset event against the S3 URI ``f"s3://bucket/my-task"``  with optional extra information ``extra``. If the asset does not exist, Airflow will dynamically create it and log a warning message.
 

--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -362,7 +362,7 @@ Dynamic data events emitting and asset creation through AssetAlias
 -----------------------------------------------------------------------
 Use ``AssetAlias`` when a task must declare an asset dependency before the Asset's fixed attributes
 (like URI or name) are available. The alias is listed in ``outlets`` as a stable name, and the task
-resolves it at runtime byadding one or more concrete ``Asset`` objects through ``outlet_events`` or
+resolves it at runtime by adding one or more concrete ``Asset`` objects through ``outlet_events`` or
 yielded ``Metadata``. Downstream Dags can depend on the alias, and Airflow triggers them when events
 are emitted for the resolved assets.
 

--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -360,11 +360,11 @@ The shorthand for this is ``@asset.multi``:
 
 Dynamic data events emitting and asset creation through AssetAlias
 -----------------------------------------------------------------------
-Use ``AssetAlias`` when a task must declare an asset dependency before the concrete asset URI is
-known. The alias is listed in ``outlets`` as a stable name, and the task resolves it at runtime by
-adding one or more concrete ``Asset`` objects through ``outlet_events`` or yielded ``Metadata``.
-Downstream Dags can depend on the alias, and Airflow triggers them when events are emitted for the
-resolved assets.
+Use ``AssetAlias`` when a task must declare an asset dependency before the Asset's fixed attributes
+(like URI or name) are available. The alias is listed in ``outlets`` as a stable name, and the task
+resolves it at runtime byadding one or more concrete ``Asset`` objects through ``outlet_events`` or
+yielded ``Metadata``. Downstream Dags can depend on the alias, and Airflow triggers them when events
+are emitted for the resolved assets.
 
 How to use AssetAlias
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Closes #52250. Clarifies when to use AssetAlias: when the concrete asset URI is only known at runtime, while the task still needs to declare a stable outlet dependency. Validation: git diff --check for airflow-core/docs/authoring-and-scheduling/assets.rst and targeted text search.

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=bc661fc action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Will-thom** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@Lee-W`, `@RNHTTR` is waiting on you:
> - 3 unresolved review thread(s) from `@Lee-W`, `@RNHTTR` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->