### PR TITLE
Write Cloud SQL keyfile_dict credentials with 0600 permissions

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -626,7 +626,11 @@ class CloudSqlProxyRunner(LoggingMixin):
         elif keyfile_dict:
             keyfile_content = keyfile_dict if isinstance(keyfile_dict, dict) else json.loads(keyfile_dict)
             self.log.info("Saving credentials to %s", self.credentials_path)
-            with open(self.credentials_path, "w") as file:
+            # Explicit 0o600 — the file holds a service-account private key. The plain
+            # ``open()`` form inherits the process umask (typically 0o644), which leaves the
+            # key world-readable on shared worker hosts.
+            fd = os.open(self.credentials_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as file:
                 json.dump(keyfile_content, file)
             credential_params = ["-credential_file", self.credentials_path]
         else:

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
@@ -21,7 +21,9 @@ import base64
 import json
 import os
 import platform
+import stat
 import tempfile
+from pathlib import Path
 from unittest import mock
 from unittest.mock import PropertyMock, call, mock_open
 from urllib.parse import parse_qsl, unquote, urlsplit
@@ -1933,6 +1935,34 @@ class TestCloudSqlProxyRunner:
 
         assert runner._get_credential_parameters() == ["-credential_file", "/tmp/key.json"]
         assert "-enable_iam_login" in runner.command_line_parameters
+
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.GoogleBaseHook.get_connection")
+    def test_credentials_file_from_keyfile_dict_is_chmod_0600(self, get_connection, tmp_path):
+        """The keyfile_dict credentials file must be written with explicit 0600 permissions.
+
+        Plain ``open(...)`` inherits the process umask (typically 0644), leaving the
+        service-account private key world-readable on shared worker hosts.
+        """
+        keyfile_dict = {"type": "service_account", "private_key": "PRIVATE"}
+        connection = Connection(conn_id="google_conn", conn_type="google_cloud_platform")
+        extra = json.dumps({"keyfile_dict": json.dumps(keyfile_dict)})
+        if AIRFLOW_V_3_1_PLUS:
+            connection.extra = extra
+        else:
+            connection.set_extra(extra)
+        get_connection.return_value = connection
+
+        runner = CloudSqlProxyRunner(
+            path_prefix=str(tmp_path / "creds"),
+            instance_specification="project:us-east-1:instance",
+            gcp_conn_id="google_conn",
+        )
+        runner._get_credential_parameters()
+
+        creds_path = Path(runner.credentials_path)
+        assert creds_path.exists()
+        # Mask off the file-type bits, keep only the permission bits.
+        assert stat.S_IMODE(creds_path.stat().st_mode) == 0o600
 
 
 class TestCloudSQLAsyncHook:


### PR DESCRIPTION
When the Google connection supplies credentials via `keyfile_dict`, `CloudSqlProxyRunner._get_credential_parameters` writes the credentials file with [`open(path, "w")` at `cloud_sql.py:629`](https://github.com/apache/airflow/blob/main/providers/google/src/airflow/providers/google/cloud/hooks/cloud_sql.py#L629). That inherits the process umask (typically `0o644`), leaving the service-account private key world-readable on shared worker hosts — including any other process on the same machine that can read the worker's temp directory.

Reported as F-004 in the [`apache/tooling-agents` L3 providers/google sweep `b1aec75`](https://github.com/apache/tooling-agents/issues/34).

## Change

Use `os.open(..., O_WRONLY | O_CREAT | O_TRUNC, 0o600)` followed by `os.fdopen` so the file is created with restrictive permissions atomically. Matches the explicit-mode handling already used for the SSL temp files in the same module.

## Test plan

- [x] Added `test_credentials_file_from_keyfile_dict_is_chmod_0600` — writes credentials via the real code path, reads `Path.stat().st_mode`, asserts `stat.S_IMODE == 0o600`.
- [x] `prek run ruff` clean on touched files.
- [x] `breeze run mypy` clean on the source file.
- [x] Existing `test_cloud_sql_proxy_runner_keeps_key_path_credentials_with_iam_login` still passes (no behaviour change on the `key_path` branch).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)