### PR TITLE
Remove redundant TODO comment in RedshiftHook

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -75,7 +75,6 @@ class RedshiftHook(AwsBaseHook):
         )
         return response
 
-    # TODO: Wrap create_cluster_snapshot
     def cluster_status(self, cluster_identifier: str) -> str | None:
         """
         Get status of a cluster.


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Why
`RedshiftHook` contains a `# TODO: Wrap create_cluster_snapshot` comment above `cluster_status`, but `create_cluster_snapshot` is already fully implemented further down in the same class.
Git history(4fb7a90) confirms both the TODO and the implementation were introduced in the same commit when `RedshiftHook` was first added. The comment was simply never cleaned up.

### Change
Removed the stale TODO comment for already-implemented functionality.

### Verification

- Static Checks (prek): Passed

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
