### PR TITLE
Fix/partition key semantics across DagRun 67368

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -161,6 +161,12 @@ class TriggerDAGRunPostBody(StrictBaseModel):
         return self
 
     def validate_context(self, dag: SerializedDAG) -> dict:
+        if self.partition_key is not None and not dag.timetable.partitioned:
+            raise ValueError(
+                f"DAG '{dag.dag_id}' does not use a partitioned timetable; "
+                "'partition_key' may only be set when the DAG's timetable supports partitions."
+            )
+
         coerced_logical_date = timezone.coerce_datetime(self.logical_date)
         run_after = self.run_after or timezone.utcnow()
         data_interval = None

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1499,7 +1499,6 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         )
 
         payloads_by_asset: dict[SerializedAssetUniqueKey, list[OutletEventPayload]] = defaultdict(list)
-        runtime_pks: set[str] = set()
         for outlet_event in outlet_events:
             # Alias-emitted events are handled separately further down via
             # register_asset_change_for_alias, which uses the DagRun-level
@@ -1509,20 +1508,13 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             if "source_alias_name" in outlet_event:
                 continue
             asset_key = SerializedAssetUniqueKey(**outlet_event["dest_asset_key"])
-            partition_key = outlet_event.get("partition_key")
             payloads_by_asset[asset_key].append(
-                OutletEventPayload(extra=outlet_event["extra"], partition_key=partition_key)
+                OutletEventPayload(
+                    extra=outlet_event["extra"],
+                    partition_key=outlet_event.get("partition_key"),
+                )
             )
-            if partition_key is not None:
-                runtime_pks.add(partition_key)
 
-        # Back-fill DagRun.partition_key from the task emission when the task
-        # emitted exactly one distinct partition_key across all outlet events
-        # and the DagRun did not already have one set. This lets a task that
-        # discovers the partition at runtime (rather than via params) act as
-        # the source of truth for the DagRun-level key.
-        if len(runtime_pks) == 1 and ti.dag_run.partition_key is None:
-            ti.dag_run.partition_key = next(iter(runtime_pks))
         dag_run_partition_key = ti.dag_run.partition_key
 
         asset_keys = {
@@ -1567,7 +1559,9 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                     task_instance=ti,
                     asset=am,
                     extra=payload.extra,
-                    partition_key=payload.partition_key,
+                    partition_key=payload.partition_key
+                    if payload.partition_key is not None
+                    else dag_run_partition_key,
                     session=session,
                 )
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -2466,6 +2466,15 @@ class TestTriggerDagRun:
         run = session.scalars(select(DagRun).where(DagRun.run_id == run_id_without_logical_date)).one()
         assert run.dag_id == custom_dag_id
 
+    def test_should_respond_400_if_partition_key_on_non_partitioned_dag(self, test_client):
+        now = timezone.utcnow().isoformat()
+        response = test_client.post(
+            f"/dags/{DAG1_ID}/dagRuns",
+            json={"logical_date": now, "partition_key": "us-east-1"},
+        )
+        assert response.status_code == 400
+        assert "does not use a partitioned timetable" in response.json()["detail"]
+
 
 class TestResolveRunOnLatestVersion:
     @pytest.mark.parametrize("explicit_value", [True, False])

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -3513,10 +3513,10 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
     assert pakl.target_dag_id == "asset_event_listener"
 
 
-def test_runtime_partition_key_backfills_dag_run_when_none(dag_maker, session):
-    """Single runtime key on a PartitionAtRuntime-style run (dag_run.partition_key=None) back-fills the run."""
+def test_runtime_partition_key_does_not_backfill_dag_run(dag_maker, session):
+    """A task-emitted partition key lands on the AssetEvent but never writes back to DagRun.partition_key."""
     asset = Asset(name="hello")
-    with dag_maker(dag_id="rt_pk_backfill", schedule=None) as dag:
+    with dag_maker(dag_id="rt_pk_no_backfill", schedule=None) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(session=session)
     assert dr.partition_key is None
@@ -3532,8 +3532,9 @@ def test_runtime_partition_key_backfills_dag_run_when_none(dag_maker, session):
     )
     event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
     assert event.partition_key == "us"
+    # DagRun.partition_key must remain None — back-fill logic has been removed.
     session.refresh(dr)
