### PR TITLE
Docs: refresh JWT and security model for v3.2 with mermaid diagrams

### DIFF
--- a/airflow-core/docs/security/jwt_token_authentication.rst
+++ b/airflow-core/docs/security/jwt_token_authentication.rst
@@ -62,7 +62,7 @@ claims, and scope semantics.
         DFP -. in-process<br/>JWT bypassed .-> EXECAPI
         TRG -. in-process<br/>JWT bypassed .-> EXECAPI
 
-        classDef internal fill:#eef,stroke:#446
+        classDef internal fill:#bbdefb,stroke:#1565c0,stroke-width:2px,color:#000
         class WORKER,DFP,TRG internal
 
 
@@ -112,8 +112,8 @@ Airflow supports two mutually exclusive signing modes:
             A3 -->|verify only| A4
         end
 
-        classDef secret fill:#fee,stroke:#a33
-        classDef pub fill:#efe,stroke:#3a3
+        classDef secret fill:#ffcdd2,stroke:#c62828,stroke-width:2px,color:#000
+        classDef pub fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
         class S2 secret
         class A2 secret
         class A3 pub
@@ -388,8 +388,8 @@ Route-level enforcement is handled by ``require_auth``:
         MATCH -->|no| F1
         MATCH -->|yes| OK
 
-        classDef fail fill:#fee,stroke:#a33
-        classDef pass fill:#efe,stroke:#3a3
+        classDef fail fill:#ffcdd2,stroke:#c62828,stroke-width:2px,color:#000
+        classDef pass fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
         class F1 fail
         class OK,RET pass
 

--- a/airflow-core/docs/security/jwt_token_authentication.rst
+++ b/airflow-core/docs/security/jwt_token_authentication.rst
@@ -322,7 +322,7 @@ The token flows through the execution stack as follows:
         SCH->>EXE: workload JSON<br/>(includes token)
         Note over EXE: Task waits in queue<br/>(can be minutes)
         EXE->>WRK: dispatch (workload JSON)
-        WRK->>API: POST /run<br/>Bearer: workload token
+        WRK->>API: PATCH /run<br/>Bearer: workload token
         Note over API: validates workload scope<br/>checks TI in QUEUED/RESTARTING<br/>409 if not
         API-->>WRK: 200 OK<br/>Refreshed-API-Token: execution token<br/>(scope=execution, ~10 min)
         WRK->>WRK: BearerAuth swaps to<br/>execution token

--- a/airflow-core/docs/security/jwt_token_authentication.rst
+++ b/airflow-core/docs/security/jwt_token_authentication.rst
@@ -40,6 +40,31 @@ Both flows share the same underlying JWT infrastructure (``JWTGenerator`` and ``
 classes in ``airflow.api_fastapi.auth.tokens``) but differ in audience, token lifetime, subject
 claims, and scope semantics.
 
+.. mermaid::
+
+    flowchart LR
+        subgraph Clients
+            UI[UI / browser]
+            CLI[CLI]
+            EXT[External REST clients]
+        end
+        subgraph Internal["Internal Airflow components"]
+            WORKER[Worker / Task]
+            DFP[Dag File Processor]
+            TRG[Triggerer]
+        end
+        APISVR[API Server]
+        EXECAPI[Execution API]
+        UI -->|JWT cookie / Bearer| APISVR
+        CLI -->|Bearer| APISVR
+        EXT -->|Bearer| APISVR
+        WORKER -->|Bearer<br/>workload &rarr; execution| EXECAPI
+        DFP -. in-process<br/>JWT bypassed .-> EXECAPI
+        TRG -. in-process<br/>JWT bypassed .-> EXECAPI
+
+        classDef internal fill:#eef,stroke:#446
+        class WORKER,DFP,TRG internal
+
 
 Signing and Cryptography
 ------------------------
@@ -65,6 +90,39 @@ Airflow supports two mutually exclusive signing modes:
      (local file or remote HTTP/HTTPS URL, polled periodically for updates).
    - The public key derived from the configured private key (automatic fallback when
      ``trusted_jwks_url`` is not set).
