### PR TITLE
Fix Dag run span parent context handling

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -127,6 +127,19 @@ log = structlog.get_logger(__name__)
 
 tracer = trace.get_tracer(__name__)
 
+_ROOT_DAGRUN_SPAN_TRIGGERED_BY = frozenset(
+    {
+        DagRunTriggeredByType.REST_API,
+        DagRunTriggeredByType.UI,
+        DagRunTriggeredByType.TIMETABLE,
+        DagRunTriggeredByType.ASSET,
+        DagRunTriggeredByType.BACKFILL,
+    }
+)
+_ROOT_DAGRUN_SPAN_RUN_TYPES = frozenset(
+    {DagRunType.SCHEDULED, DagRunType.ASSET_TRIGGERED, DagRunType.BACKFILL_JOB}
+)
+
 
 class TISchedulingDecision(NamedTuple):
     """Type of return for DagRun.task_instance_scheduling_decisions."""
@@ -1056,7 +1069,17 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = {ti for ti in tis if ti.task_id in leaf_task_ids if ti.state != TaskInstanceState.REMOVED}
         return leaf_tis
 
-    def _emit_dagrun_span(self, state: DagRunState):
+    def _should_force_root_dagrun_span(self) -> bool:
+        """Whether this DagRun span should be emitted without an active parent context."""
+        if self.triggered_by is None or isinstance(self.triggered_by, DagRunTriggeredByType):
+            triggered_by = self.triggered_by
+        else:
+            triggered_by = DagRunTriggeredByType(self.triggered_by)
+        if triggered_by in _ROOT_DAGRUN_SPAN_TRIGGERED_BY:
+            return True
+        return DagRunType(self.run_type) in _ROOT_DAGRUN_SPAN_RUN_TYPES
+
+    def _emit_dagrun_span(self, state: DagRunState, *, force_root_span: bool = False):
         # just to be safe
         if not isinstance(self.context_carrier, dict):
             return
@@ -1081,19 +1104,14 @@ class DagRun(Base, LoggingMixin):
                 attributes["airflow.dag_run.logical_date"] = str(self.logical_date)
             if self.partition_key:
                 attributes["airflow.dag_run.partition_key"] = str(self.partition_key)
-            # TODO: make the empty parent context optional. Default should be to
-            # nest the dag run span under the currently active parent span (by
-            # omitting `context` here); only use the empty `context.Context()` to
-            # force a root span when Airflow itself initiates the run (e.g. dag
-            # triggered via API, scheduler, or backfill). Today this forces a
-            # root span unconditionally.
-            # Tracked at https://github.com/apache/airflow/issues/67210
-            span = tracer.start_span(
-                name=f"dag_run.{self.dag_id}",
-                start_time=int((self.queued_at or self.start_date or timezone.utcnow()).timestamp() * 1e9),
-                attributes=attributes,
-                context=context.Context(),
-            )
+            start_span_kwargs: dict[str, Any] = {
+                "name": f"dag_run.{self.dag_id}",
+                "start_time": int((self.queued_at or self.start_date or timezone.utcnow()).timestamp() * 1e9),
+                "attributes": attributes,
+            }
+            if force_root_span:
+                start_span_kwargs["context"] = context.Context()
+            span = tracer.start_span(**start_span_kwargs)
             status_code = StatusCode.OK if state == DagRunState.SUCCESS else StatusCode.ERROR
             span.set_status(status_code)
             span.end()
@@ -1282,7 +1300,10 @@ class DagRun(Base, LoggingMixin):
             )
             session.flush()
             try:
-                self._emit_dagrun_span(state=self.state)
+                self._emit_dagrun_span(
+                    state=self.state,
+                    force_root_span=self._should_force_root_dagrun_span(),
+                )
             except Exception:
                 self.log.warning("Failed to emit dag run span", exc_info=True)
 

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -3628,7 +3628,7 @@ class TestDagRunTracing:
         with mock.patch.object(dr, "_emit_dagrun_span") as mock_emit:
             dr.update_state(session=session)
 
-        mock_emit.assert_called_once_with(state=final_state)
+        mock_emit.assert_called_once_with(state=final_state, force_root_span=False)
 
     def test_emit_dagrun_span_not_called_while_running(self, dag_maker, session):
         """_emit_dagrun_span should not be called while the dag run is still running."""
@@ -3651,6 +3651,18 @@ class TestDagRunTracing:
             dr.update_state(session=session)
 
         mock_emit.assert_not_called()
