### PR TITLE
Fix SimpleAuthManager redirect to next URL after login

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -28,6 +28,7 @@ from airflow.api_fastapi.auth.managers.simple.utils import parse_login_body
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.common.types import Mimetype
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import is_safe_url
 from airflow.configuration import conf
 
 login_router = AirflowRouter(tags=["SimpleAuthManagerLogin"])
@@ -85,7 +86,10 @@ def create_token_all_admins() -> LoginResponse:
 )
 def login_all_admins(request: Request) -> RedirectResponse:
     """Login the user with no credentials."""
-    response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"))
+    fallback_url = conf.get("api", "base_url", fallback="/")
+    next_url = request.query_params.get("next")
+    redirect_url = next_url if next_url and is_safe_url(next_url, request=request) else fallback_url
+    response = RedirectResponse(url=redirect_url)
 
     # The default config has this as an empty string, so we can't use `has_option`.
     # And look at the request info (needs `--proxy-headers` flag to api-server)

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -87,6 +87,26 @@ class TestLogin:
             assert response.cookies.get("_token") is not None
             assert "samesite=lax" in response.headers["set-cookie"].lower()
 
+    def test_login_all_admins_redirects_to_next_url(self, test_client):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
+            response = test_client.get(
+                "/auth/token/login?next=/dags/example_dag/runs/manual__2026-05-20/tasks/example_task",
+                follow_redirects=False,
+            )
+            assert response.status_code == 307
+            assert response.headers["location"] == "/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+            assert response.cookies.get("_token") is not None
+
+    def test_login_all_admins_ignores_unsafe_next_url(self, test_client):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
+            response = test_client.get(
+                "/auth/token/login?next=https://example.com/malicious",
+                follow_redirects=False,
+            )
+            assert response.status_code == 307
+            assert response.headers["location"] == "/"
+            assert response.cookies.get("_token") is not None
+
     def test_login_all_admins_config_disabled(self, test_client):
         response = test_client.get("/auth/token/login", follow_redirects=False)
         assert response.status_code == 403

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -94,7 +94,9 @@ class TestLogin:
                 follow_redirects=False,
             )
             assert response.status_code == 307
-            assert response.headers["location"] == "/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+            assert (
+                response.headers["location"] == "/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+            )
             assert response.cookies.get("_token") is not None
 
     def test_login_all_admins_ignores_unsafe_next_url(self, test_client):


### PR DESCRIPTION
## Why

When opening a deep link in a fresh browser session without a valid `_token` cookie, SimpleAuthManager redirects through `/auth/token/login` but drops the original `next` URL.

As a result, the user lands on `/` after auto-login instead of the originally requested DAG run or task URL. Opening the same link again works because the `_token` cookie already exists.

## What changed

This updates the SimpleAuthManager `/auth/token/login` route to:

- Read the `next` query parameter
- Redirect to it after login when it is safe
- Fall back to the configured API base URL when `next` is missing or unsafe
- Preserve existing `_token` cookie behavior

The fix reuses the existing `is_safe_url` helper to avoid introducing an open redirect issue.

## Tests

Added regression tests for:

- Redirecting to a safe internal `next` URL after login
- Ignoring an unsafe external `next` URL and falling back to `/`

Ran:

```bash
uv run pytest airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py -q