### PR TITLE
Fix broken tests due to pymysql 1.2.0 incompat with aiomysql

### DIFF
--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -107,6 +107,7 @@ PIP package                                 Version required
 ``mysql-connector-python``                  ``>=9.1.0; python_version < "3.12"``
 ``mysql-connector-python``                  ``>=9.1.0,!=9.7.0; python_version >= "3.12"``
 ``aiomysql``                                ``>=0.2.0``
+``pymysql``                                 ``>=1.0.3,<1.2``
 ==========================================  =============================================
 
 Cross provider package dependencies

--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -68,7 +68,10 @@ dependencies = [
     'mysqlclient>=2.2.5; sys_platform != "darwin"',
     'mysql-connector-python>=9.1.0; python_version < "3.12"',
     'mysql-connector-python>=9.1.0, !=9.7.0; python_version >= "3.12"',
+    # pymysql 1.2.0 changed ping() to require reconnect as a positional arg;
+    # aiomysql is not yet compatible — cap until aiomysql releases a fix
     "aiomysql>=0.2.0",
+    "pymysql>=1.0.3,<1.2",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/uv.lock
+++ b/uv.lock
@@ -6262,6 +6262,7 @@ dependencies = [
     { name = "apache-airflow-providers-common-sql" },
     { name = "mysql-connector-python" },
     { name = "mysqlclient", marker = "sys_platform != 'darwin'" },
+    { name = "pymysql" },
 ]
 
 [package.optional-dependencies]
@@ -6312,6 +6313,7 @@ requires-dist = [
     { name = "mysql-connector-python", marker = "python_full_version < '3.12'", specifier = ">=9.1.0" },
     { name = "mysql-connector-python", marker = "python_full_version >= '3.12'", specifier = ">=9.1.0,!=9.7.0" },
     { name = "mysqlclient", marker = "sys_platform != 'darwin'", specifier = ">=2.2.5" },
+    { name = "pymysql", specifier = ">=1.0.3,<1.2" },
 ]
 provides-extras = ["mysql-connector-python", "amazon", "openlineage", "presto", "trino", "vertica"]
 
@@ -19152,11 +19154,11 @@ wheels = [
 
 [[package]]
 name = "pymysql"
-version = "1.2.0"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/ec/8d45c920e90445f0b75c590b32851853ed319763b0d8dff8d283052da8cf/pymysql-1.1.3.tar.gz", hash = "sha256:e70ebf2047a4edf6138cf79c68ad418ef620af65900aa585c5e8bfc95044d43a", size = 48207, upload-time = "2026-05-01T09:09:54.532Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/dc/9085f3d6f497e9b25fb40d6e8ecef3ddbb5cf977a949b933624a299f5c16/pymysql-1.1.3-py3-none-any.whl", hash = "sha256:8164ba62c552f6105f3b11753352d0f16b90d1703ba67d81923d5a8a5d1c5289", size = 45356, upload-time = "2026-05-01T09:09:53.316Z" },
 ]
 
 [[package]]
@@ -21074,8 +21076,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "python_full_version >= '3.14' or platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Fix for CI like: https://github.com/apache/airflow/actions/runs/26391986239/job/77689459612?pr=67460 and in main too

## Current behaviour

`pymysql 1.2.0` changed the default of `Connection.ping(reconnect)` from `True` to `False`.
SQLAlchemy's `_send_false_to_ping` memoized property inspects this signature — when it sees
`reconnect=False` it switches to calling `dbapi_connection.ping()` with no arguments. 

But SQLAlchemy's `AsyncAdapt_aiomysql_connection.ping(self, reconnect: bool)` has no default for
`reconnect`, so the bare call raises a `TypeError` every time the async connection pool runs a
pre-ping health check (`pool_pre_ping=True`).

Error looks like this:

```shell
_____________________________________________________________________________________ TestSession.test_async_session _____________________________________________________________________________________
airflow-core/tests/unit/utils/test_session.py:66: in test_async_session
    my_special_log_event = await session.scalar(select(Log).where(Log.event == "hihi1234").limit(1))
/usr/python/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/session.py:505: in scalar
    return await greenlet_spawn(
/usr/python/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py:203: in greenlet_spawn
    result = context.switch(value)
/usr/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py:2399: in scalar
    return self._execute_internal(
/usr/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py:2239: in _execute_internal
    conn = self._connection_for_bind(bind)
/usr/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py:2108: in _connection_for_bind
    return trans._connection_for_bind(engine, execution_options)
<string>:2: in _connection_for_bind
    ???
/usr/python/lib/python3.10/site-packages/sqlalchemy/orm/state_changes.py:137: in _go
    ret_value = fn(self, *arg, **kw)
/usr/python/lib/python3.10/site-packages/sqlalchemy/orm/session.py:1187: in _connection_for_bind
    conn = bind.connect()
/usr/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py:3293: in connect
    return self._connection_cls(self)
/usr/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py:143: in __init__
    self._dbapi_connection = engine.raw_connection()
/usr/python/lib/python3.10/site-packages/sqlalchemy/engine/base.py:3317: in raw_connection
    return self.pool.connect()
/usr/python/lib/python3.10/site-packages/sqlalchemy/pool/base.py:448: in connect
    return _ConnectionFairy._checkout(self)
/usr/python/lib/python3.10/site-packages/sqlalchemy/pool/base.py:1371: in _checkout
    with util.safe_reraise():
/usr/python/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py:121: in __exit__
    raise exc_value.with_traceback(exc_tb)
/usr/python/lib/python3.10/site-packages/sqlalchemy/pool/base.py:1309: in _checkout
    result = pool._dialect._do_ping_w_event(
/usr/python/lib/python3.10/site-packages/sqlalchemy/engine/default.py:729: in _do_ping_w_event
    return self.do_ping(dbapi_connection)
/usr/python/lib/python3.10/site-packages/sqlalchemy/dialects/mysql/pymysql.py:123: in do_ping
    dbapi_connection.ping()
E   TypeError: AsyncAdapt_aiomysql_connection.ping() missing 1 required positional argument: 'reconnect'
```

## Solution

Cap `pymysql<1.2` in the mysql provider's dependencies until SQLAlchemy's aiomysql adapter is
updated to handle the new signature.




---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
