### PR TITLE
Fix branch skips inside mapped task groups

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -60,8 +60,13 @@ class NotPreviouslySkippedDep(BaseTIDep):
 
                 # Use the parent's map context to look up the XCom. An unmapped parent
                 # (e.g. LatestOnlyOperator) writes XCom with map_index=-1, so we must
-                # query with -1 instead of the child's map_index.
-                xcom_map_index = ti.map_index if parent.is_mapped else -1
+                # query with -1 instead of the child's map_index. Operators inside a
+                # mapped task group are not themselves MappedOperators, but their TIs
+                # still write SkipMixin XComs with the runtime map_index.
+                if parent.is_mapped or parent.get_closest_mapped_task_group() is not None:
+                    xcom_map_index = ti.map_index
+                else:
+                    xcom_map_index = -1
                 prev_result = ti.xcom_pull(
                     task_ids=parent.task_id,
                     key=XCOM_SKIPMIXIN_KEY,

--- a/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -25,6 +25,7 @@ from airflow.models import DagRun, TaskInstance
 from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import BranchPythonOperator
+from airflow.sdk import task_group
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.not_previously_skipped_dep import (
     XCOM_SKIPMIXIN_FOLLOWED,
@@ -141,6 +142,58 @@ def test_parent_skip_branch(session, dag_maker):
     assert len(list(dep.get_dep_statuses(tis["op2"], session, DepContext()))) == 1
     assert not dep.is_met(tis["op2"], session)
     assert tis["op2"].state == State.SKIPPED
+
+
+@pytest.mark.parametrize("expand_kwargs", [False, True])
+def test_branch_in_mapped_task_group_skips_same_map_index_sibling(session, dag_maker, expand_kwargs):
+    """
+    Branch operators inside mapped task groups write SkipMixin XComs with their
+    runtime map_index even though the operator itself is not a MappedOperator.
+    """
+    start_date = pendulum.datetime(2020, 1, 1)
+    with dag_maker(
+        f"test_mapped_task_group_branch_skip_dag_{expand_kwargs}",
+        schedule=None,
+        start_date=start_date,
+        session=session,
+    ):
+
+        @task_group(group_id="group")
+        def mapped_group(value):
+            _ = value
+            branch = BranchPythonOperator(task_id="branch", python_callable=lambda: "group.followed")
+            skipped = EmptyOperator(task_id="skipped")
+            followed = EmptyOperator(task_id="followed")
+            branch >> [skipped, followed]
+
+        if expand_kwargs:
+            mapped_group.expand_kwargs([{"value": 1}, {"value": 2}])
+        else:
+            mapped_group.expand(value=[1, 2])
+
+    dr = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
+    tis = {ti.task_id: ti for ti in dr.task_instances}
+
+    tis["group.branch"].state = State.SUCCESS
+    tis["group.branch"].map_index = 1
+    tis["group.skipped"].map_index = 1
+    session.merge(tis["group.branch"])
+    session.merge(tis["group.skipped"])
+    XComModel.set(
+        key=XCOM_SKIPMIXIN_KEY,
+        value={XCOM_SKIPMIXIN_FOLLOWED: ["group.followed"]},
+        dag_id=dr.dag_id,
+        task_id="group.branch",
+        run_id=dr.run_id,
+        map_index=1,
+        session=session,
+    )
+    session.flush()
+
+    dep = NotPreviouslySkippedDep()
+    assert len(list(dep.get_dep_statuses(tis["group.skipped"], session, DepContext()))) == 1
+    assert not dep.is_met(tis["group.skipped"], session)
+    assert tis["group.skipped"].state == State.SKIPPED
 
 
 def test_parent_not_executed(session, dag_maker):


### PR DESCRIPTION
Fixes: #67265

This PR fixes branch skipping for branch operators inside mapped TaskGroups.

## Problem

For branch operators inside `expand()` / `expand_kwargs()` mapped TaskGroups, non-selected branch siblings can run instead of being skipped. The skip decision is stored by the `SkipMixin` parent task instance at the runtime `map_index`, but `NotPreviouslySkippedDep` did not read that XCom using the mapped TaskGroup context for operators that are not themselves `MappedOperator` instances.

## What changed

- `NotPreviouslySkippedDep` now uses the runtime task instance `map_index` when reading SkipMixin XComs for a task whose parent is inside a mapped TaskGroup.
- Added regression coverage for both `expand()` and `expand_kwargs()` mapped TaskGroups.

## Validation

I ran these checks locally:

```console
AIRFLOW_SOURCES=/Users/agentzero/Projects/Open\ Source\ projects/airflow-worktrees/airflow-67265 uv run --no-default-groups --with "apache-airflow-devel-common[pytest,sqlalchemy] @ ./devel-common" --with "apache-airflow-providers-standard @ ./providers/standard" --with "apache-airflow-providers-common-compat @ ./providers/common/compat" pytest airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py -q
# 8 passed

uv run --no-default-groups --with ruff ruff check airflow-core/src/airflow/ti_deps/deps/not_previously_skipped_dep.py airflow-core/tests/unit/ti_deps/deps/test_not_previously_skipped_dep.py
# all checks passed

git diff --check
# no whitespace errors
```

## Screenshot / GIF

A maintainer requested UI proof. I am moving this PR to draft until I can add a screenshot or short GIF showing the mapped TaskGroup branch behavior in the UI after the fix.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: OpenAI Codex. I reviewed the generated changes and ran the focused checks listed above.

Generated-by: OpenAI Codex following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