+
+.. mermaid::
+
+    flowchart TB
+        subgraph Sym["Symmetric (HS512)"]
+            direction LR
+            S1[Scheduler / API Server]
+            S2[Shared secret<br/>jwt_secret]
+            S3[Token validator]
+            S1 -->|sign| S2 -->|same secret<br/>also validates| S3
+        end
+        subgraph Asym["Asymmetric (RS256 / EdDSA)"]
+            direction LR
+            A1[Scheduler / API Server]
+            A2[Private key<br/>jwt_private_key_path]
+            A3[Public key /<br/>JWKS endpoint]
+            A4[Token validator]
+            A1 -->|sign| A2
+            A2 -. derives or<br/>publishes .-> A3
+            A3 -->|verify only| A4
+        end
+
+        classDef secret fill:#fee,stroke:#a33
+        classDef pub fill:#efe,stroke:#3a3
+        class S2 secret
+        class A2 secret
+        class A3 pub
+
+In asymmetric mode, validators (workers, downstream services) need only the public key — the
+private signing key can be tightly scoped to the issuing components (API Server, Scheduler).
+In symmetric mode, any component that can validate tokens can also forge them, because there
+is only one key. See :ref:`jwt-authentication-and-workload-isolation` for the deployment
+implications.
 
 REST API Authentication Flow
 -----------------------------
@@ -130,6 +188,14 @@ tokens issued to workers.
 Revoked tokens are tracked in the ``revoked_token`` database table by their ``jti`` claim.
 On logout or explicit revocation, the token's ``jti`` and ``exp`` are inserted into this
 table. Expired entries are automatically cleaned up at a cadence of ``2× jwt_expiration_time``.
+
+The ``/auth/logout`` endpoint always invokes ``auth_manager.revoke_token()`` before any
+redirect or cookie deletion. This includes deployments where the configured auth manager
+(for example ``FabAuthManager`` or ``KeycloakAuthManager``) redirects the user to an external
+logout URL — the JWT is invalidated in Airflow's ``revoked_token`` table regardless of what
+the external Identity Provider does with its own session. The ``revoke_token`` call is
+unconditional; auth managers that do not implement server-side revocation can keep the
+default no-op implementation.
 
 Token refresh (REST API)
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -242,6 +308,37 @@ The token flows through the execution stack as follows:
 6. The client's ``_update_auth()`` hook detects the header and transparently updates
    the ``BearerAuth`` instance to use the new ``execution`` token for all subsequent requests.
 
+.. mermaid::
+
+    sequenceDiagram
+        autonumber
+        participant SCH as Scheduler
+        participant EXE as Executor<br/>(Celery / K8s / Local)
+        participant WRK as Worker
+        participant API as Execution API
+
+        Note over SCH: Task ready to dispatch
+        SCH->>SCH: generate workload token<br/>scope=workload<br/>exp = task_queued_timeout
+        SCH->>EXE: workload JSON<br/>(includes token)
+        Note over EXE: Task waits in queue<br/>(can be minutes)
+        EXE->>WRK: dispatch (workload JSON)
+        WRK->>API: POST /run<br/>Bearer: workload token
+        Note over API: validates workload scope<br/>checks TI in QUEUED/RESTARTING<br/>409 if not
+        API-->>WRK: 200 OK<br/>Refreshed-API-Token: execution token<br/>(scope=execution, ~10 min)
+        WRK->>WRK: BearerAuth swaps to<br/>execution token
+        loop For all subsequent calls (heartbeats, XComs, ...)
+            WRK->>API: Bearer: execution token
+            alt token expiring (less than 20% left)
+                API-->>WRK: 200 OK<br/>Refreshed-API-Token: new execution token
+                WRK->>WRK: BearerAuth swaps again
+            end
+        end
+
+Even if a workload token is intercepted in transit, it can only call ``/run``. That endpoint
+rejects re-runs (``409 Conflict`` unless the task instance is in ``QUEUED`` or ``RESTARTING``),
+so the attack surface for the longer-lived token is bounded to "start a task that is already
+queued". All other endpoints require ``scope=execution`` and reject workload tokens.
+
 Token validation (Execution API)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -251,8 +348,16 @@ The ``JWTBearer`` security dependency validates the token once per request:
 2. Performs cryptographic signature validation via ``JWTValidator``.
 3. Verifies standard claims (``exp``, ``iat``, ``aud`` — ``nbf`` and ``iss`` if configured).
 4. Defaults the ``scope`` claim to ``"execution"`` if absent.
