### PR TITLE
Feat/kubernetes executor callback support

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_deadline_callback.py
+++ b/airflow-core/src/airflow/example_dags/example_deadline_callback.py
@@ -1,0 +1,127 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG demonstrating ExecutorCallback (DeadlineAlert) support in the Kubernetes Executor.
+
+The deadline is fixed to a date in the past so the callback fires immediately after each
+DAG run is created, exercising the full callback-pod lifecycle on Kubernetes.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+
+import pendulum
+
+from airflow.sdk import DAG, task
+
+try:
+    from airflow.sdk.definitions.callback import SyncCallback
+    from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
+
+    _DEADLINE_AVAILABLE = True
+except ImportError:
+    _DEADLINE_AVAILABLE = False
+
+
+def deadline_callback(context, **kwargs):
+    """Simple deadline alert callback – logs context and exits cleanly."""
+    dag_run = context.get("dag_run", {})
+    dag_id = dag_run.get("dag_id", "unknown")
+    run_id = dag_run.get("dag_run_id", "unknown")
+    print(f"[deadline_callback] Deadline alert fired for dag_id={dag_id} run_id={run_id}")
+
+
+def slow_deadline_callback(context, **kwargs):
+    """Slow deadline alert callback that sleeps 30s – used for scheduler-restart tests."""
+    dag_run = context.get("dag_run", {})
+    dag_id = dag_run.get("dag_id", "unknown")
+    run_id = dag_run.get("dag_run_id", "unknown")
+    print(f"[slow_deadline_callback] Starting for dag_id={dag_id} run_id={run_id}")
+    time.sleep(30)
+    print(f"[slow_deadline_callback] Done for dag_id={dag_id} run_id={run_id}")
+
+
+def failing_deadline_callback(**_):
+    """Intentionally raises – used by the K8s executor failure integration test."""
+    raise RuntimeError("Intentional callback failure for testing")
+
+
+_PAST_DEADLINE = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+if _DEADLINE_AVAILABLE:
+    with DAG(
+        dag_id="example_deadline_callback",
+        schedule=None,
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        tags=["example", "deadline", "callback"],
+        deadline=DeadlineAlert(
+            reference=DeadlineReference.FIXED_DATETIME(_PAST_DEADLINE),
+            interval=timedelta(hours=1),
+            callback=SyncCallback("airflow.example_dags.example_deadline_callback.deadline_callback"),
+        ),
+    ) as dag:
+
+        @task
+        def dummy_task():
+            """Placeholder task; the interesting work happens in the deadline callback."""
+            print("dummy_task executed")
+
+        dummy_task()
+
+    with DAG(
+        dag_id="example_deadline_callback_slow",
+        schedule=None,
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        tags=["example", "deadline", "callback"],
+        deadline=DeadlineAlert(
+            reference=DeadlineReference.FIXED_DATETIME(_PAST_DEADLINE),
+            interval=timedelta(hours=1),
+            callback=SyncCallback("airflow.example_dags.example_deadline_callback.slow_deadline_callback"),
+        ),
+    ) as dag_slow:
+
+        @task
+        def dummy_task_slow():
+            """Placeholder task for the slow-callback DAG."""
+            print("dummy_task_slow executed")
+
+        dummy_task_slow()
+
+    with DAG(
+        dag_id="example_deadline_callback_failing",
+        schedule=None,
+        start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+        catchup=False,
+        tags=["example", "deadline", "callback"],
+        deadline=DeadlineAlert(
+            reference=DeadlineReference.FIXED_DATETIME(_PAST_DEADLINE),
+            interval=timedelta(hours=1),
+            callback=SyncCallback("airflow.example_dags.example_deadline_callback.failing_deadline_callback"),
+        ),
+    ) as dag_failing:
+
+        @task
+        def dummy_task_failing():
+            """Placeholder task for the failing-callback DAG."""
+            print("dummy_task_failing executed")
+
+        dummy_task_failing()

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
@@ -246,110 +246,6 @@ class TestKubernetesExecutor(BaseK8STest):
         executor.kube_client.read_namespaced_pod.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# Helpers shared by callback tests
-# ---------------------------------------------------------------------------
-
-_CALLBACK_LABEL = "airflow-workload-type=callback"
-_CALLBACK_ANNOTATION_KEY = "callback_id"
-
-
-def _get_callback_pods(namespace: str = "airflow") -> list[dict]:
-    """Return all callback-pod objects in the namespace as a list of dicts."""
-    raw = check_output(
-        [
-            "kubectl",
-            "get",
-            "pods",
-            "-n",
-            namespace,
-            "-l",
-            _CALLBACK_LABEL,
-            "-o",
-            "json",
-        ]
-    )
-    return json.loads(raw)["items"]
-
-
-def _wait_for_callback_pod(run_id: str, namespace: str = "airflow", timeout: int = 120) -> dict:
-    """Block until a callback pod annotated with *run_id* appears; return the pod dict."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        for pod in _get_callback_pods(namespace):
-            annotations = pod.get("metadata", {}).get("annotations", {})
-            if annotations.get("run_id") == run_id:
-                return pod
-        time.sleep(1)
-    raise AssertionError(f"No callback pod for run_id={run_id!r} appeared within {timeout}s")
-
-
-def _wait_for_pod_phase(
-    pod_name: str,
-    phases: list[str],
-    namespace: str = "airflow",
-    timeout: int = 120,
-) -> str:
-    """Block until *pod_name* reaches one of *phases*; return the reached phase.
-
-    Returns ``"Deleted"`` if the pod is not found (404). Callers that want to
-    treat executor-driven pod deletion as a success should include ``"Deleted"``
-    in *phases* — the executor only removes pods after they have succeeded
-    (``delete_worker_pods=True`` and ``delete_worker_pods_on_failure=False``
-    by default).
-    """
-    deadline = time.monotonic() + timeout
-    phase = ""
-    while time.monotonic() < deadline:
-        result = subprocess.run(
-            [
-                "kubectl",
-                "get",
-                "pod",
-                pod_name,
-                "-n",
-                namespace,
-                "-o",
-                "jsonpath={.status.phase}",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode != 0 and ("NotFound" in result.stderr or "not found" in result.stderr.lower()):
-            phase = "Deleted"
-        else:
-            phase = result.stdout.strip()
-        if phase in phases:
-            return phase
-        time.sleep(2)
-    raise AssertionError(
-        f"Pod {pod_name!r} did not reach {phases} within {timeout}s (last seen phase: {phase!r})"
-    )
-
-
-def _wait_for_pod_gone(pod_name: str, namespace: str = "airflow", timeout: int = 60) -> None:
-    """Block until the named pod no longer exists in the namespace."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        result = subprocess.run(
-            ["kubectl", "get", "pod", pod_name, "-n", namespace],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        # kubectl exits non-zero and prints "NotFound" when the pod is gone
-        if result.returncode != 0 and "NotFound" in result.stderr:
-            return
-        time.sleep(5)
-    raise AssertionError(f"Pod {pod_name!r} was not deleted within {timeout}s")
-
-
-# ---------------------------------------------------------------------------
-# Integration tests for ExecutorCallback on the Kubernetes executor
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.skipif(EXECUTOR != "KubernetesExecutor", reason="Only runs on KubernetesExecutor")
 class TestKubernetesExecutorCallbackSupport(BaseK8STest):
     """
@@ -363,25 +259,109 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
       - The executor must be KubernetesExecutor.
     """
 
-    # The DAG that fires a fast callback immediately on trigger.
     _FAST_DAG_ID = "example_deadline_callback"
-    # The DAG that fires a slow (40-second) callback – used for scheduler-restart test.
     _SLOW_DAG_ID = "example_deadline_callback_slow"
-    # The DAG whose callback always raises RuntimeError – used for failure path test.
     _FAILING_DAG_ID = "example_deadline_callback_failing"
 
+    _CALLBACK_LABEL = "airflow-workload-type=callback"
+    _CALLBACK_ANNOTATION_KEY = "callback_id"
+
+    @classmethod
+    def _get_callback_pods(cls, namespace: str = "airflow") -> list[dict]:
+        raw = check_output(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                cls._CALLBACK_LABEL,
+                "-o",
+                "json",
+            ]
+        )
+        return json.loads(raw)["items"]
+
+    @classmethod
+    def _wait_for_callback_pod(cls, run_id: str, namespace: str = "airflow", timeout: int = 120) -> dict:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for pod in cls._get_callback_pods(namespace):
+                annotations = pod.get("metadata", {}).get("annotations", {})
+                if annotations.get("run_id") == run_id:
+                    return pod
+            time.sleep(1)
+        raise AssertionError(f"No callback pod for run_id={run_id!r} appeared within {timeout}s")
+
+    @staticmethod
+    def _wait_for_pod_phase(
+        pod_name: str,
+        phases: list[str],
+        namespace: str = "airflow",
+        timeout: int = 120,
+    ) -> str:
+        """
+        Block until *pod_name* reaches one of *phases*; return the reached phase.
+
+        Returns ``"Deleted"`` if the pod is not found. Include ``"Deleted"`` in *phases*
+        when executor-driven deletion counts as success — pods are only removed after they
+        succeed (``delete_worker_pods=True`` default).
+        """
+        deadline = time.monotonic() + timeout
+        phase = ""
+        while time.monotonic() < deadline:
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "pod",
+                    pod_name,
+                    "-n",
+                    namespace,
+                    "-o",
+                    "jsonpath={.status.phase}",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0 and (
+                "NotFound" in result.stderr or "not found" in result.stderr.lower()
+            ):
+                phase = "Deleted"
+            else:
+                phase = result.stdout.strip()
+            if phase in phases:
+                return phase
+            time.sleep(2)
+        raise AssertionError(
+            f"Pod {pod_name!r} did not reach {phases} within {timeout}s (last seen phase: {phase!r})"
+        )
+
+    @staticmethod
+    def _wait_for_pod_gone(pod_name: str, namespace: str = "airflow", timeout: int = 60) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = subprocess.run(
+                ["kubectl", "get", "pod", pod_name, "-n", namespace],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            # kubectl exits non-zero and prints "NotFound" when the pod is gone
+            if result.returncode != 0 and "NotFound" in result.stderr:
+                return
+            time.sleep(5)
+        raise AssertionError(f"Pod {pod_name!r} was not deleted within {timeout}s")
+
     def _trigger_dag_run(self, dag_id: str) -> str:
-        """Trigger a new DAG run and return its run_id (the most recently queued one)."""
         result_json = self.start_dag(dag_id=dag_id, host=self.host)
         dag_runs = result_json.get("dag_runs", [])
         matching = [r for r in dag_runs if r["dag_id"] == dag_id]
         assert matching, f"No dag runs returned for dag_id={dag_id!r}"
         newest = max(matching, key=lambda r: r["queued_at"])
         return newest["dag_run_id"]
-
-    # -----------------------------------------------------------------------
-    # 8.1  Happy path: callback pod appears, runs and succeeds
-    # -----------------------------------------------------------------------
 
     @pytest.mark.execution_timeout(300)
     def test_deadline_callback_executes_on_kubernetes(self):
@@ -393,23 +373,16 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         dag_run_id = self._trigger_dag_run(dag_id)
         print(f"[{dag_id}] dag_run_id={dag_run_id}")
 
-        # Wait for the callback pod to appear.
-        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod = self._wait_for_callback_pod(dag_run_id, timeout=120)
         pod_name = pod["metadata"]["name"]
         print(f"[{dag_id}] callback pod appeared: {pod_name}")
 
-        # Wait for the pod to complete successfully.  The executor deletes pods
-        # immediately after they succeed (delete_worker_pods=True default), so
-        # the pod may already be gone by the time we poll — "Deleted" is equally
-        # valid evidence of success.
-        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
+        # The executor deletes pods immediately after they succeed (delete_worker_pods=True
+        # default), so "Deleted" is equally valid evidence of success.
+        phase = self._wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
         assert phase in ("Succeeded", "Deleted"), (
             f"Callback pod {pod_name!r} reached phase {phase!r} instead of Succeeded/Deleted"
         )
-
-    # -----------------------------------------------------------------------
-    # 8.3  Correct annotations and labels on the callback pod
-    # -----------------------------------------------------------------------
 
     @pytest.mark.execution_timeout(300)
     def test_callback_pod_annotations_and_labels(self):
@@ -421,21 +394,18 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         dag_id = self._FAST_DAG_ID
         dag_run_id = self._trigger_dag_run(dag_id)
 
-        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod = self._wait_for_callback_pod(dag_run_id, timeout=120)
         annotations = pod["metadata"]["annotations"]
         labels = pod["metadata"]["labels"]
         containers = pod["spec"]["containers"]
 
-        # --- annotations ---
-        assert _CALLBACK_ANNOTATION_KEY in annotations, (
-            f"Annotation {_CALLBACK_ANNOTATION_KEY!r} missing from pod. Got: {annotations}"
+        assert self._CALLBACK_ANNOTATION_KEY in annotations, (
+            f"Annotation {self._CALLBACK_ANNOTATION_KEY!r} missing from pod. Got: {annotations}"
         )
-        callback_id = annotations[_CALLBACK_ANNOTATION_KEY]
-        # callback_id must look like a UUID (32 hex chars + 4 dashes)
+        callback_id = annotations[self._CALLBACK_ANNOTATION_KEY]
         assert re.fullmatch(r"[0-9a-f-]{36}", callback_id), (
             f"callback_id {callback_id!r} does not look like a UUID"
         )
-
         assert annotations.get("dag_id") == dag_id, (
             f"Expected dag_id annotation {dag_id!r}, got {annotations.get('dag_id')!r}"
         )
@@ -446,7 +416,6 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         for forbidden in ("task_id", "try_number", "map_index"):
             assert forbidden not in annotations, f"Unexpected annotation {forbidden!r} found on callback pod"
 
-        # --- labels ---
         assert labels.get("airflow-workload-type") == "callback", (
             f"Expected label airflow-workload-type=callback, got: {labels}"
         )
@@ -455,7 +424,6 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         )
         assert "airflow-worker" in labels, f"airflow-worker label missing. Got: {labels}"
 
-        # --- container command ---
         assert containers, "No containers found in callback pod spec"
         args = containers[0].get("args", []) or []
         cmd = containers[0].get("command", []) or []
@@ -466,10 +434,6 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         assert any("--json-string" in part for part in full_cmd), (
             f"Container command does not include '--json-string'. Full command: {full_cmd}"
         )
-
-    # -----------------------------------------------------------------------
-    # 8.2  Callback pod failure marks the callback as failed
-    # -----------------------------------------------------------------------
 
     @pytest.mark.execution_timeout(300)
     def test_deadline_callback_pod_failure(self):
@@ -486,13 +450,13 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         dag_run_id = self._trigger_dag_run(dag_id)
         print(f"[{dag_id}] dag_run_id={dag_run_id}")
 
-        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod = self._wait_for_callback_pod(dag_run_id, timeout=120)
         pod_name = pod["metadata"]["name"]
         print(f"[{dag_id}] callback pod appeared: {pod_name}")
 
         try:
             # Failed pods are NOT auto-deleted (delete_worker_pods_on_failure=False default).
-            phase = _wait_for_pod_phase(pod_name, ["Failed"], timeout=120)
+            phase = self._wait_for_pod_phase(pod_name, ["Failed"], timeout=120)
             assert phase == "Failed", f"Expected Failed phase, got {phase!r}"
 
             # Executor must not have crashed — scheduler pod must still be Running.
@@ -524,10 +488,6 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
                 check=False,
             )
 
