### PR TITLE
Doc: clarify trigger rule behavior for `removed` upstream state

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -435,6 +435,7 @@ However, this is just the default behaviour, and you can control it using the ``
 * ``all_success`` (default): All upstream tasks have succeeded
 * ``all_failed``: All upstream tasks are in a ``failed`` or ``upstream_failed`` state
 * ``all_done``: All upstream tasks are done with their execution
+* ``all_done_setup_success``: Like ``all_done``, but if the task has upstream setup tasks, at least one of them must have succeeded. This is the default trigger rule for teardown tasks.
 * ``all_done_min_one_success``: All non-skipped upstream tasks are done with their execution and at least one upstream task has succeeded
 * ``all_skipped``: All upstream tasks are in a ``skipped`` state
 * ``one_failed``: At least one upstream task has failed (does not wait for all upstream tasks to be done)
@@ -442,8 +443,18 @@ However, this is just the default behaviour, and you can control it using the ``
 * ``one_done``: At least one upstream task succeeded or failed
 * ``none_failed``: All upstream tasks have not ``failed`` or ``upstream_failed`` - that is, all upstream tasks have succeeded or been skipped
 * ``none_failed_min_one_success``: All upstream tasks have not ``failed`` or ``upstream_failed``, and at least one upstream task has succeeded.
-* ``none_skipped``: No upstream task is in a ``skipped`` state - that is, all upstream tasks are in a ``success``, ``failed``, or ``upstream_failed`` state
+* ``none_skipped``: No upstream task is in a ``skipped`` state - that is, all upstream tasks are in a ``success``, ``failed``, ``upstream_failed``, or ``removed`` state
 * ``always``: No dependencies at all, run this task at any time
+
+.. note::
+
+    The ``removed`` :ref:`Task Instance state <concepts:task-states>` means a task has vanished from the
+    Dag since the run started. For trigger rules, ``removed`` is a terminal state: it counts toward
+    "done" for rules like ``all_done``, ``all_done_setup_success``, and ``all_done_min_one_success``,
+    but it does not count as ``success``, ``failed``, ``upstream_failed``, or ``skipped``. For
+    dynamically mapped tasks, ``removed`` upstream map indexes are also subtracted from the failure
+    counts of ``all_success``, ``all_failed``, ``none_failed``, ``none_failed_min_one_success``, and
+    ``all_done_min_one_success``.
 
 
 You can also combine this with the :ref:`concepts:depends-on-past` functionality if you wish.


### PR DESCRIPTION
Hi team, I found a few places that docs description are not aligned with the code.

For example, `all_done_setup_success` is one of the trigger rules ([code link](https://github.com/apache/airflow/blob/dd8c60e487fd5033c0f0fe3ba98f71854d5f18d6/airflow-core/src/airflow/task/trigger_rule.py#L30)) but it is not in the docs.

<br><br>

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
  Generated-by: Claude 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
