### PR TITLE
Clarify Breeze usage in GitHub Codespaces

### DIFF
--- a/contributing-docs/03a_contributors_quick_start_beginners.rst
+++ b/contributing-docs/03a_contributors_quick_start_beginners.rst
@@ -46,6 +46,7 @@ For Breeze (local development):
 .. code-block:: bash
 
     curl -LsSf https://astral.sh/uv/install.sh | sh
+
 * `Prek <https://github.com/j178/prek>`__, which runs Airflow's required code-quality checks (formatting, linting, and bug-spotting) before you commit, helping save contributors and committers time during the pull request process.
 
 .. code-block:: bash
@@ -175,7 +176,7 @@ Option B – One-Click GitHub Codespaces
    (Command Palette → *Codespaces: Rebuild Container*) or restarting
    the Codespace from the GitHub Codespaces dashboard.
 
-5. Install Breeze and start the development container
+5. Install the local development tools
 
 .. code-block:: bash
 
@@ -185,7 +186,12 @@ Option B – One-Click GitHub Codespaces
       prek install -f --hook-type pre-push # for running mypy checks when pushing to repo
       ./scripts/tools/setup_breeze
       uv run dev/ide_setup/setup_vscode.py
-      breeze start-airflow
+
+   The Codespace terminal is already running inside the Airflow devcontainer/Breeze
+   environment. Do not run ``breeze start-airflow`` from a ``[Breeze:...]`` prompt
+   or another shell inside the devcontainer. That command starts Docker containers
+   and is intended to be run from the outer host shell with access to the Docker
+   socket.
 
 6. Edit a file in the editor, save, and commit via the Source Control sidebar.
    Push when prompted.

--- a/contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst
+++ b/contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst
@@ -39,8 +39,14 @@ Setup and develop using GitHub Codespaces
        :target: https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=33884891
        :alt: Open in GitHub Codespaces
 
-3. Once the codespace starts your terminal should already be in the ``Breeze`` environment and you should
-   be able to edit and run the tests in VS Code interface.
+3. Once the codespace starts your terminal should already be in the Airflow
+   devcontainer/Breeze environment and you should be able to edit and run the
+   tests in VS Code interface.
+
+   If your prompt starts with ``[Breeze:...]``, you are already inside the
+   containerized development environment. Do not run ``breeze start-airflow`` from
+   that prompt. ``breeze start-airflow`` starts Docker containers and is intended
+   to be run from the outer host shell with access to the Docker socket.
 
 4. You can use `Quick start guide for Visual Studio Code <contributors_quick_start_vscode.rst>`_ for details
    as Codespaces use Visual Studio Code as interface.
@@ -49,7 +55,11 @@ Setup and develop using GitHub Codespaces
 Troubleshooting Docker in Codespaces
 -------------------------------------
 
-If you see a "Docker is not running" error when running Breeze commands, try these steps:
+If you see a "Docker is not running" error when running Breeze commands, first
+check where the command is being run. In Codespaces the terminal is already
+inside the Airflow devcontainer/Breeze environment. Commands that start another
+set of containers, such as ``breeze start-airflow``, should be run outside that
+container context.
 
 1. Verify that Docker is accessible by running:
 
@@ -57,19 +67,31 @@ If you see a "Docker is not running" error when running Breeze commands, try the
 
       docker info
 
-2. If the command fails, check that the Docker socket exists:
+   If the output reports that the Docker client API version is too new for the
+   server, set the API version reported by the server and retry the command, for
+   example:
+
+   .. code-block:: bash
+
+      export DOCKER_API_VERSION=1.43
+      docker info
+
+2. If the command fails because Docker cannot connect to the daemon, check that
+   the Docker socket exists:
 
    .. code-block:: bash
 
       ls -la /var/run/docker.sock
 
-3. Check that your user has permission to access Docker:
+3. Check the active Docker context and socket permissions:
 
    .. code-block:: bash
 
+      docker context ls
       groups $USER
+      ls -l /var/run/docker.sock
 
-   You should see ``docker`` in the list. If not, add yourself to the group:
+   You should see ``docker`` in the group list. If not, add yourself to the group:
 
    .. code-block:: bash
 

--- a/dev/breeze/doc/01_installation.rst
+++ b/dev/breeze/doc/01_installation.rst
@@ -63,6 +63,25 @@ Here is an example configuration with more than 200GB disk space for Docker:
 
 **Docker errors that may come while running breeze**
 
+- ``breeze start-airflow`` starts Airflow by launching Docker containers. Run it
+  from the outer host shell that has access to the Docker socket, not from a
+  shell that is already inside the Breeze container or a Codespaces
+  devcontainer. In Codespaces, a ``[Breeze:...]`` prompt means you are already
+  inside the containerized development environment.
+
+- If ``docker info`` fails in Codespaces or another devcontainer, check the
+  Docker context, socket, and server API version before changing Breeze:
+
+    .. code-block:: bash
+
+        docker context ls
+        ls -l /var/run/docker.sock
+        docker version
+
+  When the Docker client reports that its API version is too new for the server,
+  set ``DOCKER_API_VERSION`` to the maximum API version reported by the server
+  and retry ``docker info``.
+
 - If docker not running in python virtual environment:
 
     1. Create the docker group if it does not exist: ``sudo groupadd docker``


### PR DESCRIPTION
## Summary
- clarify that Codespaces opens inside the Airflow devcontainer/Breeze environment
- remove `breeze start-airflow` from the Codespaces beginner flow and explain it should be run from the outer host shell with Docker socket access
- add Docker context, socket, and API-version diagnostics for Codespaces/devcontainer failures

Closes: #62405

## Tests
- `git diff --check`
- `uvx --from prek prek run rst-backticks trailing-whitespace end-of-file-fixer check-merge-conflict check-for-inclusive-language --files contributing-docs/03a_contributors_quick_start_beginners.rst contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst dev/breeze/doc/01_installation.rst`
- `uvx --with pygments --from docutils rst2html --halt=2 contributing-docs/quick-start-ide/contributors_quick_start_codespaces.rst /tmp/airflow-codespaces.html`
- `uvx --with pygments --from docutils rst2html --halt=2 dev/breeze/doc/01_installation.rst /tmp/airflow-breeze-install.html`

## Notes
- `uv run prek ...` could not start in this local environment because building `jpype1==1.7.1` requires a Java runtime that is not installed.
- Standalone docutils parsing of `contributing-docs/03a_contributors_quick_start_beginners.rst` is not Sphinx-aware and stops on the existing `:doc:` role, so I validated it with the project prek hooks and `git diff --check`.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, ChatGPT-5

Generated-by: ChatGPT-5 following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions