### PR TITLE
Fix backfill UI active state for running task instances

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py
@@ -69,6 +69,19 @@ class BackfillCollectionResponse(BaseModel):
     total_entries: int
 
 
+class BackfillUiResponse(BackfillResponse):
+    """Backfill serializer for UI responses."""
+
+    running_task_instances: NonNegativeInt
+
+
+class BackfillUiCollectionResponse(BaseModel):
+    """Backfill collection serializer for UI responses."""
+
+    backfills: Iterable[BackfillUiResponse]
+    total_entries: int
+
+
 class DryRunBackfillResponse(BaseModel):
     """Backfill serializer for responses in dry-run mode."""
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1065,7 +1065,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BackfillCollectionResponse'
+                $ref: '#/components/schemas/BackfillUiCollectionResponse'
         '404':
           content:
             application/json:
@@ -1762,6 +1762,22 @@ components:
       - total_entries
       title: BackfillCollectionResponse
       description: Backfill Collection serializer for responses.
+    BackfillUiCollectionResponse:
+      properties:
+        backfills:
+          items:
+            $ref: '#/components/schemas/BackfillUiResponse'
+          type: array
+          title: Backfills
+        total_entries:
+          type: integer
+          title: Total Entries
+      type: object
+      required:
+      - backfills
+      - total_entries
+      title: BackfillUiCollectionResponse
+      description: Backfill collection serializer for UI responses.
     BackfillResponse:
       properties:
         id:
@@ -1826,6 +1842,75 @@ components:
       - dag_display_name
       title: BackfillResponse
       description: Base serializer for Backfill.
+    BackfillUiResponse:
+      properties:
+        id:
+          type: integer
+          minimum: 0.0
+          title: Id
+        dag_id:
+          type: string
+          title: Dag Id
+        from_date:
+          type: string
+          format: date-time
+          title: From Date
+        to_date:
+          type: string
+          format: date-time
+          title: To Date
+        dag_run_conf:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Dag Run Conf
+        is_paused:
+          type: boolean
+          title: Is Paused
+        reprocess_behavior:
+          $ref: '#/components/schemas/ReprocessBehavior'
+        max_active_runs:
+          type: integer
+          title: Max Active Runs
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        completed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Completed At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+        dag_display_name:
+          type: string
+          title: Dag Display Name
+        running_task_instances:
+          type: integer
+          minimum: 0.0
+          title: Running Task Instances
+      type: object
+      required:
+      - id
+      - dag_id
+      - from_date
+      - to_date
+      - dag_run_conf
+      - is_paused
+      - reprocess_behavior
+      - max_active_runs
+      - created_at
+      - completed_at
+      - updated_at
+      - dag_display_name
+      - running_task_instances
+      title: BackfillUiResponse
+      description: Backfill serializer for UI responses.
     BaseEdgeResponse:
       properties:
         source_id:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py
@@ -18,13 +18,12 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, status
-from sqlalchemy import select
+from fastapi import Depends, Query, status
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import joinedload
 
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
-    FilterOptionEnum,
     FilterParam,
     QueryLimit,
     QueryOffset,
@@ -32,14 +31,31 @@ from airflow.api_fastapi.common.parameters import (
     filter_param_factory,
 )
 from airflow.api_fastapi.common.router import AirflowRouter
-from airflow.api_fastapi.core_api.datamodels.backfills import BackfillCollectionResponse, BackfillResponse
+from airflow.api_fastapi.core_api.datamodels.backfills import (
+    BackfillResponse,
+    BackfillUiCollectionResponse,
+    BackfillUiResponse,
+)
 from airflow.api_fastapi.core_api.openapi.exceptions import (
     create_openapi_http_exception_doc,
 )
 from airflow.api_fastapi.core_api.security import ReadableBackfillsFilterDep, requires_access_backfill
+from airflow.models import DagRun
 from airflow.models.backfill import Backfill
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.state import TaskInstanceState
 
 backfills_router = AirflowRouter(tags=["Backfill"], prefix="/backfills")
+
+
+def _running_task_instances_subquery():
+    return (
+        select(func.count(TaskInstance.id))
+        .join(DagRun, and_(DagRun.dag_id == TaskInstance.dag_id, DagRun.run_id == TaskInstance.run_id))
+        .where(DagRun.backfill_id == Backfill.id, TaskInstance.state == TaskInstanceState.RUNNING)
+        .correlate(Backfill)
+        .scalar_subquery()
+    )
 
 
 @backfills_router.get(
@@ -59,24 +75,33 @@ def list_backfills_ui(
     readable_backfills_filter: ReadableBackfillsFilterDep,
     session: SessionDep,
     dag_id: Annotated[FilterParam[str | None], Depends(filter_param_factory(Backfill.dag_id, str | None))],
-    active: Annotated[
-        FilterParam[bool | None],
-        Depends(filter_param_factory(Backfill.completed_at, bool | None, FilterOptionEnum.IS_NONE, "active")),
-    ],
-) -> BackfillCollectionResponse:
+    active: Annotated[bool | None, Query()] = None,
+) -> BackfillUiCollectionResponse:
+    running_task_instances = _running_task_instances_subquery()
+    statement = select(Backfill, running_task_instances.label("running_task_instances")).options(
+        joinedload(Backfill.dag_model)
+    )
+    if active is True:
+        statement = statement.where(or_(Backfill.completed_at.is_(None), running_task_instances > 0))
+    elif active is False:
+        statement = statement.where(Backfill.completed_at.is_not(None), running_task_instances == 0)
+
     select_stmt, total_entries = paginated_select(
-        statement=select(Backfill).options(joinedload(Backfill.dag_model)),
-        filters=[dag_id, active, readable_backfills_filter],
+        statement=statement,
+        filters=[dag_id, readable_backfills_filter],
         order_by=order_by,
         offset=offset,
         limit=limit,
         session=session,
     )
     backfills = [
-        BackfillResponse(**row._mapping) if not isinstance(row, Backfill) else row
-        for row in session.scalars(select_stmt)
+        BackfillUiResponse(
+            **BackfillResponse.model_validate(backfill).model_dump(),
+            running_task_instances=running_task_instances,
+        )
+        for backfill, running_task_instances in session.execute(select_stmt)
     ]