-    # -----------------------------------------------------------------------
-    # 8.5  Callback pod is cleaned up after success
-    # -----------------------------------------------------------------------
-
     @pytest.mark.execution_timeout(300)
     def test_callback_pod_is_cleaned_up_after_success(self):
         """
@@ -537,20 +497,14 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         dag_id = self._FAST_DAG_ID
         dag_run_id = self._trigger_dag_run(dag_id)
 
-        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod = self._wait_for_callback_pod(dag_run_id, timeout=120)
         pod_name = pod["metadata"]["name"]
 
-        # Wait for the pod to finish.  If the pod is already gone ("Deleted"),
-        # that itself is proof of executor-driven cleanup — skip the explicit
-        # deletion wait in that case.
-        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
+        # If the pod is already gone ("Deleted"), that itself is proof of executor-driven
+        # cleanup — skip the explicit deletion wait in that case.
+        phase = self._wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
         if phase != "Deleted":
-            # The executor's delete_worker_pods=True (default) must delete the pod.
-            _wait_for_pod_gone(pod_name, timeout=60)
-
-    # -----------------------------------------------------------------------
-    # 8.4  Scheduler restart with an in-flight callback pod
-    # -----------------------------------------------------------------------
+            self._wait_for_pod_gone(pod_name, timeout=60)
 
     @pytest.mark.execution_timeout(400)
     def test_callback_pod_survives_scheduler_restart(self):
@@ -563,24 +517,23 @@ class TestKubernetesExecutorCallbackSupport(BaseK8STest):
         dag_run_id = self._trigger_dag_run(dag_id)
 
         # Wait until the callback pod is actually Running before killing the scheduler.
-        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod = self._wait_for_callback_pod(dag_run_id, timeout=120)
         pod_name = pod["metadata"]["name"]
-        pre_restart_phase = _wait_for_pod_phase(
+        pre_restart_phase = self._wait_for_pod_phase(
             pod_name, ["Running", "Succeeded", "Failed", "Deleted"], timeout=60
         )
 
-        # Restart the scheduler.
         self._delete_airflow_pod("scheduler")
         self.ensure_resource_health("airflow-scheduler")
         print(f"[{dag_id}] Scheduler restarted; waiting for callback pod to complete.")
 
         if pre_restart_phase in ("Succeeded", "Deleted"):
-            # Pod already completed before the restart — the test goal (pod
-            # completion despite scheduler lifecycle) is still met.
+            # Pod already completed before the restart — the test goal (pod completion
+            # despite scheduler lifecycle) is still met.
             return
 
-        # The slow callback sleeps for 40 s; allow plenty of time for completion.
-        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=180)
+        # The slow callback sleeps for 30s; allow plenty of time for completion.
+        phase = self._wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=180)
         assert phase in ("Succeeded", "Deleted"), (
             f"Callback pod {pod_name!r} reached {phase!r} after scheduler restart (expected Succeeded/Deleted)"
         )

--- a/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
+++ b/kubernetes-tests/tests/kubernetes_tests/test_kubernetes_executor.py
@@ -16,6 +16,11 @@
 # under the License.
 from __future__ import annotations
 
+import json
+import re
+import subprocess
+import time
+from subprocess import check_output
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
@@ -239,3 +244,343 @@ class TestKubernetesExecutor(BaseK8STest):
 
         # Verify that kube_client methods were not called
         executor.kube_client.read_namespaced_pod.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by callback tests
+# ---------------------------------------------------------------------------
+
+_CALLBACK_LABEL = "airflow-workload-type=callback"
+_CALLBACK_ANNOTATION_KEY = "callback_id"
+
+
+def _get_callback_pods(namespace: str = "airflow") -> list[dict]:
+    """Return all callback-pod objects in the namespace as a list of dicts."""
+    raw = check_output(
+        [
+            "kubectl",
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            _CALLBACK_LABEL,
+            "-o",
+            "json",
+        ]
+    )
+    return json.loads(raw)["items"]
+
+
+def _wait_for_callback_pod(run_id: str, namespace: str = "airflow", timeout: int = 120) -> dict:
+    """Block until a callback pod annotated with *run_id* appears; return the pod dict."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for pod in _get_callback_pods(namespace):
+            annotations = pod.get("metadata", {}).get("annotations", {})
+            if annotations.get("run_id") == run_id:
+                return pod
+        time.sleep(1)
+    raise AssertionError(f"No callback pod for run_id={run_id!r} appeared within {timeout}s")
+
+
+def _wait_for_pod_phase(
+    pod_name: str,
+    phases: list[str],
+    namespace: str = "airflow",
+    timeout: int = 120,
+) -> str:
+    """Block until *pod_name* reaches one of *phases*; return the reached phase.
+
+    Returns ``"Deleted"`` if the pod is not found (404). Callers that want to
+    treat executor-driven pod deletion as a success should include ``"Deleted"``
+    in *phases* — the executor only removes pods after they have succeeded
+    (``delete_worker_pods=True`` and ``delete_worker_pods_on_failure=False``
+    by default).
+    """
+    deadline = time.monotonic() + timeout
+    phase = ""
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "pod",
+                pod_name,
+                "-n",
+                namespace,
+                "-o",
+                "jsonpath={.status.phase}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0 and ("NotFound" in result.stderr or "not found" in result.stderr.lower()):
+            phase = "Deleted"
+        else:
+            phase = result.stdout.strip()
+        if phase in phases:
+            return phase
+        time.sleep(2)
+    raise AssertionError(
+        f"Pod {pod_name!r} did not reach {phases} within {timeout}s (last seen phase: {phase!r})"
+    )
+
+
+def _wait_for_pod_gone(pod_name: str, namespace: str = "airflow", timeout: int = 60) -> None:
+    """Block until the named pod no longer exists in the namespace."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["kubectl", "get", "pod", pod_name, "-n", namespace],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # kubectl exits non-zero and prints "NotFound" when the pod is gone
+        if result.returncode != 0 and "NotFound" in result.stderr:
+            return
+        time.sleep(5)
+    raise AssertionError(f"Pod {pod_name!r} was not deleted within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for ExecutorCallback on the Kubernetes executor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(EXECUTOR != "KubernetesExecutor", reason="Only runs on KubernetesExecutor")
+class TestKubernetesExecutorCallbackSupport(BaseK8STest):
+    """
+    Integration tests for ExecutorCallback (DeadlineAlert / SyncCallback) support in the
+    Kubernetes executor.
+
+    Prerequisites:
+      - The ``example_deadline_callback`` and ``example_deadline_callback_slow`` DAGs must
+        be loaded in the cluster (they live in airflow-core/src/airflow/example_dags/ and
+        are baked into the k8s image via ``breeze k8s build-k8s-image``).
+      - The executor must be KubernetesExecutor.
+    """
+
+    # The DAG that fires a fast callback immediately on trigger.
+    _FAST_DAG_ID = "example_deadline_callback"
+    # The DAG that fires a slow (40-second) callback – used for scheduler-restart test.
+    _SLOW_DAG_ID = "example_deadline_callback_slow"
+    # The DAG whose callback always raises RuntimeError – used for failure path test.
+    _FAILING_DAG_ID = "example_deadline_callback_failing"
+
+    def _trigger_dag_run(self, dag_id: str) -> str:
+        """Trigger a new DAG run and return its run_id (the most recently queued one)."""
+        result_json = self.start_dag(dag_id=dag_id, host=self.host)
+        dag_runs = result_json.get("dag_runs", [])
+        matching = [r for r in dag_runs if r["dag_id"] == dag_id]
+        assert matching, f"No dag runs returned for dag_id={dag_id!r}"
+        newest = max(matching, key=lambda r: r["queued_at"])
+        return newest["dag_run_id"]
+
+    # -----------------------------------------------------------------------
+    # 8.1  Happy path: callback pod appears, runs and succeeds
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.execution_timeout(300)
+    def test_deadline_callback_executes_on_kubernetes(self):
+        """
+        A DAG with a past deadline fires a SyncCallback that is executed as a Kubernetes pod.
+        The pod must reach the Succeeded phase.
+        """
+        dag_id = self._FAST_DAG_ID
+        dag_run_id = self._trigger_dag_run(dag_id)
+        print(f"[{dag_id}] dag_run_id={dag_run_id}")
+
+        # Wait for the callback pod to appear.
+        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod_name = pod["metadata"]["name"]
+        print(f"[{dag_id}] callback pod appeared: {pod_name}")
+
+        # Wait for the pod to complete successfully.  The executor deletes pods
+        # immediately after they succeed (delete_worker_pods=True default), so
+        # the pod may already be gone by the time we poll — "Deleted" is equally
+        # valid evidence of success.
+        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
+        assert phase in ("Succeeded", "Deleted"), (
+            f"Callback pod {pod_name!r} reached phase {phase!r} instead of Succeeded/Deleted"
+        )
+
+    # -----------------------------------------------------------------------
+    # 8.3  Correct annotations and labels on the callback pod
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.execution_timeout(300)
+    def test_callback_pod_annotations_and_labels(self):
+        """
+        The callback pod must carry the expected Airflow annotations (callback_id, dag_id, run_id)
+        and labels (airflow-workload-type=callback, kubernetes_executor=True, airflow-worker=…).
+        Its container command must invoke execute_workload.
+        """
+        dag_id = self._FAST_DAG_ID
+        dag_run_id = self._trigger_dag_run(dag_id)
+
+        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        annotations = pod["metadata"]["annotations"]
+        labels = pod["metadata"]["labels"]
+        containers = pod["spec"]["containers"]
+
+        # --- annotations ---
+        assert _CALLBACK_ANNOTATION_KEY in annotations, (
+            f"Annotation {_CALLBACK_ANNOTATION_KEY!r} missing from pod. Got: {annotations}"
+        )
+        callback_id = annotations[_CALLBACK_ANNOTATION_KEY]
+        # callback_id must look like a UUID (32 hex chars + 4 dashes)
+        assert re.fullmatch(r"[0-9a-f-]{36}", callback_id), (
+            f"callback_id {callback_id!r} does not look like a UUID"
+        )
+
+        assert annotations.get("dag_id") == dag_id, (
+            f"Expected dag_id annotation {dag_id!r}, got {annotations.get('dag_id')!r}"
+        )
+        assert "run_id" in annotations, f"run_id annotation missing. Got: {annotations}"
+        assert annotations.get("run_id"), "run_id annotation must be non-empty"
+
+        # Task-specific annotations must NOT be present on callback pods.
+        for forbidden in ("task_id", "try_number", "map_index"):
+            assert forbidden not in annotations, f"Unexpected annotation {forbidden!r} found on callback pod"
+
+        # --- labels ---
+        assert labels.get("airflow-workload-type") == "callback", (
+            f"Expected label airflow-workload-type=callback, got: {labels}"
+        )
+        assert labels.get("kubernetes_executor") == "True", (
+            f"Expected label kubernetes_executor=True, got: {labels}"
+        )
+        assert "airflow-worker" in labels, f"airflow-worker label missing. Got: {labels}"
+
+        # --- container command ---
+        assert containers, "No containers found in callback pod spec"
+        args = containers[0].get("args", []) or []
+        cmd = containers[0].get("command", []) or []
+        full_cmd = cmd + args
+        assert any("execute_workload" in part for part in full_cmd), (
+            f"Container command does not include 'execute_workload'. Full command: {full_cmd}"
+        )
+        assert any("--json-string" in part for part in full_cmd), (
+            f"Container command does not include '--json-string'. Full command: {full_cmd}"
+        )
+
+    # -----------------------------------------------------------------------
+    # 8.2  Callback pod failure marks the callback as failed
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.execution_timeout(300)
+    def test_deadline_callback_pod_failure(self):
+        """
+        When the callback pod exits with a non-zero code the watcher must emit a FAILED
+        state and the executor must not crash.
+
+        Uses ``example_deadline_callback_failing``, whose callback always raises
+        ``RuntimeError``, causing ``sys.exit(1)`` in the pod and a ``Failed`` phase.
+        Failed pods are NOT auto-deleted (``delete_worker_pods_on_failure=False`` default),
+        so the pod stays and we can assert its phase before cleaning it up manually.
+        """
+        dag_id = self._FAILING_DAG_ID
+        dag_run_id = self._trigger_dag_run(dag_id)
+        print(f"[{dag_id}] dag_run_id={dag_run_id}")
+
+        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod_name = pod["metadata"]["name"]
+        print(f"[{dag_id}] callback pod appeared: {pod_name}")
+
+        try:
+            # Failed pods are NOT auto-deleted (delete_worker_pods_on_failure=False default).
+            phase = _wait_for_pod_phase(pod_name, ["Failed"], timeout=120)
+            assert phase == "Failed", f"Expected Failed phase, got {phase!r}"
+
+            # Executor must not have crashed — scheduler pod must still be Running.
+            result = subprocess.run(
+                [
+                    "kubectl",
+                    "get",
+                    "pod",
+                    "-n",
+                    "airflow",
+                    "-l",
+                    "component=scheduler",
+                    "-o",
+                    "jsonpath={.items[0].status.phase}",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            scheduler_phase = result.stdout.strip()
+            assert scheduler_phase == "Running", (
+                f"Scheduler pod is in phase {scheduler_phase!r} after callback failure"
+            )
+        finally:
+            # Clean up the failed pod manually (won't be auto-deleted by executor).
+            subprocess.run(
+                ["kubectl", "delete", "pod", pod_name, "-n", "airflow", "--ignore-not-found"],
+                capture_output=True,
+                check=False,
+            )
+
+    # -----------------------------------------------------------------------
+    # 8.5  Callback pod is cleaned up after success
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.execution_timeout(300)
+    def test_callback_pod_is_cleaned_up_after_success(self):
+        """
+        After the callback pod reaches Succeeded, the executor must delete it so no
+        orphaned callback pods linger in the namespace.
+        """
+        dag_id = self._FAST_DAG_ID
+        dag_run_id = self._trigger_dag_run(dag_id)
+
+        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod_name = pod["metadata"]["name"]
+
+        # Wait for the pod to finish.  If the pod is already gone ("Deleted"),
+        # that itself is proof of executor-driven cleanup — skip the explicit
+        # deletion wait in that case.
+        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=120)
+        if phase != "Deleted":
+            # The executor's delete_worker_pods=True (default) must delete the pod.
+            _wait_for_pod_gone(pod_name, timeout=60)
+
+    # -----------------------------------------------------------------------
+    # 8.4  Scheduler restart with an in-flight callback pod
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.execution_timeout(400)
+    def test_callback_pod_survives_scheduler_restart(self):
+        """
+        A callback pod running in Kubernetes must complete even when the scheduler
+        is restarted mid-execution. After restart, the new scheduler must re-adopt
+        the pod via the watcher label selector and record the terminal state.
+        """
+        dag_id = self._SLOW_DAG_ID
+        dag_run_id = self._trigger_dag_run(dag_id)
+
+        # Wait until the callback pod is actually Running before killing the scheduler.
+        pod = _wait_for_callback_pod(dag_run_id, timeout=120)
+        pod_name = pod["metadata"]["name"]
+        pre_restart_phase = _wait_for_pod_phase(
+            pod_name, ["Running", "Succeeded", "Failed", "Deleted"], timeout=60
+        )
+
+        # Restart the scheduler.
+        self._delete_airflow_pod("scheduler")
+        self.ensure_resource_health("airflow-scheduler")
+        print(f"[{dag_id}] Scheduler restarted; waiting for callback pod to complete.")
+
+        if pre_restart_phase in ("Succeeded", "Deleted"):
+            # Pod already completed before the restart — the test goal (pod
+            # completion despite scheduler lifecycle) is still met.
+            return
+
+        # The slow callback sleeps for 40 s; allow plenty of time for completion.
+        phase = _wait_for_pod_phase(pod_name, ["Succeeded", "Failed", "Deleted"], timeout=180)
+        assert phase in ("Succeeded", "Deleted"), (
+            f"Callback pod {pod_name!r} reached {phase!r} after scheduler restart (expected Succeeded/Deleted)"
+        )

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -52,7 +52,7 @@ from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
 from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
-from airflow.providers.common.compat.sdk import Stats, conf
+from airflow.providers.common.compat.sdk import Stats, conf, timezone
 from airflow.utils.log.logging_mixin import remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
@@ -68,9 +68,23 @@ if TYPE_CHECKING:
     from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
+    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import WorkloadKey
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
         AirflowKubernetesScheduler,
     )
+
+
+def _format_workload_key_for_log(key: WorkloadKey) -> str:
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
+    if isinstance(key, TaskInstanceKey):
+        return f"{key.dag_id}.{key.task_id}.{key.try_number}"
+    if AIRFLOW_V_3_3_PLUS:
+        from airflow.models.callback import CallbackKey
+
+        if isinstance(key, CallbackKey):
+            return f"callback:{key.id}"
+    return str(key)
 
 
 class KubernetesExecutor(BaseExecutor):
@@ -111,9 +125,9 @@ class KubernetesExecutor(BaseExecutor):
         self.kube_client: client.CoreV1Api | None = None
         self.scheduler_job_id: str | None = None
         self._last_completed_pod_adoption = 0.0
-        self.last_handled: dict[TaskInstanceKey, float] = {}
+        self.last_handled: dict[WorkloadKey, float] = {}
         self.kubernetes_queue: str | None = None
-        self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
+        self.task_publish_retries: Counter[WorkloadKey] = Counter()
         self.task_publish_max_retries = self.conf.getint(
             "kubernetes_executor", "task_publish_max_retries", fallback=0
         )
@@ -204,7 +218,7 @@ class KubernetesExecutor(BaseExecutor):
 
     def execute_async(
         self,
-        key: TaskInstanceKey,
+        key: WorkloadKey,
         command: Any,
         queue: str | None = None,
         executor_config: Any | None = None,
@@ -246,28 +260,30 @@ class KubernetesExecutor(BaseExecutor):
             return
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
-    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
+    def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 
         if AIRFLOW_V_3_3_PLUS:
             from airflow.executors.workloads import ExecuteCallback
 
-        for workload in workloads:
+        for workload in workload_items:
             if isinstance(workload, ExecuteTask):
                 # TODO: AIP-72 handle populating tokens once https://github.com/apache/airflow/issues/45107 is handled.
                 command = [workload]
-                key = workload.ti.key
+                task_key = workload.ti.key
                 queue = workload.ti.queue
                 executor_config = workload.ti.executor_config or {}
 
-                del self.queued_tasks[key]
-                self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
-                self.running.add(key)
+                del self.queued_tasks[task_key]
+                self.execute_async(
+                    key=task_key, command=command, queue=queue, executor_config=executor_config
+                )
+                self.running.add(task_key)
             elif AIRFLOW_V_3_3_PLUS and isinstance(workload, ExecuteCallback):
-                key = workload.callback.key
-                del self.queued_callbacks[key]
-                self.execute_async(key=key, command=[workload], queue=None, executor_config=None)
-                self.running.add(key)
+                callback_key = workload.callback.key
+                del self.queued_callbacks[callback_key]
+                self.execute_async(key=callback_key, command=[workload], queue=None, executor_config=None)
+                self.running.add(callback_key)
             else:
                 raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
@@ -445,11 +461,7 @@ class KubernetesExecutor(BaseExecutor):
 
                 termination_reason = f"Pod failed because of {pod_reason}"
 
-                task_key_str = (
-                    f"callback:{key.id}"
-                    if not hasattr(key, "dag_id")
-                    else f"{key.dag_id}.{key.task_id}.{key.try_number}"
-                )
+                task_key_str = _format_workload_key_for_log(key)
                 self.log.warning(
                     "Task %s failed in pod %s/%s. Pod phase: %s, reason: %s, message: %s, "
                     "container_type: %s, container_name: %s, container_state: %s, container_reason: %s, "
@@ -468,11 +480,7 @@ class KubernetesExecutor(BaseExecutor):
                     exit_code,
                 )
             else:
-                task_key_str = (
-                    f"callback:{key.id}"
-                    if not hasattr(key, "dag_id")
-                    else f"{key.dag_id}.{key.task_id}.{key.try_number}"
-                )
+                task_key_str = _format_workload_key_for_log(key)
                 self.log.warning(
                     "Task %s failed in pod %s/%s (no details available)", task_key_str, namespace, pod_name
                 )
@@ -512,11 +520,9 @@ class KubernetesExecutor(BaseExecutor):
         # If we don't have a TI state, look it up from the db. event_buffer expects the TI state.
         # For callback keys there is no TaskInstance row — treat state=None as success directly.
         if state is None:
-            if AIRFLOW_V_3_3_PLUS and not hasattr(key, "dag_id"):
-                from airflow.utils.state import CallbackState
+            from airflow.models.taskinstancekey import TaskInstanceKey
 
-                state = CallbackState.SUCCESS
-            else:
+            if isinstance(key, TaskInstanceKey):
                 from airflow.models.taskinstance import TaskInstance
 
                 filter_for_tis = TaskInstance.filter_for_tis([key])
@@ -525,6 +531,12 @@ class KubernetesExecutor(BaseExecutor):
                 else:
                     state = None
                 state = TaskInstanceState(state) if state else None
+            elif AIRFLOW_V_3_3_PLUS:
+                from airflow.utils.state import CallbackState
+
+                state = CallbackState.SUCCESS
+            else:
+                raise ValueError(f"Unsupported Kubernetes workload key: {key!r}")
 
         self.event_buffer[key] = state, termination_reason
 
@@ -743,7 +755,6 @@ class KubernetesExecutor(BaseExecutor):
             from sqlalchemy import select
 
             from airflow.jobs.job import Job
-            from airflow.utils import timezone
             from airflow.utils.session import create_session
             from airflow.utils.state import JobState
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -249,6 +249,7 @@ class KubernetesExecutor(BaseExecutor):
         # try and remove it from the QUEUED state while we process it
         self.last_handled[key] = time.time()
 
+    # TODO: Remove this once the minimum supported version is 3.3+, and defer to BaseExecutor.queue_workload.
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -68,7 +68,10 @@ if TYPE_CHECKING:
     from airflow.executors import workloads
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskinstancekey import TaskInstanceKey
-    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import WorkloadKey
+    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+        WorkloadCommand,
+        WorkloadKey,
+    )
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
         AirflowKubernetesScheduler,
     )
@@ -219,7 +222,7 @@ class KubernetesExecutor(BaseExecutor):
     def execute_async(
         self,
         key: WorkloadKey,
-        command: Any,
+        command: WorkloadCommand,
         queue: str | None = None,
         executor_config: Any | None = None,
     ) -> None:

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -51,7 +51,7 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types impor
 from airflow.providers.cncf.kubernetes.kube_config import KubeConfig
 from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import annotations_to_key
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator
-from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_3_PLUS
 from airflow.providers.common.compat.sdk import Stats, conf
 from airflow.utils.log.logging_mixin import remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -79,6 +79,9 @@ class KubernetesExecutor(BaseExecutor):
     RUNNING_POD_LOG_LINES = 100
     supports_ad_hoc_ti_run: bool = True
     supports_multi_team: bool = True
+
+    if AIRFLOW_V_3_3_PLUS:
+        supports_callbacks: bool = True
 
     if TYPE_CHECKING and AIRFLOW_V_3_0_PLUS:
         # In the v3 path, we store workloads, not commands as strings.
@@ -235,28 +238,38 @@ class KubernetesExecutor(BaseExecutor):
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads
 
-        if not isinstance(workload, workloads.ExecuteTask):
-            raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
-        ti = workload.ti
-        self.queued_tasks[ti.key] = workload
+        if isinstance(workload, workloads.ExecuteTask):
+            self.queued_tasks[workload.ti.key] = workload
+            return
+        if AIRFLOW_V_3_3_PLUS and isinstance(workload, workloads.ExecuteCallback):
+            self.queued_callbacks[workload.callback.key] = workload
+            return
+        raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
     def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 
-        # Airflow V3 version
-        for w in workloads:
-            if not isinstance(w, ExecuteTask):
-                raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(w)}")
+        if AIRFLOW_V_3_3_PLUS:
+            from airflow.executors.workloads import ExecuteCallback
 
-            # TODO: AIP-72 handle populating tokens once https://github.com/apache/airflow/issues/45107 is handled.
-            command = [w]
-            key = w.ti.key
-            queue = w.ti.queue
-            executor_config = w.ti.executor_config or {}
+        for workload in workloads:
+            if isinstance(workload, ExecuteTask):
+                # TODO: AIP-72 handle populating tokens once https://github.com/apache/airflow/issues/45107 is handled.
+                command = [workload]
+                key = workload.ti.key
+                queue = workload.ti.queue
+                executor_config = workload.ti.executor_config or {}
 
-            del self.queued_tasks[key]
-            self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
-            self.running.add(key)
+                del self.queued_tasks[key]
+                self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
+                self.running.add(key)
+            elif AIRFLOW_V_3_3_PLUS and isinstance(workload, ExecuteCallback):
+                key = workload.callback.key
+                del self.queued_callbacks[key]
+                self.execute_async(key=key, command=[workload], queue=None, executor_config=None)
+                self.running.add(key)
+            else:
+                raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
     def sync(self) -> None:
         """Synchronize task state."""
@@ -432,7 +445,11 @@ class KubernetesExecutor(BaseExecutor):
 
                 termination_reason = f"Pod failed because of {pod_reason}"
 
-                task_key_str = f"{key.dag_id}.{key.task_id}.{key.try_number}"
+                task_key_str = (
+                    f"callback:{key.id}"
+                    if not hasattr(key, "dag_id")
+                    else f"{key.dag_id}.{key.task_id}.{key.try_number}"
+                )
                 self.log.warning(
                     "Task %s failed in pod %s/%s. Pod phase: %s, reason: %s, message: %s, "
                     "container_type: %s, container_name: %s, container_state: %s, container_reason: %s, "
@@ -451,7 +468,11 @@ class KubernetesExecutor(BaseExecutor):
                     exit_code,
                 )
             else:
-                task_key_str = f"{key.dag_id}.{key.task_id}.{key.try_number}"
+                task_key_str = (
+                    f"callback:{key.id}"
+                    if not hasattr(key, "dag_id")
+                    else f"{key.dag_id}.{key.task_id}.{key.try_number}"
+                )
                 self.log.warning(
                     "Task %s failed in pod %s/%s (no details available)", task_key_str, namespace, pod_name
                 )
@@ -488,16 +509,22 @@ class KubernetesExecutor(BaseExecutor):
             self.log.debug("TI key not in running, not adding to event_buffer: %s", key)
             return
 
-        # If we don't have a TI state, look it up from the db. event_buffer expects the TI state
+        # If we don't have a TI state, look it up from the db. event_buffer expects the TI state.
+        # For callback keys there is no TaskInstance row — treat state=None as success directly.
         if state is None:
-            from airflow.models.taskinstance import TaskInstance
+            if AIRFLOW_V_3_3_PLUS and not hasattr(key, "dag_id"):
+                from airflow.utils.state import CallbackState
 
-            filter_for_tis = TaskInstance.filter_for_tis([key])
-            if filter_for_tis is not None:
-                state = session.scalar(select(TaskInstance.state).where(filter_for_tis))
+                state = CallbackState.SUCCESS
             else:
-                state = None
-            state = TaskInstanceState(state) if state else None
+                from airflow.models.taskinstance import TaskInstance
+
+                filter_for_tis = TaskInstance.filter_for_tis([key])
+                if filter_for_tis is not None:
+                    state = session.scalar(select(TaskInstance.state).where(filter_for_tis))
+                else:
+                    state = None
+                state = TaskInstanceState(state) if state else None
 
         self.event_buffer[key] = state, termination_reason
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     # test) key/state, not just a task one.  Widen the executor NamedTuple fields
     # accordingly while falling back to the task-only types on older Airflow.
     if AIRFLOW_V_3_3_PLUS:
+        from airflow.executors.workloads import ExecuteCallback, ExecuteTask
         from airflow.executors.workloads.types import (
             WorkloadKey as _WorkloadKey,
             WorkloadState as _WorkloadState,
@@ -38,9 +39,14 @@ if TYPE_CHECKING:
 
         WorkloadKey: TypeAlias = _WorkloadKey
         WorkloadState: TypeAlias = _WorkloadState
+        # KubernetesJob.command carries either the legacy Airflow-2 argv
+        # (Sequence[str]) or, on Airflow 3, a single-element list wrapping the
+        # workload object (ExecuteTask or ExecuteCallback).
+        WorkloadCommand: TypeAlias = Sequence[str] | Sequence[ExecuteTask] | Sequence[ExecuteCallback]
     else:
         WorkloadKey: TypeAlias = TaskInstanceKey  # type: ignore[no-redef, misc]
         WorkloadState: TypeAlias = TaskInstanceState  # type: ignore[no-redef, misc]
+        WorkloadCommand: TypeAlias = Sequence[str]  # type: ignore[no-redef, misc]
 
 
 ADOPTED = "adopted"
@@ -90,7 +96,7 @@ class KubernetesJob(NamedTuple):
     """Job definition for Kubernetes execution."""
 
     key: WorkloadKey
-    command: Sequence[str]
+    command: WorkloadCommand
     kube_executor_config: Any
     pod_template_file: str | None
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
 
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS  # noqa: TC001
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import TypeAlias
 
     from airflow.models.taskinstance import TaskInstanceKey
-    from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS
     from airflow.utils.state import TaskInstanceState
 
     # On Airflow 3.3+ a workload key/state may also be a callback (or connection

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -20,9 +20,26 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import TypeAlias
 
     from airflow.models.taskinstance import TaskInstanceKey
+    from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS
     from airflow.utils.state import TaskInstanceState
+
+    # On Airflow 3.3+ a workload key/state may also be a callback (or connection
+    # test) key/state, not just a task one.  Widen the executor NamedTuple fields
+    # accordingly while falling back to the task-only types on older Airflow.
+    if AIRFLOW_V_3_3_PLUS:
+        from airflow.executors.workloads.types import (
+            WorkloadKey as _WorkloadKey,
+            WorkloadState as _WorkloadState,
+        )
+
+        WorkloadKey: TypeAlias = _WorkloadKey
+        WorkloadState: TypeAlias = _WorkloadState
+    else:
+        WorkloadKey: TypeAlias = TaskInstanceKey  # type: ignore[no-redef, misc]
+        WorkloadState: TypeAlias = TaskInstanceState  # type: ignore[no-redef, misc]
 
 
 ADOPTED = "adopted"
@@ -45,8 +62,8 @@ class FailureDetails(TypedDict, total=False):
 class KubernetesResults(NamedTuple):
     """Results from Kubernetes task execution."""
 
-    key: TaskInstanceKey
-    state: TaskInstanceState | str | None
+    key: WorkloadKey
+    state: WorkloadState | str | None
     pod_name: str
     namespace: str
     resource_version: str
@@ -58,7 +75,7 @@ class KubernetesWatch(NamedTuple):
 
     pod_name: str
     namespace: str
-    state: TaskInstanceState | str | None
+    state: WorkloadState | str | None
     annotations: dict[str, str]
     resource_version: str
     failure_details: FailureDetails | None
@@ -71,7 +88,7 @@ CommandType = "Sequence[str]"
 class KubernetesJob(NamedTuple):
     """Job definition for Kubernetes execution."""
 
-    key: TaskInstanceKey
+    key: WorkloadKey
     command: Sequence[str]
     kube_executor_config: Any
     pod_template_file: str | None
@@ -88,4 +105,18 @@ the revocation.  So we don't want it to process that as an external deletion.
 So we want events on a revoked pod to be ignored.
 
 :meta private:
+"""
+
+CALLBACK_WORKLOAD_TYPE_KEY = "airflow-workload-type"
+"""Label key used to mark callback pods.
+
+Callback pods carry ``CALLBACK_WORKLOAD_TYPE_KEY=callback`` so the watcher
+can distinguish them from task pods and route annotations correctly.
+"""
+
+CALLBACK_POD_ANNOTATION_KEY = "callback_id"
+"""Annotation key that stores the callback UUID on callback pods.
+
+The watcher reads this annotation to reconstruct a ``CallbackKey`` instead of
+a ``TaskInstanceKey``.
 """

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -54,6 +54,8 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from kubernetes.client import Configuration, models as k8s
 
