### PR TITLE
Fix Celery worker service account in RBAC bindings

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -726,6 +726,17 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- end }}
 {{- end }}
 
+{{/* Create the name of the worker celery service account to use */}}
+{{- define "worker.celery.serviceAccountName" -}}
+  {{- $filteredCeleryServiceAccount := include "removeNilFields" .Values.workers.celery.serviceAccount | fromYaml -}}
+  {{- $serviceAccount := include "workersMergeValues" (list .Values.workers.serviceAccount $filteredCeleryServiceAccount "" list) | fromYaml -}}
+  {{- if and (hasKey .Values.workers "name") (ne .Values.workers.name "default") }}
+    {{- include "_serviceAccountNameGen" (merge (dict "sa" $serviceAccount "key" "workers" "nameSuffix" (printf "%s-%s" "worker" .Values.workers.name)) .) -}}
+  {{- else }}
+    {{- include "_serviceAccountNameGen" (merge (dict "sa" $serviceAccount "key" "workers" "nameSuffix" "worker") .) -}}
+  {{- end }}
+{{- end }}
+
 {{/* Create the name of the worker kubernetes service account to use */}}
 {{- define "worker.kubernetes.serviceAccountName" -}}
   {{- include "_serviceAccountName" (merge (dict "key" "workers" "subKey" "kubernetes" "nameSuffix" "worker-kubernetes") .) -}}

--- a/chart/templates/rbac/job-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/job-launcher-rolebinding.yaml
@@ -55,14 +55,21 @@ roleRef:
   name: {{ include "airflow.fullname" . }}-job-launcher-role
   {{- end }}
 subjects:
+  {{- $workerServiceAccountName := include "worker.serviceAccountName" $ }}
+  {{- $workerCeleryServiceAccountName := include "worker.celery.serviceAccountName" $ }}
   {{- if and .Values.scheduler.enabled (or (contains "LocalExecutor" .Values.executor) (contains "KubernetesExecutor" .Values.executor)) }}
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
   {{- end }}
-  {{- if or (contains "CeleryExecutor" .Values.executor) (and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil)) }}
+  {{- if contains "CeleryExecutor" .Values.executor }}
   - kind: ServiceAccount
-    name: {{ include "worker.serviceAccountName" $ }}
+    name: {{ $workerCeleryServiceAccountName }}
+    namespace: "{{ $.Release.Namespace }}"
+  {{- end }}
+  {{- if and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil) (or (not (contains "CeleryExecutor" .Values.executor)) (ne $workerServiceAccountName $workerCeleryServiceAccountName)) }}
+  - kind: ServiceAccount
+    name: {{ $workerServiceAccountName }}
     namespace: "{{ $.Release.Namespace }}"
   {{- end }}
   {{- if and (or .Values.workers.kubernetes.serviceAccount.create .Values.workers.kubernetes.serviceAccount.name) (contains "KubernetesExecutor" .Values.executor) }}

--- a/chart/templates/rbac/pod-launcher-rolebinding.yaml
+++ b/chart/templates/rbac/pod-launcher-rolebinding.yaml
@@ -55,14 +55,21 @@ roleRef:
   name: {{ include "airflow.fullname" . }}-pod-launcher-role
   {{- end }}
 subjects:
+  {{- $workerServiceAccountName := include "worker.serviceAccountName" $ }}
+  {{- $workerCeleryServiceAccountName := include "worker.celery.serviceAccountName" $ }}
   {{- if and .Values.scheduler.enabled (or (contains "LocalExecutor" .Values.executor) (contains "KubernetesExecutor" .Values.executor)) }}
   - kind: ServiceAccount
     name: {{ include "scheduler.serviceAccountName" $ }}
     namespace: "{{ $.Release.Namespace }}"
   {{- end }}
-  {{- if or (contains "CeleryExecutor" .Values.executor) (and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil)) }}
+  {{- if contains "CeleryExecutor" .Values.executor }}
   - kind: ServiceAccount
