### PR TITLE
Persist DAG list filters across navigation

### DIFF
--- a/airflow-core/src/airflow/ui/src/constants/localStorage.ts
+++ b/airflow-core/src/airflow/ui/src/constants/localStorage.ts
@@ -36,6 +36,7 @@ export const openGroupsKey = (dagId: string) => `${dagId}/open-groups`;
 export const allGroupsKey = (dagId: string) => `${dagId}/all-groups`;
 
 // Page-scoped keys
+export const dagsFilterKey = (filterName: string) => `dags-filter-${filterName}`;
 export const tableSortKey = (pageName: string) => `${pageName.replaceAll("/", "-").slice(1)}-table-sort`;
 
 // SearchBar advanced (substring) toggle, scoped per searchbar via a caller-provided id.

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
@@ -18,7 +18,7 @@
  */
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 import { AppWrapper } from "src/utils/AppWrapper";
 
@@ -37,6 +37,10 @@ const mockConfig: Record<string, unknown> = {
 vi.mock("src/queries/useConfig", () => ({
   useConfig: (key: string) => mockConfig[key],
 }));
+
+afterEach(() => {
+  localStorage.clear();
+});
 
 describe("Paused filter with hide_paused_dags_by_default enabled", () => {
   it("defaults to showing only active dags", async () => {

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/DagsFilters.tsx
@@ -26,6 +26,11 @@ import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searc
 import { useConfig } from "src/queries/useConfig";
 import { useDagTagsInfinite } from "src/queries/useDagTagsInfinite";
 
+import {
+  type DagsBooleanFilterValue,
+  type DagsRunStateFilterValue,
+  useDagsFilterParams,
+} from "../useDagsFilterParams";
 import { useTagFilter } from "../useTagFilter";
 import { FavoriteFilter } from "./FavoriteFilter";
 import { PausedFilter } from "./PausedFilter";
@@ -34,36 +39,27 @@ import { StateFilters } from "./StateFilters";
 import { TagFilter } from "./TagFilter";
 
 const {
-  FAVORITE: FAVORITE_PARAM,
-  LAST_DAG_RUN_STATE: LAST_DAG_RUN_STATE_PARAM,
-  NEEDS_REVIEW: NEEDS_REVIEW_PARAM,
   OFFSET: OFFSET_PARAM,
-  PAUSED: PAUSED_PARAM,
 }: SearchParamsKeysType = SearchParamsKeys;
 
-type StateValue = "all" | "failed" | "queued" | "running" | "success";
-type BooleanFilterValue = "all" | "false" | "true";
-
-const stateValues: ReadonlyArray<StateValue> = ["failed", "queued", "running", "success"];
-const booleanFilterValues: ReadonlyArray<BooleanFilterValue> = ["all", "true", "false"];
-
-const toStateValue = (value: string | null): StateValue =>
-  stateValues.includes(value as StateValue) ? (value as StateValue) : "all";
-
 const toBooleanFilterValue = (
-  value: string | null,
-  defaultValue: BooleanFilterValue = "all",
-): BooleanFilterValue =>
-  booleanFilterValues.includes(value as BooleanFilterValue) ? (value as BooleanFilterValue) : defaultValue;
+  value: DagsBooleanFilterValue | null,
+  defaultValue: DagsBooleanFilterValue = "all",
+): DagsBooleanFilterValue => value ?? defaultValue;
 
 export const DagsFilters = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { selectedTags, setSelectedTags, setTagFilterMode, tagFilterMode } = useTagFilter();
-
-  const showPaused = searchParams.get(PAUSED_PARAM);
-  const showFavorites = searchParams.get(FAVORITE_PARAM);
-  const needsReview = searchParams.get(NEEDS_REVIEW_PARAM);
-  const state = searchParams.get(LAST_DAG_RUN_STATE_PARAM);
+  const {
+    favoriteFilter,
+    lastDagRunStateFilter,
+    needsReviewFilter,
+    pausedFilter,
+    setFavoriteFilter,
+    setLastDagRunStateFilter,
+    setNeedsReviewFilter,
+    setPausedFilter,
+  } = useDagsFilterParams();
 
   const [pattern, setPattern] = useState("");
 
@@ -74,7 +70,7 @@ export const DagsFilters = () => {
   });
 
   const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
-  const defaultShowPaused: BooleanFilterValue = hidePausedDagsByDefault ? "false" : "all";
+  const defaultShowPaused: DagsBooleanFilterValue = hidePausedDagsByDefault ? "false" : "all";
 
   const { setTableURLState, tableURLState } = useTableURLState();
   const { pagination, sorting } = tableURLState;
@@ -87,44 +83,24 @@ export const DagsFilters = () => {
     searchParams.delete(OFFSET_PARAM);
   };
 
-  const handlePausedChange = (value: BooleanFilterValue) => {
-    if (value === "all" && !hidePausedDagsByDefault) {
-      searchParams.delete(PAUSED_PARAM);
-    } else {
-      searchParams.set(PAUSED_PARAM, value);
-    }
+  const handlePausedChange = (value: DagsBooleanFilterValue) => {
     resetPagination();
-    setSearchParams(searchParams);
+    setPausedFilter(value, hidePausedDagsByDefault);
   };
 
-  const handleFavoriteChange = (value: BooleanFilterValue) => {
-    if (value === "all") {
-      searchParams.delete(FAVORITE_PARAM);
-    } else {
-      searchParams.set(FAVORITE_PARAM, value);
-    }
+  const handleFavoriteChange = (value: DagsBooleanFilterValue) => {
     resetPagination();
-    setSearchParams(searchParams);
+    setFavoriteFilter(value);
   };
 
-  const handleStateChange = (value: StateValue) => {
-    if (value === "all") {
-      searchParams.delete(LAST_DAG_RUN_STATE_PARAM);
-    } else {
-      searchParams.set(LAST_DAG_RUN_STATE_PARAM, value);
-    }
+  const handleStateChange = (value: DagsRunStateFilterValue) => {
     resetPagination();
-    setSearchParams(searchParams);
+    setLastDagRunStateFilter(value);
   };
 
   const handleNeedsReviewToggle = () => {
-    if (needsReview === "true") {
-      searchParams.delete(NEEDS_REVIEW_PARAM);
-    } else {
-      searchParams.set(NEEDS_REVIEW_PARAM, "true");
-    }
     resetPagination();
-    setSearchParams(searchParams);
+    setNeedsReviewFilter(needsReviewFilter === "true" ? "all" : "true");
   };
 
   const handleSelectTagsChange = (
@@ -140,16 +116,16 @@ export const DagsFilters = () => {
     setTagFilterMode(checked ? "all" : "any");
   };
 
-  const stateValue = toStateValue(state);
-  const pausedValue = toBooleanFilterValue(showPaused, defaultShowPaused);
-  const favoriteValue = toBooleanFilterValue(showFavorites);
+  const stateValue = lastDagRunStateFilter ?? "all";
+  const pausedValue = toBooleanFilterValue(pausedFilter, defaultShowPaused);
+  const favoriteValue = toBooleanFilterValue(favoriteFilter);
 
   return (
     <HStack flexWrap="wrap" gap={2} justifyContent="space-between">
       <Box overflowX="auto">
         <StateFilters onChange={handleStateChange} value={stateValue} />
       </Box>
-      <RequiredActionFilter needsReview={needsReview === "true"} onToggle={handleNeedsReviewToggle} />
+      <RequiredActionFilter needsReview={needsReviewFilter === "true"} onToggle={handleNeedsReviewToggle} />
       <PausedFilter onChange={handlePausedChange} value={pausedValue} />
       <TagFilter
         onMenuScrollToBottom={() => {

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.test.tsx
@@ -18,9 +18,15 @@
  */
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 
+import { dagsFilterKey } from "src/constants/localStorage";
+import { SearchParamsKeys } from "src/constants/searchParams";
 import { AppWrapper } from "src/utils/AppWrapper";
+
+afterEach(() => {
+  localStorage.clear();
+});
 
 describe("Dag Filters", () => {
   it("Filter by selected last run state", async () => {
@@ -33,5 +39,14 @@ describe("Dag Filters", () => {
     await waitFor(() => expect(screen.getByText("states.failed")).toBeInTheDocument());
     await waitFor(() => screen.getByText("states.failed").click());
     await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument());
+  });
+
+  it("restores selected last run state from localStorage", async () => {
+    localStorage.setItem(dagsFilterKey(SearchParamsKeys.LAST_DAG_RUN_STATE), JSON.stringify("failed"));
+
+    render(<AppWrapper initialEntries={["/dags"]} />);
+
+    await waitFor(() => expect(screen.getByText("tutorial_taskflow_api_failed")).toBeInTheDocument());
+    expect(screen.queryByText("tutorial_taskflow_api_success")).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
-import type { DagRunState, DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import { DeleteDagButton } from "src/components/DagActions/DeleteDagButton";
 import { FavoriteDagButton } from "src/components/DagActions/FavoriteDagButton";
 import DagRunInfo from "src/components/DagRunInfo";
@@ -48,6 +48,7 @@ import { DagTags } from "./DagTags";
 import { DagsFilters } from "./DagsFilters";
 import { Schedule } from "./Schedule";
 import { SortSelect } from "./SortSelect";
+import { useDagsFilterParams } from "./useDagsFilterParams";
 import { useTagFilter } from "./useTagFilter";
 
 const createColumns = (
@@ -171,15 +172,7 @@ const createColumns = (
   },
 ];
 
-const {
-  FAVORITE,
-  LAST_DAG_RUN_STATE,
-  NAME_PATTERN,
-  NEEDS_REVIEW,
-  OFFSET,
-  OWNERS,
-  PAUSED,
-}: SearchParamsKeysType = SearchParamsKeys;
+const { NAME_PATTERN, OFFSET, OWNERS }: SearchParamsKeysType = SearchParamsKeys;
 
 const cardDef: CardDef<DAGWithLatestDagRunsResponse> = {
   card: ({ row }) => <DagCard dag={row} />,
@@ -197,12 +190,9 @@ export const DagsList = () => {
   const hidePausedDagsByDefault = Boolean(useConfig("hide_paused_dags_by_default"));
   const defaultShowPaused = hidePausedDagsByDefault ? false : undefined;
 
-  const showPaused = searchParams.get(PAUSED);
-  const showFavorites = searchParams.get(FAVORITE);
-
-  const lastDagRunState = searchParams.get(LAST_DAG_RUN_STATE) as DagRunState;
+  const { favoriteFilter, lastDagRunStateFilter, needsReviewFilter, pausedFilter } =
+    useDagsFilterParams();
   const { selectedTags, tagFilterMode: selectedMatchMode } = useTagFilter();
-  const pendingReviews = searchParams.get(NEEDS_REVIEW);
   const owners = searchParams.getAll(OWNERS);
 
   const { setTableURLState, tableURLState } = useTableURLState();
@@ -234,23 +224,23 @@ export const DagsList = () => {
   let isFavorite = undefined;
   let pendingHitl = undefined;
 
-  if (showPaused === "all") {
+  if (pausedFilter === "all") {
     paused = undefined;
-  } else if (showPaused === "true") {
+  } else if (pausedFilter === "true") {
     paused = true;
-  } else if (showPaused === "false") {
+  } else if (pausedFilter === "false") {
     paused = false;
   }
 
-  if (showFavorites === "true") {
+  if (favoriteFilter === "true") {
     isFavorite = true;
-  } else if (showFavorites === "false") {
+  } else if (favoriteFilter === "false") {
     isFavorite = false;
   }
 
-  if (pendingReviews === "true") {
+  if (needsReviewFilter === "true") {
     pendingHitl = true;
-  } else if (pendingReviews === "false") {
+  } else if (needsReviewFilter === "false") {
     pendingHitl = false;
   }
 
@@ -259,7 +249,10 @@ export const DagsList = () => {
     dagDisplayNamePattern: Boolean(dagDisplayNamePattern) ? dagDisplayNamePattern : undefined,
     dagRunsLimit,
     isFavorite,
-    lastDagRunState,
+    lastDagRunState:
+      lastDagRunStateFilter === null || lastDagRunStateFilter === "all"
+        ? undefined
+        : lastDagRunStateFilter,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
     orderBy: [orderBy],

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/useDagsFilterParams.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/useDagsFilterParams.test.tsx
@@ -1,0 +1,104 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { dagsFilterKey } from "src/constants/localStorage";
+import { SearchParamsKeys } from "src/constants/searchParams";
+import { BaseWrapper } from "src/utils/Wrapper";
+
+import { useDagsFilterParams } from "./useDagsFilterParams";
+
+const createWrapper =
+  (initialEntries: Array<string> = ["/"]) =>
+  ({ children }: PropsWithChildren) => (
+    <BaseWrapper>
+      <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+    </BaseWrapper>
+  );
+
+const saveFilter = (key: SearchParamsKeys, value: string) => {
+  localStorage.setItem(dagsFilterKey(key), JSON.stringify(value));
+};
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("useDagsFilterParams", () => {
+  it("falls back to saved DAG list filters when URL params are absent", () => {
+    saveFilter(SearchParamsKeys.PAUSED, "true");
+    saveFilter(SearchParamsKeys.FAVORITE, "false");
+    saveFilter(SearchParamsKeys.LAST_DAG_RUN_STATE, "failed");
+    saveFilter(SearchParamsKeys.NEEDS_REVIEW, "true");
+
+    const { result } = renderHook(() => useDagsFilterParams(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.pausedFilter).toBe("true");
+    expect(result.current.favoriteFilter).toBe("false");
+    expect(result.current.lastDagRunStateFilter).toBe("failed");
+    expect(result.current.needsReviewFilter).toBe("true");
+  });
+
+  it("prefers URL filters over saved values", () => {
+    saveFilter(SearchParamsKeys.PAUSED, "true");
+    saveFilter(SearchParamsKeys.FAVORITE, "false");
+    saveFilter(SearchParamsKeys.LAST_DAG_RUN_STATE, "failed");
+    saveFilter(SearchParamsKeys.NEEDS_REVIEW, "true");
+
+    const { result } = renderHook(() => useDagsFilterParams(), {
+      wrapper: createWrapper(["/?paused=false&favorite=true&last_dag_run_state=success&needs_review=false"]),
+    });
+
+    expect(result.current.pausedFilter).toBe("false");
+    expect(result.current.favoriteFilter).toBe("true");
+    expect(result.current.lastDagRunStateFilter).toBe("success");
+    expect(result.current.needsReviewFilter).toBe("false");
+  });
+
+  it("persists changed filters", () => {
+    const { result } = renderHook(() => useDagsFilterParams(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.setPausedFilter("false");
+      result.current.setFavoriteFilter("true");
+      result.current.setLastDagRunStateFilter("running");
+      result.current.setNeedsReviewFilter("true");
+    });
+
+    expect(JSON.parse(localStorage.getItem(dagsFilterKey(SearchParamsKeys.PAUSED)) ?? "null")).toBe(
+      "false",
+    );
+    expect(JSON.parse(localStorage.getItem(dagsFilterKey(SearchParamsKeys.FAVORITE)) ?? "null")).toBe(
+      "true",
+    );
+    expect(
+      JSON.parse(localStorage.getItem(dagsFilterKey(SearchParamsKeys.LAST_DAG_RUN_STATE)) ?? "null"),
+    ).toBe("running");
+    expect(
+      JSON.parse(localStorage.getItem(dagsFilterKey(SearchParamsKeys.NEEDS_REVIEW)) ?? "null"),
+    ).toBe("true");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/useDagsFilterParams.ts
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/useDagsFilterParams.ts
@@ -1,0 +1,118 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useSearchParams } from "react-router-dom";
+import { useLocalStorage } from "usehooks-ts";
+
+import { dagsFilterKey } from "src/constants/localStorage";
+import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
+
+const {
+  FAVORITE,
+  LAST_DAG_RUN_STATE,
+  NEEDS_REVIEW,
+  OFFSET,
+  PAUSED,
+}: SearchParamsKeysType = SearchParamsKeys;
+
+export type DagsBooleanFilterValue = "all" | "false" | "true";
+export type DagsRunStateFilterValue = "all" | "failed" | "queued" | "running" | "success";
+
+const stateValues: ReadonlyArray<DagsRunStateFilterValue> = [
+  "all",
+  "failed",
+  "queued",
+  "running",
+  "success",
+];
+const booleanFilterValues: ReadonlyArray<DagsBooleanFilterValue> = ["all", "true", "false"];
+
+const getSavedFilterValue = (
+  searchParams: URLSearchParams,
+  searchParamName: string,
+  savedValue: string | null,
+) => searchParams.get(searchParamName) ?? savedValue;
+
+const toStateValue = (value: string | null): DagsRunStateFilterValue | null =>
+  stateValues.includes(value as DagsRunStateFilterValue) ? (value as DagsRunStateFilterValue) : null;
+
+const toBooleanFilterValue = (value: string | null): DagsBooleanFilterValue | null =>
+  booleanFilterValues.includes(value as DagsBooleanFilterValue)
+    ? (value as DagsBooleanFilterValue)
+    : null;
+
+export const useDagsFilterParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [savedPaused, setSavedPaused] = useLocalStorage<string | null>(dagsFilterKey(PAUSED), null);
+  const [savedFavorite, setSavedFavorite] = useLocalStorage<string | null>(
+    dagsFilterKey(FAVORITE),
+    null,
+  );
+  const [savedLastDagRunState, setSavedLastDagRunState] = useLocalStorage<string | null>(
+    dagsFilterKey(LAST_DAG_RUN_STATE),
+    null,
+  );
+  const [savedNeedsReview, setSavedNeedsReview] = useLocalStorage<string | null>(
+    dagsFilterKey(NEEDS_REVIEW),
+    null,
+  );
+
+  const setFilterParam = ({
+    persistAllInUrl = false,
+    saveValue,
+    searchParamName,
+    value,
+  }: {
+    persistAllInUrl?: boolean;
+    saveValue: (value: string) => void;
+    searchParamName: string;
+    value: DagsBooleanFilterValue | DagsRunStateFilterValue;
+  }) => {
+    saveValue(value);
+    if (value === "all" && !persistAllInUrl) {
+      searchParams.delete(searchParamName);
+    } else {
+      searchParams.set(searchParamName, value);
+    }
+    searchParams.delete(OFFSET);
+    setSearchParams(searchParams);
+  };
+
+  return {
+    favoriteFilter: toBooleanFilterValue(getSavedFilterValue(searchParams, FAVORITE, savedFavorite)),
+    lastDagRunStateFilter: toStateValue(
+      getSavedFilterValue(searchParams, LAST_DAG_RUN_STATE, savedLastDagRunState),
+    ),
+    needsReviewFilter: toBooleanFilterValue(
+      getSavedFilterValue(searchParams, NEEDS_REVIEW, savedNeedsReview),
+    ),
+    pausedFilter: toBooleanFilterValue(getSavedFilterValue(searchParams, PAUSED, savedPaused)),
+    setFavoriteFilter: (value: DagsBooleanFilterValue) => {
+      setFilterParam({ saveValue: setSavedFavorite, searchParamName: FAVORITE, value });
+    },
+    setLastDagRunStateFilter: (value: DagsRunStateFilterValue) => {
+      setFilterParam({ saveValue: setSavedLastDagRunState, searchParamName: LAST_DAG_RUN_STATE, value });
+    },
+    setNeedsReviewFilter: (value: DagsBooleanFilterValue) => {
+      setFilterParam({ saveValue: setSavedNeedsReview, searchParamName: NEEDS_REVIEW, value });
+    },
+    setPausedFilter: (value: DagsBooleanFilterValue, persistAllInUrl = false) => {
+      setFilterParam({ persistAllInUrl, saveValue: setSavedPaused, searchParamName: PAUSED, value });
+    },
+  };
+};


### PR DESCRIPTION
Fixes: #66933

This PR persists selected DAG list filters when navigating away from and back to the DAG list in the Airflow UI.

## Problem

In Airflow 3.x, DAG list filters such as status, last run state, favorites, and required actions can be lost during in-app navigation when the user returns to `/dags` without the original query parameters. That makes the list feel inconsistent and forces users to reapply filters.

## What changed

- Added page-scoped localStorage keys for DAG list filters.
- `useDagsFilterParams` now falls back to the saved page-scoped values when the URL does not include those filter params.
- URL params still take precedence when present.
- Changing filters keeps the existing URL behavior and also saves the selection for later navigation back to `/dags`.
- Added unit coverage for the hook and filter components.

## Validation

I ran these checks locally from the UI package:

```console
NODE_OPTIONS=--no-experimental-webstorage npx --yes pnpm@10 test src/pages/DagsList/useDagsFilterParams.test.tsx src/pages/DagsList/DagsList.test.tsx src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
# 8 tests passed

npx --yes pnpm@10 exec tsc --p tsconfig.app.json --noEmit
# passed

npx --yes pnpm@10 exec eslint src/constants/localStorage.ts src/pages/DagsList/useDagsFilterParams.ts src/pages/DagsList/useDagsFilterParams.test.tsx src/pages/DagsList/DagsList.tsx src/pages/DagsList/DagsList.test.tsx src/pages/DagsList/DagsFilters/DagsFilters.tsx src/pages/DagsList/DagsFilters/DagsFilters.test.tsx
# passed
```

The focused Vitest run prints existing MSW bypass `ECONNREFUSED` noise for localhost:3000, but exits green. On Node 25 I had to set `NODE_OPTIONS=--no-experimental-webstorage`; existing localStorage-related UI tests require the same flag in this environment.

## Screenshots

A maintainer requested screenshots. I am moving this PR to draft until I can add before/after screenshots or a short GIF that shows filters persisting across navigation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: OpenAI Codex. I reviewed the generated changes and ran the focused checks listed above.

Generated-by: OpenAI Codex following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
