### PR TITLE
Warn when remote_log_conn_id is configured but not found

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -95,7 +95,16 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
             try:
                 return GCSHook(gcp_conn_id=conn_id)
             except AirflowNotFoundException:
-                pass
+                # The operator configured a ``remote_log_conn_id`` that doesn't exist. We
+                # fall back to Application Default Credentials, but the operator almost
+                # certainly didn't mean that — a misconfigured remote-log connection is a
+                # security control failure (logs going through the wrong credentials) and
+                # must be visible in the worker log.
+                self.log.warning(
+                    "remote_log_conn_id %r is not configured; falling back to Application "
+                    "Default Credentials for GCS log handler.",
+                    conn_id,
+                )
         return None
 
     @cached_property

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from airflow.providers.common.compat.sdk import AirflowNotFoundException
 from airflow.providers.google.cloud.log.gcs_task_handler import GCSRemoteLogIO, GCSTaskHandler
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.timezone import datetime
@@ -596,3 +597,49 @@ class TestGCSTaskHandler:
             gcs_log_folder="gs://bucket/remote/log/location",
             filename_template=None,
         )
+
+
+class TestGCSRemoteLogIOMisconfiguredConn:
+    """A misconfigured ``remote_log_conn_id`` must surface as a warning.
+
+    Silently swallowing the ``AirflowNotFoundException`` lets an operator believe they had
+    configured a specific service-account key for log uploads when in fact Application
+    Default Credentials are being used — a security-control failure that should be visible.
+    """
+
+    @mock.patch("airflow.providers.google.cloud.log.gcs_task_handler.GCSHook")
+    def test_hook_warns_when_remote_log_conn_id_missing(self, mock_hook, caplog):
+        mock_hook.side_effect = AirflowNotFoundException("conn 'nonexistent' not found")
+        remote_io = GCSRemoteLogIO(
+            remote_base="gs://bucket/remote/log/location",
+            base_log_folder="/tmp/airflow-test-logs",
+            delete_local_copy=False,
+        )
+
+        with conf_vars({("logging", "remote_log_conn_id"): "nonexistent"}):
+            with caplog.at_level(logging.WARNING):
+                assert remote_io.hook is None
+
+        warnings_emitted = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("nonexistent" in r.getMessage() for r in warnings_emitted), (
+            "expected a warning mentioning the misconfigured conn_id, got: "
+            f"{[r.getMessage() for r in warnings_emitted]}"
+        )
+
+    @mock.patch("airflow.providers.google.cloud.log.gcs_task_handler.GCSHook")
+    def test_hook_silent_when_no_remote_log_conn_id_configured(self, mock_hook, caplog):
+        """No ``remote_log_conn_id`` set → silent fall-through to ADC; no warning."""
+        remote_io = GCSRemoteLogIO(
+            remote_base="gs://bucket/remote/log/location",
+            base_log_folder="/tmp/airflow-test-logs",
+            delete_local_copy=False,
+        )
+
+        with conf_vars({("logging", "remote_log_conn_id"): ""}):
+            with caplog.at_level(logging.WARNING):
+                assert remote_io.hook is None
+
+        assert not any(
+            "remote_log_conn_id" in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        )
+        mock_hook.assert_not_called()


### PR DESCRIPTION
`GCSRemoteLogIO.hook` silently swallowed `AirflowNotFoundException` when the configured `remote_log_conn_id` did not exist, falling back to Application Default Credentials without any signal. That made a misconfigured remote-log connection (logs effectively going through the wrong credentials) invisible to operators — a security-control failure with no operational indication.

Reported as F-008 in the [`apache/tooling-agents` L3 providers/google sweep `b1aec75`](https://github.com/apache/tooling-agents/issues/34).

## Change

Replace the silent `pass` at [`gcs_task_handler.py:97-98`](https://github.com/apache/airflow/blob/main/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py#L97) with `self.log.warning` mentioning the unresolved `conn_id` so the fallback is visible in worker logs. Behaviour (falling back to ADC) is unchanged when no `remote_log_conn_id` is configured.

## Test plan

- [x] `test_hook_warns_when_remote_log_conn_id_missing` — patches `GCSHook` to raise `AirflowNotFoundException`, asserts the warning is emitted with the unresolved conn_id name and `hook is None`.
- [x] `test_hook_silent_when_no_remote_log_conn_id_configured` — empty conn_id means silent fall-through to ADC, no warning emitted.
- [x] `prek run ruff` clean.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)