### PR TITLE
fix(ui): Calendar view respects user-selected timezone

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
@@ -19,6 +19,8 @@
 import { Box, HStack, Text } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
 import dayjs from "dayjs";
+import tz from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
@@ -30,6 +32,7 @@ import { ErrorAlert } from "src/components/ErrorAlert";
 import { IconButton } from "src/components/ui";
 import { ButtonGroupToggle } from "src/components/ui/ButtonGroupToggle";
 import { CALENDAR_GRANULARITY_KEY, CALENDAR_VIEW_MODE_KEY } from "src/constants/localStorage";
+import { useTimezone } from "src/context/timezone";
 
 import { CalendarLegend } from "./CalendarLegend";
 import { DailyCalendarView } from "./DailyCalendarView";
@@ -40,6 +43,9 @@ const spin = keyframes`
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 `;
+
+dayjs.extend(utc);
+dayjs.extend(tz);
 
 export const Calendar = () => {
   const { dagId = "" } = useParams();
@@ -53,14 +59,20 @@ export const Calendar = () => {
 
   const currentDate = dayjs();
 
+  const { selectedTimezone } = useTimezone();
+
   const { data: dag } = useDagServiceGetDagDetails({ dagId });
   const isPartitioned = dag?.timetable_partitioned ?? false;
 
-  const startDate = granularity === "daily" ? selectedDate.startOf("year") : selectedDate.startOf("month");
-  const endDate = granularity === "daily" ? selectedDate.endOf("year") : selectedDate.endOf("month");
+  // Compute the date range in the selected timezone, then convert to UTC for API
+  const tzDate = selectedDate.tz(selectedTimezone, true);
+  const startDate =
+    granularity === "daily" ? tzDate.startOf("year") : tzDate.startOf("month");
+  const endDate =
+    granularity === "daily" ? tzDate.endOf("year") : tzDate.endOf("month");
 
-  const gte = startDate.format("YYYY-MM-DD[T]HH:mm:ss[Z]");
-  const lte = endDate.format("YYYY-MM-DD[T]HH:mm:ss[Z]");
+  const gte = startDate.utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+  const lte = endDate.utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
 
   const { data, error, isLoading } = useCalendarServiceGetCalendar(
     {
@@ -74,7 +86,7 @@ export const Calendar = () => {
     { enabled: Boolean(dagId) },
   );
 
-  const scale = createCalendarScale(data?.dag_runs ?? [], viewMode, granularity);
+  const scale = createCalendarScale(data?.dag_runs ?? [], viewMode, granularity, selectedTimezone);
 
   if (!data && !isLoading) {
     return (
@@ -226,6 +238,7 @@ export const Calendar = () => {
               data-testid="calendar-daily-view"
               scale={scale}
               selectedYear={selectedDate.year()}
+              timezone={selectedTimezone}
               viewMode={viewMode}
             />
             <CalendarLegend scale={scale} viewMode={viewMode} />
@@ -238,6 +251,7 @@ export const Calendar = () => {
                 scale={scale}
                 selectedMonth={selectedDate.month()}
                 selectedYear={selectedDate.year()}
+                timezone={selectedTimezone}
                 viewMode={viewMode}
               />
             </Box>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/Calendar.tsx
@@ -66,10 +66,8 @@ export const Calendar = () => {
 
   // Compute the date range in the selected timezone, then convert to UTC for API
   const tzDate = selectedDate.tz(selectedTimezone, true);
-  const startDate =
-    granularity === "daily" ? tzDate.startOf("year") : tzDate.startOf("month");
-  const endDate =
-    granularity === "daily" ? tzDate.endOf("year") : tzDate.endOf("month");
+  const startDate = granularity === "daily" ? tzDate.startOf("year") : tzDate.startOf("month");
+  const endDate = granularity === "daily" ? tzDate.endOf("year") : tzDate.endOf("month");
 
   const gte = startDate.utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
   const lte = endDate.utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
@@ -86,7 +84,11 @@ export const Calendar = () => {
     { enabled: Boolean(dagId) },
   );
 
-  const scale = createCalendarScale(data?.dag_runs ?? [], viewMode, granularity, selectedTimezone);
+  const scale = createCalendarScale(data?.dag_runs ?? [], {
+    granularity,
+    timezone: selectedTimezone,
+    viewMode,
+  });
 
   if (!data && !isLoading) {
     return (

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/DailyCalendarView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/DailyCalendarView.tsx
@@ -49,12 +49,13 @@ type Props = {
   readonly data: Array<CalendarTimeRangeResponse>;
   readonly scale: CalendarScale;
   readonly selectedYear: number;
+  readonly timezone: string;
   readonly viewMode?: CalendarColorMode;
 };
 
-export const DailyCalendarView = ({ data, scale, selectedYear, viewMode = "total" }: Props) => {
+export const DailyCalendarView = ({ data, scale, selectedYear, timezone, viewMode = "total" }: Props) => {
   const { t: translate } = useTranslation("dag");
-  const dailyData = generateDailyCalendarData(data, selectedYear);
+  const dailyData = generateDailyCalendarData(data, selectedYear, timezone);
 
   const weekdays = [
     translate("calendar.weekdays.sunday"),

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
@@ -66,7 +66,7 @@ export const HourlyCalendarView = ({
   viewMode = "total",
 }: Props) => {
   const { t: translate } = useTranslation("dag");
-  const hourlyData = generateHourlyCalendarData(data, selectedYear, selectedMonth, timezone);
+  const hourlyData = generateHourlyCalendarData(data, { selectedMonth, selectedYear, timezone });
 
   return (
     <Box data-testid="calendar-hourly-view" mb={4}>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/HourlyCalendarView.tsx
@@ -53,6 +53,7 @@ type Props = {
   readonly scale: CalendarScale;
   readonly selectedMonth: number;
   readonly selectedYear: number;
+  readonly timezone: string;
   readonly viewMode?: CalendarColorMode;
 };
 
@@ -61,10 +62,11 @@ export const HourlyCalendarView = ({
   scale,
   selectedMonth,
   selectedYear,
+  timezone,
   viewMode = "total",
 }: Props) => {
   const { t: translate } = useTranslation("dag");
-  const hourlyData = generateHourlyCalendarData(data, selectedYear, selectedMonth);
+  const hourlyData = generateHourlyCalendarData(data, selectedYear, selectedMonth, timezone);
 
   return (
     <Box data-testid="calendar-hourly-view" mb={4}>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
@@ -77,9 +77,7 @@ describe("calculateDataBounds", () => {
           run("failed", 1, "2026-04-08T10:00:00Z"),
           run("running", 4, "2026-04-08T11:00:00Z"),
         ],
-        "total",
-        "hourly",
-        "UTC",
+        { granularity: "hourly", timezone: "UTC", viewMode: "total" },
       ),
     ).toEqual({ maxCount: 4, minCount: 3 });
   });
@@ -88,15 +86,19 @@ describe("calculateDataBounds", () => {
     expect(
       calculateDataBounds(
         [run("queued", 100, "2026-04-08T10:00:00Z"), run("success", 1, "2026-04-08T11:00:00Z")],
-        "total",
-        "hourly",
-        "UTC",
+        { granularity: "hourly", timezone: "UTC", viewMode: "total" },
       ),
     ).toEqual({ maxCount: 1, minCount: 1 });
   });
 
   it("keeps queued-only total mode data from using an empty scale", () => {
-    expect(calculateDataBounds([run("queued", 100)], "total", "hourly", "UTC")).toEqual({
+    expect(
+      calculateDataBounds([run("queued", 100)], {
+        granularity: "hourly",
+        timezone: "UTC",
+        viewMode: "total",
+      }),
+    ).toEqual({
       maxCount: 100,
       minCount: 100,
     });
@@ -111,9 +113,7 @@ describe("calculateDataBounds", () => {
           run("failed", 5, "2026-04-08T11:00:00Z"),
           run("queued", 20, "2026-04-08T11:00:00Z"),
         ],
-        "failed",
-        "hourly",
-        "UTC",
+        { granularity: "hourly", timezone: "UTC", viewMode: "failed" },
       ),
     ).toEqual({ maxCount: 5, minCount: 2 });
   });
@@ -121,25 +121,41 @@ describe("calculateDataBounds", () => {
 
 describe("createCalendarScale", () => {
   it("returns the planned color for a planned-only cell", () => {
-    const scale = createCalendarScale([run("planned", 1)], "total", "hourly", "UTC");
+    const scale = createCalendarScale([run("planned", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, planned: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns the default total color for a success-only cell", () => {
-    const scale = createCalendarScale([run("success", 1)], "total", "hourly", "UTC");
+    const scale = createCalendarScale([run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, success: 1, total: 1 })).toEqual(DEFAULT_TOTAL_COLOR);
   });
 
   it("returns the planned color for a queued-only cell in total mode", () => {
-    const scale = createCalendarScale([run("queued", 1)], "total", "hourly", "UTC");
+    const scale = createCalendarScale([run("queued", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns a mixed color for planned and actual runs in total mode", () => {
-    const scale = createCalendarScale([run("planned", 1), run("success", 1)], "total", "hourly", "UTC");
+    const scale = createCalendarScale([run("planned", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, planned: 1, success: 1, total: 2 })).toEqual({
       actual: DEFAULT_TOTAL_COLOR,
@@ -148,7 +164,11 @@ describe("createCalendarScale", () => {
   });
 
   it("returns a mixed color for queued and actual runs in total mode", () => {
-    const scale = createCalendarScale([run("queued", 1), run("success", 1)], "total", "hourly", "UTC");
+    const scale = createCalendarScale([run("queued", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, success: 1, total: 2 })).toEqual({
       actual: DEFAULT_TOTAL_COLOR,
@@ -157,14 +177,22 @@ describe("createCalendarScale", () => {
   });
 
   it("uses failed counts for failed mode", () => {
-    const scale = createCalendarScale([run("success", 5), run("failed", 1)], "failed", "hourly", "UTC");
+    const scale = createCalendarScale([run("success", 5), run("failed", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "failed",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, success: 5, total: 5 })).toEqual(EMPTY_COLOR);
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(DEFAULT_FAILED_COLOR);
   });
 
   it("returns a mixed color for planned and failed runs in failed mode", () => {
-    const scale = createCalendarScale([run("planned", 1), run("failed", 1)], "failed", "hourly", "UTC");
+    const scale = createCalendarScale([run("planned", 1), run("failed", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "failed",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, planned: 1, total: 2 })).toEqual({
       actual: DEFAULT_FAILED_COLOR,
@@ -173,13 +201,21 @@ describe("createCalendarScale", () => {
   });
 
   it("returns the planned color for a queued-only cell in failed mode", () => {
-    const scale = createCalendarScale([run("queued", 1)], "failed", "hourly", "UTC");
+    const scale = createCalendarScale([run("queued", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "failed",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns a mixed color for queued and failed runs in failed mode", () => {
-    const scale = createCalendarScale([run("queued", 1), run("failed", 1)], "failed", "hourly", "UTC");
+    const scale = createCalendarScale([run("queued", 1), run("failed", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "failed",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, queued: 1, total: 2 })).toEqual({
       actual: DEFAULT_FAILED_COLOR,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
@@ -79,6 +79,7 @@ describe("calculateDataBounds", () => {
         ],
         "total",
         "hourly",
+        "UTC",
       ),
     ).toEqual({ maxCount: 4, minCount: 3 });
   });
@@ -89,12 +90,13 @@ describe("calculateDataBounds", () => {
         [run("queued", 100, "2026-04-08T10:00:00Z"), run("success", 1, "2026-04-08T11:00:00Z")],
         "total",
         "hourly",
+        "UTC",
       ),
     ).toEqual({ maxCount: 1, minCount: 1 });
   });
 
   it("keeps queued-only total mode data from using an empty scale", () => {
-    expect(calculateDataBounds([run("queued", 100)], "total", "hourly")).toEqual({
+    expect(calculateDataBounds([run("queued", 100)], "total", "hourly", "UTC")).toEqual({
       maxCount: 100,
       minCount: 100,
     });
@@ -111,6 +113,7 @@ describe("calculateDataBounds", () => {
         ],
         "failed",
         "hourly",
+        "UTC",
       ),
     ).toEqual({ maxCount: 5, minCount: 2 });
   });
@@ -118,25 +121,25 @@ describe("calculateDataBounds", () => {
 
 describe("createCalendarScale", () => {
   it("returns the planned color for a planned-only cell", () => {
-    const scale = createCalendarScale([run("planned", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("planned", 1)], "total", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, planned: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns the default total color for a success-only cell", () => {
-    const scale = createCalendarScale([run("success", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("success", 1)], "total", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, success: 1, total: 1 })).toEqual(DEFAULT_TOTAL_COLOR);
   });
 
   it("returns the planned color for a queued-only cell in total mode", () => {
-    const scale = createCalendarScale([run("queued", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("queued", 1)], "total", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns a mixed color for planned and actual runs in total mode", () => {
-    const scale = createCalendarScale([run("planned", 1), run("success", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("planned", 1), run("success", 1)], "total", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, planned: 1, success: 1, total: 2 })).toEqual({
       actual: DEFAULT_TOTAL_COLOR,
@@ -145,7 +148,7 @@ describe("createCalendarScale", () => {
   });
 
   it("returns a mixed color for queued and actual runs in total mode", () => {
-    const scale = createCalendarScale([run("queued", 1), run("success", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("queued", 1), run("success", 1)], "total", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, success: 1, total: 2 })).toEqual({
       actual: DEFAULT_TOTAL_COLOR,
@@ -154,14 +157,14 @@ describe("createCalendarScale", () => {
   });
 
   it("uses failed counts for failed mode", () => {
-    const scale = createCalendarScale([run("success", 5), run("failed", 1)], "failed", "hourly");
+    const scale = createCalendarScale([run("success", 5), run("failed", 1)], "failed", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, success: 5, total: 5 })).toEqual(EMPTY_COLOR);
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(DEFAULT_FAILED_COLOR);
   });
 
   it("returns a mixed color for planned and failed runs in failed mode", () => {
-    const scale = createCalendarScale([run("planned", 1), run("failed", 1)], "failed", "hourly");
+    const scale = createCalendarScale([run("planned", 1), run("failed", 1)], "failed", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, planned: 1, total: 2 })).toEqual({
       actual: DEFAULT_FAILED_COLOR,
@@ -170,13 +173,13 @@ describe("createCalendarScale", () => {
   });
 
   it("returns the planned color for a queued-only cell in failed mode", () => {
-    const scale = createCalendarScale([run("queued", 1)], "failed", "hourly");
+    const scale = createCalendarScale([run("queued", 1)], "failed", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, total: 1 })).toEqual(PLANNED_COLOR);
   });
 
   it("returns a mixed color for queued and failed runs in failed mode", () => {
-    const scale = createCalendarScale([run("queued", 1), run("failed", 1)], "failed", "hourly");
+    const scale = createCalendarScale([run("queued", 1), run("failed", 1)], "failed", "hourly", "UTC");
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, queued: 1, total: 2 })).toEqual({
       actual: DEFAULT_FAILED_COLOR,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -18,6 +18,8 @@
  */
 import dayjs from "dayjs";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
+import tz from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 
 import type { CalendarTimeRangeResponse } from "openapi/requests/types.gen";
 
@@ -32,6 +34,8 @@ import type {
 } from "./types";
 
 dayjs.extend(isSameOrBefore);
+dayjs.extend(utc);
+dayjs.extend(tz);
 
 // Calendar color constants
 export const PLANNED_COLOR = { _dark: "stone.600", _light: "stone.500" };
@@ -58,11 +62,11 @@ const getActualRunCount = (counts: RunCounts, viewMode: CalendarColorMode) =>
 
 const getPendingRunCount = (counts: RunCounts) => counts.planned + counts.queued;
 
-const createDailyDataMap = (data: Array<CalendarTimeRangeResponse>) => {
+const createDailyDataMap = (data: Array<CalendarTimeRangeResponse>, timezone: string) => {
   const dailyDataMap = new Map<string, Array<CalendarTimeRangeResponse>>();
 
   data.forEach((run) => {
-    const dateStr = run.date.slice(0, 10); // "YYYY-MM-DD"
+    const dateStr = dayjs(run.date).tz(timezone).format("YYYY-MM-DD");
     const dailyRuns = dailyDataMap.get(dateStr);
 
     if (dailyRuns) {
@@ -75,11 +79,11 @@ const createDailyDataMap = (data: Array<CalendarTimeRangeResponse>) => {
   return dailyDataMap;
 };
 
-const createHourlyDataMap = (data: Array<CalendarTimeRangeResponse>) => {
+const createHourlyDataMap = (data: Array<CalendarTimeRangeResponse>, timezone: string) => {
   const hourlyDataMap = new Map<string, Array<CalendarTimeRangeResponse>>();
 
   data.forEach((run) => {
-    const hourStr = run.date.slice(0, 13); // "YYYY-MM-DDTHH"
+    const hourStr = dayjs(run.date).tz(timezone).format("YYYY-MM-DDTHH");
     const hourlyRuns = hourlyDataMap.get(hourStr);
 
     if (hourlyRuns) {
@@ -117,12 +121,13 @@ export const calculateRunCounts = (runs: Array<CalendarTimeRangeResponse>): RunC
 export const generateDailyCalendarData = (
   data: Array<CalendarTimeRangeResponse>,
   selectedYear: number,
+  timezone: string,
 ): DailyCalendarData => {
-  const dailyDataMap = createDailyDataMap(data);
+  const dailyDataMap = createDailyDataMap(data, timezone);
 
   const weeks = [];
-  const startOfYear = dayjs().year(selectedYear).startOf("year");
-  const endOfYear = dayjs().year(selectedYear).endOf("year");
+  const startOfYear = dayjs().tz(timezone).year(selectedYear).startOf("year");
+  const endOfYear = dayjs().tz(timezone).year(selectedYear).endOf("year");
 
   let currentDate = startOfYear.startOf("week");
   const endDate = endOfYear.endOf("week");
@@ -148,11 +153,12 @@ export const generateHourlyCalendarData = (
   data: Array<CalendarTimeRangeResponse>,
   selectedYear: number,
   selectedMonth: number,
+  timezone: string,
 ): HourlyCalendarData => {
-  const hourlyDataMap = createHourlyDataMap(data);
+  const hourlyDataMap = createHourlyDataMap(data, timezone);
 
-  const monthStart = dayjs().year(selectedYear).month(selectedMonth).startOf("month");
-  const monthEnd = dayjs().year(selectedYear).month(selectedMonth).endOf("month");
+  const monthStart = dayjs().tz(timezone).year(selectedYear).month(selectedMonth).startOf("month");
+  const monthEnd = dayjs().tz(timezone).year(selectedYear).month(selectedMonth).endOf("month");
   const monthData = [];
 
   let currentDate = monthStart;
@@ -178,6 +184,7 @@ export const calculateDataBounds = (
   data: Array<CalendarTimeRangeResponse>,
   viewMode: CalendarColorMode,
   granularity: CalendarGranularity,
+  timezone: string,
 ): { maxCount: number; minCount: number } => {
   if (data.length === 0) {
     return { maxCount: 0, minCount: 0 };
@@ -186,7 +193,7 @@ export const calculateDataBounds = (
   const counts: Array<number> = [];
   const pendingCounts: Array<number> = [];
   const mapCreator = granularity === "daily" ? createDailyDataMap : createHourlyDataMap;
-  const dataMap = mapCreator(data);
+  const dataMap = mapCreator(data, timezone);
 
   dataMap.forEach((runs) => {
     const runCounts = calculateRunCounts(runs);
@@ -224,8 +231,9 @@ export const createCalendarScale = (
   data: Array<CalendarTimeRangeResponse>,
   viewMode: CalendarColorMode,
   granularity: CalendarGranularity,
+  timezone: string,
 ): CalendarScale => {
-  const { maxCount, minCount } = calculateDataBounds(data, viewMode, granularity);
+  const { maxCount, minCount } = calculateDataBounds(data, viewMode, granularity, timezone);
 
   // Handle empty data case
   if (maxCount === 0) {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -149,12 +149,17 @@ export const generateDailyCalendarData = (
   return weeks;
 };
 
+type HourlyOptions = {
+  selectedMonth: number;
+  selectedYear: number;
+  timezone: string;
+};
+
 export const generateHourlyCalendarData = (
   data: Array<CalendarTimeRangeResponse>,
-  selectedYear: number,
-  selectedMonth: number,
-  timezone: string,
+  options: HourlyOptions,
 ): HourlyCalendarData => {
+  const { selectedMonth, selectedYear, timezone } = options;
   const hourlyDataMap = createHourlyDataMap(data, timezone);
 
   const monthStart = dayjs().tz(timezone).year(selectedYear).month(selectedMonth).startOf("month");
@@ -180,12 +185,18 @@ export const generateHourlyCalendarData = (
   return { days: monthData, month: monthStart.format("MMM YYYY") };
 };
 
+type BoundsOptions = {
+  granularity: CalendarGranularity;
+  timezone: string;
+  viewMode: CalendarColorMode;
+};
+
 export const calculateDataBounds = (
   data: Array<CalendarTimeRangeResponse>,
-  viewMode: CalendarColorMode,
-  granularity: CalendarGranularity,
-  timezone: string,
+  options: BoundsOptions,
 ): { maxCount: number; minCount: number } => {
+  const { granularity, timezone, viewMode } = options;
+
   if (data.length === 0) {
     return { maxCount: 0, minCount: 0 };
   }
@@ -227,13 +238,18 @@ export const calculateDataBounds = (
   };
 };
 
+type ScaleOptions = {
+  granularity: CalendarGranularity;
+  timezone: string;
+  viewMode: CalendarColorMode;
+};
+
 export const createCalendarScale = (
   data: Array<CalendarTimeRangeResponse>,
-  viewMode: CalendarColorMode,
-  granularity: CalendarGranularity,
-  timezone: string,
+  options: ScaleOptions,
 ): CalendarScale => {
-  const { maxCount, minCount } = calculateDataBounds(data, viewMode, granularity, timezone);
+  const { granularity, timezone, viewMode } = options;
+  const { maxCount, minCount } = calculateDataBounds(data, { granularity, timezone, viewMode });
 
   // Handle empty data case
   if (maxCount === 0) {


### PR DESCRIPTION
### Problem

The Calendar view in the Airflow UI always shows Dag runs in UTC, ignoring the user's selected timezone from the TimezoneContext. Runs are grouped by their raw UTC date/hour via string slicing, and the calendar grid bounds are computed using the browser-local timezone.

### Root Cause

The Calendar feature tree had no awareness of `useTimezone()` / `TimezoneContext`:

1. **API queries** — The date range sent to the API used `selectedDate` directly without timezone conversion
2. **Run grouping** — `createDailyDataMap` and `createHourlyDataMap` used `run.date.slice(0, 10)` / `run.date.slice(0, 13)` to extract date/hour, ignoring the user's timezone
3. **Grid construction** — `generateDailyCalendarData` and `generateHourlyCalendarData` used `dayjs().year(...)` instead of `dayjs().tz(timezone).year(...)`, computing grid bounds in browser-local time

### Changes

- **`calendarUtils.ts`** — Added `dayjs/plugin/timezone` and `dayjs/plugin/utc` imports. Threaded a `timezone: string` parameter through all exported/internal functions. Replaced `run.date.slice(0, 10)` / `run.date.slice(0, 13)` with `dayjs(run.date).tz(timezone).format(...)`. Grid construction now uses `dayjs().tz(timezone)` instead of bare `dayjs()`.

- **`Calendar.tsx`** — Imported `useTimezone`, added dayjs tz/utc plugins. Gets `selectedTimezone` from context. Computes `startDate`/`endDate` in the selected timezone via `selectedDate.tz(selectedTimezone, true)`, then converts to UTC with `.utc().format(...)` for API queries. Passes `timezone` prop to view components and `createCalendarScale`.

- **`DailyCalendarView.tsx`** — Accepts `timezone` prop, passes it to `generateDailyCalendarData`.

- **`HourlyCalendarView.tsx`** — Accepts `timezone` prop, passes it to `generateHourlyCalendarData`.

- **`calendarUtils.test.ts`** — All `calculateDataBounds` and `createCalendarScale` calls updated with `"UTC"` as the 4th argument.

Fixes #67477
