### PR TITLE
Add regression test for unlimited pool slots API

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -217,6 +217,20 @@ class TestGetPools(TestPoolsEndpoint):
         assert body["total_entries"] == expected_total_entries
         assert [pool["name"] for pool in body["pools"]] == expected_ids
 
+    def test_should_respond_200_with_unlimited_slots(self, test_client, session):
+        self.create_pools()
+        session.add(Pool(pool="unlimited_pool", slots=-1, include_deferred=False))
+        session.commit()
+
+        response = test_client.get("/pools")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_entries"] == 5
+        unlimited_pool = next(pool for pool in body["pools"] if pool["name"] == "unlimited_pool")
+        assert unlimited_pool["slots"] == -1
+        assert unlimited_pool["open_slots"] == -1
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/pools", params={"pool_name_pattern": "~"})
         assert response.status_code == 401


### PR DESCRIPTION
Adds a focused regression test for the public pools list endpoint when a pool has unlimited slots (`slots == -1`). Current `main` already sanitizes `Pool.open_slots()` from `inf` to `-1`; this test covers the issue-reported `GET /pools` path so the behavior stays guarded.

Fixes #65377

Tests run:
- `uv run --no-dev --with ruff ruff check airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py`
- `AIRFLOW_SOURCES="$PWD" uv run --no-dev --with pytest --with pytest-mock --with time-machine --with 'apache-airflow-core @ ./airflow-core' --with 'apache-airflow-task-sdk @ ./task-sdk' --with 'apache-airflow-devel-common[no-doc] @ ./devel-common' --with 'apache-airflow-providers-git @ ./providers/git' --with 'apache-airflow-shared-secrets-masker @ ./shared/secrets_masker' pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py::TestGetPools`\n\nBlocked checks:\n- Plain `uv run pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py::TestGetPools::test_should_respond_200_with_unlimited_slots` could not build `jpype1` because this machine has no Java runtime; reran the focused tests with a trimmed dependency set above.