+    from airflow.executors.workloads import ExecuteCallback
+    from airflow.models.callback import CallbackKey
     from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import WorkloadKey
 
 
@@ -588,8 +590,9 @@ class AirflowKubernetesScheduler(LoggingMixin):
         if AIRFLOW_V_3_3_PLUS and len(command) == 1:
             from airflow.executors.workloads import ExecuteCallback
 
-            if isinstance(command[0], ExecuteCallback):
-                self._run_next_callback(key, command[0], pod_template_file)
+            workload = command[0]
+            if isinstance(workload, ExecuteCallback):
+                self._run_next_callback(workload.key, workload, pod_template_file)
                 return
 
         from airflow.models.taskinstancekey import TaskInstanceKey
@@ -601,15 +604,18 @@ class AirflowKubernetesScheduler(LoggingMixin):
         if len(command) == 1:
             from airflow.executors.workloads import ExecuteTask
 
-            if isinstance(command[0], ExecuteTask):
-                workload = command[0]
-                command = workload_to_command_args(workload)
+            task_workload = command[0]
+            if isinstance(task_workload, ExecuteTask):
+                args = workload_to_command_args(task_workload)
             else:
                 raise ValueError(
-                    f"KubernetesExecutor doesn't know how to handle workload of type: {type(command[0])}"
+                    f"KubernetesExecutor doesn't know how to handle workload of type: {type(task_workload)}"
                 )
