### PR TITLE
Run custom connection form validators

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -53,6 +53,7 @@ from airflow.api_fastapi.core_api.security import (
 from airflow.api_fastapi.core_api.services.public.connections import (
     BulkConnectionService,
     update_orm_from_pydantic,
+    validate_connection_form_widgets,
 )
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.configuration import conf
@@ -160,6 +161,7 @@ def post_connection(
     session: SessionDep,
 ) -> ConnectionResponse:
     """Create connection entry."""
+    validate_connection_form_widgets(post_body)
     connection = Connection(**post_body.model_dump(by_alias=True))
     session.add(connection)
     return connection
@@ -217,6 +219,9 @@ def patch_connection(
             ConnectionBody(**patch_body.model_dump())
         except ValidationError as e:
             raise RequestValidationError(errors=e.errors())
+
+    if update_mask is None or "extra" in update_mask:
+        validate_connection_form_widgets(patch_body)
 
     update_orm_from_pydantic(connection, patch_body, update_mask)
     return connection

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py
@@ -18,8 +18,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
 
 from fastapi import HTTPException, status
+from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 from sqlalchemy import select
 
@@ -35,6 +40,137 @@ from airflow.api_fastapi.core_api.datamodels.common import (
 from airflow.api_fastapi.core_api.datamodels.connections import ConnectionBody
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.models.connection import Connection
+from airflow.providers_manager import ProvidersManager
+
+
+class _StopValidation:
+    pass
+
+
+_STOP_VALIDATION = _StopValidation()
+
+
+class _ConnectionExtraField:
+    """Minimal WTForms-compatible field object for legacy connection validators."""
+
+    def __init__(self, name: str, data: Any):
+        self.name = name
+        self.data = data
+        self.raw_data = [] if data is None else [str(data)]
+        self.errors: list[str] = []
+
+
+def _get_form_widget_validators(field: Any) -> Iterable:
+    if isinstance(field, dict):
+        return ()
+    if hasattr(field, "kwargs"):
+        return field.kwargs.get("validators", ())
+    return getattr(field, "validators", ())
+
+
+def _get_form_widget_default(field: Any) -> Any:
+    if hasattr(field, "kwargs"):
+        return field.kwargs.get("default")
+    return getattr(field, "default", None)
+
+
+def _optional_flask_request_context():
+    try:
+        from flask import Flask, has_request_context
+
+        if has_request_context():
+            return nullcontext()
+
+        app = Flask("airflow_connection_form_validation")
+        app.secret_key = "airflow-connection-form-validation"
+        return app.test_request_context()
+    except ImportError:
+        return nullcontext()
+
+
+def _run_form_widget_validator(
+    validator, form: SimpleNamespace, field: _ConnectionExtraField
+) -> str | _StopValidation | None:
+    try:
+        with _optional_flask_request_context():
+            validator(form, field)
+    except Exception as err:
+        if err.__class__.__name__ == "StopValidation":
+            return str(err) or _STOP_VALIDATION
+        if err.__class__.__name__ == "ValidationError" or isinstance(err, ValueError):
+            return str(err)
+        raise
+    return None
+
+
+def validate_connection_form_widgets(connection: ConnectionBody) -> None:
+    """Run legacy provider WTForms validators for extra fields on connection form submission."""
+    try:
+        extra = json.loads(connection.extra or "{}")
+    except json.JSONDecodeError:
+        return
+
+    if not isinstance(extra, dict) or not extra:
+        return
+
+    prefix = f"extra__{connection.conn_type}__"
+    providers_manager = ProvidersManager()
+    if connection.conn_type in providers_manager.hooks:
+        providers_manager.hooks[connection.conn_type]
+    elif not any(
+        widget_key.startswith(prefix)
+        for widget_key in providers_manager._connection_form_widgets_from_metadata
+    ):
+        return
+
+    form_fields = {
+        "connection_id": _ConnectionExtraField("connection_id", connection.connection_id),
+        "conn_type": _ConnectionExtraField("conn_type", connection.conn_type),
+        "description": _ConnectionExtraField("description", connection.description),
+        "host": _ConnectionExtraField("host", connection.host),
+        "login": _ConnectionExtraField("login", connection.login),
+        "schema": _ConnectionExtraField("schema", connection.schema_),
+        "port": _ConnectionExtraField("port", connection.port),
+        "password": _ConnectionExtraField("password", connection.password),
+        "team_name": _ConnectionExtraField("team_name", connection.team_name),
+    }
+    form_fields.update({key: _ConnectionExtraField(key, value) for key, value in extra.items()})
+
+    errors = []
+    for widget_key, widget in providers_manager._connection_form_widgets_from_metadata.items():
+        if not widget_key.startswith(prefix):
+            continue
+
+        validators = tuple(_get_form_widget_validators(widget.field))
+        if not validators:
+            continue
+
+        field_name = widget.field_name
+        field = form_fields.setdefault(
+            field_name,
+            _ConnectionExtraField(field_name, extra.get(field_name, _get_form_widget_default(widget.field))),
+        )
+        form = SimpleNamespace(
+            **form_fields, data={name: form_field.data for name, form_field in form_fields.items()}
+        )
+
+        for validator in validators:
+            validation_result = _run_form_widget_validator(validator, form, field)
+            if validation_result is _STOP_VALIDATION:
+                break
+            if validation_result is not None:
+                errors.append(
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "extra", field_name),
+                        "msg": validation_result,
+                        "input": field.data,
+                    }
+                )
+                break
+
+    if errors:
+        raise RequestValidationError(errors=errors)
 
 
 def update_orm_from_pydantic(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -29,6 +29,7 @@ from airflow.api_fastapi.core_api.datamodels.common import BulkActionResponse, B
 from airflow.api_fastapi.core_api.datamodels.connections import ConnectionBody
 from airflow.api_fastapi.core_api.services.public.connections import BulkConnectionService
 from airflow.models import Connection
+from airflow.providers_manager import ConnectionFormWidgetInfo
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -60,6 +61,27 @@ TEST_CONN_LOGIN_2 = "some_login_b"
 
 TEST_CONN_ID_3 = "test_connection_id_3"
 TEST_CONN_TYPE_3 = "test_type_3"
+
+
+class _FakeFormWidgetField:
+    def __init__(self, validators):
+        self.kwargs = {"validators": validators}
+
+
+def _mock_form_widget_manager(validators):
+    widget_key = f"extra__{TEST_CONN_TYPE}__cms_authentication"
+    manager = mock.Mock()
+    manager.hooks = {TEST_CONN_TYPE: mock.Mock()}
+    manager._connection_form_widgets_from_metadata = {
+        widget_key: ConnectionFormWidgetInfo(
+            hook_class_name="TestHook",
+            package_name="test-provider",
+            field=_FakeFormWidgetField(validators),
+            field_name="cms_authentication",
+            is_sensitive=False,
+        )
+    }
+    return manager
 
 
 @provide_session
@@ -300,6 +322,62 @@ class TestPostConnection(TestConnectionEndpoint):
         connection = session.scalars(select(Connection)).all()
         assert len(connection) == 1
         _check_last_log(session, dag_id=None, event="post_connection", logical_date=None)
+
+    @mock.patch("airflow.api_fastapi.core_api.services.public.connections.ProvidersManager")
+    def test_post_runs_custom_form_widget_validators(self, providers_manager, test_client, session):
+        validator_calls = []
+
+        def validate_cms_authentication(form, field):
+            validator_calls.append((form.conn_type.data, field.data))
+            if field.data != "secEnterprise":
+                raise ValueError("Invalid authentication")
+
+        providers_manager.return_value = _mock_form_widget_manager([validate_cms_authentication])
+
+        response = test_client.post(
+            "/connections",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "extra": '{"cms_authentication": "invalid"}',
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body", "extra", "cms_authentication"]
+        assert response.json()["detail"][0]["msg"] == "Invalid authentication"
+        assert validator_calls == [(TEST_CONN_TYPE, "invalid")]
+        assert session.scalars(select(Connection)).all() == []
+
+    @mock.patch("airflow.api_fastapi.core_api.services.public.connections.ProvidersManager")
+    def test_post_honors_stop_validation_from_form_widget_validator(
+        self, providers_manager, test_client, session
+    ):
+        class StopValidation(Exception):
+            pass
+
+        validator_calls = []
+
+        def optional_validator(form, field):
+            raise StopValidation()
+
+        def custom_validator(form, field):
+            validator_calls.append((form.conn_type.data, field.data))
+
+        providers_manager.return_value = _mock_form_widget_manager([optional_validator, custom_validator])
+
+        response = test_client.post(
+            "/connections",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "extra": '{"cms_authentication": null}',
+            },
+        )
+
+        assert response.status_code == 201
+        assert validator_calls == []
+        assert len(session.scalars(select(Connection)).all()) == 1
 
     @conf_vars({("core", "multi_team"): "True"})
     def test_post_should_respond_201_with_team(self, test_client, session, testing_team):
@@ -988,6 +1066,35 @@ class TestPatchConnection(TestConnectionEndpoint):
             params={"update_mask": ["extra"]},
         )
         assert response.status_code == 422
+
+    @mock.patch("airflow.api_fastapi.core_api.services.public.connections.ProvidersManager")
+    def test_patch_runs_custom_form_widget_validators(self, providers_manager, test_client, session):
+        self.create_connection()
+        validator_calls = []
+
+        def validate_cms_authentication(form, field):
+            validator_calls.append((form.conn_type.data, field.data))
+            if field.data != "secEnterprise":
+                raise ValueError("Invalid authentication")
+
+        providers_manager.return_value = _mock_form_widget_manager([validate_cms_authentication])
+
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID}",
+            json={
+                "connection_id": TEST_CONN_ID,
+                "conn_type": TEST_CONN_TYPE,
+                "extra": '{"cms_authentication": "invalid"}',
+            },
+            params={"update_mask": ["extra"]},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body", "extra", "cms_authentication"]
+        assert response.json()["detail"][0]["msg"] == "Invalid authentication"
+        assert validator_calls == [(TEST_CONN_TYPE, "invalid")]
+        connection = session.scalar(select(Connection).filter_by(conn_id=TEST_CONN_ID))
+        assert connection.extra is None
 
     def test_patch_with_update_mask_rejects_extra_fields(self, test_client):
         """Partial model should still forbid unknown fields."""


