### PR TITLE
Fix deferred slots in pool summary chart

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.test.tsx
@@ -1,0 +1,115 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import type * as ReactI18Next from "react-i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as OpenapiQueries from "openapi/queries";
+import type { PoolResponse } from "openapi/requests/types.gen";
+import type * as SrcUtils from "src/utils";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { PoolSummary } from "./PoolSummary";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      // eslint-disable-next-line id-length
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("openapi/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenapiQueries>();
+
+  return {
+    ...actual,
+    useAuthLinksServiceGetAuthMenus: vi.fn(),
+  };
+});
+
+vi.mock("openapi/queries/queries", () => ({
+  usePoolServiceGetPools: vi.fn(),
+}));
+
+vi.mock("src/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof SrcUtils>();
+
+  return {
+    ...actual,
+    useAutoRefresh: () => false,
+  };
+});
+
+const { useAuthLinksServiceGetAuthMenus } = await import("openapi/queries");
+const { usePoolServiceGetPools } = await import("openapi/queries/queries");
+
+const makePool = (overrides: Partial<PoolResponse>): PoolResponse => ({
+  deferred_slots: 0,
+  description: null,
+  include_deferred: false,
+  name: "default_pool",
+  occupied_slots: 0,
+  open_slots: 128,
+  queued_slots: 0,
+  running_slots: 0,
+  scheduled_slots: 0,
+  slots: 128,
+  team_name: null,
+  ...overrides,
+});
+
+const renderPoolSummary = (pools: Array<PoolResponse>) => {
+  vi.mocked(usePoolServiceGetPools).mockReturnValue({
+    data: { pools, total_entries: pools.length },
+    error: null,
+    isLoading: false,
+  } as ReturnType<typeof usePoolServiceGetPools>);
+
+  render(<PoolSummary />, { wrapper: Wrapper });
+};
+
+beforeEach(() => {
+  vi.mocked(useAuthLinksServiceGetAuthMenus).mockReturnValue({
+    data: { authorized_menu_items: ["Pools"] },
+  } as ReturnType<typeof useAuthLinksServiceGetAuthMenus>);
+});
+
+describe("PoolSummary", () => {
+  it("does not include deferred tasks in the chart when they do not consume pool slots", () => {
+    renderPoolSummary([makePool({ deferred_slots: 1, include_deferred: false })]);
+
+    expect(screen.getByText("128")).toBeInTheDocument();
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("includes deferred tasks in the chart when they consume pool slots", () => {
+    renderPoolSummary([
+      makePool({ deferred_slots: 1, include_deferred: true, occupied_slots: 1, open_slots: 127 }),
+    ]);
+
+    expect(screen.getByText("127")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/PoolSummary/PoolSummary.tsx
@@ -74,7 +74,7 @@ export const PoolSummary = () => {
 
   pools?.forEach((pool) => {
     slotKeys.forEach((slotKey) => {
-      const slotValue = pool[slotKey];
+      const slotValue = slotKey === "deferred_slots" && !pool.include_deferred ? 0 : pool[slotKey];
 
       if (slotValue === UNLIMITED_SLOTS) {
         aggregatePool[slotKey] = UNLIMITED_SLOTS;


### PR DESCRIPTION
## Summary
- exclude deferred slots from the dashboard pool summary chart when a pool is configured with `include_deferred: false`
- keep deferred slots visible in the aggregate chart when they do consume pool slots
- add focused PoolSummary regression coverage

Fixes #55734

## Tests
- `npm exec --yes pnpm@10.25.0 -- install --frozen-lockfile`
- `npm exec --yes pnpm@10.25.0 -- test src/pages/Dashboard/PoolSummary/PoolSummary.test.tsx`
- `npm exec --yes pnpm@10.25.0 -- exec eslint src/pages/Dashboard/PoolSummary/PoolSummary.tsx src/pages/Dashboard/PoolSummary/PoolSummary.test.tsx`
- `npm exec --yes pnpm@10.25.0 -- exec tsc -p tsconfig.app.json --noEmit`

## Screenshots
Not included. This is a dashboard aggregation fix covered by a component test; I did not run a full Airflow backend with representative deferred task data locally.