-        elif command[0:3] != ["airflow", "tasks", "run"]:
-            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+        else:
+            # Legacy Airflow-2 argv path: the command is already a list of strings.
+            args = cast("list[str]", list(command))
+            if args[0:3] != ["airflow", "tasks", "run"]:
+                raise ValueError('The command must start with ["airflow", "tasks", "run"].')
 
         base_worker_pod = self._get_base_worker_pod(pod_template_file)
 
@@ -624,7 +630,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             map_index=map_index,
             date=None,
             run_id=run_id,
-            args=list(command),
+            args=args,
             pod_override_object=kube_executor_config,
             base_worker_pod=base_worker_pod,
             with_mutation_hook=True,
@@ -637,14 +643,16 @@ class AirflowKubernetesScheduler(LoggingMixin):
             pod.metadata.name,
             annotations_for_logging_task_metadata(pod.metadata.annotations),
         )
-        self.log.debug("Kubernetes running for command %s", command)
+        self.log.debug("Kubernetes running for command %s", args)
         self.log.debug("Kubernetes launching image %s", pod.spec.containers[0].image)
 
         # the watcher will monitor pods, so we do not block.
         self.run_pod_async(pod, **self.kube_config.kube_client_request_args)
         self.log.debug("Kubernetes Job created!")
 
-    def _run_next_callback(self, key: Any, workload: Any, pod_template_file: str | None) -> None:
+    def _run_next_callback(
+        self, key: CallbackKey, workload: ExecuteCallback, pod_template_file: str | None
+    ) -> None:
         """Build and submit a callback pod for an ExecuteCallback workload."""
         base_worker_pod = self._get_base_worker_pod(pod_template_file)
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -54,6 +54,8 @@ from airflow.utils.state import TaskInstanceState
 if TYPE_CHECKING:
     from kubernetes.client import Configuration, models as k8s
 
+    from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import WorkloadKey
+
 
 class ResourceVersion:
     """Singleton for tracking resourceVersion from Kubernetes."""
@@ -590,6 +592,11 @@ class AirflowKubernetesScheduler(LoggingMixin):
                 self._run_next_callback(key, command[0], pod_template_file)
                 return
 
+        from airflow.models.taskinstancekey import TaskInstanceKey
+
+        if not isinstance(key, TaskInstanceKey):
+            raise ValueError(f"KubernetesExecutor doesn't know how to handle workload key: {type(key)}")
+
         dag_id, task_id, run_id, try_number, map_index = key
         if len(command) == 1:
             from airflow.executors.workloads import ExecuteTask
@@ -752,6 +759,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             task.state,
             annotations_for_logging_task_metadata(task.annotations),
         )
+        key: WorkloadKey
         if AIRFLOW_V_3_3_PLUS and CALLBACK_POD_ANNOTATION_KEY in task.annotations:
             from airflow.models.callback import CallbackKey
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -31,6 +31,7 @@ from airflow.providers.cncf.kubernetes.backcompat import get_logical_date_key
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
     ALL_NAMESPACES,
+    CALLBACK_POD_ANNOTATION_KEY,
     POD_EXECUTOR_DONE_KEY,
     POD_REVOKED_KEY,
     FailureDetails,
@@ -45,6 +46,7 @@ from airflow.providers.cncf.kubernetes.kubernetes_helper_functions import (
     create_unique_id,
 )
 from airflow.providers.cncf.kubernetes.pod_generator import PodGenerator, workload_to_command_args
+from airflow.providers.cncf.kubernetes.version_compat import AIRFLOW_V_3_3_PLUS
 from airflow.providers.common.compat.sdk import AirflowException, Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
@@ -160,16 +162,25 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             if event["type"] == "ERROR":
                 return self.process_error(event)
             annotations = task.metadata.annotations
-            task_instance_related_annotations = {
-                "dag_id": annotations["dag_id"],
-                "task_id": annotations["task_id"],
-                logical_date_key: annotations.get(logical_date_key),
-                "run_id": annotations.get("run_id"),
-                "try_number": annotations["try_number"],
-            }
-            map_index = annotations.get("map_index")
-            if map_index is not None:
-                task_instance_related_annotations["map_index"] = map_index
+            if AIRFLOW_V_3_3_PLUS and CALLBACK_POD_ANNOTATION_KEY in annotations:
+                # Callback pod: forward only the annotations that process_watcher_task needs.
+                # Callback pods carry callback_id instead of task_id/try_number.
+                task_instance_related_annotations = {
+                    CALLBACK_POD_ANNOTATION_KEY: annotations[CALLBACK_POD_ANNOTATION_KEY],
+                    "dag_id": annotations.get("dag_id", ""),
+                    "run_id": annotations.get("run_id", ""),
+                }
+            else:
+                task_instance_related_annotations = {
+                    "dag_id": annotations["dag_id"],
+                    "task_id": annotations["task_id"],
+                    logical_date_key: annotations.get(logical_date_key),
+                    "run_id": annotations.get("run_id"),
+                    "try_number": annotations["try_number"],
+                }
+                map_index = annotations.get("map_index")
+                if map_index is not None:
+                    task_instance_related_annotations["map_index"] = map_index
 
             self.process_status(
                 pod_name=task.metadata.name,
@@ -224,8 +235,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             )
         elif hasattr(pod.status, "reason") and pod.status.reason == "ProviderFailed":
             # Most likely this happens due to Kubernetes setup (virtual kubelet, virtual nodes, etc.)
-            key = annotations_to_key(annotations=annotations)
-            task_key_str = f"{key.dag_id}.{key.task_id}.{key.try_number}" if key else "unknown"
+            task_key_str = _format_pod_log_key(annotations)
             self.log.warning(
                 "Event: %s failed to start with reason ProviderFailed, task: %s, annotations: %s",
                 pod_name,
@@ -268,10 +278,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                         ):
                             if waiting_reason == "ErrImagePull" and waiting_message == "pull QPS exceeded":
                                 continue
-                            key = annotations_to_key(annotations=annotations)
-                            task_key_str = (
-                                f"{key.dag_id}.{key.task_id}.{key.try_number}" if key else "unknown"
-                            )
+                            task_key_str = _format_pod_log_key(annotations)
                             self.log.warning(
                                 "Event: %s has container %s with fatal reason %s, task: %s",
                                 pod_name,
@@ -303,8 +310,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                     "Failed to collect pod failure details for %s/%s: %s", namespace, pod_name, e
                 )
 
-            key = annotations_to_key(annotations=annotations)
-            task_key_str = f"{key.dag_id}.{key.task_id}.{key.try_number}" if key else "unknown"
+            task_key_str = _format_pod_log_key(annotations)
             self.log.warning(
                 "Event: %s Failed, task: %s, annotations: %s", pod_name, task_key_str, annotations_string
             )
@@ -354,6 +360,14 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 annotations,
                 resource_version,
             )
+
+
+def _format_pod_log_key(annotations: dict[str, str]) -> str:
+    """Return a human-readable key string for pod-event logging."""
+    if AIRFLOW_V_3_3_PLUS and CALLBACK_POD_ANNOTATION_KEY in annotations:
+        return f"callback:{annotations[CALLBACK_POD_ANNOTATION_KEY]}"
+    key = annotations_to_key(annotations=annotations)
+    return f"{key.dag_id}.{key.task_id}.{key.try_number}" if key else "unknown"
 
 
 def collect_pod_failure_details(pod: k8s.V1Pod, logger) -> FailureDetails | None:
