### PR TITLE
fix(openlineage): self-heal ProcessPoolExecutor on BrokenProcessPool

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from concurrent.futures.process import BrokenProcessPool
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from concurrent.futures.process import BrokenProcessPool
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from functools import cache
@@ -1049,7 +1050,15 @@ class OpenLineageListener:
             self.log.warning("OpenLineage received exception in method on_dag_run_failed", exc_info=e)
 
     def submit_callable(self, callable, *args, **kwargs):
-        fut = self.executor.submit(callable, *args, **kwargs)
+        try:
+            fut = self.executor.submit(callable, *args, **kwargs)
+        except BrokenProcessPool:
+            self.log.warning(
+                "ProcessPoolExecutor is broken; recreating and retrying submission."
+            )
+            self._executor.shutdown(wait=False)
+            self._executor = None
+            fut = self.executor.submit(callable, *args, **kwargs)
         fut.add_done_callback(self.log_submit_error)
         return fut
 

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -1053,9 +1053,7 @@ class OpenLineageListener:
         try:
             fut = self.executor.submit(callable, *args, **kwargs)
         except BrokenProcessPool:
-            self.log.warning(
-                "ProcessPoolExecutor is broken; recreating and retrying submission."
-            )
+            self.log.warning("ProcessPoolExecutor is broken; recreating and retrying submission.")
             self._executor.shutdown(wait=False)
             self._executor = None
             fut = self.executor.submit(callable, *args, **kwargs)

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -2128,6 +2128,38 @@ class TestOpenLineageListenerAirflow3:
         listener.log.debug.assert_not_called()
         listener.log.warning.assert_called_once()
 
+    def test_submit_callable_recreates_executor_on_broken_pool(self):
+        """When a child process dies and BrokenProcessPool is raised, the
+        listener should shut down the broken executor, create a fresh one, and
+        retry the submission."""
+        from concurrent.futures.process import BrokenProcessPool
+
+        listener = OpenLineageListener()
+        broken_executor = MagicMock()
+        broken_executor.submit.side_effect = BrokenProcessPool()
+        new_executor = MagicMock()
+        new_future = MagicMock()
+        new_executor.submit.return_value = new_future
+
+        listener._executor = broken_executor
+        listener.log = MagicMock()
+
+        def dummy_callable():
+            pass
+
+        with mock.patch(
+            "airflow.providers.openlineage.plugins.listener.ProcessPoolExecutor",
+            return_value=new_executor,
+        ):
+            fut = listener.submit_callable(dummy_callable, "arg1", kwarg1="val1")
+
+        broken_executor.shutdown.assert_called_once_with(wait=False)
+        new_executor.submit.assert_called_once_with(dummy_callable, "arg1", kwarg1="val1")
+        new_future.add_done_callback.assert_called_once_with(listener.log_submit_error)
+        assert fut is new_future
+        listener.log.warning.assert_called_once()
+        assert "recreating" in listener.log.warning.call_args[0][0]
+
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 tests")
 class TestOpenLineageSelectiveEnableAirflow2:


### PR DESCRIPTION
## Summary

The OpenLineage listener uses a `ProcessPoolExecutor` to asynchronously emit lineage events from the scheduler. When a child process in the pool terminates abruptly, Python's `concurrent.futures` marks the pool as permanently broken. After that point, every subsequent OpenLineage event fails with `BrokenProcessPool` and lineage data stops flowing indefinitely — only a scheduler restart recovers it.

## Fix

`submit_callable` now catches `BrokenProcessPool`, shuts down the broken executor, creates a fresh one, and retries the submission. This makes the listener self-healing: lineage reporting recovers automatically without a scheduler restart.

### Changes

- `listener.py`: catch `BrokenProcessPool` in `submit_callable`, recreate the executor, and retry
- `test_listener.py`: add `test_submit_callable_recreates_executor_on_broken_pool` that verifies the broken pool is shut down, a new executor is created, and the submission is retried

## Test Plan

- [x] New unit test passes
- [x] All existing OpenLineage listener unit tests pass (26 passed, 35 skipped, 0 failed)

Closes #67283
