### PR TITLE
Add first-run asset counter regression coverage

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -146,6 +146,43 @@ class TestNextRunAssets:
             ],
         }
 
+    def test_first_ever_run_reports_queued_assets(self, test_client, dag_maker, session):
+        with dag_maker(
+            dag_id="first_ever_consumer",
+            schedule=[
+                Asset(name="first_run_asset_1"),
+                Asset(name="first_run_asset_2"),
+                Asset(name="first_run_asset_3"),
+            ],
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t")
+
+        dag_maker.sync_dagbag_to_db()
+
+        assets = {
+            asset.name: asset
+            for asset in session.scalars(
+                select(AssetModel).where(
+                    AssetModel.name.in_(["first_run_asset_1", "first_run_asset_2", "first_run_asset_3"])
+                )
+            )
+        }
+        timestamp = pendulum.datetime(2024, 1, 1, tz="UTC")
+        for asset_name in ("first_run_asset_1", "first_run_asset_2"):
+            asset_id = assets[asset_name].id
+            session.add(AssetDagRunQueue(asset_id=asset_id, target_dag_id="first_ever_consumer"))
+            session.add(AssetEvent(asset_id=asset_id, timestamp=timestamp))
+        session.commit()
+
+        response = test_client.get("/next_run_assets/first_ever_consumer")
+        assert response.status_code == 200
+
+        events_by_name = {event["name"]: event for event in response.json()["events"]}
+        assert events_by_name["first_run_asset_1"]["lastUpdate"] is not None
+        assert events_by_name["first_run_asset_2"]["lastUpdate"] is not None
+        assert events_by_name["first_run_asset_3"]["lastUpdate"] is None
+
     def test_last_update_respects_latest_run_filter(self, test_client, dag_maker, session):
         with dag_maker(
             dag_id="filter_run",


### PR DESCRIPTION
Related: #64616

This PR adds regression coverage for the first-ever asset consumer DAG counter path.

## Context

Issue #64616 reported that the asset consumer DAG UI could show `0 of N assets updated` on the first-ever run path even when queued asset updates existed.

While investigating, I found that current `main` already returns the queued first-run asset state correctly from the private UI route. This PR therefore does not change runtime behavior. It adds focused coverage so the first-run case does not regress.

## What changed

- Added a `TestNextRunAssets` regression case for an asset-scheduled DAG that has never had a consumer DagRun.
- The test creates three name-only assets, queues updates for two of them, and verifies `/ui/next_run_assets/{dag_id}` reports the queued update state before the first consumer DagRun exists.

## Validation

I ran these checks locally from `airflow-core`:

```console
uv run pytest tests/unit/api_fastapi/core_api/routes/ui/test_assets.py::TestNextRunAssets -q
# 8 passed

uv run ruff format tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
# reformatted

uv run ruff check tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
# all checks passed
```

I first tried a root-level pytest invocation, but that attempted to build all-provider dependencies and failed locally on `jpype1` because Java is not installed. The focused `airflow-core` test environment passed.

No UI behavior changes in this PR, so screenshots are not applicable.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: OpenAI Codex. I reviewed the generated test and ran the focused checks listed above.

Generated-by: OpenAI Codex following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
