### PR TITLE
Fix backfill API session handling for SQLite

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -250,6 +250,7 @@ def create_backfill(
             triggering_user_name=user.get_name(),
             reprocess_behavior=backfill_request.reprocess_behavior,
             run_on_latest_version=resolved_run_on_latest,
+            session=session,
         )
         return BackfillResponse.model_validate(backfill_obj)
 

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -24,6 +24,7 @@ Internal classes for management of dag backfills.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from contextlib import nullcontext
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -603,11 +604,13 @@ def _create_backfill(
     triggering_user_name: str | None,
     reprocess_behavior: ReprocessBehavior | None = None,
     run_on_latest_version: bool = False,
+    session: Session | None = None,
 ) -> Backfill:
     from airflow.models import DagModel
     from airflow.models.serialized_dag import SerializedDagModel
 
-    with create_session() as session:
+    session_context = nullcontext(session) if session is not None else create_session()
+    with session_context as session:
         serdag = session.scalar(SerializedDagModel.latest_item_select_object(dag_id))
         if not serdag:
             raise DagNotFound(f"Could not find dag {dag_id}")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -255,6 +255,30 @@ class TestCreateBackfill(TestBackfillEndpoint):
         }
         check_last_log(session, dag_id="TEST_DAG_1", event="create_backfill", logical_date=None)
 
+    def test_create_backfill_uses_request_session(self, session, dag_maker, test_client):
+        with dag_maker(session=session, dag_id="TEST_DAG_1", schedule="0 * * * *") as dag:
+            EmptyOperator(task_id="mytask")
+        session.scalars(select(DagModel)).all()
+        session.commit()
+        data = {
+            "dag_id": dag.dag_id,
+            "from_date": to_iso(pendulum.parse("2024-01-01")),
+            "to_date": to_iso(pendulum.parse("2024-02-01")),
+            "max_active_runs": 5,
+            "run_backwards": False,
+        }
+
+        with mock.patch(
+            "airflow.models.backfill.create_session",
+            side_effect=AssertionError("_create_backfill should use the request session"),
+        ):
+            response = test_client.post(
+                url="/backfills",
+                json=data,
+            )
+
+        assert response.status_code == 200
+
     def test_dag_not_exist(self, session, test_client):
         session.scalars(select(DagModel)).all()
         session.commit()


### PR DESCRIPTION
## Summary
- pass the request-scoped API session into `_create_backfill` when creating backfills
- keep existing CLI/model behavior by letting `_create_backfill` create its own session when one is not supplied
- add a regression test that fails if the API path opens a separate backfill model session

Fixes #66726

## Testing
- `uv run --no-dev --package apache-airflow-core --with 'apache-airflow-devel-common[basic]' ruff check airflow-core/src/airflow/models/backfill.py airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py`
- `PYTHONPATH="airflow-core/src:airflow-core/tests:devel-common/src:providers/git/src:providers/standard/src:providers/fab/src:shared/configuration/src:shared/dagnode/src:shared/listeners/src:shared/logging/src:shared/module_loading/src:shared/observability/src:shared/plugins_manager/src:shared/providers_discovery/src:shared/secrets_backend/src:shared/secrets_masker/src:shared/serialization/src:shared/state/src:shared/template_rendering/src:shared/timezones/src" uv run --python 3.12 --no-dev --package apache-airflow-core --with-editable ./devel-common --with 'apache-airflow-devel-common[basic]' --with-editable ./providers/git --with-editable ./providers/standard --with-editable ./providers/fab python -m pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py::TestCreateBackfill -q`

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — OpenAI Codex

Generated-by: OpenAI Codex following the guidelines in contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions