### PR TITLE
Fix `dags next-execution --table` crash when no next schedule exists

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -368,7 +368,17 @@ def dag_next_execution(args) -> None:
         else:
             columns = ["logical_date", "data_interval.start", "data_interval.end", "run_after"]
         getters = [(c, operator.attrgetter(c)) for c in columns]
-        AirflowConsole().print_as_table([{n: f(o) for n, f in getters} for o in iter_next_dagrun_info()])
+        rows = []
+        for o in iter_next_dagrun_info():
+            if o is None:
+                print(
+                    "[WARN] No following schedule can be found. "
+                    "This DAG may have schedule interval '@once' or `None`.",
+                    file=sys.stderr,
+                )
+            else:
+                rows.append({n: f(o) for n, f in getters})
+        AirflowConsole().print_as_table(rows)
         return
 
     if args.field:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -272,6 +272,36 @@ class TestCliDags:
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
+    def test_next_execution_table_none_schedule(self, tmp_path, stdout_capture, capsys):
+        """--table must not crash when schedule=None yields a None DagRunInfo."""
+        dag_id = "no_schedule_table_test"
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC'), schedule=None)",
+                "task = EmptyOperator(task_id='empty_task', dag=dag)",
+            ]
+        )
+        dag_file = tmp_path / f"{dag_id}.py"
+        dag_file.write_text(file_content)
+
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
+
+        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table"])
+        # Must not raise AttributeError when DagRunInfo is None
+        dag_command.dag_next_execution(args)
+
+        captured = capsys.readouterr()
+        assert "No following schedule can be found" in captured.err
+
+        # Rebuild Test DB for other tests
+        clear_db_dags()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
+
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_report(self, stdout_capture):
         args = self.parser.parse_args(["dags", "report", "--output", "json"])


### PR DESCRIPTION
## Summary

`airflow dags next-execution <dag_id> --table` crashes with `AttributeError` when the DAG has no next scheduled run (e.g. `schedule=None`, or an `@once` DAG after its run, or `--num-executions` exceeds available runs).

The root cause is in the table-output branch:

```python
# Before (buggy)
AirflowConsole().print_as_table([{n: f(o) for n, f in getters} for o in iter_next_dagrun_info()])
```

`iter_next_dagrun_info()` yields `DagRunInfo | None`. When `o` is `None`, calling `operator.attrgetter(c)(None)` raises `AttributeError: 'NoneType' object has no attribute 'logical_date'`.

The non-table path already handles `None` correctly:

```python
for info in iter_next_dagrun_info():
    if info is None:
        print("[WARN] No following schedule can be found. ...", file=sys.stderr)
        ...
```

## Reproduce

```python
# no_schedule_dag.py
from airflow import DAG
from pendulum import datetime

with DAG("no_schedule", start_date=datetime(2025, 1, 1, tz="UTC"), schedule=None):
    pass
```

```bash
airflow dags next-execution no_schedule --table
# AttributeError: 'NoneType' object has no attribute 'logical_date'
```

## Fix

Mirror the non-table `None` guard in the table path: skip `None` items and print the same warning to stderr.

Fixes #67394