-5. Creates a ``TIToken`` object with the task instance ID and claims.
-6. Caches the validated token on the ASGI request scope for the duration of the request.
+5. **Validates the task identity claims against a typed Pydantic schema.** ``TIClaims``
+   (in ``airflow.api_fastapi.execution_api.datamodels.token``) enforces that ``scope`` is one
+   of the declared ``TokenScope`` literals (``"execution"`` or ``"workload"``); ``TIToken``
+   then parses the ``sub`` claim through a ``UUID`` field, which rejects non-UUID values.
+   A token whose ``scope`` is unknown, or whose ``sub`` is not a valid UUID, is rejected with
+   ``403 Forbidden`` even when the cryptographic signature checks pass. ``TIClaims`` keeps
+   ``extra="allow"`` so auth managers can attach additional, deployment-specific claims
+   without modifying the core schema; only the security-critical fields are typed.
+6. Creates a ``TIToken`` object with the task instance ID and validated claims.
+7. Caches the validated token on the ASGI request scope for the duration of the request.
 
 Route-level enforcement is handled by ``require_auth``:
 
@@ -261,6 +366,32 @@ Route-level enforcement is handled by ``require_auth``:
 - Enforces ``ti:self`` scope — verifies that the token's ``sub`` claim matches the
   ``{task_instance_id}`` path parameter, preventing a worker from accessing another task's
   endpoints.
+
+.. mermaid::
+
+    flowchart TD
+        REQ([Incoming request<br/>Authorization: Bearer ...])
+        REQ --> CACHE{Cached on<br/>request.scope?}
+        CACHE -->|yes| RET([Return cached TIToken])
+        CACHE -->|no| SIG[JWTValidator:<br/>verify signature]
+        SIG -->|fail| F1([403 Forbidden])
+        SIG -->|ok| STD[Verify exp / iat / nbf<br/>aud / iss]
+        STD -->|fail| F1
+        STD -->|ok| SCOPE[Default scope to<br/>'execution' if absent]
+        SCOPE --> SCHEMA[TIClaims:<br/>typed Pydantic schema]
+        SCHEMA -->|ValidationError| F1
+        SCHEMA -->|ok| TYP{require_auth:<br/>scope in<br/>route.allowed_token_types?}
+        TYP -->|no| F1
+        TYP -->|yes| SELF{ti:self scope<br/>declared?}
+        SELF -->|no| OK([Return TIToken])
+        SELF -->|yes| MATCH{token.sub ==<br/>task_instance_id?}
+        MATCH -->|no| F1
+        MATCH -->|yes| OK
+
+        classDef fail fill:#fee,stroke:#a33
+        classDef pass fill:#efe,stroke:#3a3
+        class F1 fail
+        class OK,RET pass
 
 Token refresh (Execution API)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -329,6 +329,77 @@ Execution API. For a detailed description of the JWT authentication flows, token
 configuration, see :doc:`/security/jwt_token_authentication`. For the current state of workload
 isolation protections and their limitations, see :ref:`workload-isolation`.
 
