### PR TITLE
Fix Composer external task execution range checks

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -562,6 +562,7 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
+        has_task_instances_in_range = False
         for task_instance in task_instances:
             if (
                 start_date.timestamp()
@@ -569,9 +570,11 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
                     task_instance["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
                 ).timestamp()
                 < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+            ):
+                has_task_instances_in_range = True
+                if task_instance["state"] not in states:
+                    return False
+        return has_task_instances_in_range
 
     def _get_composer_airflow_version(self) -> int:
         """Return Composer Airflow version."""

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -444,6 +444,7 @@ class CloudComposerExternalTaskTrigger(BaseTrigger):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
+        has_task_instances_in_range = False
         for task_instance in task_instances:
             if (
                 start_date.timestamp()
@@ -451,9 +452,11 @@ class CloudComposerExternalTaskTrigger(BaseTrigger):
                     task_instance["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
                 ).timestamp()
                 < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+            ):
+                has_task_instances_in_range = True
+                if task_instance["state"] not in states:
+                    return False
+        return has_task_instances_in_range
 
     def _get_async_hook(self) -> CloudComposerAsyncHook:
         return CloudComposerAsyncHook(

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -69,6 +69,17 @@ TEST_GET_TASK_INSTANCES_RESULT = lambda state, date_key, task_id: {
     "task_instances": TEST_TASK_INSTANCES_RESULT(state, date_key, task_id),
     "total_entries": 1,
 }
+
+
+def build_task_instance_result(state, date_key, task_id, logical_date):
+    return {
+        "task_id": task_id,
+        "dag_id": "test_dag_id",
+        "state": state,
+        date_key: logical_date,
+        "start_date": "2024-05-22T11:20:01.531988+00:00",
+        "end_date": "2024-05-22T11:20:11.997479+00:00",
+    }
 
 
 class TestCloudComposerDAGRunSensor:
@@ -262,6 +273,60 @@ class TestCloudComposerExternalTaskSensor:
         task._composer_airflow_version = composer_airflow_version
 
         assert not task.poke(context={"logical_date": datetime(2024, 5, 23, 0, 0, 0)})
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @pytest.mark.parametrize(
+        ("task_instance_dates", "expected_status"),
+        [
+            pytest.param(
+                ["2024-05-22T10:30:00+00:00", "2024-05-22T12:30:00+00:00"],
+                False,
+                id="all-task-instances-outside-execution-range",
+            ),
+            pytest.param(
+                ["2024-05-22T11:00:00+00:00", "2024-05-22T12:00:00+00:00"],
+                False,
+                id="only-boundary-task-instances",
+            ),
+            pytest.param(
+                ["2024-05-22T10:30:00+00:00", "2024-05-22T11:10:00+00:00"],
+                True,
+                id="mixed-outside-and-inside-execution-range",
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
+    def test_execution_range_requires_matching_task_instance(
+        self, mock_hook, task_instance_dates, expected_status, composer_airflow_version
+    ):
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        mock_hook.return_value.get_task_instances.return_value = {
+            "task_instances": [
+                build_task_instance_result("success", date_key, TEST_COMPOSER_EXTERNAL_TASK_ID, date)
+                for date in task_instance_dates
+            ],
+            "total_entries": len(task_instance_dates),
+        }
+
+        task = CloudComposerExternalTaskSensor(
+            task_id="task-id",
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            environment_id=TEST_ENVIRONMENT_ID,
+            composer_external_dag_id="test_dag_id",
+            composer_external_task_id=TEST_COMPOSER_EXTERNAL_TASK_ID,
+            allowed_states=["success"],
+            execution_range=[
+                datetime(2024, 5, 22, 11, 0, 0, tzinfo=timezone.utc),
+                datetime(2024, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            ],
+        )
+        task._composer_airflow_version = composer_airflow_version
+
+        assert (
+            task.poke(context={"logical_date": datetime(2024, 5, 22, 12, 0, 0, tzinfo=timezone.utc)})
+            is expected_status
+        )
 
     @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -59,6 +59,17 @@ TEST_EXEC_RESULT = {
     "output_end": True,
     "exit_info": {"exit_code": 0, "error": ""},
 }
+
+
+def build_task_instance_result(state, date_key, task_id, logical_date):
+    return {
+        "task_id": task_id,
+        "dag_id": TEST_COMPOSER_DAG_ID,
+        "state": state,
+        date_key: logical_date,
+        "start_date": "2024-03-22T11:20:01.531988+00:00",
+        "end_date": "2024-03-22T11:20:11.997479+00:00",
+    }
 
 
 @pytest.fixture
@@ -209,3 +220,57 @@ class TestCloudComposerExternalTaskTrigger:
             },
         )
         assert actual_data == expected_data
+
+    @pytest.mark.parametrize("composer_airflow_version", [2, 3])
+    @pytest.mark.parametrize(
+        ("task_instance_states_and_dates", "expected_status"),
+        [
+            pytest.param(
+                [
+                    ("success", "2024-03-22T10:30:00+00:00"),
+                    ("success", "2024-03-22T12:30:00+00:00"),
+                ],
+                False,
+                id="all-task-instances-outside-execution-range",
+            ),
+            pytest.param(
+                [
+                    ("success", "2024-03-22T11:00:00+00:00"),
+                    ("success", "2024-03-22T12:00:00+00:00"),
+                ],
+                False,
+                id="only-boundary-task-instances",
+            ),
+            pytest.param(
+                [
+                    ("running", "2024-03-22T10:30:00+00:00"),
+                    ("success", "2024-03-22T11:10:00+00:00"),
+                ],
+                True,
+                id="mixed-outside-and-inside-execution-range",
+            ),
+        ],
+    )
+    def test_execution_range_requires_matching_task_instance(
+        self,
+        external_task_trigger,
+        task_instance_states_and_dates,
+        expected_status,
+        composer_airflow_version,
+    ):
+        external_task_trigger.composer_airflow_version = composer_airflow_version
+        date_key = "execution_date" if composer_airflow_version < 3 else "logical_date"
+        task_instances = [
+            build_task_instance_result(state, date_key, TEST_COMPOSER_EXTERNAL_TASK_IDS[0], logical_date)
+            for state, logical_date in task_instance_states_and_dates
+        ]
+
+        assert (
+            external_task_trigger._check_task_instances_states(
+                task_instances=task_instances,
+                start_date=datetime(2024, 3, 22, 11, 0, 0, tzinfo=timezone.utc),
+                end_date=datetime(2024, 3, 22, 12, 0, 0, tzinfo=timezone.utc),
+                states=TEST_ALLOWED_STATES,
+            )
+            is expected_status
+        )


### PR DESCRIPTION
Fix `CloudComposerExternalTaskSensor` and `CloudComposerExternalTaskTrigger` so execution-range state checks only succeed after at least one task instance is actually inside the requested open interval.

Why this is needed:
- the previous helper returned `True` when every returned task instance was outside `execution_range`
- that allowed the sync sensor, and the deferrable trigger path using the same helper, to report success without any relevant in-window task instance
- out-of-window task instances are still ignored when an in-window task instance satisfies the requested states

What is covered:
- all returned task instances outside the execution range
- only boundary task instances, preserving the existing open-interval boundary behavior
- mixed out-of-window and in-window task instances for Airflow 2 `execution_date` and Airflow 3 `logical_date` response shapes

Tests:
- `cd providers/google && uv sync`
- `cd providers/google && uv run pytest tests/unit/google/cloud/sensors/test_cloud_composer.py::TestCloudComposerExternalTaskSensor tests/unit/google/cloud/triggers/test_cloud_composer.py::TestCloudComposerExternalTaskTrigger` (27 passed)
- `cd providers/google && uv run ruff check src/airflow/providers/google/cloud/sensors/cloud_composer.py src/airflow/providers/google/cloud/triggers/cloud_composer.py tests/unit/google/cloud/sensors/test_cloud_composer.py tests/unit/google/cloud/triggers/test_cloud_composer.py`
- `git diff --check`

Note: a root-level `uv run pytest ...` attempt was not used for validation because it tried to build the full Airflow all-providers environment and failed on unrelated `jpype1` Java runtime discovery. The provider-scoped environment and tests above passed.

closes: #67051

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)