-    assert dr.partition_key == "us"
+    assert dr.partition_key is None
 
 
 def test_runtime_partition_key_does_not_overwrite_scheduler_partition(dag_maker, session):
@@ -3582,10 +3583,10 @@ def test_runtime_partition_keys_fan_out_to_one_event_per_key(dag_maker, session)
     assert dr.partition_key is None
 
 
-def test_runtime_partition_key_is_none_when_event_has_no_key(dag_maker, session):
-    """An outlet event without partition_key produces an AssetEvent with partition_key=None."""
+def test_extra_only_event_inherits_dag_run_partition_key(dag_maker, session):
+    """An outlet event without an explicit partition_key inherits DagRun.partition_key."""
     asset = Asset(name="hello")
-    with dag_maker(dag_id="rt_pk_none", schedule=None) as dag:
+    with dag_maker(dag_id="rt_pk_extra_only", schedule=None) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(partition_key="from-run", session=session)
     [ti] = dr.get_task_instances(session=session)
@@ -3599,11 +3600,12 @@ def test_runtime_partition_key_is_none_when_event_has_no_key(dag_maker, session)
         session=session,
     )
     event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
-    assert event.partition_key is None
+    # No explicit partition_key in the event → falls back to DagRun.partition_key.
+    assert event.partition_key == "from-run"
 
 
 def test_runtime_partition_key_mixed_events_for_same_asset(dag_maker, session):
-    """One event with partition_key + one without produce two AssetEvents (key + None)."""
+    """One event with explicit partition_key + one without produce two events; the keyless one inherits the run key."""
     asset = Asset(name="hello")
     with dag_maker(dag_id="rt_pk_mixed", schedule=None) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
@@ -3620,7 +3622,8 @@ def test_runtime_partition_key_mixed_events_for_same_asset(dag_maker, session):
         session=session,
     )
     events = session.scalars(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id)).all()
-    assert {e.partition_key for e in events} == {"us", None}
+    # Explicit "us" is preserved; the keyless event falls back to the DagRun key "from-run".
+    assert {e.partition_key for e in events} == {"us", "from-run"}
     session.refresh(dr)
     assert dr.partition_key == "from-run"
 

--- a/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
+++ b/providers/tableau/src/airflow/providers/tableau/operators/tableau.py
@@ -64,6 +64,9 @@ class TableauOperator(BaseOperator):
         between each instance state checks until operation is completed
     :param tableau_conn_id: The :ref:`Tableau Connection id <howto/connection:tableau>`
         containing the credentials to authenticate to the Tableau Server.
+    :param incremental: When set to True triggers an incremental extract refresh instead of a full
+        refresh. Only applies when ``method="refresh"`` on datasource or workbook resources.
+        Defaults to False (full refresh).
     """
 
     template_fields: Sequence[str] = (
@@ -82,6 +85,7 @@ class TableauOperator(BaseOperator):
         blocking_refresh: bool = True,
         check_interval: float = 20,
         tableau_conn_id: str = "tableau_default",
+        incremental: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -93,6 +97,7 @@ class TableauOperator(BaseOperator):
         self.site_id = site_id
         self.blocking_refresh = blocking_refresh
         self.tableau_conn_id = tableau_conn_id
+        self.incremental = incremental
 
     def execute(self, context: Context) -> str:
         """
@@ -124,6 +129,9 @@ class TableauOperator(BaseOperator):
                 if not job_items:
                     raise ValueError("Tableau tasks.run returned no JobItem in response")
                 job_id = job_items[0].id
+            elif self.method == "refresh":
+                response = method(resource_id, incremental=self.incremental)
+                job_id = response.id
             else:
                 response = method(resource_id)
                 job_id = response.id

--- a/providers/tableau/tests/unit/tableau/operators/test_tableau.py
+++ b/providers/tableau/tests/unit/tableau/operators/test_tableau.py
@@ -70,7 +70,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -106,7 +106,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -135,7 +135,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
     @patch("airflow.providers.tableau.operators.tableau.TableauHook")
@@ -167,7 +167,7 @@ class TestTableauOperator:
 
         job_id = operator.execute(context={})
 
