### PR TITLE
Handle no next run in dags next-execution --table

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -368,7 +368,18 @@ def dag_next_execution(args) -> None:
         else:
             columns = ["logical_date", "data_interval.start", "data_interval.end", "run_after"]
         getters = [(c, operator.attrgetter(c)) for c in columns]
-        AirflowConsole().print_as_table([{n: f(o) for n, f in getters} for o in iter_next_dagrun_info()])
+        rows = []
+        for info in iter_next_dagrun_info():
+            if info is None:
+                print(
+                    "[WARN] No following schedule can be found. "
+                    "This DAG may have schedule interval '@once' or `None`.",
+                    file=sys.stderr,
+                )
+                break
+            rows.append({n: f(info) for n, f in getters})
+        if rows:
+            AirflowConsole().print_as_table(rows)
         return
 
     if args.field:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -272,14 +272,17 @@ class TestCliDags:
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
-    def test_next_execution_table_with_no_schedule(self, tmp_path, capsys):
+    def test_next_execution_table_with_no_schedule(self, tmp_path, stdout_capture, stderr_capture):
         dag_id = "future_schedule_none_table"
         file_content = os.linesep.join(
             [
                 "from airflow import DAG",
                 "from airflow.providers.standard.operators.empty import EmptyOperator",
                 "from datetime import timedelta; from pendulum import today",
-                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=5), schedule=None, catchup=True)",
+                (
+                    f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=5), "
+                    "schedule=None, catchup=True)"
+                ),
                 "task = EmptyOperator(task_id='empty_task',dag=dag)",
             ]
         )
@@ -290,24 +293,32 @@ class TestCliDags:
             clear_db_dags()
             parse_and_sync_to_db(tmp_path, include_examples=False)
 
-        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table"])
-        dag_command.dag_next_execution(args)
-        captured = capsys.readouterr()
+        with stdout_capture as temp_stdout:
+            with stderr_capture as temp_stderr:
+                args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table"])
+                dag_command.dag_next_execution(args)
+                out = temp_stdout.getvalue()
+                err = temp_stderr.getvalue()
 
-        assert captured.out == ""
-        assert "[WARN] No following schedule can be found." in captured.err
+        assert out == ""
+        assert "[WARN] No following schedule can be found." in err
 
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
-    def test_next_execution_table_with_once_and_multiple_executions(self, tmp_path, capsys):
+    def test_next_execution_table_with_once_and_multiple_executions(
+        self, tmp_path, stdout_capture, stderr_capture
+    ):
         dag_id = "past_schedule_once_table"
         file_content = os.linesep.join(
             [
                 "from airflow import DAG",
                 "from airflow.providers.standard.operators.empty import EmptyOperator",
                 "from datetime import timedelta; from pendulum import today",
-                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=-5), schedule='@once', catchup=True)",
+                (
+                    f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=-5), "
+                    "schedule='@once', catchup=True)"
+                ),
                 "task = EmptyOperator(task_id='empty_task',dag=dag)",
             ]
         )
@@ -318,14 +329,17 @@ class TestCliDags:
             clear_db_dags()
             parse_and_sync_to_db(tmp_path, include_examples=False)
 
-        args = self.parser.parse_args(
-            ["dags", "next-execution", dag_id, "--table", "--num-executions", "2"]
-        )
-        dag_command.dag_next_execution(args)
-        captured = capsys.readouterr()
+        with stdout_capture as temp_stdout:
+            with stderr_capture as temp_stderr:
+                args = self.parser.parse_args(
+                    ["dags", "next-execution", dag_id, "--table", "--num-executions", "2"]
+                )
+                dag_command.dag_next_execution(args)
+                out = temp_stdout.getvalue()
+                err = temp_stderr.getvalue()
 
-        assert dec_27.isoformat() in captured.out
-        assert "[WARN] No following schedule can be found." in captured.err
+        assert str(dec_27) in out
+        assert "[WARN] No following schedule can be found." in err
 
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -272,6 +272,64 @@ class TestCliDags:
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
+    def test_next_execution_table_with_no_schedule(self, tmp_path, capsys):
+        dag_id = "future_schedule_none_table"
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from datetime import timedelta; from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=5), schedule=None, catchup=True)",
+                "task = EmptyOperator(task_id='empty_task',dag=dag)",
+            ]
+        )
+        dag_file = tmp_path / f"{dag_id}.py"
+        dag_file.write_text(file_content)
+
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
+
+        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table"])
+        dag_command.dag_next_execution(args)
+        captured = capsys.readouterr()
+
+        assert captured.out == ""
+        assert "[WARN] No following schedule can be found." in captured.err
+
+        clear_db_dags()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
+
+    def test_next_execution_table_with_once_and_multiple_executions(self, tmp_path, capsys):
+        dag_id = "past_schedule_once_table"
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from datetime import timedelta; from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=-5), schedule='@once', catchup=True)",
+                "task = EmptyOperator(task_id='empty_task',dag=dag)",
+            ]
+        )
+        dag_file = tmp_path / f"{dag_id}.py"
+        dag_file.write_text(file_content)
+
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
+
+        args = self.parser.parse_args(
+            ["dags", "next-execution", dag_id, "--table", "--num-executions", "2"]
+        )
+        dag_command.dag_next_execution(args)
+        captured = capsys.readouterr()
+
+        assert dec_27.isoformat() in captured.out
+        assert "[WARN] No following schedule can be found." in captured.err
+
+        clear_db_dags()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
+
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_report(self, stdout_capture):
         args = self.parser.parse_args(["dags", "report", "--output", "json"])


### PR DESCRIPTION
## What this does

- handle the `None` sentinel in `airflow dags next-execution --table`
- stop building table rows once there is no following schedule
- add regression tests for `schedule=None` and `@once` with `--num-executions 2 --table`

## Why

The non-table path already handles the "no next run" case, but the table path iterated over `DagRunInfo | None` and applied attribute getters unconditionally. That could raise when a DAG has `schedule=None`, or when an `@once` DAG is asked for additional executions.

Closes #67394.

## Testing

- Not run (not requested in this local workflow)


<!-- pr-triage-fold: triaged=2026-07-18T16:36:56Z head=b40e94a action=strip -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @fallintoplace** · by `@potiuk` · 2026-07-18 16:36 UTC
>
> I've removed the `ready for maintainer review` label — the next step here is yours:
> - :x: **Merge conflicts** with `main`. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> It'll return to the maintainer queue automatically once resolved — no need to re-add the label by hand. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for details.
>
> **The ball is in your court** — you've been assigned. Rebase onto `main`, push, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
