### PR TITLE
Fix UI docs links for unreleased versions

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.test.tsx
@@ -53,4 +53,15 @@ describe("DocsButton", () => {
 
     expect(await screen.findByText("docs.restApiReference")).toBeInTheDocument();
   });
+
+  it("links dev versions to stable documentation", async () => {
+    render(<DocsButton externalViews={[]} showAPI version="3.2.0.dev0" />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: /nav.docs/iu }));
+
+    expect(await screen.findByLabelText("3.2.0.dev0")).toHaveAttribute(
+      "href",
+      "https://airflow.apache.org/docs/apache-airflow/stable/index.html",
+    );
+  });
 });

--- a/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Nav/DocsButton.tsx
@@ -22,6 +22,7 @@ import { FiBookOpen, FiExternalLink } from "react-icons/fi";
 
 import { Menu } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig";
+import { getAirflowDocsUrl } from "src/utils/links";
 import type { NavItemResponse } from "src/utils/types";
 
 import { NavButton } from "./NavButton";
@@ -56,7 +57,7 @@ export const DocsButton = ({
   const { t: translate } = useTranslation("common");
   const showAPIDocs = Boolean(useConfig("enable_swagger_ui")) && showAPI;
 
-  const versionLink = `https://airflow.apache.org/docs/apache-airflow/${version}/index.html`;
+  const versionLink = getAirflowDocsUrl(version, "index.html");
 
   return (
     <Menu.Root positioning={{ placement: "right" }}>

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.test.tsx
@@ -18,13 +18,25 @@
  */
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type * as OpenApiQueries from "openapi/queries";
 import { Wrapper } from "src/utils/Wrapper";
 
 import { NothingFoundInfo } from "./NothingFoundInfo";
 
+const mockVersion = vi.hoisted(() => ({ version: "3.2.0.dev0" }));
+
+vi.mock("openapi/queries", async (importOriginal) => ({
+  ...(await importOriginal<typeof OpenApiQueries>()),
+  useVersionServiceGetVersion: () => ({ data: mockVersion }),
+}));
+
 describe("NothingFoundInfo", () => {
+  beforeEach(() => {
+    mockVersion.version = "3.2.0.dev0";
+  });
+
   it("should have correct external link attributes", () => {
     render(<NothingFoundInfo />, { wrapper: Wrapper });
 
@@ -32,5 +44,14 @@ describe("NothingFoundInfo", () => {
 
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("links dev versions to stable documentation", () => {
+    render(<NothingFoundInfo />, { wrapper: Wrapper });
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html#visibility-in-ui-and-cli",
+    );
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/NothingFoundInfo.tsx
@@ -20,11 +20,12 @@ import { Box, Text, Link, Stack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import { useVersionServiceGetVersion } from "openapi/queries";
+import { getAirflowDocsUrl } from "src/utils/links";
 
 export const NothingFoundInfo = () => {
   const { t: translate } = useTranslation("admin");
   const { data } = useVersionServiceGetVersion();
-  const docsLink = `https://airflow.apache.org/docs/apache-airflow/${data?.version}/howto/connection.html#visibility-in-ui-and-cli`;
+  const docsLink = getAirflowDocsUrl(data?.version, "howto/connection.html#visibility-in-ui-and-cli");
 
   return (
     <Box textAlign="center">

--- a/airflow-core/src/airflow/ui/src/utils/links.test.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.test.ts
@@ -22,11 +22,30 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 
 import {
   buildTaskInstanceUrl,
+  getAirflowDocsUrl,
   getNextHref,
   getSafeExternalUrl,
   getTaskInstanceAdditionalPath,
   getTaskInstanceLink,
 } from "./links";
+
+describe("getAirflowDocsUrl", () => {
+  it.each([
+    ["3.1.1", "index.html", "https://airflow.apache.org/docs/apache-airflow/3.1.1/index.html"],
+    ["3.2.0", "index.html", "https://airflow.apache.org/docs/apache-airflow/stable/index.html"],
+    ["3.2.0.dev0", "index.html", "https://airflow.apache.org/docs/apache-airflow/stable/index.html"],
+    ["3.2.0a1", "index.html", "https://airflow.apache.org/docs/apache-airflow/stable/index.html"],
+    ["3.2.0b1", "index.html", "https://airflow.apache.org/docs/apache-airflow/stable/index.html"],
+    ["3.2.0rc1", "index.html", "https://airflow.apache.org/docs/apache-airflow/stable/index.html"],
+    [
+      undefined,
+      "howto/connection.html#visibility-in-ui-and-cli",
+      "https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html#visibility-in-ui-and-cli",
+    ],
+  ])("builds a valid docs URL for version %s", (version, page, expected) => {
+    expect(getAirflowDocsUrl(version, page)).toBe(expected);
+  });
+});
 
 describe("getTaskInstanceLink", () => {
   const testCases = [

--- a/airflow-core/src/airflow/ui/src/utils/links.ts
+++ b/airflow-core/src/airflow/ui/src/utils/links.ts
@@ -19,6 +19,20 @@
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { taskInstanceRoutes } from "src/router";
 
+const AIRFLOW_DOCS_BASE_URL = "https://airflow.apache.org/docs/apache-airflow/";
+const STABLE_DOCS_VERSION = "stable";
+
+const getDocsVersion = (version?: string): string => {
+  if (version === undefined || !/^\d+\.\d+\.\d+$/u.test(version) || version.endsWith(".0")) {
+    return STABLE_DOCS_VERSION;
+  }
+
+  return version;
+};
+
+export const getAirflowDocsUrl = (version?: string, page = ""): string =>
+  new URL(`${getDocsVersion(version)}/${page}`, AIRFLOW_DOCS_BASE_URL).href;
+
 export const getTaskInstanceLink = (
   tiOrParams:
     | TaskInstanceResponse


### PR DESCRIPTION
Closes #64541.

## What's changed
- Add a shared UI docs URL helper that falls back to stable docs for unreleased/pre-release Airflow versions.
- Use the helper for the nav docs version link and the connections empty-state docs link.
- Keep external docs links using `target="_blank"` with `rel="noopener noreferrer"`.

## Tests
- `vitest run src/utils/links.test.ts src/layouts/Nav/DocsButton.test.tsx src/pages/Connections/NothingFoundInfo.test.tsx`
- `eslint src/utils/links.ts src/utils/links.test.ts src/layouts/Nav/DocsButton.tsx src/layouts/Nav/DocsButton.test.tsx src/pages/Connections/NothingFoundInfo.tsx src/pages/Connections/NothingFoundInfo.test.tsx`
- `tsc --p tsconfig.app.json --noEmit`

Note: local UI dependencies were provided via a temporary symlink to a sibling worktree install because this worktree did not have `node_modules` and `pnpm` was not installed on PATH.