@@ -552,12 +566,29 @@ class AirflowKubernetesScheduler(LoggingMixin):
                 ResourceVersion().resource_version[namespace] = "0"
                 self.kube_watchers[namespace] = self._make_kube_watcher(namespace)
 
+    def _get_base_worker_pod(self, pod_template_file: str | None) -> k8s.V1Pod:
+        """Load the base worker pod from the template, raising if it is missing."""
+        base_worker_pod = get_base_pod_from_template(pod_template_file, self.kube_config)
+        if not base_worker_pod:
+            raise AirflowException(
+                f"could not find a valid worker template yaml at {self.kube_config.pod_template_file}"
+            )
+        return base_worker_pod
+
     def run_next(self, next_job: KubernetesJob) -> None:
         """Receives the next job to run, builds the pod, and creates it."""
         key = next_job.key
         command = next_job.command
         kube_executor_config = next_job.kube_executor_config
         pod_template_file = next_job.pod_template_file
+
+        # Callback workloads follow a separate pod-construction path.
+        if AIRFLOW_V_3_3_PLUS and len(command) == 1:
+            from airflow.executors.workloads import ExecuteCallback
+
+            if isinstance(command[0], ExecuteCallback):
+                self._run_next_callback(key, command[0], pod_template_file)
+                return
 
         dag_id, task_id, run_id, try_number, map_index = key
         if len(command) == 1:
@@ -573,12 +604,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         elif command[0:3] != ["airflow", "tasks", "run"]:
             raise ValueError('The command must start with ["airflow", "tasks", "run"].')
 
-        base_worker_pod = get_base_pod_from_template(pod_template_file, self.kube_config)
-
-        if not base_worker_pod:
-            raise AirflowException(
-                f"could not find a valid worker template yaml at {self.kube_config.pod_template_file}"
-            )
+        base_worker_pod = self._get_base_worker_pod(pod_template_file)
 
         pod = PodGenerator.construct_pod(
             namespace=self.namespace,
@@ -610,6 +636,40 @@ class AirflowKubernetesScheduler(LoggingMixin):
         # the watcher will monitor pods, so we do not block.
         self.run_pod_async(pod, **self.kube_config.kube_client_request_args)
         self.log.debug("Kubernetes Job created!")
+
+    def _run_next_callback(self, key: Any, workload: Any, pod_template_file: str | None) -> None:
+        """Build and submit a callback pod for an ExecuteCallback workload."""
+        base_worker_pod = self._get_base_worker_pod(pod_template_file)
+
+        # Extract dag_id and run_id from the standardised log_path:
+        # "executor_callbacks/<dag_id>/<run_id>/<callback_id>"
+        log_parts = (workload.log_path or "").split("/")
+        dag_id = log_parts[1] if len(log_parts) >= 4 else ""
+        run_id = log_parts[2] if len(log_parts) >= 4 else ""
+
+        args = workload_to_command_args(workload)
+
+        pod = PodGenerator.construct_callback_pod(
+            namespace=self.namespace,
+            scheduler_job_id=self.scheduler_job_id,
+            callback_id=workload.callback.id,
+            dag_id=dag_id,
+            run_id=run_id,
+            kube_image=self.kube_config.kube_image,
+            args=args,
+            base_worker_pod=base_worker_pod,
+            with_mutation_hook=True,
+        )
+
+        self.log.info(
+            "Creating kubernetes pod for callback %s, pod name %s, annotations: %s",
+            key,
+            pod.metadata.name,
+            annotations_for_logging_task_metadata(pod.metadata.annotations),
+        )
+
+        self.run_pod_async(pod, **self.kube_config.kube_client_request_args)
+        self.log.debug("Kubernetes callback pod created!")
 
     def delete_pod(self, pod_name: str, namespace: str) -> None:
         """Delete Pod from a namespace; does not raise if it does not exist."""
@@ -692,7 +752,19 @@ class AirflowKubernetesScheduler(LoggingMixin):
             task.state,
             annotations_for_logging_task_metadata(task.annotations),
         )
-        key = annotations_to_key(annotations=task.annotations)
+        if AIRFLOW_V_3_3_PLUS and CALLBACK_POD_ANNOTATION_KEY in task.annotations:
+            from airflow.models.callback import CallbackKey
+
+            key = CallbackKey(id=task.annotations[CALLBACK_POD_ANNOTATION_KEY])
+        else:
+            try:
+                key = annotations_to_key(annotations=task.annotations)
+            except KeyError:
+                self.log.debug(
+                    "Pod %s has unrecognised annotations; skipping (no dag_id/task_id/callback_id found)",
+                    task.pod_name,
+                )
+                return
         if key:
             self.log.debug("finishing job %s - %s (%s)", key, task.state, task.pod_name)
             self.result_queue.put(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/pod_generator.py
@@ -62,11 +62,11 @@ log = logging.getLogger(__name__)
 MAX_LABEL_LEN = 63
 
 
-def workload_to_command_args(workload: workloads.ExecuteTask) -> list[str]:
+def workload_to_command_args(workload: workloads.All) -> list[str]:
     """
     Convert a workload object to Task SDK command arguments.
 
-    :param workload: The ExecuteTask workload to convert
+    :param workload: The workload to convert (e.g. ExecuteTask or ExecuteCallback)
     :return: List of command arguments for the Task SDK
     """
     ser_input = workload.model_dump_json()
@@ -448,6 +448,81 @@ class PodGenerator:
 
         try:
             pod = reduce(PodGenerator.reconcile_pods, pod_list)
+        except Exception as e:
+            raise PodReconciliationError from e
+
+        if with_mutation_hook:
+            from airflow.settings import pod_mutation_hook
+
+            try:
+                pod_mutation_hook(pod)
+            except Exception as e:
+                raise PodMutationHookException from e
+
+        return pod
+
+    @classmethod
+    def construct_callback_pod(
+        cls,
+        *,
+        namespace: str,
+        scheduler_job_id: str,
+        callback_id: str,
+        dag_id: str,
+        run_id: str,
+        kube_image: str,
+        args: list[str],
+        base_worker_pod: k8s.V1Pod,
+        with_mutation_hook: bool = False,
+    ) -> k8s.V1Pod:
+        """Create a Pod for executing an ExecuteCallback workload."""
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+            CALLBACK_WORKLOAD_TYPE_KEY,
+        )
+
+        # Derive a k8s-safe pod name from the callback UUID.
+        short_id = callback_id.replace("-", "")[:8]
+        pod_id = add_unique_suffix(name=f"callback-{short_id}", rand_len=8, max_len=POD_NAME_MAX_LENGTH)
+
+        try:
+            image = base_worker_pod.spec.containers[0].image
+            if not image:
+                image = kube_image
+        except Exception:
+            image = kube_image
+
+        annotations = {
+            CALLBACK_POD_ANNOTATION_KEY: callback_id,
+            "dag_id": dag_id,
+            "run_id": run_id,
+        }
+
+        labels = {
+            "kubernetes_executor": "True",
+            "airflow-worker": make_safe_label_value(scheduler_job_id),
+            CALLBACK_WORKLOAD_TYPE_KEY: "callback",
+        }
+
+        main_container = k8s.V1Container(
+            name="base",
+            args=args,
+            image=image,
+            env=[k8s.V1EnvVar(name="AIRFLOW_IS_K8S_EXECUTOR_POD", value="True")],
+        )
+
+        dynamic_pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                namespace=namespace,
+                annotations=annotations,
+                name=pod_id,
+                labels=labels,
+            ),
+            spec=k8s.V1PodSpec(containers=[main_container]),
+        )
+
+        try:
+            pod = reduce(cls.reconcile_pods, [base_worker_pod, dynamic_pod])
         except Exception as e:
             raise PodReconciliationError from e
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -66,7 +66,11 @@ except ImportError:
 from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
 
 try:
     # Check whether a module-level function from stats is importable.
@@ -2359,5 +2363,624 @@ class TestKubernetesExecutorMultiTeam:
 
             # Should return the team-specific namespace from the executor's conf
             assert namespace == "team-a-ns"
