### PR TITLE
Cap pymysql<1.2 in PyPI constraints generation script

### DIFF
--- a/providers/mysql/pyproject.toml
+++ b/providers/mysql/pyproject.toml
@@ -69,7 +69,9 @@ dependencies = [
     'mysql-connector-python>=9.1.0; python_version < "3.12"',
     'mysql-connector-python>=9.1.0, !=9.7.0; python_version >= "3.12"',
     # pymysql 1.2.0 changed ping() to require reconnect as a positional arg;
-    # aiomysql is not yet compatible — cap until aiomysql releases a fix
+    # SQLAlchemy's AsyncAdapt_aiomysql_connection.ping has no default for it — cap
+    # until the SQLAlchemy fix is released. Tracked upstream at
+    # https://github.com/sqlalchemy/sqlalchemy/issues/13306
     "aiomysql>=0.2.0",
     "pymysql>=1.0.3,<1.2",
 ]

--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -392,9 +392,16 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
     # * pyarrow>=22.0.0 on Python 3.14 — older pyarrow releases have no prebuilt wheels for
     #   Python 3.14 and uv falls back to building from source, which fails. pyarrow 22.0.0 is
     #   the first release shipping cp314 wheels.
+    # * pymysql<1.2 — pymysql 1.2.0 changed Connection.ping() to require `reconnect` as a
+    #   positional arg, which breaks SQLAlchemy's AsyncAdapt_aiomysql_connection.ping() (it
+    #   has no default for `reconnect`). The released apache-airflow-providers-mysql on PyPI
+    #   does not yet carry this cap, so we mirror it here so PyPI constraints stay installable
+    #   until the SQLAlchemy fix is released. Tracked upstream at
+    #   https://github.com/sqlalchemy/sqlalchemy/issues/13306
     #
     additional_constraints_for_highest_resolution: list[str] = [
         "pyarrow>=22.0.0; python_version >= '3.14'",
+        "pymysql>=1.0.3,<1.2",
     ]
 
     result = run_command(


### PR DESCRIPTION
PR #67467 added `pymysql>=1.0.3,<1.2` to `providers/mysql/pyproject.toml`
because pymysql 1.2.0 broke SQLAlchemy's `AsyncAdapt_aiomysql_connection.ping()`
(see https://github.com/sqlalchemy/sqlalchemy/issues/13306 — fix is merged
but not yet released).

PyPI constraints generation, however, installs the *released*
`apache-airflow-providers-mysql` from PyPI, which does not yet carry that
cap. So `generate_constraints_pypi_providers` still picks up pymysql 1.2.0
and produces broken constraints.

This mirrors the cap in
`scripts/in_container/run_generate_constraints.py`'s
`additional_constraints_for_highest_resolution`, alongside the existing
`pyarrow>=22.0.0; python_version >= '3.14'` exclusion, with a comment
explaining why and linking to the upstream SQLAlchemy issue.

Also extends the existing comment in `providers/mysql/pyproject.toml` to
name the actual root cause (SQLAlchemy's aiomysql adapter, not aiomysql
itself) and link the same tracking issue, matching the convention in
`CLAUDE.md` for workaround sites.

Both caps can be removed once a SQLAlchemy release containing the fix
for #13306 is published.

related: #67467

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)