### PR TITLE
Fix Akeyless JWT connection credential is not redacted

### DIFF
--- a/providers/akeyless/provider.yaml
+++ b/providers/akeyless/provider.yaml
@@ -75,7 +75,7 @@ connection-types:
           type:
             - string
             - 'null'
-      jwt:
+      jwt_token:
         label: JWT
         schema:
           type:

--- a/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/get_provider_info.py
@@ -54,7 +54,7 @@ def get_provider_info():
                     "uid_token": {"label": "UID Token", "schema": {"type": ["string", "null"]}},
                     "gcp_audience": {"label": "GCP Audience", "schema": {"type": ["string", "null"]}},
                     "azure_object_id": {"label": "Azure Object ID", "schema": {"type": ["string", "null"]}},
-                    "jwt": {"label": "JWT", "schema": {"type": ["string", "null"]}},
+                    "jwt_token": {"label": "JWT", "schema": {"type": ["string", "null"]}},
                     "k8s_auth_config_name": {
                         "label": "K8s Auth Config Name",
                         "schema": {"type": ["string", "null"]},

--- a/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
+++ b/providers/akeyless/src/airflow/providers/akeyless/hooks/akeyless.py
@@ -97,7 +97,7 @@ class AkeylessHook(BaseHook):
             body.cloud_id = self._get_cloud_id(access_type)
         elif access_type == "jwt":
             body.access_type = "jwt"
-            body.jwt = self._extra.get("jwt")
+            body.jwt = self._extra.get("jwt_token")
         elif access_type == "k8s":
             body.access_type = "k8s"
             body.k8s_auth_config_name = self._extra.get("k8s_auth_config_name")
@@ -211,7 +211,7 @@ class AkeylessHook(BaseHook):
             "uid_token": StringField(lazy_gettext("UID Token"), widget=BS3TextFieldWidget()),
             "gcp_audience": StringField(lazy_gettext("GCP Audience"), widget=BS3TextFieldWidget()),
             "azure_object_id": StringField(lazy_gettext("Azure Object ID"), widget=BS3TextFieldWidget()),
-            "jwt": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
+            "jwt_token": StringField(lazy_gettext("JWT"), widget=BS3TextFieldWidget()),
             "k8s_auth_config_name": StringField(
                 lazy_gettext("K8s Auth Config Name"), widget=BS3TextFieldWidget()
             ),

--- a/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
+++ b/providers/akeyless/tests/unit/akeyless/hooks/test_akeyless.py
@@ -191,6 +191,21 @@ class TestAkeylessHook:
         with pytest.raises(ValueError, match="Unsupported access_type"):
             hook.authenticate()
 
+    @patch(
+        f"{HOOK_MODULE}.AkeylessHook.get_connection",
+        return_value=_make_connection(extra='{"access_type": "jwt", "jwt_token": "jwt-token-value"}'),
+    )
+    @patch(f"{HOOK_MODULE}.akeyless")
+    def test_jwt_auth_uses_jwt_token_extra(self, mock_sdk, mock_conn):
+        api = mock_sdk.V2Api.return_value
+        api.auth.return_value = MagicMock(token="t")
+        from airflow.providers.akeyless.hooks.akeyless import AkeylessHook
+
+        hook = AkeylessHook()
+        hook.authenticate()
+        auth_body = api.auth.call_args.args[0]
+        assert auth_body.jwt == "jwt-token-value"
+
     @patch(f"{HOOK_MODULE}.AkeylessHook.get_connection", return_value=_make_connection())
     @patch(f"{HOOK_MODULE}.akeyless")
     def test_get_rotated_secret_passes_list(self, mock_sdk, mock_conn):


### PR DESCRIPTION
### Why

Airflow's default secrets redaction does not treat a bare jwt extra key as sensitive. Akeyless JWT credentials stored in connection extra can therefore be returned unmasked via the API and UI, exposing reusable authentication credentials to users who can read connections.

### What

Rename the Akeyless connection extra key from jwt to jwt_token in provider metadata and generated provider info so it matches Airflow's default sensitive-key substrings and is redacted by default.
providers/akeyless/provider.yaml

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
