### PR TITLE
Fix flaky OTel integration tests by bounding scheduler shutdown wait

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -357,17 +357,13 @@ class TestOtelIntegration:
         finally:
             # Terminate the processes.
 
-            scheduler_process.terminate()
-            scheduler_process.wait()
-
+            self._terminate_process(scheduler_process)
             scheduler_status = scheduler_process.poll()
             assert scheduler_status is not None, (
                 "The scheduler_1 process status is None, which means that it hasn't terminated as expected."
             )
 
-            apiserver_process.terminate()
-            apiserver_process.wait()
-
+            self._terminate_process(apiserver_process)
             apiserver_status = apiserver_process.poll()
             assert apiserver_status is not None, (
                 "The apiserver process status is None, which means that it hasn't terminated as expected."
@@ -387,7 +383,8 @@ class TestOtelIntegration:
             )
         return ti
 
-    @pytest.mark.execution_timeout(90)
+    # 160s = 10s startup + 90s dag-run wait + 10s post-run sleep + 30s shutdown grace + 20s CI buffer
+    @pytest.mark.execution_timeout(160)
     @pytest.mark.parametrize(
         ("legacy_names_on_bool", "legacy_names_exported"),
         [
@@ -423,7 +420,7 @@ class TestOtelIntegration:
             if legacy_names_exported:
                 assert set(legacy_metric_names).issubset(metrics_dict.keys())
 
-    @pytest.mark.execution_timeout(90)
+    @pytest.mark.execution_timeout(160)
     def test_export_metrics_during_process_shutdown(self, capfd):
         out, dag = self.dag_execution_for_testing_metrics(capfd)
 
@@ -442,7 +439,7 @@ class TestOtelIntegration:
 
             assert set(metrics_to_check).issubset(metrics_dict.keys())
 
-    @pytest.mark.execution_timeout(90)
+    @pytest.mark.execution_timeout(160)
     @pytest.mark.parametrize(
         ("task_span_detail_level", "expected_hierarchy"),
         [
@@ -520,17 +517,13 @@ class TestOtelIntegration:
                     dump_airflow_metadata_db(session)
 
             # Terminate the processes.
-            scheduler_process.terminate()
-            scheduler_process.wait()
-
+            self._terminate_process(scheduler_process)
             scheduler_status = scheduler_process.poll()
             assert scheduler_status is not None, (
                 "The scheduler_1 process status is None, which means that it hasn't terminated as expected."
             )
 
-            apiserver_process.terminate()
-            apiserver_process.wait()
-
+            self._terminate_process(apiserver_process)
             apiserver_status = apiserver_process.poll()
             assert apiserver_status is not None, (
                 "The apiserver process status is None, which means that it hasn't terminated as expected."
@@ -571,6 +564,17 @@ class TestOtelIntegration:
 
         nested = get_span_hierarchy()
         assert nested == expected_hierarchy
+
+    @staticmethod
+    def _terminate_process(proc: subprocess.Popen, timeout: int = 30) -> None:
+        # Grace period covers OTel atexit flush (force_flush default: 10s);
+        # SIGKILL is the fallback if the process is still alive after timeout.
+        proc.terminate()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
     def start_scheduler(self, capture_output: bool = False):
         stdout = None if capture_output else subprocess.DEVNULL


### PR DESCRIPTION
  The OTel integration test methods (test_export_legacy_metric_names) failed intermittently with `Failed: Timeout >90.0s` at `scheduler_process.wait()`.                                                                                                                             
                                                                                                                                                          
  **Root cause:** The `execution_timeout(90)` was sized to match `wait_for_dag_run(max_wait_time=90)` but ignored the fixed overheads around it:       
                                                                                                                                       
    10s  startup sleep  (start_scheduler)        
    90s  dag run wait   (wait_for_dag_run max)    
    10s  post-run sleep (span_status propagation)     
    Xs   scheduler shutdown — includes OTel atexit flush (force_flush,  up to 10s)
    ───                      
    110s+ worst case > 90s limit   
                                                                                                                                                          
  When the dag run took ~65–70s, only 5–10s remained for scheduler shutdown — not enough for force_flush(). The subprocess.wait() call had no timeout, blocking in os.waitpid() until SIGALRM fired. The 60→90 bump in #67170 was still too small for the same reason.                                                                                       
                                                                                                                                                          
  **Changes:**                                                                                                                                            
  - Replace bare subprocess.wait() with wait(timeout=30) + TimeoutExpired / kill() / wait() in both finally blocks.                                                                                       
  - Raise execution_timeout from 90→160 on all three test methods.                                                                                        
    Budget: 10 + 90 + 10 + 30 = 140s worst case + 20s CI buffer = 160s.                                                                                   
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ##### Was generative AI tooling used to co-author this PR?                                                                                              
                                                                                                                                                          
  - [X] Yes — Claude Code (claude-sonnet-4-6)
                                                                                                                                                          
  Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)