### PR TITLE
API: Return 400 instead of 500 from materialize_asset on invalid input

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -73,6 +73,7 @@ from airflow.api_fastapi.core_api.security import (
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
+from airflow.exceptions import ParamValidationError
 from airflow.models.asset import (
     AssetAliasModel,
     AssetDagRunQueue,
@@ -443,21 +444,24 @@ def materialize_asset(
             f"Dag with dag_id: '{dag_id}' does not allow asset materialization runs",
         )
 
-    params = (body or MaterializeAssetBody()).validate_context(dag)
-    return dag.create_dagrun(
-        run_id=params["run_id"],
-        logical_date=params["logical_date"],
-        data_interval=params["data_interval"],
-        run_after=params["run_after"],
-        conf=params["conf"],
-        run_type=DagRunType.ASSET_MATERIALIZATION,
-        triggered_by=DagRunTriggeredByType.REST_API,
-        triggering_user_name=user.get_name(),
-        state=DagRunState.QUEUED,
-        partition_key=params["partition_key"],
-        note=params["note"],
-        session=session,
-    )
+    try:
+        params = (body or MaterializeAssetBody()).validate_context(dag)
+        return dag.create_dagrun(
+            run_id=params["run_id"],
+            logical_date=params["logical_date"],
+            data_interval=params["data_interval"],
+            run_after=params["run_after"],
+            conf=params["conf"],
+            run_type=DagRunType.ASSET_MATERIALIZATION,
+            triggered_by=DagRunTriggeredByType.REST_API,
+            triggering_user_name=user.get_name(),
+            state=DagRunState.QUEUED,
+            partition_key=params["partition_key"],
+            note=params["note"],
+            session=session,
+        )
+    except (ParamValidationError, ValueError) as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e)) from e
 
 
 @assets_router.get(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1609,6 +1609,19 @@ class TestPostAssetMaterialize(TestAssets):
                 user=mock.ANY,
             )
 
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_should_respond_400_on_invalid_dag_run_id(self, test_client):
+        """A dag_run_id containing '..' triggers ValueError in DagRun.validate_run_id.
+
+        It must surface as 400 BAD_REQUEST, not 500 INTERNAL_SERVER_ERROR.
+        """
+        response = test_client.post(
+            "/assets/1/materialize",
+            json={"dag_run_id": "bad..id"},
+        )
+        assert response.status_code == 400
+        assert "must not contain '..'" in response.json()["detail"]
+
 
 class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
     @pytest.mark.usefixtures("time_freezer")


### PR DESCRIPTION
The `POST /assets/{asset_id}/materialize` endpoint passed user input (`dag_run_id`, `logical_date` / `data_interval` pairing, `partition_key`) straight through to `MaterializeAssetBody.validate_context()` and `dag.create_dagrun()`. Those raise `ValueError` / `ParamValidationError` on invalid input — e.g. `dag_run_id` containing `..` (path-traversal guard in `DagRun.validate_run_id`), `logical_date` set with no `data_interval`, or a `partition_key` of the wrong type. The exceptions escaped uncaught and were returned as **500 Internal Server Error**, even though the route's OpenAPI spec already documents **400** for this case.

This wraps the `validate_context` / `create_dagrun` calls in a `try/except (ParamValidationError, ValueError)` and re-raises as `HTTPException(400)` with the validator's message in the `detail`. Mirrors the established pattern in the sibling endpoint `airflow.api_fastapi.core_api.routes.public.dag_run.trigger_dag_run`.

### Reproduction (before)

    POST /assets/1/materialize
    {"dag_run_id": "bad..id"}
    → 500 Internal Server Error

### After

    POST /assets/1/materialize
    {"dag_run_id": "bad..id"}
    → 400 Bad Request
      {"detail": "The run_id 'bad..id' must not contain '..' to prevent path traversal"}

### Tests

Adds `TestPostAssetMaterialize::test_should_respond_400_on_invalid_dag_run_id` asserting the endpoint returns 400 with the validator's message. The test fails (returns 500) on the unpatched code.

### Related

- `AGENTS.md` rule added in #67221: *"Translate domain-layer exceptions to HTTPException at FastAPI route boundaries."*
- Sibling pattern: `airflow.api_fastapi.core_api.routes.public.dag_run.trigger_dag_run`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — (Cursor) used to test the gap 