### PR TITLE
Mark DAGs stale when DAG bundles are removed

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 from itsdangerous import URLSafeSerializer
 from pydantic import BaseModel, ValidationError
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 
 from airflow._shared.module_loading import import_string
 from airflow.configuration import conf
@@ -286,12 +286,21 @@ class DagBundlesManager(LoggingMixin):
                 bundle.teams = []
 
         # Import here to avoid circular import
+        from airflow.models import DagModel
         from airflow.models.errors import ParseImportError
 
         for name, bundle in stored.items():
             bundle.active = False
             bundle.teams = []
             self.log.warning("DAG bundle %s is no longer found in config and has been disabled", name)
+            stale_dags = session.execute(
+                update(DagModel)
+                .where(DagModel.bundle_name == name, DagModel.is_stale.is_(False))
+                .values(is_stale=True)
+                .execution_options(synchronize_session="fetch")
+            )
+            if stale_dag_count := getattr(stale_dags, "rowcount", 0):
+                self.log.info("Marked %s DAGs from disabled bundle %s as stale", stale_dag_count, name)
             session.execute(delete(ParseImportError).where(ParseImportError.bundle_name == name))
             self.log.info("Deleted import errors for bundle %s which is no longer configured", name)
 

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -28,11 +28,12 @@ from sqlalchemy import func, select
 from airflow.dag_processing.bundles.base import BaseDagBundle
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.exceptions import AirflowConfigException
+from airflow.models import DagModel
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.errors import ParseImportError
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.db import clear_db_dag_bundles
+from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags
 
 
 @pytest.mark.parametrize(
@@ -147,8 +148,10 @@ def test_get_bundle():
 
 @pytest.fixture
 def clear_db():
+    clear_db_dags()
     clear_db_dag_bundles()
     yield
+    clear_db_dags()
     clear_db_dag_bundles()
 
 
@@ -175,17 +178,17 @@ def test_sync_bundles_to_db(clear_db, session):
             stacktrace="some error",
         )
     )
+    session.add(DagModel(dag_id="dag-in-removed-bundle", bundle_name="my-test-bundle", is_stale=False))
     session.flush()
 
-    # simulate bundle config change (now 'dags-folder' is active, 'my-test-bundle' becomes inactive)
-    manager = DagBundlesManager()
-    manager.sync_bundles_to_db()
-    assert _get_bundle_names_and_active() == [
-        ("dags-folder", True),
-        ("my-test-bundle", False),
-    ]
+    # simulate bundle config change (now 'my-test-bundle' becomes inactive)
+    with patch.dict(os.environ, {"AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": "[]"}):
+        manager = DagBundlesManager()
+        manager.sync_bundles_to_db()
+    assert _get_bundle_names_and_active() == [("my-test-bundle", False)]
     # Since my-test-bundle is inactive, the associated import errors should be deleted
     assert session.scalar(select(func.count(ParseImportError.id))) == 0
+    assert session.get(DagModel, "dag-in-removed-bundle").is_stale is True
 
     # Re-enable one that reappears in config
     with patch.dict(
@@ -193,10 +196,7 @@ def test_sync_bundles_to_db(clear_db, session):
     ):
         manager = DagBundlesManager()
         manager.sync_bundles_to_db()
-    assert _get_bundle_names_and_active() == [
-        ("dags-folder", False),
-        ("my-test-bundle", True),
-    ]
+    assert _get_bundle_names_and_active() == [("my-test-bundle", True)]
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
Fixes #67271

## What changed
- Mark non-stale DAGs as stale in the same `sync_bundles_to_db()` pass that disables a removed DAG bundle.
- Keep the existing import-error cleanup for disabled bundles.
- Extend the bundle sync test to cover `dag_bundle_config_list = []` and assert DAGs from the removed bundle become stale immediately.

## Tests
- `uvx ruff check airflow-core/src/airflow/dag_processing/bundles/manager.py airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py`
- `uv run --no-dev --with pytest --with time-machine --with uuid6 --with-editable ./devel-common --with-editable ./shared/secrets_masker pytest airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py`

## Notes
- A plain `uv run pytest ...` / `uv run ruff ...` attempted to sync the full default dev environment and failed locally while building `jpype1` because Java is not installed. The commands above avoid the unrelated JDBC provider build while still testing the touched backend path.
