### PR TITLE
Reduce required bug report fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
@@ -34,8 +34,6 @@ body:
         - "Airflow Core"
         - "Helm chart"
         - "Task SDK"
-    validations:
-      required: true
   - type: input
     attributes:
       label: Apache Airflow version
@@ -251,8 +249,6 @@ body:
         - "1.0.0"
         - "main (development)"
       default: 0
-    validations:
-      required: true
   - type: input
     attributes:
       label: Kubernetes Version


### PR DESCRIPTION
## Summary
- make the bug report category optional
- make the Helm chart version optional unless reporters have Helm chart context to share
- keep Airflow version, reproduction details, and Code of Conduct required

closes: #55840

## Testing
- Parsed .github/ISSUE_TEMPLATE/1-airflow_bug_report.yml with PyYAML
- git diff --check