### PR TITLE
Chart: add serviceAccountTokenVolume to cleanup cron

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -788,12 +788,12 @@ This container-specific approach ensures that:
 Configuration Options
 ^^^^^^^^^^^^^^^^^^^^^
 
-The service account token volume configuration is available for the scheduler component and includes the following options:
+The service account token volume configuration is available for the scheduler and cleanup component and includes the following options:
 
 .. code-block:: yaml
    :caption: values.yaml
 
-   scheduler:
+   (scheduler|cleanup):
      serviceAccount:
        automountServiceAccountToken: false
        serviceAccountTokenVolume:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1151,3 +1151,54 @@ Usage:
   {{- end -}}
   {{- toYaml $newValues -}}
 {{- end -}}
+
+
+{{/*
+serviceAccountTokenVolume mount
+
+Usage:
+  {{ include "serviceAccountTokenVolumeMount" (list . .Values.scheduler.serviceAccount) }}
+*/}}
+{{- define "serviceAccountTokenVolumeMount" -}}
+  {{- $root := index . 0 -}}
+  {{- $sa := index . 1 -}}
+  {{- if and (eq (include "airflow.podLaunchingExecutor" $root ) "true") (not $sa.automountServiceAccountToken) $sa.serviceAccountTokenVolume.enabled }}
+- name: {{ $sa.serviceAccountTokenVolume.volumeName }}
+  mountPath: {{ $sa.serviceAccountTokenVolume.mountPath }}
+  readOnly: true
+  {{- end }}
+{{- end -}}
+
+{{/*
+serviceAccountTokenVolume
+
+Usage:
+  {{ include "serviceAccountTokenVolume" (list . .Values.scheduler.serviceAccount) }}
+*/}}
+{{- define "serviceAccountTokenVolume" -}}
+  {{- $root := index . 0 -}}
+  {{- $sa := index . 1 -}}
+  {{- if and (eq (include "airflow.podLaunchingExecutor" $root ) "true") (not $sa.automountServiceAccountToken) $sa.serviceAccountTokenVolume.enabled }}
+- name: {{ $sa.serviceAccountTokenVolume.volumeName }}
+  projected:
+    defaultMode: 420
+    sources:
+    - serviceAccountToken:
+        {{- if $sa.serviceAccountTokenVolume.audience }}
+        audience: {{ $sa.serviceAccountTokenVolume.audience }}
+        {{- end }}
+        expirationSeconds: {{ $sa.serviceAccountTokenVolume.expirationSeconds }}
+        path: token
+    - configMap:
+        items:
+        - key: ca.crt
+          path: ca.crt
+        name: kube-root-ca.crt
+    - downwardAPI:
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
+          path: namespace
+  {{- end }}
+{{- end -}}

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -110,6 +110,7 @@ spec:
                 {{- if .Values.volumeMounts }}
                   {{- toYaml .Values.volumeMounts | nindent 16 }}
                 {{- end }}
+                {{- include "serviceAccountTokenVolumeMount" (list . .Values.cleanup.serviceAccount)  | nindent 16 }}
               resources: {{- toYaml .Values.cleanup.resources | nindent 16 }}
           volumes:
             - name: config
@@ -118,4 +119,6 @@ spec:
             {{- if .Values.volumes }}
               {{- toYaml .Values.volumes | nindent 12 }}
             {{- end }}