+        finally:
+            executor.end()
+
+
+@pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="ExecuteCallback requires Airflow 3.3+")
+class TestKubernetesExecutorCallbackSupport:
+    """Tests for ExecuteCallback support in the Kubernetes executor."""
+
+    _CALLBACK_ID = "12345678-1234-5678-1234-567812345678"
+    _LOG_PATH = f"executor_callbacks/my_dag/run_id_1/{_CALLBACK_ID}"
+
+    def setup_method(self) -> None:
+        self.executor = KubernetesExecutor()
+        self.executor.job_id = 5
+        self.executor._last_completed_pod_adoption = time.monotonic()
+
+    @classmethod
+    def _make_callback_workload(cls):
+        from airflow.executors.workloads import ExecuteCallback
+        from airflow.executors.workloads.base import BundleInfo
+        from airflow.executors.workloads.callback import CallbackDTO, CallbackFetchMethod
+
+        return ExecuteCallback(
+            callback=CallbackDTO(
+                id=cls._CALLBACK_ID,
+                fetch_method=CallbackFetchMethod.IMPORT_PATH,
+                data={"path": "my_dag.deadline_alert", "kwargs": {}},
+            ),
+            dag_rel_path="my_dag.py",
+            bundle_info=BundleInfo(name="default", version="1"),
+            token="test_token",
+            log_path=cls._LOG_PATH,
+        )
+
+    @pytest.fixture(autouse=True)
+    def _patch_k8s_clients(self):
+        with (
+            mock.patch(
+                "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher"
+            ),
+            mock.patch(
+                "airflow.providers.cncf.kubernetes.kube_client.get_kube_client"
+            ) as mock_get_kube_client,
+        ):
+            self._mock_get_kube_client = mock_get_kube_client
+            yield
+
+    @staticmethod
+    def _make_task_workload():
+        from airflow.executors import workloads
+
+        return workloads.ExecuteTask(
+            ti=workloads.TaskInstance(
+                id="00000000-0000-0000-0000-000000000001",
+                dag_version_id="00000000-0000-0000-0000-000000000002",
+                task_id="test_task",
+                dag_id="test_dag",
+                run_id="test_run",
+                try_number=1,
+                map_index=-1,
+                pool_slots=1,
+                queue="default",
+                priority_weight=1,
+            ),
+            dag_rel_path="test_dag.py",
+            bundle_info=workloads.BundleInfo(name="test-bundle", version=None),
+            token="test-token",
+            log_path="test.log",
+        )
+
+    def test_supports_callbacks_attribute(self):
+        assert self.executor.supports_callbacks is True
+
+    def test_queue_callback_workload(self):
+        from airflow.models.callback import CallbackKey
+
+        workload = self._make_callback_workload()
+        expected_key = CallbackKey(id=self._CALLBACK_ID)
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queue_workload(workload, session=None)
+            assert expected_key in executor.queued_callbacks
+            assert executor.queued_callbacks[expected_key] is workload
+            assert len(executor.queued_tasks) == 0
+        finally:
+            executor.end()
+
+    def test_queue_task_and_callback_are_independent(self):
+        from airflow.models.callback import CallbackKey
+
+        callback_workload = self._make_callback_workload()
+        callback_key = CallbackKey(id=self._CALLBACK_ID)
+        task_key = TaskInstanceKey("dag", "task", "run_id", 1)
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queued_tasks[task_key] = mock.MagicMock()
+            executor.queue_workload(callback_workload, session=None)
+            assert len(executor.queued_tasks) == 1
+            assert len(executor.queued_callbacks) == 1
+            assert callback_key in executor.queued_callbacks
+        finally:
+            executor.end()
+
+    def test_process_workloads_callback(self):
+        from airflow.models.callback import CallbackKey
+
+        workload = self._make_callback_workload()
+        callback_key = CallbackKey(id=self._CALLBACK_ID)
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queued_callbacks[callback_key] = workload
+            with mock.patch.object(executor, "execute_async") as mock_execute_async:
+                executor._process_workloads([workload])
+            mock_execute_async.assert_called_once_with(
+                key=callback_key, command=[workload], queue=None, executor_config=None
+            )
+            assert callback_key not in executor.queued_callbacks
+            assert callback_key in executor.running
+        finally:
+            executor.end()
+
+    def test_process_workloads_mixed(self):
+        """A task and a callback processed together both reach execute_async and running."""
+        from airflow.models.callback import CallbackKey
+
+        task_workload = self._make_task_workload()
+        callback_workload = self._make_callback_workload()
+        task_key = task_workload.ti.key
+        callback_key = CallbackKey(id=self._CALLBACK_ID)
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queued_tasks[task_key] = task_workload
+            executor.queued_callbacks[callback_key] = callback_workload
+            with mock.patch.object(executor, "execute_async") as mock_execute_async:
+                executor._process_workloads([task_workload, callback_workload])
+            assert mock_execute_async.call_count == 2
+            assert task_key in executor.running
+            assert callback_key in executor.running
+            assert executor.queued_tasks == {}
+            assert callback_key not in executor.queued_callbacks
+        finally:
+            executor.end()
+
+    def test_execute_async_callback_command(self):
+        """execute_async enqueues the callback workload as a KubernetesJob on the task_queue.
+
+        Note: in the v3 path the *workload* (not the rendered command args) is what
+        travels on the queue; the command-args translation happens later in run_next.
+        """
+        from airflow.models.callback import CallbackKey
+
+        workload = self._make_callback_workload()
+        key = CallbackKey(id=self._CALLBACK_ID)
+
+        executor = self.executor
+        executor.task_queue = mock.MagicMock()
+        executor.execute_async(key=key, command=[workload], queue=None, executor_config=None)
+
+        executor.task_queue.put.assert_called_once()
+        job = executor.task_queue.put.call_args[0][0]
+        assert job.key == key
+        assert job.command == [workload]
+        assert job.command[0].callback.id == self._CALLBACK_ID
+
+    def test_queue_non_callback_non_task_raises(self):
+        executor = self.executor
+        with pytest.raises(RuntimeError, match="cannot handle workloads"):
+            executor.queue_workload(mock.MagicMock(), session=None)
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.delete_pod"
+    )
+    def test_change_state_callback_success_explicit_state(self, mock_delete_pod):
+        from airflow.models.callback import CallbackKey
+        from airflow.utils.state import CallbackState
+
+        executor = self.executor
+        executor.start()
+        try:
+            key = CallbackKey(id=self._CALLBACK_ID)
+            executor.running = {key}
+            results = KubernetesResults(key, CallbackState.SUCCESS, "pod_name", "default", "rv", None)
+            executor._change_state(results)
+            assert executor.event_buffer[key][0] == CallbackState.SUCCESS
+            assert key not in executor.running
+            mock_delete_pod.assert_called_once_with(pod_name="pod_name", namespace="default")
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.delete_pod"
+    )
+    def test_change_state_callback_success_state_none(self, _mock_delete_pod):
+        """state=None (pod Succeeded) must resolve to CallbackState.SUCCESS without a DB lookup."""
+        from airflow.models.callback import CallbackKey
+        from airflow.utils.state import CallbackState
+
+        executor = self.executor
+        executor.start()
+        try:
+            key = CallbackKey(id=self._CALLBACK_ID)
+            executor.running = {key}
+            results = KubernetesResults(key, None, "pod_name", "default", "rv", None)
+
+            with mock.patch("airflow.models.taskinstance.TaskInstance.filter_for_tis") as mock_filter:
+                executor._change_state(results)
+                mock_filter.assert_not_called()
+
+            assert executor.event_buffer[key][0] == CallbackState.SUCCESS
+            assert key not in executor.running
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.delete_pod"
+    )
+    def test_change_state_callback_failed(self, mock_delete_pod):
+        from airflow.models.callback import CallbackKey
+
+        executor = self.executor
+        executor.kube_config.delete_worker_pods_on_failure = True
+        executor.start()
+        try:
+            key = CallbackKey(id=self._CALLBACK_ID)
+            executor.running = {key}
+            results = KubernetesResults(key, TaskInstanceState.FAILED, "pod_name", "default", "rv", None)
+            executor._change_state(results)
+            assert executor.event_buffer[key][0] == TaskInstanceState.FAILED
+            assert key not in executor.running
+            mock_delete_pod.assert_called_once()
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.patch_pod_executor_done"
+    )
+    def test_change_state_callback_pod_not_deleted_if_keep_pods(self, mock_patch_pod):
+        from airflow.models.callback import CallbackKey
+        from airflow.utils.state import CallbackState
+
+        executor = self.executor
+        executor.kube_config.delete_worker_pods = False
+        executor.start()
+        try:
+            key = CallbackKey(id=self._CALLBACK_ID)
+            executor.running = {key}
+            results = KubernetesResults(key, CallbackState.SUCCESS, "pod_name", "default", "rv", None)
+            executor._change_state(results)
+            mock_patch_pod.assert_called_once_with(pod_name="pod_name", namespace="default")
+            assert key not in executor.running
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.delete_pod"
+    )
+    def test_sync_drains_callback_results(self, _mock_delete_pod):
+        """sync() drains a callback KubernetesResults from result_queue and updates event_buffer."""
+        from queue import Empty
+
+        from airflow.models.callback import CallbackKey
+        from airflow.utils.state import CallbackState
+
+        executor = self.executor
+        executor.start()
+        try:
+            key = CallbackKey(id=self._CALLBACK_ID)
+            executor.running = {key}
+            results = KubernetesResults(key, CallbackState.SUCCESS, "pod_name", "default", "rv", None)
+
+            executor.result_queue = mock.MagicMock()
+            executor.result_queue.get_nowait.side_effect = [results, Empty()]
+            executor.sync()
+
+            assert executor.event_buffer[key][0] == CallbackState.SUCCESS
+            assert key not in executor.running
+        finally:
+            executor.end()
+
+    def _run_next_callback_and_get_pod(self, data_file):
+        """Helper: start executor, run a callback job, and return the pod passed to run_pod_async."""
+        from airflow.models.callback import CallbackKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import KubernetesJob
+
+        workload = self._make_callback_workload()
+        callback_key = CallbackKey(id=self._CALLBACK_ID)
+        template_file = data_file("pods/generator_base_with_secrets.yaml").as_posix()
+        mock_kube_client = mock.MagicMock()
+        self._mock_get_kube_client.return_value = mock_kube_client
+
+        with conf_vars({("kubernetes_executor", "pod_template_file"): template_file}):
+            executor = self.executor
+            executor.start()
+            try:
+                with mock.patch.object(executor.kube_scheduler, "run_pod_async") as mock_run_pod:
+                    job = KubernetesJob(callback_key, [workload], None, None)
+                    executor.kube_scheduler.run_next(job)
+                    assert mock_run_pod.called, "run_pod_async should have been called"
+                    return mock_run_pod.call_args[0][0]
+            finally:
+                executor.end()
+
+    def test_run_next_callback_creates_pod(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        assert pod is not None
+
+    def test_callback_pod_has_callback_id_annotation(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        assert pod.metadata.annotations.get("callback_id") == self._CALLBACK_ID
+
+    def test_callback_pod_has_workload_type_label(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        assert pod.metadata.labels.get("airflow-workload-type") == "callback"
+
+    def test_callback_pod_has_dag_id_and_run_id_annotations(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        annotations = pod.metadata.annotations
+        # log_path = "executor_callbacks/my_dag/run_id_1/<uuid>"
+        assert annotations.get("dag_id") == "my_dag"
+        assert annotations.get("run_id") == "run_id_1"
+
+    def test_callback_pod_does_not_have_task_annotations(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        annotations = pod.metadata.annotations
+        assert "task_id" not in annotations
+        assert "try_number" not in annotations
+        assert "map_index" not in annotations
+
+    def test_callback_pod_command_is_execute_workload(self, data_file):
+        from airflow.executors.workloads import ExecuteCallback
+
+        pod = self._run_next_callback_and_get_pod(data_file)
+        args = pod.spec.containers[0].args
+        assert "airflow.sdk.execution_time.execute_workload" in args
+        assert "--json-string" in args
+
+        json_str = args[args.index("--json-string") + 1]
+        restored = ExecuteCallback.model_validate_json(json_str)
+        assert restored.callback.id == self._CALLBACK_ID
+
+    def test_callback_pod_name_does_not_collide_with_task_pod(self, data_file):
+        pod = self._run_next_callback_and_get_pod(data_file)
+        # Callback pods use a dedicated "callback-" prefix, distinct from the
+        # dag/task slug a task pod sharing the same dag would get.
+        assert pod.metadata.name.startswith("callback-")
+        assert not pod.metadata.name.startswith("my-dag")
+
+    def test_process_watcher_task_callback_succeeded(self):
+        from airflow.models.callback import CallbackKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+        )
+
+        result_queue = mock.MagicMock()
+        scheduler = AirflowKubernetesScheduler(
+            kube_config=mock.MagicMock(),
+            result_queue=result_queue,
+            kube_client=mock.MagicMock(),
+            scheduler_job_id="sched-1",
+        )
+        task = KubernetesWatch(
+            pod_name="callback-pod",
+            namespace="default",
+            state=None,
+            annotations={CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID},
+            resource_version="1",
+            failure_details=None,
+        )
+        scheduler.process_watcher_task(task)
+        result_queue.put.assert_called_once()
+        result = result_queue.put.call_args[0][0]
+        assert isinstance(result.key, CallbackKey)
+        assert result.key.id == self._CALLBACK_ID
+        assert result.state is None
+
+    def test_process_watcher_task_callback_failed(self):
+        from airflow.models.callback import CallbackKey
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+        )
+
+        result_queue = mock.MagicMock()
+        scheduler = AirflowKubernetesScheduler(
+            kube_config=mock.MagicMock(),
+            result_queue=result_queue,
+            kube_client=mock.MagicMock(),
+            scheduler_job_id="sched-1",
+        )
+        task = KubernetesWatch(
+            pod_name="callback-pod",
+            namespace="default",
+            state=TaskInstanceState.FAILED,
+            annotations={CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID},
+            resource_version="1",
+            failure_details=None,
+        )
+        scheduler.process_watcher_task(task)
+        result = result_queue.put.call_args[0][0]
+        assert isinstance(result.key, CallbackKey)
+        assert result.state == TaskInstanceState.FAILED
+
+    def test_process_watcher_task_task_still_uses_task_key(self):
+        result_queue = mock.MagicMock()
+        scheduler = AirflowKubernetesScheduler(
+            kube_config=mock.MagicMock(),
+            result_queue=result_queue,
+            kube_client=mock.MagicMock(),
+            scheduler_job_id="sched-1",
+        )
+        task = KubernetesWatch(
+            pod_name="task-pod",
+            namespace="default",
+            state=None,
+            annotations={
+                "dag_id": "my_dag",
+                "task_id": "my_task",
+                "run_id": "run_id_1",
+                "try_number": "1",
+                LOGICAL_DATE_KEY: None,
+            },
+            resource_version="1",
+            failure_details=None,
+        )
+        scheduler.process_watcher_task(task)
+        result = result_queue.put.call_args[0][0]
+        assert isinstance(result.key, TaskInstanceKey)
+
+    def test_process_watcher_task_unknown_annotations_dropped(self):
+        """Watch event with neither callback_id nor task annotations is silently dropped."""
+        result_queue = mock.MagicMock()
+        scheduler = AirflowKubernetesScheduler(
+            kube_config=mock.MagicMock(),
+            result_queue=result_queue,
+            kube_client=mock.MagicMock(),
+            scheduler_job_id="sched-1",
+        )
+        task = KubernetesWatch(
+            pod_name="unknown-pod",
+            namespace="default",
+            state=None,
+            annotations={},
+            resource_version="1",
+            failure_details=None,
+        )
+        scheduler.process_watcher_task(task)
+        result_queue.put.assert_not_called()
+
+    def test_process_status_callback_pod_succeeded(self):
+        """Watcher.process_status() puts the correct KubernetesWatch for a succeeded callback pod."""
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+        )
+
+        watcher = KubernetesJobWatcher(
+            namespace="default",
+            watcher_queue=mock.MagicMock(),
+            resource_version="0",
+            scheduler_job_id="123",
+            kube_config=mock.MagicMock(),
+        )
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                name="callback-pod",
+                annotations={
+                    CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID,
+                    "dag_id": "my_dag",
+                    "run_id": "r1",
+                },
+                labels={},
+                resource_version="42",
+                namespace="default",
+            ),
+            status=k8s.V1PodStatus(phase="Succeeded"),
+        )
+        event = {"type": "MODIFIED", "object": pod, "raw_object": {"status": {"phase": "Succeeded"}}}
+        watcher.process_status("callback-pod", "default", "Succeeded", pod.metadata.annotations, "42", event)
+
+        watcher.watcher_queue.put.assert_called_once()
+        watch_event = watcher.watcher_queue.put.call_args[0][0]
+        assert watch_event.state is None
+        assert watch_event.annotations[CALLBACK_POD_ANNOTATION_KEY] == self._CALLBACK_ID
+
+    def test_process_status_callback_pod_running_not_queued(self):
+        """Running+MODIFIED (no deletion) does not enqueue a watcher event — same as task pods."""
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+        )
+
+        watcher = KubernetesJobWatcher(
+            namespace="default",
+            watcher_queue=mock.MagicMock(),
+            resource_version="0",
+            scheduler_job_id="123",
+            kube_config=mock.MagicMock(),
+        )
+
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                name="callback-pod",
+                annotations={CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID},
+                labels={},
+                resource_version="42",
+                namespace="default",
+            ),
+            status=k8s.V1PodStatus(phase="Running"),
+        )
+        event = {"type": "MODIFIED", "object": pod, "raw_object": {}}
+        watcher.process_status("callback-pod", "default", "Running", pod.metadata.annotations, "42", event)
+        watcher.watcher_queue.put.assert_not_called()
+
+    def test_process_status_callback_pod_failed(self):
+        """Phase Failed enqueues a FAILED KubernetesWatch carrying failure details."""
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+        )
+
+        watcher = KubernetesJobWatcher(
+            namespace="default",
+            watcher_queue=mock.MagicMock(),
+            resource_version="0",
+            scheduler_job_id="123",
+            kube_config=mock.MagicMock(),
+        )
+
+        annotations = {CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID, "dag_id": "my_dag", "run_id": "r1"}
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                name="callback-pod",
+                annotations=annotations,
+                labels={},
+                resource_version="42",
+                namespace="default",
+            ),
+            status=k8s.V1PodStatus(phase="Failed"),
+        )
+        event = {"type": "MODIFIED", "object": pod, "raw_object": {"status": {"phase": "Failed"}}}
+        watcher.process_status("callback-pod", "default", "Failed", annotations, "42", event)
+
+        watcher.watcher_queue.put.assert_called_once()
+        watch_event = watcher.watcher_queue.put.call_args[0][0]
+        assert watch_event.state == TaskInstanceState.FAILED
+        assert watch_event.annotations[CALLBACK_POD_ANNOTATION_KEY] == self._CALLBACK_ID
+        assert watch_event.failure_details is not None
+        assert watch_event.failure_details["pod_status"] == "Failed"
+
+    def test_process_status_callback_pod_revoked_label_skipped(self):
+        """A revoked pod is skipped even when it carries a callback_id annotation."""
+        from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
+            CALLBACK_POD_ANNOTATION_KEY,
+            POD_REVOKED_KEY,
+        )
+
+        watcher = KubernetesJobWatcher(
+            namespace="default",
+            watcher_queue=mock.MagicMock(),
+            resource_version="0",
+            scheduler_job_id="123",
+            kube_config=mock.MagicMock(),
+        )
+
+        annotations = {CALLBACK_POD_ANNOTATION_KEY: self._CALLBACK_ID}
+        pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                name="callback-pod",
+                annotations=annotations,
+                labels={POD_REVOKED_KEY: "True"},
+                resource_version="42",
+                namespace="default",
+            ),
+            status=k8s.V1PodStatus(phase="Succeeded"),
+        )
+        event = {"type": "MODIFIED", "object": pod, "raw_object": {"status": {"phase": "Succeeded"}}}
+        watcher.process_status("callback-pod", "default", "Succeeded", annotations, "42", event)
+        watcher.watcher_queue.put.assert_not_called()
+
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.AIRFLOW_V_3_3_PLUS", False)
+    def test_task_execution_unaffected_on_older_airflow(self):
+        """With AIRFLOW_V_3_3_PLUS False, an ExecuteTask still flows through without callback code."""
+        task_workload = self._make_task_workload()
+        task_key = task_workload.ti.key
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queued_tasks[task_key] = task_workload
+            with mock.patch.object(executor, "execute_async") as mock_execute_async:
+                executor._process_workloads([task_workload])
+            mock_execute_async.assert_called_once()
+            assert task_key in executor.running
+            assert task_key not in executor.queued_tasks
+        finally:
+            executor.end()
+
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.AIRFLOW_V_3_3_PLUS", False)
+    def test_supports_callbacks_does_not_break_old_airflow(self):
+        """queue_workload(ExecuteTask) still stores in queued_tasks when callbacks are gated off."""
+        task_workload = self._make_task_workload()
+        task_key = task_workload.ti.key
+
+        executor = self.executor
+        executor.start()
+        try:
+            executor.queue_workload(task_workload, session=None)
+            assert task_key in executor.queued_tasks
+            assert len(executor.queued_callbacks) == 0
         finally:
             executor.end()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Implements `supports_callbacks` on KubernetesExecutor by running each ExecuteCallback workload as its own pod, alongside the existing task-pod pipeline. Gated on `AIRFLOW_V_3_3_PLUS`.