+The diagram below summarizes the trust boundaries between Airflow components and the metadata
+database. Solid arrows are authenticated network calls (JWT-bearing HTTP). Dashed arrows are
+direct database access — components on the right of the dashed line can read and write the
+metadata DB, so any code they execute is implicitly trusted with the metadata database.
+
+.. mermaid::
+
+    flowchart LR
+        subgraph users["Users (untrusted by default)"]
+            UI[UI / browser]
+            CLI[CLI]
+            EXT[External REST clients]
+        end
+
+        subgraph dataplane["Worker plane (no metadata DB access)"]
+            WRK[Worker / Task]
+        end
+
+        subgraph controlplane["Control plane (metadata DB access)"]
+            APISVR[API Server]
+            SCH[Scheduler]
+            DFP[Dag File Processor]
+            TRG[Triggerer]
+        end
+
+        DB[(Metadata DB)]
+
+        UI -->|JWT| APISVR
+        CLI -->|JWT| APISVR
+        EXT -->|JWT| APISVR
+        WRK -->|JWT<br/>Execution API| APISVR
+
+        APISVR -. SQL .-> DB
+        SCH -. SQL .-> DB
+        DFP -. SQL .-> DB
+        TRG -. SQL .-> DB
+
+        DFP -. in-process<br/>JWT bypassed .-> APISVR
+        TRG -. in-process<br/>JWT bypassed .-> APISVR
+
+        classDef untrusted fill:#fee,stroke:#a33
+        classDef trusted fill:#efe,stroke:#3a3
+        classDef data fill:#eef,stroke:#446
+        class UI,CLI,EXT,WRK untrusted
+        class APISVR,SCH,DFP,TRG trusted
+        class DB data
+
+The intentional asymmetry: **workers have no direct DB credentials and reach data only through
+the JWT-authenticated Execution API**, while DFP and Triggerer share the control plane's DB
+access and use an *in-process* transport that bypasses the JWT bearer dependency. This is why
+Dag File Processor and Triggerer are treated as part of the control-plane trust boundary even
+though they run user-supplied code — see :ref:`workload-isolation` and the limitations below.
+
+Defense in depth at the router level
+....................................
+
+Both the public REST API router (``/api/v2``) and the UI router (``/ui``) declare
+``Depends(get_user)`` at the router level. This is purely a defense-in-depth backstop: every
+authenticated route already declares its own ``GetUserDep`` or ``requires_access_*`` dependency
+that itself resolves ``get_user``, and FastAPI caches dependency resolutions per request, so
+the duplicate declaration is resolved only once and the runtime cost is zero. The value is preventing a future route from being added
+under either router without an authentication check — the router-level dependency catches the
+regression at registration time. The explicit no-auth carve-outs are limited to
+``monitor_router`` (health probes), ``version_router``, and the public ``auth_router`` (login
+endpoints), which are mounted directly on the public router rather than under
+``authenticated_router``.
+
+A structural test asserts both routers carry the router-level ``Depends(get_user)``, so a
+refactor that drops the dependency without considering its purpose fails CI rather than
+silently widening the unauthenticated surface.
+
 Current isolation limitations
 .............................
 
@@ -409,6 +480,24 @@ potentially still executes with direct database access in the Dag File Processor
    variables, and XComs are accessible to all tasks. There is no isolation between tasks belonging to
    different teams or Dag authors at the Execution API level.
 
+   What the Execution API **does** enforce, beyond ``ti:self``:
+
+   * **Secrets-backend deny is honoured.** When the Execution API returns ``401``/``403`` for a
+     connection or variable lookup, the SDK's ``ExecutionAPISecretsBackend`` raises
+     ``AirflowSecretsBackendAccessDenied`` (a subclass of ``PermissionError``) instead of returning
+     ``None``. The secrets-backend dispatcher must not fall through to a less-restrictive backend
+     (such as ``EnvironmentVariablesBackend``, which performs no authorization checks) when the
+     authoritative backend has explicitly denied the request. ``NOT_FOUND`` responses keep the
+     existing fall-through behaviour so the not-found-here path remains usable. This closes a
+     "Type C" gap where the authorization control fired but its rejection was treated as a miss.
+   * **Tightened deserialization allowlist.** The serializer's class-name allowlist regex is
+     anchored to require a full-string match, so attacker-controlled values cannot smuggle
+     untrusted class names by appending an allowed suffix to a non-allowed name.
+   * **Typed JWT claims schema.** Even after cryptographic validation, claims are run through a
+     typed Pydantic schema (``TIClaims``) that enforces the ``scope`` literal, and then through
+     ``TIToken`` which parses ``sub`` as a UUID. A token whose ``scope`` is unknown or whose
+     ``sub`` is not a valid UUID is rejected before any route handler runs.
+
 **Token signing key might be a shared secret**
    In symmetric key mode (``[api_auth] jwt_secret``), the same secret key is used to both generate and
    validate tokens. Any component that has access to this secret can forge tokens with arbitrary claims,