-    return BackfillCollectionResponse(
+    return BackfillUiCollectionResponse(
         backfills=backfills,
         total_entries=total_entries,
     )

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -202,7 +202,7 @@ export const ensureUseBackfillServiceGetBackfillData = (queryClient: QueryClient
 * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id`
 * @param data.dagId
 * @param data.active
-* @returns BackfillCollectionResponse Successful Response
+* @returns BackfillUiCollectionResponse Successful Response
 * @throws ApiError
 */
 export const ensureUseBackfillServiceListBackfillsUiData = (queryClient: QueryClient, { active, dagId, limit, offset, orderBy }: {

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -202,7 +202,7 @@ export const prefetchUseBackfillServiceGetBackfill = (queryClient: QueryClient, 
 * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id`
 * @param data.dagId
 * @param data.active
-* @returns BackfillCollectionResponse Successful Response
+* @returns BackfillUiCollectionResponse Successful Response
 * @throws ApiError
 */
 export const prefetchUseBackfillServiceListBackfillsUi = (queryClient: QueryClient, { active, dagId, limit, offset, orderBy }: {

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -202,7 +202,7 @@ export const useBackfillServiceGetBackfill = <TData = Common.BackfillServiceGetB
 * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id`
 * @param data.dagId
 * @param data.active
-* @returns BackfillCollectionResponse Successful Response
+* @returns BackfillUiCollectionResponse Successful Response
 * @throws ApiError
 */
 export const useBackfillServiceListBackfillsUi = <TData = Common.BackfillServiceListBackfillsUiDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ active, dagId, limit, offset, orderBy }: {

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -202,7 +202,7 @@ export const useBackfillServiceGetBackfillSuspense = <TData = Common.BackfillSer
 * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id`
 * @param data.dagId
 * @param data.active
-* @returns BackfillCollectionResponse Successful Response
+* @returns BackfillUiCollectionResponse Successful Response
 * @throws ApiError
 */
 export const useBackfillServiceListBackfillsUiSuspense = <TData = Common.BackfillServiceListBackfillsUiDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ active, dagId, limit, offset, orderBy }: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -480,6 +480,26 @@ export const $BackfillCollectionResponse = {
     description: 'Backfill Collection serializer for responses.'
 } as const;
 
+export const $BackfillUiCollectionResponse = {
+    properties: {
+        backfills: {
+            items: {
+                '$ref': '#/components/schemas/BackfillUiResponse'
+            },
+            type: 'array',
+            title: 'Backfills'
+        },
+        total_entries: {
+            type: 'integer',
+            title: 'Total Entries'
+        }
+    },
+    type: 'object',
+    required: ['backfills', 'total_entries'],
+    title: 'BackfillUiCollectionResponse',
+    description: 'Backfill collection serializer for UI responses.'
+} as const;
+
 export const $BackfillPostBody = {
     properties: {
         dag_id: {
@@ -617,6 +637,88 @@ export const $BackfillResponse = {
     required: ['id', 'dag_id', 'from_date', 'to_date', 'dag_run_conf', 'is_paused', 'reprocess_behavior', 'max_active_runs', 'created_at', 'completed_at', 'updated_at', 'dag_display_name'],
     title: 'BackfillResponse',
     description: 'Base serializer for Backfill.'
+} as const;
+
+export const $BackfillUiResponse = {
+    properties: {
+        id: {
+            type: 'integer',
+            minimum: 0,
+            title: 'Id'
+        },
+        dag_id: {
+            type: 'string',
+            title: 'Dag Id'
+        },
+        from_date: {
+            type: 'string',
+            format: 'date-time',
+            title: 'From Date'
+        },
+        to_date: {
+            type: 'string',
+            format: 'date-time',
+            title: 'To Date'
+        },
+        dag_run_conf: {
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Dag Run Conf'
+        },
+        is_paused: {
+            type: 'boolean',
+            title: 'Is Paused'
+        },
+        reprocess_behavior: {
+            '$ref': '#/components/schemas/ReprocessBehavior'
+        },
+        max_active_runs: {
+            type: 'integer',
+            title: 'Max Active Runs'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        completed_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Completed At'
+        },
+        updated_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Updated At'
+        },
+        dag_display_name: {
+            type: 'string',
+            title: 'Dag Display Name'
+        },
+        running_task_instances: {
+            type: 'integer',
+            minimum: 0,
+            title: 'Running Task Instances'
+        }
+    },
+    type: 'object',
+    required: ['id', 'dag_id', 'from_date', 'to_date', 'dag_run_conf', 'is_paused', 'reprocess_behavior', 'max_active_runs', 'created_at', 'completed_at', 'updated_at', 'dag_display_name', 'running_task_instances'],
+    title: 'BackfillUiResponse',
+    description: 'Backfill serializer for UI responses.'
 } as const;
 
 export const $BaseInfoResponse = {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -608,7 +608,7 @@ export class BackfillService {
      * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id`
      * @param data.dagId
      * @param data.active
-     * @returns BackfillCollectionResponse Successful Response
+     * @returns BackfillUiCollectionResponse Successful Response
      * @throws ApiError
      */
     public static listBackfillsUi(data: ListBackfillsUiData = {}): CancelablePromise<ListBackfillsUiResponse> {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -138,6 +138,14 @@ export type BackfillCollectionResponse = {
 };
 
 /**
+ * Backfill collection serializer for UI responses.
+ */
+export type BackfillUiCollectionResponse = {
+    backfills: Array<BackfillUiResponse>;
+    total_entries: number;
+};
+
+/**
  * Object used for create backfill request.
  */
 export type BackfillPostBody = {
@@ -175,6 +183,13 @@ export type BackfillResponse = {
     updated_at: string;
     dag_display_name: string;
 };
+
+/**
+ * Backfill serializer for UI responses.
+ */
+export type BackfillUiResponse = (BackfillResponse & {
+    running_task_instances: number;
+});
 
 /**
  * Base info serializer for responses.
@@ -2710,7 +2725,7 @@ export type ListBackfillsUiData = {
     orderBy?: Array<(string)>;
 };
 
-export type ListBackfillsUiResponse = BackfillCollectionResponse;
+export type ListBackfillsUiResponse = BackfillUiCollectionResponse;
 
 export type DeleteConnectionData = {
     connectionId: string;
@@ -4958,7 +4973,7 @@ export type $OpenApiTs = {
                 /**
                  * Successful Response
                  */
-                200: BackfillCollectionResponse;
+                200: BackfillUiCollectionResponse;
                 /**
                  * Not Found
                  */

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -29,7 +29,7 @@ import {
   useBackfillServicePauseBackfill,
   useBackfillServiceUnpauseBackfill,
 } from "openapi/queries";
-import type { BackfillResponse } from "openapi/requests/types.gen";
+import type { BackfillUiResponse } from "openapi/requests/types.gen";
 import { useAutoRefresh } from "src/utils";
 
 import Time from "../Time";
@@ -48,6 +48,9 @@ const buttonProps = {
   variant: "outline",
 } satisfies ButtonProps;
 
+const isBackfillActive = (backfill: BackfillUiResponse) =>
+  backfill.completed_at === null || backfill.running_task_instances > 0;
+
 const BackfillBanner = ({ dagId }: Props) => {
   const { t: translate } = useTranslation("components");
   const refetchInterval = useAutoRefresh({ dagId });
@@ -60,12 +63,12 @@ const BackfillBanner = ({ dagId }: Props) => {
     undefined,
     {
       refetchInterval: (query) =>
-        query.state.data?.backfills.some((bf: BackfillResponse) => bf.completed_at === null && !bf.is_paused)
+        query.state.data?.backfills.some((bf: BackfillUiResponse) => isBackfillActive(bf) && !bf.is_paused)
           ? refetchInterval
           : false,
     },
   );
-  const [backfill] = data?.backfills.filter((bf: BackfillResponse) => bf.completed_at === null) ?? [];
+  const [backfill] = data?.backfills.filter(isBackfillActive) ?? [];
 
   const queryClient = useQueryClient();
   const onSuccess = async () => {
@@ -101,6 +104,7 @@ const BackfillBanner = ({ dagId }: Props) => {
   if (isLoading || backfill === undefined) {
     return undefined;
   }
+  const canManageBackfill = backfill.completed_at === null;
 
   return (
     <Box bg="info.solid" borderRadius="full" color="info.contrast" my="1" px="2" py="1">
@@ -114,26 +118,30 @@ const BackfillBanner = ({ dagId }: Props) => {
 
         <Spacer flex="max-content" />
         <ProgressBar size="xs" visibility="visible" />
-        <Button
-          aria-label={backfill.is_paused ? translate("banner.unpause") : translate("banner.pause")}
-          loading={isPausePending || isUnPausePending}
-          onClick={() => {
-            togglePause();
-          }}
-          {...buttonProps}
-        >
-          {backfill.is_paused ? <MdPlayArrow /> : <MdPause />}
-        </Button>
-        <Button
-          aria-label={translate("banner.cancel")}
-          loading={isStopPending}
-          onClick={() => {
-            cancel();
-          }}
-          {...buttonProps}
-        >
-          <MdStop />
-        </Button>
+        {canManageBackfill ? (
+          <>
+            <Button
+              aria-label={backfill.is_paused ? translate("banner.unpause") : translate("banner.pause")}
+              loading={isPausePending || isUnPausePending}
+              onClick={() => {
+                togglePause();
+              }}
+              {...buttonProps}
+            >
+              {backfill.is_paused ? <MdPlayArrow /> : <MdPause />}
+            </Button>
+            <Button
+              aria-label={translate("banner.cancel")}
+              loading={isStopPending}
+              onClick={() => {
+                cancel();
+              }}
+              {...buttonProps}
+            >
+              <MdStop />
+            </Button>
+          </>
+        ) : undefined}
       </HStack>
     </Box>
   );

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Backfills/Backfills.tsx
@@ -22,14 +22,14 @@ import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
 import { useBackfillServiceListBackfillsUi } from "openapi/queries";
-import type { BackfillResponse } from "openapi/requests/types.gen";
+import type { BackfillUiResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
-const getColumns = (translate: (key: string) => string): Array<ColumnDef<BackfillResponse>> => [
+const getColumns = (translate: (key: string) => string): Array<ColumnDef<BackfillUiResponse>> => [
   {
     accessorKey: "date_from",
     cell: ({ row }) => (

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py
@@ -18,12 +18,16 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pendulum
 import pytest
 
 from airflow._shared.timezones import timezone
 from airflow.models import DagModel
-from airflow.models.backfill import Backfill
+from airflow.models.backfill import Backfill, BackfillDagRun
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.session import provide_session
+from airflow.utils.state import DagRunState, TaskInstanceState
+from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.db import (
@@ -118,6 +122,7 @@ class TestListBackfills(TestBackfillEndpoint):
                 "is_paused": False,
                 "reprocess_behavior": "none",
                 "max_active_runs": 10,
+                "running_task_instances": 0,
                 "to_date": from_datetime_to_zulu(to_date),
                 "updated_at": mock.ANY,
             },
@@ -132,6 +137,7 @@ class TestListBackfills(TestBackfillEndpoint):
                 "is_paused": False,
                 "reprocess_behavior": "none",
                 "max_active_runs": 10,
+                "running_task_instances": 0,
                 "to_date": from_datetime_to_zulu(to_date),
                 "updated_at": mock.ANY,
             },
@@ -146,6 +152,7 @@ class TestListBackfills(TestBackfillEndpoint):
                 "is_paused": True,
                 "reprocess_behavior": "none",
                 "max_active_runs": 10,
+                "running_task_instances": 0,
                 "to_date": from_datetime_to_zulu(to_date),
                 "updated_at": mock.ANY,
             },
@@ -192,3 +199,75 @@ class TestListBackfills(TestBackfillEndpoint):
         body = response.json()
         assert body["total_entries"] == 2
         assert {b["dag_id"] for b in body["backfills"]} == {"TEST_DAG_2", "TEST_DAG_3"}
+
+    def test_active_filter_includes_backfill_with_running_task_instances(
+        self, test_client, dag_maker, session
+    ):
+        dag_id = "TEST_DAG_RUNNING_TASKS"
+        from_date = pendulum.datetime(2024, 1, 1, tz="UTC")
+        to_date = pendulum.datetime(2024, 1, 2, tz="UTC")
+        with dag_maker(dag_id=dag_id, schedule="@daily", serialized=True, session=session):
+            EmptyOperator(task_id=TASK_ID)
+
+        backfill = Backfill(
+            dag_id=dag_id,
+            from_date=from_date,
+            to_date=to_date,
+            completed_at=timezone.utcnow(),
+        )
+        session.add(backfill)
+        session.flush()
+
+        older_run = dag_maker.create_dagrun(
+            run_id="backfill_old",
+            logical_date=from_date,
+            run_type=DagRunType.BACKFILL_JOB,
+            state=DagRunState.SUCCESS,
+        )
+        newer_run = dag_maker.create_dagrun(
+            run_id="backfill_new",
+            logical_date=to_date,
+            run_type=DagRunType.BACKFILL_JOB,
+            state=DagRunState.SUCCESS,
+        )
+        older_run.backfill_id = backfill.id
+        newer_run.backfill_id = backfill.id
+        session.add_all(
+            [
+                BackfillDagRun(
+                    backfill_id=backfill.id,
+                    dag_run_id=older_run.id,
+                    logical_date=from_date,
+                    sort_ordinal=2,
+                ),
+                BackfillDagRun(
+                    backfill_id=backfill.id,
+                    dag_run_id=newer_run.id,
+                    logical_date=to_date,
+                    sort_ordinal=1,
+                ),
+            ]
+        )
+        for task_instance in older_run.task_instances:
+            task_instance.state = TaskInstanceState.RUNNING
+        for task_instance in newer_run.task_instances:
+            task_instance.state = TaskInstanceState.SUCCESS
+        session.commit()
+
+        active_response = test_client.get("/backfills", params={"dag_id": dag_id, "active": True})
+        inactive_response = test_client.get("/backfills", params={"dag_id": dag_id, "active": False})
+
+        assert active_response.status_code == 200
+        assert inactive_response.status_code == 200
+        assert active_response.json()["total_entries"] == 1
+        assert active_response.json()["backfills"][0]["running_task_instances"] == 1
+        assert inactive_response.json() == {"backfills": [], "total_entries": 0}
+
+        older_run.task_instances[0].state = TaskInstanceState.SUCCESS
+        session.commit()
+
+        response = test_client.get("/backfills", params={"dag_id": dag_id, "active": False})
+
+        assert response.status_code == 200
+        assert response.json()["total_entries"] == 1
+        assert response.json()["backfills"][0]["running_task_instances"] == 0


### PR DESCRIPTION
Closes #64827.\n\nThis updates the private UI backfills endpoint to include the number of running task instances associated with each backfill and treats a backfill as active while any of those task instances are still running. The backfill banner now keeps rendering/refetching for that case, including backwards backfills where a newer run has completed while an older task instance is still running.\n\nTests:\n- `uv run --no-dev --with pytest --with-editable ./devel-common --with-editable ./providers/git pytest airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py -q`\n- `uv run --no-dev --with ruff ruff check airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py`\n- `python3 -m py_compile airflow-core/src/airflow/api_fastapi/core_api/datamodels/backfills.py airflow-core/src/airflow/api_fastapi/core_api/routes/ui/backfills.py airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_backfills.py`\n- `git diff --check`