### PR TITLE
Fix UI DAG list last run sorting for queued runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py
@@ -111,7 +111,7 @@ def get_dags(
             SortParam(
                 ["dag_id", "dag_display_name", "next_dagrun", "state", "start_date"],
                 DagModel,
-                {"last_run_state": DagRun.state, "last_run_start_date": DagRun.start_date},
+                {"last_run_state": DagRun.state, "last_run_start_date": DagRun.run_after},
             ).dynamic_depends()
         ),
     ],

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py
@@ -262,6 +262,61 @@ class TestGetDagRuns(TestPublicDagEndpoint):
             response = test_client.get("/dags")
         assert response.status_code == 403
 
+    def test_order_by_last_run_start_date_uses_run_after_for_queued_runs(self, session, test_client):
+        self._clear_db()
+
+        running_dag_id = "running_latest_run"
+        queued_dag_id = "queued_latest_run"
+        session.add_all(
+            [
+                DagModel(
+                    dag_id=running_dag_id,
+                    bundle_name="dag_maker",
+                    fileloc="/tmp/running_latest_run.py",
+                    is_stale=False,
+                ),
+                DagModel(
+                    dag_id=queued_dag_id,
+                    bundle_name="dag_maker",
+                    fileloc="/tmp/queued_latest_run.py",
+                    is_stale=False,
+                ),
+            ]
+        )
+        session.add_all(
+            [
+                DagRun(
+                    dag_id=running_dag_id,
+                    run_id="manual__running",
+                    run_type=DagRunType.MANUAL,
+                    logical_date=pendulum.datetime(2025, 1, 1, tz="UTC"),
+                    run_after=pendulum.datetime(2025, 1, 1, tz="UTC"),
+                    start_date=pendulum.datetime(2025, 1, 2, tz="UTC"),
+                    state=DagRunState.RUNNING,
+                    triggered_by=DagRunTriggeredByType.TEST,
+                ),
+                DagRun(
+                    dag_id=queued_dag_id,
+                    run_id="manual__queued",
+                    run_type=DagRunType.MANUAL,
+                    logical_date=pendulum.datetime(2025, 1, 3, tz="UTC"),
+                    run_after=pendulum.datetime(2025, 1, 3, tz="UTC"),
+                    start_date=None,
+                    state=DagRunState.QUEUED,
+                    triggered_by=DagRunTriggeredByType.TEST,
+                ),
+            ]
+        )
+        session.commit()
+
+        response = test_client.get(
+            "/dags",
+            params={"order_by": "-last_run_start_date", "exclude_stale": False},
+        )
+
+        assert response.status_code == 200
+        assert [dag["dag_id"] for dag in response.json()["dags"]] == [queued_dag_id, running_dag_id]
+
     def test_get_dags_no_n_plus_one_queries(self, session, test_client):
         """Test that fetching DAGs with tags doesn't trigger n+1 queries."""
         num_dags = 5


### PR DESCRIPTION
Closes: #56073

The UI DAG list keeps accepting `last_run_start_date` for compatibility, but now maps that sort key to `DagRun.run_after` so queued latest runs with `start_date = NULL` are ordered by their scheduled/trigger time instead of falling behind started runs.

Tests:
- `PYTHONPATH=$(printf '%s:' shared/*/src) uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py::TestGetDagRuns`\n- `uvx ruff check airflow-core/src/airflow/api_fastapi/core_api/routes/ui/dags.py airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dags.py`\n- `git diff --check`