### PR TITLE
Guard _load_logging_config when remote log handler discovery fails

### DIFF
--- a/task-sdk/src/airflow/sdk/log.py
+++ b/task-sdk/src/airflow/sdk/log.py
@@ -178,11 +178,24 @@ def _load_logging_config() -> None:
     from airflow.sdk.configuration import conf
     from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
 
-    remote_task_log, default_remote_conn_id = resolve_remote_task_log(
-        conf=conf,
-        providers_manager=ProvidersManagerTaskRuntime(),
-        import_string=import_string,
-    )
+    # Wrap discovery: a raise here propagates through ``load_remote_log_handler()`` into the
+    # task lifecycle handler and crashes the task with a non-obvious error. Operators relying
+    # on remote-log uploads still need to see this — surface a warning and cache "no remote
+    # handler" so the rest of the logging system initialises and the task can run with local
+    # logs only.
+    try:
+        remote_task_log, default_remote_conn_id = resolve_remote_task_log(
+            conf=conf,
+            providers_manager=ProvidersManagerTaskRuntime(),
+            import_string=import_string,
+        )
+    except Exception:
+        structlog.get_logger("airflow.logging.remote").warning(
+            "remote_log_handler_discovery_failed",
+            note="Remote log handler could not be loaded; logs will be available locally only.",
+            exc_info=True,
+        )
+        remote_task_log, default_remote_conn_id = None, None
     _ActiveLoggingConfig.set(remote_task_log, default_remote_conn_id)
 
 

--- a/task-sdk/tests/task_sdk/test_log.py
+++ b/task-sdk/tests/task_sdk/test_log.py
@@ -118,3 +118,50 @@ class TestUploadToRemote:
 
         assert captured == []
         handler.upload.assert_called_once_with(relative.as_posix(), ti)
+
+
+class TestLoadLoggingConfig:
+    """Discovery failures must not propagate into the task lifecycle.
+
+    ``_load_logging_config`` is called transitively from any logger acquisition path; a raise
+    here crashes the task with a non-obvious error. Operators relying on remote-log uploads
+    still need to see the failure, so the function should warn and fall back to "no remote
+    handler".
+    """
+
+    def test_discovery_failure_warns_and_falls_back(self):
+        boom = ImportError("module 'airflow_remote_logging' not found")
+        with (
+            mock.patch(
+                "airflow.sdk._shared.logging.factory.resolve_remote_task_log",
+                side_effect=boom,
+            ),
+            mock.patch.object(sdk_log._ActiveLoggingConfig, "logging_config_loaded", False),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log._load_logging_config()
+
+        events = [e for e in captured if e["event"] == "remote_log_handler_discovery_failed"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+        assert events[0]["exc_info"]
+        assert sdk_log._ActiveLoggingConfig.remote_task_log is None
+        assert sdk_log._ActiveLoggingConfig.default_remote_conn_id is None
+        assert sdk_log._ActiveLoggingConfig.logging_config_loaded is True
+
+    def test_discovery_success_no_warning(self):
+        remote = mock.MagicMock()
+        with (
+            mock.patch(
+                "airflow.sdk._shared.logging.factory.resolve_remote_task_log",
+                return_value=(remote, "remote_conn"),
+            ),
+            mock.patch.object(sdk_log._ActiveLoggingConfig, "logging_config_loaded", False),
+            structlog.testing.capture_logs() as captured,
+        ):
+            sdk_log._load_logging_config()
+
+        events = [e for e in captured if e["event"] == "remote_log_handler_discovery_failed"]
+        assert events == []
+        assert sdk_log._ActiveLoggingConfig.remote_task_log is remote
+        assert sdk_log._ActiveLoggingConfig.default_remote_conn_id == "remote_conn"


### PR DESCRIPTION
`_load_logging_config` called `discover_remote_log_handler` without exception protection. A raise there propagated through `load_remote_log_handler` (which is called transitively from any logger acquisition path) into the task lifecycle handler, crashing the task with a non-obvious error.

The earlier PR #66571 fixed the "no handler available" signal; the gap was that the discovery call itself wasn't guarded.

Reported as F-005 in the [`apache/tooling-agents` L3 task-sdk sweep `0920c77`](https://github.com/apache/tooling-agents/issues/24).

## Change

Wrap [`discover_remote_log_handler`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/log.py#L184) in try/except. On failure, emit a warning to the dedicated `airflow.logging.remote` structlog logger (same logger PR #66571 uses for `remote_log_handler_unavailable` / `remote_log_upload_failed`) and fall back to "no remote handler" so the rest of the logging system initialises and the task can run with local logs only.

## Test plan

- [x] `test_discovery_failure_warns_and_falls_back` — patches `discover_remote_log_handler` to raise `ImportError`; asserts the warning lands with exc_info, `_ActiveLoggingConfig.remote_task_log is None`, and `logging_config_loaded is True` (so we don't loop trying to re-discover).
- [x] `test_discovery_success_no_warning` — success path emits no warning and the returned handler is cached.
- [x] `prek run ruff` clean.
- [x] `prek run mypy-task-sdk` clean.
- [x] Full `test_log.py` suite passes.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)