### PR TITLE
Fix Breeze api-server host binding for Docker Desktop vs OrbStack

### DIFF
--- a/scripts/in_container/bin/generate_mprocs_config.py
+++ b/scripts/in_container/bin/generate_mprocs_config.py
@@ -66,22 +66,15 @@ def generate_mprocs_config() -> str:
     use_airflow_version = get_env("USE_AIRFLOW_VERSION", "")
     if not use_airflow_version.startswith("2."):
         # API Server (Airflow 3.x+)
-        # Bind dual-stack (IPv6 + IPv4) so http://localhost:28080 works from browsers that
-        # resolve `localhost` to ::1 first (e.g. Chrome/Safari on macOS with OrbStack, which
-        # forwards both IPv4 and IPv6 host ports into the container). The default `0.0.0.0`
-        # binds IPv4 only, causing the IPv6 attempt to land inside the container with no
-        # listener and TCP RST → opaque chrome-error://chromewebdata/ page.
-        api_host_arg = "--host '::'"
+        # Empty host lets uvicorn bind to all interfaces (IPv4 + IPv6), so localhost:28080
+        # works regardless of whether the container runtime resolves localhost to ::1
+        # (OrbStack) or forwards via IPv4 (Docker Desktop).
         if get_env_bool("BREEZE_DEBUG_APISERVER"):
             port = get_env("BREEZE_DEBUG_APISERVER_PORT", "5679")
-            api_cmd = (
-                f"debugpy --listen 0.0.0.0:{port} --wait-for-client -m airflow api-server {api_host_arg} -d"
-            )
+            api_cmd = f"debugpy --listen 0.0.0.0:{port} --wait-for-client -m airflow api-server --host '' -d"
         else:
             dev_mode = get_env_bool("DEV_MODE")
-            api_cmd = (
-                f"airflow api-server {api_host_arg} -d" if dev_mode else f"airflow api-server {api_host_arg}"
-            )
+            api_cmd = "airflow api-server --host '' -d" if dev_mode else "airflow api-server --host ''"
         procs["api_server"] = {"shell": api_cmd, "restart": "always", "scrollback": 100000}
     else:
         # Webserver (Airflow 2.x)

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -65,18 +65,18 @@ fi
 if [[ ! ${USE_AIRFLOW_VERSION=} =~ ^2\..*  ]]; then
   tmux split-window -h
   tmux select-pane -t 2
-    # Bind dual-stack (IPv6 + IPv4) so http://localhost:28080 works from browsers that resolve
-    # `localhost` to ::1 first (e.g. Chrome/Safari on macOS with OrbStack, which forwards both
-    # IPv4 and IPv6 host ports into the container). The default `0.0.0.0` binds IPv4 only.
+    # Empty host lets uvicorn bind to all interfaces (IPv4 + IPv6), so localhost:28080
+    # works regardless of whether the container runtime resolves localhost to ::1
+    # (OrbStack) or forwards via IPv4 (Docker Desktop).
     if [[ ${BREEZE_DEBUG_APISERVER} == "true" ]]; then
         tmux set-option -p @airflow_component "API Server(Debug Mode)"
-        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server --host '::' -d" C-m
+        tmux send-keys "debugpy --listen 0.0.0.0:${BREEZE_DEBUG_APISERVER_PORT} --wait-for-client -m airflow api-server --host '' -d" C-m
     else
   tmux set-option -p @airflow_component "API Server"
     if [[ ${DEV_MODE=} == "true" ]]; then
-        tmux send-keys "airflow api-server --host '::' -d" C-m
+        tmux send-keys "airflow api-server --host '' -d" C-m
     else
-        tmux send-keys "airflow api-server --host '::'" C-m
+        tmux send-keys "airflow api-server --host ''" C-m
     fi
     fi
 else


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
PR #67320 introduced a regression: binding the api-server to :: (IPv6) broke localhost:28080 for Docker Desktop users, whose host-to-container traffic goes through IPv4 only.

Fix: pass --host '' so uvicorn binds to all interfaces (IPv4 + IPv6) in both run_tmux and generate_mprocs_config.py.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Opus 4.7

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
