### PR TITLE
Fail closed in GCS log handler when existing-log read fails

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -130,7 +130,19 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
             log = f"{old_log}\n{log}" if old_log else log
         except Exception as e:
             if not self.no_log_found(e):
-                self.log.warning("Error checking for previous log: %s", e)
+                # Read failed for a reason other than "object does not exist" (e.g. transient
+                # GCS outage, IAM glitch, network blip). Fall through to the upload would
+                # overwrite the existing blob with only the new content and *truncate* the
+                # prior log history. Fail closed instead: keep local logs and let the next
+                # heartbeat retry. ``no_log_found`` covers the 404 case, where it is safe to
+                # write the new content as a fresh blob.
+                self.log.warning(
+                    "Refusing to overwrite remote log %s: could not read existing content (%s). "
+                    "Keeping local logs for later retry.",
+                    remote_log_location,
+                    e,
+                )
+                return False
         try:
             blob = storage.Blob.from_string(remote_log_location, self.client)
             blob.upload_from_string(log, content_type="text/plain")

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -190,17 +190,23 @@ class TestGCSRemoteLogIO:
         result = gcs_remote_log_io.write(new_log_content, remote_log_location)
 
         # verify
-        assert result == upload_success
-
-        # verify the content that was uploaded
-        if upload_success:
-            call_args = mock_blob.from_string.return_value.upload_from_string.call_args
-            if call_args:
-                uploaded_content = call_args[0][0]
-                if old_log_exists and not old_log_read_error:
-                    assert uploaded_content == f"{old_log_content}\n{new_log_content}"
-                else:
-                    assert uploaded_content == new_log_content
+        # If reading the existing blob failed for a reason other than "not found", the
+        # handler now fails closed (returns False without uploading) rather than overwriting
+        # the existing blob with only the new content. The 404 case still proceeds to upload.
+        if old_log_read_error is not None:
+            assert result is False
+            mock_blob.from_string.return_value.upload_from_string.assert_not_called()
+        else:
+            assert result == upload_success
+            # verify the content that was uploaded
+            if upload_success:
+                call_args = mock_blob.from_string.return_value.upload_from_string.call_args
+                if call_args:
+                    uploaded_content = call_args[0][0]
+                    if old_log_exists:
+                        assert uploaded_content == f"{old_log_content}\n{new_log_content}"
+                    else:
+                        assert uploaded_content == new_log_content
 
     @pytest.mark.parametrize(
         "is_stream_method",

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -546,18 +546,14 @@ class TestGCSTaskHandler:
         )
         self.gcs_task_handler.close()
 
-        mock_blob.from_string.assert_has_calls(
-            [
-                mock.call("gs://bucket/remote/log/location/1.log", mock_client.return_value),
-                mock.call().download_as_bytes(),
-                mock.call("gs://bucket/remote/log/location/1.log", mock_client.return_value),
-                mock.call().upload_from_string(
-                    "MESSAGE\n",
-                    content_type="text/plain",
-                ),
-            ],
-            any_order=False,
+        # Fail-closed contract: when reading the existing blob fails for a reason other than
+        # "object does not exist", the handler must not overwrite the remote log with only
+        # the new content. Expect the read attempt but no upload.
+        mock_blob.from_string.assert_called_once_with(
+            "gs://bucket/remote/log/location/1.log", mock_client.return_value
         )
+        mock_blob.from_string.return_value.download_as_bytes.assert_called_once()
+        mock_blob.from_string.return_value.upload_from_string.assert_not_called()
 
     @pytest.mark.parametrize(
         ("delete_local_copy", "expected_existence_of_local_copy"),


### PR DESCRIPTION
`GCSRemoteLogIO.write` reads the existing blob, appends the new log content, then uploads. When `download_as_bytes()` failed for a reason other than "object does not exist" (transient GCS outage, IAM glitch, network blip), [the read exception was caught, a warning was logged, and execution fell through to upload only the new content](https://github.com/apache/airflow/blob/main/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py#L127) — silently truncating prior log history. Forensically important since the GCS upload is the durable record once the local log is rotated.

Reported as F-012 in the [`apache/tooling-agents` L3 providers/google sweep `b1aec75`](https://github.com/apache/tooling-agents/issues/34).

## Change

Distinguish the 404 case (safe: write the new content as a fresh blob — `no_log_found` already detects this) from non-404 read failures (transient: keep local logs, return `False`, let the next heartbeat retry). The 404 path is unchanged.

## Test plan

- [x] Existing parametrised `test_write` (8 cases) updated to reflect the new fail-closed contract — when `download_as_bytes` raises a non-404 error, the handler now returns `False` and does not call `upload_from_string`. All 8 parametrised cases pass via `breeze run pytest`.
- [x] Local `uv run pytest` blocked by an unrelated DB-schema issue on the existing test fixture — verified clean via breeze.
- [x] `prek run ruff` clean.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)