### PR TITLE
Strip CR/LF from user-supplied logical_date before stdlib logging

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -33,6 +33,18 @@ from airflow.models import Log
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_for_stdlib_log(value: str) -> str:
+    """
+    Strip CR/LF from a user-supplied value before passing it to stdlib's ``%s``-style logging.
+
+    Defends against log injection when the deployment is configured with a non-JSON
+    (plain-text) log formatter: a newline in the value would otherwise let an attacker forge
+    log lines. ``structlog``-style formatters are unaffected, but the access-log path uses
+    the stdlib logger here, so the sanitisation is unconditional.
+    """
+    return value.replace("\r", " ").replace("\n", " ")
+
+
 def _mask_connection_fields(extra_fields):
     """Mask connection fields."""
     result = {}
@@ -163,7 +175,10 @@ def action_logging(event: str | None = None):
                         raise ParserError
                     log.logical_date = logical_date
                 except ParserError:
-                    logger.exception("Failed to parse logical_date from the request: %s", logical_date_value)
+                    logger.exception(
+                        "Failed to parse logical_date from the request: %s",
+                        _sanitize_for_stdlib_log(logical_date_value),
+                    )
             else:
                 logger.warning("Logical date is missing or empty")
         session.add(log)

--- a/airflow-core/tests/unit/api_fastapi/logging/__init__.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.api_fastapi.logging.decorators import _sanitize_for_stdlib_log
+
+
+class TestSanitizeForStdlibLog:
+    """User input passed to stdlib ``%s``-style logging must have CR/LF stripped.
+
+    On a deployment configured with a non-JSON (plain-text) log formatter, a newline in the
+    value would otherwise let an attacker forge log lines (CWE-117). The audit logging path
+    in ``action_logging`` passes ``logical_date`` from the request through stdlib's ``logger``,
+    so this sanitisation is unconditional regardless of the formatter actually in use.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+            ("bad\ndate", "bad date"),
+            ("bad\r\ndate", "bad  date"),
+            ("bad\rdate", "bad date"),
+            ("a\nb\nc", "a b c"),
+            ("", ""),
+        ],
+    )
+    def test_strips_cr_and_lf(self, raw, expected):
+        assert _sanitize_for_stdlib_log(raw) == expected


### PR DESCRIPTION
`action_logging` passes the raw `logical_date` query parameter into `logger.exception("... %s", value)` via Python's standard logging module on parse failure. On deployments configured with a non-JSON (plain-text) log formatter, an attacker could supply a value containing newline characters to forge fake log entries (CWE-117 log injection).

The path is narrow — only exploitable on non-default plain-text formatters AND only when the user triggers a parse failure — but the fix is cheap.

Reported as F-018 in the [`apache/tooling-agents` L3 ASVS sweep `0920c77`](https://github.com/apache/tooling-agents/issues/23).

## Change

Add `_sanitize_for_stdlib_log()` that replaces `\r` and `\n` with spaces, and apply it before formatting the `logical_date` value into the `logger.exception` message. The helper is extracted so the guard is testable in isolation. `logger.exception` stays on the stdlib logger (rather than swapping to `structlog`) to keep the change minimal and avoid coupling unrelated behaviour changes into a security fix.

## Test plan

- [x] Parametrised `TestSanitizeForStdlibLog::test_strips_cr_and_lf` covers `\n`, `\r`, `\r\n`, multi-line, empty, and the no-op case.
- [x] `prek run ruff` clean.
- [x] `prek run mypy-airflow-core` clean.
- [x] 6 tests pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)