### PR TITLE
Filter stale DAG tags from tag endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
@@ -37,7 +37,7 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.dag_tags import DAGTagCollectionResponse
 from airflow.api_fastapi.core_api.security import ReadableTagsFilterDep, requires_access_dag
-from airflow.models.dag import DagTag
+from airflow.models.dag import DagModel, DagTag
 
 dag_tags_router = AirflowRouter(tags=["DAG"], prefix="/dagTags")
 
@@ -61,7 +61,12 @@ def get_dag_tags(
     session: SessionDep,
 ) -> DAGTagCollectionResponse:
     """Get all Dag tags."""
-    query = select(DagTag.name).group_by(DagTag.name)
+    query = (
+        select(DagTag.name)
+        .join(DagModel, DagModel.dag_id == DagTag.dag_id)
+        .where(DagModel.is_stale.is_(False))
+        .group_by(DagTag.name)
+    )
     dag_tags_select, total_entries = paginated_select(
         statement=query,
         filters=[tag_name_pattern, tag_name_prefix_pattern, readable_tags_filter],

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
@@ -99,9 +99,10 @@ class TestDagEndpoint:
         session.add(dagrun_success)
 
     def _create_dag_tags(self, session=None):
+        session.add(DagTag(dag_id=DAG1_ID, name="tag_1"))
         session.add(DagTag(dag_id=DAG1_ID, name="tag_2"))
-        session.add(DagTag(dag_id=DAG2_ID, name="tag_1"))
         session.add(DagTag(dag_id=DAG3_ID, name="tag_1"))
+        session.add(DagTag(dag_id=DAG3_ID, name="stale_only"))
 
     @pytest.fixture(autouse=True)
     @provide_session


### PR DESCRIPTION
Fixes #66827.

The DAG list excludes stale DAGs by default, but the DAG tags endpoint queried distinct names directly from dag_tag. This joins through DagModel and filters out stale DAG rows so tags belonging only to removed DAGs no longer appear in the UI tag dropdown.

Tests:
- uv run --no-default-groups --with-editable ./airflow-core --with-editable ./devel-common --with-editable ./providers/standard --with-editable ./providers/git --with pytest --with pytest-mock --with httpx --with time-machine --with freezegun --with sqlalchemy-utils pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
- uv run --no-default-groups --with ruff ruff check airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py

Note: Full default uv test environment was not used because apache-airflow[all] pulls JDBC/jpype1 and this machine has no Java runtime.