### PR TITLE
Improve DAG toggle contrast in dark mode

### DIFF
--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -382,6 +382,15 @@ const defaultAirflowTheme: ThemingConfig = {
     },
     switch: {
       slots: [],
+      base: {
+        control: {
+          borderColor: { _dark: "border.emphasized", _light: "transparent" },
+          borderWidth: "1px",
+          _checked: {
+            borderColor: "colorPalette.solid",
+          },
+        },
+      },
       defaultVariants: { size: "sm" } as Record<string, string>,
     },
     // size="sm" gives px/py:2 on cell and columnHeader vs px/py:3 for "md".


### PR DESCRIPTION
## What

Improve dark-mode switch contrast by adding a dark-mode border to the shared Chakra switch control. The checked state keeps using the existing color palette token, while the unchecked/off state gains a visible outline on dark surfaces.

This addresses the DAG pause toggle contrast reported in #66759.

## Why

In dark mode, the unchecked switch track can blend into the surrounding dark background, making paused/off DAG toggles hard to distinguish. A token-based border makes the switch shape clearer without introducing new colors or changing light-mode behavior.

## Tests

- `pnpm exec eslint src/theme.ts`
- `pnpm exec tsc --p tsconfig.app.json --pretty false`
- `pnpm build`

## Screenshots

I could not capture a full Airflow DAG-list screenshot from the raw Vite dev shell because that shell depends on Airflow backend-provided base/config values to render the app. The change is limited to the theme recipe and was verified with the focused static checks and production build above.

---

closes: #66759

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)