### PR TITLE
Fix the miss redact in variable Json value

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -44,7 +44,7 @@ class VariableResponse(BaseModel):
             return self
         try:
             val_dict = json.loads(self.val)
-            redacted_dict = redact(val_dict)
+            redacted_dict = redact(val_dict, self.key)
             self.val = json.dumps(redacted_dict)
             return self
         except json.JSONDecodeError:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -53,6 +53,10 @@ TEST_VARIABLE_KEY5 = "nested_dictionary_variable"
 TEST_VARIABLE_VALUE5 = '{"config": {"password": "some_password", "next": {"api_key": "some_api_key", "next_again": {"token": "some_token"}}}}'
 TEST_VARIABLE_DESCRIPTION5 = "Variable with a nested sensitive key"
 
+TEST_VARIABLE_KEY6 = "db_password"
+TEST_VARIABLE_VALUE6 = '{"config": "actual_secret"}'
+TEST_VARIABLE_DESCRIPTION6 = "Variable with a sensitive key name and JSON value with non-sensitive inner keys"
+
 TEST_VARIABLE_KEY4 = "test_variable_key/with_slashes"
 TEST_VARIABLE_VALUE4 = "test_variable_value"
 TEST_VARIABLE_DESCRIPTION4 = "Some description for the variable"
@@ -115,6 +119,13 @@ def _create_variables(session) -> None:
         session=session,
     )
 
+    Variable.set(
+        key=TEST_VARIABLE_KEY6,
+        value=TEST_VARIABLE_VALUE6,
+        description=TEST_VARIABLE_DESCRIPTION6,
+        session=session,
+    )
+
 
 @provide_session
 def _create_team(session) -> None:
@@ -143,13 +154,13 @@ class TestDeleteVariable(TestVariableEndpoint):
     def test_delete_should_respond_204(self, test_client, session):
         self.create_variables()
         variables = session.scalars(select(Variable)).all()
-        assert len(variables) == 6
+        assert len(variables) == 7
         response = test_client.delete(f"/variables/{TEST_VARIABLE_KEY}")
         assert response.status_code == 204
         response = test_client.delete(f"/variables/{TEST_VARIABLE_KEY4}")
         assert response.status_code == 204
         variables = session.scalars(select(Variable)).all()
-        assert len(variables) == 4
+        assert len(variables) == 5
         check_last_log(session, dag_id=None, event="delete_variable", logical_date=None)
 
     def test_delete_should_respond_401(self, unauthenticated_test_client):
@@ -232,6 +243,16 @@ class TestGetVariable(TestVariableEndpoint):
                     "team_name": None,
                 },
             ),
+            (
+                TEST_VARIABLE_KEY6,
+                {
+                    "key": TEST_VARIABLE_KEY6,
+                    "value": '{"config": "***"}',
+                    "description": TEST_VARIABLE_DESCRIPTION6,
+                    "is_encrypted": True,
+                    "team_name": None,
+                },
+            ),
         ],
     )
     def test_get_should_respond_200(self, test_client, session, key, expected_response):
@@ -263,7 +284,7 @@ class TestGetVariables(TestVariableEndpoint):
             # Filters
             (
                 {},
-                6,
+                7,
                 [
                     TEST_VARIABLE_KEY,
                     TEST_VARIABLE_KEY2,
@@ -271,14 +292,15 @@ class TestGetVariables(TestVariableEndpoint):
                     TEST_VARIABLE_KEY4,
                     TEST_VARIABLE_SEARCH_KEY,
                     TEST_VARIABLE_KEY5,
+                    TEST_VARIABLE_KEY6,
                 ],
             ),
-            ({"limit": 1}, 6, [TEST_VARIABLE_KEY]),
-            ({"limit": 1, "offset": 1}, 6, [TEST_VARIABLE_KEY2]),
+            ({"limit": 1}, 7, [TEST_VARIABLE_KEY]),
+            ({"limit": 1, "offset": 1}, 7, [TEST_VARIABLE_KEY2]),
             # Sort
             (
                 {"order_by": "id"},
-                6,
+                7,
                 [
                     TEST_VARIABLE_KEY,
                     TEST_VARIABLE_KEY2,
@@ -286,12 +308,14 @@ class TestGetVariables(TestVariableEndpoint):
                     TEST_VARIABLE_KEY4,
                     TEST_VARIABLE_SEARCH_KEY,
                     TEST_VARIABLE_KEY5,
+                    TEST_VARIABLE_KEY6,
                 ],
             ),
             (
                 {"order_by": "-id"},
-                6,
+                7,
                 [
+                    TEST_VARIABLE_KEY6,
                     TEST_VARIABLE_KEY5,
                     TEST_VARIABLE_SEARCH_KEY,
                     TEST_VARIABLE_KEY4,
@@ -302,8 +326,9 @@ class TestGetVariables(TestVariableEndpoint):
             ),
             (
                 {"order_by": "key"},
-                6,
+                7,
                 [
+                    TEST_VARIABLE_KEY6,
                     TEST_VARIABLE_KEY3,
                     TEST_VARIABLE_KEY5,
                     TEST_VARIABLE_KEY2,
@@ -314,7 +339,7 @@ class TestGetVariables(TestVariableEndpoint):
             ),
             (
                 {"order_by": "-key"},
-                6,
+                7,
                 [
                     TEST_VARIABLE_SEARCH_KEY,
                     TEST_VARIABLE_KEY4,
@@ -322,12 +347,13 @@ class TestGetVariables(TestVariableEndpoint):
                     TEST_VARIABLE_KEY2,
                     TEST_VARIABLE_KEY5,
                     TEST_VARIABLE_KEY3,
+                    TEST_VARIABLE_KEY6,
                 ],
             ),
             # Search
             (
                 {"variable_key_pattern": "~"},
-                6,
+                7,
                 [
                     TEST_VARIABLE_KEY,
                     TEST_VARIABLE_KEY2,
@@ -335,6 +361,7 @@ class TestGetVariables(TestVariableEndpoint):
                     TEST_VARIABLE_KEY4,
                     TEST_VARIABLE_SEARCH_KEY,
                     TEST_VARIABLE_KEY5,
+                    TEST_VARIABLE_KEY6,
                 ],
             ),
             ({"variable_key_pattern": "search"}, 1, [TEST_VARIABLE_SEARCH_KEY]),


### PR DESCRIPTION
When a Variable's key matches the sensitive-key heuristic (e.g. db_password), its value is correctly masked when stored as a plain string but if the value is valid JSON, the redact() call in VariableResponse.redact_val was missing the variable key as the second argument. The key-name check inside redact() never fired, so the raw JSON was returned in cleartext over /api/v2/variables.

Example - 

```
key: db-password
value: {"server1": "actual_secret"}
```