### PR TITLE
Add OpenLineage support to JdbcHook

### DIFF
--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -2316,7 +2316,7 @@ def test_expected_output_push(
             ),
             {
                 "selected-providers-list-as-string": "amazon common.compat common.io common.sql "
-                "databricks dbt.cloud ftp google microsoft.mssql mysql "
+                "databricks dbt.cloud ftp google jdbc microsoft.mssql mysql "
                 "openlineage oracle postgres sftp snowflake standard trino",
                 "all-python-versions": f"['{DEFAULT_PYTHON_MAJOR_MINOR_VERSION}']",
                 "all-python-versions-list-as-string": DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
@@ -2335,7 +2335,7 @@ def test_expected_output_push(
                         {
                             "description": "amazon...standard",
                             "test_types": "Providers[amazon] Providers[common.compat,common.io,common.sql,"
-                            "databricks,dbt.cloud,ftp,microsoft.mssql,mysql,openlineage,oracle,"
+                            "databricks,dbt.cloud,ftp,jdbc,microsoft.mssql,mysql,openlineage,oracle,"
                             "postgres,sftp,snowflake,trino] Providers[google] Providers[standard]",
                         }
                     ]

--- a/providers/jdbc/docs/index.rst
+++ b/providers/jdbc/docs/index.rst
@@ -134,6 +134,7 @@ Dependent package                                                               
 ==================================================================================================================  =================
 `apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_        ``common.sql``
+`apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_      ``openlineage``
 ==================================================================================================================  =================
 
 Downloading official packages

--- a/providers/jdbc/pyproject.toml
+++ b/providers/jdbc/pyproject.toml
@@ -78,6 +78,13 @@ dependencies = [
     "jpype1>=1.7.0; python_version >= '3.14'",
 ]
 
+# The optional dependencies should be modified in place in the generated file
+# Any change in the dependencies is preserved when the file is regenerated
+[project.optional-dependencies]
+"openlineage" = [
+    "apache-airflow-providers-openlineage"
+]
+
 [dependency-groups]
 dev = [
     "apache-airflow",
@@ -85,6 +92,7 @@ dev = [
     "apache-airflow-devel-common",
     "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
+    "apache-airflow-providers-openlineage",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
 ]
 

--- a/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
@@ -262,3 +262,74 @@ class JdbcHook(DbApiHook):
                 uri = f"{uri}?{query_string}"
 
         return uri
+
+    def get_openlineage_database_info(self, connection):
+        """
+        Return JDBC database information for OpenLineage.
+
+        Returns ``None`` when the database scheme cannot be inferred from the
+        connection's ``sqlalchemy_scheme`` extra or the JDBC URL in ``host``.
+        """
+        from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+        scheme = self._get_openlineage_scheme(connection)
+        if not scheme:
+            return None
+
+        return DatabaseInfo(
+            scheme=scheme,
+            authority=self._get_openlineage_authority(connection),
+            database=connection.schema or None,
+        )
+
+    def get_openlineage_database_dialect(self, connection) -> str:
+        """Return SQL dialect inferred from the JDBC connection, or ``generic``."""
+        return self._get_openlineage_scheme(connection) or "generic"
+
+    def get_openlineage_default_schema(self) -> str | None:
+        """Return default schema from the connection."""
+        return self.connection.schema or None
+
+    @staticmethod
+    def _get_openlineage_scheme(connection) -> str | None:
+        """Infer scheme from ``sqlalchemy_scheme`` extra or JDBC URL prefix."""
+        raw: str | None = None
+        sqlalchemy_scheme = connection.extra_dejson.get("sqlalchemy_scheme")
+        if sqlalchemy_scheme:
+            raw = sqlalchemy_scheme.split("+")[0]
+        else:
+            host = connection.host or ""
+            if host.startswith("jdbc:"):
+                jdbc_part = host[5:]
+                for sep in ("://", ":"):
+                    if sep in jdbc_part:
+                        candidate = jdbc_part.split(sep)[0]
+                        if candidate:
+                            raw = candidate
+                        break
+
+        if not raw:
+            return None
+        # Normalize SQLAlchemy's "postgresql" to OL's canonical "postgres" so
+        # JDBC-Postgres shares a namespace with PostgresHook downstream.
+        return "postgres" if raw == "postgresql" else raw
+
+    @staticmethod
+    def _get_openlineage_authority(connection) -> str | None:
+        """Extract ``host:port`` from a JDBC URL in ``host`` or from plain ``host``/``port``."""
+        host = connection.host or ""
+        if host.startswith("jdbc:"):
+            rest = host[5:]
+            if "://" not in rest:
+                # Non-standard JDBC URL we can't reliably parse (e.g. Oracle
+                # ``thin:@host:port:sid``, H2 ``mem:test``).
+                return None
+            after = rest.split("://", 1)[1]
+            # Strip path, query string, and driver-specific option separator
+            # (e.g. SQL Server uses ``;`` for connection properties).
+            for sep in ("/", "?", ";"):
+                after = after.split(sep, 1)[0]
+            return after or None
+        if connection.port and host:
+            return f"{host}:{connection.port}"
+        return host or None

--- a/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
@@ -299,11 +299,12 @@ class JdbcHook(DbApiHook):
             raw = sqlalchemy_scheme.split("+")[0]
         else:
             host = connection.host or ""
-            if host.startswith("jdbc:"):
+            # The ``jdbc:`` prefix is case-insensitive per the JDBC spec.
+            if host.lower().startswith("jdbc:"):
                 jdbc_part = host[5:]
                 for sep in ("://", ":"):
                     if sep in jdbc_part:
-                        candidate = jdbc_part.split(sep)[0]
+                        candidate = jdbc_part.split(sep)[0].lower()
                         if candidate:
                             raw = candidate
                         break
@@ -318,17 +319,27 @@ class JdbcHook(DbApiHook):
     def _get_openlineage_authority(connection) -> str | None:
         """Extract ``host:port`` from a JDBC URL in ``host`` or from plain ``host``/``port``."""
         host = connection.host or ""
-        if host.startswith("jdbc:"):
+        # The ``jdbc:`` prefix is case-insensitive per the JDBC spec.
+        if host.lower().startswith("jdbc:"):
             rest = host[5:]
-            if "://" not in rest:
+            # Oracle thin service-name format (``jdbc:oracle:thin:@//host:1521/service``)
+            # uses ``:@//`` instead of ``://``. Handle before the ``://`` branch.
+            if "@//" in rest:
+                after = rest.split("@//", 1)[1]
+            elif "://" in rest:
+                after = rest.split("://", 1)[1]
+            else:
                 # Non-standard JDBC URL we can't reliably parse (e.g. Oracle
-                # ``thin:@host:port:sid``, H2 ``mem:test``).
+                # SID format ``thin:@host:port:sid``, H2 ``mem:test``).
                 return None
-            after = rest.split("://", 1)[1]
             # Strip path, query string, and driver-specific option separator
             # (e.g. SQL Server uses ``;`` for connection properties).
             for sep in ("/", "?", ";"):
                 after = after.split(sep, 1)[0]
+            # Strip userinfo (some drivers accept ``user:pass@host:port`` in the
+            # URL); we never want credentials leaking into the OL namespace.
+            if "@" in after:
+                after = after.rsplit("@", 1)[-1]
             return after or None
         if connection.port and host:
             return f"{host}:{connection.port}"

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import importlib.util
 import json
 import logging
 import sqlite3
@@ -464,6 +465,11 @@ class TestJdbcHook:
 
 class TestJdbcHookOpenLineage:
     """Static tests for the OpenLineage methods on JdbcHook."""
+
+    pytestmark = pytest.mark.skipif(
+        importlib.util.find_spec("airflow.providers.openlineage") is None,
+        reason="apache-airflow-providers-openlineage is not installed",
+    )
 
     @pytest.mark.parametrize(
         ("conn_params", "host", "port", "schema", "expected"),

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -460,3 +460,140 @@ class TestJdbcHook:
 
         jdbc_hook = get_hook(**hook_params)
         assert jdbc_hook.get_uri() == expected_uri
+
+
+class TestJdbcHookOpenLineage:
+    """Static tests for the OpenLineage methods on JdbcHook."""
+
+    @pytest.mark.parametrize(
+        ("conn_params", "host", "port", "schema", "expected"),
+        [
+            # sqlalchemy_scheme extra (preferred path)
+            (
+                {"extra": json.dumps({"sqlalchemy_scheme": "postgresql"})},
+                "myhost",
+                5432,
+                "mydb",
+                {
+                    "scheme": "postgres",  # normalized from postgresql
+                    "authority": "myhost:5432",
+                    "database": "mydb",
+                },
+            ),
+            # sqlalchemy_scheme with driver — driver suffix stripped
+            (
+                {"extra": json.dumps({"sqlalchemy_scheme": "oracle+oracledb"})},
+                "oracle-host",
+                1521,
+                "ORCL",
+                {
+                    "scheme": "oracle",
+                    "authority": "oracle-host:1521",
+                    "database": "ORCL",
+                },
+            ),
+            # JDBC URL in host (no sqlalchemy_scheme extra)
+            (
+                {"extra": json.dumps({})},
+                "jdbc:mysql://mysql-host:3306/mydb",
+                None,
+                "mydb",
+                {
+                    "scheme": "mysql",
+                    "authority": "mysql-host:3306",
+                    "database": "mydb",
+                },
+            ),
+            # sqlalchemy_scheme passthrough for non-normalized dialects
+            (
+                {"extra": json.dumps({"sqlalchemy_scheme": "snowflake"})},
+                "account.snowflakecomputing.com",
+                443,
+                "WAREHOUSE_DB",
+                {
+                    "scheme": "snowflake",
+                    "authority": "account.snowflakecomputing.com:443",
+                    "database": "WAREHOUSE_DB",
+                },
+            ),
+        ],
+    )
+    def test_get_openlineage_database_info_returns_expected_fields(
+        self, conn_params, host, port, schema, expected
+    ):
+        hook = get_hook(host=host, port=port, schema=schema, conn_params=conn_params)
+        info = hook.get_openlineage_database_info(hook.get_connection("jdbc_default"))
+        assert info is not None
+        assert info.scheme == expected["scheme"]
+        assert info.authority == expected["authority"]
+        assert info.database == expected["database"]
+
+    def test_get_openlineage_database_info_returns_none_when_scheme_unknown(self):
+        """No sqlalchemy_scheme extra and host is not a JDBC URL — returns None.
+
+        OL then skips dataset event emission rather than emit events with an
+        unidentifiable namespace.
+        """
+        hook = get_hook(host="plain-host", port=1234, conn_params={"extra": json.dumps({})})
+        assert hook.get_openlineage_database_info(hook.get_connection("jdbc_default")) is None
+
+    @pytest.mark.parametrize(
+        ("conn_params", "host", "expected_dialect"),
+        [
+            # sqlalchemy_scheme path with normalization
+            ({"extra": json.dumps({"sqlalchemy_scheme": "postgresql"})}, "h", "postgres"),
+            ({"extra": json.dumps({"sqlalchemy_scheme": "mysql"})}, "h", "mysql"),
+            ({"extra": json.dumps({"sqlalchemy_scheme": "oracle+oracledb"})}, "h", "oracle"),
+            # JDBC URL fallback
+            ({"extra": json.dumps({})}, "jdbc:trino://h:8080/c", "trino"),
+            ({"extra": json.dumps({})}, "jdbc:postgresql://h:5432/db", "postgres"),
+            # neither path resolves -> generic fallback
+            ({"extra": json.dumps({})}, "plain-host", "generic"),
+            ({"extra": json.dumps({})}, "", "generic"),
+        ],
+    )
+    def test_get_openlineage_database_dialect(self, conn_params, host, expected_dialect):
+        hook = get_hook(host=host, port=None, conn_params=conn_params)
+        dialect = hook.get_openlineage_database_dialect(hook.get_connection("jdbc_default"))
+        assert dialect == expected_dialect
+
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            ("mydb", "mydb"),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_get_openlineage_default_schema(self, schema, expected):
+        hook = get_hook(schema=schema)
+        assert hook.get_openlineage_default_schema() == expected
+
+    @pytest.mark.parametrize(
+        ("host", "port", "expected_authority"),
+        [
+            # plain host + port (sqlalchemy-style setup)
+            ("myhost", 5432, "myhost:5432"),
+            # JDBC URL with embedded host:port
+            ("jdbc:postgresql://pg-host:5432/mydb", None, "pg-host:5432"),
+            # JDBC URL with query-string options after the database
+            ("jdbc:mysql://my-host:3306/mydb?useSSL=true", None, "my-host:3306"),
+            # SQL Server uses ``;`` to separate connection properties
+            ("jdbc:sqlserver://sql-host:1433;databaseName=db", None, "sql-host:1433"),
+            # plain host without port falls through to host-only
+            ("plain-host", None, "plain-host"),
+            # Non-standard JDBC URL with no ``://`` — unparsable, returns None
+            # (Oracle thin ``thin:@host:port:sid`` and H2 ``mem:test`` formats)
+            ("jdbc:oracle:thin:@host:1521:sid", None, None),
+            ("jdbc:h2:mem:test", None, None),
+        ],
+    )
+    def test_get_openlineage_authority_extraction(self, host, port, expected_authority):
+        hook = get_hook(
+            host=host,
+            port=port,
+            conn_params={"extra": json.dumps({"sqlalchemy_scheme": "postgresql"})},
+        )
+        info = hook.get_openlineage_database_info(hook.get_connection("jdbc_default"))
+        assert info is not None
+        assert info.authority == expected_authority

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -553,6 +553,8 @@ class TestJdbcHookOpenLineage:
             # JDBC URL fallback
             ({"extra": json.dumps({})}, "jdbc:trino://h:8080/c", "trino"),
             ({"extra": json.dumps({})}, "jdbc:postgresql://h:5432/db", "postgres"),
+            # ``jdbc:`` prefix is case-insensitive; extracted dialect is lower-cased
+            ({"extra": json.dumps({})}, "JDBC:POSTGRESQL://h:5432/db", "postgres"),
             # neither path resolves -> generic fallback
             ({"extra": json.dumps({})}, "plain-host", "generic"),
             ({"extra": json.dumps({})}, "", "generic"),
@@ -589,9 +591,16 @@ class TestJdbcHookOpenLineage:
             # plain host without port falls through to host-only
             ("plain-host", None, "plain-host"),
             # Non-standard JDBC URL with no ``://`` — unparsable, returns None
-            # (Oracle thin ``thin:@host:port:sid`` and H2 ``mem:test`` formats)
+            # (Oracle thin SID ``thin:@host:port:sid`` and H2 ``mem:test`` formats)
             ("jdbc:oracle:thin:@host:1521:sid", None, None),
             ("jdbc:h2:mem:test", None, None),
+            # Oracle thin service-name format uses ``@//`` instead of ``://``
+            ("jdbc:oracle:thin:@//ora-host:1521/service", None, "ora-host:1521"),
+            # Userinfo embedded in URL (legal for several drivers) is stripped
+            # so credentials never leak into the OL namespace
+            ("jdbc:postgresql://user:pass@pg-host:5432/mydb", None, "pg-host:5432"),
+            # ``jdbc:`` prefix is case-insensitive per the JDBC spec
+            ("JDBC:postgresql://pg-host:5432/mydb", None, "pg-host:5432"),
         ],
     )
     def test_get_openlineage_authority_extraction(self, host, port, expected_authority):

--- a/uv.lock
+++ b/uv.lock
@@ -5844,12 +5844,18 @@ dependencies = [
     { name = "jpype1" },
 ]
 
+[package.optional-dependencies]
+openlineage = [
+    { name = "apache-airflow-providers-openlineage" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "apache-airflow" },
     { name = "apache-airflow-devel-common" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-sql" },
+    { name = "apache-airflow-providers-openlineage" },
     { name = "apache-airflow-task-sdk" },
 ]
 docs = [
@@ -5861,6 +5867,7 @@ requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
+    { name = "apache-airflow-providers-openlineage", marker = "extra == 'openlineage'", editable = "providers/openlineage" },
     { name = "jaydebeapi", specifier = ">=1.1.1" },
     { name = "jpype1", marker = "python_full_version >= '3.14'", specifier = ">=1.7.0" },
     { name = "jpype1", marker = "python_full_version == '3.10.*' and platform_machine == 'arm64' and sys_platform == 'darwin'", specifier = ">=1.4.0,!=1.7.0" },
@@ -5872,6 +5879,7 @@ requires-dist = [
     { name = "jpype1", marker = "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')", specifier = ">=1.5.0" },
     { name = "jpype1", marker = "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')", specifier = ">=1.5.1" },
 ]
+provides-extras = ["openlineage"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5879,6 +5887,7 @@ dev = [
     { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
+    { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
@@ -14453,6 +14462,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a2/5d27e81d24eef64668bf702bfe0e091cc48388b4666f36e025243eb9d827/jpype1-1.7.1.tar.gz", hash = "sha256:3cd88838dc3d2d546f7eaeadaaff864e590010c15f2b6a44b6f37e60796a14b2", size = 783791, upload-time = "2026-05-06T23:55:10.664Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c0/2c41dedfb65060fa05d152b3f57e7c3658c86257d92de365a3c1fcb80779/jpype1-1.7.1-1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:6590cbdb6208e4522fd99ae5f5f4bed5de707122385bc48446a1e7d7b56357ef", size = 571509, upload-time = "2026-05-19T20:19:30.416Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5e/5611d50222d146a060dbf22e69c4017545341ea6b289a591d5a9bdaad718/jpype1-1.7.1-1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4c81ee11aee5ed938d7415877cd9c7a0cc9cbf1dac87f7eab928e641323a385b", size = 571633, upload-time = "2026-05-19T20:19:33.536Z" },
+    { url = "https://files.pythonhosted.org/packages/79/32/8b2279b12364f260111c7843bf9ede7dc442d5521d6d2ca728b3d522d445/jpype1-1.7.1-1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b3ddd9f9099202212a34679dfb95dda590bcfbd23289559d104e24abec9120d1", size = 569654, upload-time = "2026-05-19T20:19:36.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/67/5caa0de30bcb1c8786cc988144a68908e0624de20cfed470a67b1dd1f60c/jpype1-1.7.1-1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:6d491a81281407f8a68552eb3c0e635e576e066c069268dc29a1ea27bb4778ae", size = 569800, upload-time = "2026-05-19T20:19:38.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/1d/9ee10b1aad9f01ea6ac6159981120eb5ace01962f9cfaa7de6b911de3eb8/jpype1-1.7.1-1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:ace0ba1a67561358fa5b57b8e93ed8bcf16f0a8d5cba79c875089c56827adf8e", size = 569753, upload-time = "2026-05-19T20:19:41.514Z" },
     { url = "https://files.pythonhosted.org/packages/04/ff/44a6f285d4c07014cb64379b8863caaefad1cc976d36923073d097b1d461/jpype1-1.7.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:472b2f53002f5fdf118d2e6b8c6b5441d6e3ca3cf1b1bdb163442be76c8b2859", size = 375560, upload-time = "2026-05-06T23:53:48.669Z" },
     { url = "https://files.pythonhosted.org/packages/42/c5/98c5ba221de29b341298341c07ad2221beae565886d18c2e6b821928db15/jpype1-1.7.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80c4c8cbab99040b8b56f28ff834e0b089aefccaabe3b472b8b43bb1e4658b86", size = 408119, upload-time = "2026-05-06T23:53:51.382Z" },
     { url = "https://files.pythonhosted.org/packages/37/3f/d3b7fd287d5bae63af0ae935b2f2c01291d18ea2e6cd706db8e4dda15354/jpype1-1.7.1-cp310-cp310-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:9c9a08d06016afbe5391daaf843b9e76c79022181685bbb23b64cd3f9aaec30d", size = 454716, upload-time = "2026-05-06T23:53:53.937Z" },


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

**Add OpenLineage support to JdbcHook**

`JdbcHook` had no OpenLineage methods, so SQL executed through it via `SQLExecuteQueryOperator`, `JdbcOperator`, or the common SQL machinery emitted no lineage at all. This unblocks lineage for any database accessed over JDBC — DB2, SAP HANA, Sybase, ClickHouse, Vertica-via-JDBC, etc.

### Changes

Adds the three standard OpenLineage hook methods(following the pattern established by `PostgresHook` / `TrinoHook` / `AthenaSQLHook`):

- **`get_openlineage_database_info`** — dialect is inferred from the connection's `sqlalchemy_scheme` extra (preferred path), falling back to parsing the JDBC URL prefix from `connection.host`. Returns `None` when the scheme cannot be inferred, so OL skips event emission rather than emitting events with an unidentifiable namespace.
- **`get_openlineage_authority_part`** — extracts the `host:port` authority, with fallback handling for embedded JDBC URLs.
- **`get_openlineage_default_schema`** — returns the connection's schema.

### Notes

- The scheme `"postgresql"` is normalized to `"postgres"` so JDBC-Postgres shares the same OL namespace as `PostgresHook`.
- Authority extraction handles both connection styles (full JDBC URL in `host`, or plain `host` + `port` with `sqlalchemy_scheme` in extras) and the SQL Server `;` option separator.

closes: #41878

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

  - [x] Yes (please specify the tool below)
  Generated-by: Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
  

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