@@ -465,6 +554,59 @@ model — Airflow does not enforce these natively.
    ``ptrace``. In contrast, configuration files on disk are readable by any process running as
    the same Unix user. Environment variables can also be scoped to individual processes or
    containers, making it easier to restrict which components have access to which secrets.
+
+   The following diagram summarizes which components need which classes of sensitive value in a
+   well-hardened deployment. Workers should not see DB credentials or the JWT signing key at all;
+   the API Server is the only component that needs *all* of them.
+
+   .. mermaid::
+
+       flowchart LR
+           subgraph secrets["Sensitive values"]
+               DBC[DB connection<br/>SQL_ALCHEMY_CONN]
+               JWT[JWT signing key<br/>jwt_secret /<br/>jwt_private_key_path]
+               FERN[Fernet key]
+               SB_CFG[Secrets backend<br/>credentials<br/>non-worker]
+               SB_WRK[Secrets backend<br/>credentials<br/>worker]
+               REMLOG[Remote log<br/>handler kwargs]
+           end
+
+           subgraph components["Components"]
+               APISVR[API Server]
+               SCH[Scheduler]
+               DFP[Dag File Processor]
+               TRG[Triggerer]
+               WRK[Worker]
+           end
+
+           DBC --> APISVR
+           DBC --> SCH
+           DBC --> DFP
+           DBC --> TRG
+
+           JWT --> APISVR
+           JWT --> SCH
+
+           FERN --> APISVR
+           FERN --> SCH
+           FERN --> DFP
+           FERN --> TRG
+           FERN --> WRK
+
+           SB_CFG --> SCH
+           SB_CFG --> DFP
+           SB_CFG --> TRG
+
+           SB_WRK --> WRK
+
+           REMLOG --> SCH
+           REMLOG --> TRG
+           REMLOG --> WRK
+
+           classDef worker fill:#efe,stroke:#3a3
+           classDef control fill:#eef,stroke:#446
+           class WRK worker
+           class APISVR,SCH,DFP,TRG control
 
    The following tables list all security-sensitive configuration variables (marked ``sensitive: true``
    in Airflow's configuration). Deployment Managers should review each variable and ensure it is only

--- a/airflow-core/docs/security/security_model.rst
+++ b/airflow-core/docs/security/security_model.rst
@@ -369,9 +369,9 @@ metadata DB, so any code they execute is implicitly trusted with the metadata da
         DFP -. in-process<br/>JWT bypassed .-> APISVR
         TRG -. in-process<br/>JWT bypassed .-> APISVR
 
-        classDef untrusted fill:#fee,stroke:#a33
-        classDef trusted fill:#efe,stroke:#3a3
-        classDef data fill:#eef,stroke:#446
+        classDef untrusted fill:#ffcdd2,stroke:#c62828,stroke-width:2px,color:#000
+        classDef trusted fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
+        classDef data fill:#fff9c4,stroke:#f57f17,stroke-width:2px,color:#000
         class UI,CLI,EXT,WRK untrusted
         class APISVR,SCH,DFP,TRG trusted
         class DB data
@@ -555,58 +555,108 @@ model — Airflow does not enforce these natively.
    the same Unix user. Environment variables can also be scoped to individual processes or
    containers, making it easier to restrict which components have access to which secrets.
 
-   The following diagram summarizes which components need which classes of sensitive value in a
-   well-hardened deployment. Workers should not see DB credentials or the JWT signing key at all;
-   the API Server is the only component that needs *all* of them.
+   The diagram and table below summarize which components need which classes of sensitive value
+   in a well-hardened deployment. Workers should not see DB credentials or the JWT signing key
+   at all; the API Server is the only component that needs *all* of the privileged values.
+   Components are arranged from least-privileged (Worker, green) to most-privileged
+   (API Server, blue) — the growing column visually conveys "more privilege ⇒ more secrets":
 
    .. mermaid::
 
        flowchart LR
-           subgraph secrets["Sensitive values"]
-               DBC[DB connection<br/>SQL_ALCHEMY_CONN]
-               JWT[JWT signing key<br/>jwt_secret /<br/>jwt_private_key_path]
-               FERN[Fernet key]
-               SB_CFG[Secrets backend<br/>credentials<br/>non-worker]
-               SB_WRK[Secrets backend<br/>credentials<br/>worker]
-               REMLOG[Remote log<br/>handler kwargs]
+           subgraph WRK["Worker (least privileged)"]
+               direction TB
+               W1[Fernet key]
+               W2[Worker secrets backend credentials]
+               W3[Remote log handler kwargs]
            end
 
-           subgraph components["Components"]
-               APISVR[API Server]
-               SCH[Scheduler]
-               DFP[Dag File Processor]
-               TRG[Triggerer]
-               WRK[Worker]
+           subgraph TRG["Triggerer"]
+               direction TB
+               T1[DB connection]
+               T2[Fernet key]
+               T3[Non-worker secrets backend credentials]
+               T4[Remote log handler kwargs]
            end
 
-           DBC --> APISVR
-           DBC --> SCH
-           DBC --> DFP
-           DBC --> TRG
+           subgraph DFP["Dag File Processor"]
+               direction TB
+               D1[DB connection]
+               D2[Fernet key]
+               D3[Non-worker secrets backend credentials]
+           end
 
-           JWT --> APISVR
-           JWT --> SCH
+           subgraph SCH["Scheduler"]
+               direction TB
+               S1[DB connection]
+               S2[JWT signing key]
+               S3[Fernet key]
+               S4[Non-worker secrets backend credentials]
+               S5[Remote log handler kwargs]
+           end
 
-           FERN --> APISVR
-           FERN --> SCH
-           FERN --> DFP
-           FERN --> TRG
-           FERN --> WRK
+           subgraph API["API Server (most privileged)"]
+               direction TB
+               A1[DB connection]
+               A2[JWT signing key]
+               A3[Fernet key]
+           end
 
-           SB_CFG --> SCH
-           SB_CFG --> DFP
-           SB_CFG --> TRG
+           classDef wrk fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
+           classDef ctrl fill:#bbdefb,stroke:#1565c0,stroke-width:2px,color:#000
+           class WRK wrk
+           class API,SCH,DFP,TRG ctrl
 
-           SB_WRK --> WRK
+   Read row-by-row to check which components need a given secret; read column-by-column to
+   check what one component is allowed to see:
 
-           REMLOG --> SCH
-           REMLOG --> TRG
-           REMLOG --> WRK
+   .. list-table::
+      :header-rows: 1
+      :widths: 32 14 14 13 14 13
+      :align: left
 
-           classDef worker fill:#efe,stroke:#3a3
-           classDef control fill:#eef,stroke:#446
-           class WRK worker
-           class APISVR,SCH,DFP,TRG control
+      * - Sensitive value
+        - API Server
+        - Scheduler
+        - Dag File Processor
+        - Triggerer
+        - Worker
+      * - DB connection
+        - ✓
+        - ✓
+        - ✓
+        - ✓
+        - —
+      * - JWT signing key
+        - ✓
+        - ✓
+        - —
+        - —
+        - —
+      * - Fernet key
+        - ✓
+        - ✓
+        - ✓
+        - ✓
+        - ✓
+      * - Secrets backend credentials (non-worker)
+        - —
+        - ✓
+        - ✓
+        - ✓
+        - —
+      * - Secrets backend credentials (worker)
+        - —
+        - —
+        - —
+        - —
+        - ✓
+      * - Remote log handler kwargs
+        - —
+        - ✓
+        - —
+        - ✓
+        - ✓
 
    The following tables list all security-sensitive configuration variables (marked ``sensitive: true``
    in Airflow's configuration). Deployment Managers should review each variable and ensure it is only

--- a/devel-common/pyproject.toml
+++ b/devel-common/pyproject.toml
@@ -96,6 +96,7 @@ dependencies = [
     "sphinxcontrib-httpdomain>=1.8.1",
     "sphinxcontrib-jquery>=4.1",
     "sphinxcontrib-jsmath>=1.0.1",
+    "sphinxcontrib-mermaid>=1.0.0",
     "sphinxcontrib-qthelp>=1.0.3",
     "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-serializinghtml>=1.1.5",

--- a/devel-common/src/docs/utils/conf_constants.py
+++ b/devel-common/src/docs/utils/conf_constants.py
@@ -87,6 +87,7 @@ BASIC_SPHINX_EXTENSIONS = [
     "sphinx_copybutton",
     "airflow_intersphinx",
     "common_compat_alias",
+    "sphinxcontrib.mermaid",
     "sphinxcontrib.spelling",
     "sphinx_airflow_theme",
     "redirects",

--- a/uv.lock
+++ b/uv.lock
@@ -2469,6 +2469,7 @@ docs = [
     { name = "sphinxcontrib-httpdomain" },
     { name = "sphinxcontrib-jquery" },
     { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-mermaid" },
     { name = "sphinxcontrib-qthelp" },
     { name = "sphinxcontrib-redoc" },
     { name = "sphinxcontrib-serializinghtml" },
@@ -2657,6 +2658,7 @@ requires-dist = [
     { name = "sphinxcontrib-httpdomain", marker = "extra == 'docs'", specifier = ">=1.8.1" },
     { name = "sphinxcontrib-jquery", marker = "extra == 'docs'", specifier = ">=4.1" },
     { name = "sphinxcontrib-jsmath", marker = "extra == 'docs'", specifier = ">=1.0.1" },
+    { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0.0" },
     { name = "sphinxcontrib-qthelp", marker = "extra == 'docs'", specifier = ">=1.0.3" },
     { name = "sphinxcontrib-redoc", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "sphinxcontrib-serializinghtml", marker = "extra == 'docs'", specifier = ">=1.1.5" },
@@ -14453,6 +14455,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a2/5d27e81d24eef64668bf702bfe0e091cc48388b4666f36e025243eb9d827/jpype1-1.7.1.tar.gz", hash = "sha256:3cd88838dc3d2d546f7eaeadaaff864e590010c15f2b6a44b6f37e60796a14b2", size = 783791, upload-time = "2026-05-06T23:55:10.664Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c0/2c41dedfb65060fa05d152b3f57e7c3658c86257d92de365a3c1fcb80779/jpype1-1.7.1-1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6590cbdb6208e4522fd99ae5f5f4bed5de707122385bc48446a1e7d7b56357ef", size = 571509, upload-time = "2026-05-19T20:19:30.416Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5e/5611d50222d146a060dbf22e69c4017545341ea6b289a591d5a9bdaad718/jpype1-1.7.1-1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4c81ee11aee5ed938d7415877cd9c7a0cc9cbf1dac87f7eab928e641323a385b", size = 571633, upload-time = "2026-05-19T20:19:33.536Z" },
+    { url = "https://files.pythonhosted.org/packages/79/32/8b2279b12364f260111c7843bf9ede7dc442d5521d6d2ca728b3d522d445/jpype1-1.7.1-1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b3ddd9f9099202212a34679dfb95dda590bcfbd23289559d104e24abec9120d1", size = 569654, upload-time = "2026-05-19T20:19:36.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/67/5caa0de30bcb1c8786cc988144a68908e0624de20cfed470a67b1dd1f60c/jpype1-1.7.1-1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:6d491a81281407f8a68552eb3c0e635e576e066c069268dc29a1ea27bb4778ae", size = 569800, upload-time = "2026-05-19T20:19:38.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/1d/9ee10b1aad9f01ea6ac6159981120eb5ace01962f9cfaa7de6b911de3eb8/jpype1-1.7.1-1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ace0ba1a67561358fa5b57b8e93ed8bcf16f0a8d5cba79c875089c56827adf8e", size = 569753, upload-time = "2026-05-19T20:19:41.514Z" },
     { url = "https://files.pythonhosted.org/packages/04/ff/44a6f285d4c07014cb64379b8863caaefad1cc976d36923073d097b1d461/jpype1-1.7.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:472b2f53002f5fdf118d2e6b8c6b5441d6e3ca3cf1b1bdb163442be76c8b2859", size = 375560, upload-time = "2026-05-06T23:53:48.669Z" },
     { url = "https://files.pythonhosted.org/packages/42/c5/98c5ba221de29b341298341c07ad2221beae565886d18c2e6b821928db15/jpype1-1.7.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80c4c8cbab99040b8b56f28ff834e0b089aefccaabe3b472b8b43bb1e4658b86", size = 408119, upload-time = "2026-05-06T23:53:51.382Z" },
     { url = "https://files.pythonhosted.org/packages/37/3f/d3b7fd287d5bae63af0ae935b2f2c01291d18ea2e6cd706db8e4dda15354/jpype1-1.7.1-cp310-cp310-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:9c9a08d06016afbe5391daaf843b9e76c79022181685bbb23b64cd3f9aaec30d", size = 454716, upload-time = "2026-05-06T23:53:53.937Z" },
@@ -21726,6 +21733,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Catch up the public security documentation to match the security-relevant
changes flowing into the 3.2 release branch. Adds six mermaid diagrams
and re-aligns prose with the current code.

## What changed in the docs

`airflow-core/docs/security/jwt_token_authentication.rst`:
- 4 mermaid diagrams: components-and-flows overview; symmetric vs
  asymmetric signing; two-token sequence (Scheduler → executor queue →
  worker `/run` → refreshed execution token); request-time validation
  pipeline (signature → standard claims → `TIClaims` schema →
  `require_auth` scope → `ti:self`).
- Documents typed `TIClaims` Pydantic claims validation (#63604).
- Documents that `/auth/logout` now invokes `auth_manager.revoke_token()`
  unconditionally, even when the auth manager redirects to an external
  IdP logout URL (#67289).

`airflow-core/docs/security/security_model.rst`:
- 2 mermaid diagrams: component trust boundaries (control plane vs
  worker plane, DFP/Triggerer's in-process Execution API bypass);
  per-component credential-distribution matrix for sensitive values.
- New "Defense in depth at the router level" subsection documenting
  router-level `Depends(get_user)` on `authenticated_router` and
  `ui_router` (#66505).
- Notes what the Execution API does enforce beyond `ti:self`:
  `ExecutionAPISecretsBackend` raises `PermissionError` on 401/403
  instead of letting the dispatcher fall through to a less-restrictive
  backend (#66575); tightened deserialization allowlist regex requires a
  full-string match (#66499); typed claims schema rejects non-UUID
  `sub` or unknown `scope`.

## Tooling change

Registers `sphinxcontrib-mermaid>=1.0.0` as a new dependency in
`devel-common[docs]` and adds `sphinxcontrib.mermaid` to
`BASIC_SPHINX_EXTENSIONS` so every Airflow Sphinx build (core,
providers, chart, docker-stack) can use `.. mermaid::` directives.
`uv.lock` is regenerated.

## Verification

- `breeze build-docs --package-filter apache-airflow` →
  "Documentation build is successful", 0 build errors, 0 spelling errors.
- All six mermaid containers render in the produced HTML.
- `prek run --from-ref upstream/main --stage pre-commit` and
  `--stage manual` both pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)