### PR TITLE
Cap default httpx connection pool on the task-sdk Client

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1136,6 +1136,13 @@ class Client(httpx.Client):
         # Set timeout if not explicitly provided
         kwargs.setdefault("timeout", API_TIMEOUT)
 
+        # Cap the httpx connection pool. Without an explicit value httpx defaults to 100 max
+        # connections, which is far higher than a single task subprocess ever needs (the
+        # supervisor sets ``max_connections=10`` in ``_ensure_client``). A bounded default
+        # keeps the behaviour predictable across both code paths and avoids surprise resource
+        # use under high concurrency. Callers can still override via ``Client(..., limits=...)``.
+        kwargs.setdefault("limits", httpx.Limits(max_keepalive_connections=5, max_connections=20))
+
         pyver = f"{'.'.join(map(str, sys.version_info[:3]))}"
         super().__init__(
             auth=auth,

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -123,6 +123,30 @@ class TestClient:
         )
         assert client.timeout == httpx.Timeout(120.0)
 
+    def test_default_pool_limits_are_bounded(self):
+        """The default httpx pool must be capped — not httpx's 100-connection default.
+
+        Without an explicit ``limits``, ``httpx.Client`` defaults to ``max_connections=100``
+        per instance, which is far higher than a single task subprocess ever needs and is
+        inconsistent with the supervisor's own ``_ensure_client`` (which caps at 10).
+        """
+        # Instantiate without a transport override so we can read the limits off the
+        # real transport that the Client built itself (mock transports ignore limits).
+        client = Client(base_url="test://server", token="")
+        pool = client._transport._pool
+        assert pool._max_connections == 20
+        assert pool._max_keepalive_connections == 5
+
+    def test_pool_limits_can_be_overridden(self):
+        client = Client(
+            base_url="test://server",
+            token="",
+            limits=httpx.Limits(max_keepalive_connections=2, max_connections=8),
+        )
+        pool = client._transport._pool
+        assert pool._max_connections == 8
+        assert pool._max_keepalive_connections == 2
+
     def test_error_parsing(self):
         responses = [
             httpx.Response(422, json={"detail": [{"loc": ["#0"], "msg": "err", "type": "required"}]})


### PR DESCRIPTION
`Client.__init__` did not set explicit `httpx.Limits`, so each Client inherited httpx's defaults of `max_connections=100` and `max_keepalive_connections=10`. The supervisor's own [`_ensure_client`](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/execution_time/supervisor.py#L1119) capped at `max_connections=10, max_keepalive_connections=1` — so the two code paths that build a task-sdk Client diverged by an order of magnitude in their pool behaviour, with no documented reason and surprising resource use under high concurrency.

Reported as F-011 in the [`apache/tooling-agents` L3 task-sdk sweep `0920c77`](https://github.com/apache/tooling-agents/issues/24).

## Change

Standardise on a single bounded default at the Client level via `kwargs.setdefault("limits", httpx.Limits(max_keepalive_connections=5, max_connections=20))`. The supervisor's lower-cap path is unchanged (it sets `limits` explicitly before passing to the Client), and any caller that needs different limits can still pass `limits=...` via kwargs.

Choosing `(5, 20)` rather than `(1, 10)`: a non-supervisor Client (e.g. instantiated directly by tests, CLI, or future callers) may handle higher per-instance concurrency than a single task subprocess, so the default sits between the supervisor's tight cap and httpx's untenably-high default.

## Test plan

- [x] `test_default_pool_limits_are_bounded` — instantiates a real (non-mock-transport) Client and asserts `pool._max_connections == 20` and `pool._max_keepalive_connections == 5`.
- [x] `test_pool_limits_can_be_overridden` — `limits=httpx.Limits(...)` kwarg overrides the default.
- [x] `prek run ruff` clean.
- [x] `prek run mypy-task-sdk` clean.
- [x] Full `test_client.py` suite: 117 passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)