### PR TITLE
Escape LIKE wildcards in non-search filter parameters

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -284,6 +284,26 @@ class _PrefixPatternParam(BaseParam[str], ABC):
         return value
 
 
+_LIKE_ESCAPE_CHAR = "\\"
+
+
+def _escape_like_pattern(value: str) -> str:
+    r"""
+    Escape SQL ``LIKE`` / ``ILIKE`` metacharacters in a user-supplied value.
+
+    Use together with ``column.ilike(f"%{_escape_like_pattern(value)}%", escape="\\")`` on filter
+    parameters that intend literal substring matching (so a user-supplied ``%`` or ``_`` does not
+    widen the match beyond what the filter semantics promise). Search parameters that explicitly
+    expose wildcard semantics (see :class:`_SearchParam`) must not call this — they want the
+    metacharacters to pass through.
+    """
+    return (
+        value.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2)
+        .replace("%", _LIKE_ESCAPE_CHAR + "%")
+        .replace("_", _LIKE_ESCAPE_CHAR + "_")
+    )
+
+
 class _SearchParam(BaseParam[str]):
     """
     Substring search on a column using ``ILIKE '%term%'`` (case-insensitive).
@@ -822,7 +842,10 @@ class _OwnersFilter(BaseParam[list[str]]):
         if not self.value:
             return select
 
-        conditions = [DagModel.owners.ilike(f"%{owner}%") for owner in self.value]
+        conditions = [
+            DagModel.owners.ilike(f"%{_escape_like_pattern(owner)}%", escape=_LIKE_ESCAPE_CHAR)
+            for owner in self.value
+        ]
         return select.where(or_(*conditions))
 
     @classmethod
@@ -1108,13 +1131,19 @@ class _AssetDependencyFilter(BaseParam[str]):
     """Filter Dags by specific asset dependencies."""
 
     def to_orm(self, select: Select) -> Select:
-        if self.value is None and self.skip_none:
+        if self.value is None:
             return select
 
+        escaped = _escape_like_pattern(self.value)
         asset_dag_subquery = (
             sql_select(DagScheduleAssetReference.dag_id)
             .join(AssetModel, DagScheduleAssetReference.asset_id == AssetModel.id)
-            .where(or_(AssetModel.name.ilike(f"%{self.value}%"), AssetModel.uri.ilike(f"%{self.value}%")))
+            .where(
+                or_(
+                    AssetModel.name.ilike(f"%{escaped}%", escape=_LIKE_ESCAPE_CHAR),
+                    AssetModel.uri.ilike(f"%{escaped}%", escape=_LIKE_ESCAPE_CHAR),
+                )
+            )
             .distinct()
         )
 
@@ -1138,16 +1167,17 @@ class _ConsumingAssetFilter(BaseParam[str | None]):
     """Filter Dag runs by consuming asset (name or URI)."""
 
     def to_orm(self, select: Select) -> Select:
-        if not self.value and self.skip_none:
+        if not self.value:
             return select
 
+        escaped = _escape_like_pattern(self.value)
         event_subquery = (
             sql_select(AssetEvent.id)
             .join(AssetModel, AssetEvent.asset_id == AssetModel.id)
             .where(
                 or_(
-                    AssetModel.name.ilike(f"%{self.value}%"),
-                    AssetModel.uri.ilike(f"%{self.value}%"),
+                    AssetModel.name.ilike(f"%{escaped}%", escape=_LIKE_ESCAPE_CHAR),
+                    AssetModel.uri.ilike(f"%{escaped}%", escape=_LIKE_ESCAPE_CHAR),
                 )
             )
             .distinct()

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -31,6 +31,10 @@ from airflow.api_fastapi.common.parameters import (
     NullableDatetimeRangeFilter,
     RangeFilter,
     SortParam,
+    _AssetDependencyFilter,
+    _ConsumingAssetFilter,
+    _escape_like_pattern,
+    _OwnersFilter,
     _PrefixPatternParam,
     _PrefixSearchParam,
     _SearchParam,
@@ -218,6 +222,67 @@ class TestSearchParam:
         sql = _compile(statement)
         assert _has_ilike(sql, "example_bash")
         assert " or " not in sql
+
+
+class TestEscapeLikePattern:
+    """The escape helper turns user input into a literal substring pattern.
+
+    Filter parameters that do *not* document wildcard semantics must call this so a user-supplied
+    ``%`` or ``_`` does not widen the match beyond the filter's intent. Search parameters that
+    explicitly expose wildcard semantics (see ``_SearchParam``) deliberately do not call it.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("plain", "plain"),
+            ("a%b", r"a\%b"),
+            ("a_b", r"a\_b"),
+            (r"a\b", r"a\\b"),
+            (r"a\%b", r"a\\\%b"),
+            ("%_\\", r"\%\_\\"),
+            ("", ""),
+        ],
+    )
+    def test_escapes_metacharacters(self, raw, expected):
+        assert _escape_like_pattern(raw) == expected
+
+
+class TestNonSearchFilterEscaping:
+    """``_OwnersFilter`` / ``_AssetDependencyFilter`` / ``_ConsumingAssetFilter`` escape ``%`` and ``_``.
+
+    Compile-time check: the rendered SQL must wrap the *escaped* user value in ``%...%`` and
+    declare an ``ESCAPE`` clause so the database treats user-supplied wildcards literally.
+    """
+
+    def test_owners_filter_escapes_user_wildcards(self):
+        param = _OwnersFilter().set_value(["100%_alice"])
+        statement = param.to_orm(select(DagModel))
+        sql = _compile(statement)
+        assert r"'%100\%\_alice%'" in sql
+        assert "escape" in sql
+
+    def test_asset_dependency_filter_escapes_user_wildcards(self):
+        param = _AssetDependencyFilter().set_value("ledger_%")
+        statement = param.to_orm(select(DagModel))
+        sql = _compile(statement)
+        assert r"'%ledger\_\%%'" in sql
+        assert "escape" in sql
+
+    def test_consuming_asset_filter_escapes_user_wildcards(self):
+        param = _ConsumingAssetFilter().set_value("foo_%bar")
+        statement = param.to_orm(select(DagRun))
+        sql = _compile(statement)
+        assert r"'%foo\_\%bar%'" in sql
+        assert "escape" in sql
+
+    def test_search_param_does_not_escape_user_wildcards(self):
+        """Counter-test: ``_SearchParam`` deliberately passes wildcards through."""
+        param = _SearchParam(DagModel.dag_id).set_value("foo_%bar")
+        statement = param.to_orm(select(DagModel))
+        sql = _compile(statement)
+        # Raw user wildcards are present, not the escaped form.
+        assert "'%foo_%bar%'" in sql
 
 
 class TestPrefixSearchParam:


