### PR TITLE
[v3-2-test] Fix broken tests due to pymysql 1.2.0 incompat with aiomysql (#67467)

### DIFF
--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -107,6 +107,7 @@ PIP package                                 Version required
 ``mysql-connector-python``                  ``>=9.1.0; python_version < "3.12"``
 ``mysql-connector-python``                  ``>=9.1.0,!=9.7.0; python_version >= "3.12"``
 ``aiomysql``                                ``>=0.2.0``
+``pymysql``                                 ``>=1.0.3,<1.2``
 ==========================================  =============================================
 
 Cross provider package dependencies

--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -68,7 +68,10 @@ dependencies = [
     'mysqlclient>=2.2.5; sys_platform != "darwin"',
     'mysql-connector-python>=9.1.0; python_version < "3.12"',
     'mysql-connector-python>=9.1.0, !=9.7.0; python_version >= "3.12"',
+    # pymysql 1.2.0 changed ping() to require reconnect as a positional arg;
+    # aiomysql is not yet compatible — cap until aiomysql releases a fix
     "aiomysql>=0.2.0",
+    "pymysql>=1.0.3,<1.2",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/uv.lock
+++ b/uv.lock
@@ -6042,6 +6042,7 @@ dependencies = [
     { name = "apache-airflow-providers-common-sql" },
     { name = "mysql-connector-python" },
     { name = "mysqlclient", marker = "sys_platform != 'darwin'" },
+    { name = "pymysql" },
 ]
 
 [package.optional-dependencies]
@@ -6092,6 +6093,7 @@ requires-dist = [
     { name = "mysql-connector-python", marker = "python_full_version < '3.12'", specifier = ">=9.1.0" },
     { name = "mysql-connector-python", marker = "python_full_version >= '3.12'", specifier = ">=9.1.0,!=9.7.0" },
     { name = "mysqlclient", marker = "sys_platform != 'darwin'", specifier = ">=2.2.5" },
+    { name = "pymysql", specifier = ">=1.0.3,<1.2" },
 ]
 provides-extras = ["mysql-connector-python", "amazon", "openlineage", "presto", "trino", "vertica"]
 


### PR DESCRIPTION
Manual backport of #67467 — auto-backport failed (https://github.com/apache/airflow/actions/runs/26402200482).

## Why auto-backport failed
Conflict in `uv.lock` on the `secretstorage` package — its dependency markers diverged between main and v3-2-test (main has more complex Python-3.14 / emscripten / win32 markers; v3-2-test has the simpler old form). Unrelated to the actual pymysql fix.

## Resolution
Kept v3-2-test's simpler `secretstorage` markers (consistent with the rest of v3-2-test's lock). Then re-ran `uv lock` to enforce the new `pymysql>=1.0.3,<1.2` constraint — pymysql resolved to 1.1.3 in the lock, no other transitive drift.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->