### PR TITLE
fix/Tableau Operator - Add Incremental Refresh Parameter

### DIFF
--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -64,6 +64,9 @@ class TableauOperator(BaseOperator):
         between each instance state checks until operation is completed
     :param tableau_conn_id: The :ref:`Tableau Connection id <howto/connection:tableau>`
         containing the credentials to authenticate to the Tableau Server.
+    :param incremental: When set to True triggers an incremental extract refresh instead of a full
+        refresh. Only applies when ``method="refresh"`` on datasource or workbook resources.
+        Defaults to False (full refresh).
     """
 
     template_fields: Sequence[str] = (
@@ -82,6 +85,7 @@ class TableauOperator(BaseOperator):
         blocking_refresh: bool = True,
         check_interval: float = 20,
         tableau_conn_id: str = "tableau_default",
+        incremental: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -93,6 +97,7 @@ class TableauOperator(BaseOperator):
         self.site_id = site_id
         self.blocking_refresh = blocking_refresh
         self.tableau_conn_id = tableau_conn_id
+        self.incremental = incremental
 
     def execute(self, context: Context) -> str:
         """
@@ -124,6 +129,9 @@ class TableauOperator(BaseOperator):
                 if not job_items:
                     raise ValueError("Tableau tasks.run returned no JobItem in response")
                 job_id = job_items[0].id
+            elif self.method == "refresh":
+                response = method(resource_id, incremental=self.incremental)
+                job_id = response.id
             else:
                 response = method(resource_id)
                 job_id = response.id

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -70,7 +70,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -106,7 +106,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -135,7 +135,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -167,7 +167,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -269,6 +269,34 @@ class TestTableauOperator:
 
         with pytest.raises(AirflowException):
             operator.execute({})
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_datasources_incremental(self, mock_tableau_hook):
+        """incremental=True must be forwarded to datasources.refresh()."""
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False, find="ds_2", resource="datasources", incremental=True, **self.kwargs
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_workbooks_incremental(self, mock_tableau_hook):
+        """incremental=True must be forwarded to workbooks.refresh()."""
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False, find="wb_2", resource="workbooks", incremental=True, **self.kwargs
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
     def test_get_resource_id(self):
         """


### PR DESCRIPTION
## What this does

The Tableau Server Client library has supported an `incremental` flag on both `datasources.refresh()` and `workbooks.refresh()` for a while now, but the `TableauOperator` had no way to pass it through every refresh was always a full refresh.

This adds `incremental: bool = False` to the operator. When you set it to `True`, the operator will trigger an incremental extract refresh rather than a full one, which is useful when your datasource is configured for incremental refresh in Tableau Server.

Example usage:

```python
TableauOperator(
    task_id="incremental_refresh_sales",
    resource="datasources",
    method="refresh",
    find="my_datasource",
    match_with="name",
    incremental=True,
)
```

## What didn't change
Everything else behaves exactly as before. The incremental param is only forwarded when method="refresh" delete, tasks.run, and all other paths are completely unaffected. The default is False so no existing DAGs need to change.

Tests
Updated four existing test assertions to include the now-explicit incremental=False kwarg (they would have started failing without this).

Added test_execute_datasources_incremental and test_execute_workbooks_incremental to verify incremental=True is correctly passed through to the underlying library call.