### PR DESCRIPTION
`_OwnersFilter`, `_AssetDependencyFilter`, and `_ConsumingAssetFilter` embedded user-supplied values directly into `ILIKE '%...%'` patterns without escaping the SQL wildcard metacharacters `%` and `_`. Unlike `_SearchParam` — whose docstring explicitly documents wildcard support — these filter classes are not documented as supporting wildcards, so a user supplying `%` or `_` triggered pattern matching instead of the literal substring matching the filter promises, widening match results beyond the filter's intent.

This is not SQL injection (SQLAlchemy parameterizes the values) and RBAC still bounds results to what the user is authorized to see — but the pattern-semantics leak is a defense-in-depth issue worth closing.

Reported as F-007 (ASVS 1.3.3) and F-008 (ASVS 2.2.1) in the [`apache/tooling-agents` L3 ASVS sweep `0920c77`](https://github.com/apache/tooling-agents/issues/23).

## Change

Add an `_escape_like_pattern()` helper that escapes `\`, `%`, and `_`, and apply it in the three affected filters along with an explicit `escape="\\"` clause on the `.ilike()` call. `_SearchParam` is left untouched.

The two affected filters' `to_orm` had a `if self.value is None and self.skip_none: return select` guard that fell through to `f"%{None}%"` (silently buggy) when `skip_none=False` — replaced with an unconditional `None`-check so the mypy narrowing for the new helper holds.

## Test plan

- [x] Added `TestEscapeLikePattern` with parametrised metacharacter coverage (`%`, `_`, `\`, and combinations).
- [x] Added `TestNonSearchFilterEscaping` asserting (a) each of the three filters renders SQL with escaped user wildcards and an `ESCAPE` clause; (b) `_SearchParam` continues to pass wildcards through.
- [x] `prek run ruff` clean.
- [x] `prek run mypy-airflow-core` clean.
- [x] Full `test_parameters.py` suite: 43 passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)