### PR TITLE
Fix flaky AzureDataFactory operator test by mocking time

### DIFF
--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_data_factory.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import functools
+import itertools
 from typing import TYPE_CHECKING
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -142,11 +143,20 @@ class TestAzureDataFactoryRunPipelineOperator:
                     operator.execute(context=self.mock_context)
             else:
                 # Demonstrating the operator timing out after surpassing the configured timeout value.
-                with pytest.raises(
-                    AzureDataFactoryPipelineRunException,
-                    match=(
-                        f"Pipeline run {PIPELINE_RUN_RESPONSE['run_id']} has not reached a terminal status "
-                        f"after {self.config['timeout']} seconds."
+                # Mock time.monotonic and time.sleep so the poll count is deterministic regardless of
+                # CI load; real sleep durations can vary enough to change how many iterations complete.
+                with (
+                    patch(
+                        "airflow.providers.microsoft.azure.hooks.data_factory.time.monotonic",
+                        side_effect=itertools.count(0.0, 1.0),
+                    ),
+                    patch("airflow.providers.microsoft.azure.hooks.data_factory.time.sleep"),
+                    pytest.raises(
+                        AzureDataFactoryPipelineRunException,
+                        match=(
+                            f"Pipeline run {PIPELINE_RUN_RESPONSE['run_id']} has not reached a terminal status "
+                            f"after {self.config['timeout']} seconds."
+                        ),
                     ),
                 ):
                     operator.execute(context=self.mock_context)


### PR DESCRIPTION
  The `test_execute_wait_for_termination[*-timeout]` cases were intermittently                                                                            
  failing on CI with `assert 3 == 4`.                                                                                                                     
                                                                                                                                                          
  ## Root cause                                                                                                                                           
                                                                                                                                                          
  The test used real `time.sleep(1)` with `timeout=3`, expecting 4 calls to                                                                               
  `get_pipeline_run`. The loop uses a strict `<` timeout check, so with exact
  1.0s sleeps you get 5 calls, and on a loaded CI runner where sleeps overshoot                                                                           
  by >0.5s you get 3 — neither is the expected 4.                                                                                                         
                                                                                                                                                          
  ## Fix                                                                                                                                                  
                                                                                                                                                          
  Patch `time.monotonic` (via `itertools.count(0.0, 1.0)`) and `time.sleep`                                                                               
  (no-op) in the hook module for the timeout cases. The deterministic sequence                                                                          
  0→1→2→3→4 fires the timeout check after exactly 3 iterations regardless                                                                                 
  of system load, giving 4 total calls.                                                                                                                   
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ##### Was generative AI tooling used to co-author this PR?                                                                                              
   
  - [X] Yes — Claude Code (claude-sonnet-4-6)