+
+    @staticmethod
+    def _create_finished_single_task_dagrun(dag_maker, session, dag_id):
+        with dag_maker(dag_id, session=session) as dag:
+            EmptyOperator(task_id="t1")
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        ti = dr.get_task_instance("t1", session=session)
+        ti.state = TaskInstanceState.SUCCESS
+        session.flush()
+        dr.dag = dag
+        return dr
 
     def test_emit_dagrun_span_uses_context_carrier_ids(self, dag_maker, session):
         """The emitted span should inherit trace_id/span_id from the context_carrier."""
@@ -3682,6 +3694,100 @@ class TestDagRunTracing:
 
         assert span.context.trace_id == stored_ctx.trace_id
         assert span.context.span_id == stored_ctx.span_id
+
+    def test_emit_dagrun_span_defaults_to_active_parent_context(self, dag_maker, session):
+        """The emitted span should nest under the active parent context by default."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        dr = self._create_finished_single_task_dagrun(dag_maker, session, "test_tracing_nested_parent")
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            with test_tracer.start_as_current_span("parent") as parent_span:
+                dr._emit_dagrun_span(state=DagRunState.SUCCESS)
+
+        dagrun_span = next(
+            span for span in in_mem_exporter.get_finished_spans() if span.name.startswith("dag_run.")
+        )
+        assert dagrun_span.parent is not None
+        assert dagrun_span.parent.span_id == parent_span.get_span_context().span_id
+
+    def test_emit_dagrun_span_can_force_root_span(self, dag_maker, session):
+        """The emitted span should be root when force_root_span is set."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        dr = self._create_finished_single_task_dagrun(dag_maker, session, "test_tracing_forced_root")
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            with test_tracer.start_as_current_span("parent"):
+                dr._emit_dagrun_span(state=DagRunState.SUCCESS, force_root_span=True)
+
+        dagrun_span = next(
+            span for span in in_mem_exporter.get_finished_spans() if span.name.startswith("dag_run.")
+        )
+        assert dagrun_span.parent is None
+
+    @pytest.mark.parametrize(
+        ("run_type", "triggered_by"),
+        [
+            (DagRunType.MANUAL, DagRunTriggeredByType.REST_API),
+            (DagRunType.MANUAL, DagRunTriggeredByType.UI),
+            (DagRunType.SCHEDULED, DagRunTriggeredByType.TIMETABLE),
+            (DagRunType.ASSET_TRIGGERED, DagRunTriggeredByType.ASSET),
+            (DagRunType.BACKFILL_JOB, DagRunTriggeredByType.BACKFILL),
+        ],
+    )
+    def test_update_state_emits_root_dagrun_span_for_airflow_initiated_runs(
+        self, dag_maker, session, run_type, triggered_by
+    ):
+        """Airflow-initiated Dag runs should emit root spans even with an active parent."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        dr = self._create_finished_single_task_dagrun(
+            dag_maker, session, f"test_tracing_root_{triggered_by.value}"
+        )
+        dr.run_type = run_type
+        dr.triggered_by = triggered_by
+        session.flush()
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            with test_tracer.start_as_current_span("parent"):
+                dr.update_state(session=session)
+
+        dagrun_span = next(
+            span for span in in_mem_exporter.get_finished_spans() if span.name.startswith("dag_run.")
+        )
+        assert dagrun_span.parent is None
+
+    def test_update_state_emits_nested_dagrun_span_for_operator_triggered_runs(self, dag_maker, session):
+        """Operator-triggered Dag runs should emit spans under the active parent context."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        dr = self._create_finished_single_task_dagrun(dag_maker, session, "test_tracing_operator_nested")
+        dr.run_type = DagRunType.OPERATOR_TRIGGERED
+        dr.triggered_by = DagRunTriggeredByType.OPERATOR
+        session.flush()
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            with test_tracer.start_as_current_span("parent") as parent_span:
+                dr.update_state(session=session)
+
+        dagrun_span = next(
+            span for span in in_mem_exporter.get_finished_spans() if span.name.startswith("dag_run.")
+        )
+        assert dagrun_span.parent is not None
+        assert dagrun_span.parent.span_id == parent_span.get_span_context().span_id
 
     @pytest.mark.parametrize("final_state", [DagRunState.SUCCESS, DagRunState.FAILED])
     def test_emit_dagrun_span_attributes_and_status(self, dag_maker, session, final_state):


### PR DESCRIPTION
## Why

Dag run spans are currently forced to root by always passing an empty context when the span is created.

That is useful for Dag runs created by Airflow entry points such as the API, scheduler, asset scheduling, UI trigger, and backfill, since those runs represent new workflow roots.

closes: #67210

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Codex GPT 5.5
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