### PR DESCRIPTION
## What

Run legacy provider connection form validators for submitted extra fields when connections are created or updated through the API-backed UI form. This restores custom `get_connection_form_widgets()` validator callbacks returning validation errors instead of saving invalid values.

Fixes #64835

## Tests

- `PYTHONPATH="airflow-core/src:devel-common/src:shared/configuration/src:shared/dagnode/src:shared/listeners/src:shared/logging/src:shared/module_loading/src:shared/observability/src:shared/plugins_manager/src:shared/providers_discovery/src:shared/secrets_backend/src:shared/secrets_masker/src:shared/serialization/src:shared/state/src:shared/template_rendering/src:shared/timezones/src:task-sdk/src" uv run --project airflow-core --no-sync pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py -k "form_widget_validator"`
- `PYTHONPATH="airflow-core/src:devel-common/src:shared/configuration/src:shared/dagnode/src:shared/listeners/src:shared/logging/src:shared/module_loading/src:shared/observability/src:shared/plugins_manager/src:shared/providers_discovery/src:shared/secrets_backend/src:shared/secrets_masker/src:shared/serialization/src:shared/state/src:shared/template_rendering/src:shared/timezones/src:task-sdk/src" uv run --project airflow-core --no-sync ruff check airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py`
- `PYTHONPATH="airflow-core/src:devel-common/src:shared/configuration/src:shared/dagnode/src:shared/listeners/src:shared/logging/src:shared/module_loading/src:shared/observability/src:shared/plugins_manager/src:shared/providers_discovery/src:shared/secrets_backend/src:shared/secrets_masker/src:shared/serialization/src:shared/state/src:shared/template_rendering/src:shared/timezones/src:task-sdk/src" uv run --project airflow-core --no-sync ruff format --check airflow-core/src/airflow/api_fastapi/core_api/services/public/connections.py airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py`

## Notes

No frontend files were changed, so frontend tests, eslint, and tsc were not run. A broader initial `uv run pytest ...` from the workspace root was blocked by `jpype1` requiring a Java runtime for the all-extras JDBC dependency on this machine.