+            {{- include "serviceAccountTokenVolume" (list . .Values.cleanup.serviceAccount) | nindent 12 }}
+
 {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -246,11 +246,7 @@ spec:
             {{- if .Values.scheduler.extraVolumeMounts }}
               {{- tpl (toYaml .Values.scheduler.extraVolumeMounts) . | nindent 12 }}
             {{- end }}
-            {{- if and (eq (include "airflow.podLaunchingExecutor" .) "true") (not .Values.scheduler.serviceAccount.automountServiceAccountToken) .Values.scheduler.serviceAccount.serviceAccountTokenVolume.enabled }}
-            - name: {{ .Values.scheduler.serviceAccount.serviceAccountTokenVolume.volumeName }}
-              mountPath: {{ .Values.scheduler.serviceAccount.serviceAccountTokenVolume.mountPath }}
-              readOnly: true
-            {{- end }}
+            {{- include "serviceAccountTokenVolumeMount" (list . .Values.scheduler.serviceAccount)  | nindent 12 }}
         {{- if and $localOrDagProcessorDisabled .Values.dags.gitSync.enabled }}
           {{- include "git_sync_container" . | indent 8 }}
         {{- end }}
@@ -334,29 +330,7 @@ spec:
         {{- if .Values.scheduler.extraVolumes }}
           {{- tpl (toYaml .Values.scheduler.extraVolumes) . | nindent 8 }}
         {{- end }}
-        {{- if and (eq (include "airflow.podLaunchingExecutor" .) "true") (not .Values.scheduler.serviceAccount.automountServiceAccountToken) .Values.scheduler.serviceAccount.serviceAccountTokenVolume.enabled }}
-        - name: {{ .Values.scheduler.serviceAccount.serviceAccountTokenVolume.volumeName }}
-          projected:
-            defaultMode: 420
-            sources:
-            - serviceAccountToken:
-                {{- if .Values.scheduler.serviceAccount.serviceAccountTokenVolume.audience }}
-                audience: {{ .Values.scheduler.serviceAccount.serviceAccountTokenVolume.audience }}
-                {{- end }}
-                expirationSeconds: {{ .Values.scheduler.serviceAccount.serviceAccountTokenVolume.expirationSeconds }}
-                path: token
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace
-        {{- end }}
+        {{- include "serviceAccountTokenVolume" (list . .Values.scheduler.serviceAccount) | nindent 8 }}
   {{- if .Values.logs.persistence.enabled }}
         - name: logs
           persistentVolumeClaim:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10300,9 +10300,46 @@
                     "additionalProperties": false,
                     "properties": {
                         "automountServiceAccountToken": {
-                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods",
+                            "description": "Specifies if ServiceAccount's API credentials should be mounted onto Pods. When false, you can use `serviceAccountTokenVolume` to manually configure service account token volume for pod-launching executors.",
                             "type": "boolean",
                             "default": true
+                        },
+                        "serviceAccountTokenVolume": {
+                            "description": "Configuration for manual service account token volume. Only used when automountServiceAccountToken is false and for pod-launching executors. (CeleryExecutor, KubernetesExecutor)",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable manual service account token volume configuration.",
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "mountPath": {
+                                    "description": "Path where the service account token volume will be mounted.",
+                                    "type": "string",
+                                    "default": "/var/run/secrets/kubernetes.io/serviceaccount"
+                                },
+                                "volumeName": {
+                                    "description": "Name of the service account token volume.",
+                                    "type": "string",
+                                    "default": "kube-api-access"
+                                },
+                                "expirationSeconds": {
+                                    "description": "Token expiration time in seconds.",
+                                    "type": "integer",
+                                    "minimum": 600,
+                                    "maximum": 7776000,
+                                    "default": 3600
+                                },
+                                "audience": {
+                                    "description": "Intended audience of the token. Optional - defaults to the identifier of the Kubernetes API server.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                }
+                            }
                         },
                         "create": {
                             "description": "Specifies whether a ServiceAccount should be created.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3755,6 +3755,25 @@ cleanup:
     # Annotations to add to cleanup CronJob Kubernetes Service Account.
     annotations: {}
 
+    # Service Account Token Volume configuration
+    # This is only used when `automountServiceAccountToken` is 'false'
+    # and allows manual configuration of the Service Account token volume
+    serviceAccountTokenVolume:
+      # Enable manual Service Account token volume configuration
+      enabled: false
+
+      # Path where the Service Account token should be mounted
+      mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+
+      # Name of the volume
+      volumeName: kube-api-access
+
+      # Token expiration in seconds
+      expirationSeconds: 3600
+
+      # Audience for the token
+      audience: ~
+
   # When not set, the values defined in the global `securityContext` will be used
   # (deprecated, use `cleanup.securityContexts` instead)
   securityContext: {}


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

# Chart support serviceAccountTokenVolume for cleanup job

When in an environment where policy dictate `automountServiceAccountToken: false`
the cleanup job require the same treatment as the scheduler, with a `serviceAccountTokenVolume` block.

## Testing

Tested with

```bash
helm template chart | yq 'select(.metadata.name == "release-name-scheduler")'
helm template chart | yq 'select(.metadata.name == "release-name-cleanup")'
```

And `values.yaml`:

```yaml
executor: "CeleryExecutor,KubernetesExecutor"

cleanup:
  enabled: true
  serviceAccount:
    automountServiceAccountToken: false
    serviceAccountTokenVolume:
      enabled: true

scheduler:
  serviceAccount:
    automountServiceAccountToken: false
    serviceAccountTokenVolume:
      enabled: true

```

as well as default `values.yaml`.


## Current workaround

```yaml
postRenders:
  - kustomize:
      patches:
        - target:
            version: v1
            kind: CronJob
            name: .*cleanup.*
          patch: |
            - op: add
              path: /spec/jobTemplate/spec/template/spec/volumes/-
              value:
                name: sa-token
                projected:
                  sources:
                    - serviceAccountToken:
                        path: token
                        expirationSeconds: 3600
                    - configMap:
                        name: kube-root-ca.crt
                        items:
                          - key: ca.crt
                            path: ca.crt
                    - downwardAPI:
                        items:
                          - path: namespace
                            fieldRef:
                              fieldPath: metadata.namespace
            - op: add
              path: /spec/jobTemplate/spec/template/spec/containers/0/volumeMounts/-
              value:
                name: sa-token
                mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                readOnly: true
```


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

