### PR TITLE
Warn when supervisor-side mask_secret IPC send fails

### DIFF
--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -263,22 +263,26 @@ def mask_secret(secret: JsonValue, name: str | None = None) -> None:
 
     comms = getattr(task_runner, "SUPERVISOR_COMMS", None)
     if comms is None:
-        # Not in a task-execution context — there is no supervisor to notify.
+        # No supervisor to notify (not running under a supervisor process).
         return
 
     from airflow.sdk.execution_time.comms import MaskSecret
 
     try:
         comms.send(MaskSecret(value=secret, name=name))
-    except Exception:
-        # Dedicated logger so operators can grep for this signal — without a
-        # warning they'd have no way to find out the supervisor never received
-        # the registration.
+    except Exception as e:
+        # Emit a grep-able signal so operators can find out the supervisor never
+        # received the registration. Record ONLY the exception *type* -- never
+        # ``exc_info``, the exception message, or the value -- because a failure
+        # to build ``MaskSecret`` can raise an error whose text contains the very
+        # secret we are trying to mask. On this path the local ``mask_logs``
+        # processor is already disabled, so including it would guarantee the leak
+        # this function exists to prevent.
         structlog.get_logger("airflow.logging.mask_secret").warning(
             "supervisor_mask_secret_failed",
             secret_name=name,
+            error_type=type(e).__name__,
             note="Could not register secret with supervisor; secret may not be masked in supervisor-level logs.",
-            exc_info=True,
         )
 
 

--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -249,19 +249,37 @@ def mask_secret(secret: JsonValue, name: str | None = None) -> None:
     they're masked in both the task subprocess AND supervisor's log output.
     Works safely in both sync and async contexts.
     """
-    from contextlib import suppress
-
     from airflow.sdk._shared.secrets_masker import _secrets_masker
 
     _secrets_masker().add_mask(secret, name)
 
-    with suppress(Exception):
-        # Try to tell supervisor (only if in task execution context)
-        from airflow.sdk.execution_time import task_runner
-        from airflow.sdk.execution_time.comms import MaskSecret
+    # Mirror the mask to the supervisor so it also masks the value in any logs
+    # forwarded through it. When this fails we *must* emit a warning rather
+    # than silently swallowing the failure: when ``sending_to_supervisor=True``
+    # the local task process skips its own ``mask_logs`` processor (it relies
+    # on the supervisor doing the masking instead), so a silent IPC failure
+    # would leave the secret unmasked in supervisor-level logs.
+    from airflow.sdk.execution_time import task_runner
 
-        if comms := getattr(task_runner, "SUPERVISOR_COMMS", None):
-            comms.send(MaskSecret(value=secret, name=name))
+    comms = getattr(task_runner, "SUPERVISOR_COMMS", None)
+    if comms is None:
+        # Not in a task-execution context — there is no supervisor to notify.
+        return
+
+    from airflow.sdk.execution_time.comms import MaskSecret
+
+    try:
+        comms.send(MaskSecret(value=secret, name=name))
+    except Exception:
+        # Dedicated logger so operators can grep for this signal — without a
+        # warning they'd have no way to find out the supervisor never received
+        # the registration.
+        structlog.get_logger("airflow.logging.mask_secret").warning(
+            "supervisor_mask_secret_failed",
+            secret_name=name,
+            note="Could not register secret with supervisor; secret may not be masked in supervisor-level logs.",
+            exc_info=True,
+        )
 
 
 def reset_logging():

--- a/task-sdk/tests/task_sdk/test_log.py
+++ b/task-sdk/tests/task_sdk/test_log.py
@@ -25,46 +25,62 @@ from airflow.sdk import log as sdk_log
 
 
 class TestMaskSecretSupervisorIPC:
-    """``mask_secret`` must surface a warning when it cannot register a secret with the supervisor.
+    """``mask_secret`` must surface a *safe* warning when it cannot register a secret with the supervisor.
 
     When the task forwards logs to the supervisor it drops its own ``mask_logs`` processor (see the
     ``sending_to_supervisor=True`` branches in ``log.py``) and relies on the supervisor to do the
-    masking. So if the registration is lost -- whether the ``MaskSecret`` message cannot be built /
-    serialized, or the IPC socket is broken -- silently swallowing the error would leave the secret
+    masking. If that registration is lost, silently swallowing the error would leave the secret
     unmasked in supervisor-level logs, so a dedicated warning is emitted instead.
+
+    The warning records only the exception *type* and the secret's *name* -- never the value, the
+    exception message, or a traceback -- so the warning itself can never leak the secret it reports
+    on. The tests below pin that property down, since the failure path is exactly the one where local
+    masking is already disabled.
     """
 