* related: #62887
* related: #61153
* related: #62645 
* continue work on: #63454

### Approach

Use the same way as how Task is dispatched to Kubernetes but with a different configuration for pod label/annotation.

**Pod annotations: tasks vs callbacks**

For task pods, `PodGenerator.construct_pod()` writes these annotations so the watcher can reconstruct `TaskInstanceKey`:

```
dag_id=<dag_id>
task_id=<task_id>
try_number=<n>
run_id=<run_id>
map_index=<n>   (if mapped)
```

For callback pods, there is no `task_id`, `try_number`, or `map_index`. The relevant identity is the callback UUID. 

Proposed annotations:

```
callback_id=<uuid-str>   ← primary identity, used to reconstruct CallbackKey
dag_id=<dag_id>          ← from ExecuteCallback.log_path (executor_callbacks/<dag_id>/...)
run_id=<run_id>          ← same source, for observability/log correlation
```

A new pod label is also needed to let the watcher distinguish callback pods from task pods without relying on annotation presence:

```
airflow-workload-type=callback
```

**Pod construction for callbacks: no `PodGenerator.construct_pod()` changes**

`PodGenerator.construct_pod()` is specifically built for task identity (takes `dag_id`, `task_id`, `try_number`, etc.). **Callback pods should not go through `construct_pod()`**.  They need their own construction path that:

1. Starts from the same base pod template (`get_base_pod_from_template`)
2. Sets the correct command: `workload_to_command_args(workload)` for `ExecuteCallback`, which serializes workload to `--json-string`
3. Sets labels: `airflow-worker=<job_id>`, `kubernetes_executor=True`, `airflow-workload-type=callback`
4. Sets annotations: `callback_id`, `dag_id`, `run_id` (extracted from `workload.log_path` or `workload.callback.data`)
5. Sets `pod_id` from `create_unique_id("callback", callback_id_short)` to avoid name collisions with task pods

The command is identical because `execute_workload` dispatches on the workload type at runtime — the same subprocess entry point handles both `ExecuteTask` and `ExecuteCallback`.

**Differences from the task pod lifecycle:**

| Step | Task pod | Callback pod |
|---|---|---|
| Queue dict | `queued_tasks[TaskInstanceKey]` | `queued_callbacks[CallbackKey]` |
| Key type | `TaskInstanceKey` (dag_id, task_id, run_id, try_number, map_index) | `CallbackKey` (id only) |
| Pod construction | `construct_pod()` | `construct_callback_pod()` |
| Distinguishing annotation | `task_id`, `try_number` | `callback_id` |
| Key reconstruction (watcher) | `annotations_to_key()` | `CallbackKey(id=annotations["callback_id"])` |
| state=None resolution | DB lookup via `TaskInstance.filter_for_tis` | `CallbackState.SUCCESS` directly (no TI row) |
| state type in event_buffer | `TaskInstanceState` | `CallbackState` |

| | ExecuteTask | ExecuteCallback |
|---|---|---|
| **`.key`** | `TaskInstanceKey(dag_id, task_id, run_id, try_number, map_index)` | `CallbackKey(id=<uuid-str>)` |
| **Identity fields** | 5 structured fields | UUID |
| **Retries** | Yes (`try_number`) | No — executes once |
| **Pod label filtering** | `airflow-worker=<job_id>` | same — same scheduler owns it |

Both `TaskInstanceState` and `CallbackState` fit into `WorkloadState` (`TaskInstanceState | CallbackState | ConnectionTestState`), which is why `KubernetesResults.state` and `KubernetesWatch.state` use the `WorkloadState` type alias — the same queue structs carry either kind of state depending on what ran in the pod.

```mermaid
sequenceDiagram
    participant Sched as Scheduler
    participant KE as KubernetesExecutor
    participant AKS as AirflowKubernetesScheduler
    participant KJW as "KubernetesJobWatcher (Process)"
    participant K8s as "Kubernetes API"

    Note over Sched,KE: Phase 1 — Queuing (CallbackKey has only .id — no dag_id)
    Sched->>KE: queue_workload(ExecuteCallback, session)
    Note right of KE: queued_callbacks[CallbackKey] = ExecuteCallback

    Note over Sched,KE: Phase 2 — Heartbeat dispatches callback
    Sched->>KE: heartbeat() → trigger_tasks() → _process_workloads()
    KE->>KE: key = workload.callback.key  (CallbackKey)
    KE->>KE: execute_async(key=CallbackKey, command=[ExecuteCallback])
    Note right of KE: task_queue.put(KubernetesJob)<br/>running.add(CallbackKey)

    Note over KE,K8s: Phase 3 — sync() builds and submits callback pod
    Sched->>KE: sync()
    KE->>AKS: run_next(KubernetesJob)
    AKS->>AKS: isinstance(command[0], ExecuteCallback) → True
    AKS->>AKS: _run_next_callback()<br/>workload_to_command_args(ExecuteCallback)<br/>→ ["python", "-m", "execute_workload", "--json-string", ...]
    AKS->>AKS: construct_callback_pod()<br/>annotations: {callback_id: uuid, dag_id, run_id}<br/>labels: {airflow-workload-type: callback, airflow-worker: ...}
    AKS->>K8s: create_namespaced_pod(callback pod spec)
    Note right of K8s: Pod: Pending → Running<br/>(Running MODIFIED: not re-queued,<br/>same behaviour as task pods)

    Note over KJW,K8s: Phase 4 — Watcher streams terminal pod event
    KJW->>K8s: watch.Watch().stream(label_selector=airflow-worker={job_id})
    Note right of K8s: Pod: Running → Succeeded
    K8s-->>KJW: event{type:MODIFIED, phase:Succeeded}
    KJW->>AKS: watcher_queue.put(KubernetesWatch(<br/>  state=None,  ← Succeeded maps to None (same as tasks)<br/>  annotations={callback_id: uuid, dag_id, run_id}<br/>))

    Note over KE,AKS: Phase 5 — Promote to result: callback_id → CallbackKey
    Sched->>KE: sync() (next heartbeat)
    KE->>AKS: kube_scheduler.sync()
    AKS->>AKS: process_watcher_task()<br/>"callback_id" in annotations → CallbackKey(id=uuid)<br/>(falls back to annotations_to_key() for task pods)
    AKS->>KE: result_queue.put(KubernetesResults(<br/>  key=CallbackKey,  ← WorkloadKey union<br/>  state=None        ← WorkloadState | None<br/>))

    Note over Sched,KE: Phase 6 — _change_state resolves None→SUCCESS without DB
    KE->>KE: _change_state(key=CallbackKey, state=None)<br/>running.remove(CallbackKey)<br/>state is None → AIRFLOW_V_3_3_PLUS and not hasattr(key,"dag_id")<br/>  → state = CallbackState.SUCCESS  (no TaskInstance row exists)<br/>event_buffer[CallbackKey] = (CallbackState.SUCCESS, None)
    KE->>AKS: delete_pod(callback pod)
    KE->>Sched: event_buffer consumed → callback result written to DB
```

### Test Cases

**Unit Test**

```
breeze testing providers-tests --test-type "Providers[cncf.kubernetes]"
```

<img width="1474" height="366" alt="Screenshot from 2026-06-07 13-32-16" src="https://github.com/user-attachments/assets/ac2980e9-d0d5-4225-8dd8-b4d2b5d79701" />

| Test | DB Test | What it verifies |
|---|---|---|
| `test_supports_callbacks_attribute` | No | `executor.supports_callbacks is True` |
| `test_queue_callback_workload` | No | `queue_workload(callback_workload, session)` stores workload in `executor.queued_callbacks[callback_workload.callback.key]` and does NOT touch `queued_tasks` |
| `test_queue_task_and_callback_are_independent` | No | Queue a task and a callback; assert `queued_tasks` has 1 entry, `queued_callbacks` has 1 entry, no cross-contamination |
| `test_process_workloads_callback` | No | After `_process_workloads([callback_workload])`: key removed from `queued_callbacks`, key present in `running`, `kube_scheduler.run_next` called once |
| `test_process_workloads_mixed` | No | Process one `ExecuteTask` and one `ExecuteCallback` together; both go to `run_next`, both in `running` |
| `test_execute_async_callback_command` | No | `execute_async(key=callback_key, command=[callback_workload])` puts a `KubernetesJob` on `task_queue` whose command is `["python", "-m", "airflow.sdk.execution_time.execute_workload", "--json-string", ...]` |
| `test_change_state_callback_success_explicit_state` | **Yes** | `KubernetesResults(key=CallbackKey, state=CallbackState.SUCCESS)`; `event_buffer[callback_key]` set, pod deleted, key removed from `running` |
| `test_change_state_callback_success_state_none` | **Yes** | `KubernetesResults(key=CallbackKey, state=None)`; implementation must NOT call `TaskInstance.filter_for_tis` (wrong key type) and must instead set `state=CallbackState.SUCCESS` without querying DB |
| `test_change_state_callback_failed` | **Yes** | `state=FAILED`; `event_buffer[callback_key]` set to failed state; pod deleted (with failure-deletion config) |
| `test_change_state_callback_pod_not_deleted_if_keep_pods` | **Yes** | `delete_worker_pods=False`; `patch_pod_executor_done` called instead of `delete_pod` |
| `test_sync_drains_callback_results` | **Yes** | Put `KubernetesResults(key=CallbackKey)` on `result_queue`; `sync()` drains it and updates `event_buffer` |

| Test | What it verifies |
|---|---|
| `test_run_next_callback_creates_pod` | `run_next(KubernetesJob(key=CallbackKey, command=[callback_workload], ...))` calls `kube_client.create_namespaced_pod` |
| `test_callback_pod_has_callback_id_annotation` | Pod spec has annotation `callback_id=<uuid>` |
| `test_callback_pod_has_workload_type_label` | Pod spec has label `airflow-workload-type=callback` |
| `test_callback_pod_has_dag_id_and_run_id_annotations` | Pod annotations include `dag_id` and `run_id` extracted from `workload.log_path` |
| `test_callback_pod_command_is_execute_workload` | Container command is `["python", "-m", "airflow.sdk.execution_time.execute_workload", "--json-string", <json>]`; `<json>` round-trips back to the original `ExecuteCallback` |
| `test_callback_pod_does_not_have_task_annotations` | Pod annotations do NOT contain `task_id`, `try_number`, or `map_index` |
| `test_callback_pod_name_does_not_collide_with_task_pod` | Callback pod name differs from a task pod name sharing the same dag/run (different naming prefix) |

| Test | What it verifies |
|---|---|
| `test_process_watcher_task_callback_succeeded` | `process_watcher_task(KubernetesWatch(..., annotations={"callback_id": "..."}))` puts `KubernetesResults(key=CallbackKey(...))` on `result_queue` |
| `test_process_watcher_task_callback_failed` | Same with `state=TaskInstanceState.FAILED` |
| `test_process_watcher_task_task_still_uses_task_key` | Watch event with `task_id`/`try_number` annotations (no `callback_id`) still resolves to `TaskInstanceKey` — regression check |
| `test_process_watcher_task_unknown_annotations_dropped` | Watch event with neither `callback_id` nor `task_id` annotations is silently dropped (no crash, no queue entry) |
| `test_process_status_callback_pod_succeeded` | `KubernetesJobWatcher.process_status()` with phase `Succeeded` and `callback_id` annotation puts correct `KubernetesWatch` on `watcher_queue` |
| `test_process_status_callback_pod_failed` | Phase `Failed`; `failure_details` included in the queued watch |
| `test_process_status_callback_pod_running` | Phase `Running` puts `KubernetesWatch` with `state=TaskInstanceState.RUNNING` |
| `test_process_status_callback_pod_revoked_label_skipped` | Pod with `airflow_pod_revoked=True` label is skipped even if it has `callback_id` annotation |

| Test | What it verifies |
|---|---|
| `test_task_execution_unaffected_on_older_airflow` | With `AIRFLOW_V_3_3_PLUS=False` patched, processing an `ExecuteTask` workload puts it on `task_queue` without touching callback code |
| `test_queue_non_callback_non_task_raises` | Queuing an unknown workload type raises `RuntimeError` |
| `test_supports_callbacks_does_not_break_old_airflow` | `queue_workload(ExecuteTask, session)` succeeds and stores in `queued_tasks` (regression guard for older Airflow) |

**k8s Tests**

```
breeze k8s deploy-cluster
breeze k8s deploy-airflow --executor Kubernetes
breeze k8s tests --executor Kubernetes
```

<img width="1324" height="462" alt="Screenshot from 2026-06-07 15-47-45" src="https://github.com/user-attachments/assets/3d53fdb6-21e8-4942-b19e-76d2e4a2ef0e" />

These tests use `breeze k8s` to deploy a local cluster and run against the Kubernetes API. They follow the polling pattern of `BaseK8STest`: trigger a Dag run via the REST API, poll for the callback's state, and assert the terminal outcome.

**Test:** `test_deadline_callback_executes_on_kubernetes`