-        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=False)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
         mock_tableau_hook.wait_for_state.assert_called_once_with(
             job_id=job_id, check_interval=20, target_state=TableauJobFinishCode.SUCCESS
@@ -269,6 +269,34 @@ class TestTableauOperator:
 
         with pytest.raises(AirflowException):
             operator.execute({})
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_datasources_incremental(self, mock_tableau_hook):
+        """incremental=True must be forwarded to datasources.refresh()."""
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False, find="ds_2", resource="datasources", incremental=True, **self.kwargs
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+
+    @patch("airflow.providers.tableau.operators.tableau.TableauHook")
+    def test_execute_workbooks_incremental(self, mock_tableau_hook):
+        """incremental=True must be forwarded to workbooks.refresh()."""
+        mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauOperator(
+            blocking_refresh=False, find="wb_2", resource="workbooks", incremental=True, **self.kwargs
+        )
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2, incremental=True)
+        assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
     def test_get_resource_id(self):
         """

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -20,6 +20,7 @@ import collections
 import contextlib
 import functools
 import inspect
+import warnings
 from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from functools import cache
@@ -865,6 +866,14 @@ class OutletEventAccessor(_AssetRefResolutionMixin):
         """Add one or more partition keys to :attr:`partition_keys`."""
         if isinstance(keys, str):
             keys = [keys]
+        if isinstance(self.key, AssetAliasUniqueKey):
+            warnings.warn(
+                "add_partitions() has no effect on asset alias outlet events. "
+                "Partition keys are not propagated through asset aliases; "
+                "use outlet_events[asset].add_partitions() on the target asset directly.",
+                UserWarning,
+                stacklevel=2,
+            )
         self.partition_keys.update(keys)
 
     def add(self, asset: Asset | AssetRef, extra: dict[str, JsonValue] | None = None) -> None:

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -495,6 +495,15 @@ class TestOutletEventAccessorPartitionKeys:
         accessor.add_partitions(["us", "eu"])
         assert accessor.partition_keys == {"us", "eu"}
 
+    def test_add_partitions_on_alias_emits_warning(self):
+        alias_accessor = OutletEventAccessor(
+            key=AssetAliasUniqueKey.from_asset_alias(AssetAlias("my_alias"))
+        )
+        with pytest.warns(UserWarning, match="add_partitions\\(\\) has no effect on asset alias"):
+            alias_accessor.add_partitions("us")
+        # The keys are still stored, but the warning signals they won't be propagated.
+        assert "us" in alias_accessor.partition_keys
+
 
 class TestTriggeringAssetEventsAccessor:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Changes

### 1. Remove DagRun back-fill from task-emitted outlet events

Previously, if a task emitted outlet events and all of them used the same `partition_key`, that key was silently written back to `DagRun.partition_key` (if the run did not already have one). This was wrong, the DagRun key represents *why the run was started* (set at trigger time), not *what the task happened to produce*. Tasks should not change the DagRun's identity.

**Removed:** the `runtime_pks` accumulator and the back-fill block in `register_asset_changes_in_db` in `taskinstance.py`.

### 2. Extra-only outlet events now inherit `dag_run.partition_key`

When a task emits an outlet event with only `extra` data and no explicit `partition_key`, the event now inherits the DagRun-level `partition_key`.
Before this fix, those events stored `None` even when the DagRun had a key, making the event's provenance invisible for "extra-only" notifications.

### 3. Warn when `add_partitions()` is called on an asset alias accessor

`OutletEventAccessor.add_partitions()` on an alias outlet has no effect, aliases do not route partition keys to downstream assets. The key just sits in the alias event's `partition_keys` set and goes nowhere. 
A `UserWarning` is now raised to steer authors toward calling `add_partitions()` on the target asset accessor directly.

### 4. Reject `partition_key` at the REST API trigger endpoint for non-partitioned DAGs

`POST /dags/{dag_id}/dagRuns` now returns **HTTP 400** if `partition_key` is  supplied but the DAG's timetable has `partitioned = False`. Storing a `partition_key` on a run that can never use it leads to confusing query results and silent data loss.

## Tests

- `test_runtime_partition_key_does_not_backfill_dag_run` — verifies the DagRun key is NOT written back by task emission
- `test_extra_only_event_inherits_dag_run_partition_key` — verifies extra-only events pick up the DagRun key
- `test_runtime_partition_key_mixed_events_for_same_asset` — updated expected set to reflect inheritance
- `test_add_partitions_on_alias_emits_warning` — checks the `UserWarning` fires and keys still accumulate locally
- `test_should_respond_400_if_partition_key_on_non_partitioned_dag` — verifies the REST API rejects the invalid combination