### PR TITLE
Fix time DAG param submissions to include seconds

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -23,6 +23,8 @@ import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 import type { FlexibleFormElementProps } from ".";
 import { DateTimeInput } from "../DateTimeInput";
 
+const normalizeTimeValue = (value: string) => (/^\d{2}:\d{2}$/u.test(value) ? `${value}:00` : value);
+
 export const FieldDateTime = ({
   name,
   namespace = "default",
@@ -32,13 +34,15 @@ export const FieldDateTime = ({
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
+    const fieldValue = rest.type === "time" ? normalizeTimeValue(value) : value;
+
     // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
     if (paramsDict[name]) {
-      paramsDict[name].value = value === "" ? null : value;
+      paramsDict[name].value = fieldValue === "" ? null : fieldValue;
     }
 
     setParamsDict(paramsDict);
-    onUpdate(value);
+    onUpdate(fieldValue);
   };
 
   if (rest.type === "datetime-local") {
@@ -62,6 +66,7 @@ export const FieldDateTime = ({
       onChange={(event) => handleChange(event.target.value)}
       required={rest.required}
       size="sm"
+      step={rest.type === "time" ? 1 : undefined}
       type={rest.type}
       value={((param.value ?? "") as string).slice(0, 16)}
     />

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
@@ -34,20 +34,18 @@ type TestParam = {
   value: string;
 };
 
-const dagParams = vi.hoisted(
-  (): { paramsDict: Record<string, TestParam> } => ({
-    paramsDict: {
-      message: {
-        description: "Message",
-        schema: {
-          title: "Message",
-          type: "string",
-        },
-        value: "Hello",
+const dagParams = vi.hoisted((): { paramsDict: Record<string, TestParam> } => ({
+  paramsDict: {
+    message: {
+      description: "Message",
+      schema: {
+        title: "Message",
+        type: "string",
       },
+      value: "Hello",
     },
-  }),
-);
+  },
+}));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -183,7 +181,9 @@ describe("TriggerDAGForm", () => {
     );
 
     await waitFor(() =>
-      expect(container.querySelector<HTMLInputElement>('input[name="element_cutoff_time"]')).toBeInTheDocument(),
+      expect(
+        container.querySelector<HTMLInputElement>('input[name="element_cutoff_time"]'),
+      ).toBeInTheDocument(),
     );
     const timeField = container.querySelector<HTMLInputElement>('input[name="element_cutoff_time"]');
 

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
@@ -18,24 +18,36 @@
  */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
 
 import TriggerDAGForm from "./TriggerDAGForm";
 
-const dagParams = vi.hoisted(() => ({
-  paramsDict: {
-    message: {
-      description: "Message",
-      schema: {
-        title: "Message",
-        type: "string",
+type TestParam = {
+  description: string;
+  schema: {
+    format?: string;
+    title: string;
+    type: string;
+  };
+  value: string;
+};
+
+const dagParams = vi.hoisted(
+  (): { paramsDict: Record<string, TestParam> } => ({
+    paramsDict: {
+      message: {
+        description: "Message",
+        schema: {
+          title: "Message",
+          type: "string",
+        },
+        value: "Hello",
       },
-      value: "Hello",
     },
-  },
-}));
+  }),
+);
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -83,6 +95,19 @@ vi.mock("../JsonEditor", () => ({
 }));
 
 describe("TriggerDAGForm", () => {
+  beforeEach(() => {
+    dagParams.paramsDict = {
+      message: {
+        description: "Message",
+        schema: {
+          title: "Message",
+          type: "string",
+        },
+        value: "Hello",
+      },
+    };
+  });
+
   it("syncs Advanced Options JSON after Run Parameters edits in prefilled re-trigger mode", async () => {
     const { container } = render(
       <TriggerDAGForm
@@ -126,6 +151,59 @@ describe("TriggerDAGForm", () => {
       }
 
       expect(configJson.value).toContain('"Updated message"');
+    });
+  });
+
+  it("submits time params with seconds when browser time inputs omit them", async () => {
+    dagParams.paramsDict = {
+      cutoff_time: {
+        description: "Cutoff time",
+        schema: {
+          format: "time",
+          title: "Cutoff time",
+          type: "string",
+        },
+        value: "07:30:00",
+      },
+    };
+
+    const { container } = render(
+      <TriggerDAGForm
+        dagDisplayName="Params Trigger UI"
+        dagId="example_params_trigger_ui"
+        error={undefined}
+        hasSchedule={false}
+        isPartitioned={false}
+        isPaused={false}
+        isPending={false}
+        onSubmitTrigger={vi.fn()}
+        open
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector<HTMLInputElement>('input[name="element_cutoff_time"]')).toBeInTheDocument(),
+    );
+    const timeField = container.querySelector<HTMLInputElement>('input[name="element_cutoff_time"]');
+
+    if (timeField === null) {
+      throw new Error("Expected time input to be rendered");
+    }
+
+    expect(timeField).toHaveAttribute("step", "1");
+
+    fireEvent.change(timeField, { target: { value: "19:30" } });
+    fireEvent.click(screen.getByText("Advanced Options"));
+
+    await waitFor(() => {
+      const configJson = screen.getByLabelText("Configuration JSON");
+
+      if (!(configJson instanceof HTMLTextAreaElement)) {
+        throw new TypeError("Expected Configuration JSON to render as a textarea");
+      }
+
+      expect(configJson.value).toContain('"cutoff_time": "19:30:00"');
     });
   });
 });


### PR DESCRIPTION
Fixes #66492.\n\n## What\n- Set DAG param time inputs to second precision with `step=1`.\n- Normalize browser minute-only time values from `HH:MM` to `HH:MM:SS` before syncing trigger form config.\n- Add trigger form regression coverage for `format="time"` params.\n\n## Tests\n- `./node_modules/.bin/vitest run src/components/TriggerDag/TriggerDAGForm.test.tsx`\n- `./node_modules/.bin/eslint src/components/FlexibleForm/FieldDateTime.tsx src/components/TriggerDag/TriggerDAGForm.test.tsx`\n- `./node_modules/.bin/tsc --p tsconfig.app.json`