### PR TITLE
Fix bulk CREATE+OVERWRITE team-context authz bypass

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -441,12 +441,13 @@ def requires_access_pool_bulk() -> Callable[[BulkBody[PoolBody], BaseUser], None
         request: BulkBody[PoolBody],
         user: GetUserDep,
     ) -> None:
-        # Build the list of pool names provided as part of the request
+        # Build the list of pool names provided as part of the request that may correspond to
+        # an existing resource (UPDATE / DELETE, or CREATE+OVERWRITE which may turn into a PUT).
         existing_pool_names = [
             cast("str", entity) if action.action == BulkAction.DELETE else cast("PoolBody", entity).pool
             for action in request.actions
             for entity in action.entities
-            if action.action != BulkAction.CREATE
+            if _bulk_action_needs_existing_team_lookup(action)
         ]
         # For each pool, find its associated team (if it exists)
         pool_name_to_team = Pool.get_name_to_team_name_mapping(existing_pool_names)
@@ -542,14 +543,15 @@ def requires_access_connection_bulk() -> Callable[[BulkBody[ConnectionBody], Bas
         request: BulkBody[ConnectionBody],
         user: GetUserDep,
     ) -> None:
-        # Build the list of ``conn_id`` provided as part of the request
+        # Build the list of ``conn_id`` provided as part of the request that may correspond to
+        # an existing resource (UPDATE / DELETE, or CREATE+OVERWRITE which may turn into a PUT).
         existing_connection_ids = [
             cast("str", entity)
             if action.action == BulkAction.DELETE
             else cast("ConnectionBody", entity).connection_id
             for action in request.actions
             for entity in action.entities
-            if action.action != BulkAction.CREATE
+            if _bulk_action_needs_existing_team_lookup(action)
         ]
         # For each connection, find its associated team (if it exists)
         conn_id_to_team = Connection.get_conn_id_to_team_name_mapping(existing_connection_ids)
@@ -684,12 +686,13 @@ def requires_access_variable_bulk() -> Callable[[BulkBody[VariableBody], BaseUse
         request: BulkBody[VariableBody],
         user: GetUserDep,
     ) -> None:
-        # Build the list of variable keys provided as part of the request
+        # Build the list of variable keys provided as part of the request that may correspond to
+        # an existing resource (UPDATE / DELETE, or CREATE+OVERWRITE which may turn into a PUT).
         existing_variable_keys = [
             cast("str", entity) if action.action == BulkAction.DELETE else cast("VariableBody", entity).key
             for action in request.actions
             for entity in action.entities
-            if action.action != BulkAction.CREATE
+            if _bulk_action_needs_existing_team_lookup(action)
         ]
         # For each variable, find its associated team (if it exists)
         var_key_to_team = Variable.get_key_to_team_name_mapping(existing_variable_keys)
@@ -936,3 +939,15 @@ def _get_resource_methods_from_bulk_request(
     if action.action == BulkAction.CREATE and action.action_on_existence == BulkActionOnExistence.OVERWRITE:
         resource_methods.append("PUT")
     return resource_methods
+
+
+def _bulk_action_needs_existing_team_lookup(
+    action: BulkCreateAction | BulkUpdateAction | BulkDeleteAction,
+) -> bool:
+    # UPDATE / DELETE always operate on existing resources, so we need the existing team for authz.
+    # CREATE with action_on_existence=OVERWRITE may turn into a PUT against an existing resource that
+    # belongs to a team; if we omit it from the lookup, the PUT authz check runs with team_name=None
+    # and bypasses the per-team membership check that the single-item PUT endpoint enforces.
+    if action.action != BulkAction.CREATE:
+        return True
+    return action.action_on_existence == BulkActionOnExistence.OVERWRITE

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -811,7 +811,9 @@ class TestFastApiSecurity:
         auth_manager = Mock()
         auth_manager.batch_is_authorized_connection.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_conn_id_to_team_name_mapping.return_value = {"test1": "team1"}
+        # test4 already exists with team1 — the CREATE+OVERWRITE PUT check must run against team1
+        # so the bulk authz behaviour matches the single-item PUT endpoint.
+        mock_get_conn_id_to_team_name_mapping.return_value = {"test4": "team1"}
 
         request = BulkBody[ConnectionBody].model_validate(
             {
@@ -840,11 +842,18 @@ class TestFastApiSecurity:
         user = Mock()
         requires_access_connection_bulk()(request, user)
 
+        # CREATE+OVERWRITE entities are now included in the existing-team lookup so the PUT check
+        # gets the actual team of the resource being overwritten (regression test for the bypass
+        # where the PUT check ran with team_name=None).
+        mock_get_conn_id_to_team_name_mapping.assert_called_once()
+        looked_up = mock_get_conn_id_to_team_name_mapping.call_args.args[0]
+        assert set(looked_up) == {"test3", "test4"}
+
         auth_manager.batch_is_authorized_connection.assert_called_once_with(
             requests=[
                 {
                     "method": "POST",
-                    "details": ConnectionDetails(conn_id="test1", team_name="team1"),
+                    "details": ConnectionDetails(conn_id="test1"),
                 },
                 {
                     "method": "POST",
@@ -856,11 +865,11 @@ class TestFastApiSecurity:
                 },
                 {
                     "method": "POST",
-                    "details": ConnectionDetails(conn_id="test4"),
+                    "details": ConnectionDetails(conn_id="test4", team_name="team1"),
                 },
                 {
                     "method": "PUT",
-                    "details": ConnectionDetails(conn_id="test4"),
+                    "details": ConnectionDetails(conn_id="test4", team_name="team1"),
                 },
             ],
             user=user,
@@ -982,7 +991,9 @@ class TestFastApiSecurity:
         auth_manager = Mock()
         auth_manager.batch_is_authorized_variable.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_key_to_team_name_mapping.return_value = {"var1": "team1", "dummy": "team2"}
+        # var4 already exists with team1 — the CREATE+OVERWRITE PUT check must run against team1
+        # so the bulk authz behaviour matches the single-item PUT endpoint.
+        mock_get_key_to_team_name_mapping.return_value = {"var4": "team1"}
         request = BulkBody[VariableBody].model_validate(
             {
                 "actions": [
@@ -1010,11 +1021,15 @@ class TestFastApiSecurity:
         user = Mock()
         requires_access_variable_bulk()(request, user)
 
+        mock_get_key_to_team_name_mapping.assert_called_once()
+        looked_up = mock_get_key_to_team_name_mapping.call_args.args[0]
+        assert set(looked_up) == {"var3", "var4"}
+
         auth_manager.batch_is_authorized_variable.assert_called_once_with(
             requests=[
                 {
                     "method": "POST",
-                    "details": VariableDetails(key="var1", team_name="team1"),
+                    "details": VariableDetails(key="var1"),
                 },
                 {
                     "method": "POST",
@@ -1026,11 +1041,11 @@ class TestFastApiSecurity:
                 },
                 {
                     "method": "POST",
-                    "details": VariableDetails(key="var4"),
+                    "details": VariableDetails(key="var4", team_name="team1"),
                 },
                 {
                     "method": "PUT",
-                    "details": VariableDetails(key="var4"),
+                    "details": VariableDetails(key="var4", team_name="team1"),
                 },
             ],
             user=user,
@@ -1150,7 +1165,9 @@ class TestFastApiSecurity:
         auth_manager = Mock()
         auth_manager.batch_is_authorized_pool.return_value = True
         mock_get_auth_manager.return_value = auth_manager
-        mock_get_name_to_team_name_mapping.return_value = {"pool1": "team1"}
+        # pool4 already exists with team1 — the CREATE+OVERWRITE PUT check must run against team1
+        # so the bulk authz behaviour matches the single-item PUT endpoint.
+        mock_get_name_to_team_name_mapping.return_value = {"pool4": "team1"}
         request = BulkBody[PoolBody].model_validate(
             {
                 "actions": [
@@ -1178,11 +1195,15 @@ class TestFastApiSecurity:
         user = Mock()
         requires_access_pool_bulk()(request, user)
 
+        mock_get_name_to_team_name_mapping.assert_called_once()
+        looked_up = mock_get_name_to_team_name_mapping.call_args.args[0]
+        assert set(looked_up) == {"pool3", "pool4"}
+
         auth_manager.batch_is_authorized_pool.assert_called_once_with(
             requests=[
                 {
                     "method": "POST",
-                    "details": PoolDetails(name="pool1", team_name="team1"),
+                    "details": PoolDetails(name="pool1"),
                 },
                 {
                     "method": "POST",
@@ -1194,11 +1215,11 @@ class TestFastApiSecurity:
                 },
                 {
                     "method": "POST",
-                    "details": PoolDetails(name="pool4"),
+                    "details": PoolDetails(name="pool4", team_name="team1"),
                 },
                 {
                     "method": "PUT",
-                    "details": PoolDetails(name="pool4"),
+                    "details": PoolDetails(name="pool4", team_name="team1"),
                 },
             ],
             user=user,


### PR DESCRIPTION
The bulk pool / connection / variable endpoints build an `existing_*_to_team` lookup from request entities, but the filter that decides which entities go into that lookup explicitly excludes every `BulkAction.CREATE`. For `CREATE + action_on_existence=overwrite`, the PUT-method authz check added in `_get_resource_methods_from_bulk_request()` then runs with `team_name=None` even when the resource being overwritten already belongs to a team — bypassing the per-team membership check the single-item PUT endpoint enforces.

Reported as F-002 in the [`apache/tooling-agents` L3 ASVS sweep `0920c77`](https://github.com/apache/tooling-agents/issues/23).

## Why this is not a CVE

Multi-team (`[core] multi_team`) is documented as **experimental** in [`security_model.rst#future-multi-team-isolation`](https://github.com/apache/airflow/blob/main/airflow-core/docs/security/security_model.rst#future-multi-team-isolation) and explicitly does not provide task-level isolation guarantees: *"Deployment Managers who enable the multi-team feature should not rely on it alone for security-critical isolation between teams at the task execution layer."* The bypass surfaces only in deployments that have already accepted the documented experimental-isolation trade-off, so it is a defense-in-depth fix on an experimental surface rather than a vulnerability disclosure. The bulk path should still match single-item PUT authz behaviour either way.

## Change

Add `_bulk_action_needs_existing_team_lookup()` that returns `True` for UPDATE / DELETE and for `CREATE + OVERWRITE`. The three bulk authz functions (`requires_access_pool_bulk`, `requires_access_connection_bulk`, `requires_access_variable_bulk`) now use that helper instead of the bare `action.action != BulkAction.CREATE` filter, so CREATE+OVERWRITE entities are included in the team-name lookup and the PUT check sees the actual owning team.

## Test plan

- [x] Updated `test_requires_access_pool_bulk` / `test_requires_access_connection_bulk` / `test_requires_access_variable_bulk` to use a realistic mock (CREATE+OVERWRITE entity exists with a team) and assert (a) the names looked up against the DB are the union of DELETE + CREATE+OVERWRITE entities, (b) the POST and PUT authz requests for the CREATE+OVERWRITE entity carry the existing team name.
- [x] `prek run ruff` clean on touched files.
- [x] `prek run mypy-airflow-core` clean on `security.py`.
- [x] All three bulk-authz tests pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)