### PR TITLE
Fix Celery worker liveness probe hostname lookup

### DIFF
--- a/chart/newsfragments/67471.bugfix.rst
+++ b/chart/newsfragments/67471.bugfix.rst
@@ -1,0 +1,1 @@
+Use Python's ``socket.gethostname()`` for the default Celery worker liveness probe hostname lookup instead of invoking the OS ``hostname`` binary.

--- a/chart/newsfragments/67471.bugfix.rst
+++ b/chart/newsfragments/67471.bugfix.rst
@@ -1,1 +1,0 @@
-Use Python's ``socket.gethostname()`` for the default Celery worker liveness probe hostname lookup instead of invoking the OS ``hostname`` binary.

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -283,7 +283,7 @@ spec:
                 {{- else }}
                 - sh
                 - -c
-                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(hostname)
+                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
                 {{- end }}
           {{- end }}
           ports:

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -1026,6 +1026,8 @@ class TestWorker:
             "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
         )
         assert "airflow.providers.celery.executors.celery_executor.app" in livenessprobe_cmd[-1]
+        assert "socket.gethostname()" in livenessprobe_cmd[-1]
+        assert "$(hostname)" not in livenessprobe_cmd[-1]
 
     @pytest.mark.parametrize(
         "workers_values",

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -1027,7 +1027,6 @@ class TestWorker:
         )
         assert "airflow.providers.celery.executors.celery_executor.app" in livenessprobe_cmd[-1]
         assert "socket.gethostname()" in livenessprobe_cmd[-1]
-        assert "$(hostname)" not in livenessprobe_cmd[-1]
 
     @pytest.mark.parametrize(
         "workers_values",


### PR DESCRIPTION
## Description

The default Celery worker liveness probe currently builds the Celery node name with the OS-level `hostname` executable:

```sh
celery inspect ping -d celery@$(hostname)
```

Some minimal container images do not include that executable, which makes the probe fail before it can check whether the Celery worker is alive.

This keeps the same behavior of targeting the worker container's hostname, but reads it with Python's standard `socket.gethostname()` instead:

```sh
celery inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
```

The probe already depends on Python to run Celery, so this avoids adding another OS binary requirement. Kubernetes also documents that the container hostname is available through the `gethostname` function call: https://kubernetes.io/docs/concepts/containers/container-environment/

## Testing

```sh
prek run --files chart/templates/workers/worker-deployment.yaml chart/tests/helm_tests/airflow_core/test_worker.py
```

```text
Passed
```

```sh
env PYTHONPATH=chart/tests /private/tmp/airflow-chart-test-venv/bin/python -m pytest chart/tests/helm_tests/airflow_core/test_worker.py
```

```text
377 passed in 168.12s
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - OpenAI assistant

Generated-by: OpenAI assistant following https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