-    def test_warns_when_mask_message_cannot_be_serialized(self):
-        """Realistic, supervisor-alive failure: the ``MaskSecret`` message cannot even be built.
+    def test_warning_never_leaks_the_secret_value(self):
+        """If building ``MaskSecret`` raises -- its validation error text can ``repr`` the offending
+        value -- the warning must record the failure WITHOUT the value, the message, or a traceback.
 
-        A value that is not JSON-serializable fails ``MaskSecret`` validation *before* the socket is
-        touched -- the supervisor is alive and reachable, ``send`` is never reached, and the warning
-        is the only signal that the secret was never registered. (This is the realistic counterpart
-        to a full supervisor crash, where the warning could not be delivered anyway.)
+        This is the leak Ash flagged: ``exc_info`` / the exception message could carry the secret into
+        the task log on the very path where the local ``mask_logs`` processor is already off.
         """
         from airflow.sdk.execution_time import task_runner
 
         comms = mock.MagicMock()
+        canary = "s3cr3t-leak-canary"
 
         class _Unserializable:
-            """Not a ``str``/``dict``/``Iterable``, so ``MaskSecret(value=...)`` rejects it."""
+            """Not a ``str``/``dict``/``Iterable`` JSON value, so ``MaskSecret(value=...)`` rejects it.
+
+            Its ``repr`` embeds the secret so that *any* code reprs/serializes it into the log would
+            surface the canary -- letting the assertion below catch a regression.
+            """
+
+            def __repr__(self) -> str:
+                return f"<Unserializable secret={canary!r}>"
 
         with (
             mock.patch.object(task_runner, "SUPERVISOR_COMMS", comms, create=True),
             structlog.testing.capture_logs() as captured,
         ):
-            sdk_log.mask_secret(_Unserializable(), name="password")
+            sdk_log.mask_secret(_Unserializable(), name="password")  # type: ignore[arg-type]
 
         events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
         assert len(events) == 1
-        assert events[0]["log_level"] == "warning"
-        assert events[0]["secret_name"] == "password"
-        assert events[0]["exc_info"]  # structlog renders exc_info=True as True in capture_logs
-        # The failure is in building the message, not the socket -- the supervisor is never contacted.
+        ev = events[0]
+        assert ev["log_level"] == "warning"
+        assert ev["secret_name"] == "password"
+        assert ev["error_type"]  # the exception class name, e.g. "ValidationError"
+        assert "exc_info" not in ev  # no traceback that could carry the value
+        # The crucial property: the secret value never appears anywhere in the emitted warning.
+        assert canary not in repr(ev)
+        # The build failed before the socket was touched -- the supervisor is never contacted.
         comms.send.assert_not_called()
 
-    def test_warns_when_supervisor_socket_is_broken(self):
-        """The IPC socket itself fails (e.g. a broken connection) -- still warn rather than swallow."""
+    def test_warns_when_supervisor_send_fails(self):
+        """A broken IPC send (e.g. ``BrokenPipeError``) is reported as a grep-able warning -- and,
+        again, only the exception *type* is recorded, never the value."""
         from airflow.sdk.execution_time import task_runner
 
         comms = mock.MagicMock()
@@ -78,9 +94,12 @@ class TestMaskSecretSupervisorIPC:
 
         events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
         assert len(events) == 1
-        assert events[0]["log_level"] == "warning"
-        assert events[0]["secret_name"] == "password"
-        assert events[0]["exc_info"]
+        ev = events[0]
+        assert ev["log_level"] == "warning"
+        assert ev["secret_name"] == "password"
+        assert ev["error_type"] == "BrokenPipeError"
+        assert "exc_info" not in ev
+        assert "hunter2" not in repr(ev)
         comms.send.assert_called_once()
 
     def test_silent_when_supervisor_send_succeeds(self):
@@ -98,8 +117,9 @@ class TestMaskSecretSupervisorIPC:
         assert events == []
         comms.send.assert_called_once()
 
-    def test_silent_when_no_supervisor_context(self):
-        """Outside a task-execution context (no SUPERVISOR_COMMS) the function is a no-op."""
+    def test_silent_when_not_running_under_a_supervisor(self):
+        """With no ``SUPERVISOR_COMMS`` (the task is not running under a supervisor) the mirror is a
+        no-op -- there is nothing to notify and nothing to warn about."""
         from airflow.sdk.execution_time import task_runner
 
         with (

--- a/task-sdk/tests/task_sdk/test_log.py
+++ b/task-sdk/tests/task_sdk/test_log.py
@@ -1,0 +1,112 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import structlog.testing
+
+from airflow.sdk import log as sdk_log
+
+
+class TestMaskSecretSupervisorIPC:
+    """``mask_secret`` must surface a warning when it cannot register a secret with the supervisor.
+
+    When the task forwards logs to the supervisor it drops its own ``mask_logs`` processor (see the
+    ``sending_to_supervisor=True`` branches in ``log.py``) and relies on the supervisor to do the
+    masking. So if the registration is lost -- whether the ``MaskSecret`` message cannot be built /
+    serialized, or the IPC socket is broken -- silently swallowing the error would leave the secret
+    unmasked in supervisor-level logs, so a dedicated warning is emitted instead.
+    """
+
+    def test_warns_when_mask_message_cannot_be_serialized(self):
+        """Realistic, supervisor-alive failure: the ``MaskSecret`` message cannot even be built.
+
+        A value that is not JSON-serializable fails ``MaskSecret`` validation *before* the socket is
+        touched -- the supervisor is alive and reachable, ``send`` is never reached, and the warning
+        is the only signal that the secret was never registered. (This is the realistic counterpart
+        to a full supervisor crash, where the warning could not be delivered anyway.)
+        """
+        from airflow.sdk.execution_time import task_runner
+
+        comms = mock.MagicMock()
+
+        class _Unserializable:
+            """Not a ``str``/``dict``/``Iterable``, so ``MaskSecret(value=...)`` rejects it."""
+
+        with (
+            mock.patch.object(task_runner, "SUPERVISOR_COMMS", comms, create=True),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log.mask_secret(_Unserializable(), name="password")
+
+        events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+        assert events[0]["secret_name"] == "password"
+        assert events[0]["exc_info"]  # structlog renders exc_info=True as True in capture_logs
+        # The failure is in building the message, not the socket -- the supervisor is never contacted.
+        comms.send.assert_not_called()
+
+    def test_warns_when_supervisor_socket_is_broken(self):
+        """The IPC socket itself fails (e.g. a broken connection) -- still warn rather than swallow."""
+        from airflow.sdk.execution_time import task_runner
+
+        comms = mock.MagicMock()
+        comms.send.side_effect = BrokenPipeError("supervisor connection lost")
+
+        with (
+            mock.patch.object(task_runner, "SUPERVISOR_COMMS", comms, create=True),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log.mask_secret("hunter2", name="password")
+
+        events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+        assert events[0]["secret_name"] == "password"
+        assert events[0]["exc_info"]
+        comms.send.assert_called_once()
+
+    def test_silent_when_supervisor_send_succeeds(self):
+        from airflow.sdk.execution_time import task_runner
+
+        comms = mock.MagicMock()
+
+        with (
+            mock.patch.object(task_runner, "SUPERVISOR_COMMS", comms, create=True),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log.mask_secret("hunter2", name="password")
+
+        events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
+        assert events == []
+        comms.send.assert_called_once()
+
+    def test_silent_when_no_supervisor_context(self):
+        """Outside a task-execution context (no SUPERVISOR_COMMS) the function is a no-op."""
+        from airflow.sdk.execution_time import task_runner
+
+        with (
+            mock.patch.object(task_runner, "SUPERVISOR_COMMS", None, create=True),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log.mask_secret("hunter2", name="password")
+
+        events = [e for e in captured if e["event"] == "supervisor_mask_secret_failed"]
+        assert events == []


### PR DESCRIPTION
`mask_secret()` mirrors the mask to the supervisor process so any forwarded logs are masked there too. The send at [`log.py:281`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/log.py#L281) was wrapped in a bare `suppress(Exception)`, so a transient IPC failure was silently swallowed.

When `sending_to_supervisor=True` the local task drops its own `mask_logs` processor (it relies on the supervisor to do the masking — see `log.py` lines 72-73 and 115-118) — so a silent send failure could leave the secret unmasked in supervisor-level logs. Operators had no signal that this had happened.

Reported as F-001 in the [`apache/tooling-agents` L3 task-sdk sweep `0920c77`](https://github.com/apache/tooling-agents/issues/24).

## Change

Replace the bare `suppress` with a targeted `try/except` that emits a warning to a dedicated `airflow.logging.mask_secret` structlog logger when the supervisor *is* available but the send fails. The "no supervisor context" case (`mask_secret` called outside task execution, no `SUPERVISOR_COMMS`) stays silent — there is no supervisor to notify.

## Test plan

- [x] `test_warns_when_supervisor_send_fails` — patches `task_runner.SUPERVISOR_COMMS` to a Mock whose `send` raises; captures structlog output and asserts the `supervisor_mask_secret_failed` event lands with the secret name and exc_info.
- [x] `test_silent_when_supervisor_send_succeeds` — success path emits no warning, `comms.send` called once.
- [x] `test_silent_when_no_supervisor_context` — outside a task-execution context the function is a no-op.
- [x] `prek run ruff` clean.
- [x] `prek run mypy-task-sdk` clean.
- [x] Full `test_log.py` suite: 8 passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)