```
1. Trigger DAG run for a Dag that has a short deadline already passed.
2. Poll until callback state = "success" (via GET /api/v2/callbacks/{id} or equivalent).
3. Assert exactly one callback pod was created in the k8s namespace with:
   - label airflow-workload-type=callback
   - annotation callback_id matching the callback UUID
4. Assert the callback pod was cleaned up (deleted or marked done) after completion.
```
**Test:** `test_deadline_callback_pod_failure_marks_callback_failed`

```
1. Configure the Dag's deadline callback to reference a non-existent function path
   (import will fail inside the pod).
2. Trigger the Dag run; wait for the callback pod to reach "Failed" phase.
3. Poll until callback state = "failed".
4. Assert executor event_buffer (via executor logs or API state) records FAILED,
   not hanging in RUNNING.
```

**Test:** `test_callback_pod_annotations_and_labels`

```
1. Trigger a Dag run that fires a Deadline Alert callback.
2. While the callback pod is Running, query the k8s API for the pod spec.
3. Assert annotations contain callback_id (UUID format).
4. Assert annotations contain dag_id and run_id matching the triggering Dag run.
5. Assert labels contain airflow-workload-type=callback and kubernetes_executor=True.
6. Assert the container command contains "execute_workload" and "--json-string".
```

**Test:** `test_callback_pod_survives_scheduler_restart`

```
1. Trigger a Dag run with a Deadline Alert callback, and pause at pod Running phase
   (use a slow callback function that sleeps).
2. Delete the scheduler pod (_delete_airflow_pod("scheduler")).
3. Wait for scheduler to be healthy again (ensure_resource_health("airflow-scheduler")).
4. Assert the callback eventually completes successfully (the new scheduler adopts the pod).
5. Assert callback state = "success".
```

**Test:** `test_callback_pod_is_cleaned_up_after_success`

```
1. Run the happy-path test (8.1).
2. After callback state reaches "success", assert zero pods with label
   airflow-workload-type=callback remain in the namespace.
   Uses _num_pods_in_namespace() with a label selector filter.
```

**Samples**

**Watch callback pods**

<img width="1180" height="418" alt="Screenshot from 2026-06-06 22-54-07" src="https://github.com/user-attachments/assets/1320a9f5-144d-4277-ad0d-d5b853f5fe3e" />

**Check a callback pod's logs**

```
irflow.configuration] loc=configuration.py:448
2026-06-07T01:50:34.912235Z [debug    ] Adding <function default_action_log at 0x7f63d396d480> to pre execution callback [airflow.utils.cli_action_loggers] loc=cli_action_loggers.py:51
{"timestamp":"2026-06-07T01:50:35.259660Z","level":"info","event":"Executing workload","workload":"ExecuteCallback(dag_rel_path=PurePosixPath('example_deadline_callback.py'), bundle_info=BundleInfo(name='dags-folder', version=None), log_path='executor_callbacks/example_deadline_callback/manual__2026-06-07T01:50:23.457423+00:00/019e9fc6-254d-726e-a295-664c7d8728e3', callback=CallbackDTO(id='019e9fc6-254d-726e-a295-664c7d8728e3', fetch_method=<CallbackFetchMethod.IMPORT_PATH: 'import_path'>, data={'path': 'airflow.example_dags.example_deadline_callback.deadline_callback', 'dag_id': 'example_deadline_callback', 'kwargs': {'context': {'dag_run': {'dag_run_id': 'manual__2026-06-07T01:50:23.457423+00:00', 'dag_id': 'example_deadline_callback', 'logical_date': '2026-06-07T01:50:23.448713Z', 'queued_at': '2026-06-07T01:50:23.463195Z', 'start_date': '2026-06-07T01:50:24.538774Z', 'end_date': None, 'duration': None, 'data_interval_start': '2026-06-07T01:50:23.448713Z', 'data_interval_end': '2026-06-07T01:50:23.448713Z', 'run_after': '2026-06-07T01:50:23.457423Z', 'last_scheduling_decision': '2026-06-07T01:50:24.558640Z', 'run_type': 'manual', 'state': 'running', 'triggered_by': 'rest_api', 'triggering_user_name': 'admin', 'conf': {}, 'note': None, 'dag_versions': [{'id': '019e9fb7-3b95-72ac-ae8d-f27f87a4a42d', 'version_number': 1, 'dag_id': 'example_deadline_callback', 'bundle_name': 'dags-folder', 'bundle_version': None, 'created_at': '2026-06-07T01:34:06.229528Z', 'dag_display_name': 'example_deadline_callback', 'bundle_url': None}], 'bundle_version': None, 'dag_display_name': 'example_deadline_callback', 'partition_key': None}, 'deadline': {'id': '019e9fc6-254f-7edd-9487-aaf3b93bc47e', 'deadline_time': '2020-01-01T01:00:00Z'}}}, 'prefix': 'deadline_alerts', 'executor': None, 'deadline_id': '019e9fc6-254f-7edd-9487-aaf3b93bc47e', 'dag_run_id': '2'}), type='ExecuteCallback')","logger":"__main__","filename":"execute_workload.py","lineno":51}
{"timestamp":"2026-06-07T01:50:35.804194Z","level":"info","event":"Using Public CAs from certifi","logger":"airflow.sdk.api.client","filename":"client.py","lineno":1155}
{"timestamp":"2026-06-07T01:50:35.822780Z","level":"debug","event":"Connecting to execution API server","server":"http://airflow-api-server:8080/execution/","logger":"supervisor","filename":"supervisor.py","lineno":1210}
{"timestamp":"2026-06-07T01:50:35.839307Z","level":"info","event":"DAG bundles loaded: dags-folder","logger":"airflow.dag_processing.bundles.manager.DagBundlesManager","filename":"manager.py","lineno":209}
{"timestamp":"2026-06-07T01:50:35.839896Z","level":"debug","event":"Added bundle path to sys.path","bundle_name":"dags-folder","path":"/opt/airflow/dags","logger":"callback_runner","filename":"callback_supervisor.py","lineno":209}
{"timestamp":"2026-06-07T01:50:35.984210Z","level":"debug","event":"Initializing Provider Manager[taskflow_decorators]","logger":"airflow.sdk._shared.providers_discovery.providers_discovery","filename":"providers_discovery.py","lineno":285}
{"timestamp":"2026-06-07T01:50:35.984610Z","level":"debug","event":"Initialization of Provider Manager[taskflow_decorators] took 0.00 seconds","logger":"airflow.sdk._shared.providers_discovery.providers_discovery","filename":"providers_discovery.py","lineno":288}
{"timestamp":"2026-06-07T01:50:35.986541Z","level":"debug","event":"Executing callback","callback_path":"airflow.example_dags.example_deadline_callback.deadline_callback","callback_kwargs":{"context":{"dag_run":{"dag_run_id":"manual__2026-06-07T01:50:23.457423+00:00","dag_id":"example_deadline_callback","logical_date":"2026-06-07T01:50:23.448713Z","queued_at":"2026-06-07T01:50:23.463195Z","start_date":"2026-06-07T01:50:24.538774Z","end_date":null,"duration":null,"data_interval_start":"2026-06-07T01:50:23.448713Z","data_interval_end":"2026-06-07T01:50:23.448713Z","run_after":"2026-06-07T01:50:23.457423Z","last_scheduling_decision":"2026-06-07T01:50:24.558640Z","run_type":"manual","state":"running","triggered_by":"rest_api","triggering_user_name":"admin","conf":{},"note":null,"dag_versions":[{"id":"019e9fb7-3b95-72ac-ae8d-f27f87a4a42d","version_number":1,"dag_id":"example_deadline_callback","bundle_name":"dags-folder","bundle_version":null,"created_at":"2026-06-07T01:34:06.229528Z","dag_display_name":"example_deadline_callback","bundle_url":null}],"bundle_version":null,"dag_display_name":"example_deadline_callback","partition_key":null},"deadline":{"id":"019e9fc6-254f-7edd-9487-aaf3b93bc47e","deadline_time":"2020-01-01T01:00:00Z"}}},"logger":"callback_runner","filename":"callback_supervisor.py","lineno":117}
{"timestamp":"2026-06-07T01:50:35.986817Z","level":"info","event":"Callback executed successfully","callback_path":"airflow.example_dags.example_deadline_callback.deadline_callback","logger":"callback_runner","filename":"callback_supervisor.py","lineno":140}
{"timestamp":"2026-06-07T01:50:35.988301Z","level":"info","event":"[deadline_callback] Deadline alert fired for dag_id=example_deadline_callback run_id=manual__2026-06-07T01:50:23.457423+00:00","logger":"task.stdout"}
{"timestamp":"2026-06-07T01:50:35.992169Z","level":"info","event":"Workload finished","workload_type":"ExecutorCallback","workload_id":"019e9fc6-254d-726e-a295-664c7d8728e3","exit_code":0,"duration":0.22140842999988308,"logger":"callback_supervisor","filename":"callback_supervisor.py","lineno":398}
(kind-airflow-python-3.10-v1.30.13:KubernetesExecutor)> 
```

**Check a callback pod's details**

```
(kind-airflow-python-3.10-v1.30.13:KubernetesExecutor)> kubectl describe pod -n airflow callback-019e9fc6-2bng48qf
Name:             callback-019e9fc6-2bng48qf
Namespace:        airflow
Priority:         0
Service Account:  airflow-worker
Node:             airflow-python-3.10-v1.30.13-worker/172.18.0.3
Start Time:       Sat, 06 Jun 2026 21:50:24 -0400
Labels:           airflow-worker=3
                  airflow-workload-type=callback
                  component=worker
                  kubernetes_executor=True
                  release=airflow
                  tier=airflow
Annotations:      callback_id: 019e9fc6-254d-726e-a295-664c7d8728e3
                  cluster-autoscaler.kubernetes.io/safe-to-evict: false
                  dag_id: example_deadline_callback
                  run_id: manual__2026-06-07T01:50:23.457423+00:00
Status:           Running
IP:               10.244.1.19
IPs:
  IP:  10.244.1.19
Containers:
  base:
    Container ID:  containerd://ca41a4c7c9e5662c1133fb5646b5eebadd1fc17f5918d165a96749a8d34d20b9
    Image:         ghcr.io/apache/airflow/main/prod/python3.10-kubernetes:latest
    Image ID:      sha256:57e4539751f0c186ea32ed48fa6356d8bb506181a01ffaeae82fb03d5370f22d
    Port:          <none>
    Host Port:     <none>
    Args:
      python
      -m
      airflow.sdk.execution_time.execute_workload
      --json-string
      {"token":"<token>","dag_rel_path":"example_deadline_callback.py","bundle_info":{"name":"dags-folder","version":null},"log_path":"executor_callbacks/example_deadline_callback/manual__2026-06-07T01:50:23.457423+00:00/019e9fc6-254d-726e-a295-664c7d8728e3","callback":{"id":"019e9fc6-254d-726e-a295-664c7d8728e3","fetch_method":"import_path","data":{"path":"airflow.example_dags.example_deadline_callback.deadline_callback","dag_id":"example_deadline_callback","kwargs":{"context":{"dag_run":{"dag_run_id":"manual__2026-06-07T01:50:23.457423+00:00","dag_id":"example_deadline_callback","logical_date":"2026-06-07T01:50:23.448713Z","queued_at":"2026-06-07T01:50:23.463195Z","start_date":"2026-06-07T01:50:24.538774Z","end_date":null,"duration":null,"data_interval_start":"2026-06-07T01:50:23.448713Z","data_interval_end":"2026-06-07T01:50:23.448713Z","run_after":"2026-06-07T01:50:23.457423Z","last_scheduling_decision":"2026-06-07T01:50:24.558640Z","run_type":"manual","state":"running","triggered_by":"rest_api","triggering_user_name":"admin","conf":{},"note":null,"dag_versions":[{"id":"019e9fb7-3b95-72ac-ae8d-f27f87a4a42d","version_number":1,"dag_id":"example_deadline_callback","bundle_name":"dags-folder","bundle_version":null,"created_at":"2026-06-07T01:34:06.229528Z","dag_display_name":"example_deadline_callback","bundle_url":null}],"bundle_version":null,"dag_display_name":"example_deadline_callback","partition_key":null},"deadline":{"id":"019e9fc6-254f-7edd-9487-aaf3b93bc47e","deadline_time":"2020-01-01T01:00:00Z"}}},"prefix":"deadline_alerts","executor":null,"deadline_id":"019e9fc6-254f-7edd-9487-aaf3b93bc47e","dag_run_id":"2"}},"type":"ExecuteCallback"}
    State:          Running
      Started:      Sat, 06 Jun 2026 21:50:25 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      AIRFLOW__CORE__EXECUTOR:              KubernetesExecutor
      AIRFLOW_HOME:                         /opt/airflow
      AIRFLOW__CORE__FERNET_KEY:            <set to the key 'fernet-key' in secret 'airflow-fernet-key'>          Optional: false
      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN:  <set to the key 'connection' in secret 'airflow-metadata'>            Optional: false
      AIRFLOW_CONN_AIRFLOW_DB:              <set to the key 'connection' in secret 'airflow-metadata'>            Optional: false
      AIRFLOW__API__SECRET_KEY:             <set to the key 'api-secret-key' in secret 'airflow-api-secret-key'>  Optional: false
      AIRFLOW_IS_K8S_EXECUTOR_POD:          True
    Mounts:
      /opt/airflow/airflow.cfg from config (ro,path="airflow.cfg")
      /opt/airflow/logs from logs (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-t49wv (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
Volumes:
  logs:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
  config:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      airflow-config
    Optional:  false
  kube-api-access-t49wv:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  10s   default-scheduler  Successfully assigned airflow/callback-019e9fc6-2bng48qf to airflow-python-3.10-v1.30.13-worker
  Normal  Pulled     9s    kubelet            Container image "ghcr.io/apache/airflow/main/prod/python3.10-kubernetes:latest" already present on machine
  Normal  Created    9s    kubelet            Created container: base
  Normal  Started    9s    kubelet            Started container base
(kind-airflow-python-3.10-v1.30.13:KubernetesExecutor)> 
```


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes

Generated-by: [Claude Code (Sonnet 4.6)] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