-    name: {{ include "worker.serviceAccountName" $ }}
+    name: {{ $workerCeleryServiceAccountName }}
+    namespace: "{{ $.Release.Namespace }}"
+  {{- end }}
+  {{- if and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil) (or (not (contains "CeleryExecutor" .Values.executor)) (ne $workerServiceAccountName $workerCeleryServiceAccountName)) }}
+  - kind: ServiceAccount
+    name: {{ $workerServiceAccountName }}
     namespace: "{{ $.Release.Namespace }}"
   {{- end }}
   {{- if and (or .Values.workers.kubernetes.serviceAccount.create .Values.workers.kubernetes.serviceAccount.name) (contains "KubernetesExecutor" .Values.executor) }}

--- a/chart/templates/rbac/security-context-constraint-rolebinding.yaml
+++ b/chart/templates/rbac/security-context-constraint-rolebinding.yaml
@@ -50,9 +50,16 @@ roleRef:
   kind: ClusterRole
   name: system:openshift:scc:anyuid
 subjects:
-  {{- if or (contains "CeleryExecutor" .Values.executor) (and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil)) }}
+  {{- $workerServiceAccountName := include "worker.serviceAccountName" . }}
+  {{- $workerCeleryServiceAccountName := include "worker.celery.serviceAccountName" . }}
+  {{- if contains "CeleryExecutor" .Values.executor }}
   - kind: ServiceAccount
-    name: {{ include "worker.serviceAccountName" . }}
+    name: {{ $workerCeleryServiceAccountName }}
+    namespace: "{{ .Release.Namespace }}"
+  {{- end }}
+  {{- if and (contains "KubernetesExecutor" .Values.executor) (eq .Values.workers.kubernetes.serviceAccount.create nil) (or (not (contains "CeleryExecutor" .Values.executor)) (ne $workerServiceAccountName $workerCeleryServiceAccountName)) }}
+  - kind: ServiceAccount
+    name: {{ $workerServiceAccountName }}
     namespace: "{{ .Release.Namespace }}"
   {{- end }}
   {{- if and (or .Values.workers.kubernetes.serviceAccount.create .Values.workers.kubernetes.serviceAccount.name) (contains "KubernetesExecutor" .Values.executor) }}

--- a/chart/tests/helm_tests/airflow_aux/test_job_launcher_role.py
+++ b/chart/tests/helm_tests/airflow_aux/test_job_launcher_role.py
@@ -147,6 +147,50 @@ class TestJobLauncher:
             "namespace": "airflow",
         }
 
+    def test_worker_role_binding_uses_celery_service_account_name(self):
+        docs = render_chart(
+            name="prod",
+            namespace="airflow",
+            values={
+                "rbac": {"create": True},
+                "allowJobLaunching": True,
+                "executor": "CeleryExecutor",
+                "workers": {"celery": {"serviceAccount": {"name": "custom-worker"}}},
+            },
+            show_only=["templates/rbac/job-launcher-rolebinding.yaml"],
+        )
+
+        assert jmespath.search("subjects[?name=='custom-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "custom-worker",
+            "namespace": "airflow",
+        }
+        assert jmespath.search("subjects[?name=='prod-airflow-worker']", docs[0]) == []
+
+    def test_worker_role_binding_keeps_kubernetes_fallback_service_account_when_celery_differs(self):
+        docs = render_chart(
+            name="prod",
+            namespace="airflow",
+            values={
+                "rbac": {"create": True},
+                "allowJobLaunching": True,
+                "executor": "CeleryExecutor,KubernetesExecutor",
+                "workers": {"celery": {"serviceAccount": {"name": "custom-worker"}}},
+            },
+            show_only=["templates/rbac/job-launcher-rolebinding.yaml"],
+        )
+
+        assert jmespath.search("subjects[?name=='custom-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "custom-worker",
+            "namespace": "airflow",
+        }
+        assert jmespath.search("subjects[?name=='prod-airflow-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "prod-airflow-worker",
+            "namespace": "airflow",
+        }
+
     def test_worker_role_binding_should_not_exists(self):
         docs = render_chart(
             name="prod",

--- a/chart/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
+++ b/chart/tests/helm_tests/airflow_aux/test_pod_launcher_role.py
@@ -148,6 +148,50 @@ class TestPodLauncher:
             "namespace": "airflow",
         }
 
+    def test_worker_role_binding_uses_celery_service_account_name(self):
+        docs = render_chart(
+            name="prod",
+            namespace="airflow",
+            values={
+                "rbac": {"create": True},
+                "allowPodLaunching": True,
+                "executor": "CeleryExecutor",
+                "workers": {"celery": {"serviceAccount": {"name": "custom-worker"}}},
+            },
+            show_only=["templates/rbac/pod-launcher-rolebinding.yaml"],
+        )
+
+        assert jmespath.search("subjects[?name=='custom-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "custom-worker",
+            "namespace": "airflow",
+        }
+        assert jmespath.search("subjects[?name=='prod-airflow-worker']", docs[0]) == []
+
+    def test_worker_role_binding_keeps_kubernetes_fallback_service_account_when_celery_differs(self):
+        docs = render_chart(
+            name="prod",
+            namespace="airflow",
+            values={
+                "rbac": {"create": True},
+                "allowPodLaunching": True,
+                "executor": "CeleryExecutor,KubernetesExecutor",
+                "workers": {"celery": {"serviceAccount": {"name": "custom-worker"}}},
+            },
+            show_only=["templates/rbac/pod-launcher-rolebinding.yaml"],
+        )
+
+        assert jmespath.search("subjects[?name=='custom-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "custom-worker",
+            "namespace": "airflow",
+        }
+        assert jmespath.search("subjects[?name=='prod-airflow-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "prod-airflow-worker",
+            "namespace": "airflow",
+        }
+
     def test_worker_role_binding_should_not_exists(self):
         docs = render_chart(
             name="prod",

--- a/chart/tests/helm_tests/security/test_scc_rolebinding.py
+++ b/chart/tests/helm_tests/security/test_scc_rolebinding.py
@@ -130,6 +130,25 @@ class TestSCCActivation:
             "namespace": "airflow",
         }
 
+    def test_worker_role_binding_uses_celery_service_account_name(self):
+        docs = render_chart(
+            name="prod",
+            namespace="airflow",
+            values={
+                "rbac": {"create": True, "createSCCRoleBinding": True},
+                "executor": "CeleryExecutor",
+                "workers": {"celery": {"serviceAccount": {"name": "custom-worker"}}},
+            },
+            show_only=["templates/rbac/security-context-constraint-rolebinding.yaml"],
+        )
+
+        assert jmespath.search("subjects[?name=='custom-worker'] | [0]", docs[0]) == {
+            "kind": "ServiceAccount",
+            "name": "custom-worker",
+            "namespace": "airflow",
+        }
+        assert jmespath.search("subjects[?name=='prod-airflow-worker']", docs[0]) == []
+
     def test_worker_role_binding_should_not_exists(self):
         docs = render_chart(
             name="prod",


### PR DESCRIPTION
Fixes #67261.

## What changed

This updates Celery worker RBAC subjects to resolve the worker service account name using `workers.celery.serviceAccount` with the same fallback behavior as the Celery worker templates.

The pod-launcher, job-launcher, and SCC role bindings now reference the custom Celery worker service account when users set `workers.celery.serviceAccount.name`. For hybrid Celery/Kubernetes executor deployments, the templates also keep the fallback Kubernetes worker service account subject when it differs from the Celery worker service account and no dedicated `workers.kubernetes.serviceAccount` is configured.

## Tests

- `uv run pytest tests/helm_tests/airflow_aux/test_pod_launcher_role.py tests/helm_tests/airflow_aux/test_job_launcher_role.py tests/helm_tests/security/test_scc_rolebinding.py`
- `helm lint chart`
- `helm template test chart --show-only templates/rbac/pod-launcher-rolebinding.yaml --set allowPodLaunching=true --set executor=CeleryExecutor --set workers.celery.serviceAccount.name=worker`
- `helm template test chart --show-only templates/rbac/job-launcher-rolebinding.yaml --set allowJobLaunching=true --set executor=CeleryExecutor --set workers.celery.serviceAccount.name=worker`
